### PR TITLE
feat: added X509Certificate validation for NodeCreate and NodeUpdate

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-addressbook-service-impl/build.gradle.kts
@@ -29,6 +29,8 @@ testModuleInfo {
     requires("com.hedera.node.app.service.token.impl")
     requires("com.hedera.node.config.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
+    requires("com.swirlds.platform.core")
+    requires("com.swirlds.platform.core.test.fixtures")
     requires("com.swirlds.state.api.test.fixtures")
     requires("com.hedera.node.app.spi.test.fixtures")
     requires("org.assertj.core")

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
@@ -23,6 +23,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SERVICE_ENDPOINT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_NODES_CREATED;
 import static com.hedera.node.app.service.addressbook.AddressBookHelper.getNextNodeID;
+import static com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator.validateX509Certificate;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
@@ -78,7 +79,7 @@ public class NodeCreateHandler implements TransactionHandler {
                 op.gossipCaCertificate().length() == 0
                         || op.gossipCaCertificate().equals(Bytes.EMPTY),
                 INVALID_GOSSIP_CA_CERTIFICATE);
-
+        validateX509Certificate(op.gossipCaCertificate());
         final var adminKey = op.adminKey();
         addressBookValidator.validateAdminKey(adminKey);
     }

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
@@ -21,6 +21,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_GOSSIP_CA_CERTI
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UPDATE_NODE_ACCOUNT_NOT_ALLOWED;
+import static com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator.validateX509Certificate;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
@@ -65,8 +66,10 @@ public class NodeUpdateHandler implements TransactionHandler {
         requireNonNull(txn);
         final var op = txn.nodeUpdate();
         validateFalsePreCheck(op.nodeId() < 0, INVALID_NODE_ID);
-        if (op.hasGossipCaCertificate())
+        if (op.hasGossipCaCertificate()) {
             validateFalsePreCheck(op.gossipCaCertificate().equals(Bytes.EMPTY), INVALID_GOSSIP_CA_CERTIFICATE);
+            validateX509Certificate(op.gossipCaCertificate());
+        }
         if (op.hasAdminKey()) {
             final var adminKey = op.adminKey();
             addressBookValidator.validateAdminKey(adminKey);

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/validators/AddressBookValidator.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/validators/AddressBookValidator.java
@@ -21,6 +21,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.GOSSIP_ENDPOINTS_EXCEED
 import static com.hedera.hapi.node.base.ResponseCodeEnum.GOSSIP_ENDPOINT_CANNOT_HAVE_FQDN;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ENDPOINT;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_GOSSIP_CA_CERTIFICATE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_GOSSIP_ENDPOINT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_IPV4_ADDRESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID;
@@ -42,9 +43,14 @@ import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ServiceEndpoint;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.config.data.NodesConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -166,5 +172,19 @@ public class AddressBookValidator {
                 addressLen != 0 && !endpoint.domainName().trim().isEmpty(), IP_FQDN_CANNOT_BE_SET_FOR_SAME_ENDPOINT);
         validateFalse(endpoint.domainName().trim().length() > nodesConfig.maxFqdnSize(), FQDN_SIZE_TOO_LARGE);
         validateFalse(addressLen != 0 && addressLen != 4, INVALID_IPV4_ADDRESS);
+    }
+
+    /**
+     *  Validate the Bytes is a real X509Certificate bytes.
+     * @param certBytes the Bytes to validate
+     * @throws PreCheckException
+     */
+    public static void validateX509Certificate(@NonNull Bytes certBytes) throws PreCheckException {
+        try {
+            final var cert = (X509Certificate) CertificateFactory.getInstance("X.509")
+                    .generateCertificate(new ByteArrayInputStream(certBytes.toByteArray()));
+        } catch (final CertificateException e) {
+            throw new PreCheckException(INVALID_GOSSIP_CA_CERTIFICATE);
+        }
     }
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/module-info.java
@@ -7,10 +7,10 @@ module com.hedera.node.app.service.addressbook.impl {
     requires transitive com.hedera.node.hapi;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.state.api;
+    requires transitive com.hedera.pbj.runtime;
     requires transitive dagger;
     requires transitive javax.inject;
     requires com.hedera.node.app.service.token;
-    requires com.hedera.pbj.runtime;
     requires org.apache.logging.log4j;
     requires static transitive java.compiler;
     requires static com.github.spotbugs.annotations;

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/AddressBookTestBase.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/AddressBookTestBase.java
@@ -38,13 +38,20 @@ import com.hedera.node.app.service.addressbook.impl.schemas.V053AddressBookSchem
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.platform.system.address.Address;
+import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
 import com.swirlds.state.spi.ReadableStates;
 import com.swirlds.state.spi.WritableStates;
 import com.swirlds.state.test.fixtures.MapReadableKVState;
 import com.swirlds.state.test.fixtures.MapWritableKVState;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Random;
+import java.util.Spliterators;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -268,5 +275,15 @@ public class AddressBookTestBase {
                 .weight(0)
                 .adminKey(key)
                 .build();
+    }
+
+    public static List<X509Certificate> generateX509Certificates(final int n) {
+        final var randomAddressBook = RandomAddressBookBuilder.create(new Random())
+                .withSize(n)
+                .withRealKeysEnabled(true)
+                .build();
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(randomAddressBook.iterator(), 0), false)
+                .map(Address::getSigCert)
+                .collect(Collectors.toList());
     }
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeUpdateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeUpdateHandlerTest.java
@@ -61,7 +61,8 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import java.io.IOException;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -87,11 +88,13 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
 
     private TransactionBody txn;
     private NodeUpdateHandler subject;
+    private List<X509Certificate> certList;
 
     @BeforeEach
     void setUp() {
         final var addressBookValidator = new AddressBookValidator();
         subject = new NodeUpdateHandler(addressBookValidator);
+        certList = generateX509Certificates(3);
     }
 
     @Test
@@ -120,7 +123,6 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
         txn = new NodeUpdateBuilder()
                 .withNodeId(1)
                 .withAccountId(accountId)
-                .withGossipCaCertificate(Bytes.wrap("cert"))
                 .withAdminKey(invalidKey)
                 .build();
         final var msg = assertThrows(PreCheckException.class, () -> subject.pureChecks(txn));
@@ -129,11 +131,11 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
 
     @Test
     @DisplayName("pureChecks succeeds when expected attributes are specified")
-    void pureCheckPass() {
+    void pureCheckPass() throws CertificateEncodingException {
         txn = new NodeUpdateBuilder()
                 .withNodeId(1)
                 .withAccountId(accountId)
-                .withGossipCaCertificate(Bytes.wrap("cert"))
+                .withGossipCaCertificate(Bytes.wrap(certList.get(1).getEncoded()))
                 .withAdminKey(key)
                 .build();
         assertDoesNotThrow(() -> subject.pureChecks(txn));
@@ -336,14 +338,14 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
     }
 
     @Test
-    void hanldeWorkAsExpected() {
+    void hanldeWorkAsExpected() throws CertificateEncodingException {
         txn = new NodeUpdateBuilder()
                 .withNodeId(1L)
                 .withAccountId(accountId)
                 .withDescription("Description")
                 .withGossipEndpoint(List.of(endpoint1, endpoint2))
                 .withServiceEndpoint(List.of(endpoint1, endpoint3))
-                .withGossipCaCertificate(Bytes.wrap("cert"))
+                .withGossipCaCertificate(Bytes.wrap(certList.get(2).getEncoded()))
                 .withGrpcCertificateHash(Bytes.wrap("hash"))
                 .withAdminKey(key)
                 .build();
@@ -372,7 +374,8 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
         assertArrayEquals(
                 (List.of(endpoint1, endpoint3)).toArray(),
                 updatedNode.serviceEndpoint().toArray());
-        assertArrayEquals("cert".getBytes(), updatedNode.gossipCaCertificate().toByteArray());
+        assertArrayEquals(
+                certList.get(2).getEncoded(), updatedNode.gossipCaCertificate().toByteArray());
         assertArrayEquals("hash".getBytes(), updatedNode.grpcCertificateHash().toByteArray());
         assertEquals(key, updatedNode.adminKey());
     }
@@ -479,7 +482,7 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
 
     @Test
     @DisplayName("check that fees are 1 for delete node trx")
-    void testCalculateFeesInvocations() throws IOException {
+    void testCalculateFeesInvocations() {
         final var feeCtx = mock(FeeContext.class);
         final var feeCalcFact = mock(FeeCalculatorFactory.class);
         final var feeCalc = mock(FeeCalculator.class);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
@@ -562,7 +562,7 @@ public class NodeCreateTest {
         }
     }
 
-    static List<X509Certificate> generateX509Certificates(final int n) {
+    public static List<X509Certificate> generateX509Certificates(final int n) {
         final var randomAddressBook = RandomAddressBookBuilder.create(new Random())
                 .withSize(n)
                 .withRealKeysEnabled(true)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeDeleteTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeDeleteTest.java
@@ -29,6 +29,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.generateX509Certificates;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ID;
@@ -39,30 +40,50 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 
+@HapiTestLifecycle
 public class NodeDeleteTest {
+    private static List<X509Certificate> gossipCertificates;
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        gossipCertificates = generateX509Certificates(1);
+    }
+
     @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
-    final Stream<DynamicTest> deleteNodeWorks() {
+    final Stream<DynamicTest> deleteNodeWorks() throws CertificateEncodingException {
         final String nodeName = "mytestnode";
 
         return hapiTest(
-                nodeCreate(nodeName),
+                nodeCreate(nodeName)
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
                 viewNode(nodeName, node -> assertFalse(node.deleted(), "Node should not be deleted")),
                 nodeDelete(nodeName),
                 viewNode(nodeName, node -> assertTrue(node.deleted(), "Node should be deleted")));
     }
 
     @EmbeddedHapiTest(MUST_SKIP_INGEST)
-    final Stream<DynamicTest> validateFees() {
+    final Stream<DynamicTest> validateFees() throws CertificateEncodingException {
         final String description = "His vorpal blade went snicker-snack!";
         return defaultHapiSpec("validateFees")
                 .given(
                         newKeyNamed("testKey"),
                         newKeyNamed("randomAccount"),
                         cryptoCreate("payer").balance(10_000_000_000L),
-                        nodeCreate("node100").description(description).fee(ONE_HBAR),
+                        nodeCreate("node100")
+                                .description(description)
+                                .fee(ONE_HBAR)
+                                .gossipCaCertificate(
+                                        gossipCertificates.getFirst().getEncoded()),
                         // Submit to a different node so ingest check is skipped
                         nodeDelete("node100")
                                 .setNode("0.0.5")
@@ -90,13 +111,16 @@ public class NodeDeleteTest {
     }
 
     @EmbeddedHapiTest(MUST_SKIP_INGEST)
-    final Stream<DynamicTest> validateFeesInsufficientAmount() {
+    final Stream<DynamicTest> validateFeesInsufficientAmount() throws CertificateEncodingException {
         final String description = "His vorpal blade went snicker-snack!";
         return hapiTest(
                 newKeyNamed("testKey"),
                 newKeyNamed("randomAccount"),
                 cryptoCreate("payer").balance(10_000_000_000L),
-                nodeCreate("node100").description(description).fee(ONE_HBAR),
+                nodeCreate("node100")
+                        .description(description)
+                        .fee(ONE_HBAR)
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
                 // Submit to a different node so ingest check is skipped
                 nodeDelete("node100")
                         .setNode("0.0.5")
@@ -118,12 +142,16 @@ public class NodeDeleteTest {
     }
 
     @HapiTest
-    final Stream<DynamicTest> failsAtIngestForUnAuthorizedTxns() {
+    final Stream<DynamicTest> failsAtIngestForUnAuthorizedTxns() throws CertificateEncodingException {
         final String description = "His vorpal blade went snicker-snack!";
         return defaultHapiSpec("failsAtIngestForUnAuthorizedTxns")
                 .given(
                         cryptoCreate("payer").balance(10_000_000_000L),
-                        nodeCreate("ntb").description(description).fee(ONE_HBAR),
+                        nodeCreate("ntb")
+                                .description(description)
+                                .fee(ONE_HBAR)
+                                .gossipCaCertificate(
+                                        gossipCertificates.getFirst().getEncoded()),
                         nodeDelete("ntb")
                                 .payingWith("payer")
                                 .fee(ONE_HBAR)
@@ -140,16 +168,17 @@ public class NodeDeleteTest {
     }
 
     @HapiTest
-    final Stream<DynamicTest> handleNodeAlreadyDeleted() {
+    final Stream<DynamicTest> handleNodeAlreadyDeleted() throws CertificateEncodingException {
         final String nodeName = "mytestnode";
         return hapiTest(
-                nodeCreate(nodeName),
+                nodeCreate(nodeName)
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
                 nodeDelete(nodeName),
                 nodeDelete(nodeName).signedBy(GENESIS).hasKnownStatus(NODE_DELETED));
     }
 
     @HapiTest
-    final Stream<DynamicTest> handleCanBeExecutedJustWithPrivilegedAccount() {
+    final Stream<DynamicTest> handleCanBeExecutedJustWithPrivilegedAccount() throws CertificateEncodingException {
         long PAYER_BALANCE = 1_999_999_999L;
         final String nodeName = "mytestnode";
 
@@ -157,7 +186,8 @@ public class NodeDeleteTest {
                 newKeyNamed("adminKey"),
                 newKeyNamed("wrongKey"),
                 cryptoCreate("payer").balance(PAYER_BALANCE).key("wrongKey"),
-                nodeCreate(nodeName),
+                nodeCreate(nodeName)
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
                 nodeDelete(nodeName)
                         .payingWith("payer")
                         .signedBy("payer", "wrongKey")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/UpdateAccountEnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/UpdateAccountEnabledTest.java
@@ -27,6 +27,7 @@ import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.viewNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.generateX509Certificates;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,6 +38,9 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,29 +52,36 @@ import org.junit.jupiter.api.DynamicTest;
  */
 @HapiTestLifecycle
 public class UpdateAccountEnabledTest {
+    private static List<X509Certificate> gossipCertificates;
+
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         testLifecycle.overrideInClass(Map.of("nodes.updateAccountIdAllowed", "true"));
+        gossipCertificates = generateX509Certificates(1);
     }
 
     @HapiTest
-    final Stream<DynamicTest> updateEmptyAccountIdFail() {
+    final Stream<DynamicTest> updateEmptyAccountIdFail() throws CertificateEncodingException {
         return hapiTest(
                 newKeyNamed("adminKey"),
-                nodeCreate("testNode").adminKey("adminKey"),
+                nodeCreate("testNode")
+                        .adminKey("adminKey")
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
                 nodeUpdate("testNode").accountId("").hasPrecheck(INVALID_NODE_ACCOUNT_ID));
     }
 
     @HapiTest
-    final Stream<DynamicTest> updateAliasAccountIdFail() {
+    final Stream<DynamicTest> updateAliasAccountIdFail() throws CertificateEncodingException {
         return hapiTest(
                 newKeyNamed("adminKey"),
-                nodeCreate("testNode").adminKey("adminKey"),
+                nodeCreate("testNode")
+                        .adminKey("adminKey")
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
                 nodeUpdate("testNode").aliasAccountId("alias").hasPrecheck(INVALID_NODE_ACCOUNT_ID));
     }
 
     @EmbeddedHapiTest(MUST_SKIP_INGEST)
-    final Stream<DynamicTest> validateFees() {
+    final Stream<DynamicTest> validateFees() throws CertificateEncodingException {
         final String description = "His vorpal blade went snicker-snack!";
         return hapiTest(
                 newKeyNamed("testKey"),
@@ -79,7 +90,8 @@ public class UpdateAccountEnabledTest {
                 nodeCreate("node100")
                         .adminKey("testKey")
                         .description(description)
-                        .fee(ONE_HBAR),
+                        .fee(ONE_HBAR)
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
                 // Submit to a different node so ingest check is skipped
                 nodeUpdate("node100")
                         .setNode("0.0.5")
@@ -112,10 +124,12 @@ public class UpdateAccountEnabledTest {
     }
 
     @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
-    final Stream<DynamicTest> updateAccountIdWork() {
+    final Stream<DynamicTest> updateAccountIdWork() throws CertificateEncodingException {
         return hapiTest(
                 newKeyNamed("adminKey"),
-                nodeCreate("testNode").adminKey("adminKey"),
+                nodeCreate("testNode")
+                        .adminKey("adminKey")
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
                 nodeUpdate("testNode").adminKey("adminKey").accountId("0.0.1000"),
                 viewNode(
                         "testNode",

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/DabEnabledUpgradeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/DabEnabledUpgradeTest.java
@@ -29,11 +29,13 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getVersionInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeDelete;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.ensureStakingActivated;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.given;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateUpgradeAddressBooks;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilStartOfNextStakingPeriod;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_BILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.generateX509Certificates;
 import static com.hedera.services.bdd.suites.regression.system.LifecycleTest.configVersionOf;
 import static java.lang.Integer.MAX_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +53,9 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.SemanticVersion;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -100,12 +105,15 @@ public class DabEnabledUpgradeTest implements LifecycleTest {
     @Account(tinybarBalance = ONE_MILLION_HBARS, stakedNodeId = 3)
     static SpecAccount NODE3_STAKER;
 
+    private static List<X509Certificate> gossipCertificates;
+
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         testLifecycle.doAdhoc(
                 ensureStakingActivated(),
                 touchBalanceOf(NODE0_STAKER, NODE1_STAKER, NODE2_STAKER, NODE3_STAKER),
-                waitUntilStartOfNextStakingPeriod(1));
+                waitUntilStartOfNextStakingPeriod(1),
+                given(() -> gossipCertificates = generateX509Certificates(1)));
     }
 
     @Nested
@@ -169,11 +177,12 @@ public class DabEnabledUpgradeTest implements LifecycleTest {
                 AccountID.newBuilder().setAccountNum(7L).build();
 
         @BeforeAll
-        static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        static void beforeAll(@NonNull final TestLifecycle testLifecycle) throws CertificateEncodingException {
             testLifecycle.doAdhoc(nodeCreate("node4")
                     .accountId(NEW_ACCOUNT_ID)
                     .description(CLASSIC_NODE_NAMES[4])
-                    .withAvailableSubProcessPorts());
+                    .withAvailableSubProcessPorts()
+                    .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()));
         }
 
         @HapiTest


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Add X509Certificate check for gossipCaCertificate field in nodeCreate and nodeUpdate.

**Related issue(s)**:

Fixes #14603 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
