### PR TITLE
fix(bug): Removed daemon config changes (#14599)

### DIFF
--- a/.github/workflows/zxc-publish-production-image.yaml
+++ b/.github/workflows/zxc-publish-production-image.yaml
@@ -177,12 +177,6 @@ jobs:
           HOME: /x
         with:
           version: v25.0.5
-          daemon-config: |
-            {
-              "registry-mirrors": [
-                "https://artifacts.swirldslabs.io/central-docker-external/"
-              ]
-            }
 
       - name: Configure Default Docker Context
         run: |

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -167,12 +167,6 @@ jobs:
           HOME: /x
         with:
           version: v25.0.5
-          daemon-config: |
-            {
-              "registry-mirrors": [
-                "https://artifacts.swirldslabs.io/central-docker-external/"
-              ]
-            }
 
       - name: Configure Default Docker Context
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
@@ -384,12 +378,6 @@ jobs:
           HOME: ${{ runner.os == 'Linux' && '/x' || steps.home.outputs.directory }}
         with:
           version: v25.0.5
-          daemon-config: |
-            {
-              "registry-mirrors": [
-                "https://artifacts.swirldslabs.io/central-docker-external/"
-              ]
-            }
 
       - name: Configure Default Docker Context
         env:


### PR DESCRIPTION
**Description**:

Cherry picks reversion of docker mirror registry changes into release/0.52

**Related issue(s)**:

Fixes #14604 
