### PR TITLE
chore: remove implicit record stream assumption from builder names

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
@@ -34,7 +34,7 @@ import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.state.addressbook.Node;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.addressbook.impl.WritableNodeStore;
-import com.hedera.node.app.service.addressbook.impl.records.NodeCreateRecordBuilder;
+import com.hedera.node.app.service.addressbook.impl.records.NodeCreateStreamBuilder;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -121,7 +121,7 @@ public class NodeCreateHandler implements TransactionHandler {
 
         nodeStore.put(node);
 
-        final var recordBuilder = handleContext.savepointStack().getBaseBuilder(NodeCreateRecordBuilder.class);
+        final var recordBuilder = handleContext.savepointStack().getBaseBuilder(NodeCreateStreamBuilder.class);
 
         recordBuilder.nodeID(node.nodeId());
     }

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/records/NodeCreateStreamBuilder.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/records/NodeCreateStreamBuilder.java
@@ -20,7 +20,7 @@ import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side-effects of a {@code NodeCreate} transaction.
+ * A {@code StreamBuilder} specialization for tracking the side-effects of a {@code NodeCreate} transaction.
  */
 public interface NodeCreateStreamBuilder extends StreamBuilder {
     /**

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/records/NodeCreateStreamBuilder.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/records/NodeCreateStreamBuilder.java
@@ -16,13 +16,13 @@
 
 package com.hedera.node.app.service.addressbook.impl.records;
 
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * A {@code RecordBuilder} specialization for tracking the side-effects of a {@code NodeCreate} transaction.
  */
-public interface NodeCreateRecordBuilder extends SingleTransactionRecordBuilder {
+public interface NodeCreateStreamBuilder extends StreamBuilder {
     /**
      * Tracks creation of a new node by nodeID.
      *
@@ -30,5 +30,5 @@ public interface NodeCreateRecordBuilder extends SingleTransactionRecordBuilder 
      * @return this builder
      */
     @NonNull
-    NodeCreateRecordBuilder nodeID(long nodeID);
+    NodeCreateStreamBuilder nodeID(long nodeID);
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
@@ -48,7 +48,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.addressbook.impl.WritableNodeStore;
 import com.hedera.node.app.service.addressbook.impl.handlers.NodeCreateHandler;
-import com.hedera.node.app.service.addressbook.impl.records.NodeCreateRecordBuilder;
+import com.hedera.node.app.service.addressbook.impl.records.NodeCreateStreamBuilder;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeCalculator;
@@ -78,7 +78,7 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
     private HandleContext handleContext;
 
     @Mock
-    private NodeCreateRecordBuilder recordBuilder;
+    private NodeCreateStreamBuilder recordBuilder;
 
     @Mock
     private StoreFactory storeFactory;

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleContext.java
@@ -36,7 +36,7 @@ import com.hedera.node.app.spi.throttle.ThrottleAdviser;
 import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.spi.info.NetworkInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -516,7 +516,7 @@ public interface HandleContext {
          * @throws IllegalArgumentException if the record builder type is unknown to the app
          */
         @NonNull
-        <T extends SingleTransactionRecordBuilder> T getBaseBuilder(@NonNull Class<T> recordBuilderClass);
+        <T extends StreamBuilder> T getBaseBuilder(@NonNull Class<T> recordBuilderClass);
 
         /**
          * Adds a child record builder to the list of record builders. If the current {@link HandleContext} (or any parent

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/DeleteCapableTransactionRecordBuilder.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/DeleteCapableTransactionRecordBuilder.java
@@ -35,7 +35,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * just-deleted account was going to receive staking rewards in the transaction, those rewards
  * should be redirected to the beneficiary account.
  */
-public interface DeleteCapableTransactionRecordBuilder extends SingleTransactionRecordBuilder {
+public interface DeleteCapableTransactionRecordBuilder extends StreamBuilder {
     /**
      * Gets number of deleted accounts in this transaction.
      * @return number of deleted accounts in this transaction

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/StreamBuilder.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/StreamBuilder.java
@@ -40,13 +40,13 @@ import java.util.Set;
  * Defines API for constructing stream items of a single transaction dispatch.
  * The implementation may produce only records or could produce block items
  */
-public interface SingleTransactionRecordBuilder {
+public interface StreamBuilder {
     /**
      * Sets the transaction for this stream item builder.
      * @param transaction the transaction
      * @return this builder
      */
-    SingleTransactionRecordBuilder transaction(@NonNull Transaction transaction);
+    StreamBuilder transaction(@NonNull Transaction transaction);
 
     /**
      * Returns the transaction for this stream item builder.
@@ -107,7 +107,7 @@ public interface SingleTransactionRecordBuilder {
      * @param status the receipt status
      * @return the builder
      */
-    SingleTransactionRecordBuilder status(@NonNull ResponseCodeEnum status);
+    StreamBuilder status(@NonNull ResponseCodeEnum status);
 
     /**
      * The transaction category of the transaction that created this record
@@ -130,21 +130,21 @@ public interface SingleTransactionRecordBuilder {
      * Sets the transactionID of the record based on the user transaction record.
      * @return the builder
      */
-    SingleTransactionRecordBuilder syncBodyIdFromRecordId();
+    StreamBuilder syncBodyIdFromRecordId();
 
     /**
      * Sets the memo of the record.
      * @param memo the memo
      * @return the builder
      */
-    SingleTransactionRecordBuilder memo(@NonNull String memo);
+    StreamBuilder memo(@NonNull String memo);
 
     /**
      * Sets the consensus timestamp of the record.
      * @param now the consensus timestamp
      * @return the builder
      */
-    SingleTransactionRecordBuilder consensusTimestamp(@NonNull final Instant now);
+    StreamBuilder consensusTimestamp(@NonNull final Instant now);
 
     /**
      * Returns the transaction ID of the record.
@@ -157,28 +157,28 @@ public interface SingleTransactionRecordBuilder {
      * @param transactionID the transaction ID
      * @return the builder
      */
-    SingleTransactionRecordBuilder transactionID(@NonNull TransactionID transactionID);
+    StreamBuilder transactionID(@NonNull TransactionID transactionID);
 
     /**
      * Sets the parent consensus timestamp of the record.
      * @param parentConsensus the parent consensus timestamp
      * @return the builder
      */
-    SingleTransactionRecordBuilder parentConsensus(@NonNull Instant parentConsensus);
+    StreamBuilder parentConsensus(@NonNull Instant parentConsensus);
 
     /**
      * Sets the transaction bytes of this builder.
      * @param transactionBytes the transaction bytes
      * @return this builder
      */
-    SingleTransactionRecordBuilder transactionBytes(@NonNull Bytes transactionBytes);
+    StreamBuilder transactionBytes(@NonNull Bytes transactionBytes);
 
     /**
      * Sets the exchange rate of this builder.
      * @param exchangeRate the exchange rate
      * @return this builder
      */
-    SingleTransactionRecordBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate);
+    StreamBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate);
 
     /**
      * Returns the number of automatic token associations

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/HandleContextTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/workflows/HandleContextTest.java
@@ -28,7 +28,7 @@ import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.signatures.VerificationAssistant;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,12 +57,11 @@ class HandleContextTest {
         final var subject = mock(HandleContext.class);
         doCallRealMethod()
                 .when(subject)
-                .dispatchPrecedingTransaction(
-                        TransactionBody.DEFAULT, SingleTransactionRecordBuilder.class, signatureTest);
+                .dispatchPrecedingTransaction(TransactionBody.DEFAULT, StreamBuilder.class, signatureTest);
         assertThrows(
                 IllegalArgumentException.class,
                 () -> subject.dispatchPrecedingTransaction(
-                        TransactionBody.DEFAULT, SingleTransactionRecordBuilder.class, signatureTest));
+                        TransactionBody.DEFAULT, StreamBuilder.class, signatureTest));
     }
 
     @Test
@@ -70,11 +69,9 @@ class HandleContextTest {
         final var subject = mock(HandleContext.class);
         doCallRealMethod()
                 .when(subject)
-                .dispatchPrecedingTransaction(WITH_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest);
-        subject.dispatchPrecedingTransaction(WITH_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest);
-        verify(subject)
-                .dispatchPrecedingTransaction(
-                        WITH_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest, PAYER_ID);
+                .dispatchPrecedingTransaction(WITH_PAYER_ID, StreamBuilder.class, signatureTest);
+        subject.dispatchPrecedingTransaction(WITH_PAYER_ID, StreamBuilder.class, signatureTest);
+        verify(subject).dispatchPrecedingTransaction(WITH_PAYER_ID, StreamBuilder.class, signatureTest, PAYER_ID);
     }
 
     @Test
@@ -82,12 +79,10 @@ class HandleContextTest {
         final var subject = mock(HandleContext.class);
         doCallRealMethod()
                 .when(subject)
-                .dispatchScheduledChildTransaction(
-                        MISSING_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest);
+                .dispatchScheduledChildTransaction(MISSING_PAYER_ID, StreamBuilder.class, signatureTest);
         assertThrows(
                 IllegalArgumentException.class,
-                () -> subject.dispatchScheduledChildTransaction(
-                        MISSING_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest));
+                () -> subject.dispatchScheduledChildTransaction(MISSING_PAYER_ID, StreamBuilder.class, signatureTest));
     }
 
     @Test
@@ -95,11 +90,10 @@ class HandleContextTest {
         final var subject = mock(HandleContext.class);
         doCallRealMethod()
                 .when(subject)
-                .dispatchScheduledChildTransaction(WITH_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest);
-        subject.dispatchScheduledChildTransaction(WITH_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest);
+                .dispatchScheduledChildTransaction(WITH_PAYER_ID, StreamBuilder.class, signatureTest);
+        subject.dispatchScheduledChildTransaction(WITH_PAYER_ID, StreamBuilder.class, signatureTest);
         verify(subject)
-                .dispatchChildTransaction(
-                        WITH_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest, PAYER_ID, SCHEDULED);
+                .dispatchChildTransaction(WITH_PAYER_ID, StreamBuilder.class, signatureTest, PAYER_ID, SCHEDULED);
     }
 
     @Test
@@ -107,12 +101,11 @@ class HandleContextTest {
         final var subject = mock(HandleContext.class);
         doCallRealMethod()
                 .when(subject)
-                .dispatchRemovableChildTransaction(
-                        TransactionBody.DEFAULT, SingleTransactionRecordBuilder.class, signatureTest);
+                .dispatchRemovableChildTransaction(TransactionBody.DEFAULT, StreamBuilder.class, signatureTest);
         assertThrows(
                 IllegalArgumentException.class,
                 () -> subject.dispatchRemovableChildTransaction(
-                        TransactionBody.DEFAULT, SingleTransactionRecordBuilder.class, signatureTest));
+                        TransactionBody.DEFAULT, StreamBuilder.class, signatureTest));
     }
 
     @Test
@@ -120,14 +113,10 @@ class HandleContextTest {
         final var subject = mock(HandleContext.class);
         doCallRealMethod()
                 .when(subject)
-                .dispatchRemovableChildTransaction(WITH_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest);
-        subject.dispatchRemovableChildTransaction(WITH_PAYER_ID, SingleTransactionRecordBuilder.class, signatureTest);
+                .dispatchRemovableChildTransaction(WITH_PAYER_ID, StreamBuilder.class, signatureTest);
+        subject.dispatchRemovableChildTransaction(WITH_PAYER_ID, StreamBuilder.class, signatureTest);
         verify(subject)
                 .dispatchRemovableChildTransaction(
-                        WITH_PAYER_ID,
-                        SingleTransactionRecordBuilder.class,
-                        signatureTest,
-                        PAYER_ID,
-                        NOOP_RECORD_CUSTOMIZER);
+                        WITH_PAYER_ID, StreamBuilder.class, signatureTest, PAYER_ID, NOOP_RECORD_CUSTOMIZER);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeAccumulator.java
@@ -19,7 +19,7 @@ package com.hedera.node.app.fees;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.node.app.service.token.api.FeeRecordBuilder;
+import com.hedera.node.app.service.token.api.FeeStreamBuilder;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.spi.fees.Fees;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -30,15 +30,15 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public class FeeAccumulator {
     private final TokenServiceApi tokenApi;
-    private final FeeRecordBuilder recordBuilder;
+    private final FeeStreamBuilder recordBuilder;
 
     /**
      * Creates a new instance of {@link FeeAccumulator}.
      *
      * @param tokenApi the {@link TokenServiceApi} to use to charge and refund fees.
-     * @param recordBuilder the {@link FeeRecordBuilder} to record any changes
+     * @param recordBuilder the {@link FeeStreamBuilder} to record any changes
      */
-    public FeeAccumulator(@NonNull final TokenServiceApi tokenApi, @NonNull final FeeRecordBuilder recordBuilder) {
+    public FeeAccumulator(@NonNull final TokenServiceApi tokenApi, @NonNull final FeeStreamBuilder recordBuilder) {
         this.tokenApi = requireNonNull(tokenApi);
         this.recordBuilder = requireNonNull(recordBuilder);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/Dispatch.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/Dispatch.java
@@ -25,7 +25,7 @@ import com.hedera.node.app.signature.AppKeyVerifier;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
@@ -79,7 +79,7 @@ public interface Dispatch {
      *
      * @return the builder
      */
-    SingleTransactionRecordBuilder recordBuilder();
+    StreamBuilder recordBuilder();
 
     /**
      * The configuration for the dispatch.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchHandleContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchHandleContext.java
@@ -60,12 +60,12 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.TransactionKeys;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.StoreFactoryImpl;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.node.app.workflows.handle.validation.AttributeValidatorImpl;
 import com.hedera.node.app.workflows.handle.validation.ExpiryValidatorImpl;
@@ -382,7 +382,7 @@ public class DispatchHandleContext implements HandleContext, FeeContext {
                 childSyntheticPayerId,
                 ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER,
                 TransactionCategory.PRECEDING,
-                SingleTransactionRecordBuilder.ReversingBehavior.IRREVERSIBLE,
+                StreamBuilder.ReversingBehavior.IRREVERSIBLE,
                 true);
     }
 
@@ -400,7 +400,7 @@ public class DispatchHandleContext implements HandleContext, FeeContext {
                 childSyntheticPayer,
                 ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER,
                 TransactionCategory.PRECEDING,
-                SingleTransactionRecordBuilder.ReversingBehavior.REMOVABLE,
+                StreamBuilder.ReversingBehavior.REMOVABLE,
                 false);
     }
 
@@ -424,7 +424,7 @@ public class DispatchHandleContext implements HandleContext, FeeContext {
                 childSyntheticPayerId,
                 ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER,
                 childCategory,
-                SingleTransactionRecordBuilder.ReversingBehavior.REVERSIBLE,
+                StreamBuilder.ReversingBehavior.REVERSIBLE,
                 false);
     }
 
@@ -448,7 +448,7 @@ public class DispatchHandleContext implements HandleContext, FeeContext {
                 childSyntheticPayerId,
                 customizer,
                 TransactionCategory.CHILD,
-                SingleTransactionRecordBuilder.ReversingBehavior.REMOVABLE,
+                StreamBuilder.ReversingBehavior.REMOVABLE,
                 false);
     }
 
@@ -477,7 +477,7 @@ public class DispatchHandleContext implements HandleContext, FeeContext {
             @NonNull final AccountID syntheticPayer,
             @NonNull final ExternalizedRecordCustomizer customizer,
             @NonNull final TransactionCategory category,
-            @NonNull final SingleTransactionRecordBuilderImpl.ReversingBehavior reversingBehavior,
+            @NonNull final RecordStreamBuilder.ReversingBehavior reversingBehavior,
             final boolean commitStack) {
         final var childDispatch = childDispatchFactory.createChildDispatch(
                 childTxBody,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchProcessor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchProcessor.java
@@ -37,7 +37,7 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.spi.authorization.Authorizer;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.handle.dispatch.DispatchValidator;
 import com.hedera.node.app.workflows.handle.dispatch.RecordFinalizer;
@@ -256,7 +256,7 @@ public class DispatchProcessor {
             final boolean rollbackStack,
             @NonNull final ResponseCodeEnum status,
             @NonNull final SavepointStackImpl stack,
-            @NonNull final SingleTransactionRecordBuilder builder) {
+            @NonNull final StreamBuilder builder) {
         builder.status(status);
         if (rollbackStack) {
             stack.rollbackFullStack();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -20,7 +20,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.BUSY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
 import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
-import static com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.ReversingBehavior.REVERSIBLE;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static com.hedera.node.app.state.logging.TransactionStateLogger.logStartEvent;
 import static com.hedera.node.app.state.logging.TransactionStateLogger.logStartRound;
 import static com.hedera.node.app.state.logging.TransactionStateLogger.logStartUserTransaction;
@@ -45,7 +45,7 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.services.ServiceScopeLookup;
 import com.hedera.node.app.spi.authorization.Authorizer;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.state.HederaRecordCache;
 import com.hedera.node.app.state.SingleTransactionRecord;
 import com.hedera.node.app.store.ReadableStoreFactory;
@@ -57,7 +57,7 @@ import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.handle.cache.CacheWarmer;
 import com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory;
 import com.hedera.node.app.workflows.handle.metric.HandleWorkflowMetrics;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.record.SystemSetup;
 import com.hedera.node.app.workflows.handle.steps.HollowAccountCompletions;
 import com.hedera.node.app.workflows.handle.steps.NodeStakeUpdates;
@@ -353,7 +353,7 @@ public class HandleWorkflow {
      */
     private Stream<SingleTransactionRecord> failInvalidStreamItems(@NonNull final UserTxn userTxn) {
         userTxn.stack().rollbackFullStack();
-        final var failInvalidBuilder = new SingleTransactionRecordBuilderImpl(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
+        final var failInvalidBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
         initializeBuilderInfo(failInvalidBuilder, userTxn.txnInfo())
                 .status(FAIL_INVALID)
                 .consensusTimestamp(userTxn.consensusNow());
@@ -419,8 +419,8 @@ public class HandleWorkflow {
      * @param txnInfo the transaction information
      * @return the initialized base builder
      */
-    private SingleTransactionRecordBuilder initializeBuilderInfo(
-            @NonNull final SingleTransactionRecordBuilder builder, @NonNull final TransactionInfo txnInfo) {
+    private StreamBuilder initializeBuilderInfo(
+            @NonNull final StreamBuilder builder, @NonNull final TransactionInfo txnInfo) {
         final var transaction = txnInfo.transaction();
         // If the transaction uses the legacy body bytes field instead of explicitly
         // setting its signed bytes, the record will have the hash of its bytes as

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/RecordDispatch.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/RecordDispatch.java
@@ -24,7 +24,7 @@ import com.hedera.node.app.service.token.records.FinalizeContext;
 import com.hedera.node.app.signature.AppKeyVerifier;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
@@ -37,7 +37,7 @@ import java.time.Instant;
 import java.util.Set;
 
 public record RecordDispatch(
-        @NonNull SingleTransactionRecordBuilder recordBuilder,
+        @NonNull StreamBuilder recordBuilder,
         @NonNull Configuration config,
         @NonNull Fees fees,
         @NonNull TransactionInfo txnInfo,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/RecordFinalizer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/RecordFinalizer.java
@@ -25,7 +25,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.impl.handlers.FinalizeRecordHandler;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.workflows.handle.Dispatch;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -98,7 +98,7 @@ public class RecordFinalizer {
     public Set<AccountID> extraRewardReceivers(
             @Nullable final TransactionBody body,
             @NonNull final HederaFunctionality function,
-            @NonNull final SingleTransactionRecordBuilder recordBuilder) {
+            @NonNull final StreamBuilder recordBuilder) {
         if (body == null || recordBuilder.status() != SUCCESS) {
             return emptySet();
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemSetup.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemSetup.java
@@ -21,7 +21,7 @@ import static com.hedera.hapi.util.HapiUtils.ACCOUNT_ID_COMPARATOR;
 import static com.hedera.hapi.util.HapiUtils.FUNDING_ACCOUNT_EXPIRY;
 import static com.hedera.node.app.ids.schemas.V0490EntityIdSchema.ENTITY_ID_STATE_KEY;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.asAccountAmounts;
-import static com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.transactionWith;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.transactionWith;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -35,10 +35,10 @@ import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.service.addressbook.ReadableNodeStore;
 import com.hedera.node.app.service.file.impl.FileServiceImpl;
 import com.hedera.node.app.service.token.impl.schemas.SyntheticAccountCreator;
-import com.hedera.node.app.service.token.records.GenesisAccountRecordBuilder;
+import com.hedera.node.app.service.token.records.GenesisAccountStreamBuilder;
 import com.hedera.node.app.service.token.records.TokenContext;
 import com.hedera.node.app.spi.workflows.SystemContext;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.workflows.handle.Dispatch;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.HederaConfig;
@@ -136,8 +136,7 @@ public class SystemSetup {
                         .<EntityNumber>getSingleton(ENTITY_ID_STATE_KEY);
                 controlledNum.put(new EntityNumber(entityNum - 1));
                 final var recordBuilder = dispatch.handleContext()
-                        .dispatchPrecedingTransaction(
-                                txBody, SingleTransactionRecordBuilder.class, key -> true, systemAdminId);
+                        .dispatchPrecedingTransaction(txBody, StreamBuilder.class, key -> true, systemAdminId);
                 if (recordBuilder.status() != SUCCESS) {
                     log.error(
                             "Failed to dispatch system create transaction {} for entity {} - {}",
@@ -152,8 +151,7 @@ public class SystemSetup {
             public void dispatchUpdate(@NonNull final TransactionBody txBody) {
                 requireNonNull(txBody);
                 final var recordBuilder = dispatch.handleContext()
-                        .dispatchPrecedingTransaction(
-                                txBody, SingleTransactionRecordBuilder.class, key -> true, systemAdminId);
+                        .dispatchPrecedingTransaction(txBody, StreamBuilder.class, key -> true, systemAdminId);
                 if (recordBuilder.status() != SUCCESS) {
                     log.error("Failed to dispatch update transaction {} for - {}", txBody, recordBuilder.status());
                 }
@@ -269,7 +267,7 @@ public class SystemSetup {
         for (final Account account : accts) {
             // Since this is only called at genesis, the active savepoint's preceding record capacity will be
             // Integer.MAX_VALUE and this will never fail with MAX_CHILD_RECORDS_EXCEEDED (c.f., HandleWorkflow)
-            final var recordBuilder = context.addPrecedingChildRecordBuilder(GenesisAccountRecordBuilder.class);
+            final var recordBuilder = context.addPrecedingChildRecordBuilder(GenesisAccountStreamBuilder.class);
             recordBuilder.accountID(account.accountId());
             if (recordMemo != null) {
                 recordBuilder.memo(recordMemo);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/TokenContextImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/TokenContextImpl.java
@@ -26,7 +26,7 @@ import com.hedera.node.app.service.token.TokenService;
 import com.hedera.node.app.service.token.records.FinalizeContext;
 import com.hedera.node.app.service.token.records.TokenContext;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.store.WritableStoreFactory;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
@@ -89,8 +89,7 @@ public class TokenContextImpl implements TokenContext, FinalizeContext {
 
     @NonNull
     @Override
-    public <T extends SingleTransactionRecordBuilder> T userTransactionRecordBuilder(
-            @NonNull Class<T> recordBuilderClass) {
+    public <T extends StreamBuilder> T userTransactionRecordBuilder(@NonNull Class<T> recordBuilderClass) {
         requireNonNull(recordBuilderClass, "recordBuilderClass must not be null");
         return stack.getBaseBuilder(recordBuilderClass);
     }
@@ -108,8 +107,7 @@ public class TokenContextImpl implements TokenContext, FinalizeContext {
 
     @NonNull
     @Override
-    public <T extends SingleTransactionRecordBuilder> T addPrecedingChildRecordBuilder(
-            @NonNull Class<T> recordBuilderClass) {
+    public <T extends StreamBuilder> T addPrecedingChildRecordBuilder(@NonNull Class<T> recordBuilderClass) {
         final var result = stack.createIrreversiblePrecedingBuilder();
         return castBuilder(result, recordBuilderClass);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/BuilderSink.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/BuilderSink.java
@@ -17,7 +17,7 @@
 package com.hedera.node.app.workflows.handle.stack;
 
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.function.Consumer;
@@ -39,21 +39,21 @@ public interface BuilderSink {
      * maximum number of preceding builders has been exceeded.
      * @param builder the builder to add
      */
-    void addPrecedingOrThrow(@NonNull SingleTransactionRecordBuilder builder);
+    void addPrecedingOrThrow(@NonNull StreamBuilder builder);
 
     /**
      * Adds a builder to the following builders of this sink. Throws a {@link HandleException} if the
      * maximum number of following builders has been exceeded.
      * @param builder the builder to add
      */
-    void addFollowingOrThrow(@NonNull SingleTransactionRecordBuilder builder);
+    void addFollowingOrThrow(@NonNull StreamBuilder builder);
 
     /**
      * Adds all the given builders to the preceding builders of this sink. Throws a {@link HandleException} if the
      * maximum number of preceding builders has been exceeded.
      * @param builders the builders to add
      */
-    default void addAllPreceding(@NonNull List<SingleTransactionRecordBuilder> builders) {
+    default void addAllPreceding(@NonNull List<StreamBuilder> builders) {
         builders.forEach(this::addPrecedingOrThrow);
     }
 
@@ -62,7 +62,7 @@ public interface BuilderSink {
      * maximum number of following builders has been exceeded.
      * @param builders the builders to add
      */
-    default void addAllFollowing(@NonNull List<SingleTransactionRecordBuilder> builders) {
+    default void addAllFollowing(@NonNull List<StreamBuilder> builders) {
         builders.forEach(this::addFollowingOrThrow);
     }
 
@@ -85,14 +85,14 @@ public interface BuilderSink {
      * builders, in the order they were added.
      * @return all accumulated builders
      */
-    List<SingleTransactionRecordBuilder> allBuilders();
+    List<StreamBuilder> allBuilders();
 
     /**
      * Returns whether this savepoint has accumulated any builders other than the designated base builder.
      * @param baseBuilder the base builder
      * @return whether this savepoint has any builders other than the base builder
      */
-    boolean hasBuilderOtherThan(@NonNull SingleTransactionRecordBuilder baseBuilder);
+    boolean hasBuilderOtherThan(@NonNull StreamBuilder baseBuilder);
 
     /**
      * For each builder in this savepoint other than the designated base builder, invokes the given consumer
@@ -104,9 +104,7 @@ public interface BuilderSink {
      * @param <T> the type to cast the builders to
      */
     <T> void forEachOtherBuilder(
-            @NonNull Consumer<T> consumer,
-            @NonNull Class<T> builderType,
-            @NonNull SingleTransactionRecordBuilder baseBuilder);
+            @NonNull Consumer<T> consumer, @NonNull Class<T> builderType, @NonNull StreamBuilder baseBuilder);
 
     /**
      * Flushes any stream item builders accumulated in this sink to the parent sink, preserving their ordering relative
@@ -134,5 +132,5 @@ public interface BuilderSink {
      * @return the following builders in the sink
      */
     @Deprecated
-    List<SingleTransactionRecordBuilder> followingBuilders();
+    List<StreamBuilder> followingBuilders();
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/Savepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/Savepoint.java
@@ -18,8 +18,8 @@ package com.hedera.node.app.workflows.handle.stack;
 
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.ReversingBehavior;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior;
 import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -64,7 +64,7 @@ public interface Savepoint extends BuilderSink {
      * @param isBaseBuilder     whether the builder is the base builder for a stack
      * @return the new builder
      */
-    SingleTransactionRecordBuilder createBuilder(
+    StreamBuilder createBuilder(
             @NonNull ReversingBehavior reversingBehavior,
             @NonNull HandleContext.TransactionCategory txnCategory,
             @NonNull ExternalizedRecordCustomizer customizer,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/AbstractSavepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/AbstractSavepoint.java
@@ -22,16 +22,16 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.REVERTED_SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS_BUT_MISSING_EXPECTED_OPERATION;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.PRECEDING;
-import static com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.ReversingBehavior.REMOVABLE;
-import static com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.ReversingBehavior.REVERSIBLE;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REMOVABLE;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.state.WrappedState;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.BuilderSink;
 import com.hedera.node.app.workflows.handle.stack.Savepoint;
 import com.swirlds.state.State;
@@ -109,15 +109,15 @@ public abstract class AbstractSavepoint extends BuilderSinkImpl implements Savep
     }
 
     @Override
-    public SingleTransactionRecordBuilder createBuilder(
-            @NonNull final SingleTransactionRecordBuilder.ReversingBehavior reversingBehavior,
+    public StreamBuilder createBuilder(
+            @NonNull final StreamBuilder.ReversingBehavior reversingBehavior,
             @NonNull final HandleContext.TransactionCategory txnCategory,
             @NonNull final ExternalizedRecordCustomizer customizer,
             final boolean isBaseBuilder) {
         requireNonNull(reversingBehavior);
         requireNonNull(txnCategory);
         requireNonNull(customizer);
-        final var builder = new SingleTransactionRecordBuilderImpl(reversingBehavior, customizer, txnCategory);
+        final var builder = new RecordStreamBuilder(reversingBehavior, customizer, txnCategory);
         if (!customizer.shouldSuppressRecord()) {
             if (txnCategory == PRECEDING && !isBaseBuilder) {
                 addPrecedingOrThrow(builder);
@@ -133,7 +133,7 @@ public abstract class AbstractSavepoint extends BuilderSinkImpl implements Savep
      */
     abstract void commitBuilders();
 
-    private void rollback(@NonNull final List<SingleTransactionRecordBuilder> builders) {
+    private void rollback(@NonNull final List<StreamBuilder> builders) {
         var iterator = builders.listIterator();
         while (iterator.hasNext()) {
             final var builder = iterator.next();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/BuilderSinkImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/BuilderSinkImpl.java
@@ -20,7 +20,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEE
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.BuilderSink;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -34,8 +34,8 @@ import java.util.function.Consumer;
  * the base builder's identity.
  */
 public class BuilderSinkImpl implements BuilderSink {
-    protected final List<SingleTransactionRecordBuilder> precedingBuilders = new ArrayList<>();
-    protected final List<SingleTransactionRecordBuilder> followingBuilders = new ArrayList<>();
+    protected final List<StreamBuilder> precedingBuilders = new ArrayList<>();
+    protected final List<StreamBuilder> followingBuilders = new ArrayList<>();
 
     private final int maxPreceding;
     private final int maxFollowing;
@@ -67,18 +67,18 @@ public class BuilderSinkImpl implements BuilderSink {
     }
 
     @Override
-    public List<SingleTransactionRecordBuilder> allBuilders() {
+    public List<StreamBuilder> allBuilders() {
         if (precedingBuilders.isEmpty()) {
             return followingBuilders;
         } else {
-            final List<SingleTransactionRecordBuilder> allBuilders = new ArrayList<>(precedingBuilders);
+            final List<StreamBuilder> allBuilders = new ArrayList<>(precedingBuilders);
             allBuilders.addAll(followingBuilders);
             return allBuilders;
         }
     }
 
     @Override
-    public boolean hasBuilderOtherThan(@NonNull final SingleTransactionRecordBuilder baseBuilder) {
+    public boolean hasBuilderOtherThan(@NonNull final StreamBuilder baseBuilder) {
         requireNonNull(baseBuilder);
         for (final var builder : precedingBuilders) {
             if (builder != baseBuilder) {
@@ -97,7 +97,7 @@ public class BuilderSinkImpl implements BuilderSink {
     public <T> void forEachOtherBuilder(
             @NonNull final Consumer<T> consumer,
             @NonNull final Class<T> builderType,
-            @NonNull final SingleTransactionRecordBuilder baseBuilder) {
+            @NonNull final StreamBuilder baseBuilder) {
         requireNonNull(builderType);
         requireNonNull(consumer);
         requireNonNull(baseBuilder);
@@ -133,7 +133,7 @@ public class BuilderSinkImpl implements BuilderSink {
     }
 
     @Override
-    public void addPrecedingOrThrow(@NonNull final SingleTransactionRecordBuilder builder) {
+    public void addPrecedingOrThrow(@NonNull final StreamBuilder builder) {
         requireNonNull(builder);
         if (precedingCapacity() == 0) {
             throw new HandleException(MAX_CHILD_RECORDS_EXCEEDED);
@@ -142,7 +142,7 @@ public class BuilderSinkImpl implements BuilderSink {
     }
 
     @Override
-    public void addFollowingOrThrow(@NonNull final SingleTransactionRecordBuilder builder) {
+    public void addFollowingOrThrow(@NonNull final StreamBuilder builder) {
         requireNonNull(builder);
         if (followingCapacity() == 0) {
             throw new HandleException(MAX_CHILD_RECORDS_EXCEEDED);
@@ -161,7 +161,7 @@ public class BuilderSinkImpl implements BuilderSink {
     }
 
     @Override
-    public List<SingleTransactionRecordBuilder> followingBuilders() {
+    public List<StreamBuilder> followingBuilders() {
         return followingBuilders;
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletions.java
@@ -29,7 +29,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.handlers.EthereumTransactionHandler;
 import com.hedera.node.app.service.file.ReadableFileStore;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.service.token.records.CryptoUpdateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoUpdateStreamBuilder;
 import com.hedera.node.app.signature.AppKeyVerifier;
 import com.hedera.node.app.signature.impl.SignatureVerificationImpl;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
@@ -169,7 +169,7 @@ public class HollowAccountCompletions {
                 // Note the null key verification callback below; we bypass signature
                 // verifications when doing hollow account finalization
                 final var recordBuilder = context.dispatchPrecedingTransaction(
-                        syntheticUpdateTxn, CryptoUpdateRecordBuilder.class, null, context.payer());
+                        syntheticUpdateTxn, CryptoUpdateStreamBuilder.class, null, context.payer());
                 // For some reason update accountId is set only for the hollow account finalization's and not
                 // for top level crypto update transactions. So we set it here.
                 recordBuilder.accountID(hollowAccount.accountIdOrThrow());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxn.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxn.java
@@ -35,14 +35,14 @@ import com.hedera.node.app.ids.EntityNumGeneratorImpl;
 import com.hedera.node.app.ids.WritableEntityIdStore;
 import com.hedera.node.app.records.BlockRecordManager;
 import com.hedera.node.app.records.BlockRecordService;
-import com.hedera.node.app.service.token.api.FeeRecordBuilder;
+import com.hedera.node.app.service.token.api.FeeStreamBuilder;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.services.ServiceScopeLookup;
 import com.hedera.node.app.signature.DefaultKeyVerifier;
 import com.hedera.node.app.spi.authorization.Authorizer;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.spi.records.RecordCache;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.store.ServiceApiFactory;
 import com.hedera.node.app.store.StoreFactoryImpl;
@@ -198,7 +198,7 @@ public record UserTxn(
             @NonNull final TransactionDispatcher dispatcher,
             @NonNull final NetworkUtilizationManager networkUtilizationManager,
             // @UserTxnScope
-            @NonNull final SingleTransactionRecordBuilder baseBuilder) {
+            @NonNull final StreamBuilder baseBuilder) {
         final var keyVerifier = new DefaultKeyVerifier(
                 txnInfo.signatureMap().sigPair().size(),
                 config.getConfigData(HederaConfig.class),
@@ -215,7 +215,7 @@ public record UserTxn(
                         .getStore(WritableEntityIdStore.class));
         final var throttleAdvisor = new AppThrottleAdviser(networkUtilizationManager, consensusNow, stack);
         final var feeAccumulator =
-                new FeeAccumulator(serviceApiFactory.getApi(TokenServiceApi.class), (FeeRecordBuilder) baseBuilder);
+                new FeeAccumulator(serviceApiFactory.getApi(TokenServiceApi.class), (FeeStreamBuilder) baseBuilder);
         final var dispatchHandleContext = new DispatchHandleContext(
                 consensusNow,
                 creatorInfo,
@@ -267,7 +267,7 @@ public record UserTxn(
      * Returns the base stream builder for this user transaction.
      * @return the base stream builder
      */
-    public SingleTransactionRecordBuilder baseBuilder() {
-        return stack.getBaseBuilder(SingleTransactionRecordBuilder.class);
+    public StreamBuilder baseBuilder() {
+        return stack.getBaseBuilder(StreamBuilder.class);
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/AppThrottleAdviserTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/AppThrottleAdviserTest.java
@@ -28,7 +28,7 @@ import com.hedera.hapi.node.contract.ContractCallTransactionBody;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.workflows.TransactionInfo;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.time.Instant;
@@ -67,10 +67,10 @@ class AppThrottleAdviserTest {
     private SavepointStackImpl stack;
 
     @Mock
-    private SingleTransactionRecordBuilderImpl oneChildBuilder;
+    private RecordStreamBuilder oneChildBuilder;
 
     @Mock
-    private SingleTransactionRecordBuilderImpl twoChildBuilder;
+    private RecordStreamBuilder twoChildBuilder;
 
     private static final Instant CONSENSUS_NOW = Instant.parse("2007-12-03T10:15:30.00Z");
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
@@ -94,7 +94,7 @@ import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.state.HederaRecordCache;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.store.ServiceApiFactory;
@@ -103,7 +103,7 @@ import com.hedera.node.app.store.WritableStoreFactory;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.handle.dispatch.ChildDispatchFactory;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.node.app.workflows.handle.validation.AttributeValidatorImpl;
 import com.hedera.node.app.workflows.handle.validation.ExpiryValidatorImpl;
@@ -216,10 +216,10 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
     private EntityNumGenerator entityNumGenerator;
 
     @Mock
-    private SingleTransactionRecordBuilderImpl oneChildBuilder;
+    private RecordStreamBuilder oneChildBuilder;
 
     @Mock
-    private SingleTransactionRecordBuilderImpl twoChildBuilder;
+    private RecordStreamBuilder twoChildBuilder;
 
     @Mock
     private ChildDispatchFactory childDispatchFactory;
@@ -272,7 +272,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
             .build();
     private static final TransactionBody txBody = asTxn(transferBody, payerId, CONSENSUS_NOW);
     private final Configuration configuration = HederaTestConfigBuilder.createConfig();
-    private SingleTransactionRecordBuilderImpl childRecordBuilder = new SingleTransactionRecordBuilderImpl();
+    private RecordStreamBuilder childRecordBuilder = new RecordStreamBuilder();
     private final TransactionBody txnBodyWithoutId = TransactionBody.newBuilder()
             .consensusSubmitMessage(ConsensusSubmitMessageTransactionBody.DEFAULT)
             .build();
@@ -540,7 +540,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
         private State baseState;
 
         @Mock(strictness = LENIENT, answer = Answers.RETURNS_SELF)
-        private SingleTransactionRecordBuilderImpl childRecordBuilder;
+        private RecordStreamBuilder childRecordBuilder;
 
         @BeforeEach
         void setup() {
@@ -574,23 +574,19 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
         @Test
         void testDispatchWithInvalidArguments() {
             assertThatThrownBy(() -> subject.dispatchPrecedingTransaction(
-                            null, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, AccountID.DEFAULT))
+                            null, StreamBuilder.class, VERIFIER_CALLBACK, AccountID.DEFAULT))
                     .isInstanceOf(NullPointerException.class);
             assertThatThrownBy(() ->
                             subject.dispatchPrecedingTransaction(txBody, null, VERIFIER_CALLBACK, AccountID.DEFAULT))
                     .isInstanceOf(NullPointerException.class);
             assertThatThrownBy(() -> subject.dispatchChildTransaction(
-                            null, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, AccountID.DEFAULT, CHILD))
+                            null, StreamBuilder.class, VERIFIER_CALLBACK, AccountID.DEFAULT, CHILD))
                     .isInstanceOf(NullPointerException.class);
             assertThatThrownBy(() ->
                             subject.dispatchChildTransaction(txBody, null, VERIFIER_CALLBACK, AccountID.DEFAULT, CHILD))
                     .isInstanceOf(NullPointerException.class);
             assertThatThrownBy(() -> subject.dispatchRemovableChildTransaction(
-                            null,
-                            SingleTransactionRecordBuilder.class,
-                            VERIFIER_CALLBACK,
-                            AccountID.DEFAULT,
-                            NOOP_RECORD_CUSTOMIZER))
+                            null, StreamBuilder.class, VERIFIER_CALLBACK, AccountID.DEFAULT, NOOP_RECORD_CUSTOMIZER))
                     .isInstanceOf(NullPointerException.class);
             assertThatThrownBy(() -> subject.dispatchRemovableChildTransaction(
                             txBody, null, VERIFIER_CALLBACK, AccountID.DEFAULT, NOOP_RECORD_CUSTOMIZER))
@@ -600,12 +596,12 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
         private static Stream<Arguments> createContextDispatchers() {
             return Stream.of(
                     Arguments.of((Consumer<HandleContext>) context -> context.dispatchPrecedingTransaction(
-                            txBody, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, ALICE.accountID())),
+                            txBody, StreamBuilder.class, VERIFIER_CALLBACK, ALICE.accountID())),
                     Arguments.of((Consumer<HandleContext>) context -> context.dispatchChildTransaction(
-                            txBody, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, ALICE.accountID(), CHILD)),
+                            txBody, StreamBuilder.class, VERIFIER_CALLBACK, ALICE.accountID(), CHILD)),
                     Arguments.of((Consumer<HandleContext>) context -> context.dispatchRemovableChildTransaction(
                             txBody,
-                            SingleTransactionRecordBuilder.class,
+                            StreamBuilder.class,
                             VERIFIER_CALLBACK,
                             ALICE.accountID(),
                             (ignore) -> Transaction.DEFAULT)));
@@ -635,7 +631,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
 
             assertThatNoException()
                     .isThrownBy(() -> context.dispatchPrecedingTransaction(
-                            txBody, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, AccountID.DEFAULT));
+                            txBody, StreamBuilder.class, VERIFIER_CALLBACK, AccountID.DEFAULT));
             verify(dispatcher, never()).dispatchHandle(any());
             verify(stack).commitFullStack();
         }
@@ -648,10 +644,10 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
 
             assertThatNoException()
                     .isThrownBy(() -> context.dispatchPrecedingTransaction(
-                            txBody, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, ALICE.accountID()));
+                            txBody, StreamBuilder.class, VERIFIER_CALLBACK, ALICE.accountID()));
             assertThatNoException()
                     .isThrownBy((() -> context.dispatchPrecedingTransaction(
-                            txBody, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, ALICE.accountID())));
+                            txBody, StreamBuilder.class, VERIFIER_CALLBACK, ALICE.accountID())));
             verify(dispatchProcessor, times(2)).processDispatch(any());
         }
 
@@ -661,8 +657,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
 
             Mockito.lenient().when(verifier.verificationFor((Key) any())).thenReturn(verification);
 
-            context.dispatchPrecedingTransaction(
-                    txBody, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, ALICE.accountID());
+            context.dispatchPrecedingTransaction(txBody, StreamBuilder.class, VERIFIER_CALLBACK, ALICE.accountID());
 
             verify(dispatchProcessor).processDispatch(childDispatch);
             verify(stack).commitFullStack();
@@ -675,7 +670,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
             Mockito.lenient().when(verifier.verificationFor((Key) any())).thenReturn(verification);
 
             context.dispatchRemovablePrecedingTransaction(
-                    txBody, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, ALICE.accountID());
+                    txBody, StreamBuilder.class, VERIFIER_CALLBACK, ALICE.accountID());
 
             verify(dispatchProcessor).processDispatch(childDispatch);
             verify(stack, never()).commitFullStack();
@@ -700,7 +695,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
             assertThat(context.dispatchPaidRewards()).isSameAs(Collections.emptyMap());
 
             context.dispatchChildTransaction(
-                    txBody, SingleTransactionRecordBuilder.class, VERIFIER_CALLBACK, ALICE.accountID(), SCHEDULED);
+                    txBody, StreamBuilder.class, VERIFIER_CALLBACK, ALICE.accountID(), SCHEDULED);
 
             verify(dispatchProcessor).processDispatch(childDispatch);
             verify(stack, never()).commitFullStack();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchProcessorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchProcessorTest.java
@@ -75,7 +75,7 @@ import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.handle.dispatch.DispatchValidator;
 import com.hedera.node.app.workflows.handle.dispatch.RecordFinalizer;
 import com.hedera.node.app.workflows.handle.metric.HandleWorkflowMetrics;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.node.app.workflows.handle.steps.PlatformStateUpdates;
 import com.hedera.node.app.workflows.handle.steps.SystemFileUpdates;
@@ -160,7 +160,7 @@ class DispatchProcessorTest {
     private SavepointStackImpl stack;
 
     @Mock
-    private SingleTransactionRecordBuilderImpl recordBuilder;
+    private RecordStreamBuilder recordBuilder;
 
     @Mock
     private PlatformState platformState;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/ChildDispatchFactoryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/ChildDispatchFactoryTest.java
@@ -53,13 +53,13 @@ import com.hedera.node.app.spi.signatures.VerificationAssistant;
 import com.hedera.node.app.spi.throttle.ThrottleAdviser;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.throttle.NetworkUtilizationManager;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.handle.Dispatch;
 import com.hedera.node.app.workflows.handle.DispatchProcessor;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -170,8 +170,7 @@ class ChildDispatchFactoryTest {
     private final Predicate<Key> callback = key -> true;
     private final HandleContext.TransactionCategory category = HandleContext.TransactionCategory.CHILD;
     private final ExternalizedRecordCustomizer customizer = recordBuilder -> recordBuilder;
-    private final SingleTransactionRecordBuilderImpl.ReversingBehavior reversingBehavior =
-            SingleTransactionRecordBuilder.ReversingBehavior.REMOVABLE;
+    private final RecordStreamBuilder.ReversingBehavior reversingBehavior = StreamBuilder.ReversingBehavior.REMOVABLE;
 
     @BeforeEach
     public void setUp() {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/RecordFinalizerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/RecordFinalizerTest.java
@@ -45,7 +45,7 @@ import com.hedera.node.app.service.token.records.FinalizeContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.handle.Dispatch;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.time.Instant;
 import java.util.List;
@@ -97,7 +97,7 @@ public class RecordFinalizerTest {
             Bytes.EMPTY,
             HederaFunctionality.CRYPTO_TRANSFER);
 
-    private SingleTransactionRecordBuilderImpl recordBuilder = new SingleTransactionRecordBuilderImpl();
+    private RecordStreamBuilder recordBuilder = new RecordStreamBuilder();
     private RecordFinalizer subject;
 
     @BeforeEach

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/StreamBuilderTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/StreamBuilderTest.java
@@ -63,7 +63,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings({"DataFlowIssue"})
 @ExtendWith(MockitoExtension.class)
-public class SingleTransactionRecordBuilderTest {
+public class StreamBuilderTest {
     public static final Instant CONSENSUS_TIME = Instant.now();
     public static final Instant PARENT_CONSENSUS_TIME = CONSENSUS_TIME.plusNanos(1L);
     public static final long TRANSACTION_FEE = 6846513L;
@@ -114,7 +114,7 @@ public class SingleTransactionRecordBuilderTest {
         final List<AccountAmount> paidStakingRewards = List.of(accountAmount);
         final List<Long> serialNumbers = List.of(1L, 2L, 3L);
 
-        SingleTransactionRecordBuilderImpl singleTransactionRecordBuilder = new SingleTransactionRecordBuilderImpl();
+        RecordStreamBuilder singleTransactionRecordBuilder = new RecordStreamBuilder();
 
         singleTransactionRecordBuilder
                 .parentConsensus(PARENT_CONSENSUS_TIME)
@@ -247,7 +247,7 @@ public class SingleTransactionRecordBuilderTest {
 
     @Test
     void testTopLevelRecordBuilder() {
-        SingleTransactionRecordBuilderImpl singleTransactionRecordBuilder = new SingleTransactionRecordBuilderImpl();
+        RecordStreamBuilder singleTransactionRecordBuilder = new RecordStreamBuilder();
 
         singleTransactionRecordBuilder.transaction(transaction);
 
@@ -268,7 +268,7 @@ public class SingleTransactionRecordBuilderTest {
 
     @Test
     void testBuilderWithAddMethods() {
-        SingleTransactionRecordBuilderImpl singleTransactionRecordBuilder = new SingleTransactionRecordBuilderImpl();
+        RecordStreamBuilder singleTransactionRecordBuilder = new RecordStreamBuilder();
 
         SingleTransactionRecord singleTransactionRecord = singleTransactionRecordBuilder
                 .transaction(transaction)

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletionsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletionsTest.java
@@ -45,7 +45,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxSigs;
 import com.hedera.node.app.service.contract.impl.handlers.EthereumTransactionHandler;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.service.token.records.CryptoUpdateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoUpdateStreamBuilder;
 import com.hedera.node.app.signature.AppKeyVerifier;
 import com.hedera.node.app.signature.impl.SignatureVerificationImpl;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
@@ -53,7 +53,7 @@ import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.handle.Dispatch;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.node.app.workflows.prehandle.PreHandleResult;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -88,7 +88,7 @@ public class HollowAccountCompletionsTest {
     private PreHandleResult preHandleResult;
 
     @Mock(strictness = LENIENT)
-    private SingleTransactionRecordBuilderImpl recordBuilder;
+    private RecordStreamBuilder recordBuilder;
 
     @Mock
     private EthereumTransactionHandler ethereumTransactionHandler;
@@ -164,7 +164,7 @@ public class HollowAccountCompletionsTest {
         verify(keyVerifier).verificationFor(Bytes.wrap(new byte[] {1, 2, 3}));
         verify(handleContext, never())
                 .dispatchPrecedingTransaction(
-                        eq(txBody), eq(CryptoUpdateRecordBuilder.class), isNull(), eq(AccountID.DEFAULT));
+                        eq(txBody), eq(CryptoUpdateStreamBuilder.class), isNull(), eq(AccountID.DEFAULT));
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
@@ -40,7 +40,7 @@ import com.hedera.node.app.service.file.FileService;
 import com.hedera.node.app.spi.fixtures.TransactionFactory;
 import com.hedera.node.app.throttle.ThrottleServiceManager;
 import com.hedera.node.app.util.FileUtilities;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.converter.BytesConverter;
 import com.hedera.node.config.converter.LongPairConverter;
@@ -129,7 +129,7 @@ class SystemFileUpdatesTest implements TransactionFactory {
         final var txBody = TransactionBody.newBuilder()
                 .cryptoTransfer(CryptoTransferTransactionBody.DEFAULT)
                 .build();
-        final var recordBuilder = new SingleTransactionRecordBuilderImpl();
+        final var recordBuilder = new RecordStreamBuilder();
 
         // then
         assertThatCode(() -> subject.handleTxBody(state, txBody)).doesNotThrowAnyException();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemSetupTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemSetupTest.java
@@ -36,7 +36,7 @@ import com.hedera.node.app.records.ReadableBlockRecordStore;
 import com.hedera.node.app.service.file.impl.FileServiceImpl;
 import com.hedera.node.app.service.token.impl.comparator.TokenComparators;
 import com.hedera.node.app.service.token.impl.schemas.SyntheticAccountCreator;
-import com.hedera.node.app.service.token.records.GenesisAccountRecordBuilder;
+import com.hedera.node.app.service.token.records.GenesisAccountStreamBuilder;
 import com.hedera.node.app.service.token.records.TokenContext;
 import com.hedera.node.app.workflows.handle.record.SystemSetup;
 import java.time.Instant;
@@ -82,7 +82,7 @@ class SystemSetupTest {
     private FileServiceImpl fileService;
 
     @Mock
-    private GenesisAccountRecordBuilder genesisAccountRecordBuilder;
+    private GenesisAccountStreamBuilder genesisAccountRecordBuilder;
 
     private SystemSetup subject;
 
@@ -90,7 +90,7 @@ class SystemSetupTest {
     void setup() {
         given(context.readableStore(ReadableBlockRecordStore.class)).willReturn(blockStore);
         given(context.consensusTime()).willReturn(CONSENSUS_NOW);
-        given(context.addPrecedingChildRecordBuilder(GenesisAccountRecordBuilder.class))
+        given(context.addPrecedingChildRecordBuilder(GenesisAccountStreamBuilder.class))
                 .willReturn(genesisAccountRecordBuilder);
         given(context.readableStore(ReadableBlockRecordStore.class)).willReturn(blockStore);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManagerTest.java
@@ -53,7 +53,7 @@ import com.hedera.node.app.throttle.ThrottleServiceManager;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.handle.Dispatch;
 import com.hedera.node.app.workflows.handle.metric.HandleWorkflowMetrics;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -132,7 +132,7 @@ class DispatchUsageManagerTest {
     private ReadableAccountStore readableAccountStore;
 
     @Mock
-    private SingleTransactionRecordBuilderImpl recordBuilder;
+    private RecordStreamBuilder recordBuilder;
 
     @Mock
     private HandleWorkflowMetrics handleWorkflowMetrics;

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
@@ -37,7 +37,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
-import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicRecordBuilder;
+import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
@@ -161,7 +161,7 @@ public class ConsensusCreateTopicHandler implements TransactionHandler {
 
             /* --- Build the record with newly created topic --- */
             final var recordBuilder =
-                    handleContext.savepointStack().getBaseBuilder(ConsensusCreateTopicRecordBuilder.class);
+                    handleContext.savepointStack().getBaseBuilder(ConsensusCreateTopicStreamBuilder.class);
 
             recordBuilder.topicID(topic.topicId());
         } catch (final HandleException e) {

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
@@ -43,7 +43,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.consensus.ReadableTopicStore;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
-import com.hedera.node.app.service.consensus.impl.records.ConsensusSubmitMessageRecordBuilder;
+import com.hedera.node.app.service.consensus.impl.records.ConsensusSubmitMessageStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -130,7 +130,7 @@ public class ConsensusSubmitMessageHandler implements TransactionHandler {
             topicStore.put(updatedTopic);
 
             final var recordBuilder =
-                    handleContext.savepointStack().getBaseBuilder(ConsensusSubmitMessageRecordBuilder.class);
+                    handleContext.savepointStack().getBaseBuilder(ConsensusSubmitMessageStreamBuilder.class);
             recordBuilder
                     .topicRunningHash(updatedTopic.runningHash())
                     .topicSequenceNumber(updatedTopic.sequenceNumber())

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusCreateTopicStreamBuilder.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusCreateTopicStreamBuilder.java
@@ -21,7 +21,7 @@ import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side-effects of a {@code ConsensusCreateTopic} transaction.
+ * A {@code StreamBuilder} specialization for tracking the side-effects of a {@code ConsensusCreateTopic} transaction.
  */
 public interface ConsensusCreateTopicStreamBuilder extends StreamBuilder {
     /**

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusCreateTopicStreamBuilder.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusCreateTopicStreamBuilder.java
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-package com.hedera.node.app.service.contract.impl.records;
+package com.hedera.node.app.service.consensus.impl.records;
 
-import com.hedera.hapi.node.base.ContractID;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.hapi.node.base.TopicID;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code ContractUpdate}.
+ * A {@code RecordBuilder} specialization for tracking the side-effects of a {@code ConsensusCreateTopic} transaction.
  */
-public interface ContractUpdateRecordBuilder extends DeleteCapableTransactionRecordBuilder {
+public interface ConsensusCreateTopicStreamBuilder extends StreamBuilder {
     /**
-     * Tracks the contract id updated by a successful top-level contract update operation.
+     * Tracks creation of a new topic by {@link TopicID}. Even if someday we support creating multiple topics within a
+     * smart contract call, we will still only need to track one created topic per child record.
      *
-     * @param contractId the {@link ContractID} of the updated top-level contract
+     * @param topicID the {@link TopicID} the new topic
      * @return this builder
      */
     @NonNull
-    ContractUpdateRecordBuilder contractID(@Nullable ContractID contractId);
+    ConsensusCreateTopicStreamBuilder topicID(@NonNull TopicID topicID);
 }

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusSubmitMessageStreamBuilder.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusSubmitMessageStreamBuilder.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.consensus.impl.records;
 
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A {@code RecordBuilder} specialization for tracking the side-effects of a {@code ConsensusSubmitMessage}
  * transaction.
  */
-public interface ConsensusSubmitMessageRecordBuilder extends SingleTransactionRecordBuilder {
+public interface ConsensusSubmitMessageStreamBuilder extends StreamBuilder {
     /**
      * Tracks the sequence number for the topic receiving the submitted message in the associated transaction.
      *
@@ -32,7 +32,7 @@ public interface ConsensusSubmitMessageRecordBuilder extends SingleTransactionRe
      * @return this builder
      */
     @NonNull
-    ConsensusSubmitMessageRecordBuilder topicSequenceNumber(long topicSequenceNumber);
+    ConsensusSubmitMessageStreamBuilder topicSequenceNumber(long topicSequenceNumber);
 
     /**
      * Tracks the running hash for the topic receiving the submitted message in the associated transaction.
@@ -41,7 +41,7 @@ public interface ConsensusSubmitMessageRecordBuilder extends SingleTransactionRe
      * @return this builder
      */
     @NonNull
-    ConsensusSubmitMessageRecordBuilder topicRunningHash(@NonNull final Bytes topicRunningHash);
+    ConsensusSubmitMessageStreamBuilder topicRunningHash(@NonNull final Bytes topicRunningHash);
 
     /**
      * Tracks the running hash version for the topic receiving the submitted message in the associated transaction.
@@ -50,5 +50,5 @@ public interface ConsensusSubmitMessageRecordBuilder extends SingleTransactionRe
      * @return this builder
      */
     @NonNull
-    ConsensusSubmitMessageRecordBuilder topicRunningHashVersion(long topicRunningHashVersion);
+    ConsensusSubmitMessageStreamBuilder topicRunningHashVersion(long topicRunningHashVersion);
 }

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusSubmitMessageStreamBuilder.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/records/ConsensusSubmitMessageStreamBuilder.java
@@ -21,7 +21,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side-effects of a {@code ConsensusSubmitMessage}
+ * A {@code StreamBuilder} specialization for tracking the side-effects of a {@code ConsensusSubmitMessage}
  * transaction.
  */
 public interface ConsensusSubmitMessageStreamBuilder extends StreamBuilder {

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusCreateTopicTest.java
@@ -45,7 +45,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.consensus.impl.handlers.ConsensusCreateTopicHandler;
-import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicRecordBuilder;
+import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.ids.EntityNumGenerator;
@@ -80,7 +80,7 @@ class ConsensusCreateTopicTest extends ConsensusTestBase {
     private ExpiryValidator expiryValidator;
 
     @Mock
-    private ConsensusCreateTopicRecordBuilder recordBuilder;
+    private ConsensusCreateTopicStreamBuilder recordBuilder;
 
     @Mock(strictness = LENIENT)
     private HandleContext.SavepointStack stack;
@@ -125,7 +125,7 @@ class ConsensusCreateTopicTest extends ConsensusTestBase {
         given(handleContext.configuration()).willReturn(config);
         given(storeFactory.writableStore(WritableTopicStore.class)).willReturn(topicStore);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(ConsensusCreateTopicRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ConsensusCreateTopicStreamBuilder.class)).willReturn(recordBuilder);
         lenient().when(handleContext.entityNumGenerator()).thenReturn(entityNumGenerator);
     }
 

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageHandlerTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageHandlerTest.java
@@ -49,7 +49,7 @@ import com.hedera.node.app.service.consensus.ReadableTopicStore;
 import com.hedera.node.app.service.consensus.impl.ReadableTopicStoreImpl;
 import com.hedera.node.app.service.consensus.impl.WritableTopicStore;
 import com.hedera.node.app.service.consensus.impl.handlers.ConsensusSubmitMessageHandler;
-import com.hedera.node.app.service.consensus.impl.records.ConsensusSubmitMessageRecordBuilder;
+import com.hedera.node.app.service.consensus.impl.records.ConsensusSubmitMessageStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
@@ -80,7 +80,7 @@ class ConsensusSubmitMessageHandlerTest extends ConsensusTestBase {
     private ReadableAccountStore accountStore;
 
     @Mock(answer = RETURNS_SELF)
-    private ConsensusSubmitMessageRecordBuilder recordBuilder;
+    private ConsensusSubmitMessageStreamBuilder recordBuilder;
 
     @Mock(strictness = LENIENT)
     private HandleContext.SavepointStack stack;
@@ -107,7 +107,7 @@ class ConsensusSubmitMessageHandlerTest extends ConsensusTestBase {
 
         given(handleContext.configuration()).willReturn(config);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(ConsensusSubmitMessageRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ConsensusSubmitMessageStreamBuilder.class)).willReturn(recordBuilder);
     }
 
     @Test

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileCreateHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileCreateHandler.java
@@ -35,7 +35,7 @@ import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.file.FileOpsUsage;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.file.impl.WritableFileStore;
-import com.hedera.node.app.service.file.impl.records.CreateFileRecordBuilder;
+import com.hedera.node.app.service.file.impl.records.CreateFileStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
@@ -158,7 +158,7 @@ public class FileCreateHandler implements TransactionHandler {
 
             handleContext
                     .savepointStack()
-                    .getBaseBuilder(CreateFileRecordBuilder.class)
+                    .getBaseBuilder(CreateFileStreamBuilder.class)
                     .fileID(fileId);
         } catch (final HandleException e) {
             if (e.getStatus() == INVALID_EXPIRATION_TIME) {

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileUpdateHandler.java
@@ -56,7 +56,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.types.LongPair;
@@ -262,7 +262,7 @@ public class FileUpdateHandler implements TransactionHandler {
         if (op.hasExpirationTime()) {
             final var category = handleContext
                     .savepointStack()
-                    .getBaseBuilder(SingleTransactionRecordBuilder.class)
+                    .getBaseBuilder(StreamBuilder.class)
                     .category();
             final var isInternalDispatch = category == CHILD || category == PRECEDING;
             final long startSeconds = isInternalDispatch

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/records/CreateFileStreamBuilder.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/records/CreateFileStreamBuilder.java
@@ -21,7 +21,7 @@ import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CreateFile} transaction.
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code CreateFile} transaction.
  */
 public interface CreateFileStreamBuilder extends StreamBuilder {
 

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/records/CreateFileStreamBuilder.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/records/CreateFileStreamBuilder.java
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-package com.hedera.node.app.service.consensus.impl.records;
+package com.hedera.node.app.service.file.impl.records;
 
-import com.hedera.hapi.node.base.TopicID;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side-effects of a {@code ConsensusCreateTopic} transaction.
+ * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CreateFile} transaction.
  */
-public interface ConsensusCreateTopicRecordBuilder extends SingleTransactionRecordBuilder {
+public interface CreateFileStreamBuilder extends StreamBuilder {
+
     /**
-     * Tracks creation of a new topic by {@link TopicID}. Even if someday we support creating multiple topics within a
-     * smart contract call, we will still only need to track one created topic per child record.
+     * Tracks creation of a new file by {@link FileID}
      *
-     * @param topicID the {@link TopicID} the new topic
+     * @param fileID the {@link FileID} of the new file
      * @return this builder
      */
     @NonNull
-    ConsensusCreateTopicRecordBuilder topicID(@NonNull TopicID topicID);
+    CreateFileStreamBuilder fileID(@NonNull FileID fileID);
 }

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileCreateTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileCreateTest.java
@@ -48,7 +48,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.fees.usage.file.FileOpsUsage;
 import com.hedera.node.app.service.file.impl.WritableFileStore;
 import com.hedera.node.app.service.file.impl.handlers.FileCreateHandler;
-import com.hedera.node.app.service.file.impl.records.CreateFileRecordBuilder;
+import com.hedera.node.app.service.file.impl.records.CreateFileStreamBuilder;
 import com.hedera.node.app.service.file.impl.test.FileTestBase;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
@@ -91,7 +91,7 @@ class FileCreateTest extends FileTestBase {
     private Configuration configuration;
 
     @Mock
-    private CreateFileRecordBuilder recordBuilder;
+    private CreateFileStreamBuilder recordBuilder;
 
     @Mock
     private HandleContext.SavepointStack stack;
@@ -217,7 +217,7 @@ class FileCreateTest extends FileTestBase {
                 .willReturn(new ExpiryMeta(expirationTime, NA, null));
         given(entityNumGenerator.newEntityNum()).willReturn(1_234L);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(CreateFileRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(CreateFileStreamBuilder.class)).willReturn(recordBuilder);
 
         subject.handle(handleContext);
 
@@ -251,7 +251,7 @@ class FileCreateTest extends FileTestBase {
                 .willReturn(new ExpiryMeta(1_234_567L, NA, null));
         given(entityNumGenerator.newEntityNum()).willReturn(1_234L);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(CreateFileRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(CreateFileStreamBuilder.class)).willReturn(recordBuilder);
 
         subject.handle(handleContext);
 

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileUpdateTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileUpdateTest.java
@@ -52,7 +52,7 @@ import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.prehandle.PreHandleContextImpl;
@@ -81,7 +81,7 @@ class FileUpdateTest extends FileTestBase {
     private HandleContext.SavepointStack stack;
 
     @Mock
-    private SingleTransactionRecordBuilder recordBuilder;
+    private StreamBuilder recordBuilder;
 
     @Mock
     private AttributeValidator attributeValidator;
@@ -275,7 +275,7 @@ class FileUpdateTest extends FileTestBase {
                 .build();
         when(handleContext.body()).thenReturn(txBody);
         when(handleContext.savepointStack()).thenReturn(stack);
-        when(stack.getBaseBuilder(SingleTransactionRecordBuilder.class)).thenReturn(recordBuilder);
+        when(stack.getBaseBuilder(StreamBuilder.class)).thenReturn(recordBuilder);
         when(recordBuilder.category()).thenReturn(HandleContext.TransactionCategory.USER);
         given(handleContext.attributeValidator()).willReturn(attributeValidator);
 
@@ -388,7 +388,7 @@ class FileUpdateTest extends FileTestBase {
                 .build();
         when(handleContext.body()).thenReturn(txBody);
         when(handleContext.savepointStack()).thenReturn(stack);
-        when(stack.getBaseBuilder(SingleTransactionRecordBuilder.class)).thenReturn(recordBuilder);
+        when(stack.getBaseBuilder(StreamBuilder.class)).thenReturn(recordBuilder);
         when(recordBuilder.category()).thenReturn(HandleContext.TransactionCategory.USER);
 
         subject.handle(handleContext);
@@ -412,7 +412,7 @@ class FileUpdateTest extends FileTestBase {
                 .build();
         when(handleContext.body()).thenReturn(txBody);
         when(handleContext.savepointStack()).thenReturn(stack);
-        when(stack.getBaseBuilder(SingleTransactionRecordBuilder.class)).thenReturn(recordBuilder);
+        when(stack.getBaseBuilder(StreamBuilder.class)).thenReturn(recordBuilder);
         when(recordBuilder.category()).thenReturn(HandleContext.TransactionCategory.USER);
 
         subject.handle(handleContext);

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
@@ -26,7 +26,7 @@ import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.schedule.ReadableScheduleStore;
-import com.hedera.node.app.service.schedule.ScheduleRecordBuilder;
+import com.hedera.node.app.service.schedule.ScheduleStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.key.KeyComparator;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
@@ -331,9 +331,9 @@ abstract class AbstractScheduleHandler {
             final Predicate<Key> assistant = new DispatchPredicate(acceptedSignatories);
             // This sets the child transaction ID to scheduled.
             final TransactionBody childTransaction = HandlerUtility.childAsOrdinary(scheduleToExecute);
-            final ScheduleRecordBuilder recordBuilder = context.dispatchChildTransaction(
+            final ScheduleStreamBuilder recordBuilder = context.dispatchChildTransaction(
                     childTransaction,
-                    ScheduleRecordBuilder.class,
+                    ScheduleStreamBuilder.class,
                     assistant,
                     scheduleToExecute.payerAccountId(),
                     TransactionCategory.SCHEDULED);
@@ -343,8 +343,8 @@ abstract class AbstractScheduleHandler {
             // set the schedule ref for the child transaction to the schedule that we're executing
             recordBuilder.scheduleRef(scheduleToExecute.scheduleId());
             // also set the child transaction ID as scheduled transaction ID in the parent record.
-            final ScheduleRecordBuilder parentRecordBuilder =
-                    context.savepointStack().getBaseBuilder(ScheduleRecordBuilder.class);
+            final ScheduleStreamBuilder parentRecordBuilder =
+                    context.savepointStack().getBaseBuilder(ScheduleStreamBuilder.class);
             parentRecordBuilder.scheduledTransactionID(childTransaction.transactionID());
             return true;
         } else {

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
@@ -34,7 +34,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.schedule.ScheduleOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
-import com.hedera.node.app.service.schedule.ScheduleRecordBuilder;
+import com.hedera.node.app.service.schedule.ScheduleStreamBuilder;
 import com.hedera.node.app.service.schedule.WritableScheduleStore;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -190,8 +190,8 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
                     finalSchedule = HandlerUtility.markExecuted(finalSchedule, currentConsensusTime);
                 }
                 scheduleStore.put(finalSchedule);
-                final ScheduleRecordBuilder scheduleRecords =
-                        context.savepointStack().getBaseBuilder(ScheduleRecordBuilder.class);
+                final ScheduleStreamBuilder scheduleRecords =
+                        context.savepointStack().getBaseBuilder(ScheduleStreamBuilder.class);
                 scheduleRecords
                         .scheduleID(finalSchedule.scheduleId())
                         .scheduledTransactionID(HandlerUtility.transactionIdForScheduled(finalSchedule));
@@ -218,7 +218,7 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
                             .scheduled(true)
                             .build();
                     context.savepointStack()
-                            .getBaseBuilder(ScheduleRecordBuilder.class)
+                            .getBaseBuilder(ScheduleStreamBuilder.class)
                             .scheduleID(candidate.scheduleId())
                             .scheduledTransactionID(scheduledTransactionID);
                     return true;

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleDeleteHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleDeleteHandler.java
@@ -31,7 +31,7 @@ import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.schedule.ScheduleOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.service.schedule.ReadableScheduleStore;
-import com.hedera.node.app.service.schedule.ScheduleRecordBuilder;
+import com.hedera.node.app.service.schedule.ScheduleStreamBuilder;
 import com.hedera.node.app.service.schedule.WritableScheduleStore;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
@@ -125,8 +125,8 @@ public class ScheduleDeleteHandler extends AbstractScheduleHandler implements Tr
                             context.keyVerifier().verificationFor(scheduleData.adminKeyOrThrow());
                     if (verificationResult.passed()) {
                         scheduleStore.delete(idToDelete, context.consensusNow());
-                        final ScheduleRecordBuilder scheduleRecords =
-                                context.savepointStack().getBaseBuilder(ScheduleRecordBuilder.class);
+                        final ScheduleStreamBuilder scheduleRecords =
+                                context.savepointStack().getBaseBuilder(ScheduleStreamBuilder.class);
                         scheduleRecords.scheduleID(idToDelete);
                     } else {
                         throw new HandleException(ResponseCodeEnum.UNAUTHORIZED);

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleSignHandler.java
@@ -34,7 +34,7 @@ import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.schedule.ScheduleOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.service.schedule.ReadableScheduleStore;
-import com.hedera.node.app.service.schedule.ScheduleRecordBuilder;
+import com.hedera.node.app.service.schedule.ScheduleStreamBuilder;
 import com.hedera.node.app.service.schedule.WritableScheduleStore;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -161,8 +161,8 @@ public class ScheduleSignHandler extends AbstractScheduleHandler implements Tran
                             verifyHasNewSignatures(scheduleToSign.signatories(), updatedSignatories);
                             scheduleStore.put(HandlerUtility.replaceSignatories(scheduleToSign, updatedSignatories));
                         }
-                        final ScheduleRecordBuilder scheduleRecords =
-                                context.savepointStack().getBaseBuilder(ScheduleRecordBuilder.class);
+                        final ScheduleStreamBuilder scheduleRecords =
+                                context.savepointStack().getBaseBuilder(ScheduleStreamBuilder.class);
                         scheduleRecords.scheduledTransactionID(
                                 HandlerUtility.transactionIdForScheduled(scheduleToSign));
                         // Based on fuzzy-record matching this field may not be set in mono-service records

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
@@ -35,7 +35,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionKeys;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.prehandle.PreHandleContextImpl;
 import java.security.InvalidKeyException;
 import java.time.Instant;
@@ -207,7 +207,7 @@ class AbstractScheduleHandlerTest extends ScheduleHandlerTestBase {
     @SuppressWarnings("unchecked")
     @Test
     void verifyTryExecute() {
-        final var mockRecordBuilder = Mockito.mock(SingleTransactionRecordBuilderImpl.class);
+        final var mockRecordBuilder = Mockito.mock(RecordStreamBuilder.class);
         BDDMockito.given(mockContext.dispatchChildTransaction(
                         any(TransactionBody.class),
                         any(),

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlerTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlerTestBase.java
@@ -33,7 +33,7 @@ import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.node.app.service.schedule.ReadableScheduleStore;
-import com.hedera.node.app.service.schedule.ScheduleRecordBuilder;
+import com.hedera.node.app.service.schedule.ScheduleStreamBuilder;
 import com.hedera.node.app.service.schedule.WritableScheduleStore;
 import com.hedera.node.app.service.schedule.impl.ScheduleTestBase;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -48,7 +48,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.TransactionKeys;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.app.workflows.handle.validation.AttributeValidatorImpl;
 import java.security.InvalidKeyException;
 import java.time.Instant;
@@ -179,16 +179,15 @@ class ScheduleHandlerTestBase extends ScheduleTestBase {
         given(keyVerifier.verificationFor(eq(otherKey), any())).willReturn(failedVerification(otherKey));
         given(mockContext.dispatchChildTransaction(
                         any(),
-                        eq(ScheduleRecordBuilder.class),
+                        eq(ScheduleStreamBuilder.class),
                         any(Predicate.class),
                         any(AccountID.class),
                         any(TransactionCategory.class)))
-                .willReturn(new SingleTransactionRecordBuilderImpl());
+                .willReturn(new RecordStreamBuilder());
 
         final var mockStack = mock(HandleContext.SavepointStack.class);
         given(mockContext.savepointStack()).willReturn(mockStack);
-        given(mockStack.getBaseBuilder(ScheduleRecordBuilder.class))
-                .willReturn(new SingleTransactionRecordBuilderImpl());
+        given(mockStack.getBaseBuilder(ScheduleStreamBuilder.class)).willReturn(new RecordStreamBuilder());
     }
 
     private static TransactionKeys createChildKeys(

--- a/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ScheduleStreamBuilder.java
+++ b/hedera-node/hedera-schedule-service/src/main/java/com/hedera/node/app/service/schedule/ScheduleStreamBuilder.java
@@ -18,7 +18,7 @@ package com.hedera.node.app.service.schedule;
 
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.TransactionID;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -30,7 +30,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * to which an instance of the implementation will be provided may be substantially any non-query
  * transaction other than a ScheduleCreate, ScheduleSign, or ScheduleDelete.
  */
-public interface ScheduleRecordBuilder extends SingleTransactionRecordBuilder {
+public interface ScheduleStreamBuilder extends StreamBuilder {
     /**
      * Schedule ref schedule record builder.
      *
@@ -38,7 +38,7 @@ public interface ScheduleRecordBuilder extends SingleTransactionRecordBuilder {
      * @return the schedule record builder
      */
     @NonNull
-    ScheduleRecordBuilder scheduleRef(ScheduleID scheduleRef);
+    ScheduleStreamBuilder scheduleRef(ScheduleID scheduleRef);
 
     /**
      * Schedule id schedule record builder.
@@ -47,7 +47,7 @@ public interface ScheduleRecordBuilder extends SingleTransactionRecordBuilder {
      * @return the schedule record builder
      */
     @NonNull
-    ScheduleRecordBuilder scheduleID(ScheduleID scheduleID);
+    ScheduleStreamBuilder scheduleID(ScheduleID scheduleID);
 
     /**
      * Scheduled transaction id schedule record builder.
@@ -56,5 +56,5 @@ public interface ScheduleRecordBuilder extends SingleTransactionRecordBuilder {
      * @return the schedule record builder
      */
     @NonNull
-    ScheduleRecordBuilder scheduledTransactionID(TransactionID scheduledTransactionID);
+    ScheduleStreamBuilder scheduledTransactionID(TransactionID scheduledTransactionID);
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/CallOutcome.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/CallOutcome.java
@@ -25,8 +25,8 @@ import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.hapi.streams.ContractActions;
 import com.hedera.hapi.streams.ContractStateChanges;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransactionResult;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -99,7 +99,7 @@ public record CallOutcome(
      * @param externalizeAbortResult whether to externalize the result of aborted calls
      */
     public void addCallDetailsTo(
-            @NonNull final ContractCallRecordBuilder recordBuilder,
+            @NonNull final ContractCallStreamBuilder recordBuilder,
             @NonNull final ExternalizeAbortResult externalizeAbortResult) {
         requireNonNull(recordBuilder);
         requireNonNull(externalizeAbortResult);
@@ -118,7 +118,7 @@ public record CallOutcome(
      * @param recordBuilder the record builder
      */
     public void addCreateDetailsTo(
-            @NonNull final ContractCreateRecordBuilder recordBuilder,
+            @NonNull final ContractCreateStreamBuilder recordBuilder,
             @NonNull final ExternalizeAbortResult externalizeAbortResult) {
         requireNonNull(recordBuilder);
         requireNonNull(externalizeAbortResult);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionModule.java
@@ -47,7 +47,7 @@ import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.hevm.HydratedEthTxData;
 import com.hedera.node.app.service.contract.impl.infra.EthTxSigsCache;
 import com.hedera.node.app.service.contract.impl.infra.EthereumCallDataHydration;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.EvmFrameStateFactory;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.state.ScopedEvmFrameStateFactory;
@@ -192,7 +192,7 @@ public interface TransactionModule {
                 hederaEvmBlocks,
                 tinybarValues,
                 systemContractGasCalculator,
-                context.savepointStack().getBaseBuilder(ContractOperationRecordBuilder.class),
+                context.savepointStack().getBaseBuilder(ContractOperationStreamBuilder.class),
                 pendingCreationMetadataRef);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaNativeOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaNativeOperations.java
@@ -34,7 +34,7 @@ import com.hedera.node.app.service.token.ReadableNftStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -114,7 +114,7 @@ public class HandleHederaNativeOperations implements HederaNativeOperations {
         // signing requirements enforced for this synthetic transaction
         try {
             final var childRecordBuilder = context.dispatchRemovablePrecedingTransaction(
-                    synthTxn, CryptoCreateRecordBuilder.class, null, context.payer());
+                    synthTxn, CryptoCreateStreamBuilder.class, null, context.payer());
             childRecordBuilder.memo(LAZY_CREATION_MEMO);
 
             return childRecordBuilder.status();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -22,7 +22,7 @@ import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.tu
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.*;
 import static com.hedera.node.app.spi.key.KeyUtils.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.SUPPRESSING_EXTERNALIZED_RECORD_CUSTOMIZER;
-import static com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.transactionWith;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.transactionWith;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.*;
@@ -36,8 +36,8 @@ import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalcu
 import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.exec.utils.PendingCreationMetadata;
 import com.hedera.node.app.service.contract.impl.exec.utils.PendingCreationMetadataRef;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.ContractStateStore;
 import com.hedera.node.app.service.contract.impl.state.WritableContractStateStore;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -328,7 +328,7 @@ public class HandleHederaOperations implements HederaOperations {
     @Override
     public void externalizeHollowAccountMerge(@NonNull ContractID contractId, @Nullable Bytes evmAddress) {
         final var recordBuilder = context.savepointStack()
-                .addRemovableChildRecordBuilder(ContractCreateRecordBuilder.class)
+                .addRemovableChildRecordBuilder(ContractCreateStreamBuilder.class)
                 .contractID(contractId)
                 .status(SUCCESS)
                 .transaction(transactionWith(TransactionBody.newBuilder()
@@ -365,7 +365,7 @@ public class HandleHederaOperations implements HederaOperations {
         final var isTopLevelCreation = bodyToExternalize == null;
         final var recordBuilder = context.dispatchRemovableChildTransaction(
                 TransactionBody.newBuilder().cryptoCreateAccount(bodyToDispatch).build(),
-                ContractCreateRecordBuilder.class,
+                ContractCreateStreamBuilder.class,
                 null,
                 context.payer(),
                 isTopLevelCreation
@@ -382,7 +382,7 @@ public class HandleHederaOperations implements HederaOperations {
         // initcode in the bytecode sidecar if it's not already externalized via a body
         final var pendingCreationMetadata = new PendingCreationMetadata(
                 isTopLevelCreation
-                        ? context.savepointStack().getBaseBuilder(ContractOperationRecordBuilder.class)
+                        ? context.savepointStack().getBaseBuilder(ContractOperationStreamBuilder.class)
                         : recordBuilder,
                 externalizeInitcodeOnSuccess == ExternalizeInitcodeOnSuccess.YES);
         final var contractId = ContractID.newBuilder().contractNum(number).build();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleSystemContractOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleSystemContractOperations.java
@@ -18,7 +18,7 @@ package com.hedera.node.app.service.contract.impl.exec.scope;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.tuweniToPbjBytes;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.CHILD;
-import static com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.transactionWith;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.transactionWith;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -32,7 +32,7 @@ import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.annotations.TransactionScope;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -86,13 +86,13 @@ public class HandleSystemContractOperations implements SystemContractOperations 
     }
 
     @Override
-    public ContractCallRecordBuilder externalizePreemptedDispatch(
+    public ContractCallStreamBuilder externalizePreemptedDispatch(
             @NonNull final TransactionBody syntheticBody, @NonNull final ResponseCodeEnum preemptingStatus) {
         requireNonNull(syntheticBody);
         requireNonNull(preemptingStatus);
 
         return context.savepointStack()
-                .addChildRecordBuilder(ContractCallRecordBuilder.class)
+                .addChildRecordBuilder(ContractCallStreamBuilder.class)
                 .transaction(transactionWith(syntheticBody))
                 .status(preemptingStatus);
     }
@@ -103,7 +103,7 @@ public class HandleSystemContractOperations implements SystemContractOperations 
     @Override
     public void externalizeResult(
             @NonNull final ContractFunctionResult result, @NonNull final ResponseCodeEnum responseStatus) {
-        final var childRecordBuilder = context.savepointStack().addChildRecordBuilder(ContractCallRecordBuilder.class);
+        final var childRecordBuilder = context.savepointStack().addChildRecordBuilder(ContractCallStreamBuilder.class);
         childRecordBuilder
                 .transaction(Transaction.DEFAULT)
                 .contractID(result.contractID())
@@ -118,7 +118,7 @@ public class HandleSystemContractOperations implements SystemContractOperations 
             @NonNull Transaction transaction) {
         requireNonNull(transaction);
         context.savepointStack()
-                .addChildRecordBuilder(ContractCallRecordBuilder.class)
+                .addChildRecordBuilder(ContractCallStreamBuilder.class)
                 .transaction(transaction)
                 .status(responseStatus)
                 .contractCallResult(result);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaOperations.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.ContractStateStore;
 import com.hedera.node.app.service.contract.impl.state.DispatchingEvmFrameState;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
@@ -239,7 +239,7 @@ public interface HederaOperations {
     long getOriginalSlotsUsed(ContractID contractID);
 
     /**
-     * Creates a {@link ContractCreateRecordBuilder}, containing information about the hollow account.
+     * Creates a {@link ContractCreateStreamBuilder}, containing information about the hollow account.
      * @param contractId    ContractId of hollow account
      * @param evmAddress    Evm address of hollow account
      */

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QuerySystemContractOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QuerySystemContractOperations.java
@@ -27,7 +27,7 @@ import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.annotations.QueryScope;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -68,7 +68,7 @@ public class QuerySystemContractOperations implements SystemContractOperations {
     }
 
     @Override
-    public ContractCallRecordBuilder externalizePreemptedDispatch(
+    public ContractCallStreamBuilder externalizePreemptedDispatch(
             @NonNull final TransactionBody syntheticBody, @NonNull final ResponseCodeEnum preemptingStatus) {
         throw new UnsupportedOperationException("Cannot externalize preempted dispatch");
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/SystemContractOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/SystemContractOperations.java
@@ -24,7 +24,7 @@ import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.function.Predicate;
 import org.apache.tuweni.bytes.Bytes;
@@ -59,7 +59,7 @@ public interface SystemContractOperations {
      * @param preemptingStatus the status code causing the preemption
      * @return the record of the preemption
      */
-    ContractCallRecordBuilder externalizePreemptedDispatch(
+    ContractCallStreamBuilder externalizePreemptedDispatch(
             @NonNull TransactionBody syntheticBody, @NonNull ResponseCodeEnum preemptingStatus);
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/FullResult.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/FullResult.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.ByteBuffer;
@@ -42,7 +42,7 @@ import org.hyperledger.besu.evm.precompile.PrecompiledContract;
 public record FullResult(
         @NonNull PrecompiledContract.PrecompileContractResult result,
         long gasRequirement,
-        @Nullable ContractCallRecordBuilder recordBuilder) {
+        @Nullable ContractCallStreamBuilder recordBuilder) {
     public FullResult {
         requireNonNull(result);
     }
@@ -79,7 +79,7 @@ public record FullResult(
     }
 
     public static FullResult revertResult(
-            @NonNull final ContractCallRecordBuilder recordBuilder, final long gasRequirement) {
+            @NonNull final ContractCallStreamBuilder recordBuilder, final long gasRequirement) {
         requireNonNull(recordBuilder);
         return new FullResult(
                 PrecompiledContract.PrecompileContractResult.revert(
@@ -90,7 +90,7 @@ public record FullResult(
     }
 
     public static FullResult haltResult(
-            @NonNull final ContractCallRecordBuilder recordBuilder, final long gasRequirement) {
+            @NonNull final ContractCallStreamBuilder recordBuilder, final long gasRequirement) {
         requireNonNull(recordBuilder);
         final var reason = recordBuilder.status() == NOT_SUPPORTED
                 ? CustomExceptionalHaltReason.NOT_SUPPORTED
@@ -112,7 +112,7 @@ public record FullResult(
     public static FullResult successResult(
             @NonNull final ByteBuffer encoded,
             final long gasRequirement,
-            @NonNull final ContractCallRecordBuilder recordBuilder) {
+            @NonNull final ContractCallStreamBuilder recordBuilder) {
         requireNonNull(encoded);
         return new FullResult(
                 PrecompiledContract.PrecompileContractResult.success(Bytes.wrap(encoded.array())),

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/PrngSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/PrngSystemContract.java
@@ -34,7 +34,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.node.util.UtilPrngTransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy.Decision;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.AbstractProxyEvmAccount;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.evm.exceptions.InvalidTransactionException;
@@ -126,7 +126,7 @@ public class PrngSystemContract extends AbstractFullContract implements HederaSy
 
             updater.enhancement()
                     .systemOperations()
-                    .dispatch(synthBody(), key -> Decision.INVALID, senderId, ContractCallRecordBuilder.class)
+                    .dispatch(synthBody(), key -> Decision.INVALID, senderId, ContractCallStreamBuilder.class)
                     .contractCallResult(data)
                     .entropyBytes(tuweniToPbjBytes(randomNum));
         }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCall.java
@@ -30,7 +30,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperatio
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.SystemContractOperations;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;
@@ -75,7 +75,7 @@ public abstract class AbstractCall implements Call {
 
     protected PricedResult completionWith(
             final long gasRequirement,
-            @NonNull final ContractCallRecordBuilder recordBuilder,
+            @NonNull final ContractCallStreamBuilder recordBuilder,
             @NonNull final ByteBuffer output) {
         requireNonNull(output);
         requireNonNull(recordBuilder);
@@ -87,11 +87,11 @@ public abstract class AbstractCall implements Call {
     }
 
     protected PricedResult reversionWith(
-            final long gasRequirement, @NonNull final ContractCallRecordBuilder recordBuilder) {
+            final long gasRequirement, @NonNull final ContractCallStreamBuilder recordBuilder) {
         return gasOnly(revertResult(recordBuilder, gasRequirement), recordBuilder.status(), isViewCall);
     }
 
-    protected PricedResult haltWith(final long gasRequirement, @NonNull final ContractCallRecordBuilder recordBuilder) {
+    protected PricedResult haltWith(final long gasRequirement, @NonNull final ContractCallStreamBuilder recordBuilder) {
         return gasOnly(haltResult(recordBuilder, gasRequirement), recordBuilder.status(), isViewCall);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/Call.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/Call.java
@@ -25,6 +25,7 @@ import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -39,7 +40,7 @@ public interface Call {
      * <ol>
      *     <li>The "full result" of the call, including both its EVM-standard {@link PrecompileContractResult}
      *     and gas requirement (which is often difficult to compute without executing the call); as well as
-     *     any {@link com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder} created
+     *     any {@link ContractCallStreamBuilder} created
      *     as a side-effect of executing the system contract.</li>
      *     <li>Any additional cost <i>beyond</i> the gas requirement.</li>
      * </ol>

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/hbarapprove/HbarApproveCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/hbarapprove/HbarApproveCall.java
@@ -27,7 +27,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
@@ -49,7 +49,7 @@ public class HbarApproveCall extends AbstractCall {
     public PricedResult execute(@NonNull final MessageFrame frame) {
         requireNonNull(frame);
         final var recordBuilder = systemContractOperations()
-                .dispatch(transactionBody, verificationStrategy, sender, ContractCallRecordBuilder.class);
+                .dispatch(transactionBody, verificationStrategy, sender, ContractCallStreamBuilder.class);
 
         final var gasRequirement = gasCalculator.gasRequirement(transactionBody, DispatchType.APPROVE, sender);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/DispatchForResponseCodeHtsCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/DispatchForResponseCodeHtsCall.java
@@ -34,7 +34,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalcu
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.ByteBuffer;
@@ -95,7 +95,7 @@ public class DispatchForResponseCodeHtsCall extends AbstractCall {
      * A function that can be used to generate the output of a dispatch from its completed
      * record builder.
      */
-    public interface OutputFn extends Function<ContractCallRecordBuilder, ByteBuffer> {
+    public interface OutputFn extends Function<ContractCallStreamBuilder, ByteBuffer> {
         /**
          * The standard output function that simply returns the encoded status.
          */
@@ -212,7 +212,7 @@ public class DispatchForResponseCodeHtsCall extends AbstractCall {
                     false);
         }
         final var recordBuilder = systemContractOperations()
-                .dispatch(syntheticBody, verificationStrategy, senderId, ContractCallRecordBuilder.class);
+                .dispatch(syntheticBody, verificationStrategy, senderId, ContractCallStreamBuilder.class);
         final var gasRequirement =
                 dispatchGasCalculator.gasRequirement(syntheticBody, gasCalculator, enhancement, senderId);
         var status = recordBuilder.status();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/ClassicCreatesCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/ClassicCreatesCall.java
@@ -57,7 +57,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -137,7 +137,7 @@ public class ClassicCreatesCall extends AbstractCall {
         // Choose a dispatch verification strategy based on whether the legacy activation address is active
         final var dispatchVerificationStrategy = verificationStrategyFor(frame, op);
         final var recordBuilder = systemContractOperations()
-                .dispatch(syntheticCreate, dispatchVerificationStrategy, spenderId, ContractCallRecordBuilder.class);
+                .dispatch(syntheticCreate, dispatchVerificationStrategy, spenderId, ContractCallStreamBuilder.class);
         recordBuilder.status(standardized(recordBuilder.status()));
 
         final var status = recordBuilder.status();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/AbstractGrantApprovalCall.java
@@ -33,7 +33,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalcu
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
@@ -66,7 +66,7 @@ public abstract class AbstractGrantApprovalCall extends AbstractCall {
         this.tokenType = tokenType;
     }
 
-    protected ContractCallRecordBuilder withMonoStandard(@NonNull final ContractCallRecordBuilder recordBuilder) {
+    protected ContractCallStreamBuilder withMonoStandard(@NonNull final ContractCallStreamBuilder recordBuilder) {
         if (recordBuilder.status() == DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL
                 || recordBuilder.status() == INVALID_SIGNATURE) {
             recordBuilder.status(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCall.java
@@ -31,7 +31,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AbiConstants;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.LogBuilder;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -60,7 +60,7 @@ public class ClassicGrantApprovalCall extends AbstractGrantApprovalCall {
         }
         final var body = synthApprovalBody();
         final var recordBuilder = systemContractOperations()
-                .dispatch(body, verificationStrategy, senderId, ContractCallRecordBuilder.class);
+                .dispatch(body, verificationStrategy, senderId, ContractCallStreamBuilder.class);
         final var status = recordBuilder.status();
         final var gasRequirement = gasCalculator.gasRequirement(body, DispatchType.APPROVE, senderId);
         if (status != SUCCESS) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCall.java
@@ -29,7 +29,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 
@@ -57,7 +57,7 @@ public class ERCGrantApprovalCall extends AbstractGrantApprovalCall {
         }
         final var body = synthApprovalBody();
         final var recordBuilder = systemContractOperations()
-                .dispatch(body, verificationStrategy, senderId, ContractCallRecordBuilder.class);
+                .dispatch(body, verificationStrategy, senderId, ContractCallStreamBuilder.class);
         final var status = withMonoStandard(recordBuilder).status();
         final var gasRequirement = gasCalculator.gasRequirement(body, DispatchType.APPROVE, senderId);
         if (status != SUCCESS) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllCall.java
@@ -35,7 +35,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.LogBuilder;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hyperledger.besu.datatypes.Address;
@@ -84,7 +84,7 @@ public class SetApprovalForAllCall extends AbstractCall {
     @Override
     public PricedResult execute() {
         final var recordBuilder = systemContractOperations()
-                .dispatch(transactionBody, verificationStrategy, sender, ContractCallRecordBuilder.class);
+                .dispatch(transactionBody, verificationStrategy, sender, ContractCallStreamBuilder.class);
 
         final var gasRequirement =
                 dispatchGasCalculator.gasRequirement(transactionBody, gasCalculator, enhancement, sender);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
@@ -40,7 +40,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalcu
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
@@ -154,7 +154,7 @@ public class ClassicTransfersCall extends AbstractCall {
                         .build()
                 : syntheticTransfer;
         final var recordBuilder = systemContractOperations()
-                .dispatch(transferToDispatch, verificationStrategy, senderId, ContractCallRecordBuilder.class);
+                .dispatch(transferToDispatch, verificationStrategy, senderId, ContractCallStreamBuilder.class);
         final var op = transferToDispatch.cryptoTransferOrThrow();
         if (recordBuilder.status() == SUCCESS) {
             maybeEmitErcLogsFor(op, frame);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersCall.java
@@ -40,7 +40,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -106,7 +106,7 @@ public class Erc20TransfersCall extends AbstractCall {
             return reversionWith(INVALID_TOKEN_ID, gasRequirement);
         }
         final var recordBuilder = systemContractOperations()
-                .dispatch(syntheticTransfer, verificationStrategy, senderId, ContractCallRecordBuilder.class);
+                .dispatch(syntheticTransfer, verificationStrategy, senderId, ContractCallStreamBuilder.class);
         final var status = recordBuilder.status();
         if (status != SUCCESS) {
             if (status == NOT_SUPPORTED) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromCall.java
@@ -39,7 +39,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -92,7 +92,7 @@ public class Erc721TransferFromCall extends AbstractCall {
         final var gasRequirement = transferGasRequirement(
                 syntheticTransfer, gasCalculator, enhancement, senderId, ERC_721_TRANSFER_FROM.selector());
         final var recordBuilder = systemContractOperations()
-                .dispatch(syntheticTransfer, verificationStrategy, senderId, ContractCallRecordBuilder.class);
+                .dispatch(syntheticTransfer, verificationStrategy, senderId, ContractCallStreamBuilder.class);
         final var status = recordBuilder.status();
         if (status != ResponseCodeEnum.SUCCESS) {
             return gasOnly(revertResult(recordBuilder, gasRequirement), status, false);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/FrameUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/FrameUtils.java
@@ -30,7 +30,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
 import com.hedera.node.app.service.contract.impl.hevm.HevmPropagatedCallFailure;
 import com.hedera.node.app.service.contract.impl.infra.StorageAccessTracker;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
 import com.hedera.node.config.data.ContractsConfig;
@@ -165,7 +165,7 @@ public class FrameUtils {
      * @param frame the frame whose EVM transaction we are tracking called contracts in
      * @return the record builder
      */
-    public static @NonNull ContractOperationRecordBuilder recordBuilderFor(@NonNull final MessageFrame frame) {
+    public static @NonNull ContractOperationStreamBuilder recordBuilderFor(@NonNull final MessageFrame frame) {
         return requireNonNull(initialFrameOf(frame).getContextVariable(HAPI_RECORD_BUILDER_CONTEXT_VARIABLE));
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/PendingCreationMetadata.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/PendingCreationMetadata.java
@@ -16,8 +16,8 @@
 
 package com.hedera.node.app.service.contract.impl.exec.utils;
 
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public record PendingCreationMetadata(
-        @NonNull ContractOperationRecordBuilder recordBuilder, boolean externalizeInitcodeOnSuccess) {}
+        @NonNull ContractOperationStreamBuilder recordBuilder, boolean externalizeInitcodeOnSuccess) {}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/PendingCreationMetadataRef.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/PendingCreationMetadataRef.java
@@ -21,14 +21,14 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.node.app.service.contract.impl.annotations.TransactionScope;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomContractCreationProcessor;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.inject.Inject;
 
 /**
- * Wrapper that holds a reference to the {@link ContractOperationRecordBuilder} that should receive
+ * Wrapper that holds a reference to the {@link ContractOperationStreamBuilder} that should receive
  * the bytecode sidecar in the next {@code codeSuccess()}  call of {@link CustomContractCreationProcessor}.
  */
 @TransactionScope

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
@@ -31,7 +31,7 @@ import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome.ExternalizeAbortResult;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -75,7 +75,7 @@ public class ContractCallHandler implements TransactionHandler {
         // (FUTURE) Remove ExternalizeAbortResult.NO, this is only
         // for mono-service fidelity during differential testing
         outcome.addCallDetailsTo(
-                context.savepointStack().getBaseBuilder(ContractCallRecordBuilder.class), ExternalizeAbortResult.NO);
+                context.savepointStack().getBaseBuilder(ContractCallStreamBuilder.class), ExternalizeAbortResult.NO);
 
         throwIfUnsuccessful(outcome.status());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
@@ -31,7 +31,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome.ExternalizeAbortResult;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -75,7 +75,7 @@ public class ContractCreateHandler implements TransactionHandler {
 
         // Assemble the appropriate top-level record for the result
         outcome.addCreateDetailsTo(
-                context.savepointStack().getBaseBuilder(ContractCreateRecordBuilder.class), ExternalizeAbortResult.NO);
+                context.savepointStack().getBaseBuilder(ContractCreateStreamBuilder.class), ExternalizeAbortResult.NO);
 
         throwIfUnsuccessful(outcome.status());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractDeleteHandler.java
@@ -39,7 +39,7 @@ import com.hedera.hapi.node.contract.ContractDeleteTransactionBody;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
-import com.hedera.node.app.service.contract.impl.records.ContractDeleteRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractDeleteStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.service.token.api.TokenServiceApi.FreeAliasOnDeletion;
@@ -113,7 +113,7 @@ public class ContractDeleteHandler implements TransactionHandler {
             throw new HandleException(obtainer.smartContract() ? INVALID_CONTRACT_ID : OBTAINER_DOES_NOT_EXIST);
         }
         validateFalse(toBeDeleted.accountIdOrThrow().equals(obtainer.accountIdOrThrow()), OBTAINER_SAME_CONTRACT_ID);
-        final var recordBuilder = context.savepointStack().getBaseBuilder(ContractDeleteRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(ContractDeleteStreamBuilder.class);
         final var deletedId = toBeDeleted.accountIdOrThrow();
         context.storeFactory()
                 .serviceApi(TokenServiceApi.class)

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -45,7 +45,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
-import com.hedera.node.app.service.contract.impl.records.ContractUpdateRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractUpdateStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -143,7 +143,7 @@ public class ContractUpdateHandler implements TransactionHandler {
         final var changed = update(requireNonNull(toBeUpdated), context, op);
         context.storeFactory().serviceApi(TokenServiceApi.class).updateContract(changed);
         context.savepointStack()
-                .getBaseBuilder(ContractUpdateRecordBuilder.class)
+                .getBaseBuilder(ContractUpdateStreamBuilder.class)
                 .contractID(ContractID.newBuilder()
                         .contractNum(toBeUpdated.accountIdOrThrow().accountNumOrThrow())
                         .build());

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
@@ -39,9 +39,9 @@ import com.hedera.node.app.service.contract.impl.exec.CallOutcome.ExternalizeAbo
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
 import com.hedera.node.app.service.contract.impl.infra.EthTxSigsCache;
 import com.hedera.node.app.service.contract.impl.infra.EthereumCallDataHydration;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
-import com.hedera.node.app.service.contract.impl.records.EthereumTransactionRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.EthereumTransactionStreamBuilder;
 import com.hedera.node.app.service.file.ReadableFileStore;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
@@ -146,15 +146,15 @@ public class EthereumTransactionHandler implements TransactionHandler {
         final var ethTxData =
                 requireNonNull(requireNonNull(component.hydratedEthTxData()).ethTxData());
         context.savepointStack()
-                .getBaseBuilder(EthereumTransactionRecordBuilder.class)
+                .getBaseBuilder(EthereumTransactionStreamBuilder.class)
                 .ethereumHash(Bytes.wrap(ethTxData.getEthereumHash()));
         if (ethTxData.hasToAddress()) {
             outcome.addCallDetailsTo(
-                    context.savepointStack().getBaseBuilder(ContractCallRecordBuilder.class),
+                    context.savepointStack().getBaseBuilder(ContractCallStreamBuilder.class),
                     ExternalizeAbortResult.YES);
         } else {
             outcome.addCreateDetailsTo(
-                    context.savepointStack().getBaseBuilder(ContractCreateRecordBuilder.class),
+                    context.savepointStack().getBaseBuilder(ContractCreateStreamBuilder.class),
                     ExternalizeAbortResult.YES);
         }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmContext.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmContext.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.exec.utils.PendingCreationMetadataRef;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.hyperledger.besu.evm.frame.BlockValues;
@@ -32,7 +32,7 @@ public record HederaEvmContext(
         @NonNull HederaEvmBlocks blocks,
         @NonNull TinybarValues tinybarValues,
         @NonNull SystemContractGasCalculator systemContractGasCalculator,
-        @Nullable ContractOperationRecordBuilder recordBuilder,
+        @Nullable ContractOperationStreamBuilder recordBuilder,
         @Nullable PendingCreationMetadataRef pendingCreationRecordBuilderReference) {
 
     public HederaEvmContext {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractCallStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractCallStreamBuilder.java
@@ -30,7 +30,7 @@ import java.util.List;
 /**
  * Exposes the record customizations needed for a HAPI contract call transaction.
  */
-public interface ContractCallRecordBuilder extends ContractOperationRecordBuilder {
+public interface ContractCallStreamBuilder extends ContractOperationStreamBuilder {
     /**
      * Returns all assessed custom fees for this call.
      *
@@ -46,7 +46,7 @@ public interface ContractCallRecordBuilder extends ContractOperationRecordBuilde
      * @return this builder
      */
     @NonNull
-    ContractCallRecordBuilder status(@NonNull ResponseCodeEnum status);
+    ContractCallStreamBuilder status(@NonNull ResponseCodeEnum status);
 
     /**
      * Returns final status of this contract call's record.
@@ -63,7 +63,7 @@ public interface ContractCallRecordBuilder extends ContractOperationRecordBuilde
      * @return this builder
      */
     @NonNull
-    ContractCallRecordBuilder contractID(@Nullable ContractID contractId);
+    ContractCallStreamBuilder contractID(@Nullable ContractID contractId);
 
     /**
      * Returns the token id created.
@@ -79,7 +79,7 @@ public interface ContractCallRecordBuilder extends ContractOperationRecordBuilde
      * @return this builder
      */
     @NonNull
-    ContractCallRecordBuilder contractCallResult(@Nullable ContractFunctionResult result);
+    ContractCallStreamBuilder contractCallResult(@Nullable ContractFunctionResult result);
 
     /**
      * Returns the in-progress {@link ContractFunctionResult}.
@@ -95,7 +95,7 @@ public interface ContractCallRecordBuilder extends ContractOperationRecordBuilde
      * @return this builder
      */
     @NonNull
-    ContractCallRecordBuilder transaction(@NonNull final Transaction txn);
+    ContractCallStreamBuilder transaction(@NonNull final Transaction txn);
 
     /**
      * Gets the newly minted serial numbers.
@@ -112,7 +112,7 @@ public interface ContractCallRecordBuilder extends ContractOperationRecordBuilde
     long getNewTotalSupply();
 
     @NonNull
-    ContractCallRecordBuilder entropyBytes(@NonNull final Bytes prngBytes);
+    ContractCallStreamBuilder entropyBytes(@NonNull final Bytes prngBytes);
 
     /**
      * Returns the number of auto-associations created in the dispatch.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractCreateStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractCreateStreamBuilder.java
@@ -21,14 +21,14 @@ import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Exposes the record customizations needed for a HAPI contract create transaction.
  */
-public interface ContractCreateRecordBuilder extends SingleTransactionRecordBuilder, ContractOperationRecordBuilder {
+public interface ContractCreateStreamBuilder extends StreamBuilder, ContractOperationStreamBuilder {
 
     /**
      * Tracks the final status of a top-level contract creation.
@@ -37,7 +37,7 @@ public interface ContractCreateRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    ContractCreateRecordBuilder status(@NonNull ResponseCodeEnum status);
+    ContractCreateStreamBuilder status(@NonNull ResponseCodeEnum status);
 
     /**
      * Tracks the contract id created by a successful top-level contract creation.
@@ -46,7 +46,7 @@ public interface ContractCreateRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    ContractCreateRecordBuilder contractID(@Nullable ContractID contractId);
+    ContractCreateStreamBuilder contractID(@Nullable ContractID contractId);
 
     /**
      * Tracks the account id created by a successful top-level contract creation.
@@ -54,7 +54,7 @@ public interface ContractCreateRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    ContractCreateRecordBuilder accountID(@Nullable AccountID accountID);
+    ContractCreateStreamBuilder accountID(@Nullable AccountID accountID);
 
     /**
      * Tracks the result of a top-level contract creation.
@@ -63,8 +63,8 @@ public interface ContractCreateRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    ContractCreateRecordBuilder contractCreateResult(@Nullable ContractFunctionResult result);
+    ContractCreateStreamBuilder contractCreateResult(@Nullable ContractFunctionResult result);
 
     @NonNull
-    ContractCreateRecordBuilder transaction(@NonNull Transaction transaction);
+    ContractCreateStreamBuilder transaction(@NonNull Transaction transaction);
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractDeleteStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractDeleteStreamBuilder.java
@@ -25,7 +25,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 /**
  * A {@code RecordBuilder} specialization for tracking the side effects of a {@code ContractDelete}.
  */
-public interface ContractDeleteRecordBuilder extends DeleteCapableTransactionRecordBuilder {
+public interface ContractDeleteStreamBuilder extends DeleteCapableTransactionRecordBuilder {
     /**
      * Tracks the contract id deleted by a successful top-level contract deletion.
      *
@@ -33,8 +33,8 @@ public interface ContractDeleteRecordBuilder extends DeleteCapableTransactionRec
      * @return this builder
      */
     @NonNull
-    ContractDeleteRecordBuilder contractID(@Nullable ContractID contractId);
+    ContractDeleteStreamBuilder contractID(@Nullable ContractID contractId);
 
     @NonNull
-    ContractDeleteRecordBuilder transaction(@NonNull final Transaction txn);
+    ContractDeleteStreamBuilder transaction(@NonNull final Transaction txn);
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractDeleteStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractDeleteStreamBuilder.java
@@ -23,7 +23,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code ContractDelete}.
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code ContractDelete}.
  */
 public interface ContractDeleteStreamBuilder extends DeleteCapableTransactionRecordBuilder {
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractOperationStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractOperationStreamBuilder.java
@@ -27,14 +27,14 @@ import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBu
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 
-public interface ContractOperationRecordBuilder extends DeleteCapableTransactionRecordBuilder {
+public interface ContractOperationStreamBuilder extends DeleteCapableTransactionRecordBuilder {
     /**
      * Sets the transaction fee.
      *
      * @param transactionFee the new transaction fee
-     * @return the updated {@link ContractOperationRecordBuilder}
+     * @return the updated {@link ContractOperationStreamBuilder}
      */
-    ContractOperationRecordBuilder transactionFee(long transactionFee);
+    ContractOperationStreamBuilder transactionFee(long transactionFee);
 
     /**
      * Tracks the ID of an account that should be explicitly considered
@@ -58,7 +58,7 @@ public interface ContractOperationRecordBuilder extends DeleteCapableTransaction
      * @param outcome the EVM transaction outcome
      * @return this updated builder
      */
-    default ContractOperationRecordBuilder withCommonFieldsSetFrom(@NonNull final CallOutcome outcome) {
+    default ContractOperationStreamBuilder withCommonFieldsSetFrom(@NonNull final CallOutcome outcome) {
         transactionFee(transactionFee() + outcome.tinybarGasCost());
         if (outcome.actions() != null) {
             addContractActions(outcome.actions(), false);
@@ -77,7 +77,7 @@ public interface ContractOperationRecordBuilder extends DeleteCapableTransaction
      * @return this builder
      */
     @NonNull
-    ContractOperationRecordBuilder addContractActions(@NonNull ContractActions contractActions, boolean isMigration);
+    ContractOperationStreamBuilder addContractActions(@NonNull ContractActions contractActions, boolean isMigration);
 
     /**
      * Updates this record builder to include contract bytecode.
@@ -87,7 +87,7 @@ public interface ContractOperationRecordBuilder extends DeleteCapableTransaction
      * @return this builder
      */
     @NonNull
-    ContractOperationRecordBuilder addContractBytecode(@NonNull ContractBytecode contractBytecode, boolean isMigration);
+    ContractOperationStreamBuilder addContractBytecode(@NonNull ContractBytecode contractBytecode, boolean isMigration);
 
     /**
      * Updates this record builder to include contract state changes.
@@ -97,6 +97,6 @@ public interface ContractOperationRecordBuilder extends DeleteCapableTransaction
      * @return this builder
      */
     @NonNull
-    ContractOperationRecordBuilder addContractStateChanges(
+    ContractOperationStreamBuilder addContractStateChanges(
             @NonNull ContractStateChanges contractStateChanges, boolean isMigration);
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractUpdateStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractUpdateStreamBuilder.java
@@ -14,27 +14,23 @@
  * limitations under the License.
  */
 
-package com.hedera.node.app.service.token.api;
+package com.hedera.node.app.service.contract.impl.records;
 
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
- * transaction.
+ * A {@code RecordBuilder} specialization for tracking the side effects of a {@code ContractUpdate}.
  */
-public interface FeeRecordBuilder {
+public interface ContractUpdateStreamBuilder extends DeleteCapableTransactionRecordBuilder {
     /**
-     * Gets the current value of the transaction fee in this builder.
-     * @return The current transaction fee value.
-     */
-    long transactionFee();
-
-    /**
-     * Sets the consensus transaction fee.
+     * Tracks the contract id updated by a successful top-level contract update operation.
      *
-     * @param transactionFee the transaction fee
-     * @return the builder
+     * @param contractId the {@link ContractID} of the updated top-level contract
+     * @return this builder
      */
     @NonNull
-    FeeRecordBuilder transactionFee(final long transactionFee);
+    ContractUpdateStreamBuilder contractID(@Nullable ContractID contractId);
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractUpdateStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractUpdateStreamBuilder.java
@@ -22,7 +22,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code ContractUpdate}.
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code ContractUpdate}.
  */
 public interface ContractUpdateStreamBuilder extends DeleteCapableTransactionRecordBuilder {
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/EthereumTransactionStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/EthereumTransactionStreamBuilder.java
@@ -23,7 +23,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
-public interface EthereumTransactionRecordBuilder extends ContractOperationRecordBuilder {
+public interface EthereumTransactionStreamBuilder extends ContractOperationStreamBuilder {
     /**
      * Tracks the final status of a HAPI Ethereum transaction.
      *
@@ -31,7 +31,7 @@ public interface EthereumTransactionRecordBuilder extends ContractOperationRecor
      * @return this builder
      */
     @NonNull
-    EthereumTransactionRecordBuilder status(@NonNull ResponseCodeEnum status);
+    EthereumTransactionStreamBuilder status(@NonNull ResponseCodeEnum status);
 
     /**
      * Tracks the contract id called or created by the HAPI Ethereum transaction.
@@ -40,7 +40,7 @@ public interface EthereumTransactionRecordBuilder extends ContractOperationRecor
      * @return this builder
      */
     @NonNull
-    EthereumTransactionRecordBuilder contractID(@Nullable ContractID contractId);
+    EthereumTransactionStreamBuilder contractID(@Nullable ContractID contractId);
 
     /**
      * Tracks the result of a HAPI Ethereum transaction performing a top-level contract call.
@@ -49,7 +49,7 @@ public interface EthereumTransactionRecordBuilder extends ContractOperationRecor
      * @return this builder
      */
     @NonNull
-    EthereumTransactionRecordBuilder contractCallResult(@Nullable ContractFunctionResult result);
+    EthereumTransactionStreamBuilder contractCallResult(@Nullable ContractFunctionResult result);
 
     /**
      * Tracks the result of a HAPI Ethereum transaction performing a top-level contract creation.
@@ -58,7 +58,7 @@ public interface EthereumTransactionRecordBuilder extends ContractOperationRecor
      * @return this builder
      */
     @NonNull
-    EthereumTransactionRecordBuilder contractCreateResult(@Nullable ContractFunctionResult result);
+    EthereumTransactionStreamBuilder contractCreateResult(@Nullable ContractFunctionResult result);
 
     /**
      * Tracks the hash of a HAPI Ethereum transaction.
@@ -67,8 +67,8 @@ public interface EthereumTransactionRecordBuilder extends ContractOperationRecor
      * @return this builder
      */
     @NonNull
-    EthereumTransactionRecordBuilder ethereumHash(@NonNull Bytes ethereumHash);
+    EthereumTransactionStreamBuilder ethereumHash(@NonNull Bytes ethereumHash);
 
     @NonNull
-    EthereumTransactionRecordBuilder feeChargedToPayer(@NonNull long amount);
+    EthereumTransactionStreamBuilder feeChargedToPayer(@NonNull long amount);
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
@@ -85,7 +85,7 @@ import com.hedera.node.app.service.contract.impl.hevm.HederaEvmContext;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransaction;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransactionResult;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.StorageAccess;
 import com.hedera.node.app.service.contract.impl.state.StorageAccesses;
 import com.hedera.node.app.spi.key.KeyUtils;
@@ -786,7 +786,7 @@ public class TestHelpers {
             @NonNull final HederaEvmBlocks blocks,
             @NonNull final TinybarValues tinybarValues,
             @NonNull final SystemContractGasCalculator systemContractGasCalculator,
-            @NonNull ContractOperationRecordBuilder recordBuilder) {
+            @NonNull ContractOperationStreamBuilder recordBuilder) {
         return new HederaEvmContext(
                 NETWORK_GAS_PRICE,
                 false,

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/CallOutcomeTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/CallOutcomeTest.java
@@ -31,8 +31,8 @@ import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -46,10 +46,10 @@ class CallOutcomeTest {
     private RootProxyWorldUpdater updater;
 
     @Mock
-    private ContractCallRecordBuilder contractCallRecordBuilder;
+    private ContractCallStreamBuilder contractCallRecordBuilder;
 
     @Mock
-    private ContractCreateRecordBuilder contractCreateRecordBuilder;
+    private ContractCreateStreamBuilder contractCreateRecordBuilder;
 
     @Test
     void doesNotSetAbortCallResultIfNotRequested() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionModuleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionModuleTest.java
@@ -57,7 +57,7 @@ import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.hevm.HydratedEthTxData;
 import com.hedera.node.app.service.contract.impl.infra.EthTxSigsCache;
 import com.hedera.node.app.service.contract.impl.infra.EthereumCallDataHydration;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.EvmFrameStateFactory;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
@@ -172,13 +172,13 @@ class TransactionModuleTest {
 
     @Test
     void providesExpectedEvmContext() {
-        final var recordBuilder = mock(ContractOperationRecordBuilder.class);
+        final var recordBuilder = mock(ContractOperationStreamBuilder.class);
         final var gasCalculator = mock(SystemContractGasCalculator.class);
         final var blocks = mock(HederaEvmBlocks.class);
         final var stack = mock(HandleContext.SavepointStack.class);
         given(hederaOperations.gasPriceInTinybars()).willReturn(123L);
         given(context.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(ContractOperationRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ContractOperationStreamBuilder.class)).willReturn(recordBuilder);
         final var pendingCreationBuilder = new PendingCreationMetadataRef();
         final var result = provideHederaEvmContext(
                 context, tinybarValues, gasCalculator, hederaOperations, blocks, pendingCreationBuilder);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
@@ -75,7 +75,7 @@ import com.hedera.node.app.service.contract.impl.hevm.HederaEvmBlocks;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransaction;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransactionResult;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.HederaEvmAccount;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import com.hedera.node.app.spi.workflows.ResourceExhaustedException;
@@ -146,7 +146,7 @@ class TransactionProcessorTest {
     private FeatureFlags featureFlags;
 
     @Mock
-    private ContractOperationRecordBuilder recordBuilder;
+    private ContractOperationStreamBuilder recordBuilder;
 
     private TransactionProcessor subject;
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
@@ -44,7 +44,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmBlocks;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmContext;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.HederaEvmAccount;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import org.hyperledger.besu.datatypes.Wei;
@@ -81,7 +81,7 @@ class CustomGasChargingTest {
     private CustomGasCharging subject;
 
     @Mock
-    private ContractOperationRecordBuilder recordBuilder;
+    private ContractOperationStreamBuilder recordBuilder;
 
     @BeforeEach
     void setUp() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaNativeOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaNativeOperationsTest.java
@@ -63,7 +63,7 @@ import com.hedera.node.app.service.token.ReadableNftStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.ids.EntityNumGenerator;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -93,7 +93,7 @@ class HandleHederaNativeOperationsTest {
     private ReadableTokenStore tokenStore;
 
     @Mock
-    private CryptoCreateRecordBuilder cryptoCreateRecordBuilder;
+    private CryptoCreateStreamBuilder cryptoCreateRecordBuilder;
 
     @Mock
     private ReadableTokenRelationStore relationStore;
@@ -183,7 +183,7 @@ class HandleHederaNativeOperationsTest {
         given(context.payer()).willReturn(A_NEW_ACCOUNT_ID);
 
         when(context.dispatchRemovablePrecedingTransaction(
-                        eq(synthLazyCreate), eq(CryptoCreateRecordBuilder.class), eq(null), eq(A_NEW_ACCOUNT_ID)))
+                        eq(synthLazyCreate), eq(CryptoCreateStreamBuilder.class), eq(null), eq(A_NEW_ACCOUNT_ID)))
                 .thenReturn(cryptoCreateRecordBuilder);
 
         given(cryptoCreateRecordBuilder.status()).willReturn(OK);
@@ -201,7 +201,7 @@ class HandleHederaNativeOperationsTest {
                 .build();
         given(context.payer()).willReturn(A_NEW_ACCOUNT_ID);
         given(context.dispatchRemovablePrecedingTransaction(
-                        eq(synthLazyCreate), eq(CryptoCreateRecordBuilder.class), eq(null), eq(A_NEW_ACCOUNT_ID)))
+                        eq(synthLazyCreate), eq(CryptoCreateStreamBuilder.class), eq(null), eq(A_NEW_ACCOUNT_ID)))
                 .willReturn(cryptoCreateRecordBuilder);
         given(cryptoCreateRecordBuilder.status()).willReturn(MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaOperationsTest.java
@@ -63,7 +63,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.exec.scope.HandleHederaOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaOperations;
 import com.hedera.node.app.service.contract.impl.exec.utils.PendingCreationMetadataRef;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.WritableContractStateStore;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -112,7 +112,7 @@ class HandleHederaOperationsTest {
     private WritableContractStateStore stateStore;
 
     @Mock
-    private ContractCreateRecordBuilder contractCreateRecordBuilder;
+    private ContractCreateStreamBuilder contractCreateRecordBuilder;
 
     @Mock
     private TinybarValues tinybarValues;
@@ -340,7 +340,7 @@ class HandleHederaOperationsTest {
                 .willReturn(contractCreateRecordBuilder);
         given(context.dispatchRemovableChildTransaction(
                         eq(synthTxn),
-                        eq(ContractCreateRecordBuilder.class),
+                        eq(ContractCreateStreamBuilder.class),
                         eq(null),
                         eq(A_NEW_ACCOUNT_ID),
                         captor.capture()))
@@ -380,7 +380,7 @@ class HandleHederaOperationsTest {
         given(context.payer()).willReturn(A_NEW_ACCOUNT_ID);
         given(context.dispatchRemovableChildTransaction(
                         eq(synthTxn),
-                        eq(ContractCreateRecordBuilder.class),
+                        eq(ContractCreateStreamBuilder.class),
                         eq(null),
                         eq(A_NEW_ACCOUNT_ID),
                         captor.capture()))
@@ -427,7 +427,7 @@ class HandleHederaOperationsTest {
                 .willReturn(contractCreateRecordBuilder);
         given(context.dispatchRemovableChildTransaction(
                         eq(synthTxn),
-                        eq(ContractCreateRecordBuilder.class),
+                        eq(ContractCreateStreamBuilder.class),
                         eq(null),
                         eq(A_NEW_ACCOUNT_ID),
                         captor.capture()))
@@ -503,7 +503,7 @@ class HandleHederaOperationsTest {
                 .willReturn(contractCreateRecordBuilder);
         given(context.dispatchRemovableChildTransaction(
                         eq(synthTxn),
-                        eq(ContractCreateRecordBuilder.class),
+                        eq(ContractCreateStreamBuilder.class),
                         eq(null),
                         eq(A_NEW_ACCOUNT_ID),
                         any(ExternalizedRecordCustomizer.class)))
@@ -517,7 +517,7 @@ class HandleHederaOperationsTest {
         verify(context)
                 .dispatchRemovableChildTransaction(
                         eq(synthTxn),
-                        eq(ContractCreateRecordBuilder.class),
+                        eq(ContractCreateStreamBuilder.class),
                         eq(null),
                         eq(A_NEW_ACCOUNT_ID),
                         any(ExternalizedRecordCustomizer.class));
@@ -553,7 +553,7 @@ class HandleHederaOperationsTest {
                 .willReturn(contractCreateRecordBuilder);
         given(context.dispatchRemovableChildTransaction(
                         eq(synthTxn),
-                        eq(ContractCreateRecordBuilder.class),
+                        eq(ContractCreateStreamBuilder.class),
                         eq(null),
                         eq(A_NEW_ACCOUNT_ID),
                         any(ExternalizedRecordCustomizer.class)))
@@ -567,7 +567,7 @@ class HandleHederaOperationsTest {
         verify(context)
                 .dispatchRemovableChildTransaction(
                         eq(synthTxn),
-                        eq(ContractCreateRecordBuilder.class),
+                        eq(ContractCreateStreamBuilder.class),
                         eq(null),
                         eq(A_NEW_ACCOUNT_ID),
                         captor.capture());
@@ -590,7 +590,7 @@ class HandleHederaOperationsTest {
         given(context.payer()).willReturn(A_NEW_ACCOUNT_ID);
         given(context.dispatchRemovableChildTransaction(
                         eq(synthTxn),
-                        eq(ContractCreateRecordBuilder.class),
+                        eq(ContractCreateStreamBuilder.class),
                         eq(null),
                         eq(A_NEW_ACCOUNT_ID),
                         any(ExternalizedRecordCustomizer.class)))
@@ -636,7 +636,7 @@ class HandleHederaOperationsTest {
         // given
         var contractId = ContractID.newBuilder().contractNum(1001).build();
         given(context.savepointStack()).willReturn(stack);
-        given(stack.addRemovableChildRecordBuilder(ContractCreateRecordBuilder.class))
+        given(stack.addRemovableChildRecordBuilder(ContractCreateStreamBuilder.class))
                 .willReturn(contractCreateRecordBuilder);
         given(contractCreateRecordBuilder.contractID(contractId)).willReturn(contractCreateRecordBuilder);
         given(contractCreateRecordBuilder.status(any())).willReturn(contractCreateRecordBuilder);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleSystemContractOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleSystemContractOperationsTest.java
@@ -38,10 +38,10 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.scope.HandleSystemContractOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy.Decision;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.service.contract.impl.utils.SystemContractUtils;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.spi.fees.ExchangeRateInfo;
 import com.hedera.node.app.spi.key.KeyVerifier;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
@@ -62,7 +62,7 @@ class HandleSystemContractOperationsTest {
     private HandleContext context;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Mock
     private ExchangeRateInfo exchangeRateInfo;
@@ -104,12 +104,12 @@ class HandleSystemContractOperationsTest {
         given(keyVerifier.verificationFor(TestHelpers.B_SECP256K1_KEY)).willReturn(failed);
         doCallRealMethod().when(strategy).asSignatureTestIn(context, A_SECP256K1_KEY);
 
-        subject.dispatch(TransactionBody.DEFAULT, strategy, A_NEW_ACCOUNT_ID, CryptoTransferRecordBuilder.class);
+        subject.dispatch(TransactionBody.DEFAULT, strategy, A_NEW_ACCOUNT_ID, CryptoTransferStreamBuilder.class);
 
         verify(context)
                 .dispatchChildTransaction(
                         eq(TransactionBody.DEFAULT),
-                        eq(CryptoTransferRecordBuilder.class),
+                        eq(CryptoTransferStreamBuilder.class),
                         captor.capture(),
                         eq(A_NEW_ACCOUNT_ID),
                         eq(CHILD));
@@ -131,7 +131,7 @@ class HandleSystemContractOperationsTest {
 
         // given
         given(context.savepointStack()).willReturn(savepointStack);
-        given(savepointStack.addChildRecordBuilder(ContractCallRecordBuilder.class))
+        given(savepointStack.addChildRecordBuilder(ContractCallStreamBuilder.class))
                 .willReturn(recordBuilder);
         given(recordBuilder.transaction(Transaction.DEFAULT)).willReturn(recordBuilder);
         given(recordBuilder.status(ResponseCodeEnum.SUCCESS)).willReturn(recordBuilder);
@@ -163,7 +163,7 @@ class HandleSystemContractOperationsTest {
 
         // given
         given(context.savepointStack()).willReturn(savepointStack);
-        given(savepointStack.addChildRecordBuilder(ContractCallRecordBuilder.class))
+        given(savepointStack.addChildRecordBuilder(ContractCallStreamBuilder.class))
                 .willReturn(recordBuilder);
         given(recordBuilder.transaction(transaction)).willReturn(recordBuilder);
         given(recordBuilder.status(ResponseCodeEnum.SUCCESS)).willReturn(recordBuilder);
@@ -187,7 +187,7 @@ class HandleSystemContractOperationsTest {
 
         // given
         given(context.savepointStack()).willReturn(savepointStack);
-        given(savepointStack.addChildRecordBuilder(ContractCallRecordBuilder.class))
+        given(savepointStack.addChildRecordBuilder(ContractCallStreamBuilder.class))
                 .willReturn(recordBuilder);
         given(recordBuilder.transaction(Transaction.DEFAULT)).willReturn(recordBuilder);
         given(recordBuilder.status(ResponseCodeEnum.FAIL_INVALID)).willReturn(recordBuilder);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/PrngSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/PrngSystemContractTest.java
@@ -35,7 +35,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.PrngSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.ProxyEvmContract;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import java.util.ArrayDeque;
@@ -71,7 +71,7 @@ class PrngSystemContractTest {
     ProxyWorldUpdater proxyWorldUpdater;
 
     @Mock
-    ContractCallRecordBuilder contractCallRecordBuilder;
+    ContractCallStreamBuilder contractCallRecordBuilder;
 
     @Mock
     private ProxyEvmContract mutableAccount;
@@ -163,7 +163,7 @@ class PrngSystemContractTest {
         given(messageFrame.getValue()).willReturn(Wei.ZERO);
         given(proxyWorldUpdater.entropy()).willReturn(Bytes.wrap(ZERO_ENTROPY.toByteArray()));
         when(systemContractOperations.externalizePreemptedDispatch(any(), any()))
-                .thenReturn(mock(ContractCallRecordBuilder.class));
+                .thenReturn(mock(ContractCallStreamBuilder.class));
 
         // when:
         var actual = subject.computeFully(PSEUDO_RANDOM_SYSTEM_CONTRACT_ADDRESS, messageFrame);
@@ -182,7 +182,7 @@ class PrngSystemContractTest {
         given(messageFrame.getWorldUpdater()).willReturn(proxyWorldUpdater);
         given(messageFrame.getValue()).willReturn(Wei.ONE);
         when(systemContractOperations.externalizePreemptedDispatch(any(), any()))
-                .thenReturn(mock(ContractCallRecordBuilder.class));
+                .thenReturn(mock(ContractCallStreamBuilder.class));
 
         // when:
         var actual = subject.computeFully(PSEUDO_RANDOM_SYSTEM_CONTRACT_ADDRESS, messageFrame);
@@ -198,7 +198,7 @@ class PrngSystemContractTest {
 
         given(systemContractGasCalculator.canonicalGasRequirement(any())).willReturn(GAS_REQUIRED);
         when(systemContractOperations.externalizePreemptedDispatch(any(), any()))
-                .thenReturn(mock(ContractCallRecordBuilder.class));
+                .thenReturn(mock(ContractCallStreamBuilder.class));
 
         // when:
         var actual = subject.computeFully(EXPECTED_RANDOM_NUMBER, messageFrame);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hbarApprove/HbarApproveCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hbarApprove/HbarApproveCallTest.java
@@ -29,7 +29,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarapprove.HbarApproveCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarapprove.HbarApproveTranslator;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
@@ -46,7 +46,7 @@ class HbarApproveCallTest extends CallTestBase {
     private TransactionBody transactionBody;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Test
     void revertsWithNoOwner() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/DispatchForResponseCodeHtsCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/DispatchForResponseCodeHtsCallTest.java
@@ -34,7 +34,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.DispatchGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -58,7 +58,7 @@ class DispatchForResponseCodeHtsCallTest extends CallTestBase {
     private DispatchGasCalculator dispatchGasCalculator;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     private final Deque<MessageFrame> stack = new ArrayDeque<>();
 
@@ -83,7 +83,7 @@ class DispatchForResponseCodeHtsCallTest extends CallTestBase {
                         TransactionBody.DEFAULT,
                         verificationStrategy,
                         AccountID.DEFAULT,
-                        ContractCallRecordBuilder.class))
+                        ContractCallStreamBuilder.class))
                 .willReturn(recordBuilder);
         given(dispatchGasCalculator.gasRequirement(
                         TransactionBody.DEFAULT, gasCalculator, mockEnhancement(), AccountID.DEFAULT))
@@ -128,7 +128,7 @@ class DispatchForResponseCodeHtsCallTest extends CallTestBase {
                         TransactionBody.DEFAULT,
                         verificationStrategy,
                         AccountID.DEFAULT,
-                        ContractCallRecordBuilder.class))
+                        ContractCallStreamBuilder.class))
                 .willReturn(recordBuilder);
         given(dispatchGasCalculator.gasRequirement(
                         TransactionBody.DEFAULT, gasCalculator, mockEnhancement(), AccountID.DEFAULT))

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/ClassicCreatesCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/ClassicCreatesCallTest.java
@@ -43,7 +43,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.ClassicCreatesCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateTranslator;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
@@ -65,7 +65,7 @@ public class ClassicCreatesCallTest extends CallTestBase {
     private AddressIdConverter addressIdConverter;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Mock
     private BlockValues blockValues;
@@ -325,7 +325,7 @@ public class ClassicCreatesCallTest extends CallTestBase {
                             any(TransactionBody.class),
                             eq(verificationStrategy),
                             eq(A_NEW_ACCOUNT_ID),
-                            eq(ContractCallRecordBuilder.class)))
+                            eq(ContractCallStreamBuilder.class)))
                     .willReturn(recordBuilder);
         }
         given(frame.getBlockValues()).willReturn(blockValues);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ClassicGrantApprovalCallTest.java
@@ -34,7 +34,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalcu
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.ClassicGrantApprovalCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
@@ -48,7 +48,7 @@ public class ClassicGrantApprovalCallTest extends CallTestBase {
     private VerificationStrategy verificationStrategy;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Mock
     private SystemContractGasCalculator systemContractGasCalculator;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
@@ -43,7 +43,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalcu
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.ERCGrantApprovalCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -62,7 +62,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
     private SystemContractGasCalculator systemContractGasCalculator;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Mock
     private Nft nft;
@@ -94,7 +94,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(OWNER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
         given(nativeOperations.readableAccountStore()).willReturn(accountStore);
@@ -126,7 +126,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(OWNER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
         given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID.tokenNum(), 100L)).willReturn(nft);
@@ -163,7 +163,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(OWNER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(INVALID_ALLOWANCE_SPENDER_ID);
         final var result = subject.execute(frame).fullResult().result();
@@ -190,7 +190,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(OWNER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status())
                 .willReturn(DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL)
@@ -220,7 +220,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(OWNER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(INVALID_TOKEN_NFT_SERIAL_NUMBER);
 
@@ -245,7 +245,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(OWNER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
         given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID.tokenNum(), 100L)).willReturn(nft);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllCallTest.java
@@ -33,7 +33,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.Addres
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.setapproval.SetApprovalForAllCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.setapproval.SetApprovalForAllTranslator;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
@@ -53,7 +53,7 @@ public class SetApprovalForAllCallTest extends CallTestBase {
     private HtsCallAttempt attempt;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Mock
     private AddressIdConverter addressIdConverter;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersCallTest.java
@@ -48,7 +48,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transf
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.SpecialRewardReceivers;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.SystemAccountCreditScreen;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import java.util.Optional;
@@ -73,7 +73,7 @@ class ClassicTransfersCallTest extends CallTestBase {
     private ApprovalSwitchHelper approvalSwitchHelper;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Mock
     private SystemAccountCreditScreen systemAccountCreditScreen;
@@ -93,7 +93,7 @@ class ClassicTransfersCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(A_NEW_ACCOUNT_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(SUCCESS);
         given(systemContractOperations.activeSignatureTestWith(verificationStrategy))
@@ -126,7 +126,7 @@ class ClassicTransfersCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(A_NEW_ACCOUNT_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(SUCCESS);
         given(systemContractOperations.activeSignatureTestWith(verificationStrategy))
@@ -150,7 +150,7 @@ class ClassicTransfersCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(A_NEW_ACCOUNT_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status())
                 .willReturn(INVALID_SIGNATURE)
@@ -209,7 +209,7 @@ class ClassicTransfersCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(A_NEW_ACCOUNT_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(SPENDER_DOES_NOT_HAVE_ALLOWANCE);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc20TransfersCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc20TransfersCallTest.java
@@ -43,7 +43,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc20TransfersCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.SpecialRewardReceivers;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -67,7 +67,7 @@ class Erc20TransfersCallTest extends CallTestBase {
     private VerificationStrategy verificationStrategy;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Mock
     private SystemContractGasCalculator systemContractGasCalculator;
@@ -105,7 +105,7 @@ class Erc20TransfersCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
         given(nativeOperations.readableAccountStore()).willReturn(readableAccountStore);
@@ -127,7 +127,7 @@ class Erc20TransfersCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(nativeOperations.readableAccountStore()).willReturn(readableAccountStore);
         given(readableAccountStore.getAliasedAccountById(A_NEW_ACCOUNT_ID)).willReturn(OWNER_ACCOUNT);
@@ -149,7 +149,7 @@ class Erc20TransfersCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(INSUFFICIENT_ACCOUNT_BALANCE);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc721TransferFromCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc721TransferFromCallTest.java
@@ -37,7 +37,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc721TransferFromCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.SpecialRewardReceivers;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -64,7 +64,7 @@ class Erc721TransferFromCallTest extends CallTestBase {
     private SpecialRewardReceivers specialRewardReceivers;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     private Erc721TransferFromCall subject;
 
@@ -76,7 +76,7 @@ class Erc721TransferFromCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
         given(addressIdConverter.convert(FROM_ADDRESS)).willReturn(SENDER_ID);
@@ -101,7 +101,7 @@ class Erc721TransferFromCallTest extends CallTestBase {
                         any(TransactionBody.class),
                         eq(verificationStrategy),
                         eq(SENDER_ID),
-                        eq(ContractCallRecordBuilder.class)))
+                        eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
         given(recordBuilder.status()).willReturn(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/SpecialRewardReceiversTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/SpecialRewardReceiversTest.java
@@ -20,7 +20,6 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.HAPI_RECORD_BUILDER_CONTEXT_VARIABLE;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.A_NEW_ACCOUNT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.B_NEW_ACCOUNT_ID;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
@@ -30,7 +29,7 @@ import com.hedera.hapi.node.base.TokenTransferList;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.AssessedCustomFee;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
@@ -50,7 +49,7 @@ class SpecialRewardReceiversTest {
     private MessageFrame initialFrame;
 
     @Mock
-    private ContractOperationRecordBuilder recordBuilder;
+    private ContractOperationStreamBuilder recordBuilder;
 
     private final Deque<MessageFrame> stack = new ArrayDeque<>();
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/FrameBuilderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/FrameBuilderTest.java
@@ -56,7 +56,7 @@ import com.hedera.node.app.service.contract.impl.exec.utils.FrameBuilder;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmBlocks;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.HederaEvmAccount;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -117,7 +117,7 @@ class FrameBuilderTest {
     void constructsExpectedFrameForCallToExtantContractIncludingOptionalContextVariables() {
         final var transaction = wellKnownHapiCall();
         givenContractExists();
-        final var recordBuilder = mock(ContractOperationRecordBuilder.class);
+        final var recordBuilder = mock(ContractOperationStreamBuilder.class);
         given(worldUpdater.getHederaAccount(CALLED_CONTRACT_ID)).willReturn(account);
         given(account.getEvmCode(Bytes.wrap(CALL_DATA.toByteArray()))).willReturn(CONTRACT_CODE);
         given(worldUpdater.updater()).willReturn(stackedUpdater);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
@@ -36,7 +36,7 @@ import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextTransactionProcessor;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCallHandler;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
@@ -69,7 +69,7 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
     private ContextTransactionProcessor processor;
 
     @Mock
-    private ContractCallRecordBuilder recordBuilder;
+    private ContractCallStreamBuilder recordBuilder;
 
     @Mock
     private HandleContext.SavepointStack stack;
@@ -92,7 +92,7 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
         given(factory.create(handleContext, HederaFunctionality.CONTRACT_CALL)).willReturn(component);
         given(component.contextTransactionProcessor()).willReturn(processor);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(ContractCallRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ContractCallStreamBuilder.class)).willReturn(recordBuilder);
         final var expectedResult = SUCCESS_RESULT.asProtoResultOf(baseProxyWorldUpdater);
         final var expectedOutcome = new CallOutcome(
                 expectedResult,
@@ -115,7 +115,7 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
         given(factory.create(handleContext, HederaFunctionality.CONTRACT_CALL)).willReturn(component);
         given(component.contextTransactionProcessor()).willReturn(processor);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(ContractCallRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ContractCallStreamBuilder.class)).willReturn(recordBuilder);
         final var expectedResult = HALT_RESULT.asProtoResultOf(baseProxyWorldUpdater);
         final var expectedOutcome =
                 new CallOutcome(expectedResult, HALT_RESULT.finalStatus(), null, HALT_RESULT.gasPrice(), null, null);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
@@ -40,7 +40,7 @@ import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextTransactionProcessor;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCreateHandler;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
@@ -78,7 +78,7 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
     private ContextTransactionProcessor processor;
 
     @Mock
-    private ContractCreateRecordBuilder recordBuilder;
+    private ContractCreateStreamBuilder recordBuilder;
 
     @Mock
     private HandleContext.SavepointStack stack;
@@ -99,7 +99,7 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
                 .willReturn(component);
         given(component.contextTransactionProcessor()).willReturn(processor);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(ContractCreateRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ContractCreateStreamBuilder.class)).willReturn(recordBuilder);
         given(baseProxyWorldUpdater.getCreatedContractIds()).willReturn(List.of(CALLED_CONTRACT_ID));
         final var expectedResult = SUCCESS_RESULT.asProtoResultOf(baseProxyWorldUpdater);
         System.out.println(expectedResult);
@@ -120,7 +120,7 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
                 .willReturn(component);
         given(component.contextTransactionProcessor()).willReturn(processor);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(ContractCreateRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ContractCreateStreamBuilder.class)).willReturn(recordBuilder);
         final var expectedResult = HALT_RESULT.asProtoResultOf(baseProxyWorldUpdater);
         final var expectedOutcome =
                 new CallOutcome(expectedResult, HALT_RESULT.finalStatus(), null, HALT_RESULT.gasPrice(), null, null);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractDeleteHandlerTest.java
@@ -43,7 +43,7 @@ import com.hedera.hapi.node.contract.ContractDeleteTransactionBody;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.handlers.ContractDeleteHandler;
-import com.hedera.node.app.service.contract.impl.records.ContractDeleteRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractDeleteStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.spi.fees.FeeCalculator;
@@ -77,7 +77,7 @@ class ContractDeleteHandlerTest {
     private ReadableAccountStore readableAccountStore;
 
     @Mock
-    private ContractDeleteRecordBuilder recordBuilder;
+    private ContractDeleteStreamBuilder recordBuilder;
 
     @Mock
     private HandleContext.SavepointStack stack;
@@ -226,7 +226,7 @@ class ContractDeleteHandlerTest {
         given(context.storeFactory()).willReturn(storeFactory);
         given(storeFactory.serviceApi(TokenServiceApi.class)).willReturn(tokenServiceApi);
         given(context.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(ContractDeleteRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ContractDeleteStreamBuilder.class)).willReturn(recordBuilder);
     }
 
     private static final Account TBD_CONTRACT = Account.newBuilder()

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerTest.java
@@ -58,7 +58,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Account.Builder;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.handlers.ContractUpdateHandler;
-import com.hedera.node.app.service.contract.impl.records.ContractUpdateRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractUpdateStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.spi.fees.FeeCalculator;
@@ -124,7 +124,7 @@ class ContractUpdateHandlerTest extends ContractHandlerTestBase {
     private TokensConfig tokensConfig;
 
     @Mock
-    private ContractUpdateRecordBuilder recordBuilder;
+    private ContractUpdateStreamBuilder recordBuilder;
 
     @Mock
     private HandleContext.SavepointStack stack;
@@ -472,7 +472,7 @@ class ContractUpdateHandlerTest extends ContractHandlerTestBase {
         when(stakingConfig.isEnabled()).thenReturn(true);
         when(contract.copyBuilder()).thenReturn(mock(Builder.class));
         when(context.savepointStack()).thenReturn(stack);
-        when(stack.getBaseBuilder(ContractUpdateRecordBuilder.class)).thenReturn(recordBuilder);
+        when(stack.getBaseBuilder(ContractUpdateStreamBuilder.class)).thenReturn(recordBuilder);
 
         subject.handle(context);
 
@@ -703,7 +703,7 @@ class ContractUpdateHandlerTest extends ContractHandlerTestBase {
         when(stakingConfig.isEnabled()).thenReturn(true);
         when(contract.copyBuilder()).thenReturn(mock(Builder.class));
         when(context.savepointStack()).thenReturn(stack);
-        when(stack.getBaseBuilder(ContractUpdateRecordBuilder.class)).thenReturn(recordBuilder);
+        when(stack.getBaseBuilder(ContractUpdateStreamBuilder.class)).thenReturn(recordBuilder);
 
         subject.handle(context);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
@@ -52,9 +52,9 @@ import com.hedera.node.app.service.contract.impl.hevm.HydratedEthTxData;
 import com.hedera.node.app.service.contract.impl.infra.EthTxSigsCache;
 import com.hedera.node.app.service.contract.impl.infra.EthereumCallDataHydration;
 import com.hedera.node.app.service.contract.impl.infra.HevmTransactionFactory;
-import com.hedera.node.app.service.contract.impl.records.ContractCallRecordBuilder;
-import com.hedera.node.app.service.contract.impl.records.ContractCreateRecordBuilder;
-import com.hedera.node.app.service.contract.impl.records.EthereumTransactionRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.EthereumTransactionStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.HederaEvmAccount;
 import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
@@ -102,13 +102,13 @@ class EthereumTransactionHandlerTest {
     private TransactionComponent.Factory factory;
 
     @Mock
-    private EthereumTransactionRecordBuilder recordBuilder;
+    private EthereumTransactionStreamBuilder recordBuilder;
 
     @Mock
-    private ContractCallRecordBuilder callRecordBuilder;
+    private ContractCallStreamBuilder callRecordBuilder;
 
     @Mock
-    private ContractCreateRecordBuilder createRecordBuilder;
+    private ContractCreateStreamBuilder createRecordBuilder;
 
     @Mock
     private HandleContext.SavepointStack stack;
@@ -185,8 +185,8 @@ class EthereumTransactionHandlerTest {
         given(component.hydratedEthTxData()).willReturn(HydratedEthTxData.successFrom(ETH_DATA_WITH_TO_ADDRESS));
         setUpTransactionProcessing();
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(EthereumTransactionRecordBuilder.class)).willReturn(recordBuilder);
-        given(stack.getBaseBuilder(ContractCallRecordBuilder.class)).willReturn(callRecordBuilder);
+        given(stack.getBaseBuilder(EthereumTransactionStreamBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ContractCallStreamBuilder.class)).willReturn(callRecordBuilder);
         givenSenderAccount();
         final var expectedResult =
                 SUCCESS_RESULT_WITH_SIGNER_NONCE.asProtoResultOf(ETH_DATA_WITH_TO_ADDRESS, baseProxyWorldUpdater);
@@ -212,8 +212,8 @@ class EthereumTransactionHandlerTest {
         given(component.hydratedEthTxData()).willReturn(HydratedEthTxData.successFrom(ETH_DATA_WITHOUT_TO_ADDRESS));
         setUpTransactionProcessing();
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(EthereumTransactionRecordBuilder.class)).willReturn(recordBuilder);
-        given(stack.getBaseBuilder(ContractCreateRecordBuilder.class)).willReturn(createRecordBuilder);
+        given(stack.getBaseBuilder(EthereumTransactionStreamBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(ContractCreateStreamBuilder.class)).willReturn(createRecordBuilder);
         given(baseProxyWorldUpdater.getCreatedContractIds()).willReturn(List.of(CALLED_CONTRACT_ID));
         final var expectedResult =
                 SUCCESS_RESULT_WITH_SIGNER_NONCE.asProtoResultOf(ETH_DATA_WITHOUT_TO_ADDRESS, baseProxyWorldUpdater);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/records/ContractOperationStreamBuilderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/records/ContractOperationStreamBuilderTest.java
@@ -34,9 +34,9 @@ import com.hedera.hapi.streams.ContractBytecode;
 import com.hedera.hapi.streams.ContractStateChange;
 import com.hedera.hapi.streams.ContractStateChanges;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
-import com.hedera.node.app.service.contract.impl.records.ContractOperationRecordBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -47,17 +47,17 @@ import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
-class ContractOperationRecordBuilderTest {
+class ContractOperationStreamBuilderTest {
     @Test
     void withGasFeeWorksAsExpected() {
-        final var subject = new ContractOperationRecordBuilder() {
+        final var subject = new ContractOperationStreamBuilder() {
             @Override
             public int getNumAutoAssociations() {
                 return 0;
             }
 
             @Override
-            public SingleTransactionRecordBuilder transaction(@NonNull Transaction transaction) {
+            public StreamBuilder transaction(@NonNull Transaction transaction) {
                 return this;
             }
 
@@ -82,17 +82,17 @@ class ContractOperationRecordBuilderTest {
             }
 
             @Override
-            public SingleTransactionRecordBuilder memo(@NonNull String memo) {
+            public StreamBuilder memo(@NonNull String memo) {
                 return this;
             }
 
             @Override
-            public SingleTransactionRecordBuilder transactionBytes(@NonNull Bytes transactionBytes) {
+            public StreamBuilder transactionBytes(@NonNull Bytes transactionBytes) {
                 return this;
             }
 
             @Override
-            public SingleTransactionRecordBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate) {
+            public StreamBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate) {
                 return this;
             }
 
@@ -120,14 +120,14 @@ class ContractOperationRecordBuilderTest {
             }
 
             @Override
-            public ContractOperationRecordBuilder transactionFee(final long transactionFee) {
+            public ContractOperationStreamBuilder transactionFee(final long transactionFee) {
                 totalFee = transactionFee;
                 return this;
             }
 
             @NonNull
             @Override
-            public ContractOperationRecordBuilder addContractActions(
+            public ContractOperationStreamBuilder addContractActions(
                     @NonNull ContractActions contractActions, boolean isMigration) {
                 this.actions = contractActions;
                 return this;
@@ -135,14 +135,14 @@ class ContractOperationRecordBuilderTest {
 
             @NonNull
             @Override
-            public ContractOperationRecordBuilder addContractBytecode(
+            public ContractOperationStreamBuilder addContractBytecode(
                     @NonNull ContractBytecode contractBytecode, boolean isMigration) {
                 return this;
             }
 
             @NonNull
             @Override
-            public ContractOperationRecordBuilder addContractStateChanges(
+            public ContractOperationStreamBuilder addContractStateChanges(
                     @NonNull ContractStateChanges contractStateChanges, boolean isMigration) {
                 stateChanges = contractStateChanges;
                 return this;
@@ -172,7 +172,7 @@ class ContractOperationRecordBuilderTest {
             }
 
             @Override
-            public SingleTransactionRecordBuilder status(@NonNull ResponseCodeEnum status) {
+            public StreamBuilder status(@NonNull ResponseCodeEnum status) {
                 return this;
             }
 
@@ -190,12 +190,12 @@ class ContractOperationRecordBuilderTest {
             public void nullOutSideEffectFields() {}
 
             @Override
-            public SingleTransactionRecordBuilder syncBodyIdFromRecordId() {
+            public StreamBuilder syncBodyIdFromRecordId() {
                 return null;
             }
 
             @Override
-            public SingleTransactionRecordBuilder consensusTimestamp(@NotNull final Instant now) {
+            public StreamBuilder consensusTimestamp(@NotNull final Instant now) {
                 return null;
             }
 
@@ -205,12 +205,12 @@ class ContractOperationRecordBuilderTest {
             }
 
             @Override
-            public SingleTransactionRecordBuilder transactionID(@NotNull final TransactionID transactionID) {
+            public StreamBuilder transactionID(@NotNull final TransactionID transactionID) {
                 return null;
             }
 
             @Override
-            public SingleTransactionRecordBuilder parentConsensus(@NotNull final Instant parentConsensus) {
+            public StreamBuilder parentConsensus(@NotNull final Instant parentConsensus) {
                 return null;
             }
         };

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
@@ -36,7 +36,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.api.ContractChangeSummary;
-import com.hedera.node.app.service.token.api.FeeRecordBuilder;
+import com.hedera.node.app.service.token.api.FeeStreamBuilder;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
@@ -326,7 +326,7 @@ public class TokenServiceApiImpl implements TokenServiceApi {
 
     @Override
     public boolean chargeNetworkFee(
-            @NonNull final AccountID payerId, final long amount, @NonNull final FeeRecordBuilder rb) {
+            @NonNull final AccountID payerId, final long amount, @NonNull final FeeStreamBuilder rb) {
         requireNonNull(rb);
         requireNonNull(payerId);
 
@@ -344,7 +344,7 @@ public class TokenServiceApiImpl implements TokenServiceApi {
             @NonNull AccountID payerId,
             AccountID nodeAccountId,
             @NonNull Fees fees,
-            @NonNull final FeeRecordBuilder rb) {
+            @NonNull final FeeStreamBuilder rb) {
         requireNonNull(rb);
         requireNonNull(fees);
         requireNonNull(payerId);
@@ -384,7 +384,7 @@ public class TokenServiceApiImpl implements TokenServiceApi {
     }
 
     @Override
-    public void refundFees(@NonNull AccountID receiver, @NonNull Fees fees, @NonNull final FeeRecordBuilder rb) {
+    public void refundFees(@NonNull AccountID receiver, @NonNull Fees fees, @NonNull final FeeStreamBuilder rb) {
         throw new UnsupportedOperationException("Not yet implemented");
     }
 
@@ -574,7 +574,7 @@ public class TokenServiceApiImpl implements TokenServiceApi {
         return account.smartContract() ? EntityType.CONTRACT : EntityType.ACCOUNT;
     }
 
-    private void distributeToNetworkFundingAccounts(final long amount, @NonNull final FeeRecordBuilder rb) {
+    private void distributeToNetworkFundingAccounts(final long amount, @NonNull final FeeStreamBuilder rb) {
         // We may have a rounding error, so we will first remove the node and staking rewards from the total, and then
         // whatever is left over goes to the funding account.
         long balance = amount;

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
@@ -74,7 +74,7 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.validators.CryptoCreateValidator;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -82,7 +82,7 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.CryptoCreateWithAliasConfig;
 import com.hedera.node.config.data.EntitiesConfig;
@@ -272,7 +272,7 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
         accountStore.put(accountCreated);
 
         final var createdAccountID = accountCreated.accountIdOrThrow();
-        final var recordBuilder = context.savepointStack().getBaseBuilder(CryptoCreateRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(CryptoCreateStreamBuilder.class);
         recordBuilder.accountID(createdAccountID);
 
         // Put if any new alias is associated with the account into account store
@@ -368,9 +368,7 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
         cryptoCreateValidator.validateKey(
                 op.keyOrThrow(), // cannot be null by this point
                 context.attributeValidator(),
-                context.savepointStack()
-                        .getBaseBuilder(SingleTransactionRecordBuilder.class)
-                        .isInternalDispatch());
+                context.savepointStack().getBaseBuilder(StreamBuilder.class).isInternalDispatch());
 
         // Validate the staking information included in this account creation.
         if (op.hasStakedAccountId() || op.hasStakedNodeId()) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteHandler.java
@@ -30,7 +30,7 @@ import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.CryptoFeeBuilder;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.service.token.api.TokenServiceApi.FreeAliasOnDeletion;
-import com.hedera.node.app.service.token.records.CryptoDeleteRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoDeleteStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -93,7 +93,7 @@ public class CryptoDeleteHandler implements TransactionHandler {
                         op.deleteAccountIDOrThrow(),
                         op.transferAccountIDOrThrow(),
                         context.expiryValidator(),
-                        context.savepointStack().getBaseBuilder(CryptoDeleteRecordBuilder.class),
+                        context.savepointStack().getBaseBuilder(CryptoDeleteStreamBuilder.class),
                         accountsConfig.releaseAliasAfterDeletion() ? FreeAliasOnDeletion.YES : FreeAliasOnDeletion.NO);
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
@@ -64,7 +64,7 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.CryptoTransferEx
 import com.hedera.node.app.service.token.impl.handlers.transfer.CustomFeeAssessmentStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
 import com.hedera.node.app.service.token.impl.validators.CryptoTransferValidator;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -235,7 +235,7 @@ public class CryptoTransferHandler implements TransactionHandler {
         // create a new transfer context that is specific only for this transaction
         final var transferContext =
                 new TransferContextImpl(context, enforceMonoServiceRestrictionsOnAutoCreationCustomFeePayments);
-        final var recordBuilder = context.savepointStack().getBaseBuilder(CryptoTransferRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(CryptoTransferStreamBuilder.class);
 
         executor.executeCryptoTransfer(txn, transferContext, context, validator, recordBuilder);
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeRecordHandler.java
@@ -37,11 +37,11 @@ import com.hedera.node.app.service.token.impl.WritableNftStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHandler;
-import com.hedera.node.app.service.token.records.ChildRecordBuilder;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.ChildStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.service.token.records.FinalizeContext;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.StakingConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -97,7 +97,7 @@ public class FinalizeRecordHandler extends RecordFinalizerBase {
             @NonNull final HederaFunctionality functionality,
             @Nullable final Set<AccountID> explicitRewardReceivers,
             @Nullable final Map<AccountID, Long> prePaidRewards) {
-        final var recordBuilder = context.userTransactionRecordBuilder(CryptoTransferRecordBuilder.class);
+        final var recordBuilder = context.userTransactionRecordBuilder(CryptoTransferStreamBuilder.class);
 
         // This handler won't ask the context for its transaction, but instead will determine the net hbar transfers and
         // token transfers based on the original value from writable state, and based on changes made during this
@@ -130,8 +130,7 @@ public class FinalizeRecordHandler extends RecordFinalizerBase {
         } catch (HandleException e) {
             if (e.getStatus() == FAIL_INVALID) {
                 logHbarFinalizationFailInvalid(
-                        context.userTransactionRecordBuilder(SingleTransactionRecordBuilder.class),
-                        writableAccountStore);
+                        context.userTransactionRecordBuilder(StreamBuilder.class), writableAccountStore);
             }
             throw e;
         }
@@ -170,8 +169,7 @@ public class FinalizeRecordHandler extends RecordFinalizerBase {
     // invoke logger parameters conditionally
     @SuppressWarnings("java:S2629")
     private void logHbarFinalizationFailInvalid(
-            @NonNull final SingleTransactionRecordBuilder recordBuilder,
-            @NonNull final WritableAccountStore accountStore) {
+            @NonNull final StreamBuilder recordBuilder, @NonNull final WritableAccountStore accountStore) {
         logger.error(
                 """
                         Non-zero net hbar change when handling body
@@ -194,7 +192,7 @@ public class FinalizeRecordHandler extends RecordFinalizerBase {
             @NonNull final Map<TokenID, List<NftTransfer>> nftTransfers,
             @NonNull final Map<AccountID, Long> hbarChanges) {
         final Map<NftID, AccountID> finalNftOwners = new HashMap<>();
-        context.forEachChildRecord(ChildRecordBuilder.class, childRecord -> {
+        context.forEachChildRecord(ChildStreamBuilder.class, childRecord -> {
             final List<AccountAmount> childHbarChangesFromRecord = childRecord.transferList() == null
                     ? emptyList()
                     : childRecord.transferList().accountAmounts();

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -52,7 +52,7 @@ import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
-import com.hedera.node.app.service.token.records.TokenAccountWipeRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenAccountWipeStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
@@ -213,7 +213,7 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
                 .build());
         // Note: record(s) for this operation will be built in a token finalization method so that we keep track of all
         // changes for records
-        final var record = context.savepointStack().getBaseBuilder(TokenAccountWipeRecordBuilder.class);
+        final var record = context.savepointStack().getBaseBuilder(TokenAccountWipeStreamBuilder.class);
         // Set newTotalSupply in record
         record.newTotalSupply(newTotalSupply);
         record.tokenType(token.tokenType());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
@@ -47,7 +47,7 @@ import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
-import com.hedera.node.app.service.token.records.TokenBurnRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBurnStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -126,7 +126,7 @@ public final class TokenBurnHandler extends BaseTokenHandler implements Transact
             validateTrue(treasuryRel.kycGranted(), ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN);
         }
 
-        TokenBurnRecordBuilder record = context.savepointStack().getBaseBuilder(TokenBurnRecordBuilder.class);
+        TokenBurnStreamBuilder record = context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class);
         if (token.tokenType() == TokenType.FUNGIBLE_COMMON) {
             validateTrue(fungibleBurnCount >= 0, INVALID_TOKEN_BURN_AMOUNT);
             final var newTotalSupply = changeSupply(

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
@@ -46,7 +46,7 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.CustomFeesValidator;
 import com.hedera.node.app.service.token.impl.validators.TokenCreateValidator;
-import com.hedera.node.app.service.token.records.TokenCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenCreateStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
@@ -127,7 +127,7 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
         final var tokenStore = storeFactory.writableStore(WritableTokenStore.class);
         final var tokenRelationStore = storeFactory.writableStore(WritableTokenRelationStore.class);
 
-        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenCreateRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenCreateStreamBuilder.class);
 
         /* Validate if the current token can be created */
         validateTrue(
@@ -193,7 +193,7 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
             final WritableAccountStore accountStore,
             @NonNull final WritableTokenRelationStore tokenRelStore,
             final List<CustomFee> requireCollectorAutoAssociation,
-            final TokenCreateRecordBuilder recordBuilder) {
+            final TokenCreateStreamBuilder recordBuilder) {
         final var tokensConfig = context.configuration().getConfigData(TokensConfig.class);
         final var entitiesConfig = context.configuration().getConfigData(EntitiesConfig.class);
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
@@ -37,7 +37,7 @@ import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -104,7 +104,7 @@ public class TokenDeleteHandler implements TransactionHandler {
                 .build();
         accountStore.put(updatedAccount);
 
-        final var record = context.savepointStack().getBaseBuilder(TokenBaseRecordBuilder.class);
+        final var record = context.savepointStack().getBaseBuilder(TokenBaseStreamBuilder.class);
         record.tokenType(updatedToken.tokenType());
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFeeScheduleUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFeeScheduleUpdateHandler.java
@@ -42,7 +42,7 @@ import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.CustomFeesValidator;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -133,7 +133,7 @@ public class TokenFeeScheduleUpdateHandler implements TransactionHandler {
         // add token to the modifications map
         tokenStore.put(copy.build());
 
-        final var record = context.savepointStack().getBaseBuilder(TokenBaseRecordBuilder.class);
+        final var record = context.savepointStack().getBaseBuilder(TokenBaseStreamBuilder.class);
         record.tokenType(token.tokenType());
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
@@ -54,7 +54,7 @@ import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
-import com.hedera.node.app.service.token.records.TokenMintRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenMintStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -134,7 +134,7 @@ public class TokenMintHandler extends BaseTokenHandler implements TransactionHan
             validateTrue(treasuryRel.kycGranted(), ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN);
         }
 
-        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenMintRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenMintStreamBuilder.class);
         if (token.tokenType() == TokenType.FUNGIBLE_COMMON) {
             validateTrue(op.amount() >= 0, INVALID_TOKEN_MINT_AMOUNT);
             // we need to know if treasury mint while creation to ignore supply key exist or not.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenPauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenPauseHandler.java
@@ -30,7 +30,7 @@ import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -89,7 +89,7 @@ public class TokenPauseHandler implements TransactionHandler {
         final var copyBuilder = token.copyBuilder();
         copyBuilder.paused(true);
         tokenStore.put(copyBuilder.build());
-        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenBaseRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenBaseStreamBuilder.class);
         recordBuilder.tokenType(token.tokenType());
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
@@ -28,7 +28,7 @@ import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -86,7 +86,7 @@ public class TokenUnpauseHandler implements TransactionHandler {
         final var copyBuilder = token.copyBuilder();
         copyBuilder.paused(false);
         tokenStore.put(copyBuilder.build());
-        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenBaseRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenBaseStreamBuilder.class);
         recordBuilder.tokenType(token.tokenType());
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -60,7 +60,7 @@ import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenKey;
 import com.hedera.node.app.service.token.impl.validators.TokenUpdateValidator;
-import com.hedera.node.app.service.token.records.TokenUpdateRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenUpdateStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
@@ -131,7 +131,7 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
         final var txn = context.body();
         final var op = txn.tokenUpdateOrThrow();
         final var tokenId = op.tokenOrThrow();
-        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenUpdateRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(TokenUpdateStreamBuilder.class);
 
         // validate fields that involve config or state
         final var validationResult = tokenUpdateValidator.validateSemantics(context, op);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
@@ -22,7 +22,7 @@ import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.
 import static com.hedera.node.app.service.token.impl.handlers.staking.EndOfStakingPeriodUtils.calculateRewardSumHistory;
 import static com.hedera.node.app.service.token.impl.handlers.staking.EndOfStakingPeriodUtils.computeNextStake;
 import static com.hedera.node.app.service.token.impl.handlers.staking.EndOfStakingPeriodUtils.readableNonZeroHistory;
-import static com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.transactionWith;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.transactionWith;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -37,7 +37,7 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.impl.WritableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
-import com.hedera.node.app.service.token.records.NodeStakeUpdateRecordBuilder;
+import com.hedera.node.app.service.token.records.NodeStakeUpdateStreamBuilder;
 import com.hedera.node.app.service.token.records.TokenContext;
 import com.hedera.node.app.spi.numbers.HederaAccountNumbers;
 import com.hedera.node.config.data.StakingConfig;
@@ -256,7 +256,7 @@ public class EndOfStakingPeriodUpdater {
         // We don't want to fail adding the preceding child record for the node stake update that happens every
         // midnight. So, we add the preceding child record builder as unchecked, that doesn't fail with
         // MAX_CHILD_RECORDS_EXCEEDED
-        final var nodeStakeUpdateBuilder = context.addPrecedingChildRecordBuilder(NodeStakeUpdateRecordBuilder.class);
+        final var nodeStakeUpdateBuilder = context.addPrecedingChildRecordBuilder(NodeStakeUpdateStreamBuilder.class);
         nodeStakeUpdateBuilder
                 .transaction(transactionWith(syntheticNodeStakeUpdateTxn.build()))
                 .memo("End of staking period calculation record")

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
@@ -50,7 +50,7 @@ import com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler;
 import com.hedera.node.app.spi.workflows.ComputeDispatchFeesAsTopLevel;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.config.data.EntitiesConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -197,9 +197,7 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
 
             // We only charge auto-association fees inline if this is a user dispatch; for internal dispatches,
             // the contract service will take the auto-association costs from the remaining EVM gas
-            if (context.savepointStack()
-                    .getBaseBuilder(SingleTransactionRecordBuilder.class)
-                    .isUserDispatch()) {
+            if (context.savepointStack().getBaseBuilder(StreamBuilder.class).isUserDispatch()) {
                 final var unlimitedAssociationsEnabled =
                         config.getConfigData(EntitiesConfig.class).unlimitedAutoAssociationsEnabled();
                 // And the "sender pays" fee model only applies when using unlimited auto-associations

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
@@ -34,7 +34,7 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.token.CryptoCreateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
@@ -94,7 +94,7 @@ public class AutoAccountCreator {
         // Dispatch the auto-creation record as a preceding record; note we pass null for the
         // "verification assistant" since we have no non-payer signatures to verify here
         final var childRecord = handleContext.dispatchRemovablePrecedingTransaction(
-                syntheticCreation.build(), CryptoCreateRecordBuilder.class, null, handleContext.payer());
+                syntheticCreation.build(), CryptoCreateStreamBuilder.class, null, handleContext.payer());
         childRecord.memo(memo);
 
         // If the child transaction failed, we should fail the parent transaction as well and propagate the failure.

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CryptoTransferExecutor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CryptoTransferExecutor.java
@@ -23,7 +23,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.impl.validators.CryptoTransferValidator;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -59,7 +59,7 @@ public class CryptoTransferExecutor {
             TransferContextImpl transferContext,
             HandleContext context,
             CryptoTransferValidator validator,
-            CryptoTransferRecordBuilder recordBuilder) {
+            CryptoTransferStreamBuilder recordBuilder) {
         executeCryptoTransfer(txn, transferContext, context, validator, recordBuilder, false);
     }
 
@@ -84,7 +84,7 @@ public class CryptoTransferExecutor {
             TransferContextImpl transferContext,
             HandleContext context,
             CryptoTransferValidator validator,
-            CryptoTransferRecordBuilder recordBuilder) {
+            CryptoTransferStreamBuilder recordBuilder) {
         executeCryptoTransfer(txn, transferContext, context, validator, recordBuilder, true);
     }
 
@@ -103,7 +103,7 @@ public class CryptoTransferExecutor {
             TransferContextImpl transferContext,
             HandleContext context,
             CryptoTransferValidator validator,
-            CryptoTransferRecordBuilder recordBuilder,
+            CryptoTransferStreamBuilder recordBuilder,
             boolean skipCustomFee) {
         final var topLevelPayer = context.payer();
         // Use the op with replaced aliases in further steps

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
@@ -71,7 +71,7 @@ import com.hedera.node.app.service.token.impl.handlers.CryptoCreateHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.CryptoCreateValidator;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
@@ -113,7 +113,7 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
     private FeeContext feeContext;
 
     @Mock
-    private CryptoCreateRecordBuilder recordBuilder;
+    private CryptoCreateStreamBuilder recordBuilder;
 
     @Mock
     private HandleContext.SavepointStack stack;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteHandlerTest.java
@@ -54,7 +54,7 @@ import com.hedera.node.app.service.token.impl.api.TokenServiceApiImpl;
 import com.hedera.node.app.service.token.impl.handlers.CryptoDeleteHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
-import com.hedera.node.app.service.token.records.CryptoDeleteRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoDeleteStreamBuilder;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.spi.store.StoreFactory;
@@ -92,7 +92,7 @@ class CryptoDeleteHandlerTest extends CryptoHandlerTestBase {
     private WritableStates writableStates;
 
     @Mock
-    private CryptoDeleteRecordBuilder recordBuilder;
+    private CryptoDeleteStreamBuilder recordBuilder;
 
     @Mock
     private HandleContext.SavepointStack stack;
@@ -293,7 +293,7 @@ class CryptoDeleteHandlerTest extends CryptoHandlerTestBase {
         givenTxnWith(deleteAccountId, transferAccountId);
         given(expiryValidator.isDetached(eq(EntityType.ACCOUNT), anyBoolean(), anyLong()))
                 .willReturn(false);
-        given(stack.getBaseBuilder(CryptoDeleteRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(CryptoDeleteStreamBuilder.class)).willReturn(recordBuilder);
 
         subject.handle(handleContext);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
@@ -62,8 +62,8 @@ import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.handlers.CryptoTransferHandler;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -71,7 +71,7 @@ import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.WarmupContext;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.app.workflows.handle.DispatchHandleContext;
 import com.hedera.node.app.workflows.handle.cache.CacheWarmer;
@@ -91,7 +91,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
     @Mock
-    private CryptoTransferRecordBuilder transferRecordBuilder;
+    private CryptoTransferStreamBuilder transferRecordBuilder;
 
     private static final TokenID TOKEN_1357 = asToken(1357);
     private static final TokenID TOKEN_9191 = asToken(9191);
@@ -462,7 +462,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
         givenTxn();
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -496,7 +496,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
         givenTxn();
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -527,8 +527,8 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
         given(handleContext.expiryValidator()).willReturn(expiryValidator);
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(SingleTransactionRecordBuilder.class)).willReturn(transferRecordBuilder);
-        given(stack.getBaseBuilder(CryptoTransferRecordBuilder.class)).willReturn(transferRecordBuilder);
+        given(stack.getBaseBuilder(StreamBuilder.class)).willReturn(transferRecordBuilder);
+        given(stack.getBaseBuilder(CryptoTransferStreamBuilder.class)).willReturn(transferRecordBuilder);
 
         subject.handle(handleContext);
 
@@ -580,7 +580,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
         givenTxn(txnBody, payerId);
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -628,7 +628,7 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
         givenTxn(txnBody, payerId);
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeRecordHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/FinalizeRecordHandlerTest.java
@@ -55,11 +55,11 @@ import com.hedera.node.app.service.token.impl.handlers.FinalizeRecordHandler;
 import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHandlerImpl;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.test.handlers.util.TestStoreFactory;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.service.token.records.FinalizeContext;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.Collections;
@@ -99,7 +99,7 @@ class FinalizeRecordHandlerTest extends CryptoTokenHandlerTestBase {
     private FinalizeContext context;
 
     @Mock
-    private CryptoTransferRecordBuilder recordBuilder;
+    private CryptoTransferStreamBuilder recordBuilder;
 
     private ReadableAccountStore readableAccountStore;
     private WritableAccountStore writableAccountStore;
@@ -135,8 +135,7 @@ class FinalizeRecordHandlerTest extends CryptoTokenHandlerTestBase {
                 .build());
         context = mockContext();
         given(context.configuration()).willReturn(configuration);
-        given(context.userTransactionRecordBuilder(SingleTransactionRecordBuilder.class))
-                .willReturn(mock(SingleTransactionRecordBuilder.class));
+        given(context.userTransactionRecordBuilder(StreamBuilder.class)).willReturn(mock(StreamBuilder.class));
 
         assertThatThrownBy(() -> subject.finalizeStakingRecord(
                         context, HederaFunctionality.CRYPTO_DELETE, Collections.emptySet(), emptyMap()))
@@ -160,8 +159,7 @@ class FinalizeRecordHandlerTest extends CryptoTokenHandlerTestBase {
                 .build());
         context = mockContext();
         given(context.configuration()).willReturn(configuration);
-        given(context.userTransactionRecordBuilder(SingleTransactionRecordBuilder.class))
-                .willReturn(mock(SingleTransactionRecordBuilder.class));
+        given(context.userTransactionRecordBuilder(StreamBuilder.class)).willReturn(mock(StreamBuilder.class));
 
         assertThatThrownBy(() -> subject.finalizeStakingRecord(
                         context, HederaFunctionality.CRYPTO_DELETE, Collections.emptySet(), emptyMap()))
@@ -253,7 +251,7 @@ class FinalizeRecordHandlerTest extends CryptoTokenHandlerTestBase {
         context = mockContext();
         given(context.configuration()).willReturn(configuration);
 
-        final var childRecord = mock(SingleTransactionRecordBuilderImpl.class);
+        final var childRecord = mock(RecordStreamBuilder.class);
         // child record has  1212 (-) -> 3434(+) transfer
         given(childRecord.transferList())
                 .willReturn(TransferList.newBuilder()
@@ -973,7 +971,7 @@ class FinalizeRecordHandlerTest extends CryptoTokenHandlerTestBase {
     }
 
     private FinalizeContext mockContext() {
-        given(context.userTransactionRecordBuilder(CryptoTransferRecordBuilder.class))
+        given(context.userTransactionRecordBuilder(CryptoTransferStreamBuilder.class))
                 .willReturn(recordBuilder);
 
         given(context.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -71,7 +71,7 @@ import com.hedera.node.app.service.token.impl.handlers.TokenAccountWipeHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.ParityTestBase;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
 import com.hedera.node.app.service.token.records.TokenAccountWipeStreamBuilder;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -232,7 +232,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
             @NonNull
             @Override
-            public TokenBaseRecordBuilder tokenType(final @NonNull TokenType tokenType) {
+            public TokenBaseStreamBuilder tokenType(final @NonNull TokenType tokenType) {
                 return this;
             }
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -70,14 +70,14 @@ import com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler;
 import com.hedera.node.app.service.token.impl.handlers.TokenAccountWipeHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.ParityTestBase;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
-import com.hedera.node.app.service.token.records.TokenAccountWipeRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenAccountWipeStreamBuilder;
 import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
@@ -102,7 +102,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
     private final TokenAccountWipeHandler subject = new TokenAccountWipeHandler(validator);
 
     private Configuration configuration;
-    private TokenAccountWipeRecordBuilder recordBuilder;
+    private TokenAccountWipeStreamBuilder recordBuilder;
 
     @BeforeEach
     public void setUp() {
@@ -111,7 +111,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
                 .withValue("tokens.nfts.areEnabled", true)
                 .withValue("tokens.nfts.maxBatchSizeWipe", 100)
                 .getOrCreateConfig();
-        recordBuilder = new TokenAccountWipeRecordBuilder() {
+        recordBuilder = new TokenAccountWipeStreamBuilder() {
             private long newTotalSupply;
 
             @Override
@@ -145,22 +145,22 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
             }
 
             @Override
-            public SingleTransactionRecordBuilder memo(@NonNull String memo) {
+            public StreamBuilder memo(@NonNull String memo) {
                 return this;
             }
 
             @Override
-            public SingleTransactionRecordBuilder transaction(@NonNull Transaction transaction) {
+            public StreamBuilder transaction(@NonNull Transaction transaction) {
                 return this;
             }
 
             @Override
-            public SingleTransactionRecordBuilder transactionBytes(@NonNull Bytes transactionBytes) {
+            public StreamBuilder transactionBytes(@NonNull Bytes transactionBytes) {
                 return this;
             }
 
             @Override
-            public SingleTransactionRecordBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate) {
+            public StreamBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate) {
                 return this;
             }
 
@@ -181,7 +181,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
             }
 
             @Override
-            public SingleTransactionRecordBuilder status(@NonNull ResponseCodeEnum status) {
+            public StreamBuilder status(@NonNull ResponseCodeEnum status) {
                 return this;
             }
 
@@ -199,12 +199,12 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
             public void nullOutSideEffectFields() {}
 
             @Override
-            public SingleTransactionRecordBuilder syncBodyIdFromRecordId() {
+            public StreamBuilder syncBodyIdFromRecordId() {
                 return null;
             }
 
             @Override
-            public SingleTransactionRecordBuilder consensusTimestamp(@NotNull final Instant now) {
+            public StreamBuilder consensusTimestamp(@NotNull final Instant now) {
                 return null;
             }
 
@@ -214,18 +214,18 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
             }
 
             @Override
-            public SingleTransactionRecordBuilder transactionID(@NotNull final TransactionID transactionID) {
+            public StreamBuilder transactionID(@NotNull final TransactionID transactionID) {
                 return null;
             }
 
             @Override
-            public SingleTransactionRecordBuilder parentConsensus(@NotNull final Instant parentConsensus) {
+            public StreamBuilder parentConsensus(@NotNull final Instant parentConsensus) {
                 return null;
             }
 
             @NonNull
             @Override
-            public TokenAccountWipeRecordBuilder newTotalSupply(final long supply) {
+            public TokenAccountWipeStreamBuilder newTotalSupply(final long supply) {
                 newTotalSupply = supply;
                 return this;
             }
@@ -1010,7 +1010,7 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
             lenient().when(context.savepointStack()).thenReturn(stack);
             lenient()
-                    .when(stack.getBaseBuilder(TokenAccountWipeRecordBuilder.class))
+                    .when(stack.getBaseBuilder(TokenAccountWipeStreamBuilder.class))
                     .thenReturn(recordBuilder);
 
             return context;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
@@ -65,14 +65,14 @@ import com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler;
 import com.hedera.node.app.service.token.impl.handlers.TokenBurnHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.ParityTestBase;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
-import com.hedera.node.app.service.token.records.TokenBurnRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBurnStreamBuilder;
 import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.test.fixtures.MapWritableKVState;
@@ -385,8 +385,8 @@ class TokenBurnHandlerTest extends ParityTestBase {
                     .build());
             final var txn = newBurnTxn(TOKEN_123, 8);
             final var context = mockContext(txn);
-            final var recordBuilder = new SingleTransactionRecordBuilderImpl();
-            given(context.savepointStack().getBaseBuilder(TokenBurnRecordBuilder.class))
+            final var recordBuilder = new RecordStreamBuilder();
+            given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
             subject.handle(context);
@@ -425,8 +425,8 @@ class TokenBurnHandlerTest extends ParityTestBase {
                     .build());
             final var txn = newBurnTxn(TOKEN_123, 8);
             final var context = mockContext(txn);
-            final var recordBuilder = new SingleTransactionRecordBuilderImpl();
-            given(context.savepointStack().getBaseBuilder(TokenBurnRecordBuilder.class))
+            final var recordBuilder = new RecordStreamBuilder();
+            given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
             subject.handle(context);
@@ -706,8 +706,8 @@ class TokenBurnHandlerTest extends ParityTestBase {
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L);
             final var context = mockContext(txn);
-            final var recordBuilder = new SingleTransactionRecordBuilderImpl();
-            given(context.savepointStack().getBaseBuilder(TokenBurnRecordBuilder.class))
+            final var recordBuilder = new RecordStreamBuilder();
+            given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
             subject.handle(context);
@@ -769,8 +769,8 @@ class TokenBurnHandlerTest extends ParityTestBase {
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L, 3L);
             final var context = mockContext(txn);
-            final var recordBuilder = new SingleTransactionRecordBuilderImpl();
-            given(context.savepointStack().getBaseBuilder(TokenBurnRecordBuilder.class))
+            final var recordBuilder = new RecordStreamBuilder();
+            given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
             subject.handle(context);
@@ -833,8 +833,8 @@ class TokenBurnHandlerTest extends ParityTestBase {
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L, 3L, 1L, 2L, 3L, 3L, 1L, 1L, 2L);
             final var context = mockContext(txn);
-            final var recordBuilder = new SingleTransactionRecordBuilderImpl();
-            given(context.savepointStack().getBaseBuilder(TokenBurnRecordBuilder.class))
+            final var recordBuilder = new RecordStreamBuilder();
+            given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
             subject.handle(context);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandlerTest.java
@@ -73,7 +73,7 @@ import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHand
 import com.hedera.node.app.service.token.impl.validators.CustomFeesValidator;
 import com.hedera.node.app.service.token.impl.validators.TokenAttributesValidator;
 import com.hedera.node.app.service.token.impl.validators.TokenCreateValidator;
-import com.hedera.node.app.service.token.records.TokenCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenCreateStreamBuilder;
 import com.hedera.node.app.spi.ids.EntityNumGenerator;
 import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
@@ -81,7 +81,7 @@ import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
@@ -107,7 +107,7 @@ class TokenCreateHandlerTest extends CryptoTokenHandlerTestBase {
     @Mock(strictness = LENIENT)
     private HandleContext.SavepointStack stack;
 
-    private TokenCreateRecordBuilder recordBuilder;
+    private TokenCreateStreamBuilder recordBuilder;
     private TokenCreateHandler subject;
     private TransactionBody txn;
     private CustomFeesValidator customFeesValidator;
@@ -128,7 +128,7 @@ class TokenCreateHandlerTest extends CryptoTokenHandlerTestBase {
     public void setUp() {
         super.setUp();
         refreshWritableStores();
-        recordBuilder = new SingleTransactionRecordBuilderImpl();
+        recordBuilder = new RecordStreamBuilder();
         tokenFieldsValidator = new TokenAttributesValidator();
         customFeesValidator = new CustomFeesValidator();
         tokenCreateValidator = new TokenCreateValidator(tokenFieldsValidator);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDeleteHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenDeleteHandlerTest.java
@@ -41,7 +41,7 @@ import com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler;
 import com.hedera.node.app.service.token.impl.handlers.TokenDeleteHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.ParityTestBase;
 import com.hedera.node.app.service.token.impl.test.util.SigReqAdapterUtils;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -167,7 +167,7 @@ class TokenDeleteHandlerTest extends ParityTestBase {
             given(storeFactory.writableStore(WritableTokenStore.class)).willReturn(writableTokenStore);
             given(storeFactory.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
             given(context.savepointStack()).willReturn(stack);
-            given(stack.getBaseBuilder(any())).willReturn(mock(TokenBaseRecordBuilder.class));
+            given(stack.getBaseBuilder(any())).willReturn(mock(TokenBaseStreamBuilder.class));
 
             return context;
         }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
@@ -51,7 +51,7 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenFeeScheduleUpdateHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.CustomFeesValidator;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
@@ -91,7 +91,7 @@ class TokenFeeScheduleUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     private PreHandleContext preHandleContext;
 
     @Mock(strictness = LENIENT)
-    private TokenBaseRecordBuilder recordBuilder;
+    private TokenBaseStreamBuilder recordBuilder;
 
     @Mock
     private StoreMetricsService storeMetricsService;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
@@ -44,7 +44,7 @@ import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenMintHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
-import com.hedera.node.app.service.token.records.TokenMintRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenMintStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -52,7 +52,7 @@ import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.time.Instant;
@@ -67,7 +67,7 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
 
     private final Bytes metadata1 = Bytes.wrap("memo".getBytes());
     private final Bytes metadata2 = Bytes.wrap("memo2".getBytes());
-    private SingleTransactionRecordBuilderImpl recordBuilder;
+    private RecordStreamBuilder recordBuilder;
     private TokenMintHandler subject;
 
     @BeforeEach
@@ -76,7 +76,7 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
         refreshWritableStores();
         givenStoresAndConfig(handleContext);
         subject = new TokenMintHandler(new TokenSupplyChangeOpsValidator());
-        recordBuilder = new SingleTransactionRecordBuilderImpl();
+        recordBuilder = new RecordStreamBuilder();
     }
 
     @Test
@@ -298,7 +298,7 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
 
         final var stack = mock(HandleContext.SavepointStack.class);
         given(handleContext.savepointStack()).willReturn(stack);
-        lenient().when(stack.getBaseBuilder(TokenMintRecordBuilder.class)).thenReturn(recordBuilder);
+        lenient().when(stack.getBaseBuilder(TokenMintStreamBuilder.class)).thenReturn(recordBuilder);
 
         return txnBody;
     }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenPauseHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenPauseHandlerTest.java
@@ -47,7 +47,7 @@ import com.hedera.node.app.service.token.impl.ReadableTokenStoreImpl;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenPauseHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.TokenHandlerTestBase;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -83,7 +83,7 @@ class TokenPauseHandlerTest extends TokenHandlerTestBase {
     private StoreFactory storeFactory;
 
     @Mock(strictness = LENIENT)
-    private TokenBaseRecordBuilder recordBuilder;
+    private TokenBaseStreamBuilder recordBuilder;
 
     @Mock(strictness = LENIENT)
     private HandleContext.SavepointStack stack;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnpauseHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnpauseHandlerTest.java
@@ -46,7 +46,7 @@ import com.hedera.node.app.service.token.impl.ReadableTokenStoreImpl;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenUnpauseHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.TokenHandlerTestBase;
-import com.hedera.node.app.service.token.records.TokenBaseRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -82,7 +82,7 @@ class TokenUnpauseHandlerTest extends TokenHandlerTestBase {
     private StoreFactory storeFactory;
 
     @Mock(strictness = LENIENT)
-    private TokenBaseRecordBuilder recordBuilder;
+    private TokenBaseStreamBuilder recordBuilder;
 
     @Mock(strictness = LENIENT)
     private HandleContext.SavepointStack stack;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
@@ -81,7 +81,7 @@ import com.hedera.node.app.service.token.impl.handlers.TokenUpdateHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.TokenAttributesValidator;
 import com.hedera.node.app.service.token.impl.validators.TokenUpdateValidator;
-import com.hedera.node.app.service.token.records.TokenUpdateRecordBuilder;
+import com.hedera.node.app.service.token.records.TokenUpdateStreamBuilder;
 import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
@@ -112,7 +112,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     private ConfigProvider configProvider;
 
     @Mock(strictness = LENIENT)
-    private TokenUpdateRecordBuilder recordBuilder;
+    private TokenUpdateStreamBuilder recordBuilder;
 
     @Mock(strictness = LENIENT)
     private HandleContext.SavepointStack stack;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
@@ -39,7 +39,7 @@ import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
 import com.hedera.node.app.service.token.impl.handlers.staking.EndOfStakingPeriodUpdater;
 import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper;
 import com.hedera.node.app.service.token.impl.test.handlers.util.TestStoreFactory;
-import com.hedera.node.app.service.token.records.NodeStakeUpdateRecordBuilder;
+import com.hedera.node.app.service.token.records.NodeStakeUpdateStreamBuilder;
 import com.hedera.node.app.service.token.records.TokenContext;
 import com.hedera.node.app.spi.fixtures.numbers.FakeHederaNumbers;
 import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
@@ -79,7 +79,7 @@ public class EndOfStakingPeriodUpdaterTest {
     private TokenContext context;
 
     @Mock
-    private NodeStakeUpdateRecordBuilder nodeStakeUpdateRecordBuilder;
+    private NodeStakeUpdateStreamBuilder nodeStakeUpdateRecordBuilder;
 
     private ReadableAccountStore accountStore;
 
@@ -420,7 +420,7 @@ public class EndOfStakingPeriodUpdaterTest {
                 .willReturn((WritableSingletonState) stakingRewardsState);
         stakingRewardsStore = new WritableNetworkStakingRewardsStore(states);
         given(context.writableStore(WritableNetworkStakingRewardsStore.class)).willReturn(stakingRewardsStore);
-        given(context.addPrecedingChildRecordBuilder(NodeStakeUpdateRecordBuilder.class))
+        given(context.addPrecedingChildRecordBuilder(NodeStakeUpdateStreamBuilder.class))
                 .willReturn(nodeStakeUpdateRecordBuilder);
         given(context.knownNodeIds()).willReturn(Set.of(NODE_NUM_1.number(), NODE_NUM_2.number(), NODE_NUM_3.number()));
     }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -39,7 +39,7 @@ import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHan
 import com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper;
 import com.hedera.node.app.service.token.impl.handlers.staking.StakingUtilities;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
-import com.hedera.node.app.service.token.records.CryptoDeleteRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoDeleteStreamBuilder;
 import com.hedera.node.app.service.token.records.FinalizeContext;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
@@ -68,7 +68,7 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
     private FinalizeContext context;
 
     @Mock
-    private CryptoDeleteRecordBuilder recordBuilder;
+    private CryptoDeleteStreamBuilder recordBuilder;
 
     private final InstantSource instantSource = InstantSource.system();
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustFungibleTokenChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustFungibleTokenChangesStepTest.java
@@ -43,7 +43,7 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesSte
 import com.hedera.node.app.service.token.impl.handlers.transfer.ReplaceAliasesWithIDsInOp;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,7 +71,7 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
                             new TokenRelation(nonFungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new SingleTransactionRecordBuilderImpl().status(SUCCESS);
+                    return new RecordStreamBuilder().status(SUCCESS);
                 });
     }
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
@@ -42,10 +42,10 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.AssociateTokenRe
 import com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.ReplaceAliasesWithIDsInOp;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,14 +53,13 @@ import org.mockito.Mock;
 
 class AdjustHbarChangesStepTest extends StepsBase {
     @Mock
-    private CryptoTransferRecordBuilder builder;
+    private CryptoTransferStreamBuilder builder;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
         refreshWritableStores();
-        given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(SingleTransactionRecordBuilder.class), eq(null), any()))
+        given(handleContext.dispatchRemovablePrecedingTransaction(any(), eq(StreamBuilder.class), eq(null), any()))
                 .will((invocation) -> {
                     final var relation =
                             new TokenRelation(fungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
@@ -68,7 +67,7 @@ class AdjustHbarChangesStepTest extends StepsBase {
                             new TokenRelation(nonFungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new SingleTransactionRecordBuilderImpl().status(SUCCESS);
+                    return new RecordStreamBuilder().status(SUCCESS);
                 });
         // since we can't change NFT owner with auto association if KYC key exists on token
         writableTokenStore.put(nonFungibleToken.copyBuilder().kycKey((Key) null).build());

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AssociateTokenRecipientsStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AssociateTokenRecipientsStepTest.java
@@ -31,7 +31,7 @@ import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.node.app.service.token.impl.handlers.transfer.AssociateTokenRecipientsStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
@@ -57,7 +57,7 @@ public class AssociateTokenRecipientsStepTest extends StepsBase {
     private HandleContext.SavepointStack stack;
 
     @Mock
-    private CryptoTransferRecordBuilder builder;
+    private CryptoTransferStreamBuilder builder;
 
     private AssociateTokenRecipientsStep subject;
     private CryptoTransferTransactionBody txn;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AutoAccountCreatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AutoAccountCreatorTest.java
@@ -30,7 +30,7 @@ import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.handlers.transfer.AutoAccountCreator;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -76,7 +76,7 @@ class AutoAccountCreatorTest extends StepsBase {
     void happyPathECKeyAliasWorks() {
         accountCreatorInternalSetup(false);
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -107,7 +107,7 @@ class AutoAccountCreatorTest extends StepsBase {
     void happyPathEDKeyAliasWorks() {
         accountCreatorInternalSetup(false);
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -139,7 +139,7 @@ class AutoAccountCreatorTest extends StepsBase {
         accountCreatorInternalSetup(false);
         final var address = new ProtoBytes(Bytes.wrap(evmAddress));
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/CustomFeeAssessmentStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/CustomFeeAssessmentStepTest.java
@@ -46,9 +46,9 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesSte
 import com.hedera.node.app.service.token.impl.handlers.transfer.ReplaceAliasesWithIDsInOp;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
 import com.hedera.node.app.service.token.impl.test.handlers.util.TestStoreFactory;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,13 +63,12 @@ class CustomFeeAssessmentStepTest extends StepsBase {
     private Token nonFungibleWithNoKyc;
 
     @Mock
-    private CryptoTransferRecordBuilder builder;
+    private CryptoTransferStreamBuilder builder;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
-        given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(SingleTransactionRecordBuilder.class), eq(null), any()))
+        given(handleContext.dispatchRemovablePrecedingTransaction(any(), eq(StreamBuilder.class), eq(null), any()))
                 .will((invocation) -> {
                     final var relation =
                             new TokenRelation(fungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
@@ -77,7 +76,7 @@ class CustomFeeAssessmentStepTest extends StepsBase {
                             new TokenRelation(nonFungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new SingleTransactionRecordBuilderImpl().status(SUCCESS);
+                    return new RecordStreamBuilder().status(SUCCESS);
                 });
 
         refreshWritableStores();
@@ -85,7 +84,7 @@ class CustomFeeAssessmentStepTest extends StepsBase {
         givenStoresAndConfig(handleContext);
         givenTxn();
         given(handleContext.body()).willReturn(txn);
-        given(stack.getBaseBuilder(CryptoTransferRecordBuilder.class)).willReturn(xferRecordBuilder);
+        given(stack.getBaseBuilder(CryptoTransferStreamBuilder.class)).willReturn(xferRecordBuilder);
         givenAutoCreationDispatchEffects(payerId);
 
         transferContext = new TransferContextImpl(handleContext);
@@ -385,15 +384,14 @@ class CustomFeeAssessmentStepTest extends StepsBase {
                                 .transfers(List.of(aaWith(payerId, -10), aaWith(ownerId, +10)))
                                 .build())
                 .build();
-        given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(SingleTransactionRecordBuilder.class), eq(null), any()))
+        given(handleContext.dispatchRemovablePrecedingTransaction(any(), eq(StreamBuilder.class), eq(null), any()))
                 .will((invocation) -> {
                     final var relation = new TokenRelation(fungibleTokenId, ownerId, 1, false, true, true, null, null);
                     final var relation1 =
                             new TokenRelation(fungibleTokenIDB, payerId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new SingleTransactionRecordBuilderImpl().status(SUCCESS);
+                    return new RecordStreamBuilder().status(SUCCESS);
                 });
         givenDifferentTxn(body, payerId);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
@@ -42,7 +42,7 @@ import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
@@ -72,7 +72,7 @@ class EnsureAliasesStepTest extends StepsBase {
     void autoCreatesAccounts() {
         ensureAliasesInternalSetup(false);
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -140,7 +140,7 @@ class EnsureAliasesStepTest extends StepsBase {
         givenTxn(body, payerId);
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy = account.copyBuilder()
                             .accountId(hbarReceiverId)
@@ -246,7 +246,7 @@ class EnsureAliasesStepTest extends StepsBase {
         transferContext = new TransferContextImpl(handleContext);
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/NFTOwnersChangeStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/NFTOwnersChangeStepTest.java
@@ -42,23 +42,22 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesSte
 import com.hedera.node.app.service.token.impl.handlers.transfer.NFTOwnersChangeStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.ReplaceAliasesWithIDsInOp;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
-import com.hedera.node.app.workflows.handle.record.SingleTransactionRecordBuilderImpl;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 class NFTOwnersChangeStepTest extends StepsBase {
     @Mock
-    private CryptoTransferRecordBuilder builder;
+    private CryptoTransferStreamBuilder builder;
 
     @BeforeEach
     public void setUp() {
         super.setUp();
-        given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(SingleTransactionRecordBuilder.class), eq(null), any()))
+        given(handleContext.dispatchRemovablePrecedingTransaction(any(), eq(StreamBuilder.class), eq(null), any()))
                 .will((invocation) -> {
                     final var relation =
                             new TokenRelation(fungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
@@ -66,7 +65,7 @@ class NFTOwnersChangeStepTest extends StepsBase {
                             new TokenRelation(nonFungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new SingleTransactionRecordBuilderImpl().status(SUCCESS);
+                    return new RecordStreamBuilder().status(SUCCESS);
                 });
 
         refreshWritableStores();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
@@ -40,7 +40,7 @@ import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
@@ -67,7 +67,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
     void autoCreatesAccounts() {
         replaceAliasesInternalSetup(false);
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -139,7 +139,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
         givenTxn(body, payerId);
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy = account.copyBuilder()
                             .accountId(hbarReceiverId)
@@ -247,7 +247,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
         transferContext = new TransferContextImpl(handleContext);
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -289,7 +289,7 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
         transferContext = new TransferContextImpl(handleContext);
 
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(payerId)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(payerId)))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/StepsBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/StepsBase.java
@@ -44,13 +44,13 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.NFTOwnersChangeS
 import com.hedera.node.app.service.token.impl.handlers.transfer.ReplaceAliasesWithIDsInOp;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
-import com.hedera.node.app.service.token.records.CryptoCreateRecordBuilder;
-import com.hedera.node.app.service.token.records.CryptoTransferRecordBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.List;
@@ -67,10 +67,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class StepsBase extends CryptoTokenHandlerTestBase {
     @Mock
-    protected CryptoTransferRecordBuilder xferRecordBuilder;
+    protected CryptoTransferStreamBuilder xferRecordBuilder;
 
     @Mock
-    protected CryptoCreateRecordBuilder cryptoCreateRecordBuilder;
+    protected CryptoCreateStreamBuilder cryptoCreateRecordBuilder;
 
     @Mock(strictness = Mock.Strictness.LENIENT)
     protected ConfigProvider configProvider;
@@ -179,7 +179,7 @@ public class StepsBase extends CryptoTokenHandlerTestBase {
         given(handleContext.expiryValidator()).willReturn(expiryValidator);
         given(handleContext.dispatchRemovableChildTransaction(
                         any(),
-                        eq(CryptoCreateRecordBuilder.class),
+                        eq(CryptoCreateStreamBuilder.class),
                         any(Predicate.class),
                         eq(payerId),
                         any(ExternalizedRecordCustomizer.class)))
@@ -195,7 +195,7 @@ public class StepsBase extends CryptoTokenHandlerTestBase {
 
     protected void givenAutoCreationDispatchEffects(AccountID syntheticPayer) {
         given(handleContext.dispatchRemovablePrecedingTransaction(
-                        any(), eq(CryptoCreateRecordBuilder.class), eq(null), eq(syntheticPayer)))
+                        any(), eq(CryptoCreateStreamBuilder.class), eq(null), eq(syntheticPayer)))
                 .will((invocation) -> {
                     final var copy = writableAccountStore
                             .get(hbarReceiverId)
@@ -219,8 +219,8 @@ public class StepsBase extends CryptoTokenHandlerTestBase {
                     return cryptoCreateRecordBuilder;
                 });
         given(storeFactory.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
-        given(stack.getBaseBuilder(CryptoCreateRecordBuilder.class)).willReturn(cryptoCreateRecordBuilder);
-        given(stack.getBaseBuilder(CryptoTransferRecordBuilder.class)).willReturn(xferRecordBuilder);
-        given(stack.getBaseBuilder(SingleTransactionRecordBuilder.class)).willReturn(xferRecordBuilder);
+        given(stack.getBaseBuilder(CryptoCreateStreamBuilder.class)).willReturn(cryptoCreateRecordBuilder);
+        given(stack.getBaseBuilder(CryptoTransferStreamBuilder.class)).willReturn(xferRecordBuilder);
+        given(stack.getBaseBuilder(StreamBuilder.class)).willReturn(xferRecordBuilder);
     }
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/FeeStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/FeeStreamBuilder.java
@@ -14,21 +14,27 @@
  * limitations under the License.
  */
 
-package com.hedera.node.app.service.token.records;
+package com.hedera.node.app.service.token.api;
 
-import com.hedera.hapi.node.base.TokenAssociation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the effects of a {@code TokenUpdate}
+ * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
  * transaction.
  */
-public interface TokenUpdateRecordBuilder extends TokenBaseRecordBuilder {
+public interface FeeStreamBuilder {
     /**
-     * Adds the token relations that are created by auto associations.
-     * This information is needed while building the transfer list, to set the auto association flag.
-     * @param tokenAssociation the token association that is created by auto association
+     * Gets the current value of the transaction fee in this builder.
+     * @return The current transaction fee value.
+     */
+    long transactionFee();
+
+    /**
+     * Sets the consensus transaction fee.
+     *
+     * @param transactionFee the transaction fee
      * @return the builder
      */
-    TokenUpdateRecordBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation tokenAssociation);
+    @NonNull
+    FeeStreamBuilder transactionFee(final long transactionFee);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/FeeStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/FeeStreamBuilder.java
@@ -19,7 +19,7 @@ package com.hedera.node.app.service.token.api;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
  * transaction.
  */
 public interface FeeStreamBuilder {

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
@@ -198,7 +198,7 @@ public interface TokenServiceApi {
      * @param recordBuilder the record builder to record the fees in
      * @return true if the full amount was charged, false otherwise
      */
-    boolean chargeNetworkFee(@NonNull AccountID payer, long amount, @NonNull final FeeRecordBuilder recordBuilder);
+    boolean chargeNetworkFee(@NonNull AccountID payer, long amount, @NonNull final FeeStreamBuilder recordBuilder);
 
     /**
      * Charges the payer the given fees, and records those fees in the given record builder.
@@ -212,7 +212,7 @@ public interface TokenServiceApi {
             @NonNull AccountID payer,
             AccountID nodeAccount,
             @NonNull Fees fees,
-            @NonNull final FeeRecordBuilder recordBuilder);
+            @NonNull final FeeStreamBuilder recordBuilder);
 
     /**
      * Refunds the given fees to the given receiver, and records those fees in the given record builder.
@@ -221,7 +221,7 @@ public interface TokenServiceApi {
      * @param fees          the fees to refund
      * @param recordBuilder the record builder to record the fees in
      */
-    void refundFees(@NonNull AccountID receiver, @NonNull Fees fees, @NonNull final FeeRecordBuilder recordBuilder);
+    void refundFees(@NonNull AccountID receiver, @NonNull Fees fees, @NonNull final FeeStreamBuilder recordBuilder);
 
     /**
      * Returns the number of storage slots used by the given account before any changes were made via

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildStreamBuilder.java
@@ -21,7 +21,7 @@ import com.hedera.hapi.node.base.TransferList;
 import java.util.List;
 
 /**
- * A {@code RecordBuilder} specialization for reading the transfer list from child records.
+ * A {@code StreamBuilder} specialization for reading the transfer list from child records.
  */
 public interface ChildStreamBuilder {
 

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/ChildStreamBuilder.java
@@ -16,10 +16,26 @@
 
 package com.hedera.node.app.service.token.records;
 
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.hapi.node.base.TokenTransferList;
+import com.hedera.hapi.node.base.TransferList;
+import java.util.List;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoDelete}
- * transaction.
+ * A {@code RecordBuilder} specialization for reading the transfer list from child records.
  */
-public interface CryptoDeleteRecordBuilder extends DeleteCapableTransactionRecordBuilder {}
+public interface ChildStreamBuilder {
+
+    /**
+     * Get the transfer list from the child record.
+     *
+     * @return the transfer list
+     */
+    TransferList transferList();
+
+    /**
+     * Get the token transfer lists, if any, from the child record.
+     *
+     * @return the token transfer lists
+     */
+    List<TokenTransferList> tokenTransferLists();
+}

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoCreateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoCreateStreamBuilder.java
@@ -22,7 +22,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
  * transaction.
  */
 public interface CryptoCreateStreamBuilder extends StreamBuilder {

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoCreateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoCreateStreamBuilder.java
@@ -16,35 +16,48 @@
 
 package com.hedera.node.app.service.token.records;
 
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
 
 /**
  * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
  * transaction.
  */
-public interface TokenMintRecordBuilder extends TokenBaseRecordBuilder {
+public interface CryptoCreateStreamBuilder extends StreamBuilder {
     /**
      * Tracks creation of a new account by number. Even if someday we support creating multiple
      * accounts within a smart contract call, we will still only need to track one created account
      * per child record.
      *
-     * @param serialNumbers the list of new serial numbers minted
+     * @param accountID the {@link AccountID} of the new account
      * @return this builder
      */
     @NonNull
-    TokenMintRecordBuilder serialNumbers(@NonNull List<Long> serialNumbers);
+    CryptoCreateStreamBuilder accountID(@NonNull AccountID accountID);
 
     /**
-     * Sets the new total supply of a token
-     * @param newTotalSupply the new total supply of a token
+     * The new EVM address of the account created by this transaction.
+     * @param evmAddress the new EVM address
      * @return this builder
      */
-    TokenMintRecordBuilder newTotalSupply(final long newTotalSupply);
+    @NonNull
+    CryptoCreateStreamBuilder evmAddress(@NonNull final Bytes evmAddress);
 
     /**
-     * Gets the new total supply of a token
-     * @return new total supply of a token
+     * The transactionFee charged for this transaction.
+     * @param transactionFee the transaction fee
+     * @return this builder
      */
-    long getNewTotalSupply();
+    @NonNull
+    CryptoCreateStreamBuilder transactionFee(@NonNull final long transactionFee);
+
+    /**
+     * The memo associated with the transaction.
+     * @param memo the memo
+     * @return this builder
+     */
+    @NonNull
+    CryptoCreateStreamBuilder memo(@NonNull final String memo);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoDeleteStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoDeleteStreamBuilder.java
@@ -16,25 +16,10 @@
 
 package com.hedera.node.app.service.token.records;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code TokenWipe}
+ * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoDelete}
  * transaction.
  */
-public interface TokenAccountWipeRecordBuilder extends TokenBaseRecordBuilder {
-
-    /**
-     * Gets the new total supply of a token
-     * @return new total supply of a token
-     */
-    long getNewTotalSupply();
-
-    /**
-     * Sets the new total supply of a token
-     * @param newTotalSupply the new total supply of a token
-     * @return this builder
-     */
-    @NonNull
-    TokenAccountWipeRecordBuilder newTotalSupply(final long newTotalSupply);
-}
+public interface CryptoDeleteStreamBuilder extends DeleteCapableTransactionRecordBuilder {}

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoDeleteStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoDeleteStreamBuilder.java
@@ -19,7 +19,7 @@ package com.hedera.node.app.service.token.records;
 import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoDelete}
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code CryptoDelete}
  * transaction.
  */
 public interface CryptoDeleteStreamBuilder extends DeleteCapableTransactionRecordBuilder {}

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoTransferStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoTransferStreamBuilder.java
@@ -22,7 +22,7 @@ import com.hedera.hapi.node.base.TokenTransferList;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.hapi.node.transaction.AssessedCustomFee;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
@@ -31,7 +31,7 @@ import java.util.List;
  * A {@code RecordBuilder} specialization for tracking the effects of a {@code CryptoTransfer}
  * transaction.
  */
-public interface CryptoTransferRecordBuilder extends SingleTransactionRecordBuilder {
+public interface CryptoTransferStreamBuilder extends StreamBuilder {
     /**
      * Tracks the <b>net</b> hbar transfers that need to be applied to the associated accounts
      * (accounts are specified in the {@code TransferList} input param)
@@ -40,7 +40,7 @@ public interface CryptoTransferRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    CryptoTransferRecordBuilder transferList(@NonNull TransferList hbarTransfers);
+    CryptoTransferStreamBuilder transferList(@NonNull TransferList hbarTransfers);
 
     /**
      * Tracks the <b>net</b> token transfers that need to be applied to the associated accounts,
@@ -51,7 +51,7 @@ public interface CryptoTransferRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    CryptoTransferRecordBuilder tokenTransferLists(@NonNull List<TokenTransferList> tokenTransferLists);
+    CryptoTransferStreamBuilder tokenTransferLists(@NonNull List<TokenTransferList> tokenTransferLists);
 
     /**
      * Tracks the total custom fees assessed in the transaction
@@ -59,14 +59,14 @@ public interface CryptoTransferRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    CryptoTransferRecordBuilder assessedCustomFees(@NonNull final List<AssessedCustomFee> assessedCustomFees);
+    CryptoTransferStreamBuilder assessedCustomFees(@NonNull final List<AssessedCustomFee> assessedCustomFees);
 
     /**
      * Tracks the total amount of hbars paid as staking rewards in the transaction
      * @param paidStakingRewards the total amount of hbars paid as staking rewards
      * @return this builder
      */
-    CryptoTransferRecordBuilder paidStakingRewards(@NonNull final List<AccountAmount> paidStakingRewards);
+    CryptoTransferStreamBuilder paidStakingRewards(@NonNull final List<AccountAmount> paidStakingRewards);
 
     /**
      * Adds the token relations that are created by auto associations.
@@ -74,7 +74,7 @@ public interface CryptoTransferRecordBuilder extends SingleTransactionRecordBuil
      * @param tokenAssociation the token association that is created by auto association
      * @return the builder
      */
-    CryptoTransferRecordBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation tokenAssociation);
+    CryptoTransferStreamBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation tokenAssociation);
 
     /**
      * Tracks the result of a contract call, if any. It is used to update the transaction record.
@@ -82,5 +82,5 @@ public interface CryptoTransferRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    CryptoTransferRecordBuilder contractCallResult(@Nullable ContractFunctionResult result);
+    CryptoTransferStreamBuilder contractCallResult(@Nullable ContractFunctionResult result);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoTransferStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoTransferStreamBuilder.java
@@ -28,7 +28,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the effects of a {@code CryptoTransfer}
+ * A {@code StreamBuilder} specialization for tracking the effects of a {@code CryptoTransfer}
  * transaction.
  */
 public interface CryptoTransferStreamBuilder extends StreamBuilder {

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoUpdateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoUpdateStreamBuilder.java
@@ -17,14 +17,14 @@
 package com.hedera.node.app.service.token.records;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoUpdate}
  * transaction.
  */
-public interface CryptoUpdateRecordBuilder extends SingleTransactionRecordBuilder {
+public interface CryptoUpdateStreamBuilder extends StreamBuilder {
     /**
      * Tracks update of a new account by number. Even if someday we support creating multiple
      * accounts within a smart contract call, we will still only need to track one created account
@@ -34,5 +34,5 @@ public interface CryptoUpdateRecordBuilder extends SingleTransactionRecordBuilde
      * @return this builder
      */
     @NonNull
-    CryptoUpdateRecordBuilder accountID(@NonNull AccountID accountID);
+    CryptoUpdateStreamBuilder accountID(@NonNull AccountID accountID);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoUpdateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoUpdateStreamBuilder.java
@@ -21,7 +21,7 @@ import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoUpdate}
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code CryptoUpdate}
  * transaction.
  */
 public interface CryptoUpdateStreamBuilder extends StreamBuilder {

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/FinalizeContext.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/FinalizeContext.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.token.records;
 
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
@@ -107,5 +107,5 @@ public interface FinalizeContext {
      * @throws IllegalArgumentException if the record builder type is unknown to the app
      */
     @NonNull
-    <T extends SingleTransactionRecordBuilder> T userTransactionRecordBuilder(@NonNull Class<T> recordBuilderClass);
+    <T extends StreamBuilder> T userTransactionRecordBuilder(@NonNull Class<T> recordBuilderClass);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/GenesisAccountStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/GenesisAccountStreamBuilder.java
@@ -24,7 +24,7 @@ import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} that collects and builds the information required to create a synthetic
+ * A {@code StreamBuilder} that collects and builds the information required to create a synthetic
  * account record, specifically for a system account created during node genesis (startup)
  */
 public interface GenesisAccountStreamBuilder extends StreamBuilder {

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/GenesisAccountStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/GenesisAccountStreamBuilder.java
@@ -20,14 +20,14 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransferList;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * A {@code RecordBuilder} that collects and builds the information required to create a synthetic
  * account record, specifically for a system account created during node genesis (startup)
  */
-public interface GenesisAccountRecordBuilder extends SingleTransactionRecordBuilder {
+public interface GenesisAccountStreamBuilder extends StreamBuilder {
 
     /**
      * Tracks the created account ID for the system account
@@ -35,7 +35,7 @@ public interface GenesisAccountRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    GenesisAccountRecordBuilder accountID(@NonNull final AccountID accountID);
+    GenesisAccountStreamBuilder accountID(@NonNull final AccountID accountID);
 
     /**
      * Tracks the synthetic transaction that represents the created system account
@@ -43,7 +43,7 @@ public interface GenesisAccountRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    GenesisAccountRecordBuilder transaction(@NonNull final Transaction txn);
+    GenesisAccountStreamBuilder transaction(@NonNull final Transaction txn);
 
     /**
      * Tracks the synthetic transaction that represents the created system account
@@ -51,7 +51,7 @@ public interface GenesisAccountRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    GenesisAccountRecordBuilder status(@NonNull ResponseCodeEnum status);
+    GenesisAccountStreamBuilder status(@NonNull ResponseCodeEnum status);
 
     /**
      * Tracks the memo for the synthetic record
@@ -59,7 +59,7 @@ public interface GenesisAccountRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    GenesisAccountRecordBuilder memo(@NonNull final String memo);
+    GenesisAccountStreamBuilder memo(@NonNull final String memo);
 
     /**
      * Tracks the <b>net</b> hbar transfers that need to be applied to the associated accounts
@@ -69,5 +69,5 @@ public interface GenesisAccountRecordBuilder extends SingleTransactionRecordBuil
      * @return this builder
      */
     @NonNull
-    CryptoTransferRecordBuilder transferList(@NonNull TransferList hbarTransfers);
+    CryptoTransferStreamBuilder transferList(@NonNull TransferList hbarTransfers);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/NodeStakeUpdateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/NodeStakeUpdateStreamBuilder.java
@@ -22,7 +22,7 @@ import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking {@code NodeStakeUpdate} at midnight UTC every day.
+ * A {@code StreamBuilder} specialization for tracking {@code NodeStakeUpdate} at midnight UTC every day.
  */
 public interface NodeStakeUpdateStreamBuilder extends StreamBuilder {
     /**

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/NodeStakeUpdateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/NodeStakeUpdateStreamBuilder.java
@@ -18,20 +18,20 @@ package com.hedera.node.app.service.token.records;
 
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.Transaction;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * A {@code RecordBuilder} specialization for tracking {@code NodeStakeUpdate} at midnight UTC every day.
  */
-public interface NodeStakeUpdateRecordBuilder extends SingleTransactionRecordBuilder {
+public interface NodeStakeUpdateStreamBuilder extends StreamBuilder {
     /**
      * Sets the status.
      *
      * @param status the status
      * @return the builder
      */
-    NodeStakeUpdateRecordBuilder status(@NonNull ResponseCodeEnum status);
+    NodeStakeUpdateStreamBuilder status(@NonNull ResponseCodeEnum status);
 
     /**
      * Sets the transaction.
@@ -40,7 +40,7 @@ public interface NodeStakeUpdateRecordBuilder extends SingleTransactionRecordBui
      * @return the builder
      */
     @NonNull
-    NodeStakeUpdateRecordBuilder transaction(@NonNull final Transaction transaction);
+    NodeStakeUpdateStreamBuilder transaction(@NonNull final Transaction transaction);
 
     /**
      * Sets the record's memo.
@@ -49,5 +49,5 @@ public interface NodeStakeUpdateRecordBuilder extends SingleTransactionRecordBui
      * @return the builder
      */
     @NonNull
-    NodeStakeUpdateRecordBuilder memo(@NonNull final String memo);
+    NodeStakeUpdateStreamBuilder memo(@NonNull final String memo);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenAccountWipeStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenAccountWipeStreamBuilder.java
@@ -16,26 +16,25 @@
 
 package com.hedera.node.app.service.token.records;
 
-import com.hedera.hapi.node.base.TokenTransferList;
-import com.hedera.hapi.node.base.TransferList;
-import java.util.List;
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for reading the transfer list from child records.
+ * A {@code RecordBuilder} specialization for tracking the side effects of a {@code TokenWipe}
+ * transaction.
  */
-public interface ChildRecordBuilder {
+public interface TokenAccountWipeStreamBuilder extends TokenBaseRecordBuilder {
 
     /**
-     * Get the transfer list from the child record.
-     *
-     * @return the transfer list
+     * Gets the new total supply of a token
+     * @return new total supply of a token
      */
-    TransferList transferList();
+    long getNewTotalSupply();
 
     /**
-     * Get the token transfer lists, if any, from the child record.
-     *
-     * @return the token transfer lists
+     * Sets the new total supply of a token
+     * @param newTotalSupply the new total supply of a token
+     * @return this builder
      */
-    List<TokenTransferList> tokenTransferLists();
+    @NonNull
+    TokenAccountWipeStreamBuilder newTotalSupply(final long newTotalSupply);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenAccountWipeStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenAccountWipeStreamBuilder.java
@@ -19,10 +19,10 @@ package com.hedera.node.app.service.token.records;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code TokenWipe}
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code TokenWipe}
  * transaction.
  */
-public interface TokenAccountWipeStreamBuilder extends TokenBaseRecordBuilder {
+public interface TokenAccountWipeStreamBuilder extends TokenBaseStreamBuilder {
 
     /**
      * Gets the new total supply of a token

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBaseRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBaseRecordBuilder.java
@@ -17,13 +17,13 @@
 package com.hedera.node.app.service.token.records;
 
 import com.hedera.hapi.node.base.TokenType;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * The base interface for Token Service record builders that record operations on Tokens.
  */
-public interface TokenBaseRecordBuilder extends SingleTransactionRecordBuilder {
+public interface TokenBaseRecordBuilder extends StreamBuilder {
     /**
      * Sets the {@link TokenType} of the token the recorded transaction created or modified.
      * @param tokenType the token type

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBaseStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBaseStreamBuilder.java
@@ -23,11 +23,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * The base interface for Token Service record builders that record operations on Tokens.
  */
-public interface TokenBaseRecordBuilder extends StreamBuilder {
+public interface TokenBaseStreamBuilder extends StreamBuilder {
     /**
      * Sets the {@link TokenType} of the token the recorded transaction created or modified.
      * @param tokenType the token type
      * @return this builder
      */
-    TokenBaseRecordBuilder tokenType(final @NonNull TokenType tokenType);
+    TokenBaseStreamBuilder tokenType(final @NonNull TokenType tokenType);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBurnStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBurnStreamBuilder.java
@@ -23,7 +23,7 @@ import java.util.List;
  * A {@code RecordBuilder} specialization for tracking the side effects of a {@code TokenBurn}
  * transaction.
  */
-public interface TokenBurnRecordBuilder extends TokenBaseRecordBuilder {
+public interface TokenBurnStreamBuilder extends TokenBaseRecordBuilder {
 
     /**
      * Gets the new total supply of a token
@@ -37,7 +37,7 @@ public interface TokenBurnRecordBuilder extends TokenBaseRecordBuilder {
      * @return this builder
      */
     @NonNull
-    TokenBurnRecordBuilder newTotalSupply(final long newTotalSupply);
+    TokenBurnStreamBuilder newTotalSupply(final long newTotalSupply);
 
     /**
      * Sets the list of serial numbers burned
@@ -45,5 +45,5 @@ public interface TokenBurnRecordBuilder extends TokenBaseRecordBuilder {
      * @return this builder
      */
     @NonNull
-    TokenBurnRecordBuilder serialNumbers(@NonNull List<Long> serialNumbers);
+    TokenBurnStreamBuilder serialNumbers(@NonNull List<Long> serialNumbers);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBurnStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenBurnStreamBuilder.java
@@ -20,10 +20,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code TokenBurn}
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code TokenBurn}
  * transaction.
  */
-public interface TokenBurnStreamBuilder extends TokenBaseRecordBuilder {
+public interface TokenBurnStreamBuilder extends TokenBaseStreamBuilder {
 
     /**
      * Gets the new total supply of a token

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenContext.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenContext.java
@@ -18,7 +18,7 @@ package com.hedera.node.app.service.token.records;
 
 import com.hedera.node.app.service.token.TokenService;
 import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
@@ -81,7 +81,7 @@ public interface TokenContext {
      * @throws IllegalArgumentException if the record builder type is unknown to the app
      */
     @NonNull
-    <T extends SingleTransactionRecordBuilder> T addPrecedingChildRecordBuilder(@NonNull Class<T> recordBuilderClass);
+    <T extends StreamBuilder> T addPrecedingChildRecordBuilder(@NonNull Class<T> recordBuilderClass);
 
     /**
      * Signal that any records created during startup migrations have been streamed.

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenCreateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenCreateStreamBuilder.java
@@ -25,7 +25,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A {@code RecordBuilder} specialization for tracking the side effects of a {@code TokenCreate}
  * transaction.
  */
-public interface TokenCreateRecordBuilder extends TokenBaseRecordBuilder {
+public interface TokenCreateStreamBuilder extends TokenBaseRecordBuilder {
     /**
      * Tracks creation of a new token by number. Even if someday we support creating multiple
      * tokens within a smart contract call, we will still only need to track one created token
@@ -35,7 +35,7 @@ public interface TokenCreateRecordBuilder extends TokenBaseRecordBuilder {
      * @return this builder
      */
     @NonNull
-    TokenCreateRecordBuilder tokenID(@NonNull TokenID tokenID);
+    TokenCreateStreamBuilder tokenID(@NonNull TokenID tokenID);
 
     /**
      * Gets the token ID of the token created
@@ -49,5 +49,5 @@ public interface TokenCreateRecordBuilder extends TokenBaseRecordBuilder {
      * @param tokenAssociation the token association that is created by auto association
      * @return the builder
      */
-    TokenCreateRecordBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation tokenAssociation);
+    TokenCreateStreamBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation tokenAssociation);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenCreateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenCreateStreamBuilder.java
@@ -22,10 +22,10 @@ import com.hedera.hapi.node.base.TokenID;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code TokenCreate}
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code TokenCreate}
  * transaction.
  */
-public interface TokenCreateStreamBuilder extends TokenBaseRecordBuilder {
+public interface TokenCreateStreamBuilder extends TokenBaseStreamBuilder {
     /**
      * Tracks creation of a new token by number. Even if someday we support creating multiple
      * tokens within a smart contract call, we will still only need to track one created token

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenMintStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenMintStreamBuilder.java
@@ -20,10 +20,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
+ * A {@code StreamBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
  * transaction.
  */
-public interface TokenMintStreamBuilder extends TokenBaseRecordBuilder {
+public interface TokenMintStreamBuilder extends TokenBaseStreamBuilder {
     /**
      * Tracks creation of a new account by number. Even if someday we support creating multiple
      * accounts within a smart contract call, we will still only need to track one created account

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenMintStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenMintStreamBuilder.java
@@ -16,48 +16,35 @@
 
 package com.hedera.node.app.service.token.records;
 
-import com.hedera.hapi.node.base.AccountID;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 
 /**
  * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CryptoCreate}
  * transaction.
  */
-public interface CryptoCreateRecordBuilder extends SingleTransactionRecordBuilder {
+public interface TokenMintStreamBuilder extends TokenBaseRecordBuilder {
     /**
      * Tracks creation of a new account by number. Even if someday we support creating multiple
      * accounts within a smart contract call, we will still only need to track one created account
      * per child record.
      *
-     * @param accountID the {@link AccountID} of the new account
+     * @param serialNumbers the list of new serial numbers minted
      * @return this builder
      */
     @NonNull
-    CryptoCreateRecordBuilder accountID(@NonNull AccountID accountID);
+    TokenMintStreamBuilder serialNumbers(@NonNull List<Long> serialNumbers);
 
     /**
-     * The new EVM address of the account created by this transaction.
-     * @param evmAddress the new EVM address
+     * Sets the new total supply of a token
+     * @param newTotalSupply the new total supply of a token
      * @return this builder
      */
-    @NonNull
-    CryptoCreateRecordBuilder evmAddress(@NonNull final Bytes evmAddress);
+    TokenMintStreamBuilder newTotalSupply(final long newTotalSupply);
 
     /**
-     * The transactionFee charged for this transaction.
-     * @param transactionFee the transaction fee
-     * @return this builder
+     * Gets the new total supply of a token
+     * @return new total supply of a token
      */
-    @NonNull
-    CryptoCreateRecordBuilder transactionFee(@NonNull final long transactionFee);
-
-    /**
-     * The memo associated with the transaction.
-     * @param memo the memo
-     * @return this builder
-     */
-    @NonNull
-    CryptoCreateRecordBuilder memo(@NonNull final String memo);
+    long getNewTotalSupply();
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenUpdateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenUpdateStreamBuilder.java
@@ -14,23 +14,21 @@
  * limitations under the License.
  */
 
-package com.hedera.node.app.service.file.impl.records;
+package com.hedera.node.app.service.token.records;
 
-import com.hedera.hapi.node.base.FileID;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.hapi.node.base.TokenAssociation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side effects of a {@code CreateFile} transaction.
+ * A {@code RecordBuilder} specialization for tracking the effects of a {@code TokenUpdate}
+ * transaction.
  */
-public interface CreateFileRecordBuilder extends SingleTransactionRecordBuilder {
-
+public interface TokenUpdateStreamBuilder extends TokenBaseRecordBuilder {
     /**
-     * Tracks creation of a new file by {@link FileID}
-     *
-     * @param fileID the {@link FileID} of the new file
-     * @return this builder
+     * Adds the token relations that are created by auto associations.
+     * This information is needed while building the transfer list, to set the auto association flag.
+     * @param tokenAssociation the token association that is created by auto association
+     * @return the builder
      */
-    @NonNull
-    CreateFileRecordBuilder fileID(@NonNull FileID fileID);
+    TokenUpdateStreamBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation tokenAssociation);
 }

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenUpdateStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/TokenUpdateStreamBuilder.java
@@ -20,10 +20,10 @@ import com.hedera.hapi.node.base.TokenAssociation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the effects of a {@code TokenUpdate}
+ * A {@code StreamBuilder} specialization for tracking the effects of a {@code TokenUpdate}
  * transaction.
  */
-public interface TokenUpdateStreamBuilder extends TokenBaseRecordBuilder {
+public interface TokenUpdateStreamBuilder extends TokenBaseStreamBuilder {
     /**
      * Adds the token relations that are created by auto associations.
      * This information is needed while building the transfer list, to set the auto association flag.

--- a/hedera-node/hedera-token-service/src/testFixtures/java/com/hedera/node/app/service/token/fixtures/FakeFeeRecordBuilder.java
+++ b/hedera-node/hedera-token-service/src/testFixtures/java/com/hedera/node/app/service/token/fixtures/FakeFeeRecordBuilder.java
@@ -19,13 +19,13 @@ package com.hedera.node.app.service.token.fixtures;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.node.app.service.token.api.FeeRecordBuilder;
+import com.hedera.node.app.service.token.api.FeeStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A fake implementation of {@link FeeRecordBuilder} for testing purposes.
+ * A fake implementation of {@link FeeStreamBuilder} for testing purposes.
  */
-public class FakeFeeRecordBuilder implements FeeRecordBuilder {
+public class FakeFeeRecordBuilder implements FeeStreamBuilder {
     private long transactionFee;
 
     public FakeFeeRecordBuilder() {
@@ -40,7 +40,7 @@ public class FakeFeeRecordBuilder implements FeeRecordBuilder {
 
     @Override
     @NonNull
-    public FeeRecordBuilder transactionFee(long transactionFee) {
+    public FeeStreamBuilder transactionFee(long transactionFee) {
         this.transactionFee = transactionFee;
         return this;
     }

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/UtilPrngHandler.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/UtilPrngHandler.java
@@ -20,7 +20,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.service.util.impl.records.PrngRecordBuilder;
+import com.hedera.node.app.service.util.impl.records.PrngStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -113,7 +113,7 @@ public class UtilPrngHandler implements TransactionHandler {
 
         // If `range` is provided then generate a random number in the given range from the pseudoRandomBytes,
         // otherwise just use the full pseudoRandomBytes as the random number.
-        final var recordBuilder = context.savepointStack().getBaseBuilder(PrngRecordBuilder.class);
+        final var recordBuilder = context.savepointStack().getBaseBuilder(PrngStreamBuilder.class);
         if (range > 0) {
             final var pseudoRandomNumber = randomNumFromBytes(pseudoRandomBytes, range);
             recordBuilder.entropyNumber(pseudoRandomNumber);

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/records/PrngStreamBuilder.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/records/PrngStreamBuilder.java
@@ -21,7 +21,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A {@code RecordBuilder} specialization for tracking the side-effects of a
+ * A {@code StreamBuilder} specialization for tracking the side-effects of a
  * {@code ConsensusCreateTopic} transaction.
  */
 public interface PrngStreamBuilder extends StreamBuilder {

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/records/PrngStreamBuilder.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/records/PrngStreamBuilder.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.service.util.impl.records;
 
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -24,7 +24,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * A {@code RecordBuilder} specialization for tracking the side-effects of a
  * {@code ConsensusCreateTopic} transaction.
  */
-public interface PrngRecordBuilder extends SingleTransactionRecordBuilder {
+public interface PrngStreamBuilder extends StreamBuilder {
     /**
      * Tracks the random number generated within the range provided in
      * {@link com.hedera.hapi.node.util.UtilPrngTransactionBody} if range is greater than 0.
@@ -33,7 +33,7 @@ public interface PrngRecordBuilder extends SingleTransactionRecordBuilder {
      * @return this builder
      */
     @NonNull
-    PrngRecordBuilder entropyNumber(final int num);
+    PrngStreamBuilder entropyNumber(final int num);
 
     /**
      * Tracks the pseudorandom 384-bit string generated when no output range is provided or range of 0 is provided in
@@ -43,5 +43,5 @@ public interface PrngRecordBuilder extends SingleTransactionRecordBuilder {
      * @return this builder
      */
     @NonNull
-    PrngRecordBuilder entropyBytes(@NonNull final Bytes prngBytes);
+    PrngStreamBuilder entropyBytes(@NonNull final Bytes prngBytes);
 }

--- a/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/UtilPrngHandlerTest.java
+++ b/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/UtilPrngHandlerTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.verify;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.node.util.UtilPrngTransactionBody;
 import com.hedera.node.app.service.util.impl.handlers.UtilPrngHandler;
-import com.hedera.node.app.service.util.impl.records.PrngRecordBuilder;
+import com.hedera.node.app.service.util.impl.records.PrngStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -62,7 +62,7 @@ class UtilPrngHandlerTest {
     private HandleContext handleContext;
 
     @Mock
-    private PrngRecordBuilder recordBuilder;
+    private PrngStreamBuilder recordBuilder;
 
     @Mock(strictness = LENIENT)
     private HandleContext.SavepointStack stack;
@@ -85,7 +85,7 @@ class UtilPrngHandlerTest {
 
         subject = new UtilPrngHandler();
         given(handleContext.savepointStack()).willReturn(stack);
-        given(stack.getBaseBuilder(PrngRecordBuilder.class)).willReturn(recordBuilder);
+        given(stack.getBaseBuilder(PrngStreamBuilder.class)).willReturn(recordBuilder);
         givenTxnWithoutRange();
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip993/NaturalDispatchOrderingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip993/NaturalDispatchOrderingTest.java
@@ -54,8 +54,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder;
-import com.hedera.node.app.spi.workflows.record.SingleTransactionRecordBuilder.ReversingBehavior;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.StreamDataListener;
@@ -88,13 +88,13 @@ import org.junit.jupiter.api.DynamicTest;
  * HIP-993 <a href="https://hips.hedera.com/hip/hip-993#natural-ordering-of-preceding-records">here</a>.
  * <p>
  * The only stream items created in a savepoint that are <b>not</b> expected to be present are those with reversing
- * behavior {@link SingleTransactionRecordBuilder.ReversingBehavior#REMOVABLE}, and whose originating savepoint was rolled back.
+ * behavior {@link StreamBuilder.ReversingBehavior#REMOVABLE}, and whose originating savepoint was rolled back.
  * <p>
  * All other stream items are expected to be present in the record stream once created; but if they are
- * {@link SingleTransactionRecordBuilder.ReversingBehavior#REVERSIBLE}, their status may be changed from {@code SUCCESS} to
+ * {@link StreamBuilder.ReversingBehavior#REVERSIBLE}, their status may be changed from {@code SUCCESS} to
  * {@code REVERTED_SUCCESS} when their originating savepoint is rolled back.
  * <p>
- * Only {@link SingleTransactionRecordBuilder.ReversingBehavior#IRREVERSIBLE} streams items appear unchanged in the record stream no matter whether
+ * Only {@link StreamBuilder.ReversingBehavior#IRREVERSIBLE} streams items appear unchanged in the record stream no matter whether
  * their originating savepoint is rolled back.
  */
 @DisplayName("given HIP-993 natural dispatch ordering")


### PR DESCRIPTION
**Description**:
 - Rename record stream builders to just `StreamBuilder`'s to reduce confusion in migration to block stream.