### PR TITLE
fix: move `VirtualMap#registerMetrics()` call to a node initializer

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -298,29 +298,30 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
                             return map;
                         });
                     } else {
-                        stateRoot.putServiceStateIfAbsent(md, () -> {
-                            // MAX_IN_MEMORY_HASHES (ramToDiskThreshold) = 8388608
-                            // PREFER_DISK_BASED_INDICES = false
-                            final var tableConfig = new MerkleDbTableConfig<>(
-                                            (short) 1,
-                                            DigestType.SHA_384,
-                                            (short) 1,
-                                            new OnDiskKeySerializer<>(
-                                                    md.onDiskKeySerializerClassId(),
-                                                    md.onDiskKeyClassId(),
-                                                    md.stateDefinition().keyCodec()),
-                                            (short) 1,
-                                            new OnDiskValueSerializer<>(
-                                                    md.onDiskValueSerializerClassId(),
-                                                    md.onDiskValueClassId(),
-                                                    md.stateDefinition().valueCodec()))
-                                    .maxNumberOfKeys(def.maxKeysHint());
-                            final var label = StateUtils.computeLabel(serviceName, stateKey);
-                            final var dsBuilder = new MerkleDbDataSourceBuilder<>(tableConfig);
-                            final var virtualMap = new VirtualMap<>(label, dsBuilder);
-                            virtualMap.registerMetrics(metrics);
-                            return virtualMap;
-                        });
+                        stateRoot.putServiceStateIfAbsent(
+                                md,
+                                () -> {
+                                    // MAX_IN_MEMORY_HASHES (ramToDiskThreshold) = 8388608
+                                    // PREFER_DISK_BASED_INDICES = false
+                                    final var tableConfig = new MerkleDbTableConfig<>(
+                                                    (short) 1,
+                                                    DigestType.SHA_384,
+                                                    (short) 1,
+                                                    new OnDiskKeySerializer<>(
+                                                            md.onDiskKeySerializerClassId(),
+                                                            md.onDiskKeyClassId(),
+                                                            md.stateDefinition().keyCodec()),
+                                                    (short) 1,
+                                                    new OnDiskValueSerializer<>(
+                                                            md.onDiskValueSerializerClassId(),
+                                                            md.onDiskValueClassId(),
+                                                            md.stateDefinition().valueCodec()))
+                                            .maxNumberOfKeys(def.maxKeysHint());
+                                    final var label = StateUtils.computeLabel(serviceName, stateKey);
+                                    final var dsBuilder = new MerkleDbDataSourceBuilder<>(tableConfig);
+                                    return new VirtualMap<>(label, dsBuilder);
+                                },
+                                (VirtualMap<?, ?> virtualMap) -> virtualMap.registerMetrics(metrics));
                     }
                 });
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
@@ -58,7 +58,7 @@ public class SimpleFreezeOnly extends HapiSuite {
     final Stream<DynamicTest> simpleFreezeWithTimestamp() {
         return defaultHapiSpec("SimpleFreezeWithTimeStamp")
                 .given(freezeOnly().payingWith(GENESIS).startingAt(Instant.now().plusSeconds(10)))
-                .when(sleepFor(1000))
+                .when(sleepFor(40000))
                 .then();
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/SimpleFreezeOnly.java
@@ -58,7 +58,7 @@ public class SimpleFreezeOnly extends HapiSuite {
     final Stream<DynamicTest> simpleFreezeWithTimestamp() {
         return defaultHapiSpec("SimpleFreezeWithTimeStamp")
                 .given(freezeOnly().payingWith(GENESIS).startingAt(Instant.now().plusSeconds(10)))
-                .when(sleepFor(40000))
+                .when(sleepFor(1000))
                 .then();
     }
 }


### PR DESCRIPTION
**Description**:
 - Closes #14520 
 - Instead of calling `VirtualMap#registerMetrics()` only at the moment of creating an _absent_ node in `MerkleStateRoot#putServiceStateIfAbsent()`, does this work in an initialization callback that receives the node for the state being defined, no matter if present or absent at beginning of the call.