### PR TITLE
fix: cherry-pick: TokenUpdateNftsHandler throwing HandleException in preHandle

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
@@ -173,6 +173,7 @@ public class TokenUpdateNftsHandler implements TransactionHandler {
      * @param nftStore the nft store
      * @param tokenId the token id
      * @return true if all serial numbers are owned by the treasury account
+     * @throws PreCheckException if the Nft does not exist
      */
     private boolean serialNumbersInTreasury(
             @NonNull final AccountID treasuryAccount,
@@ -180,18 +181,18 @@ public class TokenUpdateNftsHandler implements TransactionHandler {
             @NonNull final ReadableNftStore nftStore,
             @NonNull final TokenID tokenId)
             throws PreCheckException {
+        boolean serialNumbersInTreasury = true;
         for (final Long serialNumber : serialNumbers) {
-            Nft nft = nftStore.get(NftID.newBuilder()
+            final Nft nft = nftStore.get(NftID.newBuilder()
                     .tokenId(tokenId)
                     .serialNumber(serialNumber)
                     .build());
-            if (nft == null) {
-                throw new PreCheckException(INVALID_NFT_ID);
-            }
+            validateTruePreCheck(nft != null, INVALID_NFT_ID);
             if (nft.ownerId() != null && !Objects.equals(nft.ownerId(), treasuryAccount)) {
-                return false;
+                serialNumbersInTreasury = false;
+                break;
             }
         }
-        return true;
+        return serialNumbersInTreasury;
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateNftsHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateNftsHandlerTest.java
@@ -265,7 +265,7 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
         when(readableTokenStore.get(TokenID.DEFAULT)).thenReturn(null);
 
         Assertions.assertThatThrownBy(() -> subject.preHandle(preHandleContext))
-                .isInstanceOf(HandleException.class)
+                .isInstanceOf(PreCheckException.class)
                 .has(responseCode(INVALID_TOKEN_ID));
     }
 
@@ -282,8 +282,6 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
         when(readableNftStore.get(nftIdSl1)).thenReturn(nft);
         when(token.tokenIdOrThrow()).thenReturn(nonFungibleTokenId);
         when(nft.ownerId()).thenReturn(AccountID.newBuilder().accountNum(1).build());
-        when(nft.nftId()).thenReturn(nftId);
-        when(nftId.tokenId()).thenReturn(nonFungibleTokenId);
         when(token.hasMetadataKey()).thenReturn(true);
 
         assertThatCode(() -> subject.preHandle(preHandleContext)).doesNotThrowAnyException();
@@ -302,8 +300,6 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
         when(readableNftStore.get(nftIdSl1)).thenReturn(nft);
         when(token.tokenIdOrThrow()).thenReturn(nonFungibleTokenId);
         when(nft.ownerId()).thenReturn(AccountID.newBuilder().accountNum(1).build());
-        when(nft.nftId()).thenReturn(nftId);
-        when(nftId.tokenId()).thenReturn(nonFungibleTokenId);
         when(token.hasMetadataKey()).thenReturn(false);
 
         Assertions.assertThatThrownBy(() -> subject.preHandle(preHandleContext))


### PR DESCRIPTION
**Description**:
Cherry pick of fix from release 53 branch.
This PR fixes TokenUpdateNftsHandler to not throw a HandleException when the Token or Nft cannot be retrieved. Instead a PreCheckException will be thrown.

**Related issue(s)**:

Fixes #14595 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
