### PR TITLE
fix: Add test with deleted sender account

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
@@ -121,8 +121,10 @@ public class TokenAirdropValidator {
                         .filter(item -> item.amount() < 0)
                         .findFirst();
                 final var senderId = senderAccountAmount.orElseThrow().accountIDOrThrow();
-                final var senderAccount = accountStore.get(senderId);
-                validateTrue(senderAccount != null, INVALID_ACCOUNT_ID);
+
+                final var senderAccount =
+                        getIfUsable(senderId, accountStore, context.expiryValidator(), INVALID_ACCOUNT_ID);
+
                 // 1. Validate allowances and token associations
                 validateFungibleTransfers(
                         context.payer(), senderAccount, tokenId, senderAccountAmount.get(), tokenRelStore);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
@@ -436,6 +436,7 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
         // set up transaction and context
         givenAirdropTxn(false, zeroAccountId, TOKEN_AIRDROP);
         given(handleContext.expiryValidator()).willReturn(expiryValidator);
+        given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
 
         Assertions.assertThatThrownBy(() -> tokenAirdropHandler.handle(handleContext))
                 .isInstanceOf(HandleException.class)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -1323,6 +1323,27 @@ public class TokenAirdropTest {
                             .signedByPayerAnd(ALICE)
                             .hasKnownStatus(INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE));
         }
+
+        @HapiTest
+        @DisplayName("account that supposed to signed has been deleted")
+        final Stream<DynamicTest> accountThatSupposedToSignedHasBeenDeleted() {
+            final String ALICE = "alice";
+            final String BOB = "bob";
+            final String FUNGIBLE_TOKEN_A = "fungibleTokenA";
+            return hapiTest(
+                    cryptoCreate(ALICE).balance(ONE_HUNDRED_HBARS),
+                    cryptoCreate(BOB).balance(ONE_HUNDRED_HBARS),
+                    tokenCreate(FUNGIBLE_TOKEN_A)
+                            .treasury(BOB)
+                            .tokenType(FUNGIBLE_COMMON)
+                            .initialSupply(15L),
+                    tokenAssociate(ALICE, FUNGIBLE_TOKEN_A),
+                    cryptoDelete(ALICE),
+                    tokenAirdrop(moving(10, FUNGIBLE_TOKEN_A).between(ALICE, BOB))
+                            // pay by default payer, but sign with ALICE too
+                            .signedByPayerAnd(ALICE)
+                            .hasKnownStatus(ACCOUNT_DELETED));
+        }
     }
 
     @Nested


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
(AIRDROP - 59) Given sender is a deleted account when it attempts to sign a tokenAirdropTransaction then the transaction should fail.

**Related issue(s)**:

Fixes #14578

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
