### PR TITLE
ci: Cherry pick release fixes into develop

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.evm-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.evm-publish.gradle.kts
@@ -19,6 +19,14 @@ plugins {
     id("com.hedera.gradle.maven-publish")
 }
 
+// Publishing tasks are only enabled if we publish to the matching group.
+// Otherwise, Nexus configuration and credentials do not fit.
+val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    enabled = publishingPackageGroup == "com.hedera"
+}
+
 publishing {
     publications {
         named<MavenPublication>("maven") {

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-module-dependencies.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-module-dependencies.gradle.kts
@@ -27,7 +27,7 @@ javaModuleDependencies {
     moduleNamePrefixToGroup.put("com.hedera.node.", "com.hedera.hashgraph")
     moduleNamePrefixToGroup.put("com.hedera.storage.", "com.hedera.storage.blocknode")
     moduleNameToGA.put("com.hedera.evm", "com.hedera.evm:hedera-evm")
-    moduleNameToGA.put("com.hedera.evm.impl", "com.hedera:hedera-evm-impl")
+    moduleNameToGA.put("com.hedera.evm.impl", "com.hedera.evm:hedera-evm-impl")
     moduleNameToGA.put(
         "com.hedera.cryptography.pairings.signatures",
         "com.hedera.cryptography:hedera-cryptography-pairings-signatures"

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.root.gradle.kts
@@ -42,18 +42,14 @@ tasks.register("githubVersionSummary") {
     group = "github"
 
     inputs.property("version", productVersion)
-    outputs.file(
-        providers
-            .environmentVariable("GITHUB_STEP_SUMMARY")
-            .orElse(
-                provider {
-                    throw IllegalArgumentException(
-                        "This task may only be run in a Github Actions CI environment! " +
-                            "Unable to locate the GITHUB_STEP_SUMMARY environment variable."
-                    )
-                }
-            )
-    )
+
+    if (!providers.environmentVariable("GITHUB_STEP_SUMMARY").isPresent) {
+        throw IllegalArgumentException(
+            "This task may only be run in a Github Actions CI environment! " +
+                "Unable to locate the GITHUB_STEP_SUMMARY environment variable."
+        )
+    }
+    outputs.file(providers.environmentVariable("GITHUB_STEP_SUMMARY"))
 
     doLast {
         generateProjectVersionReport(
@@ -115,19 +111,14 @@ tasks.register("versionAsSnapshot") {
 tasks.register("versionAsSpecified") {
     group = "versioning"
 
-    inputs.property(
-        "newVersion",
-        providers
-            .gradleProperty("newVersion")
-            .orElse(
-                provider {
-                    throw IllegalArgumentException(
-                        "No newVersion property provided! " +
-                            "Please add the parameter -PnewVersion=<version> when running this task."
-                    )
-                }
-            )
-    )
+    inputs.property("newVersion", providers.gradleProperty("newVersion").orNull)
+
+    if (inputs.properties["newVersion"] == null) {
+        throw IllegalArgumentException(
+            "No newVersion property provided! " +
+                "Please add the parameter -PnewVersion=<version> when running this task."
+        )
+    }
     outputs.file(layout.projectDirectory.versionTxt())
 
     doLast {


### PR DESCRIPTION
**Description**:

From release/0.52 branch: Enables publishing of `com.hedera.evm` exclusively under `com.hedera` instead of under both `com.hedera` and `com.swirlds`

From release/0.53 branch: Enables the versionAsSpecified Check to run successfully

**Related issue(s)**:

Fixes #14543 
