### PR TITLE
fix: TokenUpdateNftsHandler throwing HandleException in preHandle

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
@@ -85,7 +85,7 @@ public class TokenUpdateNftsHandler implements TransactionHandler {
         final var op = txn.tokenUpdateNftsOrThrow();
         final var tokenStore = context.createStore(ReadableTokenStore.class);
         final var token = tokenStore.get(op.tokenOrElse(TokenID.DEFAULT));
-        if (token == null) throw new PreCheckException(INVALID_TOKEN_ID);
+        validateTruePreCheck(token != null, INVALID_TOKEN_ID);
 
         final var nftStore = context.createStore(ReadableNftStore.class);
         if (serialNumbersInTreasury(

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
@@ -180,7 +180,7 @@ public class TokenUpdateNftsHandler implements TransactionHandler {
             @NonNull final ReadableNftStore nftStore,
             @NonNull final TokenID tokenId)
             throws PreCheckException {
-        for (Long serialNumber : serialNumbers) {
+        for (final Long serialNumber : serialNumbers) {
             Nft nft = nftStore.get(NftID.newBuilder()
                     .tokenId(tokenId)
                     .serialNumber(serialNumber)

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
@@ -23,7 +23,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIA
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MISSING_SERIAL_NUMBERS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_METADATA_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_METADATA_OR_SUPPLY_KEY;
-import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
@@ -85,7 +84,8 @@ public class TokenUpdateNftsHandler implements TransactionHandler {
         final var txn = context.body();
         final var op = txn.tokenUpdateNftsOrThrow();
         final var tokenStore = context.createStore(ReadableTokenStore.class);
-        final var token = getIfUsable(op.tokenOrElse(TokenID.DEFAULT), tokenStore);
+        final var token = tokenStore.get(op.tokenOrElse(TokenID.DEFAULT));
+        if (token == null) throw new PreCheckException(INVALID_TOKEN_ID);
 
         final var nftStore = context.createStore(ReadableNftStore.class);
         if (serialNumbersInTreasury(
@@ -178,15 +178,20 @@ public class TokenUpdateNftsHandler implements TransactionHandler {
             @NonNull final AccountID treasuryAccount,
             @NonNull final List<Long> serialNumbers,
             @NonNull final ReadableNftStore nftStore,
-            @NonNull final TokenID tokenId) {
-        return serialNumbers.stream()
-                .map(serialNumber -> getIfUsable(
-                        NftID.newBuilder()
-                                .tokenId(tokenId)
-                                .serialNumber(serialNumber)
-                                .build(),
-                        nftStore))
-                .allMatch(nft ->
-                        nft != null && (nft.ownerId() == null || Objects.equals(nft.ownerId(), treasuryAccount)));
+            @NonNull final TokenID tokenId)
+            throws PreCheckException {
+        for (Long serialNumber : serialNumbers) {
+            Nft nft = nftStore.get(NftID.newBuilder()
+                    .tokenId(tokenId)
+                    .serialNumber(serialNumber)
+                    .build());
+            if (nft == null) {
+                throw new PreCheckException(INVALID_NFT_ID);
+            }
+            if (nft.ownerId() != null && !Objects.equals(nft.ownerId(), treasuryAccount)) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateNftsHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateNftsHandlerTest.java
@@ -265,7 +265,7 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
         when(readableTokenStore.get(TokenID.DEFAULT)).thenReturn(null);
 
         Assertions.assertThatThrownBy(() -> subject.preHandle(preHandleContext))
-                .isInstanceOf(HandleException.class)
+                .isInstanceOf(PreCheckException.class)
                 .has(responseCode(INVALID_TOKEN_ID));
     }
 
@@ -282,8 +282,6 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
         when(readableNftStore.get(nftIdSl1)).thenReturn(nft);
         when(token.tokenIdOrThrow()).thenReturn(nonFungibleTokenId);
         when(nft.ownerId()).thenReturn(AccountID.newBuilder().accountNum(1).build());
-        when(nft.nftId()).thenReturn(nftId);
-        when(nftId.tokenId()).thenReturn(nonFungibleTokenId);
         when(token.hasMetadataKey()).thenReturn(true);
 
         assertThatCode(() -> subject.preHandle(preHandleContext)).doesNotThrowAnyException();
@@ -302,8 +300,6 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
         when(readableNftStore.get(nftIdSl1)).thenReturn(nft);
         when(token.tokenIdOrThrow()).thenReturn(nonFungibleTokenId);
         when(nft.ownerId()).thenReturn(AccountID.newBuilder().accountNum(1).build());
-        when(nft.nftId()).thenReturn(nftId);
-        when(nftId.tokenId()).thenReturn(nonFungibleTokenId);
         when(token.hasMetadataKey()).thenReturn(false);
 
         Assertions.assertThatThrownBy(() -> subject.preHandle(preHandleContext))


### PR DESCRIPTION
**Description**:
This PR fixes `TokenUpdateNftsHandler` to not throw a `HandleException` when the Token or Nft cannot be retrieved. Instead a `PreCheckException` will be thrown.


**Related issue(s)**:
#14204 

Fixes #14595 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
