### PR TITLE
fix: still set record `ethereum_hash` on `CONSENSUS_GAS_EXHAUSTED`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchProcessor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchProcessor.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.workflows.handle;
 
+import static com.hedera.hapi.node.base.HederaFunctionality.ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.HederaFunctionality.SYSTEM_DELETE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTHORIZATION_FAILED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.ENTITY_NOT_ALLOWED_TO_DELETE;
@@ -35,6 +36,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.fees.ExchangeRateManager;
+import com.hedera.node.app.service.contract.impl.handlers.EthereumTransactionHandler;
 import com.hedera.node.app.spi.authorization.Authorizer;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.record.StreamBuilder;
@@ -71,6 +73,7 @@ public class DispatchProcessor {
     private final DispatchUsageManager dispatchUsageManager;
     private final ExchangeRateManager exchangeRateManager;
     private final TransactionDispatcher dispatcher;
+    private final EthereumTransactionHandler ethereumTransactionHandler;
 
     @Inject
     public DispatchProcessor(
@@ -81,7 +84,8 @@ public class DispatchProcessor {
             @NonNull final PlatformStateUpdates platformStateUpdates,
             @NonNull final DispatchUsageManager dispatchUsageManager,
             @NonNull final ExchangeRateManager exchangeRateManager,
-            @NonNull final TransactionDispatcher dispatcher) {
+            @NonNull final TransactionDispatcher dispatcher,
+            @NonNull final EthereumTransactionHandler ethereumTransactionHandler) {
         this.authorizer = requireNonNull(authorizer);
         this.validator = requireNonNull(validator);
         this.recordFinalizer = requireNonNull(recordFinalizer);
@@ -90,6 +94,7 @@ public class DispatchProcessor {
         this.dispatchUsageManager = requireNonNull(dispatchUsageManager);
         this.exchangeRateManager = requireNonNull(exchangeRateManager);
         this.dispatcher = requireNonNull(dispatcher);
+        this.ethereumTransactionHandler = requireNonNull(ethereumTransactionHandler);
     }
 
     /**
@@ -152,7 +157,11 @@ public class DispatchProcessor {
             // and current throttling is very rough-grained, we just return USER_TRANSACTION here
             return USER_TRANSACTION;
         } catch (final ThrottleException e) {
-            return nonHandleWorkDone(dispatch, validationResult, e.getStatus());
+            final var workDone = nonHandleWorkDone(dispatch, validationResult, e.getStatus());
+            if (dispatch.txnInfo().functionality() == ETHEREUM_TRANSACTION) {
+                ethereumTransactionHandler.handleThrottled(dispatch.handleContext());
+            }
+            return workDone;
         } catch (final Exception e) {
             logger.error("{} - exception thrown while handling dispatch", ALERT_MESSAGE, e);
             return nonHandleWorkDone(dispatch, validationResult, FAIL_INVALID);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManager.java
@@ -64,10 +64,10 @@ public class DispatchUsageManager {
             @NonNull final HandleWorkflowMetrics handleWorkflowMetrics,
             @NonNull final ThrottleServiceManager throttleServiceManager,
             @NonNull final NetworkUtilizationManager networkUtilizationManager) {
-        this.networkInfo = networkInfo;
-        this.handleWorkflowMetrics = handleWorkflowMetrics;
-        this.throttleServiceManager = throttleServiceManager;
-        this.networkUtilizationManager = networkUtilizationManager;
+        this.networkInfo = requireNonNull(networkInfo);
+        this.handleWorkflowMetrics = requireNonNull(handleWorkflowMetrics);
+        this.throttleServiceManager = requireNonNull(throttleServiceManager);
+        this.networkUtilizationManager = requireNonNull(networkUtilizationManager);
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/AppSignatureVerifierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/AppSignatureVerifierTest.java
@@ -25,6 +25,7 @@ import static com.hedera.node.app.spi.signatures.SignatureVerifier.SimpleKeyStat
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
@@ -108,9 +109,7 @@ class AppSignatureVerifierTest {
         @Test
         void usesDefaultKeyVerifierWithNoOverride() throws ExecutionException, InterruptedException, TimeoutException {
             final var pretendKeccak256Hash = Bytes.wrap(new byte[32]);
-            final var hederaConfig = DEFAULT_CONFIG.getConfigData(HederaConfig.class);
-            given(future.get(hederaConfig.workflowVerificationTimeoutMS(), TimeUnit.MILLISECONDS))
-                    .willReturn(verification);
+            given(future.get(anyLong(), eq(TimeUnit.MILLISECONDS))).willReturn(verification);
             given(signatureVerifier.verify(pretendKeccak256Hash, expandedPairs, KECCAK_256_HASH))
                     .willReturn(Map.of(ED_KEY, future));
 
@@ -124,9 +123,7 @@ class AppSignatureVerifierTest {
         @Test
         void usesDefaultKeyVerifierWithValidOverride()
                 throws ExecutionException, InterruptedException, TimeoutException {
-            final var hederaConfig = DEFAULT_CONFIG.getConfigData(HederaConfig.class);
-            given(future.get(hederaConfig.workflowVerificationTimeoutMS(), TimeUnit.MILLISECONDS))
-                    .willReturn(verification);
+            given(future.get(anyLong(), eq(TimeUnit.MILLISECONDS))).willReturn(verification);
             given(signatureVerifier.verify(Bytes.EMPTY, expandedPairs, RAW)).willReturn(Map.of(ED_KEY, future));
 
             assertThat(subject.verifySignature(

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchProcessorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchProcessorTest.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.workflows.handle;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CALL;
 import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_TRANSFER;
+import static com.hedera.hapi.node.base.HederaFunctionality.ETHEREUM_TRANSACTION;
 import static com.hedera.hapi.node.base.HederaFunctionality.SYSTEM_DELETE;
 import static com.hedera.hapi.node.base.HederaFunctionality.SYSTEM_UNDELETE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTHORIZATION_FAILED;
@@ -60,6 +61,7 @@ import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.fees.FeeAccumulator;
+import com.hedera.node.app.service.contract.impl.handlers.EthereumTransactionHandler;
 import com.hedera.node.app.signature.AppKeyVerifier;
 import com.hedera.node.app.signature.impl.SignatureVerificationImpl;
 import com.hedera.node.app.spi.authorization.Authorizer;
@@ -68,7 +70,6 @@ import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.throttle.NetworkUtilizationManager;
 import com.hedera.node.app.throttle.ThrottleServiceManager;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
@@ -119,6 +120,11 @@ class DispatchProcessorTest {
             new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, SYSTEM_UNDELETE);
     private static final TransactionInfo CONTRACT_TXN_INFO =
             new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CALL);
+    private static final TransactionInfo ETH_TXN_INFO =
+            new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, ETHEREUM_TRANSACTION);
+
+    @Mock
+    private EthereumTransactionHandler ethereumTransactionHandler;
 
     @Mock
     private Authorizer authorizer;
@@ -149,9 +155,6 @@ class DispatchProcessorTest {
 
     @Mock
     private TransactionDispatcher dispatcher;
-
-    @Mock
-    private NetworkUtilizationManager networkUtilizationManager;
 
     @Mock
     private Dispatch dispatch;
@@ -189,7 +192,8 @@ class DispatchProcessorTest {
                 platformStateUpdates,
                 dispatchUsageManager,
                 exchangeRateManager,
-                dispatcher);
+                dispatcher,
+                ethereumTransactionHandler);
         given(dispatch.stack()).willReturn(stack);
         given(dispatch.recordBuilder()).willReturn(recordBuilder);
     }
@@ -421,6 +425,31 @@ class DispatchProcessorTest {
         verify(recordBuilder).status(CONSENSUS_GAS_EXHAUSTED);
         verify(feeAccumulator).chargeFees(PAYER_ACCOUNT_ID, CREATOR_ACCOUNT_ID, FEES);
         verify(feeAccumulator).chargeFees(PAYER_ACCOUNT_ID, CREATOR_ACCOUNT_ID, FEES.withoutServiceComponent());
+        assertFinished();
+    }
+
+    @Test
+    void consGasExhaustedForEthTxnDoesExtraWork() throws DispatchUsageManager.ThrottleException {
+        given(dispatch.fees()).willReturn(FEES);
+        given(dispatch.handleContext()).willReturn(context);
+        given(dispatch.feeAccumulator()).willReturn(feeAccumulator);
+        given(dispatchValidator.validationReportFor(dispatch)).willReturn(successReport(CREATOR_ACCOUNT_ID, PAYER));
+        given(dispatch.payerId()).willReturn(PAYER_ACCOUNT_ID);
+        given(dispatch.txnInfo()).willReturn(ETH_TXN_INFO);
+        givenAuthorization(ETH_TXN_INFO);
+        doThrow(new DispatchUsageManager.ThrottleException(CONSENSUS_GAS_EXHAUSTED))
+                .when(dispatchUsageManager)
+                .screenForCapacity(dispatch);
+        given(dispatch.txnCategory()).willReturn(USER);
+
+        subject.processDispatch(dispatch);
+
+        verifyTrackedFeePayments();
+        verify(dispatcher, never()).dispatchHandle(context);
+        verify(recordBuilder).status(CONSENSUS_GAS_EXHAUSTED);
+        verify(feeAccumulator).chargeFees(PAYER_ACCOUNT_ID, CREATOR_ACCOUNT_ID, FEES);
+        verify(feeAccumulator).chargeFees(PAYER_ACCOUNT_ID, CREATOR_ACCOUNT_ID, FEES.withoutServiceComponent());
+        verify(ethereumTransactionHandler).handleThrottled(context);
         assertFinished();
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
@@ -161,6 +161,19 @@ public class EthereumTransactionHandler implements TransactionHandler {
         throwIfUnsuccessful(outcome.status());
     }
 
+    /**
+     * Does work needed to externalize details after an Ethereum transaction is throttled.
+     * @param context the handle context
+     */
+    public void handleThrottled(@NonNull final HandleContext context) {
+        final var component = provider.get().create(context, ETHEREUM_TRANSACTION);
+        final var ethTxData =
+                requireNonNull(requireNonNull(component.hydratedEthTxData()).ethTxData());
+        context.savepointStack()
+                .getBaseBuilder(EthereumTransactionStreamBuilder.class)
+                .ethereumHash(Bytes.wrap(ethTxData.getEthereumHash()));
+    }
+
     @NonNull
     @Override
     public Fees calculateFees(@NonNull final FeeContext feeContext) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
@@ -207,6 +207,18 @@ class EthereumTransactionHandlerTest {
     }
 
     @Test
+    void setsEthHashOnThrottledContext() {
+        given(factory.create(handleContext, ETHEREUM_TRANSACTION)).willReturn(component);
+        given(component.hydratedEthTxData()).willReturn(HydratedEthTxData.successFrom(ETH_DATA_WITH_TO_ADDRESS));
+        given(handleContext.savepointStack()).willReturn(stack);
+        given(stack.getBaseBuilder(EthereumTransactionStreamBuilder.class)).willReturn(recordBuilder);
+        given(recordBuilder.ethereumHash(Bytes.wrap(ETH_DATA_WITH_TO_ADDRESS.getEthereumHash())))
+                .willReturn(recordBuilder);
+
+        assertDoesNotThrow(() -> subject.handleThrottled(handleContext));
+    }
+
+    @Test
     void delegatesToCreatedComponentAndExposesEthTxDataCreateWithoutToAddress() {
         given(factory.create(handleContext, ETHEREUM_TRANSACTION)).willReturn(component);
         given(component.hydratedEthTxData()).willReturn(HydratedEthTxData.successFrom(ETH_DATA_WITHOUT_TO_ADDRESS));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileUpdateSuite.java
@@ -37,6 +37,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreate;
@@ -46,6 +47,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenDissociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uncheckedSubmit;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
@@ -69,6 +71,8 @@ import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.ZERO_BYTE_MEMO;
 import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hedera.services.bdd.suites.utils.contracts.SimpleBytesResult.bigIntResult;
@@ -406,12 +410,15 @@ public class FileUpdateSuite {
 
         return hapiTest(
                 overriding("contracts.maxGasPerSec", gasToOffer + ""),
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
                 cryptoCreate(civilian).balance(ONE_HUNDRED_HBARS),
                 uploadInitCode(contract),
                 contractCreate(contract),
-                contractCall(contract, INSERT_ABI, BigInteger.ONE, BigInteger.valueOf(4))
+                ethereumCall(contract, INSERT_ABI, BigInteger.ONE, BigInteger.valueOf(4))
+                        .gasLimit(gasToOffer)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
                         .payingWith(civilian)
-                        .gas(gasToOffer)
                         .via(unrefundedTxn),
                 usableTxnIdNamed(refundedTxn).payerId(civilian),
                 contractCall(contract, INSERT_ABI, BigInteger.TWO, BigInteger.valueOf(4))
@@ -419,9 +426,10 @@ public class FileUpdateSuite {
                         .gas(gasToOffer)
                         .hasAnyStatusAtAll()
                         .deferStatusResolution(),
-                uncheckedSubmit(contractCall(contract, INSERT_ABI, BigInteger.valueOf(3), BigInteger.valueOf(4))
-                                .signedBy(civilian)
-                                .gas(gasToOffer)
+                uncheckedSubmit(ethereumCall(contract, INSERT_ABI, BigInteger.valueOf(3), BigInteger.valueOf(4))
+                                .gasLimit(gasToOffer)
+                                .signingWith(SECP_256K1_SOURCE_KEY)
+                                .payingWith(civilian)
                                 .txnId(refundedTxn))
                         .payingWith(GENESIS),
                 sleepFor(6_000L),
@@ -435,6 +443,8 @@ public class FileUpdateSuite {
                         log.info("Latency allowed gas throttle bucket to drain" + " completely");
                     } else {
                         assertEquals(CONSENSUS_GAS_EXHAUSTED, status);
+                        final var hash = refundedOp.getResponseRecord().getEthereumHash();
+                        assertEquals(32, hash.size(), "Expected a 32-byte hash");
                         final var origFee = unrefundedOp.getResponseRecord().getTransactionFee();
                         final var feeSansRefund = refundedOp.getResponseRecord().getTransactionFee();
                         assertTrue(


### PR DESCRIPTION
**Description**:
 - Closes #14610 
   * In `DispatchProcessor`, if an `EthereumTransaction` is throttled, ensures the record still has the `ethereum_hash` by calling a new `handleThrottled()` method on the `EthereumTransactionHandler`.