### PR TITLE
fix: 14567: Interrupt reading from data files gracefully when the data source is closed

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/hammer/java/com/swirlds/merkledb/MerkleDbDataSourceHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/hammer/java/com/swirlds/merkledb/MerkleDbDataSourceHammerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.merkledb;
+
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.hash;
+
+import com.swirlds.common.constructable.ConstructableRegistry;
+import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
+import com.swirlds.merkledb.test.fixtures.ExampleByteArrayVirtualValue;
+import com.swirlds.merkledb.test.fixtures.TestType;
+import com.swirlds.virtualmap.VirtualKey;
+import com.swirlds.virtualmap.datasource.VirtualHashRecord;
+import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class MerkleDbDataSourceHammerTest {
+
+    private static Path testDirectory;
+
+    @BeforeAll
+    static void setup() throws Exception {
+        testDirectory = LegacyTemporaryFileBuilder.buildTemporaryFile("MerkleDbDataSourceHammerTest");
+        ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
+    }
+
+    @ParameterizedTest
+    @EnumSource(TestType.class)
+    void closeWhileFlushingTest(final TestType testType) throws IOException, InterruptedException {
+        final Path dbPath = testDirectory.resolve("merkledb-closeWhileFlushingTest-" + testType);
+        final MerkleDbDataSource<VirtualKey, ExampleByteArrayVirtualValue> dataSource =
+                testType.dataType().createDataSource(dbPath, "vm", 1000, 0, false, false);
+
+        final int count = 20;
+        final List<VirtualKey> keys = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            keys.add(testType.dataType().createVirtualLongKey(i));
+        }
+        final List<ExampleByteArrayVirtualValue> values = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            values.add(testType.dataType().createVirtualValue(i + 1));
+        }
+
+        final CountDownLatch updateStarted = new CountDownLatch(1);
+        final Thread closeThread = new Thread(() -> {
+            try {
+                updateStarted.await();
+                Thread.sleep(new Random().nextInt(100));
+                dataSource.close();
+            } catch (Exception z) {
+                // Print and ignore
+                z.printStackTrace(System.err);
+            }
+        });
+        closeThread.start();
+
+        updateStarted.countDown();
+        for (int i = 0; i < 10; i++) {
+            final int k = i;
+            try {
+                dataSource.saveRecords(
+                        count - 1,
+                        2 * count - 2,
+                        IntStream.range(0, count).mapToObj(j -> new VirtualHashRecord(k + j, hash(k + j + 1))),
+                        IntStream.range(count - 1, count)
+                                .mapToObj(
+                                        j -> new VirtualLeafRecord<>(k + j, keys.get(k), values.get((k + j) % count))),
+                        Stream.empty(),
+                        true);
+            } catch (Exception z) {
+                // Print and ignore
+                z.printStackTrace(System.err);
+                break;
+            }
+        }
+
+        closeThread.join();
+    }
+}

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -38,6 +38,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -50,9 +51,13 @@ import org.apache.logging.log4j.Logger;
  * The number of threads in the pool is defined by {@link MerkleDbConfig#compactionThreads()} property.
  *
  */
+@SuppressWarnings("rawtypes")
 class MerkleDbCompactionCoordinator {
 
     private static final Logger logger = LogManager.getLogger(MerkleDbCompactionCoordinator.class);
+
+    // Timeout to wait for all currently running compaction tasks to stop during compactor shutdown
+    private static final long SHUTDOWN_TIMEOUT = 60_000;
 
     /**
      * An executor service to run compaction tasks. Accessed using {@link #getCompactionExecutor()}.
@@ -97,6 +102,10 @@ class MerkleDbCompactionCoordinator {
 
     @NonNull
     private final DataFileCompactor pathToKeyValue;
+
+    // Number of compaction tasks currently running. Checked during shutdown to make sure all
+    // tasks are stopped
+    private final AtomicInteger tasksRunning = new AtomicInteger(0);
 
     /**
      * Creates a new instance of {@link MerkleDbCompactionCoordinator}.
@@ -195,12 +204,22 @@ class MerkleDbCompactionCoordinator {
      * All subsequent calls to compacting methods will be ignored until {@link #enableBackgroundCompaction()} is called.
      */
     void stopAndDisableBackgroundCompaction() {
+        compactionEnabled.set(false);
+        // Interrupt all running compaction tasks, if any
         synchronized (compactionFuturesByName) {
             for (var futureEntry : compactionFuturesByName.values()) {
                 futureEntry.cancel(true);
             }
             compactionFuturesByName.clear();
-            compactionEnabled.set(false);
+        }
+        // Wait till all the tasks are stopped
+        final long now = System.currentTimeMillis();
+        try {
+            while ((tasksRunning.get() != 0) && (System.currentTimeMillis() - now < SHUTDOWN_TIMEOUT)) {
+                Thread.sleep(1);
+            }
+        } catch (final InterruptedException e) {
+            logger.warn(MERKLE_DB.getMarker(), "Interrupted while waiting for compaction tasks to complete", e);
         }
     }
 
@@ -210,13 +229,10 @@ class MerkleDbCompactionCoordinator {
      * @param task a compaction task to execute
      */
     private void submitCompactionTaskForExecution(CompactionTask task) {
-        if (!compactionEnabled.get()) {
-            return;
-        }
-
-        final ExecutorService executor = getCompactionExecutor();
-
         synchronized (compactionFuturesByName) {
+            if (!compactionEnabled.get()) {
+                return;
+            }
             if (compactionFuturesByName.containsKey(task.id)) {
                 Future<?> future = compactionFuturesByName.get(task.id);
                 if (future.isDone()) {
@@ -226,7 +242,7 @@ class MerkleDbCompactionCoordinator {
                     return;
                 }
             }
-
+            final ExecutorService executor = getCompactionExecutor();
             compactionFuturesByName.put(task.id, executor.submit(task));
         }
     }
@@ -238,12 +254,22 @@ class MerkleDbCompactionCoordinator {
     /**
      * A helper class representing a task to run compaction for a specific storage type.
      */
-    private record CompactionTask(@NonNull String id, @NonNull DataFileCompactor compactor)
-            implements Callable<Boolean> {
-        private static final Logger logger = LogManager.getLogger(CompactionTask.class);
+    private class CompactionTask implements Callable<Boolean> {
+
+        // Task ID
+        private final String id;
+
+        // Compactor to run
+        private final DataFileCompactor compactor;
+
+        public CompactionTask(@NonNull String id, @NonNull DataFileCompactor compactor) {
+            this.id = id;
+            this.compactor = compactor;
+        }
 
         @Override
         public Boolean call() {
+            tasksRunning.incrementAndGet();
             try {
                 return compactor.compact();
             } catch (final InterruptedException | ClosedByInterruptException e) {
@@ -252,6 +278,8 @@ class MerkleDbCompactionCoordinator {
                 // It is important that we capture all exceptions here, otherwise a single exception
                 // will stop all  future merges from happening.
                 logger.error(EXCEPTION.getMarker(), "[{}] Compaction failed", id, e);
+            } finally {
+                tasksRunning.decrementAndGet();
             }
             return false;
         }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
@@ -315,18 +315,22 @@ public class LongListDisk extends AbstractLongList<Long> {
 
     /**
      *  Flushes and closes the file chanel and clears the free chunks offset list.
-     *
-     * @throws IOException if an I/O error occurs
      */
     @Override
-    protected void onClose() throws IOException {
-        // flush
-        if (currentFileChannel.isOpen()) {
-            currentFileChannel.force(false);
+    public void close() {
+        try {
+            // flush
+            if (currentFileChannel.isOpen()) {
+                currentFileChannel.force(false);
+            }
+            // now close
+            currentFileChannel.close();
+            freeChunks.clear();
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
         }
-        // now close
-        currentFileChannel.close();
-        freeChunks.clear();
+
+        super.close();
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
@@ -115,16 +115,11 @@ public final class LongListOffHeap extends AbstractLongList<ByteBuffer> implemen
     }
 
     /**
-     * Clean up all the direct buffers reserved for chunks
+     * Cleans up the direct buffers reserved for the chunk.
      */
     @Override
-    protected void onClose() {
-        for (int i = 0; i < chunkList.length(); i++) {
-            final ByteBuffer directBuffer = chunkList.get(i);
-            if (directBuffer != null) {
-                UNSAFE.invokeCleaner(directBuffer);
-            }
-        }
+    protected void closeChunk(@NonNull final ByteBuffer directBuffer) {
+        UNSAFE.invokeCleaner(directBuffer);
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -318,8 +318,8 @@ public class HalfDiskHashMap<K extends VirtualKey>
      */
     @Override
     public void close() throws IOException {
-        bucketIndexToBucketLocation.close();
         fileCollection.close();
+        bucketIndexToBucketLocation.close();
     }
 
     // =================================================================================================================

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -318,6 +318,8 @@ public class HalfDiskHashMap<K extends VirtualKey>
      */
     @Override
     public void close() throws IOException {
+        // Close the files first, then the index. If done in a different order, there may be
+        // file operations still running, but the index is already closed
         fileCollection.close();
         bucketIndexToBucketLocation.close();
     }


### PR DESCRIPTION
Fix summary:

* `MerkleDbDataSource.saveRecords()` now handles dirty and deleted leaves in a separate thread / executor
* On close, MerkleDb data source shuts down this executor and waits for it to complete. This is required to make sure no read / write operations are running, when data files and indices are closed
* Compaction coordinator is also improved to wait till all compaction tasks are fully stopped on shutdown
* Minor improvements like closing data files before the corresponding indices

Testing:

* A new hammer test is introduced

Fixes: https://github.com/hashgraph/hedera-services/issues/14567
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
