### PR TITLE
fix: Fixes issue with newVersion not being specified in versionAsSpecified Task

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
@@ -117,7 +117,7 @@ tasks.register("versionAsSpecified") {
 
     inputs.property("newVersion", providers.gradleProperty("newVersion").orElse(""))
 
-    if(inputs.properties["newVersion"] as String == "") {
+    if (inputs.properties["newVersion"] as String == "") {
         throw IllegalArgumentException(
             "No newVersion property provided! " +
                 "Please add the parameter -PnewVersion=<version> when running this task."

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
@@ -115,19 +115,14 @@ tasks.register("versionAsSnapshot") {
 tasks.register("versionAsSpecified") {
     group = "versioning"
 
-    inputs.property(
-        "newVersion",
-        providers
-            .gradleProperty("newVersion")
-            .orElse(
-                provider {
-                    throw IllegalArgumentException(
-                        "No newVersion property provided! " +
-                            "Please add the parameter -PnewVersion=<version> when running this task."
-                    )
-                }
-            )
-    )
+    inputs.property("newVersion", providers.gradleProperty("newVersion").orElse("INVALID"))
+
+    if(inputs.properties["newVersion"] as String == "INVALID"){
+        throw IllegalArgumentException(
+            "No newVersion property provided! " +
+                "Please add the parameter -PnewVersion=<version> when running this task."
+        )
+    }
     outputs.file(layout.projectDirectory.versionTxt())
 
     doLast {

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
@@ -115,9 +115,9 @@ tasks.register("versionAsSnapshot") {
 tasks.register("versionAsSpecified") {
     group = "versioning"
 
-    inputs.property("newVersion", providers.gradleProperty("newVersion").orElse("INVALID"))
+    inputs.property("newVersion", providers.gradleProperty("newVersion").orElse(""))
 
-    if(inputs.properties["newVersion"] as String == "INVALID"){
+    if(inputs.properties["newVersion"] as String == "") {
         throw IllegalArgumentException(
             "No newVersion property provided! " +
                 "Please add the parameter -PnewVersion=<version> when running this task."


### PR DESCRIPTION
**Description**:

Fixes issue in versionAsSpecified task where the exception is always thrown in the property definition.

**Related issue(s)**:

Fixes #14537 
