### PR TITLE
ci: fix gradle publish failures in release-0.52 for hedera.com.evm

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.evm-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.evm-publish.gradle.kts
@@ -19,6 +19,14 @@ plugins {
     id("com.hedera.gradle.maven-publish")
 }
 
+// Publishing tasks are only enabled if we publish to the matching group.
+// Otherwise, Nexus configuration and credentials do not fit.
+val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup").getOrElse("")
+
+tasks.withType<PublishToMavenRepository>().configureEach {
+    enabled = publishingPackageGroup == "com.hedera"
+}
+
 publishing {
     publications {
         named<MavenPublication>("maven") {

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-module-dependencies.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-module-dependencies.gradle.kts
@@ -27,5 +27,5 @@ javaModuleDependencies {
     moduleNamePrefixToGroup.put("com.hedera.node.", "com.hedera.hashgraph")
     moduleNamePrefixToGroup.put("com.hedera.storage.", "com.hedera.storage.blocknode")
     moduleNameToGA.put("com.hedera.evm", "com.hedera.evm:hedera-evm")
-    moduleNameToGA.put("com.hedera.evm.impl", "com.hedera:hedera-evm-impl")
+    moduleNameToGA.put("com.hedera.evm.impl", "com.hedera.evm:hedera-evm-impl")
 }


### PR DESCRIPTION
**Description**:

Cherry picks `com.hedera.evm` publish fix into release/0.53

**Related issue(s)**:

Fixes #14545 

