### PR TITLE
fix: get notification listeners up-to-date before `RECONNECT_COMPLETE`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -82,6 +82,7 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.listeners.PlatformStatusChangeListener;
+import com.swirlds.platform.listeners.PlatformStatusChangeNotification;
 import com.swirlds.platform.listeners.ReconnectCompleteListener;
 import com.swirlds.platform.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.platform.state.MerkleRoot;
@@ -136,12 +137,11 @@ import org.apache.logging.log4j.Logger;
 /**
  * Represents the Hedera Consensus Node.
  *
- * <p>This is the main entry point for the Hedera Consensus Node. It contains initialization logic for the
- * node, including its state. It constructs some artifacts for gluing the mono-service with the modular service
- * infrastructure. It constructs the Dagger dependency tree, and manages the gRPC server, and in all other ways,
+ * <p>This is the main entry point for the Hedera Consensus Node. It contains initialization logic for the node,
+ * including its state. It constructs the Dagger dependency tree, and manages the gRPC server, and in all other ways,
  * controls execution of the node. If you want to understand our system, this is a great place to start!
  */
-public final class Hedera implements SwirldMain {
+public final class Hedera implements SwirldMain, PlatformStatusChangeListener {
     private static final Logger logger = LogManager.getLogger(Hedera.class);
 
     // FUTURE: This should come from configuration, not be hardcoded.
@@ -322,6 +322,23 @@ public final class Hedera implements SwirldMain {
         return new MerkleStateRoot(new MerkleStateLifecyclesImpl(this));
     }
 
+    @Override
+    public void notify(@NonNull final PlatformStatusChangeNotification notification) {
+        platformStatus = notification.getNewStatus();
+        logger.info("HederaNode#{} is {}", platform.getSelfId(), platformStatus.name());
+        switch (platformStatus) {
+            case ACTIVE -> startGrpcServer();
+            case CATASTROPHIC_FAILURE -> shutdownGrpcServer();
+            case FREEZE_COMPLETE -> {
+                closeRecordStreams();
+                shutdownGrpcServer();
+            }
+            case REPLAYING_EVENTS, STARTING_UP, OBSERVING, RECONNECT_COMPLETE, CHECKING, FREEZING, BEHIND -> {
+                // Nothing to do here, just enumerate for completeness
+            }
+        }
+    }
+
     /*==================================================================================================================
     *
     * Initialization Step 2: Initialize the state. Either genesis or restart or reconnect or some other trigger.
@@ -461,30 +478,6 @@ public final class Hedera implements SwirldMain {
         logger.info("Initializing Hedera app with HederaNode#{}", nodeId);
         Locale.setDefault(Locale.US);
         logger.info("Locale to set to US en");
-        // The Hashgraph platform has a "platform state", and a notification service to indicate when those
-        // states change; we use these state changes for various purposes, such as turning off the gRPC
-        // server when we ISS or freeze, or turning it back on when we are active
-        final var notifications = platform.getNotificationEngine();
-        notifications.register(PlatformStatusChangeListener.class, notification -> {
-            platformStatus = notification.getNewStatus();
-            logger.info("HederaNode#{} is {}", nodeId, platformStatus.name());
-            switch (platformStatus) {
-                case ACTIVE -> startGrpcServer();
-                case CATASTROPHIC_FAILURE -> shutdownGrpcServer();
-                case FREEZE_COMPLETE -> {
-                    closeRecordStreams();
-                    shutdownGrpcServer();
-                }
-                case REPLAYING_EVENTS, STARTING_UP, OBSERVING, RECONNECT_COMPLETE, CHECKING, FREEZING, BEHIND -> {
-                    // Nothing to do here, just enumerate for completeness
-                }
-            }
-        });
-        // This reconnect listener checks if there is any upgrade-related side effect it missed while offline,
-        // and catches up with that side effect (e.g., writing a marker file, or unzipping the upgrade file)
-        notifications.register(ReconnectCompleteListener.class, daggerApp.reconnectListener());
-        // This notifaction is needed for freeze / upgrade.
-        notifications.register(StateWriteToDiskCompleteListener.class, daggerApp.stateWriteToDiskListener());
     }
 
     /**
@@ -701,11 +694,16 @@ public final class Hedera implements SwirldMain {
 
     private void initializeDagger(
             @NonNull final State state, @NonNull final InitTrigger trigger, final PlatformState platformState) {
+        final var notifications = platform.getNotificationEngine();
         // The Dagger component should be constructed every time we reach this point, even if
         // it exists (this avoids any problems with mutable singleton state by reconstructing
-        // everything); but we must ensure the gRPC server in the old component is fully stopped
+        // everything); but we must ensure the gRPC server in the old component is fully stopped,
+        // as well as unregister listeners from the last time this method ran
         if (daggerApp != null) {
             shutdownGrpcServer();
+            notifications.unregister(PlatformStatusChangeListener.class, this);
+            notifications.unregister(ReconnectCompleteListener.class, daggerApp.reconnectListener());
+            notifications.unregister(StateWriteToDiskCompleteListener.class, daggerApp.stateWriteToDiskListener());
         }
         // Fully qualified so as to not confuse javadoc
         daggerApp = com.hedera.node.app.DaggerHederaInjectionComponent.builder()
@@ -726,6 +724,9 @@ public final class Hedera implements SwirldMain {
                 .build();
         daggerApp.workingStateAccessor().setState(state);
         daggerApp.platformStateAccessor().setPlatformState(platformState);
+        notifications.register(PlatformStatusChangeListener.class, this);
+        notifications.register(ReconnectCompleteListener.class, daggerApp.reconnectListener());
+        notifications.register(StateWriteToDiskCompleteListener.class, daggerApp.stateWriteToDiskListener());
     }
 
     private static HederaSoftwareVersion getNodeStartupVersion(@NonNull final Configuration config) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/ReconnectListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/ReconnectListener.java
@@ -16,6 +16,8 @@
 
 package com.hedera.node.app.state.listeners;
 
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.node.app.service.addressbook.ReadableNodeStore;
 import com.hedera.node.app.service.file.ReadableUpgradeFileStore;
 import com.hedera.node.app.service.networkadmin.ReadableFreezeStore;
@@ -25,63 +27,60 @@ import com.hedera.node.app.state.PlatformStateAccessor;
 import com.hedera.node.app.store.ReadableStoreFactory;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.NetworkAdminConfig;
-import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.platform.listeners.ReconnectCompleteListener;
 import com.swirlds.platform.listeners.ReconnectCompleteNotification;
 import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.Executor;
-import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * A {@link ReconnectCompleteListener} that catches up on missed upgrade side effects after a reconnect.
+ */
 @Singleton
 public class ReconnectListener implements ReconnectCompleteListener {
     private static final Logger log = LogManager.getLogger(ReconnectListener.class);
 
-    private final Supplier<AutoCloseableWrapper<State>> stateAccessor;
     private final Executor executor;
     private final ConfigProvider configProvider;
     private final PlatformStateAccessor platformStateAccessor;
 
     @Inject
     public ReconnectListener(
-            @NonNull final Supplier<AutoCloseableWrapper<State>> stateAccessor,
             @NonNull @Named("FreezeService") final Executor executor,
             @NonNull final ConfigProvider configProvider,
             @NonNull final PlatformStateAccessor platformStateAccessor) {
-
-        this.stateAccessor = stateAccessor;
         this.executor = executor;
         this.configProvider = configProvider;
         this.platformStateAccessor = platformStateAccessor;
     }
 
     @Override
-    public void notify(final ReconnectCompleteNotification notification) {
+    public void notify(@NonNull final ReconnectCompleteNotification notification) {
+        requireNonNull(notification);
         log.info(
                 "ReconnectCompleteNotification Received: Reconnect Finished. "
                         + "consensusTimestamp: {}, roundNumber: {}, sequence: {}",
                 notification.getConsensusTimestamp(),
                 notification.getRoundNumber(),
                 notification.getSequence());
-        try (final var wrappedState = stateAccessor.get()) {
-            final var readableStoreFactory = new ReadableStoreFactory(wrappedState.get());
-            final var networkAdminConfig = configProvider.getConfiguration().getConfigData(NetworkAdminConfig.class);
-            final var freezeStore = readableStoreFactory.getStore(ReadableFreezeStore.class);
-            final var upgradeFileStore = readableStoreFactory.getStore(ReadableUpgradeFileStore.class);
-            final var upgradeNodeStore = readableStoreFactory.getStore(ReadableNodeStore.class);
-            final var upgradeStakingInfoStore = readableStoreFactory.getStore(ReadableStakingInfoStore.class);
-            final var upgradeActions = new ReadableFreezeUpgradeActions(
-                    networkAdminConfig,
-                    freezeStore,
-                    executor,
-                    upgradeFileStore,
-                    upgradeNodeStore,
-                    upgradeStakingInfoStore);
+        final State state = notification.getState().cast();
+        final var readableStoreFactory = new ReadableStoreFactory(state);
+        final var networkAdminConfig = configProvider.getConfiguration().getConfigData(NetworkAdminConfig.class);
+        final var freezeStore = readableStoreFactory.getStore(ReadableFreezeStore.class);
+        final var upgradeFileStore = readableStoreFactory.getStore(ReadableUpgradeFileStore.class);
+        final var upgradeNodeStore = readableStoreFactory.getStore(ReadableNodeStore.class);
+        final var upgradeStakingInfoStore = readableStoreFactory.getStore(ReadableStakingInfoStore.class);
+        final var upgradeActions = new ReadableFreezeUpgradeActions(
+                networkAdminConfig, freezeStore, executor, upgradeFileStore, upgradeNodeStore, upgradeStakingInfoStore);
+        try {
+            // Because we only leave the latest Dagger infrastructure registered with the platform
+            // notification system when the reconnect state is initialized, this platform state
+            // will be up-to-date
             upgradeActions.catchUpOnMissedSideEffects(platformStateAccessor.getPlatformState());
         } catch (Exception e) {
             log.error("Unable to catch up on missed upgrade side effects after reconnect", e);


### PR DESCRIPTION
**Description**:
 - Closes #14615 
 - When constructing the app Dagger component, _if_ it is already non-null, then:
     * First, unregister the old component's listeners with the platform `NotificationEngine`; then,
     * Immediately register the new component's listeners.
 - This ensures that the listener that receives [this](https://github.com/hashgraph/hedera-services/blob/develop/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java#L165) `ReconnectCompleteNotification` is for the latest Dagger component.
 - Also switches `ReconnectListener` to simply use the state from the notification instead of `WorkingStateAccessor`. 