### PR TITLE
Draft to use NullAway

### DIFF
--- a/platform-sdk/null-handling-sample/build.gradle.kts
+++ b/platform-sdk/null-handling-sample/build.gradle.kts
@@ -1,0 +1,28 @@
+import net.ltgt.gradle.errorprone.CheckSeverity
+import net.ltgt.gradle.errorprone.errorprone
+
+plugins {
+    id("java-library")
+    id("net.ltgt.errorprone") version "4.0.1"
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+repositories { gradlePluginPortal() }
+
+dependencies {
+    errorprone("com.uber.nullaway:nullaway:0.11.1")
+    api("org.jspecify:jspecify:1.0.0")
+    errorprone("com.google.errorprone:error_prone_core:2.29.2")
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.errorprone {
+        disableAllChecks = true
+        check("NullAway", CheckSeverity.ERROR)
+        option("NullAway:AnnotatedPackages", "com.sample")
+    }
+}

--- a/platform-sdk/null-handling-sample/src/main/java/com/sample/Caller.java
+++ b/platform-sdk/null-handling-sample/src/main/java/com/sample/Caller.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.sample;
+
+public class Caller {
+
+    private final SomeService someService;
+
+    public Caller() {
+        this.someService = new SomeService(null);
+        someService.check(null);
+    }
+}

--- a/platform-sdk/null-handling-sample/src/main/java/com/sample/SomeService.java
+++ b/platform-sdk/null-handling-sample/src/main/java/com/sample/SomeService.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.sample;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class SomeService {
+
+    private final String name;
+
+    public SomeService(@NonNull final String name) {
+        Objects.requireNonNull(name, "name cannot be null");
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @NonNull
+    public LocalDateTime getLocalDateTime() {
+        return LocalDateTime.now();
+    }
+
+    public boolean check(@NonNull final String value) {
+        Objects.requireNonNull(value, "value cannot be null");
+        return Objects.equals(value, "test");
+    }
+
+    public boolean checkNullable(@Nullable final String value) {
+        return Objects.equals(value, "test");
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -82,6 +82,8 @@ include(":swirlds-platform", "platform-sdk")
 
 include(":swirlds", "platform-sdk/swirlds")
 
+include(":null-handling-sample", "platform-sdk/null-handling-sample")
+
 include(":swirlds-base", "platform-sdk/swirlds-base")
 
 include(":swirlds-logging", "platform-sdk/swirlds-logging")


### PR DESCRIPTION
The given draft adds a module that uses JSpecify (https://jspecify.dev) `null` annotations in code and NullAway (https://github.com/uber/NullAway) to check those annotations at build time. The build will fail with an error if a `null` annotation (`NonNull`, ...) is not handled correctly.

<img width="1497" alt="Bildschirmfoto 2024-08-01 um 09 46 56" src="https://github.com/user-attachments/assets/bc78085a-fc5c-460a-b137-0a9fdd384bd3">
