### PR TITLE
refactor: remove redundant check

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSelfDestructOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/CustomSelfDestructOperation.java
@@ -99,13 +99,12 @@ public class CustomSelfDestructOperation extends AbstractOperation {
                     || !addressChecks.isPresent(beneficiaryAddress, frame)) {
                 return haltFor(null, 0, INVALID_SOLIDITY_ADDRESS);
             }
-            // Enforce Hedera-specific restrictions on account deletion for non-static frames
-            if (!frame.isStatic()) {
-                final var maybeHaltReason =
-                        proxyWorldUpdater.tryTrackingSelfDestructBeneficiary(tbdAddress, beneficiaryAddress, frame);
-                if (maybeHaltReason.isPresent()) {
-                    return haltFor(null, 0, maybeHaltReason.get());
-                }
+
+            // Enforce Hedera-specific restrictions on account deletion
+            final var maybeHaltReason =
+                    proxyWorldUpdater.tryTrackingSelfDestructBeneficiary(tbdAddress, beneficiaryAddress, frame);
+            if (maybeHaltReason.isPresent()) {
+                return haltFor(null, 0, maybeHaltReason.get());
             }
 
             // This will enforce the Hedera signing requirements (while treating any Key{contractID=tbdAddress}


### PR DESCRIPTION
**Description**:

 Remove redundant check `frame.isStatic` as it is checked at line 91

**Related issue(s)**:

Fixes #14037 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
