### PR TITLE
test: use temp dir instead of `**/swirlds-tmp`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1043,9 +1043,6 @@ platform-sdk/sdk/metricsDoc.tsv
 # Mermaid Files
 **/platform-components.mermaid
 
-# Temporary Test Folders (Poorly Behaved Tests)
-**/swirlds-tmp
-
 # Preconsensus event stream files
 *.pces
 *.pcesD

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -185,7 +185,7 @@ public final class MerkleDb {
         return defaultInstancePath.updateAndGet(p -> {
             if (p == null) {
                 try {
-                    p = LegacyTemporaryFileBuilder.buildTemporaryFile("merkledb");
+                    p = Files.createTempDirectory(null).resolve(MERKLEDB_COMPONENT);
                 } catch (IOException z) {
                     throw new UncheckedIOException(z);
                 }

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
@@ -18,7 +18,6 @@ package com.swirlds.merkledb.collections;
 
 import static java.lang.Math.toIntExact;
 
-import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
 import com.swirlds.merkledb.utilities.MerkleDbFileUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -27,6 +26,7 @@ import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
@@ -193,7 +193,7 @@ public class LongListDisk extends AbstractLongList<Long> {
     }
 
     static Path createTempFile(final String sourceFileName) throws IOException {
-        return LegacyTemporaryFileBuilder.buildTemporaryDirectory(STORE_POSTFIX).resolve(sourceFileName);
+        return Files.createTempDirectory(null).resolve(sourceFileName);
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.common.crypto.DigestType;
-import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
+import com.swirlds.common.test.fixtures.TestFileSystemManager;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.config.MerkleDbConfig;
@@ -38,14 +38,19 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class MerkleDbBuilderTest {
+
+    @TempDir
+    private static Path tempDirectory;
 
     private static Path testDirectory;
 
     @BeforeAll
     static void setup() throws IOException {
-        testDirectory = LegacyTemporaryFileBuilder.buildTemporaryFile("MerkleDbBuilderTest");
+        final var testFileSystemManager = new TestFileSystemManager(tempDirectory);
+        testDirectory = testFileSystemManager.resolve(Path.of("MerkleDbBuilderTest"));
     }
 
     @AfterEach
@@ -74,7 +79,7 @@ class MerkleDbBuilderTest {
         final MerkleDbTableConfig<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> tableConfig =
                 createTableConfig();
         final MerkleDbDataSourceBuilder<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> builder =
-                new MerkleDbDataSourceBuilder<>(tableConfig);
+                new MerkleDbDataSourceBuilder<>(testDirectory.resolve("merkledb"), tableConfig);
         VirtualDataSource<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> dataSource = null;
         try {
             dataSource = builder.build("test1", false);
@@ -95,7 +100,8 @@ class MerkleDbBuilderTest {
         final MerkleDbTableConfig<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> tableConfig =
                 createTableConfig();
         final MerkleDbDataSourceBuilder<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> builder =
-                new MerkleDbDataSourceBuilder<>(tableConfig);
+                new MerkleDbDataSourceBuilder<>(testDirectory.resolve("merkledb"), tableConfig);
+        MerkleDb.setDefaultPath(testDirectory.resolve("merkledb"));
         final MerkleDb defaultDatabase = MerkleDb.getDefaultInstance();
         VirtualDataSource<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> dataSource = null;
         try {
@@ -130,9 +136,9 @@ class MerkleDbBuilderTest {
         final MerkleDbTableConfig<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> tableConfig =
                 createTableConfig();
         tableConfig.preferDiskIndices(true).maxNumberOfKeys(1999).hashesRamToDiskThreshold(Integer.MAX_VALUE >> 4);
-        final MerkleDbDataSourceBuilder<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> builder =
-                new MerkleDbDataSourceBuilder<>(tableConfig);
         final Path defaultDbPath = testDirectory.resolve("defaultDatabasePath");
+        final MerkleDbDataSourceBuilder<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> builder =
+                new MerkleDbDataSourceBuilder<>(defaultDbPath, tableConfig);
         MerkleDb.setDefaultPath(defaultDbPath);
         VirtualDataSource<ExampleLongKeyFixedSize, ExampleFixedSizeVirtualValue> dataSource = null;
         try {

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceMetricsTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceMetricsTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.swirlds.base.units.UnitConstants;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.crypto.DigestType;
-import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
+import com.swirlds.common.test.fixtures.TestFileSystemManager;
 import com.swirlds.common.test.fixtures.junit.tags.TestComponentTags;
 import com.swirlds.merkledb.test.fixtures.ExampleByteArrayVirtualValue;
 import com.swirlds.merkledb.test.fixtures.TestType;
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class MerkleDbDataSourceMetricsTest {
 
@@ -54,13 +55,17 @@ class MerkleDbDataSourceMetricsTest {
     // default number of longs per chunk
     private static final int COUNT = 1_048_576;
     private static final int HASHES_RAM_THRESHOLD = COUNT / 2;
+
+    @TempDir
+    private static Path tempDirectory;
+
     private static Path testDirectory;
     private MerkleDbDataSource<VirtualKey, ExampleByteArrayVirtualValue> dataSource;
     private Metrics metrics;
 
     @BeforeAll
     static void setup() throws Exception {
-        testDirectory = LegacyTemporaryFileBuilder.buildTemporaryFile("MerkleDbDataSourceMetricsTest");
+        testDirectory = new TestFileSystemManager(tempDirectory).resolve(Path.of("MerkleDbDataSourceMetricsTest"));
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
     }
 

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
@@ -37,7 +37,7 @@ import com.swirlds.base.function.CheckedConsumer;
 import com.swirlds.base.units.UnitConstants;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.crypto.Hash;
-import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
+import com.swirlds.common.test.fixtures.TestFileSystemManager;
 import com.swirlds.common.test.fixtures.junit.tags.TestQualifierTags;
 import com.swirlds.merkledb.test.fixtures.ExampleByteArrayVirtualValue;
 import com.swirlds.merkledb.test.fixtures.TestType;
@@ -65,6 +65,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -75,11 +76,14 @@ class MerkleDbDataSourceTest {
     private static final int COUNT = 10_000;
     private static final Random RANDOM = new Random(1234);
 
+    @TempDir
+    private static Path tempDirectory;
+
     private static Path testDirectory;
 
     @BeforeAll
     static void setup() throws Exception {
-        testDirectory = LegacyTemporaryFileBuilder.buildTemporaryFile("MerkleDbDataSourceTest");
+        testDirectory = new TestFileSystemManager(tempDirectory).resolve(Path.of("MerkleDbDataSourceTest"));
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.merkledb");
     }
 

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
@@ -28,7 +28,6 @@ import com.swirlds.common.crypto.DigestType;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.streams.MerkleDataInputStream;
 import com.swirlds.common.io.streams.MerkleDataOutputStream;
-import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
@@ -37,6 +36,7 @@ import com.swirlds.common.metrics.platform.DefaultPlatformMetrics;
 import com.swirlds.common.metrics.platform.MetricKeyRegistry;
 import com.swirlds.common.metrics.platform.PlatformMetricsFactoryImpl;
 import com.swirlds.common.test.fixtures.AssertionUtils;
+import com.swirlds.common.test.fixtures.TestFileSystemManager;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.config.MerkleDbConfig;
@@ -65,6 +65,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @Tag(TIMING_SENSITIVE)
 class MerkleDbSnapshotTest {
@@ -75,6 +76,11 @@ class MerkleDbSnapshotTest {
 
     private static final Random RANDOM = new Random(123);
 
+    @TempDir
+    private Path tempDirectory;
+
+    private TestFileSystemManager testFileSystemManager;
+
     @BeforeAll
     static void setup() throws Exception {
         ConstructableRegistry.getInstance().registerConstructables("com.swirlds.common");
@@ -84,7 +90,8 @@ class MerkleDbSnapshotTest {
 
     @BeforeEach
     void setupTest() throws Exception {
-        MerkleDb.setDefaultPath(LegacyTemporaryFileBuilder.buildTemporaryDirectory("MerkleDbSnapshotTest"));
+        this.testFileSystemManager = new TestFileSystemManager(tempDirectory);
+        MerkleDb.setDefaultPath(testFileSystemManager.resolve(Path.of("MerkleDbSnapshotTest")));
     }
 
     @AfterEach
@@ -134,8 +141,8 @@ class MerkleDbSnapshotTest {
             initialRoot.setChild(i, vm);
         }
 
-        final Path snapshotDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshotSync");
-        final Path snapshotFile = snapshotDir.resolve("state.swh");
+        final Path snapshotDir = Files.createDirectories(testFileSystemManager.resolve(Path.of("snapshotAsync")));
+        final Path snapshotFile = Files.createFile(snapshotDir.resolve("state.swh"));
 
         final AtomicReference<MerkleInternal> lastRoot = new AtomicReference<>();
         MerkleInternal stateRoot = initialRoot;
@@ -155,7 +162,7 @@ class MerkleDbSnapshotTest {
             if (j == ITERATIONS / 2) {
                 MerkleCryptoFactory.getInstance().digestTreeSync(stateRoot);
                 final MerkleDataOutputStream out = new MerkleDataOutputStream(
-                        Files.newOutputStream(snapshotFile, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE));
+                        Files.newOutputStream(snapshotFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE));
                 out.writeMerkleTree(snapshotDir, stateRoot);
             }
             stateRoot.release();
@@ -163,7 +170,7 @@ class MerkleDbSnapshotTest {
         }
         lastRoot.set(stateRoot);
 
-        MerkleDb.resetDefaultInstancePath();
+        MerkleDb.setDefaultPath(testFileSystemManager.resolve(Path.of("merkledb")));
         final MerkleDataInputStream in =
                 new MerkleDataInputStream(Files.newInputStream(snapshotFile, StandardOpenOption.READ));
         final MerkleInternal restoredStateRoot = in.readMerkleTree(snapshotDir, Integer.MAX_VALUE);
@@ -226,14 +233,14 @@ class MerkleDbSnapshotTest {
         assertEventuallyTrue(() -> lastRoot.get() != null, Duration.ofSeconds(10), "lastRoot is null");
 
         MerkleCryptoFactory.getInstance().digestTreeSync(rootToSnapshot.get());
-        final Path snapshotDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshotAsync");
-        final Path snapshotFile = snapshotDir.resolve("state.swh");
+        final Path snapshotDir = Files.createDirectories(testFileSystemManager.resolve(Path.of("snapshotAsync")));
+        final Path snapshotFile = Files.createFile(snapshotDir.resolve("state.swh"));
         final MerkleDataOutputStream out = new MerkleDataOutputStream(
-                Files.newOutputStream(snapshotFile, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE));
+                Files.newOutputStream(snapshotFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE));
         out.writeMerkleTree(snapshotDir, rootToSnapshot.get());
         rootToSnapshot.get().release();
 
-        MerkleDb.resetDefaultInstancePath();
+        MerkleDb.setDefaultPath(testFileSystemManager.resolve(Path.of("merkledb")));
         final MerkleDataInputStream in =
                 new MerkleDataInputStream(Files.newInputStream(snapshotFile, StandardOpenOption.READ));
         final MerkleInternal restoredStateRoot = in.readMerkleTree(snapshotDir, Integer.MAX_VALUE);
@@ -271,10 +278,10 @@ class MerkleDbSnapshotTest {
                 dsBuilder.copy(original, true);
 
         try {
-            final Path snapshotDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshot");
+            final Path snapshotDir = testFileSystemManager.resolve(Path.of("snapshot"));
             dsBuilder.snapshot(snapshotDir, copy);
 
-            final Path oldSnapshotDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("oldSnapshot");
+            final Path oldSnapshotDir = testFileSystemManager.resolve(Path.of("oldSnapshot"));
             assertDoesNotThrow(() -> dsBuilder.snapshot(oldSnapshotDir, original));
         } finally {
             original.close();

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
@@ -21,7 +21,7 @@ import static com.swirlds.merkledb.files.DataFileCompactor.INITIAL_COMPACTION_LE
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.swirlds.common.config.singleton.ConfigurationHolder;
-import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
+import com.swirlds.common.test.fixtures.TestFileSystemManager;
 import com.swirlds.merkledb.collections.LongList;
 import com.swirlds.merkledb.collections.LongListOffHeap;
 import com.swirlds.merkledb.config.MerkleDbConfig;
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class DataFileReaderCloseTest {
 
@@ -46,9 +47,15 @@ class DataFileReaderCloseTest {
 
     private static final BaseSerializer<long[]> serializer = new TwoLongSerializer();
 
+    @TempDir
+    private static Path tempDirectory;
+
+    private static TestFileSystemManager testFileSystemManager;
+
     @BeforeAll
     static void setup() throws IOException {
-        final Path dir = LegacyTemporaryFileBuilder.buildTemporaryFile("readerIsOpenTest");
+        testFileSystemManager = new TestFileSystemManager(tempDirectory);
+        final Path dir = testFileSystemManager.resolve(Path.of("readerIsOpenTest"));
         final MerkleDbConfig dbConfig = ConfigurationHolder.getConfigData(MerkleDbConfig.class);
         collection = new DataFileCollection<>(dbConfig, dir, "store", serializer, null);
     }
@@ -107,7 +114,7 @@ class DataFileReaderCloseTest {
 
     @Test
     void readWhileFinishWritingTest() throws IOException {
-        final Path tmpDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("readWhileFinishWritingTest");
+        final var tmpDir = Files.createDirectory(testFileSystemManager.resolve(Path.of("readWhileFinishWritingTest")));
         final MerkleDbConfig dbConfig = ConfigurationHolder.getConfigData(MerkleDbConfig.class);
         for (int i = 0; i < 100; i++) {
             Path filePath = null;

--- a/platform-sdk/swirlds-state-api/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleTestBase.java
+++ b/platform-sdk/swirlds-state-api/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleTestBase.java
@@ -351,8 +351,6 @@ public class MerkleTestBase extends StateTestBase {
     /** A convenience method used to deserialize a merkle tree */
     protected <T extends MerkleNode> T parseTree(@NonNull final byte[] state, @NonNull final Path tempDir)
             throws IOException {
-        // Restore to a fresh MerkleDb instance
-        MerkleDb.resetDefaultInstancePath();
         final var byteInputStream = new ByteArrayInputStream(state);
         try (final var in = new MerkleDataInputStream(byteInputStream)) {
             return in.readMerkleTree(tempDir, 100);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR builds upon the changes from https://github.com/hashgraph/hedera-services/pull/14157, fixing for the only one left directory (`**/swirlds-tmp`).

**Related issue(s)**:

https://github.com/hashgraph/hedera-services/issues/6714

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

The changes introduced are mostly in `platform-sdk` tests, I have opened this as separate PR from https://github.com/hashgraph/hedera-services/pull/14157 in order to make reviewing easier (i.e. smaller diff).
Apart from test files there are also two implementation files where changes were introduced, namely `MerkleDb.java` and `LongListDisk.java`, replacing the usage of the deprecated `LegacyTemporaryFileBuilder` with `Files.createTempDirectory()`.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
