### PR TITLE
chore: add inert protobuf files for preview block stream

### DIFF
--- a/hapi/hedera-protobufs/block/block_service.proto
+++ b/hapi/hedera-protobufs/block/block_service.proto
@@ -1,0 +1,866 @@
+/**
+ * # Block Service
+ * The Service API exposed by the Block Nodes.
+ *
+ * ## Workarounds
+ * > There are incorrect elements in this file to work around bugs in the
+ * > PBJ Compiler.
+ * >> Issues 262, 263, 240, 218, 217, and 216 are related.
+ * >
+ * > Issue 263
+ * >> A number of fields reference child messages, these _should_ specify
+ * >> the parent message (i.e. `Parent.child field = #;`) but do not do
+ * >> so due to issue 263.
+ * >
+ * > Issue 262
+ * >> Some fields reference messages defined in other packages that share
+ * >> a common prefix (e.g. `com.hedera.hapi.block.stream`). These fields
+ * >> specify the entire package instead of the shorter and clearer suffix
+ * >> due to issue 262
+ * >
+ * > Issue 240
+ * >> These files currently cause PBJ integration tests to fail if included
+ * >> due to issue 240.
+ * >
+ * > Issue 218
+ * >> These files have the same value for package and java_package. Ideally
+ * >> we would not specify `java_package` or the pbj comment in that situation,
+ * >> but Issue 218 prevents eliding the unnecessary directives.
+ * >
+ * > Issue 217
+ * >> These files may cause PBJ to fail compilation due to comments preceeding
+ * >> the `syntax` keyword.
+ * >
+ * > Issue 216
+ * >> These files would do well with validation support, but cannot make
+ * >> use of validation, even as an advisory element, due to Issue 216.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "stream/block.proto";
+import "stream/block_item.proto";
+
+/**
+ * Publish a stream of blocks.
+ *
+ * Each item in the stream MUST contain one `BlockItem`.<br/>
+ * Each Block MUST begin with a single `BlockHeader` block item.<br/>
+ * The block node SHALL append each `BlockItem` to an internal structure
+ * to reconstruct full blocks.<br/>
+ * The block node MUST verify the block proof for each block before sending a
+ * response message acknowledging that block.<br/>
+ * Each Block MUST end with a single `BlockStateProof` block item.<br/>
+ * The block node MUST verify the Block using the `BlockStateProof` to
+ * ensure all data was received and processed correctly.<br/>
+ */
+message PublishStreamRequest {
+    /**
+     * A single item written to the block stream.
+     */
+    com.hedera.hapi.block.stream.BlockItem block_item = 1;
+}
+
+/**
+ * A response to writing a block stream.
+ *
+ * This message is sent in response to each Block in a block stream sent
+ * to a block node. The block stream is sent as a stream of messages, and each
+ * message MAY be acknowledged with a message of this type.<br/>
+ * Each `BlockItem` MAY be acknowledged with an `Acknowledgement`
+ * response. Item acknowledgement is an OPTIONAL feature.<br/>
+ * Each completed block SHALL be acknowledged with an `Acknowledgement`
+ * response. Block acknowledgement is a REQUIRED feature.<br/>
+ * A final response SHALL be sent with an `EndOfStream` status result after
+ * the last block stream item is received, or when the receiving system
+ * must end the stream for any reason.<br/>
+ * If a failure is detected (which may include a block or block item that
+ * fails validation) an `EndOfStream` response SHALL be sent with a
+ * relevant error status.
+ */
+message PublishStreamResponse {
+    oneof response {
+        /**
+         * A response sent for each block, and optionally for each item.
+         */
+        Acknowledgement acknowledgement = 1;
+
+        /**
+         * A response sent when a stream ends.
+         */
+        EndOfStream status = 2;
+    }
+
+    /**
+     * A response to acknowledge receipt and verification of a single item
+     * or full block.
+     */
+    message Acknowledgement {
+        oneof acknowledgements {
+            /**
+             * A response type to acknowledge a full and complete block.
+             * <p>
+             * All block node implementations SHOULD acknowledge each block.
+             */
+            BlockAcknowledgement block_ack = 1;
+
+            /**
+             * A response type to acknowledge a single `BlockItem`.<br/>
+             * This is an OPTIONAL message and implementations MAY choose to
+             * only acknowledge full blocks.
+             */
+            ItemAcknowledgement item_ack = 2;
+        }
+    }
+
+    /**
+     * Acknowledgement for a single `BlockItem`.<br/>
+     * Most nodes are expected to implement this acknowledgement only for
+     * debugging and development purposes.
+     *
+     * If a node implements single item acknowledgement, the block node SHALL
+     * send one `ItemAcknowledgement` for each `BlockItem` received
+     * and verified.
+     */
+    message ItemAcknowledgement {
+        /**
+         * A SHA2-384 hash of the `BlockItem` received.
+         * <p>
+         * This field is REQUIRED.<br/>
+         * A source system MUST verify that this value matches its own internal
+         * calculated hash value, and MUST end the stream if the values do not
+         * match.
+         */
+        bytes item_hash = 1;
+    }
+
+    /**
+     * Acknowledgement of a full block.<br/>
+     * This message is a necessary part of the block streaming protocol.
+     *
+     * This response SHALL be sent after a block state proof item is
+     * received and verified.<br/>
+     * The block node SHALL send exactly one `BlockAcknowledgement` for
+     * each successful block.<br/>
+     * The `BlockAcknowledgement` response MAY be sent after sending an
+     * `ItemAcknowledgement` response for the `BlockStateProof` item
+     * at the end of the block, if item acknowledgement is enabled.
+     */
+    message BlockAcknowledgement {
+        /**
+         * A block number number of the acknowledged block.
+         * <p>
+         * A source system SHOULD verify that this value matches the block sent.
+         */
+        uint64 block_number = 1;
+
+        /**
+         * A hash of the virtual merkle root for the block.
+         * <p>
+         * This SHALL be the hash calculated by the block node for the
+         * root node of the virtual merkle tree that is signed by the source
+         * system to validate the block.
+         */
+        bytes block_root_hash = 2;
+
+        /**
+         * A flag indicating that the received block duplicates an
+         * existing block.
+         * <p>
+         * If a source system receives acknowledgement with this flag set
+         * true the source system SHOULD end the stream. The `block_number`
+         * returned SHALL be the last block known and verified by the receiving
+         * system, and the source system MAY resume publishing immediately
+         * after that block.
+         */
+        bool block_already_exists = 3;
+    }
+
+    /**
+     * A message sent to end a stream.
+     *
+     * This response message SHALL be sent from a block node to a block
+     * stream source system when a `publishBlockStream` stream ends.<br/>
+     * This message SHALL be sent exactly once for each `publishBlockStream`
+     * call.<br/>
+     * The source system SHALL cease sending block items upon receiving
+     * this response, and MAY determine the ending state of the stream from
+     * the `status` enumeration and the `block_number` returned.<br/>
+     * A source system SHOULD verify that the `block_number` value matches the
+     * last block sent, and SHOULD resend one or more blocks if the value
+     * here does not match the expected value.
+     */
+    message EndOfStream {
+        /**
+         * A response code.
+         * <p>
+         * This code indicates the reason the stream ended.<br/>
+         * This value MUST be set to a non-default value.
+         */
+        PublishStreamResponseCode status = 1;
+
+        /**
+         * The number of the last completed and _verified_ block.
+         * <p>
+         * Nodes SHOULD only end a stream after a block state proof to avoid
+         * the need to resend items.<br/>
+         * If status is a failure code, the source node MUST start a new
+         * stream at the beginning of the first block _following_ this number
+         * (e.g. if this is 91827362983, then the new stream must start with
+         * the _header_ for block 91827362984).
+         */
+        uint64 block_number = 2;
+    }
+}
+
+/**
+ * An enumeration indicating the status of this request.
+ *
+ * This enumeration describes the reason a block stream
+ * (sent via `publishBlockStream`) ended.
+ */
+enum PublishStreamResponseCode {
+    /**
+     * An "unset value" flag, this value SHALL NOT be used.<br/>
+     * This status indicates the server software failed to set a
+     * status, and SHALL be considered a software defect.
+     */
+    STREAM_ITEMS_UNKNOWN = 0;
+
+    /**
+     * The request succeeded.<br/>
+     * No errors occurred and the source node orderly ended the stream.
+     */
+    STREAM_ITEMS_SUCCESS = 1;
+
+    /**
+     * The delay between items was too long.<br/>
+     * The source MUST start a new stream before the failed block.
+     */
+    STREAM_ITEMS_TIMEOUT = 2;
+
+    /**
+     * An item was received out-of-order.<br/>
+     * The source MUST start a new stream before the failed block.
+     */
+    STREAM_ITEMS_OUT_OF_ORDER = 3;
+
+    /**
+     * A block state proof item could not be validated.<br/>
+     * The source MUST start a new stream before the failed block.
+     */
+    STREAM_ITEMS_BAD_STATE_PROOF = 4;
+
+    /**
+     * The block node is "behind" the publisher.<br/>
+     * Ths consensus node has sent a block later than this block node
+     * can process. The publisher may retry by sending blocks immediately
+     * following the `block_number` returned, or may end the stream and
+     * try again later.
+     * <p>
+     * Block nodes that are "behind" SHOULD attempt to "catch up" by requesting
+     * blocks from another block node or other source of recent historical
+     * block stream data.
+     */
+    STREAM_ITEMS_BEHIND = 5;
+}
+
+/**
+ * A request to read a single block.
+ *
+ * A client system SHALL send this message to request a single block,
+ * including the block state proof.<br/>
+ * A client MAY request that the block be sent without verification.
+ * A compliant Block Node MAY respond to requests that allow unverified
+ * responses by returning the full requested block before verifying
+ * the included block proof.<br/>
+ * A compliant Block Node MAY support _only_ requests that allow unverified
+ * blocks, but MUST clearly document that limitation, and MUST respond to
+ * a request that does not allow unverified blocks with the
+ * `ALLOW_UNVERIFIED_REQUIRED` response code.
+ */
+message SingleBlockRequest {
+    /**
+     * The block number of a block to retrieve.
+     * <p>
+     * The requested block MUST exist on the block node.<br/>
+     * This value MUST NOT be set if `retrieve_latest` is set `true`.<br/>
+     * This value MUST be set to a valid block number if `retrieve_latest` is
+     * unset or is set `false`.
+     */
+    uint64 block_number = 1;
+
+    /**
+     * A flag to indicate that the requested block may be sent without
+     * verifying its `BlockProof`.<br/>
+     * This might be set by a client that expects to perform its own
+     * verification and wishes lower latency or, potentially, lower cost.
+     * <p>
+     * If this value is set, then the responding Block Node MAY respond with a
+     * block that has not completed verification of its `BlockProof`.<br/>
+     * If this is _not_ set then the Block Node MUST respond with either a
+     * fully verified and validated block, or `VERIFIED_BLOCK_UNAVAILABLE` if
+     * the requested block is not yet verified.<br/>
+     * The default value is _not set_.
+     */
+    bool allow_unverified = 2;
+
+    /**
+     * A flag to request the latest available block.
+     * <p>
+     * This value MAY be set `true` to request the last block available.<br/>
+     * If this value is set to `true` then `block_number` MUST NOT be set and
+     * SHALL be ignored.
+     */
+    bool retrieve_latest = 3;
+}
+
+/**
+ * A response to a `singleBlock` request.
+ *
+ * This message SHALL be sent in response to a request, and SHALL contain at
+ * least a valid `status`.<br/>
+ * If `status` is `READ_BLOCK_SUCCESS`, the response SHALL contain the
+ * requested block in the `block` field.
+ *
+ * > Note
+ * >> A block can become quite large. A client MUST be prepared to receive the
+ * >> full content of the block, perhaps many megabytes of data.
+ */
+message SingleBlockResponse {
+    /**
+     * A response status.
+     * <p>
+     * The reported status SHALL reflect the success of the request, or
+     * a detailed reason the request failed.
+     */
+    SingleBlockResponseCode status = 1;
+
+    /**
+     * The requested block.
+     * <p>
+     * This container object SHALL hold the entire sequence of block items
+     * for the requested block.<br/>
+     * The block items in this message SHALL be in the same order
+     * as received.<br/>
+     * The items in this message SHALL begin with a `BlockHeader` and end with
+     * a `BlockStateProof` applicable to this block.
+     */
+    com.hedera.hapi.block.stream.Block block = 2;
+}
+
+    /**
+     * An enumeration indicating the status of this request.
+     */
+enum SingleBlockResponseCode {
+    /**
+     * An "unset value" flag, this value SHALL NOT be used.<br/>
+     * This status indicates the server software failed to set a status,
+     * and SHALL be considered a software defect.
+     */
+    READ_BLOCK_UNKNOWN = 0;
+
+    /**
+     * The requesting client account lacks sufficient HBAR to pay the
+     * service fee for this request.<br/>
+     * The client MAY retry the request, but MUST increase the client
+     * account balance with this block node server before doing so.
+     */
+    READ_BLOCK_INSUFFICIENT_BALANCE = 1;
+
+    /**
+     * The request succeeded.<br/>
+     * The requested block SHALL be returned in the `block` field.
+     */
+    READ_BLOCK_SUCCESS = 2;
+
+    /**
+     * The requested block was not found.<br/>
+     * Something failed and a block that SHOULD be available was
+     * not found.<br/>
+     * The client MAY retry the request; if this result is repeated the
+     * request SHOULD be directed to a different block node server.
+     */
+    READ_BLOCK_NOT_FOUND = 3;
+
+    /**
+     * The requested block is not available on this block node server.<br/>
+     * The client SHOULD send a `serverStatus` request to determine the
+     * lowest and highest block numbers available at this block node server.
+     */
+    READ_BLOCK_NOT_AVAILABLE = 4;
+
+    /**
+     * The request for a verified block cannot be fulfilled.<br/>
+     * The client requested a verified block from a block node that does not
+     * offer verified blocks.
+     * <p>
+     * The client MAY retry the request with the `allow_unverified` flag set.
+     */
+    ALLOW_UNVERIFIED_REQUIRED = 5;
+
+    /**
+     * The request for a verified block cannot be fulfilled.<br/>
+     * The client requested a verified block from a block node but the
+     * requested block is not yet verified.
+     * <p>
+     * The client MAY retry the request after a short delay
+     * (typically 2 seconds or more).
+     */
+    VERIFIED_BLOCK_UNAVAILABLE = 6;
+}
+
+/**
+ * A request to stream block items from block node to a client.
+ *
+ * The block node SHALL respond to this request with a stream of
+ * `SubscribeStreamResponse` messages.<br/>
+ * The block node SHALL stream the full contents of the blocks requested.<br/>
+ * The block items SHALL be streamed in order originally produced within
+ * a block.<br/>
+ * The blocks SHALL be streamed in ascending order by `block_number`.<br/>
+ * The block node SHALL end the stream when the last requested block has
+ * been sent.<br/>
+ * The block node SHALL end the stream with a response code status of SUCCESS
+ * when the stream is complete.<br/>
+ * The client SHOULD call the `serverStatus` rpc prior to constructing this
+ * request to determine the available start and end blocks.
+ */
+message SubscribeStreamRequest {
+    /**
+     * A block number to start the stream.
+     * <p>
+     * This SHALL be the block number of the first block returned.<br/>
+     * This field MUST be less than or equal to the latest available
+     * block number.
+     */
+    uint64 start_block_number = 1;
+
+    /**
+     * A block number to end the stream.<br/>
+     * This is optional, and if not set (0), the stream will be "infinite".
+     * <p>
+     * This field MAY be zero (`0`) to indicate the stream SHOULD continue
+     * indefinitely, streaming new blocks as each becomes available.<br/>
+     * If this value is greater than zero (`0`)
+     * <ul>
+     *   <li>This value SHALL be the number of the last block returned.</li>
+     *   <li>This field MUST NOT be less than `start_block_number`.</li>
+     *   <li>This SHOULD be a block number that is immediately available
+     *       from the block node.</li>
+     *   <li>A block node SHALL continue to stream blocks until the last
+     *       requested block is transmitted.</li>
+     *   <li>A block node implementation MAY reject a request for a block
+     *       that is not yet available.</li>
+     *   <li>A block node implementation MAY accept future block numbers.</li>
+     *   <li>Block node implementations MAY charge increased fees for such
+     *       "future" streams.</li>
+     * </ul>
+     */
+    uint64 end_block_number = 2;
+
+    /**
+     * A flag to indicate that the requested block(s) may be sent before
+     * verifying each block's `BlockProof`.<br/>
+     * This might be set by a client that expects to perform its own
+     * verification and wishes lower latency or, potentially, lower cost.
+     * <p>
+     * If this value is set, then the responding Block Node MAY respond with
+     * blocks that have not (yet) completed block proof verification.<br/>
+     * If this is _not set_ then the Block Node MUST respond with only
+     * fully verified and validated block(s).<br/>
+     * If this is _set_, then a Block Node MAY stream items from
+     * blocks that have not yet been verified or do not yet have
+     * a block proof available.<br/>
+     * The default value is _not set_.
+     */
+    bool allow_unverified = 3;
+}
+
+/**
+ * One item in a stream of `subscribeBlockStream` responses.
+ *
+ * The block node SHALL respond to a `subscribeBlockStream` request with a
+ * stream of `SubscribeStreamResponse` messages.<br/>
+ * The block node SHALL stream the full contents of the blocks requested.<br/>
+ * The block items SHALL be streamed in order originally produced within
+ * a block.<br/>
+ * The blocks SHALL be streamed in ascending order by `block_number`.<br/>
+ * The block node SHALL end the stream when the last requested block has
+ * been sent.<br/>
+ * The block node SHALL end the stream with a response code status of SUCCESS
+ * when the stream is complete.<br/>
+ * The block node SHALL end the stream with a response code status of
+ * `READ_STREAM_INVALID_START_BLOCK_NUMBER` if the start block number is
+ * greater than the end block number.<br/>
+ * The block node SHALL end the stream with a response code status of
+ * `READ_STREAM_INSUFFICIENT_BALANCE` if insufficient balance remains to
+ * complete the requested stream.
+ * The block node SHALL make every reasonable effort to fulfill as much of the
+ * request as available balance supports, in the event balance is not
+ * sufficient to complete the request.
+ */
+message SubscribeStreamResponse {
+    oneof response {
+        /**
+         * A final response item describing the terminal status of this stream.
+         * <p>
+         * The block node server SHALL end the stream following this message.
+         */
+        SubscribeStreamResponseCode status = 1;
+
+        /**
+         * A stream response item containing a single `BlockItem`.
+         * <p>
+         * The full response SHALL consist of many `block_item` messages
+         * followed by a single `status` message.
+         */
+        com.hedera.hapi.block.stream.BlockItem block_item = 2;
+    }
+}
+
+/**
+* An enumeration indicating the status of this request.
+*
+* This response code SHALL be the last message in the stream of responses.
+* This code SHALL represent the final status of the full request.
+*/
+enum SubscribeStreamResponseCode {
+    /**
+         * An "unset value" flag, this value SHALL NOT be used.<br/>
+         * This status indicates the server software failed to set a status,
+         * and SHALL be considered a software defect.
+         */
+    READ_STREAM_UNKNOWN = 0;
+
+    /**
+     * The requesting client account lacks sufficient HBAR to pay the
+     * service fee for this request.<br/>
+     * The client MAY retry the request, but MUST increase the client
+     * account balance with this block node server before doing so.
+     */
+    READ_STREAM_INSUFFICIENT_BALANCE = 1;
+
+    /**
+     * The request succeeded.
+     * <p>
+     * The requested block(s) SHALL precede the status response
+     * with this value.
+     */
+    READ_STREAM_SUCCESS = 2;
+
+    /**
+     * The requested start block number is not valid.<br/>
+     * The start block number is after the end block number, less
+     * than `0`, or otherwise invalid.<br/>
+     * The client MAY retry this request, but MUST change the
+     * `start_block_number` field to a valid start block.
+     */
+    READ_STREAM_INVALID_START_BLOCK_NUMBER = 3;
+
+    /**
+     * The requested end block number is not valid.<br/>
+     * The end block number is greater than the highest current block
+     * number, less than `0`, or otherwise invalid.<br/>
+     * The client MAY retry this request, but MUST change the
+     * `end_block_number` field to a valid end block.
+     */
+    READ_STREAM_INVALID_END_BLOCK_NUMBER = 4;
+}
+
+/**
+ * A request to read a state snapshot.
+ *
+ * A state snapshot is a full copy of the network state at the completion of a
+ * particular block.
+ *
+ * This request MUST contain a block number that has already reached this block
+ * node and completed verification, or request the "latest" snapshot.<br/>
+ * This request MAY specify the "latest" snapshot, and the block node SHALL
+ * respond with a reference to a snapshot containing the most recent contents
+ * of the network state known to that block node.
+ */
+message StateSnapshotRequest {
+    /**
+     * A block number.
+     * <p>
+     * This SHALL be the last block number present in the snapshot
+     * returned.<br/>
+     * If `retrieve_latest` is set `true` this field SHOULD NOT be set
+     * and SHALL be ignored.<br/>
+     * A block node implementation MAY reject any request with a non-default
+     * value for this field, but MUST clearly document that behavior.
+     */
+    uint64 last_block_number = 2;
+
+    /**
+     * A boolean to request the latest available snapshot.
+     * <p>
+     * This value MAY be set `true` to request the most recent state snapshot
+     * available.<br/>
+     * If this value is set to `true` then `last_block_number` SHOULD NOT be
+     * set and SHALL be ignored.<br/>
+     * A block node implementation MAY reject any request with that does _not_
+     * set this field `true`, but MUST clearly document that behavior.
+     */
+    bool retrieve_latest = 3;
+}
+
+/**
+ * A response to a request for a state snapshot.
+ *
+ * This message SHALL deliver a _reference_ to the requested snapshot
+ * data if successful.<br/>
+ * This message SHALL deliver a code indicating the reason for failure
+ * if unsuccessful.
+ */
+message StateSnapshotResponse {
+    /**
+     * A status response.
+     * <p>
+     * This code SHALL indicate a successful call, or the detailed
+     * reason for failure.
+     */
+    StateSnapshotResponseCode status = 1;
+
+    /**
+     * A block number.
+     * <p>
+     * This SHALL be the number of the last block included in this
+     * state snapshot.
+     */
+    uint64 last_block_number = 2;
+
+    /**
+     * A reference to where the requested state snapshot may be obtained.
+     * <p>
+     * <blockquote>REVIEW NOTE<blockquote>
+     * This is TEMPORARY.  We have not yet designed how state snapshots may
+     * be sent. One idea is to use `Any` and let implementations decide;
+     * another is to use a time limited URL (with the same login as the block
+     * node server); another is to use a customer-pays cloud storage bucket.
+     * </blockquote></blockquote>
+     */
+    string snapshot_reference = 3;
+}
+
+/**
+ * An enumeration indicating the status of a StateSnapshotResponse request.
+ */
+enum StateSnapshotResponseCode {
+    /**
+         * An "unset value" flag, this value SHALL NOT be used.<br/>
+         * This status indicates the server software failed to set a status,
+         * and SHALL be considered a software defect.
+         */
+    STATE_SNAPSHOT_UNKNOWN = 0;
+
+    /**
+     * The requesting client account lacks sufficient HBAR to pay the
+     * service fee for this request.<br/>
+     * The client MAY retry the request, but MUST increase the client
+     * account balance with this block node server before doing so.
+     */
+    STATE_SNAPSHOT_INSUFFICIENT_BALANCE = 1;
+
+    /**
+     * The request succeeded.<br/>
+     * The full snapshot data MAY be read via the endpoint provided in the
+     * `snapshot_reference` field for the duration specified.
+     */
+    STATE_SNAPSHOT_SUCCESS = 2;
+}
+
+/**
+ * A request for the status of a block node server.
+ */
+message ServerStatusRequest {}
+
+/**
+ * A response to a server status request.
+ *
+ * This message SHALL provide a client with information needed to successfully
+ * query this block node server for a block, stream of blocks, or
+ * state snapshot.<br/>
+ * A request for blocks between `first_available_block` and
+ * `last_available_block`, inclusive, SHOULD succeed. Any request for blocks
+ * outside that range SHOULD fail.
+ */
+message ServerStatusResponse {
+    /**
+     * The lowest numbered block available on this block node server.
+     * <p>
+     * Any request for a block with lower number than this value SHALL fail
+     * with a status value indicating and invalid start block number.
+     */
+    uint64 first_available_block = 1;
+
+    /**
+     * The greatest block number available from this block node server.
+     * <p>
+     * Any request for a block with a block number higher than this
+     * value MAY fail.
+     */
+    uint64 last_available_block = 2;
+
+    /**
+     * A flag indicating this block node only offers the latest state snapshot.
+     * <p>
+     * If this value is `true` the client MUST set `retrieve_latest` `true`
+     * in any `StateSnapshotRequest` sent to this block node.
+     */
+    bool only_latest_state = 3;
+
+    /**
+     * Version information.<br/>
+     * Versions for the block network address book, block stream protocol
+     * buffer schema, and block node software.
+     */
+    BlockNodeVersions version_information = 4;
+}
+
+/**
+ * Version information for a block node.
+ *
+ * The `stream_proto_version` SHOULD be an officially released Block Stream
+ * version.
+ * The `address_book_version` SHALL be defined by networks of block nodes.
+ * The `software_version` SHALL be defined by the implementation of the
+ * Block Node specification.
+ */
+message BlockNodeVersions {
+    /**
+     * A version of the Block Node network address book.<br/>
+     * The address book version describes what version of address book
+     * this block node holds for discovering and identifying other block nodes.
+     * <p>
+     * This version SHALL be specific to each "network" of interconnected
+     * Block Nodes.
+     */
+    proto.SemanticVersion address_book_version = 1;
+
+    /**
+     * A version of the Block Stream specification.<br/>
+     * This is the Stream version currently supported by this Block Node.
+     * <p>
+     * Implementations SHOULD make reasonable effort to ensure the latest
+     * released Block Stream version is supported.<br/>
+     * This version MUST be an officially released Block Stream version if
+     * the responding block node is not private.
+     */
+    proto.SemanticVersion stream_proto_version = 2;
+
+    /**
+     * A version of the block node software.<br/>
+     * This is the software version that this block node is currently
+     * running.
+     * <p>
+     * This value is implementation-defined.
+     */
+    proto.SemanticVersion software_version = 3;
+}
+
+/**
+ * Remote procedure calls (RPCs) for the Block Node.
+ */
+service BlockStreamService {
+    /**
+     * Read the status of this block node server.
+     * <p>
+     * A client SHOULD request server status prior to requesting block stream
+     * data or a state snapshot.
+     */
+    rpc serverStatus(ServerStatusRequest) returns (ServerStatusResponse);
+
+    /**
+     * Read a single block from the block node.
+     * <p>
+     * The request SHALL describe the block number of the block to retrieve.
+     */
+    rpc singleBlock(SingleBlockRequest) returns (SingleBlockResponse);
+
+    /**
+     * Read a state snapshot from the block node.
+     * <p>
+     * The request SHALL describe the last block number present in the
+     * snapshot.<br/>
+     * Block node implementations MAY decline a request for a snapshot older
+     * than the latest available, but MUST clearly document this behavior.
+     */
+    rpc stateSnapshot(StateSnapshotRequest) returns (StateSnapshotResponse);
+
+    /**
+     * Publish a stream of blocks.
+     * <p>
+     * Each item in the stream MUST contain one `BlockItem`.<br/>
+     * Each Block MUST begin with a single `BlockHeader` block item.<br/>
+     * The block node SHALL append each `BlockItem` to an internal structure
+     * to construct full blocks.<br/>
+     * Each Block MUST end with a single `BlockStateProof` block item.<br/>
+     * It is RECOMMENDED that the implementations verify the Block using the
+     * `BlockStateProof` to validate all data was received correctly.<br/>
+     * This API SHOULD, generally, be restricted based on mTLS authentication
+     * to a limited set of source (i.e. consensus node) systems.
+     */
+    rpc publishBlockStream (stream PublishStreamRequest) returns (stream PublishStreamResponse);
+
+    /**
+     * Subscribe to a stream of blocks.
+     * <p>
+     * Each item in the stream SHALL contain one `BlockItem` or a
+     * response code.<br/>
+     * The request message MUST specify start and end block numbers
+     * to return/<br/>
+     * The block node SHALL stream the full contents of the blocks
+     * requested.<br/>
+     * The block items SHALL be streamed in order originally produced within
+     * a block.<br/>
+     * The blocks shall be streamed in ascending order by `block_number`.<br/>
+     * The block node SHALL end the stream when the last requested block,
+     * if set, has been sent.<br/>
+     * A request with an end block of `0` SHALL be interpreted to indicate the
+     * stream has no end. The block node SHALL continue to stream new blocks
+     * as soon as each becomes available.<br/>
+     * The block node SHALL end the stream with response code containing a
+     * status of SUCCESS when the stream is complete.<br/>
+     * The block node SHALL end the stream with a response code containing a
+     * status of `READ_STREAM_INVALID_START_BLOCK_NUMBER` if the start block
+     * number is greater than the end block number.<br/>
+     * The block node SHALL end the stream with a response code containing a
+     * status of `READ_STREAM_PAYMENT_INSUFFICIENT` if insufficient payment
+     * remains to complete the requested stream.<br/>
+     * The block node SHALL make every reasonable effort to fulfill as much
+     * of the request as possible in the event payment is not sufficient to
+     * complete the request.
+     */
+    rpc subscribeBlockStream(SubscribeStreamRequest) returns (stream SubscribeStreamResponse);
+}

--- a/hapi/hedera-protobufs/block/stream/block.proto
+++ b/hapi/hedera-protobufs/block/stream/block.proto
@@ -1,0 +1,71 @@
+/**
+ * # Block Stream
+ * The base element of the block stream _at rest_.
+ * A `Block` contains a record of all transactions, results, and outputs for
+ * a block in the chain. Each `Block` also contains a state proof for
+ * validation and a header with version and algorithm information.
+ *
+ * Block entries are not designed for streaming, but for storing blocks in
+ * persistent storage, verifying block stream data, and as query responses
+ * when a block is requested from a block node.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "stream/block_item.proto";
+
+/**
+ * A single complete Hedera block chain block.
+ *
+ * This is a single block structure and SHALL NOT represent the primary
+ * mechanism to transmit a block stream.<br/>
+ * The primary mechanism for transmitting block stream data SHALL be to
+ * stream individual block items to the block node(s).<br/>
+ * The only delimiter between blocks when streamed SHALL be the `BlockHeader`
+ * item and `BlockProof` item.
+ *
+ * This block SHALL be verifiable as correct using only data in the block,
+ * including the `BlockProof`, and public keys for the consensus nodes.
+ */
+message Block {
+    /**
+     * A list of items that, together, make up this block.
+     * <p>
+     * This list SHALL begin with a `BlockHeader`.<br/>
+     * This list SHALL end with a `BlockProof`.<br/>
+     * Items in this list SHALL be in exactly the same order produced by
+     * consensus.<br/>
+     * Items in this list MAY be filtered, if so requested.<br/>
+     * If this list is filtered, removed items SHALL be replaced with
+     * `FilteredBlockItem` entries.<br/>
+     */
+    repeated BlockItem items = 1;
+}

--- a/hapi/hedera-protobufs/block/stream/block_item.proto
+++ b/hapi/hedera-protobufs/block/stream/block_item.proto
@@ -1,0 +1,247 @@
+/**
+ * # Block Item
+ * A single item in the block stream, such as transaction data, event metadata,
+ * or a a system transaction.<br/>
+ * Each block consists of a block header, one or more block items,
+ * and a block state proof. Within the block are a series of events delimited
+ * by start_event block items.
+ *
+ * This structure here MUST support a stream of block items with no enclosing
+ * message.<br/>
+ * Implementations SHOULD behave in a reasonable manner if used in a gRPC
+ * bidirectional streaming RPC similar to
+ * `rpc processBlocks(stream BlockItem) returns (stream Acknowledgement);`.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "event/event_transaction.proto";
+import "stream/block_proof.proto";
+import "stream/record_file_item.proto";
+import "stream/input/event_metadata.proto";
+import "stream/input/round_header.proto";
+import "stream/output/block_header.proto";
+import "stream/output/state_changes.proto";
+import "stream/output/transaction_output.proto";
+import "stream/output/transaction_result.proto";
+
+/**
+ * A single item within a block stream.
+ *
+ * Each item in the block stream SHALL be self-contained and independent,
+ * with the following constraints applicable to the _unfiltered_ stream.
+ * - A block SHALL start with a `header`.
+ * - A block SHALL end with a `state_proof`.
+ * - A `block_header` SHALL be followed by an `event_header`.
+ * - An `event_header` SHALL be followed by one or more
+ *   `event_transaction` items.
+ * - An `event_transaction` SHALL be followed by a `transaction_result`.
+ * - A `transaction_result` MAY be followed by a `transaction_output`.
+ * - A `transaction_result` (or a `transaction_output`, if present) MAY be
+ *     followed by one or more `state_changes`.
+ *
+ * This forms the following required sequence for each block, which is then
+ * repeated within the block stream, indefinitely.  Note that there is no
+ * container structure in the stream, the indentation below is only to
+ * highlight repeated subsequences.<br/>
+ * The order of items within each block below is REQUIRED and SHALL NOT change.
+ *
+ * ```text
+ * header
+ *   repeated {
+ *     start_event
+ *     repeated {
+ *       event_transaction
+ *       transaction_result
+ *       (optional) transaction_output
+ *       (optional) repeated state_changes
+ *     }
+ *   }
+ * state_proof
+ * ```
+ * A filtered stream may exclude some items above, depending on filter
+ * criteria. A filtered item is replaced with a merkle path and hash value
+ * to maintain block stream verifiability.
+ *
+ * A BlockItem SHALL be individually and directly processed to create the
+ * item hash.<br/>
+ * Items to be hashed MUST NOT be contained within another item.<br/>
+ * Items which might be filtered out of the stream MUST NOT be
+ * contained in other items.
+ */
+message BlockItem {
+    oneof item {
+        /**
+         * An header for the block, marking the start of a new block.
+         */
+        com.hedera.hapi.block.stream.output.BlockHeader block_header = 1;
+
+        /**
+         * An header emitted at the start of a new network "event".
+         * <p>
+         * This item SHALL contain the properties relevant to a single
+         * gossip event.
+         */
+        com.hedera.hapi.block.stream.input.EventHeader event_header = 2;
+
+        /**
+         * An header emitted at the start of a new consensus "round".
+         * <p>
+         * This item SHALL contain the properties relevant to a single
+         * consensus round.
+         */
+        com.hedera.hapi.block.stream.input.RoundHeader round_header = 3;
+
+        /**
+         * A single transaction.
+         * <p>
+         * This item SHALL contain the serialized bytes of a
+         * single transaction.<br/>
+         * Each event transaction SHALL be either a `SignedTransaction` or
+         * an internal system-generated transaction.<br/>
+         * This item MUST NOT contain data for more than one
+         * `SignedTransaction` or system-generated transaction.
+         */
+        com.hedera.hapi.platform.event.EventTransaction event_transaction = 4;
+
+        /**
+         * The result of running a transaction.
+         * <p>
+         * This item SHALL be present immediately after an
+         * `event_transaction` item.<br/>
+         * This item MAY be redacted in some circumstances, and SHALL be
+         * replaced with a `filtered_item` if removed.
+         */
+        com.hedera.hapi.block.stream.output.TransactionResult transaction_result = 5;
+
+        /**
+         * A transaction output.
+         * <p>
+         * This item MAY not be present if a transaction does not produce
+         * an output.<br/>
+         * If a transaction does produce an output that is not reflected
+         * in state changes, then this item MUST be present after the
+         * `transaction_result` for that transaction.
+         */
+        com.hedera.hapi.block.stream.output.TransactionOutput transaction_output = 6;
+
+        /**
+         * A set of state changes.
+         * <p>
+         * All changes to values in network state SHALL be described by
+         * stream items of this type.<br/>
+         * The source of these state changes SHALL be described by the
+         * `reason` enumeration.
+         */
+        com.hedera.hapi.block.stream.output.StateChanges state_changes = 7;
+
+        /**
+         * Verification data for an item filtered from the stream.<br/>
+         * This is a hash for a merkle tree node where the contents of that
+         * part of the merkle tree have been removed from this stream.
+         * <p>
+         * Items of this type SHALL NOT be present in the full (unfiltered)
+         * block stream.<br/>
+         * Items of this type SHALL replace any item removed from a partial
+         * (filtered) block stream.<br/>
+         * Presence of `filtered_item` entries SHALL NOT prevent verification
+         * of a block, but MAY preclude verification or reconstruction of
+         * consensus state.<br/>
+         */
+        FilteredItemHash filtered_item_hash = 8;
+
+        /**
+         * A signed block proof.<br/>
+         * The signed merkle proof for this block. This will validate
+         * a "virtual" merkle tree containing the previous block "virtual"
+         * root, an "input" subtree, an "output" subtree, and
+         * a "state changes" subtree.
+         * <p>
+         * This item is not part of the block stream hash chain/tree, and
+         * MUST follow after the end of a block.
+         */
+        BlockProof block_proof = 9;
+
+        /**
+         * A record file and associated data.
+         * <p>
+         * This MUST contain a single Record file, associated Sidecar files,
+         * and data from related Signature files.
+         * If this item is present, special treatment is
+         * REQUIRED for this block.
+         * <ul>
+         *   <li>The block SHALL NOT have a `BlockHeader`.</li>
+         *   <li>The block SHALL NOT have a `BlockProof`.</li>
+         *   <li>The block SHALL contain _exactly one_ `RecordFileItem`.</li>
+         *   <li>The block SHALL NOT contain any item other than a
+         *       `RecordFileItem`.</li>
+         *   <li>The content of the `RecordFileItem` MUST be validated using
+         *       the signature data and content provided within according to
+         *       the process used for Record Files prior to the creation
+         *       of Block Stream.</li>
+         * </ul>
+         */
+        RecordFileItem record_file = 10;
+    }
+}
+
+/**
+ * Verification data for an item filtered from the stream.
+ *
+ * Items of this type SHALL NOT be present in the full (unfiltered) block
+ * stream.<br/>
+ * Items of this type SHALL replace any item removed from a partial (filtered)
+ * block stream.<br/>
+ * Presence of `filtered_item` entries SHALL NOT prevent verification
+ * of a block, but MAY preclude verification or reconstruction
+ * of consensus state.<br/>
+ */
+message FilteredItemHash {
+    /**
+     * A hash of an item filtered from the stream.
+     * <p>
+     * The hash algorithm used MUST match the hash algorithm specified in
+     * the block header for the containing block.<br/>
+     * This field is REQUIRED.
+     */
+    bytes item_hash = 1;
+
+    /**
+     * A record of the merkle path to the item that was filtered
+     * from the stream.<br/>
+     * This path begins at the root of the block proof merkle tree.
+     * <p>
+     * This REQUIRED field SHALL describe the full path in the virtual
+     * merkle tree constructed for the block proof that contained the
+     * item filtered from the stream.
+     */
+    uint64 filtered_path = 3;
+}

--- a/hapi/hedera-protobufs/block/stream/block_proof.proto
+++ b/hapi/hedera-protobufs/block/stream/block_proof.proto
@@ -1,0 +1,212 @@
+/**
+ * # Block Proof
+ * A proof for the block streamed from a consensus node.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A cryptographic proof for the "Block Merkle Tree".
+ *
+ * This message SHALL offer a proof for the "Block Merkle Tree".
+ * The information in the "Block Merkle Tree" SHALL be used to validate the
+ * full content of the most recent block, and, with chained validation,
+ * all prior blocks.
+ *
+ * ### Block Merkle Tree
+ * The Block Hash of any block is a merkle root hash comprised of a 4 leaf
+ * binary merkle tree. The 4 leaves represent
+ * 1. Previous block proof hash
+ * 1. Merkle root of transaction inputs tree
+ * 1. Merkle root of transaction outputs tree
+ * 1. Merkle rook of state tree
+ *
+ * #### Computing the hash
+ * The process for computing a block hash is somewhat complex, and involves
+ * creating a "virtual" merkle tree to obtain the root merkle hash of
+ * that virtual tree.<br/>
+ * The merkle tree SHALL have a 4 part structure with 2 internal nodes,
+ * structured in a strictly binary tree.
+ * - The merkle tree root SHALL be the parent of both
+ *   internal nodes.
+ *    1. The first "internal" node SHALL be the parent of the
+ *       two "left-most" nodes.
+ *       1. The first leaf MUST be the previous block hash, and is a
+ *          single 48-byte value.
+ *       1. The second leaf MUST be the root of a, strictly binary, merkle tree
+ *          composed of all "input" block items in the block.<br/>
+ *          Input items SHALL be transactions, system transactions,
+ *          and events.<br/>
+ *          Leaf nodes in this subtree SHALL be ordered in the same order
+ *          that the block items are encountered in the stream.
+ *    1. The second "internal" node SHALL be the parent of the two
+ *       "right-most" nodes.
+ *       1. The third leaf MUST be the root of a, strictly binary, merkle tree
+ *          composed of all "output" block items in the block.<br/>
+ *          Output items SHALL be transaction result, transaction
+ *          output, and state changes.<br/>
+ *          Leaf nodes in this subtree SHALL be ordered in the same order that
+ *          the block items are encountered in the stream.
+ *       1. The fourth leaf MUST be the merkle tree root hash for network state
+ *          at the start of the block, and is a single 48-byte value.
+ * - The block hash SHALL be the hash calculated for the root of this merkle
+ *   tree.
+ * - The hash algorithm used SHALL be the algorithm specified in the
+ *   corresponding block header.
+ *
+ * The "inputs" and "outputs" subtrees SHALL be "complete" binary merkle trees,
+ * with nodes that would otherwise be missing replaced by a "null" hash
+ * leaf.
+ */
+message BlockProof {
+    /**
+     * The block this proof secures.<br/>
+     * We provide this because a proof for a future block can be used to prove
+     * the state of the ledger at that block and the blocks before it.<br/>
+     * <p>
+     * This value SHOULD match the block number of the current block,
+     * under normal operation.
+     */
+    uint64 block = 1;
+
+    /**
+     * A merkle root hash of the previous block.
+     * <p>
+     * This MUST contain a hash of the "block" merkle tree root for the
+     * previous block.<br/>
+     * The hash algorithm used MUST match the algorithm declared in the
+     * block header _for that block_.
+     */
+    bytes previous_block_root_hash = 2;
+
+    /**
+     * A merkle root hash of the network state.<br/>
+     * This is present to support validation of this block proof by clients
+     * that do not maintain a full copy of the network state.
+     * <p>
+     * This MUST contain a hash of the "state" merkle tree root at the start
+     * of the current block (which this block proof verifies).<br/>
+     * State processing clients SHOULD calculate the state root hash
+     * independently and SHOULD NOT rely on this value.<br/>
+     * State processing clients MUST validate the application of state changes
+     * for a block using the value present in the Block Proof of the
+     * _following_ block.
+     * Compliant consensus nodes MUST produce an "empty" block (containing
+     * only `BlockHeader` and `BlockProof` as the last block prior to a
+     * network "freeze" to ensure the final state hash is incorporated into
+     * the Block Stream correctly.
+     * Stateless (non-state-processing) clients MUST use this value to
+     * construct the block merkle tree.
+     */
+    bytes start_of_block_state_root_hash = 3;
+
+    /**
+     * A TSS signature for one block.<br/>
+     * This is a single signature representing the collection of partial
+     * signatures from nodes holding strictly greater than 2/3 of the
+     * current network "weight" in aggregate. The signature is produced by
+     * cryptographic "aggregation" of the partial signatures to produce a
+     * single signature that can be verified with the network public key,
+     * but could not be produced by fewer nodes than required to meet the
+     * threshold for network stake "weight".
+     * <p>
+     * This message MUST make use of a threshold signature scheme like `BLS`
+     * which provides the necessary cryptographic guarantees.<br/>
+     * This signature SHALL use a TSS signature to provide a single signature
+     * that represents the consensus signature of consensus nodes.<br/>
+     * The exact subset of nodes that signed SHALL neither be known nor
+     * tracked, but it SHALL be cryptographically verifiable that the
+     * threshold was met if the signature itself can be validated with
+     * the network public key (a.k.a `LedgerID`).
+     */
+    bytes block_signature = 4;
+
+    /**
+     * A set of hash values along with ordering information.<br/>
+     * This list of hash values form the set of sibling hash values needed to
+     * correctly reconstruct the parent hash, and all hash values "above" that
+     * hash in the merkle tree.
+     * <p>
+     * A Block proof can be constructed by combining the sibling hashes for
+     * a previous block hash and sibling hashes for each entry "above" that
+     * node in the merkle tree of a block proof that incorporates that previous
+     * block hash. This form of block proof may be used to prove a chain of
+     * blocks when one or more older blocks is missing the original block
+     * proof that signed the block's merkle root directly.
+     * <p>
+     * This list MUST be ordered from the sibling of the node that contains
+     * this block's root node hash, and continues up the merkle tree to the
+     * root hash of the signed block proof.
+     * <p>
+     * If this block proof has a "direct" signature, then this list MUST be
+     * empty.<br/>
+     * If this list is not empty, then this block proof MUST be verified by
+     * first constructing the "block" merkle tree and computing the root hash
+     * of that tree, then combining that hash with the values in this list,
+     * paying attention to the first/second sibling ordering, until the root
+     * merkle hash is produced from the last pair of sibling hashes. That
+     * "secondary" root hash MUST then be verified using
+     * the value of `block_signature`.
+     */
+    repeated MerkleSiblingHash sibling_hashes = 5;
+}
+
+/**
+ * A hash of a "sibling" to an entry in a Merkle tree.
+ *
+ * When constructing a binary merkle tree, each internal node is a hash
+ * constructed from the hash of two "descendant" nodes. Those two nodes
+ * are "siblings" and the order (first, second) in which the two hash values
+ * are combined affects the parent hash.<br/>
+ * This may be used to reconstruct a portion of a merkle tree starting from
+ * a node of interest up to the root of the tree.
+ */
+message MerkleSiblingHash {
+    /**
+     * A flag for the position of this sibling.
+     * <p>
+     * If this is set then this sibling MUST be the first hash in the pair of
+     * sibling hashes of a binary merkle tree.<br/>
+     * If this is unset, then this sibling MUST be the second hash in the pair
+     * of sibling hashes of a binary merkle tree.
+     */
+    bool is_first = 1;
+
+    /**
+     * A byte array of a sibling hash.<br/>
+     * This is the hash for the sibling at this point in the merkle tree.
+     * <p>
+     * The algorithm for this hash SHALL match the algorithm for the block that
+     * contains this sibling.<br/>
+     * This SHALL contain the raw (e.g.) 384 bits (48 bytes) of the hash value.
+     */
+    bytes sibling_hash = 2;
+}

--- a/hapi/hedera-protobufs/block/stream/input/event_metadata.proto
+++ b/hapi/hedera-protobufs/block/stream/input/event_metadata.proto
@@ -1,0 +1,55 @@
+/**
+ * # Event Header
+ * This header precedes the event messages that contain transactions.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.input;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.input.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.input">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "event/event_core.proto";
+
+/**
+ * A header for a single event.<br/>
+ * This message delivers information about an event and its parents.
+ */
+message EventHeader {
+    /**
+     * An event core value.<br/>
+     * This provides information about the event creator and the event
+     * "parents". Event "parents" includes the "self parent" if any.
+     */
+    com.hedera.hapi.platform.event.EventCore event_core = 1;
+
+    /**
+     * A single node event signature.<br/>
+     * This is the event creator's signature for this event.
+     */
+    bytes signature = 2;
+}

--- a/hapi/hedera-protobufs/block/stream/input/round_header.proto
+++ b/hapi/hedera-protobufs/block/stream/input/round_header.proto
@@ -1,0 +1,46 @@
+/**
+ * # Round Header
+ * This header delineates the start of a single consensus round.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.input;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.input.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.input">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A header for a single round.<br/>
+ * This message delivers information about a consensus round.
+ */
+message RoundHeader {
+    /**
+     * A round number.<br/>
+     * This is the number assigned to the round for consensus.
+     */
+    uint64 round_number = 1;
+}

--- a/hapi/hedera-protobufs/block/stream/output/block_header.proto
+++ b/hapi/hedera-protobufs/block/stream/output/block_header.proto
@@ -1,0 +1,165 @@
+/**
+ * # Block Header
+ * The block header reports information required to correctly process a block.
+ * This includes versions, block number, and algorithms used.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+/**
+ * A Block Header.
+ *
+ * Each block in the block stream SHALL begin with a block header.<br/>
+ * The block header SHALL provide the base minimum information needed to
+ * correctly interpret and process that block, or stop processing
+ * if appropriate.<br/>
+ * The block header MUST describe, at minimum, the following items.
+ *  - The version of the block stream data
+ *  - The block number
+ *  - The hash of the previous block
+ *  - The hash algorithm used to generate the block hash
+ *
+ * All fields of this message are REQUIRED, with the exception that
+ * `hash_algorithm` MAY be _transmitted_ as a default value to improve
+ * data efficiency.
+ */
+message BlockHeader {
+    /**
+     * A version of the HAPI specification.<br/>
+     * This is the API version that was used to serialize the block.
+     */
+    proto.SemanticVersion hapi_proto_version = 1;
+
+    /**
+     * A version of the consensus node software.<br/>
+     * This is the software version that executed the transactions
+     * within this block.
+     */
+    proto.SemanticVersion software_version = 2;
+
+    /**
+     * A block number for this block.
+     * <p>
+     * This value MUST be exactly `1` more than the previous block.<br/>
+     * Client systems SHOULD optimistically reject any block with a gap or
+     * reverse in `number` sequence, and MAY assume the block stream has
+     * encountered data loss, data corruption, or unauthorized modification.
+     */
+    uint64 number = 3;
+
+    /**
+     * A block root hash for the previous block.
+     * <p>
+     * This value MUST match the block merkle tree root hash of the previous
+     * block in the block stream.<br/>
+     * This value SHALL be empty for the genesis block, and SHALL NOT be empty
+     * for any other block.<br/>
+     * Client systems SHOULD optimistically reject any block with a
+     * `previous_block_proof_hash` that does not match the block hash of the
+     * previous block and MAY assume the block stream has encountered data
+     * loss, data corruption, or unauthorized modification.
+     * <p>
+     * The process for computing a block hash is somewhat complex, and involves
+     * creating a "virtual" merkle tree to obtain the root merkle hash of
+     * that virtual tree.<br/>
+     * The merkle tree SHALL have a 4 part structure with 2 internal nodes,
+     * structured in a strictly binary tree.
+     * <ul>
+     *   <li>The merkle tree root SHALL be the parent of both
+     *       internal nodes.
+     *     <ol>
+     *       <li>The first "internal" node SHALL be the parent of the
+     *           two "left-most" nodes.
+     *         <ol>
+     *           <li>The first leaf MUST be the previous block hash, and is a
+     *               single 48-byte value.</li>
+     *           <li>The second leaf MUST be the root of a, strictly binary,
+     *               merkle tree composed of all "input" block items in
+     *               the block.<br/>
+     *               Input items SHALL be transactions, system transactions,
+     *               and events.<br/>
+     *               Leaf nodes in this subtree SHALL be ordered in the
+     *               same order that the block items are encountered
+     *               in the stream.</li>
+     *         </ol>
+     *       </li>
+     *       <li>The second "internal" node SHALL be the parent of the
+     *           two "right-most" nodes.
+     *         <ol>
+     *           <li>The third leaf MUST be the root of a, strictly binary,
+     *               merkle tree composed of all "output" block items in
+     *               the block.<br/>
+     *               Output items SHALL be transaction result, transaction
+     *               output, and state changes.<br/>
+     *               Leaf nodes in this subtree SHALL be ordered in the
+     *               same order that the block items are encountered
+     *               in the stream.</li>
+     *           <li>The fourth leaf MUST be the merkle tree root hash for
+     *               network state at the end of the block, and is a single
+     *               48-byte value.</li>
+     *         </ol>
+     *       </li>
+     *     </ol>
+     *   </li>
+     *   <li>The block hash SHALL be the SHA-384 hash calculated for the root
+     *       of this merkle tree.</li>
+     * </ul>
+     */
+    bytes previous_block_hash = 4;
+
+    /**
+     * A consensus timestamp for the start of this block.
+     * <p>
+     * This SHALL be the timestamp assigned by the hashgraph consensus
+     * algorithm to the first transaction of this block.
+     */
+    proto.Timestamp first_transaction_consensus_time = 5;
+
+    /**
+     * A hash algorithm used for this block, including the block proof.
+     * <p>
+     * This SHOULD always be `SHA2_384`, currently.
+     */
+    proto.BlockHashAlgorithm hash_algorithm = 6;
+
+    /**
+     * A version for the network address book.<br/>
+     * The address book version is needed to determine the correct public
+     * key(s) to use to validate block signatures and state proofs.
+     * <p>
+     * This MUST be the version of the address book that signed this
+     * block.
+     */
+    proto.SemanticVersion address_book_version = 7;
+}

--- a/hapi/hedera-protobufs/block/stream/output/consensus_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/consensus_service.proto
@@ -1,0 +1,160 @@
+/**
+ * # Consensus Service
+ * Block stream messages that report the results of transactions handled
+ * by the `Consensus` service.
+ *
+ * ### Topic Running Hash Calculation
+ * Submitted messages include a topic running hash. This value has changed
+ * over time, with the known versions detailed in the `RunningHashVersion`
+ * enumeration.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Block Stream data for a `createTopic` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in the
+ * original transaction.
+ */
+message CreateTopicOutput {}
+
+/**
+ * Block Stream data for a `updateTopic` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in the
+ * original transaction.
+ */
+message UpdateTopicOutput {}
+
+/**
+ * Block Stream data for a `deleteTopic` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in the
+ * original transaction.
+ */
+message DeleteTopicOutput {}
+
+/**
+ * Block Stream data for a `submitMessage` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in the
+ * original transaction.<br/>
+ * The actual topic running hash SHALL be present in a `StateChanges` block
+ * item, and is not duplicated here.
+ */
+message SubmitMessageOutput {}
+
+/**
+ * A version of the topic running hash.
+ *
+ * The inputs to the topic running hash have changed over time.
+ * This is tracked in earlier record streams as an integer. For the
+ * block stream we chose to use an enumeration for both efficiency
+ * and clarity. Placing the most recent, and most common/highest
+ * volume, version as `0` reduces the serialized size of this message
+ * by not serializing that default value.
+ *
+ * <hr style="margin: 0.2em 5em 0.2em 5em; height: 0.5em;
+ *     border-style: solid none solid none; border-width: 2px;"/>
+ *
+ * The topic running hash is a 48-byte value that is the output
+ * of a hash digest with input data determined by the value of
+ * the `topic_running_hash_version` field.<br/>
+ * All new transactions SHALL use `topic_running_hash_version`
+ * `WITH_MESSAGE_DIGEST_AND_PAYER`.<br/>
+ */
+enum RunningHashVersion {
+    /**
+     * The most recent version.
+     * <p>
+     * This version SHALL include, in order
+     * <ol>
+     *  <li>The previous running hash of the topic (48 bytes)</li>
+     *  <li>The `topic_running_hash_version` field (8 bytes)</li>
+     *  <li>The payer account's shard (8 bytes)</li>
+     *  <li>The payer account's realm (8 bytes)</li>
+     *  <li>The payer account's number (8 bytes)</li>
+     *  <li>The topic's shard (8 bytes)</li>
+     *  <li>The topic's realm (8 bytes)</li>
+     *  <li>The topic's number (8 bytes)</li>
+     *  <li>The number of seconds since the epoch when the
+     *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
+     *  <li>The number of nanoseconds within the second when the
+     *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
+     *  <li>The `topic_sequence_number` field (8 bytes)</li>
+     *  <li>The output of a SHA-384 digest of the message bytes from the
+     *      `ConsensusSubmitMessage` (48 bytes)</li>
+     * </ol>
+     */
+    WITH_MESSAGE_DIGEST_AND_PAYER = 0;
+
+    /**
+     * An earlier version.
+     * <p>
+     * This version SHALL include, in order
+     * <ol>
+     *  <li>The previous running hash of the topic (48 bytes)</li>
+     *  <li>The `topic_running_hash_version` field (8 bytes)</li>
+     *  <li>The topic's shard (8 bytes)</li>
+     *  <li>The topic's realm (8 bytes)</li>
+     *  <li>The topic's number (8 bytes)</li>
+     *  <li>The number of seconds since the epoch when the
+     *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
+     *  <li>The number of nanoseconds within the second when the
+     *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
+     *  <li>The `topic_sequence_number` field (8 bytes)</li>
+     *  <li>The output of a SHA-384 digest of the message bytes from the
+     *      `ConsensusSubmitMessage` (48 bytes)</li>
+     * </ol>
+     */
+    WITH_MESSAGE_DIGEST = 1;
+
+    /**
+     * The original version, used at genesis.
+     * <p>
+     * This version SHALL include, in order
+     * <ol>
+     *  <li>The previous running hash of the topic (48 bytes)</li>
+     *  <li>The topic's shard (8 bytes)</li>
+     *  <li>The topic's realm (8 bytes)</li>
+     *  <li>The topic's number (8 bytes)</li>
+     *  <li>The number of seconds since the epoch when the
+     *      `ConsensusSubmitMessage` reached consensus (8 bytes)</li>
+     *  <li>The number of nanoseconds within the second when the
+     *      `ConsensusSubmitMessage` reached consensus (4 bytes)</li>
+     *  <li>The `topic_sequence_number` field (8 bytes)</li>
+     *  <li>The message bytes from the `ConsensusSubmitMessage`
+     *      (variable)</li>
+     * </ol>
+     */
+    WITH_FULL_MESSAGE = 2;
+}

--- a/hapi/hedera-protobufs/block/stream/output/crypto_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/crypto_service.proto
@@ -1,0 +1,96 @@
+/**
+ * # Crypto Service
+ * Block stream messages that report the results of transactions handled by
+ * the `Crypto` service. This service primarily handles account management
+ * and HBAR transfers.
+ *
+ * > Note
+ * >> Tokens other than HBAR, including all NFTs, are managed by the `Token` Service.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "custom_fees.proto";
+
+/**
+ * Block Stream data for a `approveAllowances` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message ApproveAllowanceOutput {}
+
+/**
+ * Block Stream data for a `deleteAllowances` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message DeleteAllowanceOutput {}
+
+/**
+ * Block Stream data for a `createAccount` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message CreateAccountOutput {}
+
+/**
+ * Block Stream data for a `cryptoDelete` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message DeleteAccountOutput {}
+
+/**
+ * Block Stream data for a `cryptoTransfer` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message CryptoTransferOutput {
+  /**
+   * Custom fees assessed during a CryptoTransfer.
+   * <p>
+   * These fees SHALL be present in the full transfer list for the transaction.
+   */
+  repeated proto.AssessedCustomFee assessed_custom_fees = 1;
+}
+
+/**
+ * Block Stream data for a `updateAccount` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UpdateAccountOutput {}

--- a/hapi/hedera-protobufs/block/stream/output/file_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/file_service.proto
@@ -1,0 +1,96 @@
+/**
+ * # File Service
+ * Block stream messages that report the results of transactions handled
+ * by the `File` service.
+ *
+ * A `file` in Hedera is an arbitrary sequence of bytes and may be up to
+ * `1048576` total bytes. Files are used anywhere a transaction requires a
+ * large amount of data (anything that would not fit within the
+ * transaction size limit).
+ *
+ * Examples
+ *  - smart contract bytecode
+ *  - network configuration updates
+ *  - network fee schedules
+ *  - image files for NFTs
+ *  - property title documents
+ * There are many other uses; these examples are illustrative.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Block Stream data for a `fileAppend` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained
+ * in the original transaction.
+ */
+message AppendFileOutput {}
+
+/**
+ * Block Stream data for a `fileCreate` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message CreateFileOutput {}
+
+/**
+ * Block Stream data for a `fileDelete` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message DeleteFileOutput {}
+
+/**
+ * Block Stream data for a `fileUpdate` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UpdateFileOutput {}
+
+/**
+ * Block Stream data for a `systemDelete` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message SystemDeleteOutput {}
+
+/**
+ * Block Stream data for a `systemUndelete` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message SystemUndeleteOutput {}

--- a/hapi/hedera-protobufs/block/stream/output/network_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/network_service.proto
@@ -1,0 +1,48 @@
+/**
+ * # Network Admin
+ * Network Admin service transactions.
+ *
+ * The network service handles certain critical transactions, but the
+ * transaction output for those transactions is complex and may be difficult
+ * to handle, so this file is not yet filled in.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+message UpdateNodeStakeOutput {}
+
+message FreezeOutput {}
+
+// There is no message for `uncheckedSubmit`; that transaction is handled by
+// workflow *before* consensus. Only the wrapped transaction is submitted to
+// consensus, and that is what will appear in the block stream.  Also,
+// `uncheckedSubmit` MUST NOT ever be enabled in any public network
+// (i.e. previewnet, testnet, mainnet).

--- a/hapi/hedera-protobufs/block/stream/output/schedule_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/schedule_service.proto
@@ -1,0 +1,110 @@
+/**
+ * # Schedule Service
+ * Block stream messages that report the results of transactions handled by
+ * the `Schedule` service.
+ *
+ * The Schedule service handles delayed execution in two major forms.
+ * - Transactions that only execute after being signed, via scheduleSign
+ *   transactions, with additional keys beyond the keys that signe the
+ *   scheduleCreate transaction.
+ * - Transactions that only execute after a specified consensus time.
+ *
+ * Some outputs contain a scheduled transaction identifier.<br/>
+ * That value SHALL be set if, and only if, the transaction resulted in
+ * _execution_ of the scheduled child transaction.<br/>
+ * Most outputs from this service SHALL NOT set the scheduled transaction
+ * identifier, because the transaction has not executed yet. Only when the
+ * schedule has gathered all of the signatures required to execute the
+ * scheduled child transaction is the network able to execute that child
+ * transaction, and assign a final transaction identifier.
+ *
+ * When a scheduled child transaction is executed, the identifier of the
+ * schedule that executed that transaction SHALL be included as a
+ * `schedule_ref` in the _result_ for the _child_ transaction.<br/>
+ * The output of the schedule transaction (create or sign) SHALL NOT contain
+ * the `schedule_ref`.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Block Stream data for a `createSchedule` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message CreateScheduleOutput {
+    /**
+     * A scheduled transaction identifier.
+     * <p>
+     * This value SHALL be the transaction identifier for the _scheduled_
+     * child transaction executed as a result of gathering sufficient
+     * signatures to complete the schedule.<br/>
+     * This value SHALL NOT be set unless the scheduled transaction was
+     * executed as a child of this schedule create transaction.<br/>
+     * This value SHALL NOT be set unless this schedule create transaction
+     * was signed by sufficient keys to meet the signature requirements
+     * for the scheduled child transaction immediately.
+     */
+    proto.TransactionID scheduled_transaction_id = 2;
+}
+
+/**
+ * Block Stream data for a `deleteSchedule` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message DeleteScheduleOutput {}
+
+/**
+ * Block Stream data for a `signSchedule` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message SignScheduleOutput {
+    /**
+     * A scheduled transaction identifier.
+     * <p>
+     * This value SHALL be the transaction identifier for the _scheduled_
+     * child transaction executed as a result of gathering sufficient
+     * signatures to complete the schedule.<br/>
+     * This value SHALL NOT be set unless the scheduled transaction was
+     * executed as a child of this schedule sign transaction.<br/>
+     * This value SHALL NOT be set unless this schedule sign transaction
+     * was signed by sufficient additional keys to meet the signature
+     * requirements for the scheduled child transaction.
+     */
+    proto.TransactionID scheduled_transaction_id = 1;
+}

--- a/hapi/hedera-protobufs/block/stream/output/smart_contract_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/smart_contract_service.proto
@@ -1,0 +1,141 @@
+/**
+ * #  Service
+ * Block stream messages that report the results of transactions handled
+ * by the `` service.
+ *
+ * > REVIEW NOTE
+ * >> The use of sidecar records is a bit odd here. We may find it more
+ * >> effective to extract the actual changes into proper output messages
+ * >> and fields included in the ethereum call output and/or related state
+ * >> changes items, and remove the whole sidecar concept going forward.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "contract_call_local.proto";
+import "sidecar_file.proto";
+
+/**
+ * Block Stream data for a `contractCallMethod` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message CallContractOutput {
+    repeated proto.TransactionSidecarRecord sidecars = 1;
+
+    /**
+     * An EVM contract call result.
+     * <p>
+     * This field SHALL contain all of the data produced by the contract
+     * call transaction as well as basic accounting results.
+     */
+    proto.ContractFunctionResult contract_call_result = 2;
+}
+
+/**
+ * Block Stream data for a `createContract` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message CreateContractOutput {
+    repeated proto.TransactionSidecarRecord sidecars = 1;
+
+    /**
+     * An EVM contract call result.
+     * <p>
+     * This field SHALL contain all of the data produced by the contract
+     * create transaction as well as basic accounting results.
+     */
+    proto.ContractFunctionResult contract_create_result = 2;
+}
+
+// no evm exec, only modified entity
+/**
+ * Block Stream data for a `updateContract` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UpdateContractOutput {}
+
+// no evm exec, only modified entity
+/**
+ * Block Stream data for a `deleteContract` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message DeleteContractOutput {}
+
+/**
+ * Block Stream data for a contract `systemUndelete` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message SystemUnDeleteContractOutput {}
+
+/**
+ * Block Stream data for a contract `systemDelete` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message SystemDeleteContractOutput {}
+
+/**
+ * Block Stream data for a `callEthereum` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message EthereumOutput {
+    /**
+     * A list of additional outputs.
+     * <p>
+     * This field MAY record one or more additional outputs and smart
+     * contract state changes produced during the ethereum call
+     * transaction handling.<br/>
+     * This field SHALL NOT be set if the transaction handling did not
+     * produce additional outputs.<br/>
+     * This field is not settled and MAY be removed or modified.
+     */
+    repeated proto.TransactionSidecarRecord sidecars = 1;
+
+    /**
+     * An ethereum hash value.
+     * <p>
+     * This SHALL be a keccak256 hash of the ethereumData.
+     */
+    bytes ethereum_hash = 2;
+}

--- a/hapi/hedera-protobufs/block/stream/output/state_changes.proto
+++ b/hapi/hedera-protobufs/block/stream/output/state_changes.proto
@@ -1,0 +1,857 @@
+/**
+ * # State Changes
+ * Serialization of change records which describe the mutation of state
+ * during a block.
+ *
+ * The _ordered_ application of all `StateChanges` in a block to an initial
+ * state that matches network state at the beginning of that block MUST produce
+ * a resultant state that matches the network state at the end of that block.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "google/protobuf/wrappers.proto";
+import "basic_types.proto";
+import "exchange_rate.proto";
+import "state/addressbook/node.proto";
+import "state/blockrecords/block_info.proto";
+import "state/blockrecords/running_hashes.proto";
+import "state/blockstream/block_stream_info.proto";
+import "state/common.proto";
+import "state/congestion/congestion_level_starts.proto";
+import "state/consensus/topic.proto";
+import "state/contract/bytecode.proto";
+import "state/contract/storage_slot.proto";
+import "state/file/file.proto";
+import "state/recordcache/recordcache.proto";
+import "state/schedule/schedule.proto";
+import "state/throttles/throttle_usage_snapshots.proto";
+import "state/token/account.proto";
+import "state/token/account_pending_airdrop.proto";
+import "state/token/network_staking_rewards.proto";
+import "state/token/nft.proto";
+import "state/token/staking_node_info.proto";
+import "state/token/token.proto";
+import "state/token/token_relation.proto";
+import "timestamp.proto";
+
+/**
+ * The "cause" of a state change.
+ *
+ * What was the network doing that led to the change in state?<br/>
+ * The most common event is, of course, a user transaction.
+ * Other sources of state changes include end-of-block housekeeping changes,
+ * data migration, and "system" transactions.
+ */
+enum StateChangesCause {
+    /**
+     * A set of transaction state changes.<br/>
+     * This is a deliberate default because this is the most common 'cause'
+     * and we wish to minimize serialized size.
+     */
+    STATE_CHANGE_CAUSE_TRANSACTION = 0;
+
+    /**
+     * A system-internal state change.<br/>
+     * System-initiated transactions exist to enable the network to maintain
+     * state signatures and network communication.
+     */
+    STATE_CHANGE_CAUSE_SYSTEM = 1;
+
+    /**
+     * A set of end-of-block state changes.<br/>
+     * The network performs certain processes, such as writing to the block
+     * stream, updating singleton states, or updating queue states at the end
+     * of a block to minimize impacts on consensus nodes.
+     */
+    STATE_CHANGE_CAUSE_END_OF_BLOCK = 2;
+
+    /**
+     * A set of data migration state changes.<br/>
+     * Data migration is typically necessary following a network upgrade to
+     * make required storage format updates and enable new features.
+     */
+    STATE_CHANGE_CAUSE_MIGRATION = 3;
+}
+
+/**
+ * A set of state changes.
+ *
+ * Each set of changes in the network deterministically mutates the
+ * current state to a new state, and all nodes MUST apply the same
+ * changes in the same order.<br/>
+ * Each change set described in the block stream SHALL describe an
+ * ordered set of mutations which mutate the previous valid state to
+ * produce a new valid state.<br/>
+ * The order of state change sets SHALL be determined by the
+ * `consensus_timestamp`, which is a strictly ascending value
+ * determined by network consensus.
+ *
+ * ### Consensus Timestamp
+ * This value enables a consumer of the block stream to order state
+ * changes by a consistent ascending value that is determined by network
+ * consensus. A primary use case would be to enter state changes in a
+ * time-series database.<br/>
+ * This value depends on the cause of the state change.
+ *  1. For transactions, this is the transaction consensus timestamp.
+ *  1. For events without transactions, this is the consensus timestamp of
+ *     the event (round?).
+ *  1. For changes that are not the result of a transaction, but still follow
+ *     a transaction within an event, this is the consensus timestamp of the
+ *     preceding transaction.
+ */
+message StateChanges {
+    /**
+     * The proximate source of this state change set.
+     * <p>
+     * This field describes the source (e.g. user transaction, system
+     * "housekeeping", end of block, etc...) of the changes included
+     * in this change set.
+     */
+    StateChangesCause cause = 1;
+
+    /**
+     * The consensus timestamp of this set of changes.
+     * <p>
+     * This value SHALL be deterministic with the cause of the state change.
+     */
+    proto.Timestamp consensus_timestamp = 2;
+
+    /**
+     * An ordered list of individual changes.
+     * <p>
+     * These changes MUST be applied in the order listed to produce
+     * a correct modified state.
+     */
+    repeated StateChange state_changes = 3;
+}
+
+/**
+ * A change to any item in the merkle tree.
+ *
+ * A State change SHALL represent one mutation of the network state merkle
+ * tree. The state changes published in the block stream MAY be combined
+ * into an ordered set of state mutations that transform the tree from any
+ * initial state to a destination state.<br/>
+ * When the full set of state change items from the block stream for a round
+ * is applied to the network state at the start of that round the result
+ * SHALL match the network state at the end of the round.
+ * TODO: Need documentation for how the merkle tree is constructed.
+ *       Need to reference that document, stored in platform docs?, here.
+ */
+message StateChange {
+    /**
+     * A state identifier.<br/>
+     * The reason we use an integer field here, and not an enum field is to
+     * better support forward compatibility. There will be many cases when a
+     * block node or other client (such as a dApp) with HAPI version N wants
+     * to process blocks from HAPI version N+1, for example. If we use a
+     * protobuf enum then when that is mapped Java or Rust it would not be
+     * parsed as an enum value because those languages do not support unknown
+     * enum values. ProtoC has a workaround for this but it is complex and
+     * requires non-deterministic parsing. Our solution to create an integer
+     * field and provide an enumeration for mapping that integer is intended
+     * as an acceptable compromise solution.
+     * <p>
+     * This number SHALL identify the merkle subtree "state" to be modified and
+     * often corresponds to a `VirtualMap` identifier.
+     * This number SHALL be a valid value for the `StateIdentifier` enum.
+     */
+    uint32 state_id = 1;
+
+    oneof change_operation {
+        /**
+         * Addition of a new state.<br/>
+         * This may be a singleton, virtual map, or queue state.
+         */
+        NewStateChange state_add = 2;
+
+        /**
+         * Removal of an existing state.<br/>
+         * The entire singleton, virtual map, or queue state is removed,
+         * and not just the contents.
+         */
+        RemovedStateChange state_remove = 3;
+
+        /**
+         * An add or update to a `Singleton` state.
+         */
+        SingletonUpdateChange singleton_update = 4;
+
+        /**
+         * An add or update to a single item in a `VirtualMap`.
+         */
+        MapUpdateChange map_update = 5;
+
+        /**
+         * A removal of a single item from a `VirtualMap`.
+         */
+        MapDeleteChange map_delete = 6;
+
+        /**
+         * Addition of an item to a `Queue` state.
+         */
+        QueuePushChange queue_push = 7;
+
+        /**
+         * Removal of an item from a `Queue` state.
+         */
+        QueuePopChange queue_pop = 8;
+    }
+}
+
+/**
+ * An informational enumeration of all known states.
+ * This enumeration is included here So that people know the mapping from
+ * integer to state "name".
+ *
+ * State changes are expressed in terms of changes to named states at the
+ * high level conceptual model of the state type like map key/values or
+ * queue appends. To say which state the change is on we will include an
+ * `integer` number for the state name. This is done for performance and
+ * efficiency as there will be 10s of thousands of state changes in a block.
+ *
+ * We use an integer, and provide this enumeration, for the following reasons.
+ * - If we have a extra 8-10 bytes per state change at 40-50K state changes
+ *   per second then that is an extra 2.5-4 megabits of bandwidth. Compression
+ *   should help a lot but that is not guaranteed.
+ * - When the state name is used as part of complex key in the big state
+ *   merkle map. The smaller the key is, in bytes, the more efficient the
+ *   database is, because more keys can fit in a single disk page.
+ * - When parsing keys, parsing a UTF-8 string to a Java String is a many
+ *   times more expensive than parsing a VARINT to an integer.
+ *
+ * Note: This enumeration is never transmitted directly in the block stream.
+ * This enumeration is provided for clients to _interpret_ the value
+ * of the `StateChange`.`state_id` field.
+ */
+enum StateIdentifier {
+    /**
+     * A state identifier for the Topics state.
+     */
+    STATE_ID_TOPICS = 0;
+
+    /**
+     * A state identifier for the next entity Identifier.
+     */
+    STATE_ID_ENTITY_ID = 1;
+
+    /**
+     * A state identifier for the Accounts state.
+     */
+    STATE_ID_ACCOUNTS = 2;
+
+    /**
+     * A state identifier for account aliases.
+     */
+    STATE_ID_ALIASES = 3;
+
+    /**
+     * A state identifier for contract storage slots.
+     */
+    STATE_ID_CONTRACT_STORAGE = 4;
+
+    /**
+     * A state identifier for contract bytecode.
+     */
+    STATE_ID_CONTRACT_BYTECODE = 5;
+
+    /**
+     * A state identifier for Hedera File Service (HFS).
+     */
+    STATE_ID_FILES = 6;
+
+    /**
+     * A state identifier for Hedera Token Service (HTS).
+     */
+    STATE_ID_TOKENS = 7;
+
+    /**
+     * A state identifier for non-fungible/unique tokens.
+     */
+    STATE_ID_NFTS = 8;
+
+    /**
+     * A state identifier for token relationships.
+     */
+    STATE_ID_TOKEN_RELATIONS = 9;
+
+    /**
+     * A state identifier for network staking information.
+     */
+    STATE_ID_STAKING_INFO = 10;
+
+    /**
+     * A state identifier for network staking rewards.
+     */
+    STATE_ID_NETWORK_REWARDS = 11;
+
+    /**
+     * A state identifier for throttle usage.
+     */
+    STATE_ID_THROTTLE_USAGE = 12;
+
+    /**
+     * A state identifier for network congestion start times.
+     */
+    STATE_ID_CONGESTION_STARTS = 13;
+
+    /**
+     * A state identifier for scheduled transactions.
+     */
+    STATE_ID_SCHEDULES_BY_ID = 14;
+
+    /**
+     * A state identifier for scheduled transaction expiration.
+     */
+    STATE_ID_SCHEDULES_BY_EXPIRY = 15;
+
+    /**
+     * A state identifier for scheduled transaction deduplication.
+     */
+    STATE_ID_SCHEDULES_BY_EQUALITY = 16;
+
+    /**
+     * A state identifier for conversion rate updates.
+     */
+    STATE_ID_MIDNIGHT_RATES = 17;
+
+    /**
+     * A state identifier for the network running hash(es).
+     */
+    STATE_ID_RUNNING_HASHES = 18;
+
+    /**
+     * A state identifier for network block information.
+     */
+    STATE_ID_BLOCK_INFO = 19;
+
+    /**
+     * A state identifier for address book nodes.
+     */
+    STATE_ID_NODES = 20;
+
+    /**
+     * A state identifier for the next "upgrade" file.
+     */
+    STATE_ID_UPGRADE_FILE = 21;
+
+    /**
+     * A state identifier for the hash of the next "upgrade" file.
+     */
+    STATE_ID_UPGRADE_FILE_HASH = 22;
+
+    /**
+     * A state identifier for the next network freeze time.
+     */
+    STATE_ID_FREEZE_TIME = 23;
+
+    /**
+     * A state identifier for the block stream information.
+     */
+    STATE_ID_BLOCK_STREAM_INFO = 24;
+
+    /**
+     * A state identifier for the record cache.
+     */
+    STATE_ID_RECORD_QUEUE = 25;
+
+    /**
+     * A state identifier for pending airdrops.
+     */
+    STATE_ID_PENDING_AIRDROPS = 26;
+
+    /**
+     * A state for the `150` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_150 = 10001;
+
+    /**
+     * A state for the `151` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_151 = 10002;
+
+    /**
+     * A state for the `152` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_152 = 10003;
+
+    /**
+     * A state for the `153` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_153 = 10004;
+
+    /**
+     * A state for the `154` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_154 = 10005;
+
+    /**
+     * A state for the `155` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_155 = 10006;
+
+    /**
+     * A state for the `156` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_156 = 10007;
+
+    /**
+     * A state for the `157` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_157 = 10008;
+
+    /**
+     * A state for the `158` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_158 = 10009;
+
+    /**
+     * A state for the `159` upgrade file data
+     */
+    STATE_ID_UPGRADE_DATA_159 = 10010;
+}
+
+/**
+ * An addition of a new named state.
+ *
+ * Adding a new named state SHALL only require the name and type.<br/>
+ * The content of the new state SHALL be filled in via subsequent
+ * state change items specific to the type of state
+ * (e.g. SingletonUpdateChange or MapUpdateChange).
+ */
+message NewStateChange {
+    /**
+     * The type (e.g. Singleton, Virtual Map, Queue) of state to add.
+     */
+    NewStateType state_type = 1;
+}
+
+/**
+ * An enumeration of the types of named states.<br/>
+ * The default, Singleton, is the type of state most frequently
+ * added and removed.
+ */
+enum NewStateType {
+    SINGLETON = 0;
+    VIRTUAL_MAP = 1;
+    QUEUE = 2;
+}
+
+/**
+ * A removal of a named state.
+ *
+ * Removing a named state does not, currently, require additional
+ * information beyond the state name common to all state changes.<br/>
+ * A named state, other than a singleton, SHOULD be empty before it is removed.
+ */
+message RemovedStateChange {
+}
+
+/**
+ * An update to a `Singleton` state.
+ */
+message SingletonUpdateChange {
+    oneof new_value {
+        /**
+         * A change to the block info singleton.
+         * <p>
+         * The `BlockInfo` SHALL be updated at the end of every block and
+         * SHALL store, among other fields, the last 256 block hash values.
+         * <blockquote>REVIEW NOTE<blockquote>
+         * The full BlockInfo will be in the state proof, and may not be
+         * necessary here.</blockquote></blockquote>
+         */
+        proto.BlockInfo block_info_value = 1;
+
+        /**
+         * A change to the congestion level starts singleton.
+         * <p>
+         * This change SHALL be present if congestion level pricing for
+         * general fees or gas fees started during the current block.
+         */
+        proto.CongestionLevelStarts congestion_level_starts_value = 2;
+
+        /**
+         * A change to the Entity Identifier singleton.
+         * <p>
+         * The Entity Identifier singleton SHALL track the highest entity
+         * identifier used for the current shard and realm and SHALL be used
+         * to issue new entity numbers.
+         */
+        proto.EntityNumber entity_number_value = 3;
+
+        /**
+         * A change to the exchange rates singleton.
+         * <p>
+         * This change SHALL be present if the <tt>HBAR&lt;=&gt;USD</tt> exchange
+         * rate, as stored in the "midnight rates" singleton changed
+         * during the current block.
+         */
+        proto.ExchangeRateSet exchange_rate_set_value = 4;
+
+        /**
+         * A change to the network staking rewards singleton.
+         * <p>
+         * Network staking rewards SHALL be updated for every non-empty block.
+         */
+        proto.NetworkStakingRewards network_staking_rewards_value = 5;
+
+        /**
+         * A change to a raw byte array singleton.
+         * <p>
+         * This change SHALL present a change made to a raw byte array
+         * singleton.<br/>
+         * The "upgrade file hash" state is an example of a raw byte
+         * array singleton.
+         */
+        google.protobuf.BytesValue bytes_value = 6;
+
+        /**
+         * A change to a raw string singleton.
+         * <p>
+         * <dl><dt>Note</dt><dd>There are no current examples of a raw string
+         * singleton state.</dd></dl>
+         */
+        google.protobuf.StringValue string_value = 7;
+
+        /**
+         * A change to the running hashes singleton.
+         * <p>
+         * Running hashes SHALL be updated for each transaction.
+         * <p>
+         * <blockquote>REVIEW NOTE<blockquote>
+         * Running hashes is a record stream item. Can it be elided from
+         * the block stream? It's not written to the record stream, as far
+         * as I can tell. If we do write this it's adding over 144 bytes
+         * for every transaction. It's also not clear how we'll calculate
+         * this, as it's a hash of the records currently, so it would have
+         * to be a hash of the block items, including this one...
+         * </blockquote></blockquote>
+         */
+        proto.RunningHashes running_hashes_value = 8;
+
+        /**
+         * A change to the throttle usage snapshots singleton.
+         * <p>
+         * Throttle usage snapshots SHALL be updated for _every transaction_
+         * to reflect the amount used for each tps throttle and
+         * for the gas throttle.
+         */
+        proto.ThrottleUsageSnapshots throttle_usage_snapshots_value = 9;
+
+        /**
+         * A change to a raw `Timestamp` singleton.<br/>
+         * An example of a raw `Timestamp` singleton is the
+         * "network freeze time" singleton state, which, if set, stores
+         * the time for the next scheduled freeze.
+         */
+        proto.Timestamp timestamp_value = 10;
+
+        /**
+         * A change to the block stream information singleton.
+         */
+        proto.BlockStreamInfo block_stream_info_value = 11;
+    }
+}
+
+/**
+ * An update to a single item in a `VirtualMap`.<br/>
+ * Each update consists of a "key" and a "value".
+ * Keys are often identifiers or scalar values.
+ * Values are generally full messages or byte arrays.
+ *
+ * The key presented here is not mutable, we do not update map keys.<br/>
+ * The value associated to the key provided is updated, or the value is
+ * added and associated with that key.<br/>
+ * A change of key would be expressed as removal of the prior key and
+ * an addition for the new key.
+ */
+message MapUpdateChange {
+    /**
+     * A key in a virtual map.
+     * <p>
+     * This key MUST be mapped to the value added or updated.<br/>
+     * This field is REQUIRED.
+     */
+    MapChangeKey key = 1;
+
+    /**
+     * A value in a virtual map.
+     * <p>
+     * This value MUST correctly represent the state of the map entry
+     * _after_ the asserted update.<br/>
+     * This value MAY be reduced to only transmit fields that differ
+     * from the prior state.<br/>
+     * This field is REQUIRED.
+     */
+    MapChangeValue value = 2;
+}
+
+/**
+ * A removal of a single item from a `VirtualMap`.
+ */
+message MapDeleteChange {
+    /**
+     * A key in a virtual map.
+     * <p>
+     * This key SHALL be removed.<br/>
+     * The mapped value SHALL also be removed.<br/>
+     * This field is REQUIRED.
+     */
+    MapChangeKey key = 1;
+}
+
+/**
+ * A key identifying a specific entry in a key-value "virtual map".
+ */
+message MapChangeKey {
+    oneof key_choice {
+        /**
+         * A key for a change affecting a map keyed by an Account identifier.
+         */
+        proto.AccountID account_id_key = 1;
+
+        /**
+         * A change to the token relationships virtual map.<br/>
+         * This map is keyed by the pair of account identifier and
+         * token identifier.
+         */
+        proto.EntityIDPair entity_id_pair_key = 2;
+
+        /**
+         * A change to a map keyed by an EntityNumber (which is a single int64).
+         * <p>
+         * This SHOULD NOT be used. Virtual maps SHOULD be keyed to
+         * full identifiers that include shard and realm information.
+         */
+        proto.EntityNumber entity_number_key = 3;
+
+        /**
+         * A change to a virtual map keyed by File identifier.
+         */
+        proto.FileID file_id_key = 4;
+
+        /**
+         * A change to a virtual map keyed by NFT identifier.
+         */
+        proto.NftID nft_id_key = 5;
+
+        /**
+         * A change to a virtual map keyed by a byte array.
+         */
+        google.protobuf.BytesValue proto_bytes_key = 6;
+
+        /**
+         * A change to a virtual map keyed by an int64 value.
+         */
+        google.protobuf.Int64Value proto_long_key = 7;
+
+        /**
+         * A change to a virtual map keyed by a string value.
+         */
+        google.protobuf.StringValue proto_string_key = 8;
+
+        /**
+         * A change to a virtual map keyed by a Schedule identifier.
+         */
+        proto.ScheduleID schedule_id_key = 9;
+
+        /**
+         * A change to the EVM storage "slot" virtual map.
+         */
+        proto.SlotKey slot_key_key = 10;
+
+        /**
+         * A change to a virtual map keyed by a Token identifier.
+         */
+        proto.TokenID token_id_key = 11;
+
+        /**
+         * A change to a virtual map keyed by a Topic identifier.
+         */
+        proto.TopicID topic_id_key = 12;
+
+        /**
+         * A change to a virtual map keyed by contract id identifier.
+         */
+        proto.ContractID contract_id_key = 13;
+
+        /**
+         * A change to a virtual map keyed by pending airdrop id identifier.
+         */
+        proto.PendingAirdropId pending_airdrop_id_key = 14;
+    }
+}
+
+/**
+ * A value updated in, or added to, a virtual map.
+ *
+ */
+message MapChangeValue {
+    oneof value_choice {
+        /**
+         * An account value.
+         */
+        proto.Account account_value = 1;
+
+        /**
+         * An account identifier.<br/>
+         * In some cases a map is used to connect a value or identifier
+         * to another identifier.
+         */
+        proto.AccountID account_id_value = 2;
+
+        /**
+         * Compiled EVM bytecode.
+         */
+        proto.Bytecode bytecode_value = 3;
+
+        /**
+         * An Hedera "file" value.
+         * <p>
+         * <blockquote>REVIEW NOTE<blockquote>
+         * A file can become quite large (up to 1048576 bytes).<br/>
+         * Do we want to structure file changes separately?<br/>
+         * Perhaps a file metadata update and a separate byte array for
+         * just the bytes appended (or initial bytes on create). We only
+         * allow create/append/delete, so the separate byte array would work
+         * and keep the size below 6K per state change.
+         * </blockquote></blockquote>
+         */
+        proto.File file_value = 4;
+
+        /**
+         * A non-fungible/unique token value.
+         */
+        proto.Nft nft_value = 5;
+
+        /**
+         * A string value.
+         */
+        google.protobuf.StringValue proto_string_value = 6;
+
+        /**
+         * A scheduled transaction value.
+         */
+        proto.Schedule schedule_value = 7;
+
+        /**
+         * A list of scheduled transactions.<br/>
+         * An example for this value is the map of consensus second to
+         * scheduled transactions that expire at that consensus time.
+         */
+        proto.ScheduleList schedule_list_value = 8;
+
+        /**
+         * An EVM storage slot value.
+         */
+        proto.SlotValue slot_value_value = 9;
+
+        /**
+         * An updated set of staking information for all nodes in
+         * the address book.
+         */
+        proto.StakingNodeInfo staking_node_info_value = 10;
+
+        /**
+         * An HTS token value.
+         */
+        proto.Token token_value = 11;
+
+        /**
+         * A token relationship value.<br/>
+         * These values track which accounts are willing to transact
+         * in specific HTS tokens.
+         */
+        proto.TokenRelation token_relation_value = 12;
+
+        /**
+         * An HCS topic value.
+         */
+        proto.Topic topic_value = 13;
+
+        /**
+         * An network node value.
+        */
+        com.hedera.hapi.node.state.addressbook.Node node_value = 14;
+
+        /**
+         * A pending airdrop value.
+         */
+        proto.AccountPendingAirdrop account_pending_airdrop_value = 15;
+
+    }
+}
+
+/**
+ * Addition of an item to a `Queue` state.<br/>
+ *
+ * The new item SHALL be added after the current "last" element in the
+ * queue.<br/>
+ * The new item MUST be the same type of value as all other items in the queue.
+ */
+message QueuePushChange {
+    oneof value {
+        /**
+         * A byte array added to the queue state.
+         */
+        google.protobuf.BytesValue proto_bytes_element = 1;
+
+        /**
+         * A string added to the queue state.
+         */
+        google.protobuf.StringValue proto_string_element = 2;
+
+        /**
+         * A transaction record entry added to queue state.
+         * <p>
+         * <blockquote>REVIEW NOTE<blockquote>
+         * Do we really intend to push `transaction records` as state
+         * changes in the block stream? I would think that any queue holding
+         * transaction records is temporary storage (e.g. record cache) and
+         * will be removed or replaced with a block item queue as part
+         * of the change over to block stream.
+         * </blockquote></blockquote>
+         */
+        proto.TransactionRecordEntry transaction_record_entry_element = 3;
+    }
+}
+
+/**
+ * Removal of an item from a `Queue` state.<br/>
+ *
+ * The item removed SHALL be the current "front" (or "head") of the queue.<br/>
+ * Removing from a queue "head" does not, currently, require additional
+ * information beyond the state name common to all state changes.
+ */
+message QueuePopChange {
+}

--- a/hapi/hedera-protobufs/block/stream/output/token_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/token_service.proto
@@ -1,0 +1,163 @@
+/**
+ * # Token Service
+ * Block stream messages that report the results of transactions
+ * handled by the `Token` service.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Block Stream data for a `createToken` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message CreateTokenOutput {}
+
+/**
+ * Block Stream data for a `freezeTokenAccount` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message FreezeTokenAccountOutput {}
+
+/**
+ * Block Stream data for an `unfreezeTokenAccount` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UnfreezeTokenAccountOutput {}
+
+/**
+ * Block Stream data for a `grantKycToTokenAccount` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message GrantTokenKycOutput {}
+
+/**
+ * Block Stream data for a `revokeKycFromTokenAccount` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message RevokeTokenKycOutput {}
+
+/**
+ * Block Stream data for a `deleteToken` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message DeleteTokenOutput {}
+
+/**
+ * Block Stream data for an `updateToken` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UpdateTokenOutput {}
+
+/**
+ * Block Stream data for a `mintToken` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message MintTokenOutput {}
+
+/**
+ * Block Stream data for a `burnToken` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message BurnTokenOutput {}
+
+/**
+ * Block Stream data for a `wipeTokenAccount` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message WipeTokenAccountOutput {}
+
+/**
+ * Block Stream data for an `associateTokens` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message AssociateTokenOutput {}
+
+/**
+ * Block Stream data for a `dissociateTokens` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message DissociateTokenOutput {}
+
+/**
+ * Block Stream data for an `updateTokenFeeSchedule` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UpdateTokenFeeScheduleOutput {}
+
+/**
+ * Block Stream data for a `pauseToken` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message PauseTokenOutput {}
+
+/**
+ * Block Stream data for an `unpauseToken` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UnpauseTokenOutput {}
+
+/**
+ * Block Stream data for an `updateNfts` transaction.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UpdateTokenNftsOutput {}

--- a/hapi/hedera-protobufs/block/stream/output/transaction_output.proto
+++ b/hapi/hedera-protobufs/block/stream/output/transaction_output.proto
@@ -1,0 +1,153 @@
+/**
+ * # Transaction Output
+ * Messages that describe the output of a transaction; data reported
+ * in the block stream that is not in the transaction body and is
+ * not reported in state changes.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "stream/output/schedule_service.proto";
+import "stream/output/util_service.proto";
+import "stream/output/crypto_service.proto";
+import "stream/output/smart_contract_service.proto";
+
+/**
+ * Output from a transaction.
+ *
+ * The values in transaction outputs SHALL be data that is neither present
+ * in the original transaction nor present in state changes.
+ *
+ * > Note
+ * >> Only a few transactions produce output that is not in the transaction
+ * >> and also not reflected in state changes. All other transaction types
+ * >> are _currently_ not included here. We have, however, allocated names
+ * >> and indexes for those transaction types to preserve consistency if we
+ * >> add them later.
+ *
+ * <!--
+ * Reserved definitions:
+ * import "stream/output/consensus_service.proto";
+ *    SubmitMessageOutput submit_message;
+ *
+ * import "stream/smart_contract_service.proto";
+ *    UpdateContractOutput contract_update;
+ *    DeleteContractOutput contract_delete;
+ *    SystemDeleteContractOutput
+ *    SystemUnDeleteContractOutput
+ *    CreateTopicOutput create_topic;
+ *    UpdateTopicOutput update_topic;
+ *
+ * import "stream/file_service.proto";
+ *    CreateFileOutput file_create;
+ *    AppendFileOutput file_append;
+ *    UpdateFileOutput file_update;
+ *    DeleteFileOutput file_delete;
+ *    SystemDeleteOutput system_delete;
+ *    SystemUndeleteOutput system_undelete;
+ *
+ * import "stream/crypto_service.proto";
+ *    UpdateNodeStakeOutput update_node_stake;
+ *    ApproveAllowanceOutput approve_allowance;
+ *    DeleteAllowanceOutput delete_allowance;
+ *    CreateAccountOutput create_account;
+ *    UpdateAccountOutput update_account;
+ *    DeleteAccountOutput delete_account;
+ *
+ * import "stream/token_service.proto";
+ *    CreateTokenOutput create_token;
+ *    DeleteTokenOutput delete_token;
+ *    FreezeTokenAccountOutput freeze_token_account;
+ *    UnfreezeTokenAccountOutput unfreeze_token_account;
+ *    GrantTokenKycOutput grant_token_account_kyc;
+ *    RevokeTokenKycOutput revoke_token_account_kyc;
+ *    UpdateTokenOutput update_token;
+ *    UpdateTokenNftsOutput update_token_nfts;
+ *    MintTokenOutput mint_token;
+ *    BurnTokenOutput burn_token;
+ *    WipeTokenAccountOutput wipe_token_account;
+ *    AssociateTokenOutput associate_token;
+ *    DissociateTokenOutput dissociate_token;
+ *    UpdateTokenFeeScheduleOutput update_token_fee_schedule;
+ *    PauseTokenOutput pause_token;
+ *    UnpauseTokenOutput unpause_token;
+ *
+ * import "stream/consensus_service.proto";
+ *    DeleteTopicOutput delete_topic;
+ *
+ * import "stream/schedule_service.proto";
+ *    DeleteScheduleOutput delete_schedule;
+ *
+ * import "stream/network_service.proto";
+ *    FreezeOutput freeze_network;
+ * -->
+ */
+message TransactionOutput {
+    oneof transaction {
+        /**
+         * Output from a crypto transfer transaction.
+         */
+        CryptoTransferOutput crypto_transfer = 1;
+
+        /**
+         * Output from a utilPrng transaction to request a
+         * deterministic pseudo-random number.
+         */
+        UtilPrngOutput util_prng = 2;
+
+        /**
+         * Output from a contract call transaction.
+         */
+        CallContractOutput contract_call = 3;
+
+        /**
+         * Output from an ethereum call transaction.
+         */
+        EthereumOutput ethereum_call = 4;
+
+        /**
+         * Output from a contract create transaction.
+         */
+        CreateContractOutput contract_create = 5;
+
+        /**
+         * Output from a schedule create transaction that executed
+         * immediately on creation.
+         */
+        CreateScheduleOutput create_schedule = 6;
+
+        /**
+         * Output from a schedule sign transaction that resulted in
+         * executing the scheduled transaction.
+         */
+        SignScheduleOutput sign_schedule = 7;
+    }
+}

--- a/hapi/hedera-protobufs/block/stream/output/transaction_result.proto
+++ b/hapi/hedera-protobufs/block/stream/output/transaction_result.proto
@@ -1,0 +1,169 @@
+/**
+ * # Transaction Result
+ * The result of a transaction, sometimes called a receipt.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+//import "custom_fees.proto";
+import "exchange_rate.proto";
+import "response_code.proto";
+import "timestamp.proto";
+
+/**
+ * While we have the state changes as part of the block stream,
+ * we may not have the full data set needed. To surface information
+ * such as staking rewards, fees, etc. we need to include some of the
+ * data from the original TransactionRecord.
+ *
+ * > REVIEW NOTE
+ * >> Should we have custom fees here, and remove that from the
+ * >> CryptoTransfer output message? That would make more sense, as I believe
+ * >> TokenTransfer output would also need custom fees, and we may wish
+ * >> to add custom fees to other transactions in the future.
+ */
+message TransactionResult {
+    /**
+     * A response code.
+     * <p>
+     * This value SHALL indicate the status of this transaction.<br/>
+     * This code SHALL indicate success or a specific failure.
+     */
+    proto.ResponseCodeEnum status = 1;
+
+    /**
+     * A consensus timestamp.
+     * <p>
+     * The time index, agreed by all network nodes, when this transaction
+     * reached consensus.<br/>
+     * This field SHALL be set for all transactions.
+     */
+    proto.Timestamp consensus_timestamp = 2;
+
+    /**
+     * A consensus timestamp.
+     * <p>
+     * The time index, agreed by all network nodes, when the "parent"
+     * transaction, if any, for this transaction reached consensus.<br/>
+     * This SHALL NOT be set on a user-submitted transaction.<br/>
+     * This SHALL be set on an internal "child" transaction initiated as
+     * part of completing a user-submitted transaction.
+     */
+    proto.Timestamp parent_consensus_timestamp = 3;
+
+    /**
+     * An exchange rate set.
+     * <p>
+     * This field SHALL describe the exchange rates in effect when this
+     * transaction reached consensus.
+     */
+    proto.ExchangeRateSet exchange_rate = 4;
+
+    /**
+     * A schedule that executed this transaction, if this transaction
+     * was scheduled.
+     * <p>
+     * This value SHALL NOT be set unless this transaction result represents
+     * the result of a _scheduled_ child transaction.
+     */
+    proto.ScheduleID schedule_ref = 5;
+
+    /**
+     * An amount, in tinybar, charged for this transaction.
+     * <p>
+     * This SHALL be the actual transaction fee charged, and SHALL NOT be the
+     * transactionFee value from TransactionBody.
+     */
+    uint64 transaction_fee_charged = 6;
+
+    /**
+     * A list of HBAR transfers, in double-entry form.
+     * <p>
+     * This SHALL include all HBAR transfers completed as a result
+     * of this transaction.<br/>
+     * This MUST include, at least,
+     * <ul>
+     *   <li>Each source and recipient of transaction fees</li>
+     *   <li>All transfers directly performed by this transaction</li>
+     *   <li>All transfers due to staking rewards paid as a result of
+     *       this transaction</li>
+     *   <li>Any transfers performed by a smart contract call associated
+     *       with this transaction</li>
+     *   <li>Any transfers caused by the creation of threshold records</li>
+     * </ul>
+     * <p>
+     * This transfer list is exposed in the Mirror Node API (MAPI) and in use
+     * by clients of the MAPI. Additionally, there are some transfers that
+     * are mingled with transactions and only split out here.
+     */
+    proto.TransferList transfer_list = 7;
+
+    /**
+     * A list of _non-HBAR_ token transfers, in single-entry form.
+     * <p>
+     * This SHALL include all _non-HBAR_ token transfers completed as a
+     * result of this transaction.<br/>
+     * This MUST include, at least,
+     * <ul>
+     *   <li>Each source and recipient of custom fees</li>
+     *   <li>All transfers directly performed by this transaction</li>
+     *   <li>Any transfers performed by a smart contract call associated
+     *       with this transaction</li>
+     * </ul>
+     */
+    repeated proto.TokenTransferList token_transfer_lists = 8;
+
+    /**
+     * A list of token associations.
+     * <p>
+     * This field SHALL list all token associations created automatically
+     * while handling this transaction.
+     */
+    repeated proto.TokenAssociation automatic_token_associations = 9;
+
+    /**
+     * A list of accounts and amounts.
+     * <p>
+     * This SHALL list all accounts paid staking rewards as a result
+     * of this transaction.<br/>
+     * Each entry SHALL contain both the account and the amount paid.
+     */
+    repeated proto.AccountAmount paid_staking_rewards = 10;
+
+    /**
+     * A congestion pricing multiplier.
+     * <p>
+     * This SHALL be the multiplier that is applied to the transaction
+     * fees charged for this transaction.
+     */
+    uint64 congestion_pricing_multiplier = 11;
+}

--- a/hapi/hedera-protobufs/block/stream/output/util_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/util_service.proto
@@ -1,0 +1,67 @@
+/**
+ * # Util Service
+ * Block stream messages that report the results of transactions handled by
+ * the `Util` service.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream.output;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.output.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream.output">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Block data produced by `prng` transactions submitted to the `Util` service.
+ *
+ * The `entropy` reported in this block stream message is deterministically
+ * produced, but has high dispersion and is very difficult to predict.
+ *
+ * This message SHALL NOT duplicate information already contained in
+ * the original transaction.
+ */
+message UtilPrngOutput {
+  oneof entropy {
+    /**
+     * A deterministic pseudo-random sequence of 48 bytes.
+     * <p>
+     * This value SHALL be the result of a corresponding
+     * `UtilService` `prng` transaction.
+     */
+    bytes prng_bytes = 1;
+
+    /**
+     * A deterministic pseudo-random number generated within a
+     * specified range.
+     * <p>
+     * This value SHALL be the result of a corresponding `UtilService`
+     * `prng` transaction.<br/>
+     * Note that the transaction only permits a non-negative range, the
+     * output SHALL always be a whole number.
+     */
+    uint32 prng_number = 2;
+  }
+}

--- a/hapi/hedera-protobufs/block/stream/record_file_item.proto
+++ b/hapi/hedera-protobufs/block/stream/record_file_item.proto
@@ -1,0 +1,104 @@
+/**
+ * # Record File Block
+ * This block carries the data from "record stream" and "sidecar"
+ * files that preceded the block stream. Record blocks are full blocks,
+ * not block items, but do not have a block header or block proof.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.block.stream;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.block.stream.protoc";
+// <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+/**
+ * A Block Item for record files.
+ *
+ * A `RecordFileItem` contains data produced before the innovation of the
+ * Block Stream, when data was stored in files and validated by individual
+ * signature files rather than a block proof.<br/>
+ * This item enables a single format, the Block Stream, to carry both
+ * historical and current data; eliminating the need to search two sources for
+ * block and block chain data.<br/>
+ * Any block containing this item requires special handling.
+ * - The block SHALL NOT have a `BlockHeader`.
+ * - The block SHALL NOT have a `BlockProof`.
+ * - The block SHALL contain _exactly one_ `RecordFileItem`.
+ * - The block SHALL NOT contain any item other than a `RecordFileItem`.
+ * - The content of the `RecordFileItem` MUST be validated using the
+ *   signature data and content provided herein according to the
+ *   process used for Record Files prior to the creation of Block Stream.
+ *    - This block item only replaces the requirement to read several
+ *      individual files from cloud storage services.
+ */
+message RecordFileItem {
+    /**
+     * The block number of this block.
+     * <p>
+     * This value MUST be exactly `1` more than the previous block.<br/>
+     * Client systems SHOULD optimistically reject any block with a gap or
+     * reverse in `number` sequence, and MAY assume the block stream has
+     * encountered data loss, data corruption, or unauthorized modification.
+     */
+    uint64 number = 1;
+
+    /**
+     * The consensus time the record file was produced for.<br/>
+     * This comes from the record file name.
+     */
+    proto.Timestamp creation_time = 2;
+
+    /**
+     * The contents of a record file.<br/>
+     * The first 4 bytes are a 32bit int little endian version number.
+     * The versions that existed are 2,3,5 and 6.
+     */
+    bytes record_file_contents = 3;
+
+    /**
+     * The contents of sidecar files for this block.<br/>
+     * Each block can have zero or more sidecar files.
+     */
+    repeated bytes sidecar_file_contents = 4;
+
+    /**
+     * A hash algorithm.<br/>
+     * This is the algorithm used to hash the block.
+     * <p>
+     * This SHOULD always be `SHA2_384`.
+     */
+    proto.BlockHashAlgorithm hash_algorithm = 5;
+
+    /**
+     * A collection of RSA signatures from consensus nodes.<br/>
+     * These signatures validate the hash of the record_file_contents field.
+     */
+    repeated bytes record_file_hash_signatures = 6;
+}

--- a/hapi/hedera-protobufs/platform/event/event_consensus_data.proto
+++ b/hapi/hedera-protobufs/platform/event/event_consensus_data.proto
@@ -1,0 +1,69 @@
+/**
+ * # Event Consensus Data
+ * A message that describes the consensus data for an event.
+ *
+ * The `EventConsensusData` contains two fields that are determined once an
+ * event reaches consensus, the `consensus_timestamp` and `consensus_order`.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.platform.event;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "basic_types.proto";
+import "event/event_descriptor.proto";
+import "timestamp.proto";
+
+option java_package = "com.hedera.hapi.platform.event.legacy";
+// <<<pbj.java_package = "com.hedera.hapi.platform.event">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Event Consensus Data.<br/>
+ * This message records the critical values produced by consensus for an event.
+ */
+message EventConsensusData {
+    /**
+     * A consensus timestamp.<br/>
+     * The network's consensus agreement on a timestamp for this event.
+     * <p>
+     * This timestamp MUST be strictly greater than the `consensus_timestamp` of
+     * the previous consensus event.<br/>
+     * This is a consensus value and MAY NOT match real-world "wall clock" time.
+     */
+    proto.Timestamp consensus_timestamp = 1;
+
+    /**
+     * A consensus order sequence number.<br/>
+     * A non-negative sequence number that identifies an event's consensus order
+     * since genesis.
+     * <p>
+     * This SHALL be the unique for each consensus event.<br/>
+     * This SHALL always increase, and SHALL NOT decrease.<br/>
+     * This SHALL increment by one for each consensus event.
+     */
+    uint64 consensus_order = 2;
+}
+

--- a/hapi/hedera-protobufs/platform/event/event_core.proto
+++ b/hapi/hedera-protobufs/platform/event/event_core.proto
@@ -1,0 +1,83 @@
+/**
+ * # Core Event Data
+ * A message that describes the metadata for an event.
+ *
+ * The `EventCore` contains a list of the event's parents, as well as the software
+ * version, an identifier for the node that created this event, the birth round, and
+ * the creation timestamp for the event.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.platform.event;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "basic_types.proto";
+import "event/event_descriptor.proto";
+import "timestamp.proto";
+
+option java_package = "com.hedera.hapi.platform.event.legacy";
+// <<<pbj.java_package = "com.hedera.hapi.platform.event">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Contains information about an event and its parents.
+ */
+message EventCore {
+  /**
+   * The creator node identifier.<br/>
+   * This SHALL be the unique identifier for the node that created the event.<br/>
+   * This SHALL match the ID of the node as it appears in the address book.
+   */
+  int64 creator_node_id = 1;
+
+  /**
+   * The birth round of the event.<br/>
+   * The birth round SHALL be the pending consensus round at the time the event is created.<br/>
+   * The pending consensus round SHALL be **one greater** than the latest round to reach consensus.
+   */
+  int64 birth_round = 2;
+
+  /**
+   * The wall clock time at which the event was created, according to the node creating the event.<br/>
+   * If the event has a self parent, this timestamp MUST be strictly greater than the `time_created` of the self parent.
+   */
+  proto.Timestamp time_created = 3;
+
+  /**
+   * A list of EventDescriptors representing the parents of this event.<br/>
+   * The list of parents SHALL include zero or one self parents, and zero or more other parents.<br/>
+   * The first element of the list SHALL be the self parent, if one exists.<br/>
+   * The list of parents SHALL NOT include more than one parent from the same creator.
+   */
+  repeated EventDescriptor parents = 4;
+
+  /**
+   * The event specification version.<br/>
+   * The specification described by this version SHALL encompass the format of the `GossipEvent` message, and also the
+   * format of all contained messages.<br/>
+   * This SHALL exactly match the specification version passed into the platform at construction.
+   */
+  proto.SemanticVersion version = 17; // This field is temporary until birth_round migration is complete. Field number 17 chosen to avoid polluting cheaper 1 byte field numbers 1-16
+}

--- a/hapi/hedera-protobufs/platform/event/event_descriptor.proto
+++ b/hapi/hedera-protobufs/platform/event/event_descriptor.proto
@@ -1,0 +1,80 @@
+/**
+ * # Event Descriptor
+ * Unique identifier for an event.
+ *
+ * Contains the hash of the event, the creator identifier, the birth round, and the generation.
+ *
+ * An event's descriptor is constructed individually by each node that receives a `GossipEvent`,
+ * to uniquely identify that event. An event's descriptor isn't part of the `GossipEvent` itself,
+ * since the descriptor contains the fields `hash` and `generation`, which can be computed locally.
+ * Nodes receiving a `GossipEvent` have the required information to construct the event descriptor
+ * immediately upon receiving the event, without needing to wait for the event to reach consensus.
+ *
+ * Aside from being a unique identifier for events that have been received through gossip,
+ * the event descriptor contains the necessary information to describe an event's parents,
+ * in the `parents` field of `GossipEvent`.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.platform.event;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.platform.event.legacy";
+// <<<pbj.java_package = "com.hedera.hapi.platform.event">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Unique identifier for an event.
+ */
+message EventDescriptor {
+  /**
+   * The hash of the event.<br/>
+   * The hash SHALL be a SHA-384 hash.<br/>
+   * The hash SHALL have the following inputs, in the specified order:<br/>
+   * 1. The bytes of the `EventCore` protobuf<br/>
+   * 2. The SHA-384 hash of each individual `EventTransaction`, in the order the transactions appear in the `event_transactions` field of the `GossipEvent` protobuf
+   */
+  bytes hash = 1;
+
+  /**
+   * The creator node identifier.<br/>
+   * This SHALL be the unique identifier for the node that created the event.<br/>
+   * This SHALL match the ID of the node as it appears in the address book.
+   */
+  int64 creator_node_id = 2;
+
+  /**
+   * The birth round of the event.<br/>
+   * The birth round SHALL be the pending consensus round at the time the event is created.<br/>
+   * The pending consensus round SHALL be **one greater** than the latest round to reach consensus.
+   */
+  int64 birth_round = 3;
+
+  /**
+  * The generation of the event.<br/>
+  * This value SHALL be **one greater** than the _maximum_ generation of all parents.<br/>
+  */
+  int64 generation = 17; // This field is temporary until birth_round migration is complete. Field number 17 chosen to avoid polluting cheaper 1 byte field numbers 1-16
+}

--- a/hapi/hedera-protobufs/platform/event/event_transaction.proto
+++ b/hapi/hedera-protobufs/platform/event/event_transaction.proto
@@ -1,0 +1,65 @@
+/**
+ * # Event Transaction
+ * An Event Transaction gossiped between nodes as part of events.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.platform.event;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "event/state_signature_transaction.proto";
+
+option java_package = "com.hedera.hapi.platform.event.legacy";
+// <<<pbj.java_package = "com.hedera.hapi.platform.event">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * An Event Transaction gossiped between nodes as part of events.
+ *
+ * Each node MUST extract this transaction and process according to the type
+ * of transaction encoded.<br/>
+ * Both the platform and the application built on that platform MAY define event
+ * transactions.<br/>
+ * The encoded data MUST be a serialized protobuf message.
+ */
+message EventTransaction {
+  oneof transaction {
+      /**
+       * An application transaction.
+       * <p>
+       * The contents of this transaction SHALL be defined by the application
+       * subsystem that created the event.<br/>
+       * The contents MUST be a serialized protobuf message.
+       */
+      bytes application_transaction = 1;
+      /**
+       * A state signature.
+       * <p>
+       * This transaction SHALL be a valid state signature for a state snapshot.
+       */
+      StateSignatureTransaction state_signature_transaction = 2;
+  }
+
+}

--- a/hapi/hedera-protobufs/platform/event/gossip_event.proto
+++ b/hapi/hedera-protobufs/platform/event/gossip_event.proto
@@ -1,0 +1,68 @@
+/**
+ * # Gossip Event
+ * An event that is sent and received via gossip
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.platform.event;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "event/event_transaction.proto";
+import "event/event_core.proto";
+
+option java_package = "com.hedera.hapi.platform.event.legacy";
+// <<<pbj.java_package = "com.hedera.hapi.platform.event">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * An event that is sent and received via gossip
+ */
+message GossipEvent {
+  /**
+   * The core event data
+   */
+  EventCore event_core = 1;
+
+  /**
+   * A node signature on the event hash.<br/>
+   * The signature SHALL be created with the SHA384withRSA algorithm.<br/>
+   * The signature MUST verify using the public key belonging to the `event_creator`.<br/>
+   * The `event_creator` public key SHALL be read from the address book that corresponds to the event's birth round.<br/>
+   * The signed event hash SHALL be a SHA-384 hash.<br/>
+   * The signed event hash SHALL have the following inputs, in the specified order:<br/>
+   * 1. The bytes of the `event_core` field<br/>
+   * 2. The SHA-384 hash of each individual `EventTransaction`, in the order the transaction appear in the `event_transaction` field
+   */
+  bytes signature = 2;
+
+  /**
+   * The event transaction.
+   * <p>
+   * This field MAY contain zero transactions.<br/>
+   * This field MUST NOT exceed `maxTransactionCountPerEvent` entries, initially `245760`.<br/>
+   * This total size of this field MUST NOT exceed `maxTransactionBytesPerEvent`, initially `245760` bytes.
+   */
+  repeated EventTransaction event_transaction = 3;
+}

--- a/hapi/hedera-protobufs/platform/event/state_signature_transaction.proto
+++ b/hapi/hedera-protobufs/platform/event/state_signature_transaction.proto
@@ -1,0 +1,64 @@
+/**
+ * # State Signature Transaction
+ * An signature of a state snapshot gossiped to other nodes.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.platform.event;
+
+/*
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2018 - 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.platform.event.legacy";
+// <<<pbj.java_package = "com.hedera.hapi.platform.event">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * An signature of a state snapshot gossiped to other nodes.
+ * Each node SHALL hash the root of the merkle tree of a state snapshot every
+ * round. Once this hash is calculated, it SHOULD be signed with the nodes
+ * private signing key. This signature, together with the hash SHOULD be added
+ * to an event as a StateSignatureTransaction.
+ */
+message StateSignatureTransaction {
+
+  /**
+   * The round number corresponding to the round number of the state snapshot
+   * being signed.<br/>
+   * This number MUST be greater than 0.
+   */
+  int64 round = 1;
+
+  /**
+   * The signature of state snapshot hash.<br/>
+   * This signature MUST be a RSA signature with a maximum length of 384 bytes.<br/>
+   * The signature algorithm used MUST be RSASSA-PKCS1-v1_5 with SHA-384.
+   */
+  bytes signature = 2;
+
+  /**
+   * The hash of the state snapshot being signed.<br/>
+   * This hash MUST be a SHA-384 hash.
+   */
+  bytes hash = 3;
+}

--- a/hapi/hedera-protobufs/platform/state/platform_state.proto
+++ b/hapi/hedera-protobufs/platform/state/platform_state.proto
@@ -1,0 +1,341 @@
+/**
+ * # PlatformState
+ * Messages that hold platform state in the network state.
+ *
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119)
+ * and clarified in [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
+syntax = "proto3";
+
+package com.hedera.hapi.platform.state;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hedera.hapi.platform.state.legacy";
+// <<<pbj.java_package = "com.hedera.hapi.platform.state">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+/**
+ * The current state of platform consensus.<br/>
+ * This message stores the current consensus data for the platform
+ * in network state.
+ *
+ * The platform state SHALL represent the latest round's consensus.<br/>
+ * This data SHALL be used to ensure consistency and provide critical data for
+ * restart and reconnect.
+ */
+message PlatformState {
+
+    /**
+     * A version describing the current version of application software.
+     * <p>
+     * This SHALL be the software version that created this state.
+     */
+    proto.SemanticVersion creation_software_version = 1;
+
+    /**
+     * A number of non-ancient rounds.
+     * <p>
+     * This SHALL be the count of rounds considered non-ancient.
+     */
+    uint32 rounds_non_ancient = 2;
+
+    /**
+     * A snapshot of the consensus state at the end of the round.
+     * <p>
+     * This SHALL be used for restart/reconnect.
+     */
+    ConsensusSnapshot consensus_snapshot = 3;
+
+    /**
+     * A timestamp for the next scheduled time when a freeze will start.
+     * <p>
+     * If a freeze is not scheduled, this SHALL NOT be set.<br/>
+     * If a freeze is currently scheduled, this MUST be set, and MUST
+     * match the timestamp requested for that freeze.
+     */
+    proto.Timestamp freeze_time = 4;
+
+    /**
+     * A timestamp for the last time a freeze was performed.<br/>
+     * If not set, there has never been a freeze.
+     */
+    proto.Timestamp last_frozen_time = 5;
+
+    // Fields below are to be deprecated in the foreseeable future.
+
+    /**
+     * A running event hash.<br/>
+     * This is computed by the consensus event stream.
+     * <p>
+     * This will be _removed_ and the field number reserved once the consensus
+     * event stream is retired.
+     */
+     bytes legacy_running_event_hash = 10000 [deprecated = true];
+
+    /**
+     * A consensus generation.<br/>
+     * The lowest judge generation before birth round mode was enabled.
+     * <p>
+     * This SHALL be `MAX_UNSIGNED` if birth round mode has not yet been enabled.
+     */
+    uint64 lowest_judge_generation_before_birth_round_mode = 10001 [deprecated = true];
+
+    /**
+     * A consensus round.<br/>
+     * The last round before the birth round mode was enabled.
+     * Will be removed after the birth round migration.
+     * <p>
+     * This SHALL be `MAX_UNSIGNED` if birth round mode has not yet been enabled.
+     */
+    uint64 last_round_before_birth_round_mode = 10002 [deprecated = true];
+
+    /**
+     * A consensus node semantic version.<br/>
+     * The software version that enabled birth round mode.
+     * <p>
+     * This SHALL be unset if birth round migration has not yet happened.<br/>
+     * If birth round migration is complete, this SHALL be the _first_ software
+     * version that enabled birth round mode.
+    */
+    proto.SemanticVersion first_version_in_birth_round_mode = 10003 [deprecated = true];
+
+    /**
+     * An address book for this round.
+     * <p>
+     * This SHALL be the latest network-consensus view of consensus nodes.
+     */
+    AddressBook address_book = 10004 [deprecated = true];
+
+    /**
+     * A previous address book.
+     * <p>
+     * If present, the previous address book SHALL be the address book from the
+     * most recent preceding round.
+     * <p>
+     * This is a temporary workaround until dynamic address books are supported.
+     */
+    AddressBook previous_address_book = 10005 [deprecated = true];
+}
+
+
+/**
+ * A consensus snapshot.<br/>
+ * This is a snapshot of the consensus state for a particular round.
+ *
+ * This message SHALL record consensus data necessary for restart
+ * and reconnect.
+ */
+message ConsensusSnapshot {
+    /**
+     * A consensus round.<br/>
+     * The round number of this snapshot.
+     */
+    uint64 round = 1;
+    /**
+     * A list of SHA-384 hash values.<br/>
+     * The hashes of all judges for this round.
+     * <p>
+     * This list SHALL be ordered by creator ID.<br/>
+     * This list MUST be deterministically ordered.
+     */
+    repeated bytes judge_hashes = 2;
+
+    /**
+     * A list of minimum judge information entries.<br/>
+     * These are "minimum ancient" entries for non-ancient rounds.
+     */
+    repeated MinimumJudgeInfo minimum_judge_info_list = 3;
+
+    /**
+     * A single consensus number.<br/>
+     * The consensus order of the next event to reach consensus.
+     */
+    uint64 next_consensus_number = 4;
+
+    /**
+     * A "consensus" timestamp.<br/>
+     * The consensus timestamp of this snapshot.
+     * <p>
+     * Depending on the context this timestamp may have different meanings:
+     * <ul>
+     * <li>if there are transactions, the timestamp is equal to the timestamp of the last transaction</li>
+     * <li>if there are no transactions, the timestamp is equal to the timestamp of the last event</li>
+     * <li>if there are no events, the timestamp is equal to the timestamp of the previous round plus a small constant</li>
+     * </ul>
+     * <p>
+     * This SHALL be a consensus value and MAY NOT correspond to an actual
+     * "wall clock" timestamp.<br/>
+     * Consensus Timestamps SHALL always increase.
+     */
+    proto.Timestamp consensus_timestamp = 5;
+
+}
+
+/**
+ * Records the minimum ancient indicator for all judges in a particular round.
+ */
+message MinimumJudgeInfo {
+    /**
+     * A consensus round.<br/>
+     * The round this judge information applies to.
+     */
+    uint64 round = 1;
+
+    /**
+     * This is a minimum ancient threshold for all judges for a given round.
+     * The value should be interpreted as a generation if the birth
+     * round migration is not yet completed, and a birth round thereafter.
+     * <p>
+     * This SHALL reflect the relevant minimum threshold, whether
+     * generation-based or birth-round-based.
+     */
+    uint64 minimum_judge_ancient_threshold = 2;
+}
+
+/**
+ * A network address book.<br/>
+ * The address book records the address of every known consensus node that
+ * participates in the network, including `0 weight` nodes.<br/>
+ */
+message AddressBook {
+  /**
+   * A consensus round.<br/>
+   * The round when this address book was created.
+   */
+  int64 round = 1;
+
+  /**
+   * The node ID of the next address that can be added.
+   * <p>
+   * The next node identifier assigned SHALL be equal to this value.<br/>
+   * All existing node identifiers SHALL be strictly less than this value.<br/>
+   */
+  NodeId next_node_id = 2;
+
+  /**
+   * A list of all consensus node addresses.
+   * <p>
+   * This list SHALL NOT be empty.
+   * If a consensus node is not in this list it SHALL NOT participate in the
+   * network.
+   */
+  repeated Address addresses = 3;
+}
+
+/**
+ * A single network address.
+ * This is one address in the network address book, including all required
+ * information to include that consensus node in the consensus gossip.
+ *
+ */
+message Address {
+  /**
+   * The ID of this member.
+   * <p>
+   * This identifier SHALL be agreed upon by all consensus nodes.
+   */
+  NodeId id = 1;
+
+  /**
+   * The nickname other consensus nodes will use to refer to this consensus node.
+   */
+  string nickname = 2;
+
+  /**
+   * The name that a consensus node uses to refer to themselves.
+   */
+  string self_name = 3;
+
+  /**
+   * A consensus weight.<br/>
+   * This value is the relative weight for this consensus node in the
+   * consensus voting algorithm.
+   */
+  uint64 weight = 4;
+
+  /**
+   * A string network address.<br/>
+   * This value is the hostname assigned on the "internal" network
+   * interface behind any network firewalls, protocol gateways, or
+   * DNS translations.
+   * <p>
+   * This value SHALL be either a FQDN host name or an IPv4 address.
+   */
+  string hostname_internal = 5;
+
+  /**
+   * Network port number.<br/>
+   * This value is the "translated" port number assigned on the "internal"
+   * network behind any network firewalls or other address translations.
+   * <p>
+   * This value SHALL be between 1 and 65535.
+   */
+  uint32 port_internal = 6;
+
+  /**
+   * A string network address.<br/>
+   * This value is the hostname assigned on the "public" network
+   * interface visible to the general internet.
+   * <p>
+   * This value SHALL be either a FQDN host name or an IPv4 address.
+   */
+  string hostname_external = 7;
+
+  /**
+   * Network port number.<br/>
+   * This value is the port number visible to the general internet.
+   * <p>
+   * This value SHALL be between 1 and 65535.
+   */
+  uint32 port_external = 8;
+
+  /**
+   * The signing x509 certificate of the consensus node.
+   * <p>
+   * This SHALL provide the public key used for signing.
+   */
+  bytes signing_certificate = 9;
+
+  /**
+   * The agreement x509 certificate of the consensus node.
+   * <p>
+   * This SHALL be used for establishing TLS connections.
+   */
+  bytes agreement_certificate = 10;
+
+  /**
+   * A string that provides additional information about this consensus node.
+   */
+  string memo = 11;
+}
+
+/**
+ * A consensus node identifier.<br/>
+ * This value uniquely identifies a single consensus node within the network.
+ */
+message NodeId {
+  /**
+   * A numeric identifier.
+   */
+  uint64 id = 1;
+}

--- a/hapi/hedera-protobufs/services/address_book_service.proto
+++ b/hapi/hedera-protobufs/services/address_book_service.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+
+import "query.proto";
+import "response.proto";
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * The Address Book service provides the ability for Hedera network node
+ * administrators to add, update, and remove consensus nodes. This addition,
+ * update, or removal of a consensus node requires governing council approval,
+ * but each node operator may update their own operational attributes without
+ * additional approval, reducing overhead for routine operations.
+ *
+ * Most operations are `privileged operations` and require governing council
+ * approval.
+ *
+ * ### For a node creation transaction.
+ * - The node operator SHALL create a `createNode` transaction.
+ *    - The node operator SHALL sign this transaction with the active `key` for
+ *      the account to be assigned as the "node account".
+ *    - The node operator MUST deliver the signed transaction to the Hedera
+ *      council representative.
+ *    - The Hedera council representative SHALL arrange for council members to
+ *      review and sign the transaction.
+ *    - Once sufficient council members have signed the transaction, the
+ *      Hedera council representative SHALL submit the transaction to the
+ *      network.
+ * - Upon receipt of a valid and signed node creation transaction the network
+ *   software SHALL
+ *    - Validate the threshold signature for the Hedera governing council
+ *    - Validate the signature of the active `key` for the account to be
+ *      assigned as the "node account".
+ *    - Create the new node in state, this new node SHALL NOT be active in the
+ *      network at this time.
+ *    - When executing the next `freeze` transaction with `freeze_type` set to
+ *      `PREPARE_UPGRADE`, update network configuration and bring the
+ *      new node to an active status within the network. The node to be added
+ *      SHALL be active in the network following this upgrade.
+ *
+ * ### For a node deletion transaction.
+ * - The node operator or Hedera council representative SHALL create a
+ *   `deleteNode` transaction.
+ *    - If the node operator creates the transaction
+ *       - The node operator MUST sign this transaction with the active `key`
+ *         for the account assigned as the "node account".
+ *       - The node operator SHALL deliver the signed transaction to the Hedera
+ *         council representative.
+ *    - The Hedera council representative SHALL arrange for council members to
+ *      review and sign the transaction.
+ *    - Once sufficient council members have signed the transaction, the
+ *      Hedera council representative SHALL submit the transaction to the
+ *      network.
+ * - Upon receipt of a valid and signed node deletion transaction the network
+ *   software SHALL
+ *    - Validate the threshold signature for the Hedera governing council
+ *    - Remove the existing node from network state. The node SHALL still
+ *      be active in the network at this time.
+ *    - When executing the next `freeze` transaction with `freeze_type` set to
+ *      `PREPARE_UPGRADE`, update network configuration and remove the
+ *      node to be deleted from the network. The node to be deleted SHALL NOT
+ *      be active in the network following this upgrade.
+ *
+ * ### For a node update transaction.
+ * - The node operator or Hedera council representative SHALL create an
+ *   `updateNode` transaction.
+ *    - If the node operator creates the transaction
+ *       - The node operator MUST sign this transaction with the active `key`
+ *         for the account assigned as the current "node account".
+ *       - If the transaction changes the value of the "node account" the
+ *         node operator MUST _also_ sign this transaction with the active `key`
+ *         for the account to be assigned as the new "node account".
+ *       - The node operator SHALL submit the transaction to the
+ *         network.  Hedera council approval SHALL NOT be sought for this
+ *         transaction
+ *    - If the Hedera council representative creates the transaction
+ *       - The Hedera council representative SHALL arrange for council members
+ *         to review and sign the transaction.
+ *       - Once sufficient council members have signed the transaction, the
+ *         Hedera council representative SHALL submit the transaction to the
+ *         network.
+ * - Upon receipt of a valid and signed node update transaction the network
+ *   software SHALL
+ *    - If the transaction is signed by the Hedera governing council
+ *       - Validate the threshold signature for the Hedera governing council
+ *    - If the transaction is signed by the active `key` for the node account
+ *       - Validate the signature of the active `key` for the account assigned
+ *         as the "node account".
+ *    - If the transaction modifies the value of the "node account",
+ *       - Validate the signature of the _new_ `key` for the account to be
+ *         assigned as the new "node account".
+ *    - Modify the node information held in network state with the changes
+ *      requested in the update transaction. The node changes SHALL NOT be
+ *      applied to network configuration, and SHALL NOT affect network
+ *      operation at this time.
+ *    - When executing the next `freeze` transaction with `freeze_type` set to
+ *      `PREPARE_UPGRADE`, update network configuration according to the
+ *      modified information in network state. The requested changes SHALL
+ *      affect network operation following this upgrade.
+ */
+service AddressBookService {
+    /**
+     * A transaction to create a new consensus node in the network.
+     * address book.
+     * <p>
+     * This transaction, once complete, SHALL add a new consensus node to the
+     * network state.<br/>
+     * The new consensus node SHALL remain in state, but SHALL NOT participate
+     * in network consensus until the network updates the network configuration.
+     * <p>
+     * Hedera governing council authorization is REQUIRED for this transaction.
+     */
+    rpc createNode (proto.Transaction) returns (proto.TransactionResponse);
+
+    /**
+     * A transaction to remove a consensus node from the network address
+     * book.
+     * <p>
+     * This transaction, once complete, SHALL remove the identified consensus
+     * node from the network state.
+     * <p>
+     * Hedera governing council authorization is REQUIRED for this transaction.
+     */
+    rpc deleteNode (proto.Transaction) returns (proto.TransactionResponse);
+
+    /**
+     * A transaction to update an existing consensus node from the network
+     * address book.
+     * <p>
+     * This transaction, once complete, SHALL modify the identified consensus
+     * node state as requested.
+     * <p>
+     * This transaction MAY be authorized by either the node operator OR the
+     * Hedera governing council.
+     */
+    rpc updateNode (proto.Transaction) returns (proto.TransactionResponse);
+}

--- a/hapi/hedera-protobufs/services/basic_types.proto
+++ b/hapi/hedera-protobufs/services/basic_types.proto
@@ -1,0 +1,1775 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Each shard has a nonnegative shard number. Each realm within a given shard has a nonnegative
+ * realm number (that number might be reused in other shards). And each account, file, and smart
+ * contract instance within a given realm has a nonnegative number (which might be reused in other
+ * realms).  Every account, file, and smart contract instance is within exactly one realm. So a
+ * FileID is a triplet of numbers, like 0.1.2 for entity number 2 within realm 1  within shard 0.
+ * Each realm maintains a single counter for assigning numbers,  so if there is a file with ID
+ * 0.1.2, then there won't be an account or smart  contract instance with ID 0.1.2.
+ *
+ * Everything is partitioned into realms so that each Solidity smart contract can  access everything
+ * in just a single realm, locking all those entities while it's  running, but other smart contracts
+ * could potentially run in other realms in  parallel. So realms allow Solidity to be parallelized
+ * somewhat, even though the  language itself assumes everything is serial.
+ */
+message ShardID {
+    /**
+     * the shard number (nonnegative)
+     */
+    int64 shardNum = 1;
+}
+
+/**
+ * The ID for a realm. Within a given shard, every realm has a unique ID. Each account, file, and
+ * contract instance belongs to exactly one realm.
+ */
+message RealmID {
+    /**
+     * The shard number (nonnegative)
+     */
+    int64 shardNum = 1;
+
+    /**
+     * The realm number (nonnegative)
+     */
+    int64 realmNum = 2;
+}
+
+/**
+ * A specific hash algorithm.
+ *
+ * We did not reuse Record Stream `HashAlgorithm` here because in all cases,
+ * currently, this will be `SHA2_384` and if that is the default value then
+ * we can save space by not serializing it, whereas `HASH_ALGORITHM_UNKNOWN`
+ * is the default for Record Stream `HashAlgorithm`.
+ *
+ * Note that enum values here MUST NOT match the name of any other enum value
+ * in the same `package`, as protobuf follows `C++` scope rules and all enum
+ * _names_ are treated as global constants within the `package`.
+ */
+enum BlockHashAlgorithm {
+    /**
+     * A SHA2 algorithm SHA-384 hash.
+     * <p>
+     * This is the default value, if a field of this enumerated type is
+     * not set, then this is the value that will be decoded when the
+     * serialized message is read.
+     */
+    SHA2_384 = 0;
+}
+
+/**
+ * The ID for an a cryptocurrency account
+ */
+message AccountID {
+    /**
+     * The shard number (nonnegative)
+     */
+    int64 shardNum = 1;
+
+    /**
+     * The realm number (nonnegative)
+     */
+    int64 realmNum = 2;
+
+    /**
+     * The account number unique within its realm which can be a non-negative integer, an alias public key or an EVM address.
+     * For any AccountID fields in the query response, transaction record or transaction receipt only accountNum will
+     * be populated.
+     */
+    oneof account {
+        /**
+         * A non-negative account number unique within its realm
+         */
+        int64 accountNum = 3;
+
+        /**
+         * The public key bytes to be used as the account's alias. The public key bytes are the result of serializing
+         * a protobuf Key message for any primitive key type. Currently only primitive key bytes are supported as an alias
+         * (ThresholdKey, KeyList, ContractID, and delegatable_contract_id are not supported)
+         *
+         * May also be the ethereum account 20-byte EVM address to be used initially in place of the public key bytes. This EVM
+         * address may be either the encoded form of the shard.realm.num or the keccak-256 hash of a ECDSA_SECP256K1 primitive key.
+         *
+         * At most one account can ever have a given alias and it is used for account creation if it
+         * was automatically created using a crypto transfer. It will be null if an account is created normally.
+         * It is immutable once it is set for an account.
+         *
+         * If a transaction auto-creates the account, any further transfers to that alias will simply be deposited
+         * in that account, without creating anything, and with no creation fee being charged.
+         *
+         * If a transaction lazily-creates this account, a subsequent transaction will be required containing the public key bytes
+         * that map to the EVM address bytes. The provided public key bytes will then serve as the final alias bytes.
+         */
+        bytes alias = 4;
+    }
+}
+
+/**
+ * Identifier for a unique token (or "NFT"), used by both contract and token services.
+ */
+message NftID {
+    /**
+     * The (non-fungible) token of which this NFT is an instance; uppercase for "ID"
+     * for backward compatibility with original definition of this field.
+     */
+    TokenID token_ID = 1;
+
+    /**
+     * The serial number of this NFT within its token type
+     */
+    int64 serial_number = 2;
+}
+
+/**
+ * The ID for a file
+ */
+message FileID {
+    /**
+     * The shard number (nonnegative)
+     */
+    int64 shardNum = 1;
+
+    /**
+     * The realm number (nonnegative)
+     */
+    int64 realmNum = 2;
+
+    /**
+     * A nonnegative File number unique within its realm
+     */
+    int64 fileNum = 3;
+}
+
+/**
+ * The ID for a smart contract instance
+ */
+message ContractID {
+    /**
+     * The shard number (nonnegative)
+     */
+    int64 shardNum = 1;
+
+    /**
+     * The realm number (nonnegative)
+     */
+    int64 realmNum = 2;
+
+    oneof contract {
+        /**
+        * A nonnegative number unique within a given shard and realm
+        */
+        int64 contractNum = 3;
+
+        /**
+        * The 20-byte EVM address of the contract to call.
+        *
+        * Every contract has an EVM address determined by its <tt>shard.realm.num</tt> id.
+        * This address is as follows:
+        *   <ol>
+        *     <li>The first 4 bytes are the big-endian representation of the shard.</li>
+        *     <li>The next 8 bytes are the big-endian representation of the realm.</li>
+        *     <li>The final 8 bytes are the big-endian representation of the number.</li>
+        *   </ol>
+        *
+        * Contracts created via CREATE2 have an <b>additional, primary address</b> that is
+        * derived from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a>
+        * specification, and does not have a simple relation to a <tt>shard.realm.num</tt> id.
+        *
+        * (Please do note that CREATE2 contracts can also be referenced by the three-part
+        * EVM address described above.)
+        */
+        bytes evm_address = 4;
+    }
+}
+
+/**
+ * The ID for a transaction. This is used for retrieving receipts and records for a transaction, for
+ * appending to a file right after creating it, for instantiating a smart contract with bytecode in
+ * a file just created, and internally by the network for detecting when duplicate transactions are
+ * submitted. A user might get a transaction processed faster by submitting it to N nodes, each with
+ * a different node account, but all with the same TransactionID. Then, the transaction will take
+ * effect when the first of all those nodes submits the transaction and it reaches consensus. The
+ * other transactions will not take effect. So this could make the transaction take effect faster,
+ * if any given node might be slow. However, the full transaction fee is charged for each
+ * transaction, so the total fee is N times as much if the transaction is sent to N nodes.
+ *
+ * Applicable to Scheduled Transactions:
+ *  - The ID of a Scheduled Transaction has transactionValidStart and accountIDs inherited from the
+ *    ScheduleCreate transaction that created it. That is to say that they are equal
+ *  - The scheduled property is true for Scheduled Transactions
+ *  - transactionValidStart, accountID and scheduled properties should be omitted
+ */
+message TransactionID {
+    /**
+     * The transaction is invalid if consensusTimestamp < transactionID.transactionStartValid
+     */
+    Timestamp transactionValidStart = 1;
+
+    /**
+     * The Account ID that paid for this transaction
+     */
+    AccountID accountID = 2;
+
+    /**
+     * Whether the Transaction is of type Scheduled or no
+     */
+    bool scheduled = 3;
+
+    /**
+     * The identifier for an internal transaction that was spawned as part
+     * of handling a user transaction. (These internal transactions share the
+     * transactionValidStart and accountID of the user transaction, so a
+     * nonce is necessary to give them a unique TransactionID.)
+     *
+     * An example is when a "parent" ContractCreate or ContractCall transaction
+     * calls one or more HTS precompiled contracts; each of the "child"
+     * transactions spawned for a precompile has a id with a different nonce.
+     */
+    int32 nonce = 4;
+}
+
+/**
+ * An account, and the amount that it sends or receives during a cryptocurrency or token transfer.
+ */
+message AccountAmount {
+    /**
+     * The Account ID that sends/receives cryptocurrency or tokens
+     */
+    AccountID accountID = 1;
+
+    /**
+     * The amount of tinybars (for Crypto transfers) or in the lowest
+     * denomination (for Token transfers) that the account sends(negative) or
+     * receives(positive)
+     */
+    sint64 amount = 2;
+
+    /**
+     * If true then the transfer is expected to be an approved allowance and the
+     * accountID is expected to be the owner. The default is false (omitted).
+     */
+    bool is_approval = 3;
+}
+
+/**
+ * A list of accounts and amounts to transfer out of each account (negative) or into it (positive).
+ */
+message TransferList {
+    /**
+     * Multiple list of AccountAmount pairs, each of which has an account and
+     * an amount to transfer into it (positive) or out of it (negative)
+     */
+    repeated AccountAmount accountAmounts = 1;
+}
+
+/**
+ * A sender account, a receiver account, and the serial number of an NFT of a Token with
+ * NON_FUNGIBLE_UNIQUE type. When minting NFTs the sender will be the default AccountID instance
+ * (0.0.0) and when burning NFTs, the receiver will be the default AccountID instance.
+ */
+message NftTransfer {
+    /**
+     * The accountID of the sender
+     */
+    AccountID senderAccountID = 1;
+
+    /**
+     * The accountID of the receiver
+     */
+    AccountID receiverAccountID = 2;
+
+    /**
+     * The serial number of the NFT
+     */
+    int64 serialNumber = 3;
+
+    /**
+     * If true then the transfer is expected to be an approved allowance and the
+     * senderAccountID is expected to be the owner. The default is false (omitted).
+     */
+    bool is_approval = 4;
+}
+
+/**
+ * A list of token IDs and amounts representing the transferred out (negative) or into (positive)
+ * amounts, represented in the lowest denomination of the token
+ */
+message TokenTransferList {
+    /**
+     * The ID of the token
+     */
+    TokenID token = 1;
+
+    /**
+     * Applicable to tokens of type FUNGIBLE_COMMON. Multiple list of AccountAmounts, each of which
+     * has an account and amount
+     */
+    repeated AccountAmount transfers = 2;
+
+    /**
+     * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. Multiple list of NftTransfers, each of
+     * which has a sender and receiver account, including the serial number of the NFT
+     */
+    repeated NftTransfer nftTransfers = 3;
+
+    /**
+     * If present, the number of decimals this fungible token type is expected to have. The transfer
+     * will fail with UNEXPECTED_TOKEN_DECIMALS if the actual decimals differ.
+     */
+    google.protobuf.UInt32Value expected_decimals = 4;
+}
+
+/**
+ * A rational number, used to set the amount of a value transfer to collect as a custom fee
+ */
+message Fraction {
+    /**
+     * The rational's numerator
+     */
+    int64 numerator = 1;
+
+    /**
+     * The rational's denominator; a zero value will result in FRACTION_DIVIDES_BY_ZERO
+     */
+    int64 denominator = 2;
+}
+
+/**
+ * Unique identifier for a topic (used by the consensus service)
+ */
+message TopicID {
+    /**
+     * The shard number (nonnegative)
+     */
+    int64 shardNum = 1;
+
+    /**
+     * The realm number (nonnegative)
+     */
+    int64 realmNum = 2;
+
+    /**
+     * Unique topic identifier within a realm (nonnegative).
+     */
+    int64 topicNum = 3;
+}
+
+/**
+ * Unique identifier for a token
+ */
+message TokenID {
+    /**
+     * A nonnegative shard number
+     */
+    int64 shardNum = 1;
+
+    /**
+     * A nonnegative realm number
+     */
+    int64 realmNum = 2;
+
+    /**
+     * A nonnegative token number
+     */
+    int64 tokenNum = 3;
+}
+
+/**
+ * Unique identifier for a Schedule
+ */
+message ScheduleID {
+    /**
+     * A nonnegative shard number
+     */
+    int64 shardNum = 1;
+
+    /**
+     * A nonnegative realm number
+     */
+    int64 realmNum = 2;
+
+    /**
+     * A nonnegative schedule number
+     */
+    int64 scheduleNum = 3;
+}
+
+/**
+ * Possible Token Types (IWA Compatibility).
+ * Apart from fungible and non-fungible, Tokens can have either a common or unique representation.
+ * This distinction might seem subtle, but it is important when considering how tokens can be traced
+ * and if they can have isolated and unique properties.
+ */
+enum TokenType {
+    /**
+     * Interchangeable value with one another, where any quantity of them has the same value as
+     * another equal quantity if they are in the same class.  Share a single set of properties, not
+     * distinct from one another. Simply represented as a balance or quantity to a given Hedera
+     * account.
+     */
+    FUNGIBLE_COMMON = 0;
+
+    /**
+     * Unique, not interchangeable with other tokens of the same type as they typically have
+     * different values.  Individually traced and can carry unique properties (e.g. serial number).
+     */
+    NON_FUNGIBLE_UNIQUE = 1;
+}
+
+/**
+ * Allows a set of resource prices to be scoped to a certain type of a HAPI operation.
+ *
+ * For example, the resource prices for a TokenMint operation are different between minting fungible
+ * and non-fungible tokens. This enum allows us to "mark" a set of prices as applying to one or the
+ * other.
+ *
+ * Similarly, the resource prices for a basic TokenCreate without a custom fee schedule yield a
+ * total price of $1. The resource prices for a TokenCreate with a custom fee schedule are different
+ * and yield a total base price of $2.
+ */
+enum SubType {
+    /**
+     * The resource prices have no special scope
+     */
+    DEFAULT = 0;
+
+    /**
+     * The resource prices are scoped to an operation on a fungible common token
+     */
+    TOKEN_FUNGIBLE_COMMON = 1;
+
+    /**
+     * The resource prices are scoped to an operation on a non-fungible unique token
+     */
+    TOKEN_NON_FUNGIBLE_UNIQUE = 2;
+
+    /**
+     * The resource prices are scoped to an operation on a fungible common
+     * token with a custom fee schedule
+     */
+    TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES = 3;
+
+    /**
+     * The resource prices are scoped to an operation on a non-fungible unique
+     * token with a custom fee schedule
+     */
+    TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES = 4;
+
+    /**
+     * The resource prices are scoped to a ScheduleCreate containing a ContractCall.
+     */
+    SCHEDULE_CREATE_CONTRACT_CALL = 5;
+}
+
+/**
+ * Possible Token Supply Types (IWA Compatibility).
+ * Indicates how many tokens can have during its lifetime.
+ */
+enum TokenSupplyType {
+    /**
+     * Indicates that tokens of that type have an upper bound of Long.MAX_VALUE.
+     */
+    INFINITE = 0;
+
+    /**
+     * Indicates that tokens of that type have an upper bound of maxSupply,
+     * provided on token creation.
+     */
+    FINITE = 1;
+}
+
+/**
+ * Types of validation strategies for token keys.
+ */
+enum TokenKeyValidation {
+    /**
+     * Currently the default behaviour. It will perform all token key validations.
+     */
+    FULL_VALIDATION = 0;
+
+    /**
+     * Perform no validations at all for all passed token keys.
+     */
+    NO_VALIDATION = 1;
+}
+
+/**
+ * Possible Freeze statuses returned on TokenGetInfoQuery or CryptoGetInfoResponse in
+ * TokenRelationship
+ */
+enum TokenFreezeStatus {
+    /**
+     * UNDOCUMENTED
+     */
+    FreezeNotApplicable = 0;
+
+    /**
+     * UNDOCUMENTED
+     */
+    Frozen = 1;
+
+    /**
+     * UNDOCUMENTED
+     */
+    Unfrozen = 2;
+}
+
+/**
+ * Possible KYC statuses returned on TokenGetInfoQuery or CryptoGetInfoResponse in TokenRelationship
+ */
+enum TokenKycStatus {
+    /**
+     * UNDOCUMENTED
+     */
+    KycNotApplicable = 0;
+
+    /**
+     * UNDOCUMENTED
+     */
+    Granted = 1;
+
+    /**
+     * UNDOCUMENTED
+     */
+    Revoked = 2;
+}
+
+/**
+ * Possible Pause statuses returned on TokenGetInfoQuery
+ */
+enum TokenPauseStatus {
+    /**
+     * Indicates that a Token has no pauseKey
+     */
+    PauseNotApplicable = 0;
+
+    /**
+     * Indicates that a Token is Paused
+     */
+    Paused = 1;
+
+    /**
+     * Indicates that a Token is Unpaused.
+     */
+    Unpaused = 2;
+}
+
+/**
+ * A Key can be a public key from either the Ed25519 or ECDSA(secp256k1) signature schemes, where
+ * in the ECDSA(secp256k1) case we require the 33-byte compressed form of the public key. We call
+ * these public keys <b>primitive keys</b>.
+ *
+ * If an account has primitive key associated to it, then the corresponding private key must sign
+ * any transaction to transfer cryptocurrency out of it.
+ *
+ * A Key can also be the ID of a smart contract instance, which is then authorized to perform any
+ * precompiled contract action that requires this key to sign.
+ *
+ * Note that when a Key is a smart contract ID, it <i>doesn't</i> mean the contract with that ID
+ * will actually create a cryptographic signature. It only means that when the contract calls a
+ * precompiled contract, the resulting "child transaction" will be authorized to perform any action
+ * controlled by the Key.
+ *
+ * A Key can be a "threshold key", which means a list of M keys, any N of which must sign in order
+ * for the threshold signature to be considered valid. The keys within a threshold signature may
+ * themselves be threshold signatures, to allow complex signature requirements.
+ *
+ * A Key can be a "key list" where all keys in the list must sign unless specified otherwise in the
+ * documentation for a specific transaction type (e.g.  FileDeleteTransactionBody).  Their use is
+ * dependent on context. For example, a Hedera file is created with a list of keys, where all of
+ * them must sign a transaction to create or modify the file, but only one of them is needed to sign
+ * a transaction to delete the file. So it's a single list that sometimes acts as a 1-of-M threshold
+ * key, and sometimes acts as an M-of-M threshold key.  A key list is always an M-of-M, unless
+ * specified otherwise in documentation. A key list can have nested key lists or threshold keys.
+ * Nested key lists are always M-of-M. A key list can have repeated primitive public keys, but all
+ * repeated keys are only required to sign once.
+ *
+ * A Key can contain a ThresholdKey or KeyList, which in turn contain a Key, so this mutual
+ * recursion would allow nesting arbitrarily deep. A ThresholdKey which contains a list of primitive
+ * keys has 3 levels: ThresholdKey -> KeyList -> Key. A KeyList which contains several primitive
+ * keys has 2 levels: KeyList -> Key. A Key with 2 levels of nested ThresholdKeys has 7 levels:
+ * Key -> ThresholdKey -> KeyList -> Key -> ThresholdKey -> KeyList -> Key.
+ *
+ * Each Key should not have more than 46 levels, which implies 15 levels of nested ThresholdKeys.
+ */
+message Key {
+    oneof key {
+        /**
+         * smart contract instance that is authorized as if it had signed with a key
+         */
+        ContractID contractID = 1;
+
+        /**
+         * Ed25519 public key bytes
+         */
+        bytes ed25519 = 2;
+
+        /**
+         * (NOT SUPPORTED) RSA-3072 public key bytes
+         */
+        bytes RSA_3072 = 3;
+
+        /**
+         * (NOT SUPPORTED) ECDSA with the p-384 curve public key bytes
+         */
+        bytes ECDSA_384 = 4;
+
+        /**
+         * a threshold N followed by a list of M keys, any N of which are required to form a valid
+         * signature
+         */
+        ThresholdKey thresholdKey = 5;
+
+        /**
+         * A list of Keys of the Key type.
+         */
+        KeyList keyList = 6;
+
+        /**
+         * Compressed ECDSA(secp256k1) public key bytes
+         */
+        bytes ECDSA_secp256k1 = 7;
+
+        /**
+         * A smart contract that, if the recipient of the active message frame, should be treated
+         * as having signed. (Note this does not mean the <i>code being executed in the frame</i>
+         * will belong to the given contract, since it could be running another contract's code via
+         * <tt>delegatecall</tt>. So setting this key is a more permissive version of setting the
+         * contractID key, which also requires the code in the active message frame belong to the
+         * the contract with the given id.)
+         */
+        ContractID delegatable_contract_id = 8;
+    }
+}
+
+/**
+ * A set of public keys that are used together to form a threshold signature.  If the threshold is N
+ * and there are M keys, then this is an N of M threshold signature. If an account is associated
+ * with ThresholdKeys, then a transaction to move cryptocurrency out of it must be signed by a list
+ * of M signatures, where at most M-N of them are blank, and the other at least N of them are valid
+ * signatures corresponding to at least N of the public keys listed here.
+ */
+message ThresholdKey {
+    /**
+     * A valid signature set must have at least this many signatures
+     */
+    uint32 threshold = 1;
+
+    /**
+     * List of all the keys that can sign
+     */
+    KeyList keys = 2;
+}
+
+/**
+ * A list of keys that requires all keys (M-of-M) to sign unless otherwise specified in
+ * documentation. A KeyList may contain repeated keys, but all repeated keys are only required to
+ * sign once.
+ */
+message KeyList {
+    /**
+     * list of keys
+     */
+    repeated Key keys = 1;
+}
+
+/**
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
+ * here only for historical reasons.
+ *
+ * Please use the SignaturePair and SignatureMap messages.
+ */
+message Signature {
+    option deprecated = true;
+
+    oneof signature {
+        /**
+         * smart contract virtual signature (always length zero)
+         */
+        bytes contract = 1;
+
+        /**
+         * ed25519 signature bytes
+         */
+        bytes ed25519 = 2;
+
+        /**
+         * RSA-3072 signature bytes
+         */
+        bytes RSA_3072 = 3;
+
+        /**
+         * ECDSA p-384 signature bytes
+         */
+        bytes ECDSA_384 = 4;
+
+        /**
+         * A list of signatures for a single N-of-M threshold Key. This must be a list of exactly M
+         * signatures, at least N of which are non-null.
+         */
+        ThresholdSignature thresholdSignature = 5;
+
+        /**
+         * A list of M signatures, each corresponding to a Key in a KeyList of the same length.
+         */
+        SignatureList signatureList = 6;
+    }
+}
+
+/**
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
+ * here only for historical reasons.
+ *
+ * Please use the SignaturePair and SignatureMap messages.
+ */
+message ThresholdSignature {
+    option deprecated = true;
+
+    /**
+     * for an N-of-M threshold key, this is a list of M signatures, at least N of which must be
+     * non-null
+     */
+    SignatureList sigs = 2;
+}
+
+/**
+ * This message is <b>DEPRECATED</b> and <b>UNUSABLE</b> with network nodes. It is retained
+ * here only for historical reasons.
+ *
+ * Please use the SignaturePair and SignatureMap messages.
+ */
+message SignatureList {
+    option deprecated = true;
+
+    /**
+     * each signature corresponds to a Key in the KeyList
+     */
+    repeated Signature sigs = 2;
+}
+
+/**
+ * The client may use any number of bytes from zero to the whole length of the public key for
+ * pubKeyPrefix. If zero bytes are used, then it must be that only one primitive key is required
+ * to sign the linked transaction; it will surely resolve to <tt>INVALID_SIGNATURE</tt> otherwise.
+ *
+ * <b>IMPORTANT:</b> In the special case that a signature is being provided for a key used to
+ * authorize a precompiled contract, the <tt>pubKeyPrefix</tt> must contain the <b>entire public
+ * key</b>! That is, if the key is a Ed25519 key, the <tt>pubKeyPrefix</tt> should be 32 bytes
+ * long. If the key is a ECDSA(secp256k1) key, the <tt>pubKeyPrefix</tt> should be 33 bytes long,
+ * since we require the compressed form of the public key.
+ *
+ * Only Ed25519 and ECDSA(secp256k1) keys and hence signatures are currently supported.
+ */
+message SignaturePair {
+    /**
+     * First few bytes of the public key
+     */
+    bytes pubKeyPrefix = 1;
+
+    oneof signature {
+        /**
+         * smart contract virtual signature (always length zero)
+         */
+        bytes contract = 2;
+
+        /**
+         * ed25519 signature
+         */
+        bytes ed25519 = 3;
+
+        /**
+         * RSA-3072 signature
+         */
+        bytes RSA_3072 = 4;
+
+        /**
+         * ECDSA p-384 signature
+         */
+        bytes ECDSA_384 = 5;
+
+        /**
+         * ECDSA(secp256k1) signature
+         */
+        bytes ECDSA_secp256k1 = 6;
+    }
+}
+
+/**
+ * A set of signatures corresponding to every unique public key used to sign a given transaction. If
+ * one public key matches more than one prefixes on the signature map, the transaction containing
+ * the map will fail immediately with the response code KEY_PREFIX_MISMATCH.
+ */
+message SignatureMap {
+    /**
+     * Each signature pair corresponds to a unique Key required to sign the transaction.
+     */
+    repeated SignaturePair sigPair = 1;
+}
+
+/**
+ * The transactions and queries supported by Hedera Hashgraph.
+ */
+enum HederaFunctionality {
+    /**
+     * UNSPECIFIED - Need to keep first value as unspecified because first element is ignored and
+     * not parsed (0 is ignored by parser)
+     */
+    NONE = 0;
+
+    /**
+     * crypto transfer
+     */
+    CryptoTransfer = 1;
+
+    /**
+     * crypto update account
+     */
+    CryptoUpdate = 2;
+
+    /**
+     * crypto delete account
+     */
+    CryptoDelete = 3;
+
+    /**
+     * Add a livehash to a crypto account
+     */
+    CryptoAddLiveHash = 4;
+
+    /**
+     * Delete a livehash from a crypto account
+     */
+    CryptoDeleteLiveHash = 5;
+
+    /**
+     * Smart Contract Call
+     */
+    ContractCall = 6;
+
+    /**
+     * Smart Contract Create Contract
+     */
+    ContractCreate = 7;
+
+    /**
+     * Smart Contract update contract
+     */
+    ContractUpdate = 8;
+
+    /**
+     * File Operation create file
+     */
+    FileCreate = 9;
+
+    /**
+     * File Operation append file
+     */
+    FileAppend = 10;
+
+    /**
+     * File Operation update file
+     */
+    FileUpdate = 11;
+
+    /**
+     * File Operation delete file
+     */
+    FileDelete = 12;
+
+    /**
+     * crypto get account balance
+     */
+    CryptoGetAccountBalance = 13;
+
+    /**
+     * crypto get account record
+     */
+    CryptoGetAccountRecords = 14;
+
+    /**
+     * Crypto get info
+     */
+    CryptoGetInfo = 15;
+
+    /**
+     * Smart Contract Call
+     */
+    ContractCallLocal = 16;
+
+    /**
+     * Smart Contract get info
+     */
+    ContractGetInfo = 17;
+
+    /**
+     * Smart Contract, get the runtime code
+     */
+    ContractGetBytecode = 18;
+
+    /**
+     * Smart Contract, get by solidity ID
+     */
+    GetBySolidityID = 19;
+
+    /**
+     * Smart Contract, get by key
+     */
+    GetByKey = 20;
+
+    /**
+     * Get a live hash from a crypto account
+     */
+    CryptoGetLiveHash = 21;
+
+    /**
+     * Crypto, get the stakers for the node
+     */
+    CryptoGetStakers = 22;
+
+    /**
+     * File Operations get file contents
+     */
+    FileGetContents = 23;
+
+    /**
+     * File Operations get the info of the file
+     */
+    FileGetInfo = 24;
+
+    /**
+     * Crypto get the transaction records
+     */
+    TransactionGetRecord = 25;
+
+    /**
+     * Contract get the transaction records
+     */
+    ContractGetRecords = 26;
+
+    /**
+     * crypto create account
+     */
+    CryptoCreate = 27;
+
+    /**
+     * system delete file
+     */
+    SystemDelete = 28;
+
+    /**
+     * system undelete file
+     */
+    SystemUndelete = 29;
+
+    /**
+     * delete contract
+     */
+    ContractDelete = 30;
+
+    /**
+     * freeze
+     */
+    Freeze = 31;
+
+    /**
+     * Create Tx Record
+     */
+    CreateTransactionRecord = 32;
+
+    /**
+     * Crypto Auto Renew
+     */
+    CryptoAccountAutoRenew = 33;
+
+    /**
+     * Contract Auto Renew
+     */
+    ContractAutoRenew = 34;
+
+    /**
+     * Get Version
+     */
+    GetVersionInfo = 35;
+
+    /**
+     * Transaction Get Receipt
+     */
+    TransactionGetReceipt = 36;
+
+    /**
+     * Create Topic
+     */
+    ConsensusCreateTopic = 50;
+
+    /**
+     * Update Topic
+     */
+    ConsensusUpdateTopic = 51;
+
+    /**
+     * Delete Topic
+     */
+    ConsensusDeleteTopic = 52;
+
+    /**
+     * Get Topic information
+     */
+    ConsensusGetTopicInfo = 53;
+
+    /**
+     * Submit message to topic
+     */
+    ConsensusSubmitMessage = 54;
+
+    UncheckedSubmit = 55;
+    /**
+     * Create Token
+     */
+    TokenCreate = 56;
+
+    /**
+     * Get Token information
+     */
+    TokenGetInfo = 58;
+
+    /**
+     * Freeze Account
+     */
+    TokenFreezeAccount = 59;
+
+    /**
+     * Unfreeze Account
+     */
+    TokenUnfreezeAccount = 60;
+
+    /**
+     * Grant KYC to Account
+     */
+    TokenGrantKycToAccount = 61;
+
+    /**
+     * Revoke KYC from Account
+     */
+    TokenRevokeKycFromAccount = 62;
+
+    /**
+     * Delete Token
+     */
+    TokenDelete = 63;
+
+    /**
+     * Update Token
+     */
+    TokenUpdate = 64;
+
+    /**
+     * Mint tokens to treasury
+     */
+    TokenMint = 65;
+
+    /**
+     * Burn tokens from treasury
+     */
+    TokenBurn = 66;
+
+    /**
+     * Wipe token amount from Account holder
+     */
+    TokenAccountWipe = 67;
+
+    /**
+     * Associate tokens to an account
+     */
+    TokenAssociateToAccount = 68;
+
+    /**
+     * Dissociate tokens from an account
+     */
+    TokenDissociateFromAccount = 69;
+
+    /**
+     * Create Scheduled Transaction
+     */
+    ScheduleCreate = 70;
+
+    /**
+     * Delete Scheduled Transaction
+     */
+    ScheduleDelete = 71;
+
+    /**
+     * Sign Scheduled Transaction
+     */
+    ScheduleSign = 72;
+
+    /**
+     * Get Scheduled Transaction Information
+     */
+    ScheduleGetInfo = 73;
+
+    /**
+     * Get Token Account Nft Information
+     */
+    TokenGetAccountNftInfos = 74;
+
+    /**
+     * Get Token Nft Information
+     */
+    TokenGetNftInfo = 75;
+
+    /**
+     * Get Token Nft List Information
+     */
+    TokenGetNftInfos = 76;
+
+    /**
+     * Update a token's custom fee schedule, if permissible
+     */
+    TokenFeeScheduleUpdate = 77;
+
+    /**
+     * Get execution time(s) by TransactionID, if available
+     */
+    NetworkGetExecutionTime = 78;
+
+    /**
+     * Pause the Token
+     */
+    TokenPause = 79;
+
+    /**
+     * Unpause the Token
+     */
+    TokenUnpause = 80;
+
+    /**
+     * Approve allowance for a spender relative to the owner account
+     */
+    CryptoApproveAllowance = 81;
+
+    /**
+     * Deletes granted allowances on owner account
+     */
+    CryptoDeleteAllowance = 82;
+
+    /**
+     * Gets all the information about an account, including balance and allowances. This does not get the list of
+     * account records.
+     */
+    GetAccountDetails = 83;
+
+    /**
+     * Ethereum Transaction
+     */
+    EthereumTransaction = 84;
+
+    /**
+     * Updates the staking info at the end of staking period to indicate new staking period has started.
+     */
+    NodeStakeUpdate = 85;
+
+    /**
+     * Generates a pseudorandom number.
+     */
+    UtilPrng = 86;
+
+    /**
+     * Get a record for a transaction.
+     */
+    TransactionGetFastRecord = 87;
+
+    /**
+     * Update the metadata of one or more NFT's of a specific token type.
+     */
+    TokenUpdateNfts = 88;
+
+    /**
+     * Create a node
+     */
+    NodeCreate = 89;
+
+    /**
+     * Update a node
+     */
+    NodeUpdate = 90;
+
+    /**
+     * Delete a node
+     */
+    NodeDelete = 91;
+
+    /**
+     * Transfer one or more token balances held by the requesting account to the treasury for each token type.
+     */
+    TokenReject = 92;
+
+    /**
+     * Airdrop one or more tokens to one or more accounts.
+     */
+    TokenAirdrop = 93;
+
+    /**
+    * Remove one or more pending airdrops from state on behalf of the sender(s) for each airdrop.
+    */
+    TokenCancelAirdrop = 94;
+
+    /**
+      * Claim one or more pending airdrops
+     */
+    TokenClaimAirdrop = 95;
+}
+
+/**
+ * A set of prices the nodes use in determining transaction and query fees, and constants involved
+ * in fee calculations.  Nodes multiply the amount of resources consumed by a transaction or query
+ * by the corresponding price to calculate the appropriate fee. Units are one-thousandth of a
+ * tinyCent.
+ */
+message FeeComponents {
+    /**
+     * A minimum, the calculated fee must be greater than this value
+     */
+    int64 min = 1;
+
+    /**
+     * A maximum, the calculated fee must be less than this value
+     */
+    int64 max = 2;
+
+    /**
+     * A constant contribution to the fee
+     */
+    int64 constant = 3;
+
+    /**
+     * The price of bandwidth consumed by a transaction, measured in bytes
+     */
+    int64 bpt = 4;
+
+    /**
+     * The price per signature verification for a transaction
+     */
+    int64 vpt = 5;
+
+    /**
+     * The price of RAM consumed by a transaction, measured in byte-hours
+     */
+    int64 rbh = 6;
+
+    /**
+     * The price of storage consumed by a transaction, measured in byte-hours
+     */
+    int64 sbh = 7;
+
+    /**
+     * The price of computation for a smart contract transaction, measured in gas
+     */
+    int64 gas = 8;
+
+    /**
+     * The price per hbar transferred for a transfer
+     */
+    int64 tv = 9;
+
+    /**
+     * The price of bandwidth for data retrieved from memory for a response, measured in bytes
+     */
+    int64 bpr = 10;
+
+    /**
+     * The price of bandwidth for data retrieved from disk for a response, measured in bytes
+     */
+    int64 sbpr = 11;
+}
+
+/**
+ * The fees for a specific transaction or query based on the fee data.
+ */
+message TransactionFeeSchedule {
+    /**
+     * A particular transaction or query
+     */
+    HederaFunctionality hederaFunctionality = 1;
+
+    /**
+     * Resource price coefficients
+     */
+    FeeData feeData = 2 [deprecated = true];
+
+    /**
+     * Resource price coefficients. Supports subtype price definition.
+     */
+    repeated FeeData fees = 3;
+}
+
+/**
+ * The total fee charged for a transaction. It is composed of three components - a node fee that
+ * compensates the specific node that submitted the transaction, a network fee that compensates the
+ * network for assigning the transaction a consensus timestamp, and a service fee that compensates
+ * the network for the ongoing maintenance of the consequences of the transaction.
+ */
+message FeeData {
+    /**
+     * Fee paid to the submitting node
+     */
+    FeeComponents nodedata = 1;
+
+    /**
+     * Fee paid to the network for processing a transaction into consensus
+     */
+    FeeComponents networkdata = 2;
+
+    /**
+     * Fee paid to the network for providing the service associated with the
+     * transaction; for instance, storing a file
+     */
+    FeeComponents servicedata = 3;
+
+    /**
+     * SubType distinguishing between different types of FeeData, correlating
+     * to the same HederaFunctionality
+     */
+    SubType subType = 4;
+}
+
+/**
+ * A list of resource prices fee for different transactions and queries and the time period at which
+ * this fee schedule will expire. Nodes use the prices to determine the fees for all transactions
+ * based on how much of those resources each transaction uses.
+ */
+message FeeSchedule {
+    /**
+     * List of price coefficients for network resources
+     */
+    repeated TransactionFeeSchedule transactionFeeSchedule = 1;
+
+    /**
+     * FeeSchedule expiry time
+     */
+    TimestampSeconds expiryTime = 2;
+}
+
+/**
+ * This contains two Fee Schedules with expiry timestamp.
+ */
+message CurrentAndNextFeeSchedule {
+    /**
+     * Contains current Fee Schedule
+     */
+    FeeSchedule currentFeeSchedule = 1;
+
+    /**
+     * Contains next Fee Schedule
+     */
+    FeeSchedule nextFeeSchedule = 2;
+}
+
+/**
+ * Contains the IP address and the port representing a service endpoint of
+ * a Node in a network. Used to reach the Hedera API and submit transactions
+ * to the network.
+ *
+ * When the `domain_name` field is set, the `ipAddressV4` field
+ * MUST NOT be set.<br/>
+ * When the `ipAddressV4` field is set, the `domain_name` field
+ * MUST NOT be set.
+ */
+message ServiceEndpoint {
+    /**
+     * The 4-byte IPv4 address of the endpoint encoded in left to right order
+     * (e.g. 127.0.0.1 has bytes [127, 0, 0, 1])
+     */
+    bytes ipAddressV4 = 1;
+
+    /**
+     * The port of the service endpoint
+     */
+    int32 port = 2;
+
+    /**
+     * A node domain name.<br/>
+     * This MUST be the fully qualified domain(DNS) name of the node.<br/>
+     * This value MUST NOT be more than 253 characters.
+     * domain_name and ipAddressV4 are mutually exclusive.
+     * When the `domain_name` field is set, the `ipAddressV4` field MUST NOT be set.<br/>
+     * When the `ipAddressV4` field is set, the `domain_name` field MUST NOT be set.
+     */
+    string domain_name = 3;
+}
+
+/**
+ * The data about a node, including its service endpoints and the Hedera account to be paid for
+ * services provided by the node (that is, queries answered and transactions submitted.)
+ *
+ * If the `serviceEndpoint` list is not set, or empty, then the endpoint given by the
+ * (deprecated) `ipAddress` and `portno` fields should be used.
+ *
+ * All fields are populated in the 0.0.102 address book file while only fields that start with # are
+ * populated in the 0.0.101 address book file.
+ */
+message NodeAddress {
+    /**
+     * The IP address of the Node with separator & octets encoded in UTF-8.  Usage is deprecated,
+     * ServiceEndpoint is preferred to retrieve a node's list of IP addresses and ports
+     */
+    bytes ipAddress = 1 [deprecated = true];
+
+    /**
+     * The port number of the grpc server for the node.  Usage is deprecated, ServiceEndpoint is
+     * preferred to retrieve a node's list of IP addresses and ports
+     */
+    int32 portno = 2 [deprecated = true];
+
+    /**
+     * Usage is deprecated, nodeAccountId is preferred to retrieve a node's account ID
+     */
+    bytes memo = 3 [deprecated = true];
+
+    /**
+     * The node's X509 RSA public key used to sign stream files (e.g., record stream
+     * files). Precisely, this field is a string of hexadecimal characters which,
+     * translated to binary, are the public key's DER encoding.
+     */
+    string RSA_PubKey = 4;
+
+    /**
+     * # A non-sequential identifier for the node
+     */
+    int64 nodeId = 5;
+
+    /**
+     * # The account to be paid for queries and transactions sent to this node
+     */
+    AccountID nodeAccountId = 6;
+
+    /**
+     * # Hash of the node's TLS certificate. Precisely, this field is a string of
+     * hexadecimal characters which, translated to binary, are the SHA-384 hash of
+     * the UTF-8 NFKD encoding of the node's TLS cert in PEM format. Its value can be
+     * used to verify the node's certificate it presents during TLS negotiations.
+     */
+    bytes nodeCertHash = 7;
+
+    /**
+     * # A node's service IP addresses and ports
+     */
+    repeated ServiceEndpoint serviceEndpoint = 8;
+
+    /**
+     * A description of the node, with UTF-8 encoding up to 100 bytes
+     */
+    string description = 9;
+
+    /**
+     * [Deprecated] The amount of tinybars staked to the node
+     */
+    int64 stake = 10 [deprecated = true];
+}
+
+/**
+ * A list of nodes and their metadata that contains all details of the nodes for the network.  Used
+ * to parse the contents of system files <tt>0.0.101</tt> and <tt>0.0.102</tt>.
+ */
+message NodeAddressBook {
+    /**
+     * Metadata of all nodes in the network
+     */
+    repeated NodeAddress nodeAddress = 1;
+}
+
+/**
+ * Hedera follows semantic versioning (https://semver.org/) for both the HAPI protobufs and the
+ * Services software.  This type allows the <tt>getVersionInfo</tt> query in the
+ * <tt>NetworkService</tt> to return the deployed versions of both protobufs and software on the
+ * node answering the query.
+ */
+message SemanticVersion {
+    /**
+     * Increases with incompatible API changes
+     */
+    int32 major = 1;
+
+    /**
+     * Increases with backwards-compatible new functionality
+     */
+    int32 minor = 2;
+
+    /**
+     * Increases with backwards-compatible bug fixes
+     */
+    int32 patch = 3;
+
+    /**
+     * A pre-release version MAY be denoted by appending a hyphen and a series of dot separated
+     * identifiers (https://semver.org/#spec-item-9); so given a semver 0.14.0-alpha.1+21AF26D3,
+     * this field would contain 'alpha.1'
+     */
+    string pre = 4;
+
+    /**
+     * Build metadata MAY be denoted by appending a plus sign and a series of dot separated
+     * identifiers immediately following the patch or pre-release version
+     * (https://semver.org/#spec-item-10); so given a semver 0.14.0-alpha.1+21AF26D3, this field
+     * would contain '21AF26D3'
+     */
+    string build = 5;
+}
+
+/**
+ * UNDOCUMENTED
+ */
+message Setting {
+    /**
+     * name of the property
+     */
+    string name = 1;
+
+    /**
+     * value of the property
+     */
+    string value = 2;
+
+    /**
+     * any data associated with property
+     */
+    bytes data = 3;
+}
+
+/**
+ * UNDOCUMENTED
+ */
+message ServicesConfigurationList {
+    /**
+     * list of name value pairs of the application properties
+     */
+    repeated Setting nameValue = 1;
+}
+
+/**
+ * Token's information related to the given Account
+ */
+message TokenRelationship {
+    /**
+     * The ID of the token
+     */
+    TokenID tokenId = 1;
+
+    /**
+     * The Symbol of the token
+     */
+    string symbol = 2;
+
+    /**
+     * For token of type FUNGIBLE_COMMON - the balance that the Account holds in the smallest
+     * denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of NFTs held by the account
+     */
+    uint64 balance = 3;
+
+    /**
+     * The KYC status of the account (KycNotApplicable, Granted or Revoked). If the token does not
+     * have KYC key, KycNotApplicable is returned
+     */
+    TokenKycStatus kycStatus = 4;
+
+    /**
+     * The Freeze status of the account (FreezeNotApplicable, Frozen or Unfrozen). If the token does
+     * not have Freeze key, FreezeNotApplicable is returned
+     */
+    TokenFreezeStatus freezeStatus = 5;
+
+    /**
+     * Tokens divide into <tt>10<sup>decimals</sup></tt> pieces
+     */
+    uint32 decimals = 6;
+
+    /**
+     * Specifies if the relationship is created implicitly. False : explicitly associated, True :
+     * implicitly associated.
+     */
+    bool automatic_association = 7;
+}
+
+/**
+ * A number of <i>transferable units</i> of a certain token.
+ *
+ * The transferable unit of a token is its smallest denomination, as given by the token's
+ * <tt>decimals</tt> property---each minted token contains <tt>10<sup>decimals</sup></tt>
+ * transferable units. For example, we could think of the cent as the transferable unit of the US
+ * dollar (<tt>decimals=2</tt>); and the tinybar as the transferable unit of hbar
+ * (<tt>decimals=8</tt>).
+ *
+ * Transferable units are not directly comparable across different tokens.
+ */
+message TokenBalance {
+    /**
+     * A unique token id
+     */
+    TokenID tokenId = 1;
+
+    /**
+     * Number of transferable units of the identified token. For token of type FUNGIBLE_COMMON -
+     * balance in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of
+     * NFTs held by the account
+     */
+    uint64 balance = 2;
+
+    /**
+     * Tokens divide into <tt>10<sup>decimals</sup></tt> pieces
+     */
+    uint32 decimals = 3;
+}
+
+/**
+ * A sequence of token balances
+ */
+message TokenBalances {
+    repeated TokenBalance tokenBalances = 1;
+}
+
+/* A token - account association */
+message TokenAssociation {
+    TokenID token_id = 1;  // The token involved in the association
+    AccountID account_id = 2; // The account involved in the association
+}
+
+/**
+ * Staking metadata for an account or a contract returned in CryptoGetInfo or ContractGetInfo queries
+ */
+message StakingInfo {
+
+    /**
+     * If true, this account or contract declined to receive a staking reward.
+     */
+    bool decline_reward = 1;
+
+    /**
+     * The staking period during which either the staking settings for this account or contract changed (such as starting
+     * staking or changing staked_node_id) or the most recent reward was earned, whichever is later. If this account or contract
+     * is not currently staked to a node, then this field is not set.
+     */
+    Timestamp stake_period_start = 2;
+
+    /**
+     * The amount in tinybars that will be received in the next reward situation.
+     */
+    int64 pending_reward = 3;
+
+    /**
+     * The total of balance of all accounts staked to this account or contract.
+     */
+    int64 staked_to_me = 4;
+
+    /**
+     * ID of the account or node to which this account or contract is staking.
+     */
+    oneof staked_id {
+
+        /**
+         * The account to which this account or contract is staking.
+         */
+        AccountID staked_account_id = 5;
+
+        /**
+         * The ID of the node this account or contract is staked to.
+         */
+        int64 staked_node_id = 6;
+    }
+}
+
+/**
+ * A unique, composite, identifier for a pending airdrop.
+ *
+ * Each pending airdrop SHALL be uniquely identified by a PendingAirdropId.
+ * A PendingAirdropId SHALL be recorded when created and MUST be provided in any transaction
+ * that would modify that pending airdrop (such as a `claimAirdrop` or `cancelAirdrop`).
+ */
+message PendingAirdropId {
+    /**
+     * A sending account.<br/>
+     * This is the account that initiated, and SHALL fund, this pending airdrop.<br/>
+     * This field is REQUIRED.
+     */
+    AccountID sender_id = 1;
+
+    /**
+     * A receiving account.<br/>
+     * This is the ID of the account that SHALL receive the airdrop.<br/>
+     * This field is REQUIRED.
+     */
+    AccountID receiver_id = 2;
+
+    oneof token_reference {
+        /**
+         * A token ID.<br/>
+         * This is the type of token for a fungible/common token airdrop.<br/>
+         * This field is REQUIRED for a fungible/common token and MUST NOT be used for a
+         * non-fungible/unique token.
+         */
+        TokenID fungible_token_type = 3;
+
+        /**
+         * The id of a single NFT, consisting of a Token ID and serial number.<br/>
+         * This is the type of token for a non-fungible/unique token airdrop.<br/>
+         * This field is REQUIRED for a non-fungible/unique token and MUST NOT be used for a
+         * fungible/common token.
+         */
+        NftID non_fungible_token = 4;
+    }
+}
+
+/**
+ * A single pending airdrop value.
+ *
+ * This message SHALL record the airdrop amount for a fungible/common token.<br/>
+ * This message SHOULD be null for a non-fungible/unique token.<br/>
+ * If a non-null `PendingAirdropValue` is set for a non-fungible/unique token, the amount
+ * field MUST be `0`.
+ *
+ * It is RECOMMENDED that implementations store pending airdrop information as a key-value map
+ * from `PendingAirdropId` to `PendingAirdropValue`, with a `null` value used for non-fungible
+ * pending airdrops.
+ */
+message PendingAirdropValue {
+    /**
+     * An amount to transfer for fungible/common tokens.<br/>
+     * This is expressed in the smallest available units for that token
+     * (i.e. 10<sup>-`decimals`</sup> whole tokens).<br/>
+     * This amount SHALL be transferred from the sender to the receiver, if claimed.<br/>
+     * If the token is a fungible/common token, this value MUST be strictly greater than `0`.
+     * If the token is a non-fungible/unique token, this message SHOULD NOT be set, and if
+     * set, this field MUST be `0`.
+     */
+    uint64 amount = 1;
+}

--- a/hapi/hedera-protobufs/services/consensus_create_topic.proto
+++ b/hapi/hedera-protobufs/services/consensus_create_topic.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.consensus">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+
+/**
+ * See [ConsensusService.createTopic()](#proto.ConsensusService)
+ */
+message ConsensusCreateTopicTransactionBody {
+    /**
+     * Short publicly visible memo about the topic. No guarantee of uniqueness.
+     */
+    string memo = 1;
+
+    /**
+     * Access control for updateTopic/deleteTopic.
+     * Anyone can increase the topic's expirationTime via ConsensusService.updateTopic(), regardless of the adminKey.
+     * If no adminKey is specified, updateTopic may only be used to extend the topic's expirationTime, and deleteTopic
+     * is disallowed.
+     */
+    Key adminKey = 2;
+
+    /**
+     * Access control for submitMessage.
+     * If unspecified, no access control is performed on ConsensusService.submitMessage (all submissions are allowed).
+     */
+    Key submitKey = 3;
+
+    /**
+     * The initial lifetime of the topic and the amount of time to attempt to extend the topic's lifetime by
+     * automatically at the topic's expirationTime, if the autoRenewAccount is configured (once autoRenew functionality
+     * is supported by HAPI).
+     * Limited to MIN_AUTORENEW_PERIOD and MAX_AUTORENEW_PERIOD value by server-side configuration.
+     * Required.
+     */
+    Duration autoRenewPeriod = 6;
+
+    /**
+     * Optional account to be used at the topic's expirationTime to extend the life of the topic (once autoRenew
+     * functionality is supported by HAPI).
+     * The topic lifetime will be extended up to a maximum of the autoRenewPeriod or however long the topic
+     * can be extended using all funds on the account (whichever is the smaller duration/amount and if any extension
+     * is possible with the account's funds).
+     * If specified, there must be an adminKey and the autoRenewAccount must sign this transaction.
+     */
+    AccountID autoRenewAccount = 7;
+}

--- a/hapi/hedera-protobufs/services/consensus_delete_topic.proto
+++ b/hapi/hedera-protobufs/services/consensus_delete_topic.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.consensus">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * See [ConsensusService.deleteTopic()](#proto.ConsensusService)
+ */
+message ConsensusDeleteTopicTransactionBody {
+    /**
+     * Topic identifier
+     */
+    TopicID topicID = 1;
+}

--- a/hapi/hedera-protobufs/services/consensus_get_topic_info.proto
+++ b/hapi/hedera-protobufs/services/consensus_get_topic_info.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.consensus">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "consensus_topic_info.proto";
+
+/**
+ * See [ConsensusService.getTopicInfo()](#proto.ConsensusService)
+ */
+message ConsensusGetTopicInfoQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of response is requested
+     * (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The Topic for which information is being requested
+     */
+    TopicID topicID = 2;
+}
+
+/**
+ * Retrieve the parameters of and state of a consensus topic.
+ */
+message ConsensusGetTopicInfoResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof, or both, or neither.
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * Topic identifier.
+     */
+    TopicID topicID = 2;
+
+
+    /**
+     * Current state of the topic
+     */
+    ConsensusTopicInfo topicInfo = 5;
+}

--- a/hapi/hedera-protobufs/services/consensus_service.proto
+++ b/hapi/hedera-protobufs/services/consensus_service.proto
@@ -1,0 +1,123 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.consensus">>> This comment is special code for setting PBJ Compiler java package
+
+import "query.proto";
+import "response.proto";
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * The Consensus Service provides the ability for Hedera Hashgraph to provide aBFT consensus as to
+ * the order and validity of messages submitted to a *topic*, as well as a *consensus timestamp* for
+ * those messages.
+ *
+ * Automatic renewal can be configured via an autoRenewAccount.
+ * Any time an autoRenewAccount is added to a topic, that createTopic/updateTopic transaction must
+ * be signed by the autoRenewAccount.
+ *
+ * The autoRenewPeriod on an account must currently be set a value in createTopic between
+ * MIN_AUTORENEW_PERIOD (6999999 seconds) and MAX_AUTORENEW_PERIOD (8000001 seconds). During
+ * creation this sets the initial expirationTime of the topic (see more below).
+ *
+ * If no adminKey is on a topic, there may not be an autoRenewAccount on the topic, deleteTopic is
+ * not allowed, and the only change allowed via an updateTopic is to extend the expirationTime.
+ *
+ * If an adminKey is on a topic, every updateTopic and deleteTopic transaction must be signed by the
+ * adminKey, except for updateTopics which only extend the topic's expirationTime (no adminKey
+ * authorization required).
+ *
+ * If an updateTopic modifies the adminKey of a topic, the transaction signatures on the updateTopic
+ * must fulfill both the pre-update and post-update adminKey signature requirements.
+ *
+ * Mirrornet ConsensusService may be used to subscribe to changes on the topic, including changes to
+ * the topic definition and the consensus ordering and timestamp of submitted messages.
+ *
+ * Until autoRenew functionality is supported by HAPI, the topic will not expire, the
+ * autoRenewAccount will not be charged, and the topic will not automatically be deleted.
+ *
+ * Once autoRenew functionality is supported by HAPI:
+ *
+ * 1. Once the expirationTime is encountered, if an autoRenewAccount is configured on the topic, the
+ * account will be charged automatically at the expirationTime, to extend the expirationTime of the
+ * topic up to the topic's autoRenewPeriod (or as much extension as the account's balance will
+ * supply).
+ *
+ * 2. If the topic expires and is not automatically renewed, the topic will enter the EXPIRED state.
+ * All transactions on the topic will fail with TOPIC_EXPIRED, except an updateTopic() call that
+ * modifies only the expirationTime.  getTopicInfo() will succeed. This state will be available for
+ * a AUTORENEW_GRACE_PERIOD grace period (7 days).
+ *
+ * 3. After the grace period, if the topic's expirationTime is not extended, the topic will be
+ * automatically deleted and no transactions or queries on the topic will succeed after that point.
+ */
+service ConsensusService {
+    /**
+     * Create a topic to be used for consensus.
+     * If an autoRenewAccount is specified, that account must also sign this transaction.
+     * If an adminKey is specified, the adminKey must sign the transaction.
+     * On success, the resulting TransactionReceipt contains the newly created TopicId.
+     * Request is [ConsensusCreateTopicTransactionBody](#proto.ConsensusCreateTopicTransactionBody)
+     */
+    rpc createTopic (Transaction) returns (TransactionResponse);
+
+    /**
+     * Update a topic.
+     * If there is no adminKey, the only authorized update (available to anyone) is to extend the expirationTime.
+     * Otherwise transaction must be signed by the adminKey.
+     * If an adminKey is updated, the transaction must be signed by the pre-update adminKey and post-update adminKey.
+     * If a new autoRenewAccount is specified (not just being removed), that account must also sign the transaction.
+     * Request is [ConsensusUpdateTopicTransactionBody](#proto.ConsensusUpdateTopicTransactionBody)
+     */
+    rpc updateTopic (Transaction) returns (TransactionResponse);
+
+    /**
+     * Delete a topic. No more transactions or queries on the topic (via HAPI) will succeed.
+     * If an adminKey is set, this transaction must be signed by that key.
+     * If there is no adminKey, this transaction will fail UNAUTHORIZED.
+     * Request is [ConsensusDeleteTopicTransactionBody](#proto.ConsensusDeleteTopicTransactionBody)
+     */
+    rpc deleteTopic (Transaction) returns (TransactionResponse);
+
+    /**
+     * Retrieve the latest state of a topic. This method is unrestricted and allowed on any topic by any payer account.
+     * Deleted accounts will not be returned.
+     * Request is [ConsensusGetTopicInfoQuery](#proto.ConsensusGetTopicInfoQuery)
+     * Response is [ConsensusGetTopicInfoResponse](#proto.ConsensusGetTopicInfoResponse)
+     */
+    rpc getTopicInfo (Query) returns (Response);
+
+    /**
+     * Submit a message for consensus.
+     * Valid and authorized messages on valid topics will be ordered by the consensus service, gossipped to the
+     * mirror net, and published (in order) to all subscribers (from the mirror net) on this topic.
+     * The submitKey (if any) must sign this transaction.
+     * On success, the resulting TransactionReceipt contains the topic's updated topicSequenceNumber and
+     * topicRunningHash.
+     * Request is [ConsensusSubmitMessageTransactionBody](#proto.ConsensusSubmitMessageTransactionBody)
+     */
+    rpc submitMessage (Transaction) returns (TransactionResponse);
+}

--- a/hapi/hedera-protobufs/services/consensus_submit_message.proto
+++ b/hapi/hedera-protobufs/services/consensus_submit_message.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.consensus">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * UNDOCUMENTED
+ */
+message ConsensusMessageChunkInfo {
+    /**
+     * TransactionID of the first chunk, gets copied to every subsequent chunk in a fragmented message.
+     */
+    TransactionID initialTransactionID = 1;
+
+    /**
+     * The total number of chunks in the message.
+     */
+    int32 total = 2;
+
+    /**
+     * The sequence number (from 1 to total) of the current chunk in the message.
+     */
+    int32 number = 3;
+}
+
+/**
+ * UNDOCUMENTED
+ */
+message ConsensusSubmitMessageTransactionBody {
+    /**
+     * Topic to submit message to.
+     */
+    TopicID topicID = 1;
+
+    /**
+     * Message to be submitted. Max size of the Transaction (including signatures) is 6KiB.
+     */
+    bytes message = 2;
+
+    /**
+     * Optional information of the current chunk in a fragmented message.
+     */
+    ConsensusMessageChunkInfo chunkInfo = 3;
+}

--- a/hapi/hedera-protobufs/services/consensus_topic_info.proto
+++ b/hapi/hedera-protobufs/services/consensus_topic_info.proto
@@ -1,0 +1,90 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.consensus">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+import "timestamp.proto";
+
+/**
+ * Current state of a topic.
+ */
+message ConsensusTopicInfo {
+    /**
+     * The memo associated with the topic (UTF-8 encoding max 100 bytes)
+     */
+    string memo = 1;
+
+
+    /**
+     * When a topic is created, its running hash is initialized to 48 bytes of binary zeros.
+     * For each submitted message, the topic's running hash is then updated to the output
+     * of a particular SHA-384 digest whose input data include the previous running hash.
+     * 
+     * See the TransactionReceipt.proto documentation for an exact description of the
+     * data included in the SHA-384 digest used for the update.
+     */
+    bytes runningHash = 2;
+
+    /**
+     * Sequence number (starting at 1 for the first submitMessage) of messages on the topic.
+     */
+    uint64 sequenceNumber = 3;
+
+    /**
+     * Effective consensus timestamp at (and after) which submitMessage calls will no longer succeed on the topic
+     * and the topic will expire and after AUTORENEW_GRACE_PERIOD be automatically deleted.
+     */
+    Timestamp expirationTime = 4;
+
+    /**
+     * Access control for update/delete of the topic. Null if there is no key.
+     */
+    Key adminKey = 5;
+
+    /**
+     * Access control for ConsensusService.submitMessage. Null if there is no key.
+     */
+    Key submitKey = 6;
+
+    /**
+     * If an auto-renew account is specified, when the topic expires, its lifetime will be extended
+     * by up to this duration (depending on the solvency of the auto-renew account). If the
+     * auto-renew account has no funds at all, the topic will be deleted instead.
+     */
+    Duration autoRenewPeriod = 7;
+
+    /**
+     * The account, if any, to charge for automatic renewal of the topic's lifetime upon expiry.
+     */
+    AccountID autoRenewAccount = 8;
+
+    /**
+     * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+     */
+    bytes ledger_id = 9;
+}

--- a/hapi/hedera-protobufs/services/consensus_update_topic.proto
+++ b/hapi/hedera-protobufs/services/consensus_update_topic.proto
@@ -1,0 +1,90 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.consensus">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "google/protobuf/wrappers.proto";
+import "basic_types.proto";
+import "duration.proto";
+import "timestamp.proto";
+
+/**
+ * All fields left null will not be updated.
+ * See [ConsensusService.updateTopic()](#proto.ConsensusService)
+ */
+message ConsensusUpdateTopicTransactionBody {
+    /**
+     * UNDOCUMENTED
+     */
+    TopicID topicID = 1;
+
+    /**
+     * If set, the new memo to be associated with the topic (UTF-8 encoding max 100 bytes)
+     */
+    google.protobuf.StringValue memo = 2;
+
+    /**
+     * Effective consensus timestamp at (and after) which all consensus transactions and queries will fail.
+     * The expirationTime may be no longer than MAX_AUTORENEW_PERIOD (8000001 seconds) from the consensus timestamp of
+     * this transaction.
+     * On topics with no adminKey, extending the expirationTime is the only updateTopic option allowed on the topic.
+     * If unspecified, no change.
+     */
+    Timestamp expirationTime = 4;
+
+    /**
+     * Access control for update/delete of the topic.
+     * If unspecified, no change.
+     * If empty keyList - the adminKey is cleared.
+     */
+    Key adminKey = 6;
+
+    /**
+     * Access control for ConsensusService.submitMessage.
+     * If unspecified, no change.
+     * If empty keyList - the submitKey is cleared.
+     */
+    Key submitKey = 7;
+
+    /*
+     * The amount of time to extend the topic's lifetime automatically at expirationTime if the autoRenewAccount is
+     * configured and has funds (once autoRenew functionality is supported by HAPI).
+     * Limited to between MIN_AUTORENEW_PERIOD (6999999 seconds) and MAX_AUTORENEW_PERIOD (8000001 seconds) by
+     * servers-side configuration (which may change).
+     * If unspecified, no change.
+     */
+    Duration autoRenewPeriod = 8;
+
+    /**
+     * Optional account to be used at the topic's expirationTime to extend the life of the topic.
+     * Once autoRenew functionality is supported by HAPI, the topic lifetime will be extended up to a maximum of the
+     * autoRenewPeriod or however long the topic can be extended using all funds on the account (whichever is the
+     * smaller duration/amount).
+     * If specified as the default value (0.0.0), the autoRenewAccount will be removed.
+     * If unspecified, no change.
+     */
+    AccountID autoRenewAccount = 9;
+}

--- a/hapi/hedera-protobufs/services/contract_call.proto
+++ b/hapi/hedera-protobufs/services/contract_call.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Call a function of the given smart contract instance, giving it functionParameters as its inputs.
+ * The call can use at maximum the given amount of gas - the paying account will not be charged for
+ * any unspent gas.
+ *
+ * If this function results in data being stored, an amount of gas is calculated that reflects this
+ * storage burden.
+ *
+ * The amount of gas used, as well as other attributes of the transaction, e.g. size, number of
+ * signatures to be verified, determine the fee for the transaction - which is charged to the paying
+ * account.
+ */
+message ContractCallTransactionBody {
+    /**
+     * The contract to call
+     */
+    ContractID contractID = 1;
+
+    /**
+     * the maximum amount of gas to use for the call
+     */
+    int64 gas = 2;
+
+    /**
+     * number of tinybars sent (the function must be payable if this is nonzero)
+     */
+    int64 amount = 3;
+
+    /**
+     * which function to call, and the parameters to pass to the function
+     */
+    bytes functionParameters = 4;
+}

--- a/hapi/hedera-protobufs/services/contract_call_local.proto
+++ b/hapi/hedera-protobufs/services/contract_call_local.proto
@@ -1,0 +1,239 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "contract_types.proto";
+
+import "google/protobuf/wrappers.proto";
+
+/**
+ * The log information for an event returned by a smart contract function call. One function call
+ * may return several such events.
+ */
+message ContractLoginfo {
+    /**
+     * address of a contract that emitted the event
+     */
+    ContractID contractID = 1;
+
+    /**
+     * bloom filter for a particular log
+     */
+    bytes bloom = 2;
+
+    /**
+     * topics of a particular event
+     */
+    repeated bytes topic = 3;
+
+    /**
+     * event data
+     */
+    bytes data = 4;
+}
+
+/**
+ * The result returned by a call to a smart contract function. This is part of the response to a
+ * ContractCallLocal query, and is in the record for a ContractCall or ContractCreateInstance
+ * transaction. The ContractCreateInstance transaction record has the results of the call to the
+ * constructor.
+ */
+message ContractFunctionResult {
+    /**
+     * the smart contract instance whose function was called
+     */
+    ContractID contractID = 1;
+
+    /**
+     * the result returned by the function
+     */
+    bytes contractCallResult = 2;
+
+    /**
+     * message In case there was an error during smart contract execution
+     */
+    string errorMessage = 3;
+
+    /**
+     * bloom filter for record
+     */
+    bytes bloom = 4;
+
+    /**
+     * units of gas used to execute contract
+     */
+    uint64 gasUsed = 5;
+
+    /**
+     * the log info for events returned by the function
+     */
+    repeated ContractLoginfo logInfo = 6;
+
+    /**
+     * [DEPRECATED] the list of smart contracts that were created by the function call.
+     * 
+     * The created ids will now _also_ be externalized through internal transaction 
+     * records, where each record has its alias field populated with the new contract's 
+     * EVM address. (This is needed for contracts created with CREATE2, since 
+     * there is no longer a simple relationship between the new contract's 0.0.X id 
+     * and its Solidity address.)
+     */
+    repeated ContractID createdContractIDs = 7 [deprecated=true];
+
+    reserved 8;
+
+    /**
+     * The new contract's 20-byte EVM address. Only populated after release 0.23, 
+     * where each created contract will have its own record. (This is an important 
+     * point--the field is not <tt>repeated</tt> because there will be a separate 
+     * child record for each created contract.)
+     * 
+     * Every contract has an EVM address determined by its <tt>shard.realm.num</tt> id.
+     * This address is as follows:
+     *   <ol>
+     *     <li>The first 4 bytes are the big-endian representation of the shard.</li>
+     *     <li>The next 8 bytes are the big-endian representation of the realm.</li>
+     *     <li>The final 8 bytes are the big-endian representation of the number.</li>
+     *   </ol>  
+     * 
+     * Contracts created via CREATE2 have an <b>additional, primary address</b> that is 
+     * derived from the <a href="https://eips.ethereum.org/EIPS/eip-1014">EIP-1014</a> 
+     * specification, and does not have a simple relation to a <tt>shard.realm.num</tt> id. 
+     * 
+     * (Please do note that CREATE2 contracts can also be referenced by the three-part 
+     * EVM address described above.)
+     */
+    google.protobuf.BytesValue evm_address = 9;
+
+    /**
+     * The amount of gas available for the call, aka the gasLimit. 
+     *
+     * This field should only be populated when the paired TransactionBody in the record stream is not a
+     * ContractCreateTransactionBody or a ContractCallTransactionBody.     
+     */
+    int64 gas = 10;
+
+    /**
+     * Number of tinybars sent (the function must be payable if this is nonzero).
+     *
+     * This field should only be populated when the paired TransactionBody in the record stream is not a
+     * ContractCreateTransactionBody or a ContractCallTransactionBody.     
+     */
+    int64 amount = 11;
+
+    /**
+     * The parameters passed into the contract call.
+     *
+     * This field should only be populated when the paired TransactionBody in the record stream is not a
+     * ContractCreateTransactionBody or a ContractCallTransactionBody.     
+     */
+    bytes functionParameters = 12;
+
+    /**
+     * The account that is the "sender." If not present it is the accountId from the transactionId.
+     *
+     * This field should only be populated when the paired TransactionBody in the record stream is not a
+     * ContractCreateTransactionBody or a ContractCallTransactionBody.     
+     */
+    AccountID sender_id = 13;
+
+    /**
+     * A list of updated contract account nonces containing the new nonce value for each contract account.
+     * This is always empty in a ContractCallLocalResponse#ContractFunctionResult message, since no internal creations can happen in a static EVM call.
+     */
+    repeated ContractNonceInfo contract_nonces = 14;
+
+    /**
+     * If not null this field specifies what the value of the signer account nonce is post transaction execution.
+     * For transactions that don't update the signer nonce, this field should be null.
+     */
+    google.protobuf.Int64Value signer_nonce = 15;
+}
+
+/**
+ * Call a function of the given smart contract instance, giving it functionParameters as its inputs.
+ * This is performed locally on the particular node that the client is communicating with.
+ * It cannot change the state of the contract instance (and so, cannot spend anything from the instance's cryptocurrency account).
+ * It will not have a consensus timestamp. It cannot generate a record or a receipt. The response will contain the output
+ * returned by the function call.  This is useful for calling getter functions, which purely read the state and don't change it.
+ * It is faster and cheaper than a normal call, because it is purely local to a single  node.
+ * 
+ * Unlike a ContractCall transaction, the node will consume the entire amount of provided gas in determining
+ * the fee for this query.
+ */
+message ContractCallLocalQuery {
+    /**
+     * standard info sent from client to node, including the signed payment, and what kind of response is requested (cost, state proof, both, or neither). The payment must cover the fees and all of the gas offered.
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The contract to make a static call against
+     */
+    ContractID contractID = 2;
+
+    /**
+     * The amount of gas to use for the call; all of the gas offered will be used and charged a corresponding fee
+     */
+    int64 gas = 3;
+
+    /**
+     * which function to call, and the parameters to pass to the function
+     */
+    bytes functionParameters = 4;
+
+    /**
+     * max number of bytes that the result might include. The run will fail if it would have returned more than this number of bytes.
+     */
+    int64 maxResultSize = 5 [deprecated=true];
+
+
+    /**
+     * The account that is the "sender." If not present it is the accountId from the transactionId.
+     * Typically a different value than specified in the transactionId requires a valid signature 
+     * over either the hedera transaction or foreign transaction data.
+     */
+    AccountID sender_id = 6;
+}
+
+/**
+ * Response when the client sends the node ContractCallLocalQuery
+ */
+message ContractCallLocalResponse {
+    /**
+     * standard response from node to client, including the requested fields: cost, or state proof, or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * the value returned by the function (if it completed and didn't fail)
+     */
+    ContractFunctionResult functionResult = 2;
+}

--- a/hapi/hedera-protobufs/services/contract_create.proto
+++ b/hapi/hedera-protobufs/services/contract_create.proto
@@ -1,0 +1,206 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+
+/**
+ * Start a new smart contract instance. After the instance is created, the ContractID for it is in
+ * the receipt, and can be retrieved by the Record or with a GetByKey query. The instance will run
+ * the bytecode, either stored in a previously created file or in the transaction body itself for 
+ * small contracts.
+ * 
+ * 
+ * The constructor will be executed using the given amount of gas, and any unspent gas will be
+ * refunded to the paying account. Constructor inputs come from the given constructorParameters.
+ *  - The instance will exist for autoRenewPeriod seconds. When that is reached, it will renew
+ *    itself for another autoRenewPeriod seconds by charging its associated cryptocurrency account
+ *    (which it creates here). If it has insufficient cryptocurrency to extend that long, it will
+ *    extend as long as it can. If its balance is zero, the instance will be deleted.
+ *
+ *  - A smart contract instance normally enforces rules, so "the code is law". For example, an
+ *    ERC-20 contract prevents a transfer from being undone without a signature by the recipient of
+ *    the transfer. This is always enforced if the contract instance was created with the adminKeys
+ *    being null. But for some uses, it might be desirable to create something like an ERC-20
+ *    contract that has a specific group of trusted individuals who can act as a "supreme court"
+ *    with the ability to override the normal operation, when a sufficient number of them agree to
+ *    do so. If adminKeys is not null, then they can sign a transaction that can change the state of
+ *    the smart contract in arbitrary ways, such as to reverse a transaction that violates some
+ *    standard of behavior that is not covered by the code itself. The admin keys can also be used
+ *    to change the autoRenewPeriod, and change the adminKeys field itself. The API currently does
+ *    not implement this ability. But it does allow the adminKeys field to be set and queried, and
+ *    will in the future implement such admin abilities for any instance that has a non-null
+ *    adminKeys.
+ *
+ *  - If this constructor stores information, it is charged gas to store it. There is a fee in hbars
+ *    to maintain that storage until the expiration time, and that fee is added as part of the
+ *    transaction fee.
+ *
+ *  - An entity (account, file, or smart contract instance) must be created in a particular realm.
+ *    If the realmID is left null, then a new realm will be created with the given admin key. If a
+ *    new realm has a null adminKey, then anyone can create/modify/delete entities in that realm.
+ *    But if an admin key is given, then any transaction to create/modify/delete an entity in that
+ *    realm must be signed by that key, though anyone can still call functions on smart contract
+ *    instances that exist in that realm. A realm ceases to exist when everything within it has
+ *    expired and no longer exists.
+ *
+ *  - The current API ignores shardID, realmID, and newRealmAdminKey, and creates everything in
+ *    shard 0 and realm 0, with a null key. Future versions of the API will support multiple realms
+ *    and multiple shards.
+ *
+ *  - The optional memo field can contain a string whose length is up to 100 bytes. That is the size
+ *    after Unicode NFD then UTF-8 conversion. This field can be used to describe the smart contract.
+ *    It could also be used for other purposes. One recommended purpose is to hold a hexadecimal
+ *    string that is the SHA-384 hash of a PDF file containing a human-readable legal contract. Then,
+ *    if the admin keys are the public keys of human arbitrators, they can use that legal document to
+ *    guide their decisions during a binding arbitration tribunal, convened to consider any changes
+ *    to the smart contract in the future. The memo field can only be changed using the admin keys.
+ *    If there are no admin keys, then it cannot be changed after the smart contract is created.
+ *
+ * <b>Signing requirements:</b> If an admin key is set, it must sign the transaction. If an 
+ * auto-renew account is set, its key must sign the transaction.
+ */
+message ContractCreateTransactionBody {
+
+    /**
+     * There are two ways to specify the initcode of a ContractCreateTransction. If the initcode is
+     * large (> 5K) then it must be stored in a file as hex encoded ascii. If it is small then it may
+     * either be stored as a hex encoded file or as a binary encoded field as part of the transaciton.
+     *
+     */
+    oneof initcodeSource {
+        /**
+         * The file containing the smart contract initcode. A copy will be made and held by the
+         * contract instance, and have the same expiration time as the instance.
+         */
+        FileID fileID = 1;
+
+        /**
+         * The bytes of the smart contract initcode. This is only useful if the smart contract init
+         * is less than the hedera transaction limit. In those cases fileID must be used.
+         */
+        bytes initcode = 16;
+    }
+
+    /**
+     * the state of the instance and its fields can be modified arbitrarily if this key signs a
+     * transaction to modify it. If this is null, then such modifications are not possible, and
+     * there is no administrator that can override the normal operation of this smart contract
+     * instance. Note that if it is created with no admin keys, then there is no administrator to
+     * authorize changing the admin keys, so there can never be any admin keys for that instance.
+     */
+    Key adminKey = 3;
+
+    /**
+     * gas to run the constructor
+     */
+    int64 gas = 4;
+
+    /**
+     * initial number of tinybars to put into the cryptocurrency account associated with and owned
+     * by the smart contract
+     */
+    int64 initialBalance = 5;
+
+    /**
+     * [Deprecated] ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
+     * invalid account, or is an account that isn't a node, then this account is automatically proxy
+     * staked to a node chosen by the network, but without earning payments. If the proxyAccountID
+     * account refuses to accept proxy staking , or if it is not currently running a node, then it
+     * will behave as if  proxyAccountID was null.
+     */
+    AccountID proxyAccountID = 6 [deprecated = true];
+
+    /**
+     * the instance will charge its account every this many seconds to renew for this long
+     */
+    Duration autoRenewPeriod = 8;
+
+    /**
+     * parameters to pass to the constructor
+     */
+    bytes constructorParameters = 9;
+
+    /**
+     * shard in which to create this
+     */
+    ShardID shardID = 10;
+
+    /**
+     * realm in which to create this (leave this null to create a new realm)
+     */
+    RealmID realmID = 11;
+
+    /**
+     * if realmID is null, then this the admin key for the new realm that will be created
+     */
+    Key newRealmAdminKey = 12;
+
+    /**
+     * the memo that was submitted as part of the contract (max 100 bytes)
+     */
+    string memo = 13;
+
+    /**
+     * The maximum number of tokens that can be auto-associated with the contract.<br/>
+     * If this is less than or equal to `used_auto_associations`, or 0, then this contract
+     * MUST manually associate with a token before transacting in that token.<br/>
+     * This value MAY also be `-1` to indicate no limit.<br/>
+     * This value MUST NOT be less than `-1`.<br/>
+     * By default this value is 0 for contracts.
+     */
+    int32 max_automatic_token_associations = 14;
+
+    /**
+     * An account to charge for auto-renewal of this contract. If not set, or set to an
+     * account with zero hbar balance, the contract's own hbar balance will be used to
+     * cover auto-renewal fees.
+     */
+    AccountID auto_renew_account_id = 15;
+
+    /**
+     * ID of the new account or node to which this contract is staking.
+     */
+    oneof staked_id {
+
+        /**
+         * ID of the account to which this contract is staking.
+         */
+        AccountID staked_account_id = 17;
+
+        /**
+         * ID of the node this contract is staked to.
+         */
+        int64 staked_node_id = 18;
+    }
+
+    /**
+     * If true, the contract declines receiving a staking reward. The default value is false.
+     */
+    bool decline_reward = 19;
+}

--- a/hapi/hedera-protobufs/services/contract_delete.proto
+++ b/hapi/hedera-protobufs/services/contract_delete.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * At consensus, marks a contract as deleted and transfers its remaining hBars, if any, to a
+ * designated receiver. After a contract is deleted, it can no longer be called.
+ * 
+ * If the target contract is immutable (that is, was created without an admin key), then this
+ * transaction resolves to MODIFYING_IMMUTABLE_CONTRACT.
+ * 
+ * --- Signing Requirements ---
+ * 1. The admin key of the target contract must sign.
+ * 2. If the transfer account or contract has receiverSigRequired, its associated key must also sign
+ */
+message ContractDeleteTransactionBody {
+    /**
+     * The id of the contract to be deleted
+     */
+    ContractID contractID = 1;
+
+    oneof obtainers {
+        /**
+         * The id of an account to receive any remaining hBars from the deleted contract
+         */
+		AccountID transferAccountID = 2;
+
+        /**
+         * The id of a contract to receive any remaining hBars from the deleted contract
+         */
+	    ContractID transferContractID = 3;
+    }
+
+    /**
+     * If set to true, means this is a "synthetic" system transaction being used to 
+     * alert mirror nodes that the contract is being permanently removed from the ledger.
+     * <b>IMPORTANT:</b> User transactions cannot set this field to true, as permanent
+     * removal is always managed by the ledger itself. Any ContractDeleteTransactionBody
+     * submitted to HAPI with permanent_removal=true will be rejected with precheck status
+     * PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION.
+     */
+    bool permanent_removal = 4;
+}

--- a/hapi/hedera-protobufs/services/contract_get_bytecode.proto
+++ b/hapi/hedera-protobufs/services/contract_get_bytecode.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get the runtime bytecode for a smart contract instance
+ */
+message ContractGetBytecodeQuery {
+    /**
+     * standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * the contract for which information is requested
+     */
+    ContractID contractID = 2;
+}
+
+/**
+ * Response when the client sends the node ContractGetBytecodeQuery
+ */
+message ContractGetBytecodeResponse {
+    /**
+     * standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * the runtime bytecode of the contract
+     */
+    bytes bytecode = 6;
+}
+

--- a/hapi/hedera-protobufs/services/contract_get_info.proto
+++ b/hapi/hedera-protobufs/services/contract_get_info.proto
@@ -1,0 +1,158 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "timestamp.proto";
+import "duration.proto";
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get information about a smart contract instance. This includes the account that it uses, the file
+ * containing its initcode (if a file was used to initialize the contract), and the time when it will expire.
+ */
+message ContractGetInfoQuery {
+    /**
+     * standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * the contract for which information is requested
+     */
+    ContractID contractID = 2;
+}
+
+/**
+ * Response when the client sends the node ContractGetInfoQuery
+ */
+message ContractGetInfoResponse {
+    /**
+     * standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    message ContractInfo {
+        /**
+         * ID of the contract instance, in the format used in transactions
+         */
+        ContractID contractID = 1;
+
+        /**
+         * ID of the cryptocurrency account owned by the contract instance, in the format used in
+         * transactions
+         */
+        AccountID accountID = 2;
+
+        /**
+         * ID of both the contract instance and the cryptocurrency account owned by the contract
+         * instance, in the format used by Solidity
+         */
+        string contractAccountID = 3;
+
+        /**
+         * the state of the instance and its fields can be modified arbitrarily if this key signs a
+         * transaction to modify it. If this is null, then such modifications are not possible, and
+         * there is no administrator that can override the normal operation of this smart contract
+         * instance. Note that if it is created with no admin keys, then there is no administrator
+         * to authorize changing the admin keys, so there can never be any admin keys for that
+         * instance.
+         */
+        Key adminKey = 4;
+
+        /**
+         * the current time at which this contract instance (and its account) is set to expire
+         */
+        Timestamp expirationTime = 5;
+
+        /**
+         * the expiration time will extend every this many seconds. If there are insufficient funds,
+         * then it extends as long as possible. If the account is empty when it expires, then it is
+         * deleted.
+         */
+        Duration autoRenewPeriod = 6;
+
+        /**
+         * number of bytes of storage being used by this instance (which affects the cost to extend
+         * the expiration time)
+         */
+        int64 storage = 7;
+
+        /**
+         * the memo associated with the contract (max 100 bytes)
+         */
+        string memo = 8;
+
+        /**
+         * The current balance, in tinybars
+         */
+        uint64 balance = 9;
+
+        /**
+         * Whether the contract has been deleted
+         */
+        bool deleted = 10;
+
+        /**
+         * [DEPRECATED] The metadata of the tokens associated to the contract. This field was 
+         * deprecated by <a href="https://hips.hedera.com/hip/hip-367">HIP-367</a>, which allowed 
+         * an account to be associated to an unlimited number of tokens. This scale makes it more 
+         * efficient for users to consult mirror nodes to review their token associations.
+         */
+        repeated TokenRelationship tokenRelationships = 11 [deprecated = true];
+
+        /**
+         * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+         */
+        bytes ledger_id = 12;
+
+        /**
+         * ID of the an account to charge for auto-renewal of this contract. If not set, or set to an account with zero hbar
+         * balance, the contract's own hbar balance will be used to cover auto-renewal fees.
+         */
+        AccountID auto_renew_account_id = 13;
+
+        /**
+         * The maximum number of tokens that a contract can be implicitly associated with.
+         */
+        int32 max_automatic_token_associations = 14;
+
+        /**
+         * Staking metadata for this contract.
+         */
+        StakingInfo staking_info = 15;
+    }
+
+    /**
+     * the information about this contract instance (a state proof can be generated for this)
+     */
+    ContractInfo contractInfo = 2;
+}
+

--- a/hapi/hedera-protobufs/services/contract_get_records.proto
+++ b/hapi/hedera-protobufs/services/contract_get_records.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "transaction_record.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Before v0.9.0, requested records of all transactions against the given contract in the last 25 hours.
+ */
+message ContractGetRecordsQuery {
+    option deprecated = true;
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The smart contract instance for which the records should be retrieved
+     */
+    ContractID contractID = 2;
+}
+
+/**
+ * Before v0.9.0, returned records of all transactions against the given contract in the last 25 hours.
+ */
+message ContractGetRecordsResponse {
+    option deprecated = true;
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof, or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The smart contract instance that this record is for
+     */
+    ContractID contractID = 2;
+
+    /**
+     * List of records, each with contractCreateResult or contractCallResult as its body
+     */
+    repeated TransactionRecord records = 3;
+}

--- a/hapi/hedera-protobufs/services/contract_types.proto
+++ b/hapi/hedera-protobufs/services/contract_types.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+import "google/protobuf/wrappers.proto";
+/**
+ * Info about a contract account's nonce value.
+ * A nonce of a contract is only incremented when that contract creates another contract.
+ */
+message ContractNonceInfo {
+
+  /**
+   * Id of the contract
+   */
+  ContractID contract_id = 1;
+
+  /**
+   * The current value of the contract account's nonce property
+   */
+  int64 nonce = 2;
+}

--- a/hapi/hedera-protobufs/services/contract_update.proto
+++ b/hapi/hedera-protobufs/services/contract_update.proto
@@ -1,0 +1,139 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+import "timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * At consensus, updates the fields of a smart contract to the given values.
+ * 
+ * If no value is given for a field, that field is left unchanged on the contract. For an immutable
+ * smart contract (that is, a contract created without an adminKey), only the expirationTime may be
+ * updated; setting any other field in this case will cause the transaction status to resolve to
+ * MODIFYING_IMMUTABLE_CONTRACT.
+ * 
+ * --- Signing Requirements ---
+ * 1. Whether or not a contract has an admin key, its expiry can be extended with only the
+ *    transaction payer's signature.
+ * 2. Updating any other field of a mutable contract requires the admin key's signature.
+ * 3. If the update transaction includes a new admin key, this new key must also sign <b>unless</b>
+ *    it is exactly an empty <tt>KeyList</tt>. This special sentinel key removes the existing admin
+ *    key and causes the contract to become immutable. (Other <tt>Key</tt> structures without a
+ *    constituent <tt>Ed25519</tt> key will be rejected with <tt>INVALID_ADMIN_KEY</tt>.)
+ * 4. If the update transaction sets the AccountID auto_renew_account_id wrapper field to anything
+ *    other than the sentinel <tt>0.0.0</tt> value, then the key of the referenced account must sign.
+ */
+message ContractUpdateTransactionBody {
+    /**
+     * The id of the contract to be updated
+     */
+    ContractID contractID = 1;
+
+    /**
+     * The new expiry of the contract, no earlier than the current expiry (resolves to
+     * EXPIRATION_REDUCTION_NOT_ALLOWED otherwise)
+     */
+    Timestamp expirationTime = 2;
+
+    /**
+     * The new key to control updates to the contract
+     */
+    Key adminKey = 3;
+
+    /**
+     * [Deprecated] The new id of the account to which the contract is proxy staked
+     */
+    AccountID proxyAccountID = 6 [deprecated = true];
+
+    /**
+     * If an auto-renew account is in use, the lifetime to be added by each auto-renewal.
+     */
+    Duration autoRenewPeriod = 7;
+
+    /**
+     * This field is unused and will have no impact on the specified smart contract.
+     */
+    FileID fileID = 8 [deprecated = true];
+
+    /**
+     * The new contract memo, assumed to be Unicode encoded with UTF-8 (at most 100 bytes)
+     */
+    oneof memoField {
+      /**
+       * [Deprecated] If set with a non-zero length, the new memo to be associated with the account
+       * (UTF-8 encoding max 100 bytes)
+       */
+      string memo = 9 [deprecated = true];
+
+      /**
+       * If set, the new memo to be associated with the account (UTF-8 encoding max 100 bytes)
+       */
+      google.protobuf.StringValue memoWrapper = 10;
+    }
+
+    /**
+     * If set, modify the maximum number of tokens that can be auto-associated with the
+     * contract.<br/>
+     * If this is set and less than or equal to `used_auto_associations`, or 0, then this contract
+     * MUST manually associate with a token before transacting in that token.<br/>
+     * This value MAY also be `-1` to indicate no limit.<br/>
+     * This value MUST NOT be less than `-1`.
+     */
+    google.protobuf.Int32Value max_automatic_token_associations = 11;
+
+    /**
+     * If set to the sentinel <tt>0.0.0</tt> AccountID, this field removes the contract's auto-renew 
+     * account. Otherwise it updates the contract's auto-renew account to the referenced account.
+     */
+    AccountID auto_renew_account_id = 12;
+
+    /**
+     * ID of the new account or node to which this contract is staking.
+     */
+    oneof staked_id {
+
+        /**
+         * ID of the new account to which this contract is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
+         * this field removes the contract's staked account ID.
+         */
+        AccountID staked_account_id = 13;
+
+        /**
+         * ID of the new node this contract is staked to. If set to the sentinel <tt>-1</tt>, this field
+         * removes the contract's staked node ID.
+         */
+        int64 staked_node_id = 14;
+    }
+
+    /**
+     * If true, the contract declines receiving a staking reward.
+     */
+    google.protobuf.BoolValue decline_reward = 15;
+}

--- a/hapi/hedera-protobufs/services/crypto_add_live_hash.proto
+++ b/hapi/hedera-protobufs/services/crypto_add_live_hash.proto
@@ -1,0 +1,75 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+
+import "basic_types.proto";
+import "duration.proto";
+
+/**
+ * A hash---presumably of some kind of credential or certificate---along with a list of keys, each
+ * of which may be either a primitive or a threshold key. 
+ */
+message LiveHash {
+    /**
+     * The account to which the livehash is attached
+     */
+    AccountID accountId = 1;
+
+    /**
+     * The SHA-384 hash of a credential or certificate
+     */
+    bytes hash = 2;
+
+    /**
+     * A list of keys (primitive or threshold), all of which must sign to attach the livehash to an account, and any one of which can later delete it.
+     */
+    KeyList keys = 3;
+
+    /**
+     * The duration for which the livehash will remain valid
+     */
+    Duration duration = 5;
+}
+
+/**
+ * At consensus, attaches the given livehash to the given account.  The hash can be deleted by the
+ * key controlling the account, or by any of the keys associated to the livehash.  Hence livehashes
+ * provide a revocation service for their implied credentials; for example, when an authority grants
+ * a credential to the account, the account owner will cosign with the authority (or authorities) to
+ * attach a hash of the credential to the account---hence proving the grant. If the credential is
+ * revoked, then any of the authorities may delete it (or the account owner). In this way, the
+ * livehash mechanism acts as a revocation service.  An account cannot have two identical livehashes
+ * associated. To modify the list of keys in a livehash, the livehash should first be deleted, then
+ * recreated with a new list of keys.
+ */
+message CryptoAddLiveHashTransactionBody {
+    /**
+     * A hash of some credential or certificate, along with the keys of the entities that asserted it validity
+     */
+    LiveHash liveHash = 3;
+}

--- a/hapi/hedera-protobufs/services/crypto_approve_allowance.proto
+++ b/hapi/hedera-protobufs/services/crypto_approve_allowance.proto
@@ -1,0 +1,140 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * Creates one or more hbar/token approved allowances <b>relative to the owner account specified in the allowances of
+ * this transaction</b>. Each allowance grants a spender the right to transfer a pre-determined amount of the owner's
+ * hbar/token to any other account of the spender's choice. If the owner is not specified in any allowance, the payer
+ * of transaction is considered to be the owner for that particular allowance.
+ * Setting the amount to zero in CryptoAllowance or TokenAllowance will remove the respective allowance for the spender.
+ * 
+ * (So if account <tt>0.0.X</tt> pays for this transaction and owner is not specified in the allowance,
+ * then at consensus each spender account will have new allowances to spend hbar or tokens from <tt>0.0.X</tt>).
+ */
+message CryptoApproveAllowanceTransactionBody {
+  /**
+   * List of hbar allowances approved by the account owner.
+   */
+  repeated CryptoAllowance cryptoAllowances = 1;
+
+  /**
+   * List of non-fungible token allowances approved by the account owner.
+   */
+  repeated NftAllowance nftAllowances = 2;
+
+  /**
+   * List of fungible token allowances approved by the account owner.
+   */
+  repeated TokenAllowance tokenAllowances = 3;
+}
+
+/**
+ * An approved allowance of hbar transfers for a spender.
+ */
+message CryptoAllowance {
+  /**
+   * The account ID of the hbar owner (ie. the grantor of the allowance).
+   */
+  AccountID owner = 1;
+
+  /**
+   * The account ID of the spender of the hbar allowance.
+   */
+  AccountID spender = 2;
+
+  /**
+   * The amount of the spender's allowance in tinybars.
+   */
+  int64 amount = 3;
+}
+
+/**
+ * An approved allowance of non-fungible token transfers for a spender.
+ */
+message NftAllowance {
+  /**
+   * The NFT token type that the allowance pertains to.
+   */
+  TokenID tokenId = 1;
+
+  /**
+   * The account ID of the token owner (ie. the grantor of the allowance).
+   */
+  AccountID owner = 2;
+
+  /**
+   * The account ID of the token allowance spender.
+   */
+  AccountID spender = 3;
+
+  /**
+   * The list of serial numbers that the spender is permitted to transfer.
+   */
+  repeated int64 serial_numbers = 4;
+
+  /**
+   * If true, the spender has access to all of the owner's NFT units of type tokenId (currently
+   * owned and any in the future).
+   */
+  google.protobuf.BoolValue approved_for_all = 5;
+
+  /**
+   * The account ID of the spender who is granted approvedForAll allowance and granting
+   * approval on an NFT serial to another spender.
+   */
+  AccountID delegating_spender = 6;
+}
+
+/**
+ * An approved allowance of fungible token transfers for a spender.
+ */
+message TokenAllowance {
+  /**
+   * The token that the allowance pertains to.
+   */
+  TokenID tokenId = 1;
+
+  /**
+   * The account ID of the token owner (ie. the grantor of the allowance).
+   */
+  AccountID owner = 2;
+
+  /**
+   * The account ID of the token allowance spender.
+   */
+  AccountID spender = 3;
+
+  /**
+   * The amount of the spender's token allowance.
+   */
+  int64 amount = 4;
+}
+

--- a/hapi/hedera-protobufs/services/crypto_create.proto
+++ b/hapi/hedera-protobufs/services/crypto_create.proto
@@ -1,0 +1,176 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+
+/*
+ * Create a new account. After the account is created, the AccountID for it is in the receipt. It
+ * can also be retrieved with a GetByKey query. Threshold values can be defined, and records are
+ * generated and stored for 25 hours for any transfer that exceeds the thresholds. This account is
+ * charged for each record generated, so the thresholds are useful for limiting record generation to
+ * happen only for large transactions.
+ *
+ * The Key field is the key used to sign transactions for this account. If the account has
+ * receiverSigRequired set to true, then all cryptocurrency transfers must be signed by this
+ * account's key, both for transfers in and out. If it is false, then only transfers out have to be
+ * signed by it. When the account is created, the payer account is charged enough hbars so that the
+ * new account will not expire for the next autoRenewPeriod seconds. When it reaches the expiration
+ * time, the new account will then be automatically charged to renew for another autoRenewPeriod
+ * seconds. If it does not have enough hbars to renew for that long, then the remaining hbars are
+ * used to extend its expiration as long as possible. If it is has a zero balance when it expires,
+ * then it is deleted. This transaction must be signed by the payer account. If receiverSigRequired
+ * is false, then the transaction does not have to be signed by the keys in the keys field. If it is
+ * true, then it must be signed by them, in addition to the keys of the payer account. If the 
+ * auto_renew_account field is set, the key of the referenced account must sign.
+ *
+ * An entity (account, file, or smart contract instance) must be created in a particular realm. If
+ * the realmID is left null, then a new realm will be created with the given admin key. If a new
+ * realm has a null adminKey, then anyone can create/modify/delete entities in that realm. But if an
+ * admin key is given, then any transaction to create/modify/delete an entity in that realm must be
+ * signed by that key, though anyone can still call functions on smart contract instances that exist
+ * in that realm. A realm ceases to exist when everything within it has expired and no longer
+ * exists.
+ *
+ * The current API ignores shardID, realmID, and newRealmAdminKey, and creates everything in shard 0
+ * and realm 0, with a null key. Future versions of the API will support multiple realms and
+ * multiple shards.
+ */
+message CryptoCreateTransactionBody {
+    /**
+     * The key that must sign each transfer out of the account. If receiverSigRequired is true, then
+     * it must also sign any transfer into the account.
+     */
+    Key key = 1;
+
+    /**
+     * The initial number of tinybars to put into the account
+     */
+    uint64 initialBalance = 2;
+
+    /**
+     * [Deprecated] ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
+     * invalid account, or is an account that isn't a node, then this account is automatically proxy
+     * staked to a node chosen by the network, but without earning payments. If the proxyAccountID
+     * account refuses to accept proxy staking , or if it is not currently running a node, then it
+     * will behave as if proxyAccountID was null.
+     */
+    AccountID proxyAccountID = 3 [deprecated = true];
+
+    /**
+     * [Deprecated]. The threshold amount (in tinybars) for which an account record is created for
+     * any send/withdraw transaction
+     */
+    uint64 sendRecordThreshold = 6 [deprecated=true];
+
+    /**
+     * [Deprecated]. The threshold amount (in tinybars) for which an account record is created for
+     * any receive/deposit transaction
+     */
+    uint64 receiveRecordThreshold = 7 [deprecated=true];
+
+    /**
+     * If true, this account's key must sign any transaction depositing into this account (in
+     * addition to all withdrawals)
+     */
+    bool receiverSigRequired = 8;
+
+    /**
+     * The account is charged to extend its expiration date every this many seconds. If it doesn't
+     * have enough balance, it extends as long as possible. If it is empty when it expires, then it
+     * is deleted.
+     */
+    Duration autoRenewPeriod = 9;
+
+    /**
+     * The shard in which this account is created
+     */
+    ShardID shardID = 10;
+
+    /**
+     * The realm in which this account is created (leave this null to create a new realm)
+     */
+    RealmID realmID = 11;
+
+    /**
+     * If realmID is null, then this the admin key for the new realm that will be created
+     */
+    Key newRealmAdminKey = 12;
+
+    /**
+     * The memo associated with the account (UTF-8 encoding max 100 bytes)
+     */
+    string memo = 13;
+
+    /**
+     * The maximum number of tokens that can be auto-associated with the account.<br/>
+     * If this is less than or equal to `used_auto_associations`, or 0, then this account
+     * MUST manually associate with a token before transacting in that token.<br/>
+     * This value MAY also be `-1` to indicate no limit.<br/>
+     * This value MUST NOT be less than `-1`.<br/>
+     * By default this value is 0 for accounts except for auto-created accounts which default -1.
+     */
+    int32 max_automatic_token_associations = 14;
+
+    /**
+     * ID of the account or node to which this account is staking.
+     */
+    oneof staked_id {
+
+        /**
+         * ID of the account to which this account is staking.
+         */
+        AccountID staked_account_id = 15;
+
+        /**
+         * ID of the node this account is staked to.
+         */
+        int64 staked_node_id = 16;
+    }
+
+    /**
+     * If true, the account declines receiving a staking reward. The default value is false.
+     */
+    bool decline_reward = 17;
+
+    /**
+     * The bytes to be used as the account's alias. It will be the
+     * serialization of a protobuf Key message for an ED25519/ECDSA_SECP256K1 primitive key type. Currently only primitive key bytes are
+     * supported as the key for an account with an alias. ThresholdKey, KeyList, ContractID, and
+     * delegatable_contract_id are not supported.
+     *
+     * May also be the EOA 20-byte address to create that is derived from the keccak-256 hash of a ECDSA_SECP256K1 primitive key.
+     *
+     * A given alias can map to at most one account on the network at a time. This uniqueness will be enforced
+     * relative to aliases currently on the network at alias assignment.
+     *
+     * If a transaction creates an account using an alias, any further crypto transfers to that alias will 
+     * simply be deposited in that account, without creating anything, and with no creation fee being charged.
+     */
+     bytes alias = 18;
+}

--- a/hapi/hedera-protobufs/services/crypto_delete.proto
+++ b/hapi/hedera-protobufs/services/crypto_delete.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Mark an account as deleted, moving all its current hbars to another account. It will remain in
+ * the ledger, marked as deleted, until it expires. Transfers into it a deleted account fail. But a
+ * deleted account can still have its expiration extended in the normal way.
+ */
+message CryptoDeleteTransactionBody {
+    /**
+     * The account ID which will receive all remaining hbars
+     */
+    AccountID transferAccountID = 1;
+
+    /**
+     * The account ID which should be deleted
+     */
+    AccountID deleteAccountID = 2;
+}

--- a/hapi/hedera-protobufs/services/crypto_delete_allowance.proto
+++ b/hapi/hedera-protobufs/services/crypto_delete_allowance.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Deletes one or more non-fungible approved allowances from an owner's account. This operation
+ * will remove the allowances granted to one or more specific non-fungible token serial numbers. Each owner account
+ * listed as wiping an allowance must sign the transaction. Hbar and fungible token allowances
+ * can be removed by setting the amount to zero in CryptoApproveAllowance.
+ */
+message CryptoDeleteAllowanceTransactionBody {
+    /**
+     * List of non-fungible token allowances to remove.
+     */
+    repeated NftRemoveAllowance nftAllowances = 2;
+}
+
+/**
+ * Nft allowances to be removed on an owner account
+ */
+message NftRemoveAllowance {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The account ID of the token owner (ie. the grantor of the allowance).
+     */
+    AccountID owner = 2;
+
+    /**
+     * The list of serial numbers to remove allowances from.
+     */
+    repeated int64 serial_numbers = 3;
+}

--- a/hapi/hedera-protobufs/services/crypto_delete_live_hash.proto
+++ b/hapi/hedera-protobufs/services/crypto_delete_live_hash.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * At consensus, deletes a livehash associated to the given account. The transaction must be signed
+ * by either the key of the owning account, or at least one of the keys associated to the livehash.
+ */
+message CryptoDeleteLiveHashTransactionBody {
+    /**
+     * The account owning the livehash
+     */
+    AccountID accountOfLiveHash = 1;
+
+    /**
+     * The SHA-384 livehash to delete from the account
+     */
+    bytes liveHashToDelete = 2;
+}

--- a/hapi/hedera-protobufs/services/crypto_get_account_balance.proto
+++ b/hapi/hedera-protobufs/services/crypto_get_account_balance.proto
@@ -1,0 +1,85 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get the balance of a cryptocurrency account. This returns only the balance, so it is a smaller
+ * reply than CryptoGetInfo, which returns the balance plus additional information.
+ */
+message CryptoGetAccountBalanceQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    oneof balanceSource {
+    	/**
+    	 * The account ID for which information is requested
+    	 */
+    	AccountID accountID = 2;
+
+    	/**
+    	 * The account ID for which information is requested
+    	 */
+    	ContractID contractID = 3;
+    }
+}
+
+/**
+ * Response when the client sends the node CryptoGetAccountBalanceQuery
+ */
+message CryptoGetAccountBalanceResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither.
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The account ID that is being described (this is useful with state proofs, for proving to a
+     * third party)
+     */
+    AccountID accountID = 2;
+
+    /**
+     * The current balance, in tinybars.
+     */
+    uint64 balance = 3;
+
+    /**
+     * [DEPRECATED] The balances of the tokens associated to the account. This field was 
+     * deprecated by <a href="https://hips.hedera.com/hip/hip-367">HIP-367</a>, which allowed 
+     * an account to be associated to an unlimited number of tokens. This scale makes it more 
+     * efficient for users to consult mirror nodes to review their token balances.
+     */
+    repeated TokenBalance tokenBalances = 4 [deprecated = true];
+}

--- a/hapi/hedera-protobufs/services/crypto_get_account_records.proto
+++ b/hapi/hedera-protobufs/services/crypto_get_account_records.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "transaction_record.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Requests records of all transactions for which the given account was the effective payer in the last 3 minutes of consensus time and <tt>ledger.keepRecordsInState=true</tt> was true during <tt>handleTransaction</tt>.
+ */
+message CryptoGetAccountRecordsQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The account ID for which the records should be retrieved
+     */
+    AccountID accountID = 2;
+}
+
+/**
+ * Returns records of all transactions for which the given account was the effective payer in the last 3 minutes of consensus time and <tt>ledger.keepRecordsInState=true</tt> was true during <tt>handleTransaction</tt>.
+ */
+message CryptoGetAccountRecordsResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof, or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The account that this record is for
+     */
+    AccountID accountID = 2;
+
+    /**
+     * List of records
+     */
+    repeated TransactionRecord records = 3;
+}
+
+

--- a/hapi/hedera-protobufs/services/crypto_get_info.proto
+++ b/hapi/hedera-protobufs/services/crypto_get_info.proto
@@ -1,0 +1,189 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "timestamp.proto";
+import "duration.proto";
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "crypto_add_live_hash.proto";
+
+/**
+ * Get all the information about an account, including the balance. This does not get the list of
+ * account records.
+ */
+message CryptoGetInfoQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The account ID for which information is requested
+     */
+    AccountID accountID = 2;
+}
+
+/**
+ * Response when the client sends the node CryptoGetInfoQuery
+ */
+message CryptoGetInfoResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    message AccountInfo {
+        /**
+         * The account ID for which this information applies
+         */
+        AccountID accountID = 1;
+
+        /**
+         * The Contract Account ID comprising of both the contract instance and the cryptocurrency
+         * account owned by the contract instance, in the format used by Solidity
+         */
+        string contractAccountID = 2;
+
+        /**
+         * If true, then this account has been deleted, it will disappear when it expires, and all
+         * transactions for it will fail except the transaction to extend its expiration date
+         */
+        bool deleted = 3;
+
+        /**
+         * [Deprecated] The Account ID of the account to which this is proxy staked. If proxyAccountID is null,
+         * or is an invalid account, or is an account that isn't a node, then this account is
+         * automatically proxy staked to a node chosen by the network, but without earning payments.
+         * If the proxyAccountID account refuses to accept proxy staking , or if it is not currently
+         * running a node, then it will behave as if proxyAccountID was null.
+         */
+        AccountID proxyAccountID = 4 [deprecated = true];
+
+        /**
+         * The total number of tinybars proxy staked to this account
+         */
+        int64 proxyReceived = 6;
+
+        /**
+         * The key for the account, which must sign in order to transfer out, or to modify the
+         * account in any way other than extending its expiration date.
+         */
+        Key key = 7;
+
+        /**
+         * The current balance of account in tinybars
+         */
+        uint64 balance = 8;
+
+        /**
+         * [Deprecated]. The threshold amount, in tinybars, at which a record is created of any
+         * transaction that decreases the balance of this account by more than the threshold
+         */
+        uint64 generateSendRecordThreshold = 9 [deprecated=true];
+
+        /**
+         * [Deprecated]. The threshold amount, in tinybars, at which a record is created of any
+         * transaction that increases the balance of this account by more than the threshold
+         */
+        uint64 generateReceiveRecordThreshold = 10 [deprecated=true];
+
+        /**
+         * If true, no transaction can transfer to this account unless signed by this account's key
+         */
+        bool receiverSigRequired = 11;
+
+        /**
+         * The TimeStamp time at which this account is set to expire
+         */
+        Timestamp expirationTime = 12;
+
+        /**
+         * The duration for expiration time will extend every this many seconds. If there are
+         * insufficient funds, then it extends as long as possible. If it is empty when it expires,
+         * then it is deleted.
+         */
+        Duration autoRenewPeriod = 13;
+
+        /**
+         * All of the livehashes attached to the account (each of which is a hash along with the
+         * keys that authorized it and can delete it)
+         */
+        repeated LiveHash liveHashes = 14;
+
+        /**
+         * [DEPRECATED] The metadata of the tokens associated to the account. This field was 
+         * deprecated by <a href="https://hips.hedera.com/hip/hip-367">HIP-367</a>, which allowed 
+         * an account to be associated to an unlimited number of tokens. This scale makes it more 
+         * efficient for users to consult mirror nodes to review their token associations.
+         */
+        repeated TokenRelationship tokenRelationships = 15 [deprecated = true];
+
+        /**
+         * The memo associated with the account
+         */
+        string memo = 16;
+
+        /**
+         * The number of NFTs owned by this account
+         */
+        int64 ownedNfts = 17;
+
+        /**
+         * The maximum number of tokens that an Account can be implicitly associated with.
+         */
+        int32 max_automatic_token_associations = 18;
+
+        /**
+         * The alias of this account
+         */
+        bytes alias = 19;
+
+        /**
+         * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+         */
+        bytes ledger_id = 20;
+
+        /**
+         * The ethereum transaction nonce associated with this account.
+         */
+        int64 ethereum_nonce = 21;
+
+        /**
+         * Staking metadata for this account.
+         */
+        StakingInfo staking_info = 22;
+    }
+
+    /**
+     * Info about the account (a state proof can be generated for this)
+     */
+    AccountInfo accountInfo = 2;
+}

--- a/hapi/hedera-protobufs/services/crypto_get_live_hash.proto
+++ b/hapi/hedera-protobufs/services/crypto_get_live_hash.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "crypto_add_live_hash.proto";
+
+/**
+ * Requests a livehash associated to an account.
+ */
+message CryptoGetLiveHashQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The account to which the livehash is associated
+     */
+    AccountID accountID = 2;
+
+    /**
+     * The SHA-384 data in the livehash
+     */
+    bytes hash = 3;
+}
+
+/**
+ * Returns the full livehash associated to an account, if it is present. Note that the only way to
+ * obtain a state proof exhibiting the absence of a livehash from an account is to retrieve a state
+ * proof of the entire account with its list of livehashes.
+ */
+message CryptoGetLiveHashResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The livehash, if present
+     */
+    LiveHash liveHash = 2;
+}
+
+

--- a/hapi/hedera-protobufs/services/crypto_get_stakers.proto
+++ b/hapi/hedera-protobufs/services/crypto_get_stakers.proto
@@ -1,0 +1,95 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get all the accounts that are proxy staking to this account. For each of them, give the amount
+ * currently staked. This is not yet implemented, but will be in a future version of the API.
+ */
+message CryptoGetStakersQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The Account ID for which the records should be retrieved
+     */
+    AccountID accountID = 2;
+}
+
+/**
+ * information about a single account that is proxy staking
+ */
+message ProxyStaker {
+    /**
+     * The Account ID that is proxy staking
+     */
+    AccountID accountID = 1;
+
+    /**
+     * The number of hbars that are currently proxy staked
+     */
+    int64 amount = 2;
+}
+
+/**
+ * all of the accounts proxy staking to a given account, and the amounts proxy staked
+ */
+message AllProxyStakers {
+    /**
+     * The Account ID that is being proxy staked to
+     */
+    AccountID accountID = 1;
+
+    /**
+     * Each of the proxy staking accounts, and the amount they are proxy staking
+     */
+    repeated ProxyStaker proxyStaker = 2;
+}
+
+/**
+ * Response when the client sends the node CryptoGetStakersQuery
+ */
+message CryptoGetStakersResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * List of accounts proxy staking to this account, and the amount each is currently proxy
+     * staking
+     */
+    AllProxyStakers stakers = 3;
+}

--- a/hapi/hedera-protobufs/services/crypto_service.proto
+++ b/hapi/hedera-protobufs/services/crypto_service.proto
@@ -1,0 +1,119 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+
+import "query.proto";
+import "response.proto";
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * Transactions and queries for the Crypto Service
+ */
+service CryptoService {
+    /**
+     * Creates a new account by submitting the transaction
+     */
+    rpc createAccount (Transaction) returns (TransactionResponse);
+
+    /**
+     * Updates an account by submitting the transaction
+     */
+    rpc updateAccount (Transaction) returns (TransactionResponse);
+
+    /**
+     * Initiates a transfer by submitting the transaction
+     */
+    rpc cryptoTransfer (Transaction) returns (TransactionResponse);
+
+    /**
+     * Deletes and account by submitting the transaction
+     */
+    rpc cryptoDelete (Transaction) returns (TransactionResponse);
+
+    /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    rpc approveAllowances (Transaction) returns (TransactionResponse);
+
+    /**
+     * Deletes one or more of the specific approved NFT serial numbers on an owner account.
+     */
+    rpc deleteAllowances (Transaction) returns (TransactionResponse);
+
+    /**
+     * (NOT CURRENTLY SUPPORTED) Adds a livehash
+     */
+    rpc addLiveHash (Transaction) returns (TransactionResponse);
+
+    /**
+     * (NOT CURRENTLY SUPPORTED) Deletes a livehash
+     */
+    rpc deleteLiveHash (Transaction) returns (TransactionResponse);
+
+    /**
+     * (NOT CURRENTLY SUPPORTED) Retrieves a livehash for an account
+     */
+    rpc getLiveHash (Query) returns (Response);
+
+    /**
+     * Returns all transactions in the last 180s of consensus time for which the given account was
+     * the effective payer <b>and</b> network property <tt>ledger.keepRecordsInState</tt> was
+     * <tt>true</tt>.
+     */
+    rpc getAccountRecords (Query) returns (Response);
+
+    /**
+     * Retrieves the balance of an account
+     */
+    rpc cryptoGetBalance (Query) returns (Response);
+
+    /**
+     * Retrieves the metadata of an account
+     */
+    rpc getAccountInfo (Query) returns (Response);
+
+    /**
+     * Retrieves the latest receipt for a transaction that is either awaiting consensus, or reached
+     * consensus in the last 180 seconds
+     */
+    rpc getTransactionReceipts (Query) returns (Response);
+
+    /**
+     * (NOT CURRENTLY SUPPORTED) Returns the records of transactions recently funded by an account
+     */
+    rpc getFastTransactionRecord (Query) returns (Response);
+
+    /**
+     * Retrieves the record of a transaction that is either awaiting consensus, or reached consensus
+     * in the last 180 seconds
+     */
+    rpc getTxRecordByTxID (Query) returns (Response);
+
+    /**
+     * (NOT CURRENTLY SUPPORTED) Retrieves the stakers for a node by account id
+     */
+    rpc getStakersByAccountID (Query) returns (Response);
+}

--- a/hapi/hedera-protobufs/services/crypto_transfer.proto
+++ b/hapi/hedera-protobufs/services/crypto_transfer.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Transfers cryptocurrency among two or more accounts by making the desired adjustments to their
+ * balances. Each transfer list can specify up to 10 adjustments. Each negative amount is withdrawn
+ * from the corresponding account (a sender), and each positive one is added to the corresponding
+ * account (a receiver). The amounts list must sum to zero. Each amount is a number of tinybars
+ * (there are 100,000,000 tinybars in one hbar).  If any sender account fails to have sufficient
+ * hbars, then the entire transaction fails, and none of those transfers occur, though the
+ * transaction fee is still charged. This transaction must be signed by the keys for all the sending
+ * accounts, and for any receiving accounts that have receiverSigRequired == true. The signatures
+ * are in the same order as the accounts, skipping those accounts that don't need a signature. 
+ */
+message CryptoTransferTransactionBody {
+    /**
+     * The desired hbar balance adjustments
+     */
+    TransferList transfers = 1;
+
+    /**
+     * The desired token unit balance adjustments; if any custom fees are assessed, the ledger will
+     * try to deduct them from the payer of this CryptoTransfer, resolving the transaction to
+     * INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE if this is not possible
+     */
+    repeated TokenTransferList tokenTransfers = 2;
+}

--- a/hapi/hedera-protobufs/services/crypto_update.proto
+++ b/hapi/hedera-protobufs/services/crypto_update.proto
@@ -1,0 +1,162 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+import "timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * Change properties for the given account. Any null field is ignored (left unchanged). This
+ * transaction must be signed by the existing key for this account. If the transaction is changing
+ * the key field, then the transaction must be signed by both the old key (from before the change)
+ * and the new key. The old key must sign for security. The new key must sign as a safeguard to
+ * avoid accidentally changing to an invalid key, and then having no way to recover. 
+ * If the update transaction sets the <tt>auto_renew_account</tt> field to anything other 
+ * than the sentinel <tt>0.0.0</tt>, the key of the referenced account must sign.
+ */
+message CryptoUpdateTransactionBody {
+    /**
+     * The account ID which is being updated in this transaction
+     */
+    AccountID accountIDToUpdate = 2;
+
+    /**
+     * The new key
+     */
+    Key key = 3;
+
+    /**
+     * [Deprecated] ID of the account to which this account is proxy staked. If proxyAccountID is null, or is an
+     * invalid account, or is an account that isn't a node, then this account is automatically proxy
+     * staked to a node chosen by the network, but without earning payments. If the proxyAccountID
+     * account refuses to accept proxy staking , or if it is not currently running a node, then it
+     * will behave as if proxyAccountID was null.
+     */
+    AccountID proxyAccountID = 4 [deprecated = true];
+
+    /**
+     * [Deprecated]. Payments earned from proxy staking are shared between the node and this
+     * account, with proxyFraction / 10000 going to this account
+     */
+    int32 proxyFraction = 5 [deprecated = true];
+
+    oneof sendRecordThresholdField {
+        /**
+         * [Deprecated]. The new threshold amount (in tinybars) for which an account record is
+         * created for any send/withdraw transaction
+         */
+        uint64 sendRecordThreshold = 6 [deprecated = true];
+
+        /**
+         * [Deprecated]. The new threshold amount (in tinybars) for which an account record is
+         * created for any send/withdraw transaction
+         */
+        google.protobuf.UInt64Value sendRecordThresholdWrapper = 11 [deprecated = true];
+
+    }
+
+    oneof receiveRecordThresholdField {
+        /**
+         * [Deprecated]. The new threshold amount (in tinybars) for which an account record is
+         * created for any receive/deposit transaction.
+         */
+        uint64 receiveRecordThreshold = 7 [deprecated = true];
+
+        /**
+         * [Deprecated]. The new threshold amount (in tinybars) for which an account record is
+         * created for any receive/deposit transaction.
+         */
+        google.protobuf.UInt64Value receiveRecordThresholdWrapper = 12 [deprecated = true];
+    }
+
+    /**
+     * The duration in which it will automatically extend the expiration period. If it doesn't have
+     * enough balance, it extends as long as possible. If it is empty when it expires, then it is
+     * deleted.
+     */
+    Duration autoRenewPeriod = 8;
+
+    /**
+     * The new expiration time to extend to (ignored if equal to or before the current one)
+     */
+    Timestamp expirationTime = 9;
+
+    oneof receiverSigRequiredField {
+        /**
+         * [Deprecated] Do NOT use this field to set a false value because the server cannot
+         * distinguish from the default value. Use receiverSigRequiredWrapper field for this
+         * purpose.
+         */
+        bool receiverSigRequired = 10 [deprecated = true];
+
+        /**
+         * If true, this account's key must sign any transaction depositing into this account (in
+         * addition to all withdrawals)
+         */
+        google.protobuf.BoolValue receiverSigRequiredWrapper = 13;
+    }
+
+    /**
+     * If set, the new memo to be associated with the account (UTF-8 encoding max 100 bytes)
+     */
+    google.protobuf.StringValue memo = 14;
+
+    /**
+     * If set, modify the maximum number of tokens that can be auto-associated with the
+     * account.<br/>
+     * If this is set and less than or equal to `used_auto_associations`, or 0, then this account
+     * MUST manually associate with a token before transacting in that token.<br/>
+     * This value MAY also be `-1` to indicate no limit.<br/>
+     * This value MUST NOT be less than `-1`.
+     */
+    google.protobuf.Int32Value max_automatic_token_associations = 15;
+
+    /**
+     * ID of the account or node to which this account is staking.
+     */
+    oneof staked_id {
+
+        /**
+         * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
+         * this field removes this account's staked account ID.
+         */
+        AccountID staked_account_id = 16;
+
+        /**
+         * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
+         * removes this account's staked node ID.
+         */
+        int64 staked_node_id = 17;
+    }
+
+    /**
+     * If true, the account declines receiving a staking reward. The default value is false.
+     */
+    google.protobuf.BoolValue decline_reward = 18;
+}

--- a/hapi/hedera-protobufs/services/custom_fees.proto
+++ b/hapi/hedera-protobufs/services/custom_fees.proto
@@ -1,0 +1,175 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * A fraction of the transferred units of a token to assess as a fee. The amount assessed will never
+ * be less than the given minimum_amount, and never greater than the given maximum_amount.  The
+ * denomination is always units of the token to which this fractional fee is attached.
+ */
+message FractionalFee {
+  /**
+   * The fraction of the transferred units to assess as a fee
+   */
+  Fraction fractional_amount = 1;
+
+  /**
+   * The minimum amount to assess
+   */
+  int64 minimum_amount = 2;
+
+  /**
+   * The maximum amount to assess (zero implies no maximum)
+   */
+  int64 maximum_amount = 3;
+
+  /**
+   * If true, assesses the fee to the sender, so the receiver gets the full amount from the token
+   * transfer list, and the sender is charged an additional fee; if false, the receiver does NOT get
+   * the full amount, but only what is left over after paying the fractional fee
+   */
+  bool net_of_transfers = 4;
+}
+
+/**
+ * A fixed number of units (hbar or token) to assess as a fee during a CryptoTransfer that transfers
+ * units of the token to which this fixed fee is attached.
+ */
+message FixedFee {
+  /**
+   * The number of units to assess as a fee
+   */
+  int64 amount = 1;
+
+  /**
+   * The denomination of the fee; taken as hbar if left unset and, in a TokenCreate, taken as the id
+   * of the newly created token if set to the sentinel value of 0.0.0
+   */
+  TokenID denominating_token_id = 2;
+}
+
+/**
+ * A fee to assess during a CryptoTransfer that changes ownership of an NFT. Defines the fraction of
+ * the fungible value exchanged for an NFT that the ledger should collect as a royalty. ("Fungible
+ * value" includes both ℏ and units of fungible HTS tokens.) When the NFT sender does not receive
+ * any fungible value, the ledger will assess the fallback fee, if present, to the new NFT owner.
+ * Royalty fees can only be added to tokens of type type NON_FUNGIBLE_UNIQUE.
+ *
+ * **IMPORTANT:** Users must understand that native royalty fees are _strictly_ a convenience feature, 
+ * and that the network cannot enforce inescapable royalties on the exchange of a non-fractional NFT. 
+ * For example, if the counterparties agree to split their value transfer and NFT exchange into separate 
+ * transactions, the network cannot possibly intervene. (And note the counterparties could use a smart 
+ * contract to make this split transaction atomic if they do not trust each other.)
+ * 
+ * Counterparties that _do_ wish to respect creator royalties should follow the pattern the network 
+ * recognizes: The NFT sender and receiver should both sign a single `CryptoTransfer` that credits 
+ * the sender with all the fungible value the receiver is exchanging for the NFT.
+ * 
+ * Similarly, a marketplace using an approved spender account for an escrow transaction should credit 
+ * the account selling the NFT in the same `CryptoTransfer` that deducts fungible value from the buying 
+ * account. 
+ * 
+ * There is an [open HIP discussion](https://github.com/hashgraph/hedera-improvement-proposal/discussions/578)
+ * that proposes to broaden the class of transactions for which the network automatically collects
+ * royalties. If this interests or concerns you, please add your voice to that discussion.
+ */
+message RoyaltyFee {
+  /**
+   * The fraction of fungible value exchanged for an NFT to collect as royalty
+   */
+  Fraction exchange_value_fraction = 1;
+
+  /**
+   * If present, the fixed fee to assess to the NFT receiver when no fungible value is exchanged
+   * with the sender
+   */
+  FixedFee fallback_fee = 2;
+}
+
+/**
+ * A transfer fee to assess during a CryptoTransfer that transfers units of the token to which the
+ * fee is attached. A custom fee may be either fixed or fractional, and must specify a fee collector
+ * account to receive the assessed fees. Only positive fees may be assessed.
+ */
+message CustomFee {
+  oneof fee {
+    /**
+     * Fixed fee to be charged
+     */
+    FixedFee fixed_fee = 1;
+
+    /**
+     * Fractional fee to be charged
+     */
+    FractionalFee fractional_fee = 2;
+
+    /**
+     * Royalty fee to be charged
+     */
+    RoyaltyFee royalty_fee = 4;
+
+  }
+  /**
+   * The account to receive the custom fee
+   */
+  AccountID fee_collector_account_id = 3;
+
+  /**
+   * If true, exempts all the token's fee collection accounts from this fee.
+   * (The token's treasury and the above fee_collector_account_id will always
+   * be exempt. Please see <a href="https://hips.hedera.com/hip/hip-573">HIP-573</a> 
+   * for details.)
+   */
+  bool all_collectors_are_exempt = 5;
+}
+
+/**
+ * A custom transfer fee that was assessed during handling of a CryptoTransfer.
+ */
+message AssessedCustomFee {
+  /**
+   * The number of units assessed for the fee
+   */
+  int64 amount = 1;
+
+  /**
+   * The denomination of the fee; taken as hbar if left unset
+   */
+  TokenID token_id = 2;
+
+  /**
+   * The account to receive the assessed fee
+   */
+  AccountID fee_collector_account_id = 3;
+
+  /**
+   * The account(s) whose final balances would have been higher in the absence of this assessed fee
+   */
+  repeated AccountID effective_payer_account_id = 4;
+}

--- a/hapi/hedera-protobufs/services/duration.proto
+++ b/hapi/hedera-protobufs/services/duration.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A length of time in seconds.
+ */
+message Duration {
+    /**
+     * The number of seconds
+     */
+    int64 seconds = 1;
+}

--- a/hapi/hedera-protobufs/services/ethereum_transaction.proto
+++ b/hapi/hedera-protobufs/services/ethereum_transaction.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+message EthereumTransactionBody {
+
+  /**
+   * The raw Ethereum transaction (RLP encoded type 0, 1, and 2). Complete 
+   * unless the callData field is set.
+   */
+  bytes ethereum_data = 1;
+
+  /**
+   * For large transactions (for example contract create) this is the callData
+   * of the ethereumData. The data in the ethereumData will be re-written with 
+   * the callData element as a zero length string with the original contents in 
+   * the referenced file at time of execution. The ethereumData will need to be 
+   * "rehydrated" with the callData for signature validation to pass.
+   */
+  FileID call_data = 2;
+
+  /**
+   * The maximum amount, in tinybars, that the payer of the hedera transaction 
+   * is willing to pay to complete the transaction.
+   *
+   * Ordinarily the account with the ECDSA alias corresponding to the public 
+   * key that is extracted from the ethereum_data signature is responsible for
+   * fees that result from the execution of the transaction. If that amount of
+   * authorized fees is not sufficient then the payer of the transaction can be
+   * charged, up to but not exceeding this amount. If the ethereum_data 
+   * transaction authorized an amount that was insufficient then the payer will
+   * only be charged the amount needed to make up the difference. If the gas 
+   * price in the transaction was set to zero then the payer will be assessed 
+   * the entire fee.
+   */
+  int64 max_gas_allowance = 3;
+}

--- a/hapi/hedera-protobufs/services/exchange_rate.proto
+++ b/hapi/hedera-protobufs/services/exchange_rate.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "timestamp.proto";
+
+
+/**
+ * An exchange rate between hbar and cents (USD) and the time at which the exchange rate will
+ * expire, and be superseded by a new exchange rate. 
+ */
+message ExchangeRate {
+    /**
+     * Denominator in calculation of exchange rate between hbar and cents
+     */
+    int32 hbarEquiv = 1;
+
+    /**
+     * Numerator in calculation of exchange rate between hbar and cents
+     */
+    int32 centEquiv = 2;
+
+    /**
+     * Expiration time in seconds for this exchange rate
+     */
+    TimestampSeconds expirationTime = 3;
+}
+
+/**
+ * Two sets of exchange rates
+ */
+message ExchangeRateSet {
+    /**
+     * Current exchange rate
+     */
+    ExchangeRate currentRate = 1;
+
+    /**
+     * Next exchange rate which will take effect when current rate expires
+     */
+    ExchangeRate nextRate = 2;
+}

--- a/hapi/hedera-protobufs/services/file_append.proto
+++ b/hapi/hedera-protobufs/services/file_append.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+
+import "basic_types.proto";
+
+/**
+ * Append the given contents to the end of the specified file. If a file is too big to create with a
+ * single FileCreateTransaction, then it can be created with the first part of its contents, and
+ * then appended as many times as necessary to create the entire file. This transaction must be
+ * signed by all initial M-of-M KeyList keys. If keys contains additional KeyList or ThresholdKey
+ * then M-of-M secondary KeyList or ThresholdKey signing requirements must be meet. 
+ */
+message FileAppendTransactionBody {
+    /**
+     * The file to which the bytes will be appended
+     */
+    FileID fileID = 2;
+
+    /**
+     * The bytes that will be appended to the end of the specified file
+     */
+    bytes contents = 4;
+}

--- a/hapi/hedera-protobufs/services/file_create.proto
+++ b/hapi/hedera-protobufs/services/file_create.proto
@@ -1,0 +1,104 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+/**
+ * Create a new file, containing the given contents.
+ * After the file is created, the FileID for it can be found in the receipt, or record, or retrieved
+ * with a GetByKey query.
+ *
+ * The file contains the specified contents (possibly empty). The file will automatically disappear
+ * at the expirationTime, unless its expiration is extended by another transaction before that time.
+ * If the file is deleted, then its contents will become empty and it will be marked as deleted
+ * until it expires, and then it will cease to exist.
+ * 
+ * The keys field is a list of keys. All keys within the top-level key list must sign (M-M) to
+ * create or modify a file. However, to delete the file, only one key (1-M) is required to sign from
+ * the top-level key list.  Each of those "keys" may itself be threshold key containing other keys
+ * (including other threshold keys). In other words, the behavior is an AND for create/modify, OR
+ * for delete. This is useful for acting as a revocation server. If it is desired to have the
+ * behavior be AND for all 3 operations (or OR for all 3), then the list should have only a single
+ * Key, which is a threshold key, with N=1 for OR, N=M for AND. If the auto_renew_account field 
+ * is set, the key of the referenced account must sign.
+ *
+ * If a file is created without ANY keys in the keys field, the file is immutable and ONLY the
+ * expirationTime of the file can be changed with a FileUpdate transaction. The file contents or its
+ * keys cannot be changed.
+ *
+ * An entity (account, file, or smart contract instance) must be created in a particular realm. If
+ * the realmID is left null, then a new realm will be created with the given admin key. If a new
+ * realm has a null adminKey, then anyone can create/modify/delete entities in that realm. But if an
+ * admin key is given, then any transaction to create/modify/delete an entity in that realm must be
+ * signed by that key, though anyone can still call functions on smart contract instances that exist
+ * in that realm. A realm ceases to exist when everything within it has expired and no longer
+ * exists.
+ *
+ * The current API ignores shardID, realmID, and newRealmAdminKey, and creates everything in shard 0
+ * and realm 0, with a null key. Future versions of the API will support multiple realms and
+ * multiple shards.
+ */
+message FileCreateTransactionBody {
+    /**
+     * The time at which this file should expire (unless FileUpdateTransaction is used before then
+     * to extend its life)
+     */
+    Timestamp expirationTime = 2;
+
+    /**
+     * All keys at the top level of a key list must sign to create or modify the file. Any one of
+     * the keys at the top level key list can sign to delete the file.
+     */
+    KeyList keys = 3;
+
+    /**
+     * The bytes that are the contents of the file
+     */
+    bytes contents = 4;
+
+    /**
+     * Shard in which this file is created
+     */
+    ShardID shardID = 5;
+
+    /**
+     * The Realm in which to the file is created (leave this null to create a new realm)
+     */
+    RealmID realmID = 6;
+
+    /**
+     * If realmID is null, then this the admin key for the new realm that will be created
+     */
+    Key newRealmAdminKey = 7;
+
+    /**
+     * The memo associated with the file (UTF-8 encoding max 100 bytes)
+     */
+    string memo = 8;
+}

--- a/hapi/hedera-protobufs/services/file_delete.proto
+++ b/hapi/hedera-protobufs/services/file_delete.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Delete the given file. After deletion, it will be marked as deleted and will have no contents.
+ * But information about it will continue to exist until it expires. A list of keys was given when
+ * the file was created. All the top level keys on that list must sign transactions to create or
+ * modify the file, but any single one of the top level keys can be used to delete the file. This
+ * transaction must be signed by 1-of-M KeyList keys. If keys contains additional KeyList or
+ * ThresholdKey then 1-of-M secondary KeyList or ThresholdKey signing requirements must be meet.
+ */
+message FileDeleteTransactionBody {
+    /**
+     * The file to delete. It will be marked as deleted until it expires. Then it will disappear.
+     */
+    FileID fileID = 2;
+}

--- a/hapi/hedera-protobufs/services/file_get_contents.proto
+++ b/hapi/hedera-protobufs/services/file_get_contents.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get the contents of a file. The content field is empty (no bytes) if the file is empty.
+ */
+message FileGetContentsQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The file ID of the file whose contents are requested
+     */
+    FileID fileID = 2;
+}
+
+/**
+ * Response when the client sends the node FileGetContentsQuery
+ */
+message FileGetContentsResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    message FileContents {
+        /**
+         * The file ID of the file whose contents are being returned
+         */
+        FileID fileID = 1;
+
+        /**
+         * The bytes contained in the file
+         */
+        bytes contents = 2;
+    }
+
+    /**
+     * the file ID and contents (a state proof can be generated for this)
+     */
+    FileContents fileContents = 2;
+}
+
+

--- a/hapi/hedera-protobufs/services/file_get_info.proto
+++ b/hapi/hedera-protobufs/services/file_get_info.proto
@@ -1,0 +1,106 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "timestamp.proto";
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get all of the information about a file, except for its contents. When a file expires, it no
+ * longer exists, and there will be no info about it, and the fileInfo field will be blank. If a
+ * transaction or smart contract deletes the file, but it has not yet expired, then the fileInfo
+ * field will be non-empty, the deleted field will be true, its size will be 0, and its contents
+ * will be empty.
+ */
+message FileGetInfoQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The file ID of the file for which information is requested
+     */
+    FileID fileID = 2;
+}
+
+/**
+ * Response when the client sends the node FileGetInfoQuery
+ */
+message FileGetInfoResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+
+    message FileInfo {
+        /**
+         * The file ID of the file for which information is requested
+         */
+        FileID fileID = 1;
+
+        /**
+         * Number of bytes in contents
+         */
+        int64 size = 2;
+
+        /**
+         * The current time at which this account is set to expire
+         */
+        Timestamp expirationTime = 3;
+
+        /**
+         * True if deleted but not yet expired
+         */
+        bool deleted = 4;
+
+        /**
+         * One of these keys must sign in order to modify or delete the file
+         */
+        KeyList keys = 5;
+
+        /**
+         * The memo associated with the file
+         */
+        string memo = 6;
+
+        /**
+         * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+         */
+        bytes ledger_id = 7;
+    }
+
+    /**
+     * The information about the file
+     */
+    FileInfo fileInfo = 2;
+}

--- a/hapi/hedera-protobufs/services/file_service.proto
+++ b/hapi/hedera-protobufs/services/file_service.proto
@@ -1,0 +1,75 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+
+import "query.proto";
+import "response.proto";
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * Transactions and queries for the file service. 
+ */
+service FileService {
+    /**
+     * Creates a file
+     */
+    rpc createFile (Transaction) returns (TransactionResponse);
+
+    /**
+     * Updates a file
+     */
+    rpc updateFile (Transaction) returns (TransactionResponse);
+
+    /**
+     * Deletes a file
+     */
+    rpc deleteFile (Transaction) returns (TransactionResponse);
+
+    /**
+     * Appends to a file
+     */
+    rpc appendContent (Transaction) returns (TransactionResponse);
+
+    /**
+     * Retrieves the file contents
+     */
+    rpc getFileContent (Query) returns (Response);
+
+    /**
+     * Retrieves the file information
+     */
+    rpc getFileInfo (Query) returns (Response);
+
+    /**
+     * Deletes a file if the submitting account has network admin privileges
+     */
+    rpc systemDelete (Transaction) returns (TransactionResponse);
+
+    /**
+     * Undeletes a file if the submitting account has network admin privileges
+     */
+    rpc systemUndelete (Transaction) returns (TransactionResponse);
+}

--- a/hapi/hedera-protobufs/services/file_update.proto
+++ b/hapi/hedera-protobufs/services/file_update.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * Modify the metadata and/or contents of a file. If a field is not set in the transaction body, the
+ * corresponding file attribute will be unchanged. This transaction must be signed by all the keys
+ * in the top level of a key list (M-of-M) of the file being updated. If the keys themselves are
+ * being updated, then the transaction must also be signed by all the new keys. If the keys contain
+ * additional KeyList or ThresholdKey then M-of-M secondary KeyList or ThresholdKey signing
+ * requirements must be meet If the update transaction sets the <tt>auto_renew_account_id</tt> field 
+ * to anything other than the sentinel <tt>0.0.0</tt>, the key of the referenced account must sign.
+ */
+message FileUpdateTransactionBody {
+    /**
+     * The ID of the file to update
+     */
+    FileID fileID = 1;
+
+    /**
+     * The new expiry time (ignored if not later than the current expiry)
+     */
+    Timestamp expirationTime = 2;
+
+    /**
+     * The new list of keys that can modify or delete the file
+     */
+    KeyList keys = 3;
+
+    /**
+     * The new contents that should overwrite the file's current contents
+     */
+    bytes contents = 4;
+
+    /**
+     * If set, the new memo to be associated with the file (UTF-8 encoding max 100 bytes)
+     */
+    google.protobuf.StringValue memo = 5;
+}

--- a/hapi/hedera-protobufs/services/freeze.proto
+++ b/hapi/hedera-protobufs/services/freeze.proto
@@ -1,0 +1,82 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.freeze">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "timestamp.proto";
+import "basic_types.proto";
+import "freeze_type.proto";
+
+/**
+ * At consensus, sets the consensus time at which the platform should stop creating events and
+ * accepting transactions, and enter a maintenance window.
+ */
+message FreezeTransactionBody {
+    /**
+     * !! DEPRECATED and REJECTED by nodes
+     * The start hour (in UTC time), a value between 0 and 23
+     */
+    int32 startHour = 1 [deprecated=true];
+
+    /**
+     * !! DEPRECATED and REJECTED by nodes
+     * The start minute (in UTC time), a value between 0 and 59
+     */
+    int32 startMin = 2 [deprecated=true];
+
+    /**
+     * !! DEPRECATED and REJECTED by nodes
+     * The end hour (in UTC time), a value between 0 and 23
+     */
+    int32 endHour = 3 [deprecated=true];
+
+    /**
+     * !! DEPRECATED and REJECTED by nodes
+     * The end minute (in UTC time), a value between 0 and 59
+     */
+    int32 endMin = 4 [deprecated=true];
+
+    /**
+     * If set, the file whose contents should be used for a network software update during the
+     * maintenance window.
+     */
+    FileID update_file = 5;
+
+    /**
+     * If set, the expected hash of the contents of the update file (used to verify the update).
+     */
+    bytes file_hash = 6;
+
+    /**
+     * The consensus time at which the maintenance window should begin.
+     */
+    Timestamp start_time = 7;
+
+    /**
+     * The type of network freeze or upgrade operation to perform.
+     */
+    FreezeType freeze_type = 8;
+}

--- a/hapi/hedera-protobufs/services/freeze_service.proto
+++ b/hapi/hedera-protobufs/services/freeze_service.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.freeze">>> This comment is special code for setting PBJ Compiler java package
+
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * The request and responses for freeze service.
+ */
+service FreezeService {
+    /**
+     * Freezes the nodes by submitting the transaction. The grpc server returns the
+     * TransactionResponse
+     */
+    rpc freeze (Transaction) returns (TransactionResponse);
+}

--- a/hapi/hedera-protobufs/services/freeze_type.proto
+++ b/hapi/hedera-protobufs/services/freeze_type.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.freeze">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+* The type of network freeze or upgrade operation to be performed. This type dictates which 
+* fields are required. 
+*/
+enum FreezeType {
+    /**
+     * An (invalid) default value for this enum, to ensure the client explicitly sets 
+     * the intended type of freeze transaction.
+     */
+    UNKNOWN_FREEZE_TYPE = 0;
+
+    /**
+     * Freezes the network at the specified time. The start_time field must be provided and 
+     * must reference a future time. Any values specified for the update_file and file_hash 
+     * fields will be ignored. This transaction does not perform any network changes or 
+     * upgrades and requires manual intervention to restart the network. 
+     */
+    FREEZE_ONLY = 1; 
+
+    /**
+     * A non-freezing operation that initiates network wide preparation in advance of a 
+     * scheduled freeze upgrade. The update_file and file_hash fields must be provided and 
+     * valid. The start_time field may be omitted and any value present will be ignored.
+     */
+    PREPARE_UPGRADE = 2; 
+
+    /**
+     * Freezes the network at the specified time and performs the previously prepared 
+     * automatic upgrade across the entire network. 
+     */
+    FREEZE_UPGRADE = 3; 
+
+    /**
+     * Aborts a pending network freeze operation.
+     */
+    FREEZE_ABORT = 4; 
+
+    /**
+     * Performs an immediate upgrade on auxilary services and containers providing 
+     * telemetry/metrics. Does not impact network operations. 
+     */
+    TELEMETRY_UPGRADE = 5; 
+}

--- a/hapi/hedera-protobufs/services/get_account_details.proto
+++ b/hapi/hedera-protobufs/services/get_account_details.proto
@@ -1,0 +1,225 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "timestamp.proto";
+import "duration.proto";
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "crypto_add_live_hash.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * Gets all the information about an account, including balance and allowances. This does not get the list of
+ * account records.
+ */
+message GetAccountDetailsQuery {
+    /**
+     * Account details sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The account ID for which information is requested
+     */
+    AccountID account_id = 2;
+}
+
+/**
+ * Response when the client sends the node GetAccountDetailsQuery
+ */
+message GetAccountDetailsResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    message AccountDetails {
+        /**
+         * The account ID for which this information applies
+         */
+        AccountID account_id = 1;
+
+        /**
+         * The Contract Account ID comprising of both the contract instance and the cryptocurrency
+         * account owned by the contract instance, in the format used by Solidity
+         */
+        string contract_account_id = 2;
+
+        /**
+         * If true, then this account has been deleted, it will disappear when it expires, and all
+         * transactions for it will fail except the transaction to extend its expiration date
+         */
+        bool deleted = 3;
+
+        /**
+         * [Deprecated] The Account ID of the account to which this is proxy staked. If proxyAccountID is null,
+         * or is an invalid account, or is an account that isn't a node, then this account is
+         * automatically proxy staked to a node chosen by the network, but without earning payments.
+         * If the proxyAccountID account refuses to accept proxy staking , or if it is not currently
+         * running a node, then it will behave as if proxyAccountID was null.
+         */
+        AccountID proxy_account_id = 4 [deprecated = true];
+
+        /**
+         * The total number of tinybars proxy staked to this account
+         */
+        int64 proxy_received = 5;
+
+        /**
+         * The key for the account, which must sign in order to transfer out, or to modify the
+         * account in any way other than extending its expiration date.
+         */
+        Key key = 6;
+
+        /**
+         * The current balance of account in tinybars
+         */
+        uint64 balance = 7;
+
+        /**
+         * If true, no transaction can transfer to this account unless signed by this account's key
+         */
+        bool receiver_sig_required = 8;
+
+        /**
+         * The TimeStamp time at which this account is set to expire
+         */
+        Timestamp expiration_time = 9;
+
+        /**
+         * The duration for expiration time will extend every this many seconds. If there are
+         * insufficient funds, then it extends as long as possible. If it is empty when it expires,
+         * then it is deleted.
+         */
+        Duration auto_renew_period = 10;
+
+        /**
+         * All tokens related to this account
+         */
+        repeated TokenRelationship token_relationships = 11;
+
+        /**
+         * The memo associated with the account
+         */
+        string memo = 12;
+
+        /**
+         * The number of NFTs owned by this account
+         */
+        int64 owned_nfts = 13;
+
+        /**
+         * The maximum number of tokens that an Account can be implicitly associated with.
+         */
+        int32 max_automatic_token_associations = 14;
+
+        /**
+         * The alias of this account
+         */
+        bytes alias = 15;
+
+        /**
+         * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs.
+         */
+        bytes ledger_id = 16;
+
+        /**
+         * All of the hbar allowances approved by the account owner.
+         */
+        repeated GrantedCryptoAllowance granted_crypto_allowances = 17;
+
+        /**
+         * All of the non-fungible token allowances approved by the account owner.
+         */
+        repeated GrantedNftAllowance granted_nft_allowances = 18;
+
+        /**
+         * All of the fungible token allowances approved by the account owner.
+         */
+        repeated GrantedTokenAllowance granted_token_allowances = 19;
+
+    }
+    /**
+     * Details of the account (a state proof can be generated for this)
+     */
+    AccountDetails account_details = 2;
+}
+
+/**
+ * A granted allowance of hbar transfers for a spender relative to the owner account.
+ */
+message GrantedCryptoAllowance {
+    /**
+     * The account ID of the spender of the hbar allowance.
+     */
+    AccountID spender = 1;
+
+    /**
+     * The amount of the spender's allowance in tinybars.
+     */
+    int64 amount = 2;
+}
+
+/**
+ * A granted allowance for all the NFTs of a token for a spender relative to the owner account.
+ */
+message GrantedNftAllowance {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The account ID of the spender that has been granted access to all NFTs of the owner
+     */
+    AccountID spender = 2;
+}
+
+/**
+ * A granted allowance of fungible token transfers for a spender relative to the owner account.
+ */
+message GrantedTokenAllowance {
+    /**
+     * The token that the allowance pertains to.
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The account ID of the token allowance spender.
+     */
+    AccountID spender = 2;
+
+    /**
+     * The amount of the spender's token allowance.
+     */
+    int64 amount = 3;
+}
+

--- a/hapi/hedera-protobufs/services/get_by_key.proto
+++ b/hapi/hedera-protobufs/services/get_by_key.proto
@@ -1,0 +1,94 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "crypto_add_live_hash.proto";
+
+/**
+ * Get all accounts, claims, files, and smart contract instances whose associated keys include the
+ * given Key. The given Key must not be a contractID or a ThresholdKey. This is not yet implemented
+ * in the API, but will be in the future.
+ */
+message GetByKeyQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The key to search for. It must not contain a contractID nor a ThresholdSignature.
+     */
+    Key key = 2;
+}
+
+/**
+ * the ID for a single entity (account, livehash, file, or smart contract instance)
+ */
+message EntityID {
+    oneof entity {
+        /**
+         * The Account ID for the cryptocurrency account
+         */
+        AccountID accountID = 1;
+
+        /**
+         * A uniquely identifying livehash of an acount
+         */
+        LiveHash liveHash = 2;
+
+        /**
+         * The file ID of the file
+         */
+        FileID fileID = 3;
+
+        /**
+         * The smart contract ID that identifies instance
+         */
+        ContractID contractID = 4;
+
+    }
+}
+
+/**
+ * Response when the client sends the node GetByKeyQuery
+ */
+message GetByKeyResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The list of entities that include this public key in their associated Key list
+     */
+    repeated EntityID entities = 2;
+}

--- a/hapi/hedera-protobufs/services/get_by_solidity_id.proto
+++ b/hapi/hedera-protobufs/services/get_by_solidity_id.proto
@@ -1,0 +1,76 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get the IDs in the format used by transactions, given the ID in the format used by Solidity. If
+ * the Solidity ID is for a smart contract instance, then both the ContractID and associated
+ * AccountID will be returned.
+ */
+message GetBySolidityIDQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The ID in the format used by Solidity
+     */
+    string solidityID = 2;
+}
+
+/**
+ * Response when the client sends the node GetBySolidityIDQuery
+ */
+message GetBySolidityIDResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The Account ID for the cryptocurrency account
+     */
+    AccountID accountID = 2;
+
+    /**
+     * The file Id for the file
+     */
+    FileID fileID = 3;
+
+    /**
+     * A smart contract ID for the instance (if this is included, then the associated accountID will
+     * also be included)
+     */
+    ContractID contractID = 4;
+}

--- a/hapi/hedera-protobufs/services/network_get_execution_time.proto
+++ b/hapi/hedera-protobufs/services/network_get_execution_time.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.network">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Gets the time in nanoseconds spent in <tt>handleTransaction</tt> for one or more 
+ * TransactionIDs (assuming they have reached consensus "recently", since only a limited 
+ * number of execution times are kept in-memory, depending on the value of the node-local 
+ * property <tt>stats.executionTimesToTrack</tt>).
+ */
+message NetworkGetExecutionTimeQuery {
+  /**
+   * standard info sent from client to node including the signed payment, and what kind of response
+   * is requested (cost, state proof, both, or neither).
+   */
+  QueryHeader header = 1;
+
+  /**
+   * The id(s) of the transactions to get the execution time(s) of
+   */
+  repeated TransactionID transaction_ids = 2;
+}
+
+/**
+ * Response when the client sends the node NetworkGetExecutionTimeQuery; returns
+ * INVALID_TRANSACTION_ID if any of the given TransactionIDs do not have available
+ * execution times in the answering node.
+ */
+message NetworkGetExecutionTimeResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The execution time(s) of the requested TransactionIDs, if available
+     */
+    repeated uint64 execution_times = 2;
+}

--- a/hapi/hedera-protobufs/services/network_get_version_info.proto
+++ b/hapi/hedera-protobufs/services/network_get_version_info.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.network">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get the deployed versions of Hedera Services and the HAPI proto in semantic version format
+ */
+message NetworkGetVersionInfoQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+}
+
+/**
+ * Response when the client sends the node NetworkGetVersionInfoQuery
+ */
+message NetworkGetVersionInfoResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The Hedera API (HAPI) protobuf version recognized by the responding node.
+     */
+    SemanticVersion hapiProtoVersion = 2;
+
+    /**
+     * The version of the Hedera Services software deployed on the responding node.
+     */
+    SemanticVersion hederaServicesVersion = 3;
+}

--- a/hapi/hedera-protobufs/services/network_service.proto
+++ b/hapi/hedera-protobufs/services/network_service.proto
@@ -1,0 +1,63 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.network">>> This comment is special code for setting PBJ Compiler java package
+
+import "query.proto";
+import "response.proto";
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * The requests and responses for different network services.
+ */
+service NetworkService {
+    /**
+     * Retrieves the active versions of Hedera Services and HAPI proto
+     */
+    rpc getVersionInfo (Query) returns (Response);
+
+    /**
+     * Retrieves the time in nanoseconds spent in <tt>handleTransaction</tt> for one or more 
+     * TransactionIDs (assuming they have reached consensus "recently", since only a limited 
+     * number of execution times are kept in-memory, depending on the value of the node-local 
+     * property <tt>stats.executionTimesToTrack</tt>).
+     */
+    rpc getExecutionTime (Query) returns (Response);
+
+    /**
+     * Submits a "wrapped" transaction to the network, skipping its standard prechecks. (Note that
+     * the "wrapper" <tt>UncheckedSubmit</tt> transaction is still subject to normal prechecks,
+     * including an authorization requirement that its payer be either the treasury or system admin
+     * account.)
+     */
+    rpc uncheckedSubmit (Transaction) returns (TransactionResponse);
+
+    /**
+     * Get all the information about an account, including balance and allowances. This does not get the list of
+     * account records.
+     */
+    rpc getAccountDetails (Query) returns (Response);
+}

--- a/hapi/hedera-protobufs/services/node_create.proto
+++ b/hapi/hedera-protobufs/services/node_create.proto
@@ -1,0 +1,140 @@
+syntax = "proto3";
+
+package com.hedera.hapi.node.addressbook;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * A transaction body to add a new consensus node to the network address book.
+ *
+ * This transaction body SHALL be considered a "privileged transaction".
+ *
+ * This message supports a transaction to create a new node in the network
+ * address book. The transaction, once complete, enables a new consensus node
+ * to join the network, and requires governing council authorization.
+ *
+ * - A `NodeCreateTransactionBody` MUST be signed by the governing council.
+ * - A `NodeCreateTransactionBody` MUST be signed by the `Key` assigned to the
+ *   `admin_key` field.
+ * - The newly created node information SHALL be added to the network address
+ *   book information in the network state.
+ * - The new entry SHALL be created in "state" but SHALL NOT participate in
+ *   network consensus and SHALL NOT be present in network "configuration"
+ *   until the next "upgrade" transaction (as noted below).
+ * - All new address book entries SHALL be added to the active network
+ *   configuration during the next `freeze` transaction with the field
+ *   `freeze_type` set to `PREPARE_UPGRADE`.
+ *
+ * ### Record Stream Effects
+ * Upon completion the newly assigned `node_id` SHALL be in the transaction
+ * receipt.
+ */
+message NodeCreateTransactionBody {
+    /**
+     * A Node account identifier.
+     * <p>
+     * This account identifier MUST be in the "account number" form.<br/>
+     * This account identifier MUST NOT use the alias field.<br/>
+     * If the identified account does not exist, this transaction SHALL fail.<br/>
+     * Multiple nodes MAY share the same node account.<br/>
+     * This field is REQUIRED.
+     */
+    proto.AccountID account_id = 1;
+
+    /**
+     * A short description of the node.
+     * <p>
+     * This value, if set, MUST NOT exceed 100 bytes when encoded as UTF-8.<br/>
+     * This field is OPTIONAL.
+     */
+    string description = 2;
+
+    /**
+     * A list of service endpoints for gossip.
+     * <p>
+     * These endpoints SHALL represent the published endpoints to which other
+     * consensus nodes may _gossip_ transactions.<br/>
+     * These endpoints MUST specify a port.<br/>
+     * This list MUST NOT be empty.<br/>
+     * This list MUST NOT contain more than `10` entries.<br/>
+     * The first two entries in this list SHALL be the endpoints published to
+     * all consensus nodes.<br/>
+     * All other entries SHALL be reserved for future use.
+     * <p>
+     * Each network may have additional requirements for these endpoints.
+     * A client MUST check network-specific documentation for those
+     * details.<br/>
+     * If the network configuration value `gossipFqdnRestricted` is set, then
+     * all endpoints in this list MUST supply only IP address.<br/>
+     * If the network configuration value `gossipFqdnRestricted` is _not_ set,
+     * then endpoints in this list MAY supply either IP address or FQDN, but
+     * MUST NOT supply both values for the same endpoint.
+     */
+    repeated proto.ServiceEndpoint gossip_endpoint = 3;
+
+    /**
+     * A list of service endpoints for gRPC calls.
+     * <p>
+     * These endpoints SHALL represent the published gRPC endpoints to which
+     * clients may submit transactions.<br/>
+     * These endpoints MUST specify a port.<br/>
+     * Endpoints in this list MAY supply either IP address or FQDN, but MUST
+     * NOT supply both values for the same endpoint.<br/>
+     * This list MUST NOT be empty.<br/>
+     * This list MUST NOT contain more than `8` entries.
+     */
+    repeated proto.ServiceEndpoint service_endpoint = 4;
+
+    /**
+     * A certificate used to sign gossip events.
+     * <p>
+     * This value MUST be a certificate of a type permitted for gossip
+     * signatures.<br/>
+     * This value MUST be the DER encoding of the certificate presented.<br/>
+     * This field is REQUIRED and MUST NOT be empty.
+     */
+    bytes gossip_ca_certificate = 5;
+
+    /**
+     * A hash of the node gRPC TLS certificate.
+     * <p>
+     * This value MAY be used to verify the certificate presented by the node
+     * during TLS negotiation for gRPC.<br/>
+     * This value MUST be a SHA-384 hash.<br/>
+     * The TLS certificate to be hashed MUST first be in PEM format and MUST be
+     * encoded with UTF-8 NFKD encoding to a stream of bytes provided to
+     * the hash algorithm.<br/>
+     * This field is OPTIONAL.
+     */
+    bytes grpc_certificate_hash = 6;
+
+    /**
+    * An administrative key controlled by the node operator.
+     * <p>
+     * This key MUST sign this transaction.<br/>
+     * This key MUST sign each transaction to update this node.<br/>
+     * This field MUST contain a valid `Key` value.<br/>
+     * This field is REQUIRED and MUST NOT be set to an empty `KeyList`.
+     */
+    proto.Key admin_key = 7;
+}

--- a/hapi/hedera-protobufs/services/node_delete.proto
+++ b/hapi/hedera-protobufs/services/node_delete.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package com.hedera.hapi.node.addressbook;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A transaction body to delete a node from the network address book.
+ *
+ * This transaction body SHALL be considered a "privileged transaction".
+ *
+ * - A `NodeDeleteTransactionBody` MUST be signed by the governing council.
+ * - Upon success, the address book entry SHALL enter a "pending delete"
+ *   state.
+ * - All address book entries pending deletion SHALL be removed from the
+ *   active network configuration during the next `freeze` transaction with
+ *   the field `freeze_type` set to `PREPARE_UPGRADE`.<br/>
+ * - A deleted address book node SHALL be removed entirely from network state.
+ * - A deleted address book node identifier SHALL NOT be reused.
+ *
+ * ### Record Stream Effects
+ * Upon completion the "deleted" `node_id` SHALL be in the transaction
+ * receipt.
+ */
+message NodeDeleteTransactionBody {
+    /**
+     * A consensus node identifier in the network state.
+     * <p>
+     * The node identified MUST exist in the network address book.<br/>
+     * The node identified MUST NOT be deleted.<br/>
+     * This value is REQUIRED.
+     */
+    uint64 node_id = 1;
+}

--- a/hapi/hedera-protobufs/services/node_stake_update.proto
+++ b/hapi/hedera-protobufs/services/node_stake_update.proto
@@ -1,0 +1,165 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+/**
+ * Updates the staking info at the end of staking period to indicate new staking period has started.
+ */
+message NodeStakeUpdateTransactionBody {
+  /**
+   * Time and date of the end of the staking period that is ending
+   */
+  Timestamp end_of_staking_period = 1;
+
+  /**
+   * Staking info of each node at the beginning of the new staking period
+   */
+  repeated NodeStake node_stake = 2;
+
+  /**
+   * The maximum reward rate, in tinybars per whole hbar, that any account could receive in this
+   * staking period.
+   */
+  int64 max_staking_reward_rate_per_hbar = 3;
+
+  /**
+   * The fraction of the network and service fees paid to the node reward account 0.0.801.
+   */
+  Fraction node_reward_fee_fraction = 4;
+
+  /**
+   * The maximum number of trailing periods for which a user can collect rewards. For example, if this
+   * is 365 with a UTC calendar day period, then users must collect rewards at least once per calendar
+   * year to avoid missing any value.
+   */
+  int64 staking_periods_stored = 5;
+
+  /**
+   * The number of minutes in a staking period. Note for the special case of 1440 minutes, periods are 
+   * treated as UTC calendar days, rather than repeating 1440 minute periods left-aligned at the epoch.
+   */
+  int64 staking_period = 6;
+
+  /**
+   * The fraction of the network and service fees paid to the staking reward account 0.0.800.
+   */
+  Fraction staking_reward_fee_fraction = 7;
+
+  /**
+   * The minimum balance of staking reward account 0.0.800 required to active rewards.
+   */
+  int64 staking_start_threshold = 8;
+
+  /**
+   * (DEPRECATED) The maximum total number of tinybars to be distributed as staking rewards in the 
+   * ending period. Please consult the max_total_reward field instead.
+   */
+  int64 staking_reward_rate = 9 [deprecated = true];
+
+  /**
+   * The amount of the staking reward funds (account 0.0.800) reserved to pay pending rewards that 
+   * have been earned but not collected.
+   */
+  int64 reserved_staking_rewards = 10;
+
+  /**
+   * The unreserved balance of account 0.0.800 at the close of the just-ending period; this value is 
+   * used to compute the HIP-782 balance ratio.
+   */
+  int64 unreserved_staking_reward_balance = 11;
+
+  /**
+   * The unreserved tinybar balance of account 0.0.800 required to achieve the maximum per-hbar reward 
+   * rate in any period; please see HIP-782 for details.
+   */
+  int64 reward_balance_threshold = 12;
+
+  /**
+   * The maximum amount of tinybar that can be staked for reward while still achieving the maximum 
+   * per-hbar reward rate in any period; please see HIP-782 for details.
+   */
+  int64 max_stake_rewarded = 13;
+
+  /**
+   * The maximum total tinybars that could be paid as staking rewards in the ending period, after 
+   * applying the settings for the 0.0.800 balance threshold and the maximum stake rewarded. This
+   * field replaces the deprecated field staking_reward_rate. It is only for convenience, since a 
+   * mirror node could also calculate its value by iterating the node_stake list and summing 
+   * stake_rewarded fields; then multiplying this sum by the max_staking_reward_rate_per_hbar.
+   */
+  int64 max_total_reward = 14;
+}
+
+/**
+ * Staking info for each node at the end of a staking period.
+ */
+message NodeStake {
+  /**
+   * The maximum stake (rewarded or not rewarded) this node can have as consensus weight. If its stake to
+   * reward is above this maximum at the start of a period, then accounts staking to the node in that 
+   * period will be rewarded at a lower rate scaled by (maxStake / stakeRewardStart).
+   */
+  int64 max_stake = 1;
+
+  /**
+   * The minimum stake (rewarded or not rewarded) this node must reach before having non-zero consensus weight.
+   * If its total stake is below this minimum at the start of a period, then accounts staking to the node in 
+   * that period will receive no rewards.
+   */
+  int64 min_stake = 2;
+
+  /**
+   * The id of this node.
+   */
+  int64 node_id = 3;
+
+  /**
+   * The reward rate _per whole hbar_ that was staked to this node with declineReward=false from the start of 
+   * the staking period that is ending. 
+   */
+  int64 reward_rate = 4;
+
+  /**
+   * Consensus weight of this node for the new staking period.
+   */
+  int64 stake = 5;
+
+  /**
+   * Total of (balance + stakedToMe) for all accounts staked to this node with declineReward=true, at the 
+   * beginning of the new staking period.
+   */
+  int64 stake_not_rewarded = 6;
+
+  /**
+   * Total of (balance + stakedToMe) for all accounts staked to this node with declineReward=false, at the 
+   * beginning of the new staking period.
+   */
+  int64 stake_rewarded = 7;
+}

--- a/hapi/hedera-protobufs/services/node_update.proto
+++ b/hapi/hedera-protobufs/services/node_update.proto
@@ -1,0 +1,164 @@
+syntax = "proto3";
+
+package com.hedera.hapi.node.addressbook;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "google/protobuf/wrappers.proto";
+import "basic_types.proto";
+
+/**
+ * Transaction body to modify address book node attributes.
+ *
+ * - This transaction SHALL enable the node operator, as identified by the
+ *   `admin_key`, to modify operational attributes of the node.
+ * - This transaction MUST be signed by the active `admin_key` for the node.
+ * - If this transaction sets a new value for the `admin_key`, then both the
+ *   current `admin_key`, and the new `admin_key` MUST sign this transaction.
+ * - This transaction SHALL NOT change any field that is not set (is null) in
+ *   this transaction body.
+ * - This SHALL create a pending update to the node, but the change SHALL NOT
+ *   be immediately applied to the active configuration.
+ * - All pending node updates SHALL be applied to the active network
+ *   configuration during the next `freeze` transaction with the field
+ *   `freeze_type` set to `PREPARE_UPGRADE`.
+ *
+ * ### Record Stream Effects
+ * Upon completion the `node_id` for the updated entry SHALL be in the
+ * transaction receipt.
+ */
+message NodeUpdateTransactionBody {
+    /**
+     * A consensus node identifier in the network state.
+     * <p>
+     * The node identified MUST exist in the network address book.<br/>
+     * The node identified MUST NOT be deleted.<br/>
+     * This value is REQUIRED.
+     */
+    uint64 node_id = 1;
+
+    /**
+     * An account identifier.
+     * <p>
+     * If set, this SHALL replace the node account identifier.<br/>
+     * If set, this transaction MUST be signed by the active `key` for _both_
+     * the current node account _and_ the identified new node account.
+     */
+    proto.AccountID account_id = 2;
+
+    /**
+     * A short description of the node.
+     * <p>
+     * This value, if set, MUST NOT exceed 100 bytes when encoded as UTF-8.<br/>
+     * If set, this value SHALL replace the previous value.
+     */
+    google.protobuf.StringValue description = 3;
+
+    /**
+     * A list of service endpoints for gossip.
+     * <p>
+     * If set, this list MUST meet the following requirements.
+     * <hr/>
+     * These endpoints SHALL represent the published endpoints to which other
+     * consensus nodes may _gossip_ transactions.<br/>
+     * These endpoints SHOULD NOT specify both address and DNS name.<br/>
+     * This list MUST NOT be empty.<br/>
+     * This list MUST NOT contain more than `10` entries.<br/>
+     * The first two entries in this list SHALL be the endpoints published to
+     * all consensus nodes.<br/>
+     * All other entries SHALL be reserved for future use.
+     * <p>
+     * Each network may have additional requirements for these endpoints.
+     * A client MUST check network-specific documentation for those
+     * details.<br/>
+     * <blockquote>Example<blockquote>
+     * Hedera Mainnet _requires_ that address be specified, and does not
+     * permit DNS name (FQDN) to be specified.<br/>
+     * Mainnet also requires that the first entry be an "internal" IP
+     * address and the second entry be an "external" IP address.
+     * </blockquote>
+     * <blockquote>
+     * Solo, however, _requires_ DNS name (FQDN) but also permits
+     * address.
+     * </blockquote></blockquote>
+     * <p>
+     * If set, the new list SHALL replace the existing list.
+     */
+    repeated proto.ServiceEndpoint gossip_endpoint = 4;
+
+    /**
+     * A list of service endpoints for gRPC calls.
+     * <p>
+     * If set, this list MUST meet the following requirements.
+     * <hr/>
+     * These endpoints SHALL represent the published endpoints to which clients
+     * may submit transactions.<br/>
+     * These endpoints SHOULD specify address and port.<br/>
+     * These endpoints MAY specify a DNS name.<br/>
+     * These endpoints SHOULD NOT specify both address and DNS name.<br/>
+     * This list MUST NOT be empty.<br/>
+     * This list MUST NOT contain more than `8` entries.
+     * <p>
+     * Each network may have additional requirements for these endpoints.
+     * A client MUST check network-specific documentation for those
+     * details.
+     * <p>
+     * If set, the new list SHALL replace the existing list.
+     */
+    repeated proto.ServiceEndpoint service_endpoint = 5;
+
+    /**
+     * A certificate used to sign gossip events.
+     * <p>
+     * This value MUST be a certificate of a type permitted for gossip
+     * signatures.<br/>
+     * This value MUST be the DER encoding of the certificate presented.
+     * <p>
+     * If set, the new value SHALL replace the existing bytes value.
+     */
+    google.protobuf.BytesValue gossip_ca_certificate = 6;
+
+    /**
+     * A hash of the node gRPC TLS certificate.
+     * <p>
+     * This value MAY be used to verify the certificate presented by the node
+     * during TLS negotiation for gRPC.<br/>
+     * This value MUST be a SHA-384 hash.<br/>
+     * The TLS certificate to be hashed MUST first be in PEM format and MUST be
+     * encoded with UTF-8 NFKD encoding to a stream of bytes provided to
+     * the hash algorithm.<br/>
+     * <p>
+     * If set, the new value SHALL replace the existing hash value.
+     */
+    google.protobuf.BytesValue grpc_certificate_hash = 7;
+
+    /**
+    * An administrative key controlled by the node operator.
+     * <p>
+     * This field is OPTIONAL.<br/>
+     * If set, this key MUST sign this transaction.<br/>
+     * If set, this key MUST sign each subsequent transaction to
+     * update this node.<br/>
+     * If set, this field MUST contain a valid `Key` value.<br/>
+     * If set, this field MUST NOT be set to an empty `KeyList`.
+     */
+    proto.Key admin_key = 8;
+}

--- a/hapi/hedera-protobufs/services/query.proto
+++ b/hapi/hedera-protobufs/services/query.proto
@@ -1,0 +1,194 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "get_by_key.proto";
+import "get_by_solidity_id.proto";
+
+import "contract_call_local.proto";
+import "contract_get_info.proto";
+import "contract_get_bytecode.proto";
+import "contract_get_records.proto";
+
+import "crypto_get_account_balance.proto";
+import "crypto_get_account_records.proto";
+import "crypto_get_info.proto";
+import "crypto_get_live_hash.proto";
+import "crypto_get_stakers.proto";
+
+import "file_get_contents.proto";
+import "file_get_info.proto";
+
+import "transaction_get_receipt.proto";
+import "transaction_get_record.proto";
+import "transaction_get_fast_record.proto";
+
+import "consensus_get_topic_info.proto";
+
+import "network_get_version_info.proto";
+import "network_get_execution_time.proto";
+
+import "token_get_info.proto";
+import "schedule_get_info.proto";
+
+import "token_get_account_nft_infos.proto";
+import "token_get_nft_info.proto";
+import "token_get_nft_infos.proto";
+
+import "get_account_details.proto";
+
+/**
+ * A single query, which is sent from the client to a node. This includes all possible queries. Each
+ * Query should not have more than 50 levels.
+ */
+message Query {
+    oneof query {
+        /**
+         * Get all entities associated with a given key
+         */
+        GetByKeyQuery getByKey = 1;
+
+        /**
+         * Get the IDs in the format used in transactions, given the format used in Solidity
+         */
+        GetBySolidityIDQuery getBySolidityID = 2;
+
+        /**
+         * Call a function of a smart contract instance
+         */
+        ContractCallLocalQuery contractCallLocal = 3;
+
+        /**
+         * Get information about a smart contract instance
+         */
+        ContractGetInfoQuery contractGetInfo = 4;
+
+        /**
+         * Get runtime code used by a smart contract instance
+         */
+        ContractGetBytecodeQuery contractGetBytecode = 5;
+
+        /**
+         * Get Records of the contract instance
+         */
+        ContractGetRecordsQuery ContractGetRecords = 6;
+
+
+        /**
+         * Get the current balance in a cryptocurrency account
+         */
+        CryptoGetAccountBalanceQuery cryptogetAccountBalance = 7;
+
+        /**
+         * Get all the records that currently exist for transactions involving an account
+         */
+        CryptoGetAccountRecordsQuery cryptoGetAccountRecords = 8;
+
+        /**
+         * Get all information about an account
+         */
+        CryptoGetInfoQuery cryptoGetInfo = 9;
+
+        /**
+         * Get a single livehash from a single account, if present
+         */
+        CryptoGetLiveHashQuery cryptoGetLiveHash = 10;
+
+        /**
+         * Get all the accounts that proxy stake to a given account, and how much they proxy stake
+         * (not yet implemented in the current API)
+         */
+        CryptoGetStakersQuery cryptoGetProxyStakers = 11;
+
+        /**
+         * Get the contents of a file (the bytes stored in it)
+         */
+        FileGetContentsQuery fileGetContents = 12;
+
+        /**
+         * Get information about a file, such as its expiration date
+         */
+        FileGetInfoQuery fileGetInfo = 13;
+
+        /**
+         * Get a receipt for a transaction (lasts 180 seconds)
+         */
+        TransactionGetReceiptQuery transactionGetReceipt = 14;
+
+        /**
+         * Get a record for a transaction
+         */
+        TransactionGetRecordQuery transactionGetRecord = 15;
+
+        /**
+         * Get a record for a transaction (lasts 180 seconds)
+         */
+        TransactionGetFastRecordQuery transactionGetFastRecord = 16;
+
+        /**
+         * Get the parameters of and state of a consensus topic.
+         */
+        ConsensusGetTopicInfoQuery consensusGetTopicInfo = 50;
+
+        /**
+         * Get the versions of the HAPI protobuf and Hedera Services software deployed on the
+         * responding node.
+         */
+        NetworkGetVersionInfoQuery networkGetVersionInfo = 51;
+
+        /**
+         * Get all information about a token
+         */
+        TokenGetInfoQuery tokenGetInfo = 52;
+
+        /**
+         * Get all information about a scheduled entity
+         */
+        ScheduleGetInfoQuery scheduleGetInfo = 53;
+
+        /**
+         * Get a list of NFTs associated with the account
+         */
+        TokenGetAccountNftInfosQuery tokenGetAccountNftInfos = 54;
+
+        /**
+         * Get all information about a NFT
+         */
+        TokenGetNftInfoQuery tokenGetNftInfo = 55;
+
+        /**
+         * Get a list of NFTs for the token
+         */
+        TokenGetNftInfosQuery tokenGetNftInfos = 56;
+
+        /**
+         * Gets <tt>handleTransaction</tt> times for one or more "sufficiently recent" TransactionIDs
+         */
+        NetworkGetExecutionTimeQuery networkGetExecutionTime = 57;
+
+        /**
+         * Gets all information about an account including allowances granted by the account
+         */
+        GetAccountDetailsQuery accountDetails = 58;
+    }
+}

--- a/hapi/hedera-protobufs/services/query_header.proto
+++ b/hapi/hedera-protobufs/services/query_header.proto
@@ -1,0 +1,76 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "transaction.proto";
+
+/**
+ * The client uses the ResponseType to indicate that it desires the node send just the answer, or
+ * both the answer and a state proof. It can also ask for just the cost and not the answer itself
+ * (allowing it to tailor the payment transaction accordingly). If the payment in the query fails
+ * the precheck, then the response may have some fields blank. The state proof is only available for
+ * some types of information. It is available for a Record, but not a receipt. It is available for
+ * the information in each kind of *GetInfo request. 
+ */
+enum ResponseType {
+    /**
+     * Response returns answer
+     */
+    ANSWER_ONLY = 0;
+
+    /**
+     * (NOT YET SUPPORTED) Response returns both answer and state proof
+     */
+    ANSWER_STATE_PROOF = 1;
+
+    /**
+     * Response returns the cost of answer
+     */
+    COST_ANSWER = 2;
+
+    /**
+     * (NOT YET SUPPORTED) Response returns the total cost of answer and state proof
+     */
+    COST_ANSWER_STATE_PROOF = 3;
+}
+
+/**
+ * Each query from the client to the node will contain the QueryHeader, which gives the requested
+ * response type, and includes a payment transaction that will compensate the node for responding to
+ * the query. The payment can be blank if the query is free. 
+ */
+message QueryHeader {
+    /**
+     * A signed CryptoTransferTransaction to pay the node a fee for handling this query
+     */
+    Transaction payment = 1;
+
+    /**
+     * The requested response, asking for cost, state proof, both, or neither
+     */
+    ResponseType responseType = 2;
+}

--- a/hapi/hedera-protobufs/services/response.proto
+++ b/hapi/hedera-protobufs/services/response.proto
@@ -1,0 +1,195 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "get_by_key.proto";
+import "get_by_solidity_id.proto";
+
+import "contract_call_local.proto";
+import "contract_get_bytecode.proto";
+import "contract_get_info.proto";
+import "contract_get_records.proto";
+
+import "crypto_get_account_balance.proto";
+import "crypto_get_account_records.proto";
+import "crypto_get_info.proto";
+import "crypto_get_live_hash.proto";
+import "crypto_get_stakers.proto";
+
+import "file_get_contents.proto";
+import "file_get_info.proto";
+
+import "transaction_get_receipt.proto";
+import "transaction_get_record.proto";
+import "transaction_get_fast_record.proto";
+
+import "consensus_get_topic_info.proto";
+
+import "network_get_version_info.proto";
+import "network_get_execution_time.proto";
+
+import "token_get_account_nft_infos.proto";
+import "token_get_info.proto";
+import "token_get_nft_info.proto";
+import "token_get_nft_infos.proto";
+
+import "schedule_get_info.proto";
+
+import "get_account_details.proto";
+
+/**
+ * A single response, which is returned from the node to the client, after the client sent the node
+ * a query. This includes all responses.
+ */
+message Response {
+    oneof response {
+        /**
+         * Get all entities associated with a given key
+         */
+        GetByKeyResponse getByKey = 1;
+
+        /**
+         * Get the IDs in the format used in transactions, given the format used in Solidity
+         */
+        GetBySolidityIDResponse getBySolidityID = 2;
+
+        /**
+         * Response to call a function of a smart contract instance
+         */
+        ContractCallLocalResponse contractCallLocal = 3;
+
+        /**
+         * Get the runtime code for a smart contract instance
+         */
+        ContractGetBytecodeResponse contractGetBytecodeResponse = 5;
+
+        /**
+         * Get information about a smart contract instance
+         */
+        ContractGetInfoResponse contractGetInfo = 4;
+
+        /**
+         * Get all existing records for a smart contract instance
+         */
+        ContractGetRecordsResponse contractGetRecordsResponse = 6;
+
+        /**
+         * Get the current balance in a cryptocurrency account
+         */
+        CryptoGetAccountBalanceResponse cryptogetAccountBalance = 7;
+
+        /**
+         * Get all the records that currently exist for transactions involving an account
+         */
+        CryptoGetAccountRecordsResponse cryptoGetAccountRecords = 8;
+
+        /**
+         * Get all information about an account
+         */
+        CryptoGetInfoResponse cryptoGetInfo = 9;
+
+        /**
+         * Contains a livehash associated to an account
+         */
+        CryptoGetLiveHashResponse cryptoGetLiveHash = 10;
+
+        /**
+         * Get all the accounts that proxy stake to a given account, and how much they proxy stake
+         */
+        CryptoGetStakersResponse cryptoGetProxyStakers = 11;
+
+        /**
+         * Get the contents of a file (the bytes stored in it)
+         */
+        FileGetContentsResponse fileGetContents = 12;
+
+        /**
+         * Get information about a file, such as its expiration date
+         */
+        FileGetInfoResponse fileGetInfo = 13;
+
+        /**
+         * Get a receipt for a transaction
+         */
+        TransactionGetReceiptResponse transactionGetReceipt = 14;
+
+        /**
+         * Get a record for a transaction
+         */
+        TransactionGetRecordResponse transactionGetRecord = 15;
+
+        /**
+         * Get a record for a transaction (lasts 180 seconds)
+         */
+        TransactionGetFastRecordResponse transactionGetFastRecord = 16;
+
+        /**
+         * Parameters of and state of a consensus topic..
+         */
+        ConsensusGetTopicInfoResponse consensusGetTopicInfo = 150;
+
+        /**
+         * Semantic versions of Hedera Services and HAPI proto
+         */
+        NetworkGetVersionInfoResponse networkGetVersionInfo = 151;
+
+        /**
+         * Get all information about a token
+         */
+        TokenGetInfoResponse tokenGetInfo = 152;
+
+        /**
+         * Get all information about a schedule entity
+         */
+        ScheduleGetInfoResponse scheduleGetInfo = 153;
+
+        /**
+         * A list of the NFTs associated with the account
+         */
+        TokenGetAccountNftInfosResponse tokenGetAccountNftInfos = 154;
+
+        /**
+         * All information about an NFT
+         */
+        TokenGetNftInfoResponse tokenGetNftInfo = 155;
+
+        /**
+         * A list of the NFTs for the token
+         */
+        TokenGetNftInfosResponse tokenGetNftInfos = 156;
+
+        /**
+         * Execution times of "sufficiently recent" transactions
+         */
+        NetworkGetExecutionTimeResponse networkGetExecutionTime = 157;
+
+        /**
+         * Gets all information about an account including allowances granted by the account
+         */
+        GetAccountDetailsResponse accountDetails = 158;
+    }
+}

--- a/hapi/hedera-protobufs/services/response_code.proto
+++ b/hapi/hedera-protobufs/services/response_code.proto
@@ -1,0 +1,1565 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * UNDOCUMENTED
+ */
+enum ResponseCodeEnum {
+    /**
+     * The transaction passed the precheck validations.
+     */
+    OK = 0;
+
+    /**
+     * For any error not handled by specific error codes listed below.
+     */
+    INVALID_TRANSACTION = 1;
+
+    /**
+     * Payer account does not exist.
+     */
+    PAYER_ACCOUNT_NOT_FOUND = 2;
+
+    /**
+     * Node Account provided does not match the node account of the node the transaction was submitted
+     * to.
+     */
+    INVALID_NODE_ACCOUNT = 3;
+
+    /**
+     * Pre-Check error when TransactionValidStart + transactionValidDuration is less than current
+     * consensus time.
+     */
+    TRANSACTION_EXPIRED = 4;
+
+    /**
+     * Transaction start time is greater than current consensus time
+     */
+    INVALID_TRANSACTION_START = 5;
+
+    /**
+     * The given transactionValidDuration was either non-positive, or greater than the maximum
+     * valid duration of 180 secs.
+     *
+     */
+    INVALID_TRANSACTION_DURATION = 6;
+
+    /**
+     * The transaction signature is not valid
+     */
+    INVALID_SIGNATURE = 7;
+
+    /**
+     * Transaction memo size exceeded 100 bytes
+     */
+    MEMO_TOO_LONG = 8;
+
+    /**
+     * The fee provided in the transaction is insufficient for this type of transaction
+     */
+    INSUFFICIENT_TX_FEE = 9;
+
+    /**
+     * The payer account has insufficient cryptocurrency to pay the transaction fee
+     */
+    INSUFFICIENT_PAYER_BALANCE = 10;
+
+    /**
+     * This transaction ID is a duplicate of one that was submitted to this node or reached consensus
+     * in the last 180 seconds (receipt period)
+     */
+    DUPLICATE_TRANSACTION = 11;
+
+    /**
+     * If API is throttled out
+     */
+    BUSY = 12;
+
+    /**
+     * The API is not currently supported
+     */
+    NOT_SUPPORTED = 13;
+
+    /**
+     * The file id is invalid or does not exist
+     */
+    INVALID_FILE_ID = 14;
+
+    /**
+     * The account id is invalid or does not exist
+     */
+    INVALID_ACCOUNT_ID = 15;
+
+    /**
+     * The contract id is invalid or does not exist
+     */
+    INVALID_CONTRACT_ID = 16;
+
+    /**
+     * Transaction id is not valid
+     */
+    INVALID_TRANSACTION_ID = 17;
+
+    /**
+     * Receipt for given transaction id does not exist
+     */
+    RECEIPT_NOT_FOUND = 18;
+
+    /**
+     * Record for given transaction id does not exist
+     */
+    RECORD_NOT_FOUND = 19;
+
+    /**
+     * The solidity id is invalid or entity with this solidity id does not exist
+     */
+    INVALID_SOLIDITY_ID = 20;
+
+    /**
+     * The responding node has submitted the transaction to the network. Its final status is still
+     * unknown.
+     */
+    UNKNOWN = 21;
+
+    /**
+     * The transaction succeeded
+     */
+    SUCCESS = 22;
+
+    /**
+     * There was a system error and the transaction failed because of invalid request parameters.
+     */
+    FAIL_INVALID = 23;
+
+    /**
+     * There was a system error while performing fee calculation, reserved for future.
+     */
+    FAIL_FEE = 24;
+
+    /**
+     * There was a system error while performing balance checks, reserved for future.
+     */
+    FAIL_BALANCE = 25;
+
+    /**
+     * Key not provided in the transaction body
+     */
+    KEY_REQUIRED = 26;
+
+    /**
+     * Unsupported algorithm/encoding used for keys in the transaction
+     */
+    BAD_ENCODING = 27;
+
+    /**
+     * When the account balance is not sufficient for the transfer
+     */
+    INSUFFICIENT_ACCOUNT_BALANCE = 28;
+
+    /**
+     * During an update transaction when the system is not able to find the Users Solidity address
+     */
+    INVALID_SOLIDITY_ADDRESS = 29;
+
+    /**
+     * Not enough gas was supplied to execute transaction
+     */
+    INSUFFICIENT_GAS = 30;
+
+    /**
+     * contract byte code size is over the limit
+     */
+    CONTRACT_SIZE_LIMIT_EXCEEDED = 31;
+
+    /**
+     * local execution (query) is requested for a function which changes state
+     */
+    LOCAL_CALL_MODIFICATION_EXCEPTION = 32;
+
+    /**
+     * Contract REVERT OPCODE executed
+     */
+    CONTRACT_REVERT_EXECUTED = 33;
+
+    /**
+     * For any contract execution related error not handled by specific error codes listed above.
+     */
+    CONTRACT_EXECUTION_EXCEPTION = 34;
+
+    /**
+     * In Query validation, account with +ve(amount) value should be Receiving node account, the
+     * receiver account should be only one account in the list
+     */
+    INVALID_RECEIVING_NODE_ACCOUNT = 35;
+
+    /**
+     * Header is missing in Query request
+     */
+    MISSING_QUERY_HEADER = 36;
+
+    /**
+     * The update of the account failed
+     */
+    ACCOUNT_UPDATE_FAILED = 37;
+
+    /**
+     * Provided key encoding was not supported by the system
+     */
+    INVALID_KEY_ENCODING = 38;
+
+    /**
+     * null solidity address
+     */
+    NULL_SOLIDITY_ADDRESS = 39;
+
+    /**
+     * update of the contract failed
+     */
+    CONTRACT_UPDATE_FAILED = 40;
+
+    /**
+     * the query header is invalid
+     */
+    INVALID_QUERY_HEADER = 41;
+
+    /**
+     * Invalid fee submitted
+     */
+    INVALID_FEE_SUBMITTED = 42;
+
+    /**
+     * Payer signature is invalid
+     */
+    INVALID_PAYER_SIGNATURE = 43;
+
+    /**
+     * The keys were not provided in the request.
+     */
+    KEY_NOT_PROVIDED = 44;
+
+    /**
+     * Expiration time provided in the transaction was invalid.
+     */
+    INVALID_EXPIRATION_TIME = 45;
+
+    /**
+     * WriteAccess Control Keys are not provided for the file
+     */
+    NO_WACL_KEY = 46;
+
+    /**
+     * The contents of file are provided as empty.
+     */
+    FILE_CONTENT_EMPTY = 47;
+
+    /**
+     * The crypto transfer credit and debit do not sum equal to 0
+     */
+    INVALID_ACCOUNT_AMOUNTS = 48;
+
+    /**
+     * Transaction body provided is empty
+     */
+    EMPTY_TRANSACTION_BODY = 49;
+
+    /**
+     * Invalid transaction body provided
+     */
+    INVALID_TRANSACTION_BODY = 50;
+
+    /**
+     * the type of key (base ed25519 key, KeyList, or ThresholdKey) does not match the type of
+     * signature (base ed25519 signature, SignatureList, or ThresholdKeySignature)
+     */
+    INVALID_SIGNATURE_TYPE_MISMATCHING_KEY = 51;
+
+    /**
+     * the number of key (KeyList, or ThresholdKey) does not match that of signature (SignatureList,
+     * or ThresholdKeySignature). e.g. if a keyList has 3 base keys, then the corresponding
+     * signatureList should also have 3 base signatures.
+     */
+    INVALID_SIGNATURE_COUNT_MISMATCHING_KEY = 52;
+
+    /**
+     * the livehash body is empty
+     */
+    EMPTY_LIVE_HASH_BODY = 53;
+
+    /**
+     * the livehash data is missing
+     */
+    EMPTY_LIVE_HASH = 54;
+
+    /**
+     * the keys for a livehash are missing
+     */
+    EMPTY_LIVE_HASH_KEYS = 55;
+
+    /**
+     * the livehash data is not the output of a SHA-384 digest
+     */
+    INVALID_LIVE_HASH_SIZE = 56;
+
+    /**
+     * the query body is empty
+     */
+    EMPTY_QUERY_BODY = 57;
+
+    /**
+     * the crypto livehash query is empty
+     */
+    EMPTY_LIVE_HASH_QUERY = 58;
+
+    /**
+     * the livehash is not present
+     */
+    LIVE_HASH_NOT_FOUND = 59;
+
+    /**
+     * the account id passed has not yet been created.
+     */
+    ACCOUNT_ID_DOES_NOT_EXIST = 60;
+
+    /**
+     * the livehash already exists for a given account
+     */
+    LIVE_HASH_ALREADY_EXISTS = 61;
+
+    /**
+     * File WACL keys are invalid
+     */
+    INVALID_FILE_WACL = 62;
+
+    /**
+     * Serialization failure
+     */
+    SERIALIZATION_FAILED = 63;
+
+    /**
+     * The size of the Transaction is greater than transactionMaxBytes
+     */
+    TRANSACTION_OVERSIZE = 64;
+
+    /**
+     * The Transaction has more than 50 levels
+     */
+    TRANSACTION_TOO_MANY_LAYERS = 65;
+
+    /**
+     * Contract is marked as deleted
+     */
+    CONTRACT_DELETED = 66;
+
+    /**
+     * the platform node is either disconnected or lagging behind.
+     */
+    PLATFORM_NOT_ACTIVE = 67;
+
+    /**
+     * one public key matches more than one prefixes on the signature map
+     */
+    KEY_PREFIX_MISMATCH = 68;
+
+    /**
+     * transaction not created by platform due to large backlog
+     */
+    PLATFORM_TRANSACTION_NOT_CREATED = 69;
+
+    /**
+     * auto renewal period is not a positive number of seconds
+     */
+    INVALID_RENEWAL_PERIOD = 70;
+
+    /**
+     * the response code when a smart contract id is passed for a crypto API request
+     */
+    INVALID_PAYER_ACCOUNT_ID = 71;
+
+    /**
+     * the account has been marked as deleted
+     */
+    ACCOUNT_DELETED = 72;
+
+    /**
+     * the file has been marked as deleted
+     */
+    FILE_DELETED = 73;
+
+    /**
+     * same accounts repeated in the transfer account list
+     */
+    ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS = 74;
+
+    /**
+     * attempting to set negative balance value for crypto account
+     */
+    SETTING_NEGATIVE_ACCOUNT_BALANCE = 75;
+
+    /**
+     * when deleting smart contract that has crypto balance either transfer account or transfer smart
+     * contract is required
+     */
+    OBTAINER_REQUIRED = 76;
+
+    /**
+     * when deleting smart contract that has crypto balance you can not use the same contract id as
+     * transferContractId as the one being deleted
+     */
+    OBTAINER_SAME_CONTRACT_ID = 77;
+
+    /**
+     * transferAccountId or transferContractId specified for contract delete does not exist
+     */
+    OBTAINER_DOES_NOT_EXIST = 78;
+
+    /**
+     * attempting to modify (update or delete a immutable smart contract, i.e. one created without a
+     * admin key)
+     */
+    MODIFYING_IMMUTABLE_CONTRACT = 79;
+
+    /**
+     * Unexpected exception thrown by file system functions
+     */
+    FILE_SYSTEM_EXCEPTION = 80;
+
+    /**
+     * the duration is not a subset of [MINIMUM_AUTORENEW_DURATION,MAXIMUM_AUTORENEW_DURATION]
+     */
+    AUTORENEW_DURATION_NOT_IN_RANGE = 81;
+
+    /**
+     * Decoding the smart contract binary to a byte array failed. Check that the input is a valid hex
+     * string.
+     */
+    ERROR_DECODING_BYTESTRING = 82;
+
+    /**
+     * File to create a smart contract was of length zero
+     */
+    CONTRACT_FILE_EMPTY = 83;
+
+    /**
+     * Bytecode for smart contract is of length zero
+     */
+    CONTRACT_BYTECODE_EMPTY = 84;
+
+    /**
+     * Attempt to set negative initial balance
+     */
+    INVALID_INITIAL_BALANCE = 85;
+
+    /**
+     * [Deprecated]. attempt to set negative receive record threshold
+     */
+    INVALID_RECEIVE_RECORD_THRESHOLD = 86 [deprecated = true];
+
+    /**
+     * [Deprecated]. attempt to set negative send record threshold
+     */
+    INVALID_SEND_RECORD_THRESHOLD = 87 [deprecated = true];
+
+    /**
+     * Special Account Operations should be performed by only Genesis account, return this code if it
+     * is not Genesis Account
+     */
+    ACCOUNT_IS_NOT_GENESIS_ACCOUNT = 88;
+
+    /**
+     * The fee payer account doesn't have permission to submit such Transaction
+     */
+    PAYER_ACCOUNT_UNAUTHORIZED = 89;
+
+    /**
+     * FreezeTransactionBody is invalid
+     */
+    INVALID_FREEZE_TRANSACTION_BODY = 90;
+
+    /**
+     * FreezeTransactionBody does not exist
+     */
+    FREEZE_TRANSACTION_BODY_NOT_FOUND = 91;
+
+    /**
+     * Exceeded the number of accounts (both from and to) allowed for crypto transfer list
+     */
+    TRANSFER_LIST_SIZE_LIMIT_EXCEEDED = 92;
+
+    /**
+     * Smart contract result size greater than specified maxResultSize
+     */
+    RESULT_SIZE_LIMIT_EXCEEDED = 93;
+
+    /**
+     * The payer account is not a special account(account 0.0.55)
+     */
+    NOT_SPECIAL_ACCOUNT = 94;
+
+    /**
+     * Negative gas was offered in smart contract call
+     */
+    CONTRACT_NEGATIVE_GAS = 95;
+
+    /**
+     * Negative value / initial balance was specified in a smart contract call / create
+     */
+    CONTRACT_NEGATIVE_VALUE = 96;
+
+    /**
+     * Failed to update fee file
+     */
+    INVALID_FEE_FILE = 97;
+
+    /**
+     * Failed to update exchange rate file
+     */
+    INVALID_EXCHANGE_RATE_FILE = 98;
+
+    /**
+     * Payment tendered for contract local call cannot cover both the fee and the gas
+     */
+    INSUFFICIENT_LOCAL_CALL_GAS = 99;
+
+    /**
+     * Entities with Entity ID below 1000 are not allowed to be deleted
+     */
+    ENTITY_NOT_ALLOWED_TO_DELETE = 100;
+
+    /**
+     * Violating one of these rules: 1) treasury account can update all entities below 0.0.1000, 2)
+     * account 0.0.50 can update all entities from 0.0.51 - 0.0.80, 3) Network Function Master Account
+     * A/c 0.0.50 - Update all Network Function accounts & perform all the Network Functions listed
+     * below, 4) Network Function Accounts: i) A/c 0.0.55 - Update Address Book files (0.0.101/102),
+     * ii) A/c 0.0.56 - Update Fee schedule (0.0.111), iii) A/c 0.0.57 - Update Exchange Rate
+     * (0.0.112).
+     */
+    AUTHORIZATION_FAILED = 101;
+
+    /**
+     * Fee Schedule Proto uploaded but not valid (append or update is required)
+     */
+    FILE_UPLOADED_PROTO_INVALID = 102;
+
+    /**
+     * Fee Schedule Proto uploaded but not valid (append or update is required)
+     */
+    FILE_UPLOADED_PROTO_NOT_SAVED_TO_DISK = 103;
+
+    /**
+     * Fee Schedule Proto File Part uploaded
+     */
+    FEE_SCHEDULE_FILE_PART_UPLOADED = 104;
+
+    /**
+     * The change on Exchange Rate exceeds Exchange_Rate_Allowed_Percentage
+     */
+    EXCHANGE_RATE_CHANGE_LIMIT_EXCEEDED = 105;
+
+    /**
+     * Contract permanent storage exceeded the currently allowable limit
+     */
+    MAX_CONTRACT_STORAGE_EXCEEDED = 106;
+
+    /**
+     * Transfer Account should not be same as Account to be deleted
+     */
+    TRANSFER_ACCOUNT_SAME_AS_DELETE_ACCOUNT = 107;
+
+    TOTAL_LEDGER_BALANCE_INVALID = 108;
+    /**
+     * The expiration date/time on a smart contract may not be reduced
+     */
+    EXPIRATION_REDUCTION_NOT_ALLOWED = 110;
+
+    /**
+     * Gas exceeded currently allowable gas limit per transaction
+     */
+    MAX_GAS_LIMIT_EXCEEDED = 111;
+
+    /**
+     * File size exceeded the currently allowable limit
+     */
+    MAX_FILE_SIZE_EXCEEDED = 112;
+
+    /**
+     * When a valid signature is not provided for operations on account with receiverSigRequired=true
+     */
+    RECEIVER_SIG_REQUIRED = 113;
+
+    /**
+     * The Topic ID specified is not in the system.
+     */
+    INVALID_TOPIC_ID = 150;
+
+    /**
+     * A provided admin key was invalid. Verify the bytes for an Ed25519 public key are exactly 32 bytes; and the bytes for a compressed ECDSA(secp256k1) key are exactly 33 bytes, with the first byte either 0x02 or 0x03..
+     */
+    INVALID_ADMIN_KEY = 155;
+
+    /**
+     * A provided submit key was invalid.
+     */
+    INVALID_SUBMIT_KEY = 156;
+
+    /**
+     * An attempted operation was not authorized (ie - a deleteTopic for a topic with no adminKey).
+     */
+    UNAUTHORIZED = 157;
+
+    /**
+     * A ConsensusService message is empty.
+     */
+    INVALID_TOPIC_MESSAGE = 158;
+
+    /**
+     * The autoRenewAccount specified is not a valid, active account.
+     */
+    INVALID_AUTORENEW_ACCOUNT = 159;
+
+    /**
+     * An adminKey was not specified on the topic, so there must not be an autoRenewAccount.
+     */
+    AUTORENEW_ACCOUNT_NOT_ALLOWED = 160;
+
+    /**
+     * The topic has expired, was not automatically renewed, and is in a 7 day grace period before the
+     * topic will be deleted unrecoverably. This error response code will not be returned until
+     * autoRenew functionality is supported by HAPI.
+     */
+    TOPIC_EXPIRED = 162;
+
+    INVALID_CHUNK_NUMBER = 163; // chunk number must be from 1 to total (chunks) inclusive.
+    INVALID_CHUNK_TRANSACTION_ID = 164; // For every chunk, the payer account that is part of initialTransactionID must match the Payer Account of this transaction. The entire initialTransactionID should match the transactionID of the first chunk, but this is not checked or enforced by Hedera except when the chunk number is 1.
+    ACCOUNT_FROZEN_FOR_TOKEN = 165; // Account is frozen and cannot transact with the token
+    TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED = 166; // An involved account already has more than <tt>tokens.maxPerAccount</tt> associations with non-deleted tokens.
+    INVALID_TOKEN_ID = 167; // The token is invalid or does not exist
+    INVALID_TOKEN_DECIMALS = 168; // Invalid token decimals
+    INVALID_TOKEN_INITIAL_SUPPLY = 169; // Invalid token initial supply
+    INVALID_TREASURY_ACCOUNT_FOR_TOKEN = 170; // Treasury Account does not exist or is deleted
+    INVALID_TOKEN_SYMBOL = 171; // Token Symbol is not UTF-8 capitalized alphabetical string
+    TOKEN_HAS_NO_FREEZE_KEY = 172; // Freeze key is not set on token
+    TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN = 173; // Amounts in transfer list are not net zero
+    MISSING_TOKEN_SYMBOL = 174; // A token symbol was not provided
+    TOKEN_SYMBOL_TOO_LONG = 175; // The provided token symbol was too long
+    ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN = 176; // KYC must be granted and account does not have KYC granted
+    TOKEN_HAS_NO_KYC_KEY = 177; // KYC key is not set on token
+    INSUFFICIENT_TOKEN_BALANCE = 178; // Token balance is not sufficient for the transaction
+    TOKEN_WAS_DELETED = 179; // Token transactions cannot be executed on deleted token
+    TOKEN_HAS_NO_SUPPLY_KEY = 180; // Supply key is not set on token
+    TOKEN_HAS_NO_WIPE_KEY = 181; // Wipe key is not set on token
+    INVALID_TOKEN_MINT_AMOUNT = 182; // The requested token mint amount would cause an invalid total supply
+    INVALID_TOKEN_BURN_AMOUNT = 183; // The requested token burn amount would cause an invalid total supply
+    TOKEN_NOT_ASSOCIATED_TO_ACCOUNT = 184; // A required token-account relationship is missing
+    CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT = 185; // The target of a wipe operation was the token treasury account
+    INVALID_KYC_KEY = 186; // The provided KYC key was invalid.
+    INVALID_WIPE_KEY = 187; // The provided wipe key was invalid.
+    INVALID_FREEZE_KEY = 188; // The provided freeze key was invalid.
+    INVALID_SUPPLY_KEY = 189; // The provided supply key was invalid.
+    MISSING_TOKEN_NAME = 190; // Token Name is not provided
+    TOKEN_NAME_TOO_LONG = 191; // Token Name is too long
+    INVALID_WIPING_AMOUNT = 192; // The provided wipe amount must not be negative, zero or bigger than the token holder balance
+    TOKEN_IS_IMMUTABLE = 193; // Token does not have Admin key set, thus update/delete transactions cannot be performed
+    TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT = 194; // An <tt>associateToken</tt> operation specified a token already associated to the account
+    TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES = 195; // An attempted operation is invalid until all token balances for the target account are zero
+    ACCOUNT_IS_TREASURY = 196; // An attempted operation is invalid because the account is a treasury
+    TOKEN_ID_REPEATED_IN_TOKEN_LIST = 197; // Same TokenIDs present in the token list
+    TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED = 198; // Exceeded the number of token transfers (both from and to) allowed for token transfer list
+    EMPTY_TOKEN_TRANSFER_BODY = 199; // TokenTransfersTransactionBody has no TokenTransferList
+    EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS = 200; // TokenTransfersTransactionBody has a TokenTransferList with no AccountAmounts
+
+    /**
+     * The Scheduled entity does not exist; or has now expired, been deleted, or been executed
+     */
+    INVALID_SCHEDULE_ID = 201;
+
+    /**
+     * The Scheduled entity cannot be modified. Admin key not set
+     */
+    SCHEDULE_IS_IMMUTABLE = 202;
+
+    /**
+     * The provided Scheduled Payer does not exist
+     */
+    INVALID_SCHEDULE_PAYER_ID = 203;
+
+    /**
+     * The Schedule Create Transaction TransactionID account does not exist
+     */
+    INVALID_SCHEDULE_ACCOUNT_ID = 204;
+
+    /**
+     * The provided sig map did not contain any new valid signatures from required signers of the scheduled transaction
+     */
+    NO_NEW_VALID_SIGNATURES = 205;
+
+    /**
+     * The required signers for a scheduled transaction cannot be resolved, for example because they do not exist or have been deleted
+     */
+    UNRESOLVABLE_REQUIRED_SIGNERS = 206;
+
+    /**
+     * Only whitelisted transaction types may be scheduled
+     */
+    SCHEDULED_TRANSACTION_NOT_IN_WHITELIST = 207;
+
+    /**
+     * At least one of the signatures in the provided sig map did not represent a valid signature for any required signer
+     */
+    SOME_SIGNATURES_WERE_INVALID = 208;
+
+    /**
+     * The scheduled field in the TransactionID may not be set to true
+     */
+    TRANSACTION_ID_FIELD_NOT_ALLOWED = 209;
+
+    /**
+     * A schedule already exists with the same identifying fields of an attempted ScheduleCreate (that is, all fields other than scheduledPayerAccountID)
+     */
+    IDENTICAL_SCHEDULE_ALREADY_CREATED = 210;
+
+    /**
+     * A string field in the transaction has a UTF-8 encoding with the prohibited zero byte
+     */
+    INVALID_ZERO_BYTE_IN_STRING = 211;
+
+    /**
+     * A schedule being signed or deleted has already been deleted
+     */
+    SCHEDULE_ALREADY_DELETED = 212;
+
+    /**
+     * A schedule being signed or deleted has already been executed
+     */
+    SCHEDULE_ALREADY_EXECUTED = 213;
+
+    /**
+     * ConsensusSubmitMessage request's message size is larger than allowed.
+     */
+    MESSAGE_SIZE_TOO_LARGE = 214;
+
+    /**
+     * An operation was assigned to more than one throttle group in a given bucket
+     */
+    OPERATION_REPEATED_IN_BUCKET_GROUPS = 215;
+
+    /**
+     * The capacity needed to satisfy all opsPerSec groups in a bucket overflowed a signed 8-byte integral type
+     */
+    BUCKET_CAPACITY_OVERFLOW = 216;
+
+    /**
+     * Given the network size in the address book, the node-level capacity for an operation would never be enough to accept a single request; usually means a bucket burstPeriod should be increased
+     */
+    NODE_CAPACITY_NOT_SUFFICIENT_FOR_OPERATION = 217;
+
+    /**
+     * A bucket was defined without any throttle groups
+     */
+    BUCKET_HAS_NO_THROTTLE_GROUPS = 218;
+
+    /**
+     * A throttle group was granted zero opsPerSec
+     */
+    THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC = 219;
+
+    /**
+     * The throttle definitions file was updated, but some supported operations were not assigned a bucket
+     */
+    SUCCESS_BUT_MISSING_EXPECTED_OPERATION = 220;
+
+    /**
+     * The new contents for the throttle definitions system file were not valid protobuf
+     */
+    UNPARSEABLE_THROTTLE_DEFINITIONS = 221;
+
+    /**
+     * The new throttle definitions system file were invalid, and no more specific error could be divined
+     */
+    INVALID_THROTTLE_DEFINITIONS = 222;
+
+    /**
+     * The transaction references an account which has passed its expiration without renewal funds available, and currently remains in the ledger only because of the grace period given to expired entities
+     */
+    ACCOUNT_EXPIRED_AND_PENDING_REMOVAL = 223;
+
+    /**
+     * Invalid token max supply
+     */
+    INVALID_TOKEN_MAX_SUPPLY = 224;
+
+    /**
+     * Invalid token nft serial number
+     */
+    INVALID_TOKEN_NFT_SERIAL_NUMBER = 225;
+
+    /**
+     * Invalid nft id
+     */
+    INVALID_NFT_ID = 226;
+
+    /**
+     * Nft metadata is too long
+     */
+    METADATA_TOO_LONG = 227;
+
+    /**
+     * Repeated operations count exceeds the limit
+     */
+    BATCH_SIZE_LIMIT_EXCEEDED = 228;
+
+    /**
+     * The range of data to be gathered is out of the set boundaries
+     */
+    INVALID_QUERY_RANGE = 229;
+
+    /**
+     * A custom fractional fee set a denominator of zero
+     */
+    FRACTION_DIVIDES_BY_ZERO = 230;
+
+    /**
+     * The transaction payer could not afford a custom fee
+     */
+    INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE = 231 [deprecated = true];
+
+    /**
+     * More than 10 custom fees were specified
+     */
+    CUSTOM_FEES_LIST_TOO_LONG = 232;
+
+    /**
+     * Any of the feeCollector accounts for customFees is invalid
+     */
+    INVALID_CUSTOM_FEE_COLLECTOR = 233;
+
+    /**
+     * Any of the token Ids in customFees is invalid
+     */
+    INVALID_TOKEN_ID_IN_CUSTOM_FEES = 234;
+
+    /**
+     * Any of the token Ids in customFees are not associated to feeCollector
+     */
+    TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR = 235;
+
+    /**
+     * A token cannot have more units minted due to its configured supply ceiling
+     */
+    TOKEN_MAX_SUPPLY_REACHED = 236;
+
+    /**
+     * The transaction attempted to move an NFT serial number from an account other than its owner
+     */
+    SENDER_DOES_NOT_OWN_NFT_SERIAL_NO = 237;
+
+    /**
+     * A custom fee schedule entry did not specify either a fixed or fractional fee
+     */
+    CUSTOM_FEE_NOT_FULLY_SPECIFIED = 238;
+
+    /**
+     * Only positive fees may be assessed at this time
+     */
+    CUSTOM_FEE_MUST_BE_POSITIVE = 239;
+
+    /**
+     * Fee schedule key is not set on token
+     */
+    TOKEN_HAS_NO_FEE_SCHEDULE_KEY = 240;
+
+    /**
+     * A fractional custom fee exceeded the range of a 64-bit signed integer
+     */
+    CUSTOM_FEE_OUTSIDE_NUMERIC_RANGE = 241;
+
+    /**
+     * A royalty cannot exceed the total fungible value exchanged for an NFT
+     */
+    ROYALTY_FRACTION_CANNOT_EXCEED_ONE = 242;
+
+    /**
+     * Each fractional custom fee must have its maximum_amount, if specified, at least its minimum_amount
+     */
+    FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT = 243;
+
+    /**
+     * A fee schedule update tried to clear the custom fees from a token whose fee schedule was already empty
+     */
+    CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES = 244;
+
+    /**
+     * Only tokens of type FUNGIBLE_COMMON can be used to as fee schedule denominations
+     */
+    CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON = 245;
+
+    /**
+     * Only tokens of type FUNGIBLE_COMMON can have fractional fees
+     */
+    CUSTOM_FRACTIONAL_FEE_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 246;
+
+    /**
+     * The provided custom fee schedule key was invalid
+     */
+    INVALID_CUSTOM_FEE_SCHEDULE_KEY = 247;
+
+    /**
+     * The requested token mint metadata was invalid
+     */
+    INVALID_TOKEN_MINT_METADATA = 248;
+
+    /**
+     * The requested token burn metadata was invalid
+     */
+    INVALID_TOKEN_BURN_METADATA = 249;
+
+    /**
+     * The treasury for a unique token cannot be changed until it owns no NFTs
+     */
+    CURRENT_TREASURY_STILL_OWNS_NFTS = 250;
+
+    /**
+     * An account cannot be dissociated from a unique token if it owns NFTs for the token
+     */
+    ACCOUNT_STILL_OWNS_NFTS = 251;
+
+    /**
+     * A NFT can only be burned when owned by the unique token's treasury
+     */
+    TREASURY_MUST_OWN_BURNED_NFT = 252;
+
+    /**
+     * An account did not own the NFT to be wiped
+     */
+    ACCOUNT_DOES_NOT_OWN_WIPED_NFT = 253;
+
+    /**
+     * An AccountAmount token transfers list referenced a token type other than FUNGIBLE_COMMON
+     */
+    ACCOUNT_AMOUNT_TRANSFERS_ONLY_ALLOWED_FOR_FUNGIBLE_COMMON = 254;
+
+    /**
+     * All the NFTs allowed in the current price regime have already been minted
+     */
+    MAX_NFTS_IN_PRICE_REGIME_HAVE_BEEN_MINTED = 255;
+
+    /**
+     * The payer account has been marked as deleted
+     */
+    PAYER_ACCOUNT_DELETED = 256;
+
+    /**
+     * The reference chain of custom fees for a transferred token exceeded the maximum length of 2
+     */
+    CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH = 257;
+
+    /**
+     * More than 20 balance adjustments were to satisfy a CryptoTransfer and its implied custom fee payments
+     */
+    CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS = 258;
+
+    /**
+     * The sender account in the token transfer transaction could not afford a custom fee
+     */
+    INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE = 259;
+
+    /**
+     * Currently no more than 4,294,967,295 NFTs may be minted for a given unique token type
+     */
+    SERIAL_NUMBER_LIMIT_REACHED = 260;
+
+    /**
+     * Only tokens of type NON_FUNGIBLE_UNIQUE can have royalty fees
+     */
+    CUSTOM_ROYALTY_FEE_ONLY_ALLOWED_FOR_NON_FUNGIBLE_UNIQUE = 261;
+
+    /**
+     * The account has reached the limit on the automatic associations count.
+     */
+    NO_REMAINING_AUTOMATIC_ASSOCIATIONS = 262;
+
+    /**
+     * Already existing automatic associations are more than the new maximum automatic associations.
+     */
+    EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT = 263;
+
+    /**
+     * Cannot set the number of automatic associations for an account more than the maximum allowed
+     * token associations <tt>tokens.maxPerAccount</tt>.
+     */
+    REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT = 264;
+
+    /**
+     * Token is paused. This Token cannot be a part of any kind of Transaction until unpaused.
+     */
+    TOKEN_IS_PAUSED = 265;
+
+    /**
+     * Pause key is not set on token
+     */
+    TOKEN_HAS_NO_PAUSE_KEY = 266;
+
+    /**
+     * The provided pause key was invalid
+     */
+    INVALID_PAUSE_KEY = 267;
+
+    /**
+     * The update file in a freeze transaction body must exist.
+     */
+    FREEZE_UPDATE_FILE_DOES_NOT_EXIST = 268;
+
+    /**
+     * The hash of the update file in a freeze transaction body must match the in-memory hash.
+     */
+    FREEZE_UPDATE_FILE_HASH_DOES_NOT_MATCH = 269;
+
+    /**
+     * A FREEZE_UPGRADE transaction was handled with no previous update prepared.
+     */
+    NO_UPGRADE_HAS_BEEN_PREPARED = 270;
+
+    /**
+     * A FREEZE_ABORT transaction was handled with no scheduled freeze.
+     */
+    NO_FREEZE_IS_SCHEDULED = 271;
+
+    /**
+     * The update file hash when handling a FREEZE_UPGRADE transaction differs from the file
+     * hash at the time of handling the PREPARE_UPGRADE transaction.
+     */
+    UPDATE_FILE_HASH_CHANGED_SINCE_PREPARE_UPGRADE = 272;
+
+    /**
+     * The given freeze start time was in the (consensus) past.
+     */
+    FREEZE_START_TIME_MUST_BE_FUTURE = 273;
+
+    /**
+     * The prepared update file cannot be updated or appended until either the upgrade has
+     * been completed, or a FREEZE_ABORT has been handled.
+     */
+    PREPARED_UPDATE_FILE_IS_IMMUTABLE = 274;
+
+    /**
+     * Once a freeze is scheduled, it must be aborted before any other type of freeze can
+     * can be performed.
+     */
+    FREEZE_ALREADY_SCHEDULED = 275;
+
+    /**
+     * If an NMT upgrade has been prepared, the following operation must be a FREEZE_UPGRADE.
+     * (To issue a FREEZE_ONLY, submit a FREEZE_ABORT first.)
+     */
+    FREEZE_UPGRADE_IN_PROGRESS = 276;
+
+    /**
+     * If an NMT upgrade has been prepared, the subsequent FREEZE_UPGRADE transaction must
+     * confirm the id of the file to be used in the upgrade.
+     */
+    UPDATE_FILE_ID_DOES_NOT_MATCH_PREPARED = 277;
+
+    /**
+     * If an NMT upgrade has been prepared, the subsequent FREEZE_UPGRADE transaction must
+     * confirm the hash of the file to be used in the upgrade.
+     */
+    UPDATE_FILE_HASH_DOES_NOT_MATCH_PREPARED = 278;
+
+    /**
+     * Consensus throttle did not allow execution of this transaction. System is throttled at
+     * consensus level.
+     */
+    CONSENSUS_GAS_EXHAUSTED = 279;
+
+    /**
+     * A precompiled contract succeeded, but was later reverted.
+     */
+    REVERTED_SUCCESS = 280;
+
+    /**
+     * All contract storage allocated to the current price regime has been consumed.
+     */
+    MAX_STORAGE_IN_PRICE_REGIME_HAS_BEEN_USED = 281;
+
+    /**
+     * An alias used in a CryptoTransfer transaction is not the serialization of a primitive Key
+     * message--that is, a Key with a single Ed25519 or ECDSA(secp256k1) public key and no
+     * unknown protobuf fields.
+     */
+    INVALID_ALIAS_KEY = 282;
+
+    /**
+     * A fungible token transfer expected a different number of decimals than the involved
+     * type actually has.
+     */
+    UNEXPECTED_TOKEN_DECIMALS = 283;
+
+    /**
+     * [Deprecated] The proxy account id is invalid or does not exist.
+     */
+    INVALID_PROXY_ACCOUNT_ID = 284 [deprecated = true];
+
+    /**
+     * The transfer account id in CryptoDelete transaction is invalid or does not exist.
+     */
+    INVALID_TRANSFER_ACCOUNT_ID = 285;
+
+    /**
+     * The fee collector account id in TokenFeeScheduleUpdate is invalid or does not exist.
+     */
+    INVALID_FEE_COLLECTOR_ACCOUNT_ID = 286;
+
+    /**
+     * The alias already set on an account cannot be updated using CryptoUpdate transaction.
+     */
+    ALIAS_IS_IMMUTABLE = 287;
+
+    /**
+     * An approved allowance specifies a spender account that is the same as the hbar/token
+     * owner account.
+     */
+    SPENDER_ACCOUNT_SAME_AS_OWNER = 288;
+
+    /**
+     * The establishment or adjustment of an approved allowance cause the token allowance
+     * to exceed the token maximum supply.
+     */
+    AMOUNT_EXCEEDS_TOKEN_MAX_SUPPLY = 289;
+
+    /**
+     * The specified amount for an approved allowance cannot be negative.
+     */
+    NEGATIVE_ALLOWANCE_AMOUNT = 290;
+
+    /**
+     * [Deprecated] The approveForAll flag cannot be set for a fungible token.
+     */
+    CANNOT_APPROVE_FOR_ALL_FUNGIBLE_COMMON = 291 [deprecated = true];
+
+    /**
+     * The spender does not have an existing approved allowance with the hbar/token owner.
+     */
+    SPENDER_DOES_NOT_HAVE_ALLOWANCE = 292;
+
+    /**
+     * The transfer amount exceeds the current approved allowance for the spender account.
+     */
+    AMOUNT_EXCEEDS_ALLOWANCE = 293;
+
+    /**
+     * The payer account of an approveAllowances or adjustAllowance transaction is attempting
+     * to go beyond the maximum allowed number of allowances.
+     */
+    MAX_ALLOWANCES_EXCEEDED = 294;
+
+    /**
+     * No allowances have been specified in the approval transaction.
+     */
+    EMPTY_ALLOWANCES = 295;
+
+    /**
+     * [Deprecated] Spender is repeated more than once in Crypto or Token or NFT allowance lists in a single
+     * CryptoApproveAllowance transaction.
+     */
+    SPENDER_ACCOUNT_REPEATED_IN_ALLOWANCES = 296 [deprecated = true];
+
+    /**
+     * [Deprecated] Serial numbers are repeated in nft allowance for a single spender account
+     */
+    REPEATED_SERIAL_NUMS_IN_NFT_ALLOWANCES = 297 [deprecated = true];
+
+    /**
+     * Fungible common token used in NFT allowances
+     */
+    FUNGIBLE_TOKEN_IN_NFT_ALLOWANCES = 298;
+
+    /**
+     * Non fungible token used in fungible token allowances
+     */
+    NFT_IN_FUNGIBLE_TOKEN_ALLOWANCES = 299;
+
+    /**
+     * The account id specified as the owner is invalid or does not exist.
+     */
+    INVALID_ALLOWANCE_OWNER_ID = 300;
+
+    /**
+     * The account id specified as the spender is invalid or does not exist.
+     */
+    INVALID_ALLOWANCE_SPENDER_ID = 301;
+
+    /**
+     * [Deprecated] If the CryptoDeleteAllowance transaction has repeated crypto or token or Nft allowances to delete.
+     */
+    REPEATED_ALLOWANCES_TO_DELETE = 302 [deprecated = true];
+
+    /**
+     * If the account Id specified as the delegating spender is invalid or does not exist.
+     */
+    INVALID_DELEGATING_SPENDER = 303;
+
+    /**
+     * The delegating Spender cannot grant approveForAll allowance on a NFT token type for another spender.
+     */
+    DELEGATING_SPENDER_CANNOT_GRANT_APPROVE_FOR_ALL = 304;
+
+    /**
+     * The delegating Spender cannot grant allowance on a NFT serial for another spender as it doesnt not have approveForAll
+     * granted on token-owner.
+     */
+    DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL = 305;
+
+    /**
+     * The scheduled transaction could not be created because it's expiration_time was too far in the future.
+     */
+    SCHEDULE_EXPIRATION_TIME_TOO_FAR_IN_FUTURE = 306;
+
+    /**
+     * The scheduled transaction could not be created because it's expiration_time was less than or equal to the consensus time.
+     */
+    SCHEDULE_EXPIRATION_TIME_MUST_BE_HIGHER_THAN_CONSENSUS_TIME = 307;
+
+    /**
+     * The scheduled transaction could not be created because it would cause throttles to be violated on the specified expiration_time.
+     */
+    SCHEDULE_FUTURE_THROTTLE_EXCEEDED = 308;
+
+    /**
+     * The scheduled transaction could not be created because it would cause the gas limit to be violated on the specified expiration_time.
+     */
+    SCHEDULE_FUTURE_GAS_LIMIT_EXCEEDED = 309;
+
+    /**
+     * The ethereum transaction either failed parsing or failed signature validation, or some other EthereumTransaction error not covered by another response code.
+     */
+    INVALID_ETHEREUM_TRANSACTION = 310;
+
+    /**
+     * EthereumTransaction was signed against a chainId that this network does not support.
+     */
+    WRONG_CHAIN_ID = 311;
+
+    /**
+     * This transaction specified an ethereumNonce that is not the current ethereumNonce of the account.
+     */
+    WRONG_NONCE = 312;
+
+    /**
+     * The ethereum transaction specified an access list, which the network does not support.
+     */
+    ACCESS_LIST_UNSUPPORTED = 313;
+
+    /**
+     * A schedule being signed or deleted has passed it's expiration date and is pending execution if needed and then expiration.
+     */
+    SCHEDULE_PENDING_EXPIRATION = 314;
+
+    /**
+     * A selfdestruct or ContractDelete targeted a contract that is a token treasury.
+     */
+    CONTRACT_IS_TOKEN_TREASURY = 315;
+
+    /**
+     * A selfdestruct or ContractDelete targeted a contract with non-zero token balances.
+     */
+    CONTRACT_HAS_NON_ZERO_TOKEN_BALANCES = 316;
+
+    /**
+     * A contract referenced by a transaction is "detached"; that is, expired and lacking any
+     * hbar funds for auto-renewal payment---but still within its post-expiry grace period.
+     */
+    CONTRACT_EXPIRED_AND_PENDING_REMOVAL = 317;
+
+    /**
+     * A ContractUpdate requested removal of a contract's auto-renew account, but that contract has
+     * no auto-renew account.
+     */
+    CONTRACT_HAS_NO_AUTO_RENEW_ACCOUNT = 318;
+
+    /**
+     * A delete transaction submitted via HAPI set permanent_removal=true
+     */
+    PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION = 319;
+
+    /*
+     * A CryptoCreate or ContractCreate used the deprecated proxyAccountID field.
+     */
+    PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED = 320;
+
+    /**
+     * An account set the staked_account_id to itself in CryptoUpdate or ContractUpdate transactions.
+     */
+    SELF_STAKING_IS_NOT_ALLOWED = 321;
+
+    /**
+     * The staking account id or staking node id given is invalid or does not exist.
+     */
+    INVALID_STAKING_ID = 322;
+
+    /**
+     * Native staking, while implemented, has not yet enabled by the council.
+     */
+    STAKING_NOT_ENABLED = 323;
+
+    /**
+     * The range provided in UtilPrng transaction is negative.
+     */
+    INVALID_PRNG_RANGE = 324;
+
+    /**
+     * The maximum number of entities allowed in the current price regime have been created.
+     */
+    MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED = 325;
+
+    /**
+    * The full prefix signature for precompile is not valid
+    */
+    INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE = 326;
+
+    /**
+    * The combined balances of a contract and its auto-renew account (if any) did not cover
+    * the rent charged for net new storage used in a transaction.
+    */
+    INSUFFICIENT_BALANCES_FOR_STORAGE_RENT = 327;
+
+    /**
+    * A contract transaction tried to use more than the allowed number of child records, via
+    * either system contract records or internal contract creations.
+    */
+    MAX_CHILD_RECORDS_EXCEEDED = 328;
+
+    /**
+    * The combined balances of a contract and its auto-renew account (if any) or balance of an account did not cover
+    * the auto-renewal fees in a transaction.
+    */
+    INSUFFICIENT_BALANCES_FOR_RENEWAL_FEES = 329;
+
+    /**
+    * A transaction's protobuf message includes unknown fields; could mean that a client
+    * expects not-yet-released functionality to be available.
+    */
+    TRANSACTION_HAS_UNKNOWN_FIELDS = 330;
+
+    /**
+     * The account cannot be modified. Account's key is not set
+     */
+    ACCOUNT_IS_IMMUTABLE = 331;
+
+    /**
+     * An alias that is assigned to an account or contract cannot be assigned to another account or contract.
+     */
+    ALIAS_ALREADY_ASSIGNED = 332;
+
+    /**
+     * A provided metadata key was invalid. Verification includes, for example, checking the size of Ed25519 and ECDSA(secp256k1) public keys.
+     */
+    INVALID_METADATA_KEY = 333;
+
+    /**
+     * Metadata key is not set on token
+     */
+    TOKEN_HAS_NO_METADATA_KEY = 334;
+
+    /**
+     * Token Metadata is not provided
+     */
+    MISSING_TOKEN_METADATA = 335;
+    /**
+     * NFT serial numbers are missing in the TokenUpdateNftsTransactionBody
+     */
+    MISSING_SERIAL_NUMBERS = 336;
+
+    /**
+     * Admin key is not set on token
+     */
+    TOKEN_HAS_NO_ADMIN_KEY = 337;
+
+    /**
+     * A transaction failed because the consensus node identified is
+     * deleted from the address book.
+     */
+    NODE_DELETED = 338;
+
+    /**
+     * A transaction failed because the consensus node identified is not valid or
+     * does not exist in state.
+     */
+    INVALID_NODE_ID = 339;
+
+    /**
+     * A transaction failed because one or more entries in the list of
+     * service endpoints for the `gossip_endpoint` field is invalid.<br/>
+     * The most common cause for this response is a service endpoint that has
+     * the domain name (DNS) set rather than address and port.
+     */
+    INVALID_GOSSIP_ENDPOINT = 340;
+
+    /**
+     * A transaction failed because the node account identifier provided
+     * does not exist or is not valid.<br/>
+     * One common source of this error is providing a node account identifier
+     * using the "alias" form rather than "numeric" form.
+     */
+    INVALID_NODE_ACCOUNT_ID = 341;
+
+    /**
+     * A transaction failed because the description field cannot be encoded
+     * as UTF-8 or is more than 100 bytes when encoded.
+     */
+    INVALID_NODE_DESCRIPTION = 342;
+
+    /**
+     * A transaction failed because one or more entries in the list of
+     * service endpoints for the `service_endpoint` field is invalid.<br/>
+     * The most common cause for this response is a service endpoint that has
+     * the domain name (DNS) set rather than address and port.
+     */
+    INVALID_SERVICE_ENDPOINT = 343;
+
+    /**
+     * A transaction failed because the TLS certificate provided for the
+     * node is missing or invalid.<br/>
+     * The certificate MUST be a TLS certificate of a type permitted for gossip
+     * signatures.<br/>
+     * The value presented MUST be a UTF-8 NFKD encoding of the TLS
+     * certificate.<br/>
+     * The certificate encoded MUST be in PEM format.<br/>
+     * The `gossip_ca_certificate` field is REQUIRED and MUST NOT be empty.
+     */
+    INVALID_GOSSIP_CA_CERTIFICATE = 344;
+
+    /**
+     * A transaction failed because the hash provided for the gRPC certificate
+     * is present but invalid.<br/>
+     * The `grpc_certificate_hash` MUST be a SHA-384 hash.<br/>
+     * The input hashed MUST be a UTF-8 NFKD encoding of the actual TLS
+     * certificate.<br/>
+     * The certificate to be encoded MUST be in PEM format.
+     */
+    INVALID_GRPC_CERTIFICATE = 345;
+
+    /**
+     * The maximum automatic associations value is not valid.<br/>
+     * The most common cause for this error is a value less than `-1`.
+     */
+    INVALID_MAX_AUTO_ASSOCIATIONS = 346;
+
+    /**
+     * The maximum number of nodes allowed in the address book have been created.
+     */
+    MAX_NODES_CREATED = 347;
+
+    /**
+     * In ServiceEndpoint, domain_name and ipAddressV4 are mutually exclusive
+     */
+    IP_FQDN_CANNOT_BE_SET_FOR_SAME_ENDPOINT = 348;
+
+    /**
+     *  Fully qualified domain name is not allowed in gossip_endpoint
+     */
+    GOSSIP_ENDPOINT_CANNOT_HAVE_FQDN = 349;
+
+    /**
+     * In ServiceEndpoint, domain_name size too large
+     */
+    FQDN_SIZE_TOO_LARGE = 350;
+
+    /**
+     * ServiceEndpoint is invalid
+     */
+    INVALID_ENDPOINT = 351;
+
+    /**
+     * The number of gossip endpoints exceeds the limit
+     */
+    GOSSIP_ENDPOINTS_EXCEEDED_LIMIT = 352;
+
+    /**
+     * The transaction attempted to use duplicate `TokenReference`.<br/>
+     * This affects `TokenReject` attempting to reject same token reference more than once.
+     */
+    TOKEN_REFERENCE_REPEATED = 353;
+
+    /**
+     * The account id specified as the owner in `TokenReject` is invalid or does not exist.
+     */
+    INVALID_OWNER_ID = 354;
+
+    /**
+     * The transaction attempted to use more than the allowed number of `TokenReference`.
+     */
+    TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED = 355;
+
+    /**
+     * The number of service endpoints exceeds the limit
+     */
+    SERVICE_ENDPOINTS_EXCEEDED_LIMIT = 356;
+
+    /*
+     * The IPv4 address is invalid
+     */
+    INVALID_IPV4_ADDRESS = 357;
+
+    /**
+     * The transaction attempted to use empty `TokenReference` list.
+     */
+    EMPTY_TOKEN_REFERENCE_LIST = 358;
+
+    /*
+     * The node account is not allowed to be updated
+     */
+    UPDATE_NODE_ACCOUNT_NOT_ALLOWED = 359;
+
+    /*
+     * The token has no metadata or supply key
+     */
+    TOKEN_HAS_NO_METADATA_OR_SUPPLY_KEY = 360;
+
+    /**
+    * The transaction attempted to the use an empty List of `PendingAirdropId`.
+    */
+    EMPTY_PENDING_AIRDROP_ID_LIST = 361;
+
+    /**
+    * The transaction attempted to the same `PendingAirdropId` twice.
+    */
+    PENDING_AIRDROP_ID_REPEATED = 362;
+
+    /**
+    * The transaction attempted to use more than the allowed number of `PendingAirdropId`.
+    */
+    MAX_PENDING_AIRDROP_ID_EXCEEDED = 363;
+
+    /*
+    * A pending airdrop already exists for the specified NFT.
+    */
+    PENDING_NFT_AIRDROP_ALREADY_EXISTS = 364;
+
+    /*
+     * The identified account is sender for one or more pending airdrop(s)
+     * and cannot be deleted.<br/>
+     * Requester should cancel all pending airdrops before resending
+     * this transaction.
+     */
+    ACCOUNT_HAS_PENDING_AIRDROPS = 365;
+}

--- a/hapi/hedera-protobufs/services/response_header.proto
+++ b/hapi/hedera-protobufs/services/response_header.proto
@@ -1,0 +1,59 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "query_header.proto";
+import "response_code.proto";
+
+/**
+ * Every query receives a response containing the QueryResponseHeader. Either or both of the cost
+ * and stateProof fields may be blank, if the responseType didn't ask for the cost or stateProof.
+ */
+message ResponseHeader {
+    /**
+     * Result of fee transaction precheck, saying it passed, or why it failed
+     */
+    ResponseCodeEnum nodeTransactionPrecheckCode = 1;
+
+    /**
+     * The requested response is repeated back here, for convenience
+     */
+    ResponseType responseType = 2;
+
+    /**
+     * The fee that would be charged to get the requested information (if a cost was requested).
+     * Note: This cost only includes the query fee and does not include the transfer fee(which is
+     * required to execute the transfer transaction to debit the payer account and credit the node
+     * account with query fee)
+     */
+    uint64 cost = 3;
+
+    /**
+     * The state proof for this information (if a state proof was requested, and is available)
+     */
+    bytes stateProof = 4;
+}

--- a/hapi/hedera-protobufs/services/schedulable_transaction_body.proto
+++ b/hapi/hedera-protobufs/services/schedulable_transaction_body.proto
@@ -1,0 +1,346 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.scheduled">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "system_delete.proto";
+import "system_undelete.proto";
+import "freeze.proto";
+
+import "contract_call.proto";
+import "contract_create.proto";
+import "contract_update.proto";
+
+import "crypto_create.proto";
+import "crypto_delete.proto";
+import "crypto_transfer.proto";
+import "crypto_update.proto";
+import "crypto_approve_allowance.proto";
+import "crypto_delete_allowance.proto";
+
+import "file_append.proto";
+import "file_create.proto";
+import "file_delete.proto";
+import "file_update.proto";
+
+import "contract_delete.proto";
+
+import "consensus_create_topic.proto";
+import "consensus_update_topic.proto";
+import "consensus_delete_topic.proto";
+import "consensus_submit_message.proto";
+
+import "token_create.proto";
+import "token_freeze_account.proto";
+import "token_unfreeze_account.proto";
+import "token_grant_kyc.proto";
+import "token_revoke_kyc.proto";
+import "token_delete.proto";
+import "token_update.proto";
+import "token_mint.proto";
+import "token_burn.proto";
+import "token_wipe_account.proto";
+import "token_associate.proto";
+import "token_dissociate.proto";
+import "token_fee_schedule_update.proto";
+import "token_pause.proto";
+import "token_unpause.proto";
+import "token_update_nfts.proto";
+import "token_reject.proto";
+import "token_cancel_airdrop.proto";
+import "token_claim_airdrop.proto";
+import "token_airdrop.proto";
+
+import "schedule_delete.proto";
+import "util_prng.proto";
+
+import "node_create.proto";
+import "node_update.proto";
+import "node_delete.proto";
+
+/**
+ * A schedulable transaction. Note that the global/dynamic system property
+ * <tt>scheduling.whitelist</tt> controls which transaction types may be scheduled. As of Hedera
+ * Services 0.24.0 this list includes <tt>ConsensusSubmitMessage</tt>, <tt>CryptoTransfer</tt>, <tt>TokenMint</tt>, and <tt>TokenBurn</tt>
+ * functions.
+ */
+message SchedulableTransactionBody {
+  /**
+   * The maximum transaction fee the client is willing to pay
+   */
+  uint64 transactionFee = 1;
+
+  /**
+   * A memo to include the execution record; the UTF-8 encoding may be up to 100 bytes and must not
+   * include the zero byte
+   */
+  string memo = 2;
+
+  /**
+   * The choices here are arranged by service in roughly lexicographical order. The field ordinals are non-sequential, and a result of the historical order of implementation.
+   */
+  oneof data {
+    /**
+     * Calls a function of a contract instance
+     */
+    ContractCallTransactionBody contractCall = 3;
+
+    /**
+     * Creates a contract instance
+     */
+    ContractCreateTransactionBody contractCreateInstance = 4;
+
+    /**
+     * Updates a contract
+     */
+    ContractUpdateTransactionBody contractUpdateInstance = 5;
+
+    /**
+     * Delete contract and transfer remaining balance into specified account
+     */
+    ContractDeleteTransactionBody contractDeleteInstance = 6;
+
+    /**
+     * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+     */
+    CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 37;
+
+    /**
+     * Deletes one or more of the specific approved NFT serial numbers on an owner account.
+     */
+    CryptoDeleteAllowanceTransactionBody cryptoDeleteAllowance = 38;
+
+    /**
+     * Create a new cryptocurrency account
+     */
+    CryptoCreateTransactionBody cryptoCreateAccount = 7;
+
+    /**
+     * Delete a cryptocurrency account (mark as deleted, and transfer hbars out)
+     */
+    CryptoDeleteTransactionBody cryptoDelete = 8;
+
+    /**
+     * Transfer amount between accounts
+     */
+    CryptoTransferTransactionBody cryptoTransfer = 9;
+
+    /**
+     * Modify information such as the expiration date for an account
+     */
+    CryptoUpdateTransactionBody cryptoUpdateAccount = 10;
+
+    /**
+     * Add bytes to the end of the contents of a file
+     */
+    FileAppendTransactionBody fileAppend = 11;
+
+    /**
+     * Create a new file
+     */
+    FileCreateTransactionBody fileCreate = 12;
+
+    /**
+     * Delete a file (remove contents and mark as deleted until it expires)
+     */
+    FileDeleteTransactionBody fileDelete = 13;
+
+    /**
+     * Modify information such as the expiration date for a file
+     */
+    FileUpdateTransactionBody fileUpdate = 14;
+
+    /**
+     * Hedera administrative deletion of a file or smart contract
+     */
+    SystemDeleteTransactionBody systemDelete = 15;
+
+    /**
+     * To undelete an entity deleted by SystemDelete
+     */
+    SystemUndeleteTransactionBody systemUndelete = 16;
+
+    /**
+     * Freeze the nodes
+     */
+    FreezeTransactionBody freeze = 17;
+
+    /**
+     * Creates a topic
+     */
+    ConsensusCreateTopicTransactionBody consensusCreateTopic = 18;
+
+    /**
+     * Updates a topic
+     */
+    ConsensusUpdateTopicTransactionBody consensusUpdateTopic = 19;
+
+    /**
+     * Deletes a topic
+     */
+    ConsensusDeleteTopicTransactionBody consensusDeleteTopic = 20;
+
+    /**
+     * Submits message to a topic
+     */
+    ConsensusSubmitMessageTransactionBody consensusSubmitMessage = 21;
+
+    /**
+     * Creates a token instance
+     */
+    TokenCreateTransactionBody tokenCreation = 22;
+
+    /**
+     * Freezes account not to be able to transact with a token
+     */
+    TokenFreezeAccountTransactionBody tokenFreeze = 23;
+
+    /**
+     * Unfreezes account for a token
+     */
+    TokenUnfreezeAccountTransactionBody tokenUnfreeze = 24;
+
+    /**
+     * Grants KYC to an account for a token
+     */
+    TokenGrantKycTransactionBody tokenGrantKyc = 25;
+
+    /**
+     * Revokes KYC of an account for a token
+     */
+    TokenRevokeKycTransactionBody tokenRevokeKyc = 26;
+
+    /**
+     * Deletes a token instance
+     */
+    TokenDeleteTransactionBody tokenDeletion = 27;
+
+    /**
+     * Updates a token instance
+     */
+    TokenUpdateTransactionBody tokenUpdate = 28;
+
+    /**
+     * Mints new tokens to a token's treasury account
+     */
+    TokenMintTransactionBody tokenMint = 29;
+
+    /**
+     * Burns tokens from a token's treasury account
+     */
+    TokenBurnTransactionBody tokenBurn = 30;
+
+    /**
+     * Wipes amount of tokens from an account
+     */
+    TokenWipeAccountTransactionBody tokenWipe = 31;
+
+    /**
+     * Associate tokens to an account
+     */
+    TokenAssociateTransactionBody tokenAssociate = 32;
+
+    /**
+     * Dissociate tokens from an account
+     */
+    TokenDissociateTransactionBody tokenDissociate = 33;
+
+    /**
+     * Updates a token's custom fee schedule
+     */
+    TokenFeeScheduleUpdateTransactionBody token_fee_schedule_update = 39;
+
+    /**
+     * Pauses the Token
+     */
+    TokenPauseTransactionBody token_pause = 35;
+
+    /**
+     * Unpauses the Token
+     */
+    TokenUnpauseTransactionBody token_unpause = 36;
+
+    /**
+     * Marks a schedule in the network's action queue as deleted, preventing it from executing
+     */
+    ScheduleDeleteTransactionBody scheduleDelete = 34;
+
+    /**
+     * Generates a pseudorandom number.
+     */
+    UtilPrngTransactionBody util_prng = 40;
+
+    /**
+     * Update the metadata of one or more NFT's of a specific token type.
+     */
+    TokenUpdateNftsTransactionBody token_update_nfts = 41;
+
+    /**
+     * Transaction body for a scheduled transaction to create a new node.
+     */
+    com.hedera.hapi.node.addressbook.NodeCreateTransactionBody nodeCreate = 42;
+
+    /**
+     * Transaction body for a scheduled transaction to modify an existing node.
+     */
+    com.hedera.hapi.node.addressbook.NodeUpdateTransactionBody nodeUpdate = 43;
+
+    /**
+     * Transaction body for a scheduled transaction to remove a node.
+     */
+    com.hedera.hapi.node.addressbook.NodeDeleteTransactionBody nodeDelete = 44;
+
+    /**
+     * A transaction body to "reject" undesired tokens.<br/>
+     * This transaction will transfer one or more tokens or token
+     * balances held by the requesting account to the treasury
+     * for each token type.
+     * <p>
+     * Each transfer MUST be one of the following:
+     * <ul>
+     *   <li>A single non-fungible/unique token.</li>
+     *   <li>The full balance held for a fungible/common
+     *       token type.</li>
+     * </ul>
+     * When complete, the requesting account SHALL NOT hold the
+     * rejected tokens.<br/>
+     * Custom fees and royalties defined for the tokens rejected
+     * SHALL NOT be charged for this transaction.
+     */
+    TokenRejectTransactionBody tokenReject = 45;
+
+    /**
+     * Transaction body for a scheduled transaction to cancel an airdrop.
+     */
+    TokenCancelAirdropTransactionBody tokenCancelAirdrop = 46;
+
+    /**
+     * Transaction body for a scheduled transaction to claim an airdrop.
+     */
+    TokenClaimAirdropTransactionBody tokenClaimAirdrop = 47;
+
+    /**
+     * Transaction body for a scheduled transaction to airdrop tokens.
+     */
+    TokenAirdropTransactionBody tokenAirdrop = 48;
+  }
+}

--- a/hapi/hedera-protobufs/services/schedule_create.proto
+++ b/hapi/hedera-protobufs/services/schedule_create.proto
@@ -1,0 +1,134 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.scheduled">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+import "schedulable_transaction_body.proto";
+
+/**
+ * Create a new <i>schedule entity</i> (or simply, <i>schedule</i>) in the network's action queue.
+ * Upon <tt>SUCCESS</tt>, the receipt contains the `ScheduleID` of the created schedule. A schedule
+ * entity includes a <tt>scheduledTransactionBody</tt> to be executed.
+ * When the schedule has collected enough signing Ed25519 keys to satisfy the schedule's signing
+ * requirements, the schedule can be executed.
+ *
+ * If Long Term Scheduled Transactions are enabled and <tt>wait_for_expiry</tt> is set to <tt>true</tt>, then the schedule
+ * will execute at it's <tt>expiration_time</tt>.
+ *
+ * Otherwise it will execute immediately after the transaction that provided enough Ed25519 keys, a <tt>ScheduleCreate</tt>
+ * or <tt>ScheduleSign</tt>.
+ *
+ * Upon `SUCCESS`, the receipt also includes the <tt>scheduledTransactionID</tt> to
+ * use to query for the record of the scheduled transaction's execution (if it occurs). 
+ * 
+ * The expiration time of a schedule is controlled by it's <tt>expiration_time</tt>. It remains in state and can be queried
+ * using <tt>GetScheduleInfo</tt> until expiration, no matter if the scheduled transaction has
+ * executed or marked deleted. If Long Term Scheduled Transactions are disabled, the <tt>expiration_time</tt> is always
+ * 30 minutes in the future.
+ * 
+ * If the <tt>adminKey</tt> field is omitted, the resulting schedule is immutable. If the
+ * <tt>adminKey</tt> is set, the <tt>ScheduleDelete</tt> transaction can be used to mark it as
+ * deleted. The creator may also specify an optional <tt>memo</tt> whose UTF-8 encoding is at most
+ * 100 bytes and does not include the zero byte is also supported.
+ * 
+ * When a <tt>scheduledTransactionBody</tt> is executed, the
+ * network only charges its payer the service fee, and not the node and network fees. If the
+ * optional <tt>payerAccountID</tt> is set, the network charges this account. Otherwise it charges
+ * the payer of the originating <tt>ScheduleCreate</tt>.  
+ * 
+ * Two <tt>ScheduleCreate</tt> transactions are <i>identical</i> if they are equal in all their
+ * fields other than <tt>payerAccountID</tt>.  (For the <tt>scheduledTransactionBody</tt> field,
+ * "equal" should be understood in the sense of
+ * gRPC object equality in the network software runtime. In particular, a gRPC object with <a
+ * href="https://developers.google.com/protocol-buffers/docs/proto3#unknowns">unknown fields</a> is
+ * not equal to a gRPC object without unknown fields, even if they agree on all known fields.) 
+ * 
+ * A <tt>ScheduleCreate</tt> transaction that attempts to re-create an identical schedule already in
+ * state will receive a receipt with status <tt>IDENTICAL_SCHEDULE_ALREADY_CREATED</tt>; the receipt
+ * will include the <tt>ScheduleID</tt> of the extant schedule, which may be used in a subsequent
+ * <tt>ScheduleSign</tt> transaction. (The receipt will also include the <tt>TransactionID</tt> to
+ * use in querying for the receipt or record of the scheduled transaction.)
+ * 
+ * Other notable response codes include, <tt>INVALID_ACCOUNT_ID</tt>,
+ * <tt>UNSCHEDULABLE_TRANSACTION</tt>, <tt>UNRESOLVABLE_REQUIRED_SIGNERS</tt>,
+ * <tt>INVALID_SIGNATURE</tt>. For more information please see the section of this documentation on
+ * the <tt>ResponseCode</tt> enum. 
+ */
+message ScheduleCreateTransactionBody {
+  /**
+   * The scheduled transaction
+   */
+  SchedulableTransactionBody scheduledTransactionBody = 1;
+
+  /**
+   * An optional memo with a UTF-8 encoding of no more than 100 bytes which does not contain the
+   * zero byte
+   */
+  string memo = 2;
+
+  /**
+   * An optional Hedera key which can be used to sign a ScheduleDelete and remove the schedule
+   */
+  Key adminKey = 3;
+
+  /**
+   * An optional id of the account to be charged the service fee for the scheduled transaction at
+   * the consensus time that it executes (if ever); defaults to the ScheduleCreate payer if not
+   * given
+   */
+  AccountID payerAccountID = 4;
+
+  /**
+   * An optional timestamp for specifying when the transaction should be evaluated for execution and then expire.
+   * Defaults to 30 minutes after the transaction's consensus timestamp.
+   *
+   * Note: This field is unused and forced to be unset until Long Term Scheduled Transactions are enabled - Transactions will always
+   *       expire in 30 minutes if Long Term Scheduled Transactions are not enabled.
+   */
+  Timestamp expiration_time = 5;
+
+  /**
+   * When set to true, the transaction will be evaluated for execution at expiration_time instead
+   * of when all required signatures are received.
+   * When set to false, the transaction will execute immediately after sufficient signatures are received
+   * to sign the contained transaction. During the initial ScheduleCreate transaction or via ScheduleSign transactions.
+   *
+   * Defaults to false.
+   *
+   * Setting this to false does not necessarily mean that the transaction will never execute at expiration_time.
+   *  For Example - If the signature requirements for a Scheduled Transaction change via external means (e.g. CryptoUpdate)
+   *  such that the Scheduled Transaction would be allowed to execute, it will do so autonomously at expiration_time, unless a
+   *  ScheduleSign comes in to "poke" it and force it to go through immediately.
+   *
+   * Note: This field is unused and forced to be unset until Long Term Scheduled Transactions are enabled. Before Long Term
+   *       Scheduled Transactions are enabled, Scheduled Transactions will _never_ execute at expiration  - they will _only_
+   *       execute during the initial ScheduleCreate transaction or via ScheduleSign transactions and will _always_
+   *       expire at expiration_time.
+   */
+  bool wait_for_expiry = 13;
+}

--- a/hapi/hedera-protobufs/services/schedule_delete.proto
+++ b/hapi/hedera-protobufs/services/schedule_delete.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.scheduled">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Marks a schedule in the network's action queue as deleted. Must be signed by the admin key of the
+ * target schedule.  A deleted schedule cannot receive any additional signing keys, nor will it be
+ * executed.
+ *
+ * Other notable response codes include, <tt>INVALID_SCHEDULE_ID</tt>, <tt>SCHEDULE_PENDING_EXPIRATION</tt>,
+ * <tt>SCHEDULE_ALREADY_DELETED</tt>, <tt>SCHEDULE_ALREADY_EXECUTED</tt>, <tt>SCHEDULE_IS_IMMUTABLE</tt>.
+ * For more information please see the section of this documentation on the <tt>ResponseCode</tt>
+ * enum. 
+*/
+message ScheduleDeleteTransactionBody {
+  /**
+   * The ID of the Scheduled Entity
+   */
+  ScheduleID scheduleID = 1;
+}

--- a/hapi/hedera-protobufs/services/schedule_get_info.proto
+++ b/hapi/hedera-protobufs/services/schedule_get_info.proto
@@ -1,0 +1,149 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.scheduled">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "schedulable_transaction_body.proto";
+
+/**
+ * Gets information about a schedule in the network's action queue.
+ * 
+ * Responds with <tt>INVALID_SCHEDULE_ID</tt> if the requested schedule doesn't exist.
+ */
+message ScheduleGetInfoQuery {
+  /**
+   * standard info sent from client to node including the signed payment, and what kind of response
+   * is requested (cost, state proof, both, or neither).
+   */
+  QueryHeader header = 1;
+
+  /**
+   * The id of the schedule to interrogate
+   */
+  ScheduleID scheduleID = 2;
+}
+
+/**
+ * Information summarizing schedule state
+ */
+message ScheduleInfo {  
+  /**
+   * The id of the schedule
+   */
+  ScheduleID scheduleID = 1;
+
+  oneof data {
+    /**
+     * If the schedule has been deleted, the consensus time when this occurred
+     */
+    Timestamp deletion_time = 2;
+
+    /**
+     * If the schedule has been executed, the consensus time when this occurred
+     */
+    Timestamp execution_time = 3;
+  }
+
+  /**
+   * The time at which the schedule will be evaluated for execution and then expire.
+   *
+   * Note: Before Long Term Scheduled Transactions are enabled, Scheduled Transactions will _never_ execute at expiration - they
+   *       will _only_ execute during the initial ScheduleCreate transaction or via ScheduleSign transactions and will _always_
+   *       expire at expirationTime.
+   */
+  Timestamp expirationTime = 4;
+
+  /**
+   * The scheduled transaction
+   */
+  SchedulableTransactionBody scheduledTransactionBody = 5;
+
+  /**
+   * The publicly visible memo of the schedule
+   */
+  string memo = 6;
+
+  /**
+   * The key used to delete the schedule from state
+   */
+  Key adminKey = 7;
+
+  /**
+   * The Ed25519 keys the network deems to have signed the scheduled transaction
+   */
+  KeyList signers = 8;
+
+  /**
+   * The id of the account that created the schedule
+   */
+  AccountID creatorAccountID = 9;
+
+  /**
+   * The id of the account responsible for the service fee of the scheduled transaction
+   */
+  AccountID payerAccountID = 10;
+
+  /**
+   * The transaction id that will be used in the record of the scheduled transaction (if it
+   * executes)
+   */
+  TransactionID scheduledTransactionID = 11;
+
+  /**
+   * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+   */
+  bytes ledger_id = 12;
+
+  /**
+   * When set to true, the transaction will be evaluated for execution at expiration_time instead
+   * of when all required signatures are received.
+   * When set to false, the transaction will execute immediately after sufficient signatures are received
+   * to sign the contained transaction. During the initial ScheduleCreate transaction or via ScheduleSign transactions.
+   *
+   * Note: this field is unused until Long Term Scheduled Transactions are enabled.
+   */
+  bool wait_for_expiry = 13;
+}  
+
+/**
+ * Response wrapper for the <tt>ScheduleInfo</tt>
+ */
+message ScheduleGetInfoResponse {
+  /**
+   * Standard response from node to client, including the requested fields: cost, or state proof, or
+   * both, or neither
+   */
+  ResponseHeader header = 1;
+
+  /**
+   * The information requested about this schedule instance
+   */
+  ScheduleInfo scheduleInfo = 2;
+}

--- a/hapi/hedera-protobufs/services/schedule_service.proto
+++ b/hapi/hedera-protobufs/services/schedule_service.proto
@@ -1,0 +1,109 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.scheduled">>> This comment is special code for setting PBJ Compiler java package
+
+import "query.proto";
+import "response.proto";
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * Transactions and queries for the Schedule Service
+ *
+ * The Schedule Service allows transactions to be submitted without all the required signatures and
+ * allows anyone to provide the required signatures independently after a transaction has already
+ * been created. The transactions can be executed immediately when all required signatures are received
+ * or at a future date if Long Term Scheduled Transactions are enabled.
+ *
+ * Execution:
+ *
+ * Scheduled Transactions are executed in two different modes.
+ *
+ * 1. If Long Term Scheduled Transactions are enabled and <tt>wait_for_expiry</tt> was set to <tt>true</tt> on the
+ *    <tt>ScheduleCreate</tt>, then the transaction will be executed at the <tt>expiration_time</tt> specified on the
+ *    <tt>ScheduleCreate</tt>.
+ *
+ * 2. Otherwise Scheduled Transactions are executed once all required signatures are collected and witnessed.
+ *    Every time new signature is provided, a check is performed on the "readiness" of the execution.
+ *    The Scheduled Transaction will be executed immediately after the transaction that triggered it.
+ *
+ * NOTICE:
+ * A Scheduled Transaction being ready to execute, or even not ready to execute, at the time a <tt>ScheduleCreate</tt> or
+ * <tt>ScheduleSign</tt> comes in does not guarantee it will stay that way. Any number of things can happen over time that
+ * impact the transaction.
+ *
+ * For example, account keys can change, accounts can be deleted, and account balances can change.
+ *
+ * A particularly noteworthy case is if Long Term Scheduled Transactions are enabled and signature requirements for a Scheduled
+ * Transaction change such that existing signatures become sufficient to allow the transaction to go through. In this case the transaction
+ * will execute at expiration_time unless a ScheduleSign comes in to push it through.
+ *
+ * Transaction Record:
+ *
+ * If a Scheduled Transaction is executed immediately following the transaction that provided all required signatures,
+ * the timestamp of the Scheduled Transaction will be equal to consensusTimestamp + 1 nano, where
+ * consensusTimestamp is the timestamp of the transaction that triggered the execution.
+ *
+ * The Transaction ID of the Scheduled Transaction will have the scheduled property set to true and
+ * inherit the <tt>transactionValidStart</tt> and <tt>accountID</tt> from the <tt>ScheduleCreate</tt> transaction.
+ *
+ * The <tt>scheduleRef</tt> property of the transaction record will be populated with the <tt>ScheduleID</tt> of the
+ * Scheduled Transaction.
+ *
+ * Post execution:
+ *
+ * After execution, a Scheduled Transaction will remain in state and can be queried using <tt>GetScheduleInfo</tt> until expiration.
+ *
+ * Expiry:
+ *
+ * The expiration time of a schedule is controlled by it's <tt>expiration_time</tt>. If Long Term Scheduled Transactions are disabled,
+ * the <tt>expiration_time</tt> is always 30 minutes in the future.
+ *
+ * Once a given Scheduled Transaction expires, it will be removed from the ledger and any upcoming
+ * operation referring the ScheduleID will resolve to INVALID_SCHEDULE_ID.
+ *
+ */
+service ScheduleService {
+  /**
+   * Creates a new Schedule by submitting the transaction
+   */
+  rpc createSchedule (Transaction) returns (TransactionResponse);
+
+  /**
+   * Signs a new Schedule by submitting the transaction
+   */
+  rpc signSchedule (Transaction) returns (TransactionResponse);
+
+  /**
+   * Deletes a new Schedule by submitting the transaction
+   */
+  rpc deleteSchedule (Transaction) returns (TransactionResponse);
+
+  /**
+   * Retrieves the metadata of a schedule entity
+   */
+  rpc getScheduleInfo (Query) returns (Response);
+}

--- a/hapi/hedera-protobufs/services/schedule_sign.proto
+++ b/hapi/hedera-protobufs/services/schedule_sign.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.scheduled">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Adds zero or more signing keys to a schedule.
+ *
+ * If Long Term Scheduled Transactions are enabled and <tt>wait_for_expiry</tt> was set to <tt>true</tt> on the
+ * <tt>ScheduleCreate</tt> then the transaction will always wait till it's `expiration_time` to execute.
+ *
+ * Otherwise, if the resulting set of signing keys satisfy the
+ * scheduled transaction's signing requirements, it will be executed immediately after the
+ * triggering <tt>ScheduleSign</tt>.
+ * 
+ * Upon <tt>SUCCESS</tt>, the receipt includes the <tt>scheduledTransactionID</tt> to use to query
+ * for the record of the scheduled transaction's execution (if it occurs). 
+ * 
+ * Other notable response codes include <tt>INVALID_SCHEDULE_ID</tt>, <tt>SCHEDULE_ALREADY_DELETED</tt>,
+ * <tt>SCHEDULE_PENDING_EXPIRATION</tt>, <tt>SCHEDULE_ALREADY_EXPIRED</tt>,
+ * <tt>INVALID_ACCOUNT_ID</tt>, <tt>UNRESOLVABLE_REQUIRED_SIGNERS</tt>,
+ * <tt>SOME_SIGNATURES_WERE_INVALID</tt>, and <tt>NO_NEW_VALID_SIGNATURES</tt>. For more information
+ * please see the section of this documentation on the <tt>ResponseCode</tt> enum.
+ */
+message ScheduleSignTransactionBody {
+  /**
+   * The id of the schedule to add signing keys to
+   */
+  ScheduleID scheduleID = 1;
+}

--- a/hapi/hedera-protobufs/services/smart_contract_service.proto
+++ b/hapi/hedera-protobufs/services/smart_contract_service.proto
@@ -1,0 +1,98 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.contract">>> This comment is special code for setting PBJ Compiler java package
+
+import "transaction_response.proto";
+import "query.proto";
+import "response.proto";
+import "transaction.proto";
+
+/**
+ * Transactions and queries for the file service. 
+ */
+service SmartContractService {
+    /**
+     * Creates a contract
+     */
+    rpc createContract (Transaction) returns (TransactionResponse);
+
+    /**
+     * Updates a contract with the content
+     */
+    rpc updateContract (Transaction) returns (TransactionResponse);
+
+    /**
+     * Calls a contract
+     */
+    rpc contractCallMethod (Transaction) returns (TransactionResponse);
+
+    /**
+     * Retrieves the contract information
+     */
+    rpc getContractInfo (Query) returns (Response);
+
+    /**
+     * Calls a smart contract to be run on a single node
+     */
+    rpc contractCallLocalMethod (Query) returns (Response);
+
+    /**
+     * Retrieves the runtime code of a contract
+     */
+    rpc ContractGetBytecode (Query) returns (Response);
+
+    /**
+     * Retrieves a contract by its Solidity address
+     */
+    rpc getBySolidityID (Query) returns (Response);
+
+    /**
+     * Always returns an empty record list, as contract accounts are never effective payers for
+     * transactions
+     */
+    rpc getTxRecordByContractID (Query) returns (Response) {
+        option deprecated = true;
+    };
+
+    /**
+     * Deletes a contract instance and transfers any remaining hbars to a specified receiver
+     */
+    rpc deleteContract (Transaction) returns (TransactionResponse);
+
+    /**
+     * Deletes a contract if the submitting account has network admin privileges
+     */
+    rpc systemDelete (Transaction) returns (TransactionResponse);
+
+    /**
+     * Undeletes a contract if the submitting account has network admin privileges
+     */
+    rpc systemUndelete (Transaction) returns (TransactionResponse);
+
+    /**
+     * Ethereum transaction
+     */
+    rpc callEthereum (Transaction) returns (TransactionResponse);
+}

--- a/hapi/hedera-protobufs/services/state/addressbook/node.proto
+++ b/hapi/hedera-protobufs/services/state/addressbook/node.proto
@@ -1,0 +1,149 @@
+syntax = "proto3";
+
+package com.hedera.hapi.node.state.addressbook;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.addressbook">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A single address book node in the network state.
+ *
+ * Each node in the network address book SHALL represent a single actual
+ * consensus node that is eligible to participate in network consensus.
+ *
+ * Address book nodes SHALL NOT be _globally_ uniquely identified. A given node
+ * is only valid within a single realm and shard combination, so the identifier
+ * for a network node SHALL only be unique within a single realm and shard
+ * combination.
+ */
+message Node {
+    /**
+     * A consensus node identifier.
+     * <p>
+     * Node identifiers SHALL be unique _within_ a shard and realm,
+     * but a node SHALL NOT, ever, serve multiple shards or realms,
+     * therefore the node identifier MAY be repeated _between_ shards and realms.
+     */
+    uint64 node_id = 1;
+
+    /**
+     * An account identifier.
+     * <p>
+     * This account SHALL be owned by the entity responsible for the node.<br/>
+     * This account SHALL be charged transaction fees for any transactions that
+     * are submitted to the network by this node and fail due diligence checks.
+     */
+    proto.AccountID account_id = 2;
+
+    /**
+     * A short description of the node.
+     * <p>
+     * This value, if set, SHALL NOT exceed 100 bytes when encoded as UTF-8.
+     */
+    string description = 3;
+
+    /**
+     * A list of service endpoints for gossip.
+     * <p>
+     * These endpoints SHALL represent the published endpoints to which other
+     * consensus nodes may _gossip_ transactions.<br/>
+     * If the network configuration value `gossipFqdnRestricted` is set, then
+     * all endpoints in this list SHALL supply only IP address.<br/>
+     * If the network configuration value `gossipFqdnRestricted` is _not_ set,
+     * then endpoints in this list MAY supply either IP address or FQDN, but
+     * SHALL NOT supply both values for the same endpoint.<br/>
+     * This list SHALL NOT be empty.<br/>
+     * This list SHALL NOT contain more than `10` entries.<br/>
+     * The first two entries in this list SHALL be the endpoints published to
+     * all consensus nodes.<br/>
+     * All other entries SHALL be reserved for future use.
+     */
+    repeated proto.ServiceEndpoint gossip_endpoint = 4;
+
+    /**
+     * A list of service endpoints for gRPC calls.
+     * <p>
+     * These endpoints SHALL represent the published endpoints to which clients
+     * may submit transactions.<br/>
+     * These endpoints SHALL specify a port.<br/>
+     * Endpoints in this list MAY supply either IP address or FQDN, but SHALL
+     * NOT supply both values for the same endpoint.<br/>
+     * This list SHALL NOT be empty.<br/>
+     * This list SHALL NOT contain more than `8` entries.
+     */
+    repeated proto.ServiceEndpoint service_endpoint = 5;
+
+    /**
+     * A certificate used to sign gossip events.
+     * <p>
+     * This value SHALL be a certificate of a type permitted for gossip
+     * signatures.<br/>
+     * This value SHALL be the DER encoding of the certificate presented.<br/>
+     * This field is REQUIRED and MUST NOT be empty.
+     */
+    bytes gossip_ca_certificate = 6;
+
+    /**
+     * A hash of the node gRPC certificate.
+     * <p>
+     * This value MAY be used to verify the certificate presented by the node
+     * during TLS negotiation for gRPC.<br/>
+     * This value SHALL be a SHA-384 hash.<br/>
+     * The TLS certificate to be hashed SHALL first be in PEM format and SHALL
+     * be encoded with UTF-8 NFKD encoding to a stream of bytes provided to
+     * the hash algorithm.<br/>
+     * This field is OPTIONAL.
+     */
+    bytes grpc_certificate_hash = 7;
+
+    /**
+     * A consensus weight.
+     * <p>
+     * Each node SHALL have a weight in consensus calculations.<br/>
+     * The consensus weight of a node SHALL be calculated based on the amount
+     * of HBAR staked to that node.<br/>
+     * Consensus SHALL be calculated based on agreement of greater than `2/3`
+     * of the total `weight` value of all nodes on the network.
+     */
+    uint64 weight = 8;
+
+    /**
+     * A flag indicating this node is deleted.
+     * <p>
+     * If this field is set, then this node SHALL NOT be included in the next
+     * update of the network address book.<br/>
+     * If this field is set, then this node SHALL be immutable and SHALL NOT
+     * be modified.<br/>
+     * If this field is set, then any `nodeUpdate` transaction to modify this
+     * node SHALL fail.
+     */
+    bool deleted = 9;
+
+    /**
+    * An administrative key controlled by the node operator.
+     * <p>
+     * This key MUST sign each transaction to update this node.<br/>
+     * This field MUST contain a valid `Key` value.<br/>
+     * This field is REQUIRED and MUST NOT be set to an empty `KeyList`.
+     */
+    proto.Key admin_key = 10;
+}

--- a/hapi/hedera-protobufs/services/state/blockrecords/block_info.proto
+++ b/hapi/hedera-protobufs/services/state/blockrecords/block_info.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.blockrecords">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Information about ongoing, most recently completed, and last 256 blocks.
+ */
+message BlockInfo {
+  /**
+   * The last block number, this is the last completed immutable block.
+   */
+  int64 last_block_number = 1;
+  /**
+   * The consensus time of the first transaction of the last block, this is the last completed immutable block.
+   */
+  Timestamp first_cons_time_of_last_block = 2;
+  /**
+   * SHA384 48 byte hashes of the last 256 blocks in single byte array.
+   * First 48 bytes is the oldest block.
+   * Last 48 bytes is the newest block, which is the last fully completed immutable block.
+   * If we are shortly after genesis and there are less than 256 blocks then this could contain less than 256 hashes.
+   */
+  bytes block_hashes = 3;
+  /**
+   * The consensus time of the last transaction that was handled by the node. This property is how we 'advance the
+   * consensus clock', i.e. continually setting this property to the latest consensus timestamp (and thus transaction)
+   * handled by the node.
+   */
+  Timestamp cons_time_of_last_handled_txn = 4;
+  /**
+   * A flag indicating whether migration records have been published. This property should be marked 'false'
+   * immediately following a node upgrade, and marked 'true' once the migration records (if any) are published, which
+   * should happen during the first transaction handled by the node.
+   */
+  bool migration_records_streamed = 5;
+  /**
+   * The consensus time of the first transaction in the current block; necessary for reconnecting nodes to detect
+   * when the current block is finished.
+   */
+  Timestamp first_cons_time_of_current_block = 6;
+}

--- a/hapi/hedera-protobufs/services/state/blockrecords/running_hashes.proto
+++ b/hapi/hedera-protobufs/services/state/blockrecords/running_hashes.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.blockrecords">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * The running hash of a transaction records and the previous 3 running hashes. All hashes are 48 bytes SHA384 hashes. If the
+ * running hashes do not exist yet then they will be default values witch is empty bytes object or zero length byte array.
+ */
+message RunningHashes {
+  /**
+   * A running hash of all record stream items
+   */
+  bytes running_hash = 1;
+  /**
+   * The previous running hash of all record stream items
+   */
+  bytes n_minus_1_running_hash = 2;
+  /**
+   * The previous, previous running hash of all record stream items
+   */
+  bytes n_minus_2_running_hash = 3;
+  /**
+   * The previous, previous, previous running hash of all record stream items
+   */
+  bytes n_minus_3_running_hash = 4;
+}

--- a/hapi/hedera-protobufs/services/state/blockstream/block_stream_info.proto
+++ b/hapi/hedera-protobufs/services/state/blockstream/block_stream_info.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.blockstream">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * The state required to continue constructing blocks, and the state derived from it.
+ */
+message BlockStreamInfo {
+  /**
+   * The number of the last completed block.
+   */
+  uint64 last_block_number = 1;
+  /**
+   * The hash of the last completed block.
+   */
+  bytes last_block_hash = 2;
+  /**
+   * The consensus time of the last block, to determine if this round was the first across some distinguished boundary in 
+   * consensus time, such as UTC midnight. May also be used to purge entities expiring between the last block time and 
+   * this time.
+   */
+  Timestamp last_block_time = 3;
+  /**
+   * A concatenation of the hashes of several trailing output block item hashes, for use as a PRNG seed.
+   */
+  bytes trailing_output_hashes = 4;
+  /**
+   * A concatenation of the hashes of 256 trailing blocks, for use with EVM BLOCKHASH opcode.
+   */
+  bytes trailing_block_hashes = 5;
+}

--- a/hapi/hedera-protobufs/services/state/common.proto
+++ b/hapi/hedera-protobufs/services/state/common.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+import "basic_types.proto";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.common">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A single 64-bit number identifying a Hedera native entity.
+ */
+message EntityNumber {
+    int64 number = 1;
+}
+
+/**
+ * Pair of AccountID and TokenID to represent TokenRelation
+ */
+message EntityIDPair {
+  AccountID account_id = 1;
+  TokenID token_id = 2;
+}

--- a/hapi/hedera-protobufs/services/state/congestion/congestion_level_starts.proto
+++ b/hapi/hedera-protobufs/services/state/congestion/congestion_level_starts.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.congestion">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+message CongestionLevelStarts {
+  /**
+   * Timestamps defining generic congestion levels.
+   */
+  repeated Timestamp generic_level_starts = 1;
+
+  /**
+   * Timestamps defining gas congestion levels.
+   */
+  repeated Timestamp gas_level_starts = 2;
+}

--- a/hapi/hedera-protobufs/services/state/consensus/topic.proto
+++ b/hapi/hedera-protobufs/services/state/consensus/topic.proto
@@ -1,0 +1,101 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.consensus">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Hedera Consensus Service topic in the network Merkle tree.
+ * 
+ * As with all network entities, a topic has a unique entity number, which is usually given along 
+ * with the network's shard and realm in the form of a shard.realm.number id.
+ * 
+ * A topic consists of just two pieces of data:
+ *   1. The total number of messages sent to the topic; and,
+ *   2. The running hash of all those messages.
+ * It also has several metadata elements:
+ *   1. A consensus expiration time in seconds since the epoch.
+ *   2. (Optional) The number of an auto-renew account, in the same shard and realm as the topic, that 
+ *   has signed a transaction allowing the network to use its balance to automatically extend the topic's 
+ *   expiration time when it passes.
+ *   3. The number of seconds the network should automatically extend the topic's expiration by, if the 
+ *   topic has a valid auto-renew account, and is not deleted upon expiration.
+ *   4. A boolean marking if the topic has been deleted.
+ *   5. A memo string whose UTF-8 encoding is at most 100 bytes.
+ *   6. (Optional) An admin key whose signature must be active for the topic's metadata to be updated.
+ *   7. (Optional) A submit key whose signature must be active for the topic to receive a message.
+ */
+message Topic {
+    /**
+     * The topic's unique id in the Merkle state.
+     */
+    TopicID topic_id = 1;
+    /**
+     * The number of messages sent to the topic.
+     */
+    int64 sequence_number = 2;
+    /**
+     * The topic's consensus expiration time in seconds since the epoch.
+     */
+    int64 expiration_second = 3;
+    /**
+     * The number of seconds for which the topic will be automatically renewed 
+     * upon expiring (if it has a valid auto-renew account).
+     */
+    int64 auto_renew_period = 4;
+    /**
+     * The id of the account (if any) that the network will attempt to charge for the
+     * topic's auto-renewal upon expiration.
+     */
+    AccountID auto_renew_account_id = 5;
+    /**
+     * Whether this topic is deleted.
+     */
+    bool deleted = 6;
+    /**
+     * When a topic is created, its running hash is initialized to 48 bytes of binary zeros.
+     * For each submitted message, the topic's running hash is then updated to the output
+     * of a particular SHA-384 digest whose input data include the previous running hash.
+     * 
+     * See the TransactionReceipt.proto documentation for an exact description of the
+     * data included in the SHA-384 digest used for the update.
+     */
+    bytes running_hash = 7;
+    /**
+     * An optional description of the topic with UTF-8 encoding up to 100 bytes.
+     */
+    string memo = 8;
+    /**
+     * If present, enforces access control for updating or deleting the topic.
+     * A topic without an admin key is immutable.
+     */
+    Key admin_key = 9;
+    /**
+     * If present, enforces access control for message submission to the topic.
+     */
+    Key submit_key = 10;
+}

--- a/hapi/hedera-protobufs/services/state/contract/bytecode.proto
+++ b/hapi/hedera-protobufs/services/state/contract/bytecode.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * The bytecode for a contract id.
+ */
+message Bytecode {
+    /**
+     * The raw bytes (not hex-encoded) of a contract's bytecode.
+     */
+    bytes code = 1;
+}

--- a/hapi/hedera-protobufs/services/state/contract/storage_slot.proto
+++ b/hapi/hedera-protobufs/services/state/contract/storage_slot.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.contract">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * The key of a storage slot. A slot is scoped to a specific contract number.
+ * 
+ * For each contract, its EVM storage is a mapping of 256-bit keys (or "words") to 256-bit values. 
+ */
+message SlotKey {
+    /**
+     * The number of the contract whose storage this slot belongs to.
+     */
+    ContractID contractID = 1;
+
+    /**
+     * The EVM key of this slot, when left-padded with zeros to form a 256-bit word.
+     */
+    bytes key = 2;
+}
+
+/**
+ * The value of a contract storage slot. For the EVM, this is a single word.
+ * 
+ * Because we iterate through all the storage slots for an expired contract
+ * when purging it from state, our slot values also include the words
+ * of the previous and next keys in this contract's storage "list". 
+ */
+message SlotValue {
+    /**
+     * The EVM value in this slot, when left-padded with zeros to form a 256-bit word.
+     */
+    bytes value = 1;
+
+    /**
+     * The word of the previous key in this contract's storage list (if any).
+     */
+    bytes previous_key = 2;
+
+    /**
+     * The word of the next key in this contract's storage list (if any).
+     */
+    bytes next_key = 3;
+}

--- a/hapi/hedera-protobufs/services/state/file/file.proto
+++ b/hapi/hedera-protobufs/services/state/file/file.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Hedera Token Service file in the network Merkle tree.
+ *
+ * As with all network entities, a file has a unique entity number, which is given along
+ * with the network's shard and realm in the form of a shard.realm.number id.
+ */
+message File {
+    /**
+     * The file's unique file identifier in the Merkle state.
+     */
+    FileID file_id = 1;
+    /**
+      * The file's consensus expiration time in seconds since the epoch.
+      */
+    int64 expiration_second = 2;
+    /**
+     * All keys at the top level of a key list must sign to create, modify and delete the file.
+     */
+    KeyList keys = 3;
+    /**
+     * The bytes that are the contents of the file
+     */
+    bytes contents = 4;
+    /**
+     * The memo associated with the file (UTF-8 encoding max 100 bytes)
+     */
+    string memo = 5;
+    /**
+     * Whether this file is deleted.
+     */
+    bool deleted = 6;
+    /**
+      * The pre system delete expiration time in seconds
+      */
+    int64 pre_system_delete_expiration_second = 7;
+
+}

--- a/hapi/hedera-protobufs/services/state/primitives.proto
+++ b/hapi/hedera-protobufs/services/state/primitives.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package proto;
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This proto file contains primitive value messages.
+ * These are intended only for situations where the entire value to be stored in state is a single
+ * primitive.  These should never be used as components of another message; use the protobuf
+ * type instead.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.primitives">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * A single 64-bit number with no particular meaning.
+ */
+message ProtoLong {
+    int64 value = 1;
+}
+
+/**
+ * A single 32-bit number with no particular meaning.
+ */
+message ProtoInteger {
+    int32 value = 1;
+}
+
+/**
+ * A single boolean with no particular meaning.
+ */
+message ProtoBoolean {
+    bool value = 1;
+}
+
+/**
+ * A single string with no particular meaning.
+ */
+message ProtoString {
+    string value = 1;
+}
+
+/**
+ * A single byte array with no particular meaning.
+ */
+message ProtoBytes {
+    bytes value = 1;
+}
+

--- a/hapi/hedera-protobufs/services/state/recordcache/recordcache.proto
+++ b/hapi/hedera-protobufs/services/state/recordcache/recordcache.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+import "transaction_record.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.recordcache">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * As transactions are handled and records and receipts are created, they are stored in state for a configured time
+ * limit (perhaps, for example, 3 minutes). During this time window, any client can query the node and get the record
+ * or receipt for the transaction. The TransactionRecordEntry is the object stored in state with this information.
+ */
+message TransactionRecordEntry {
+    /**
+     * The ID of the node that submitted the transaction to consensus. The ID is the ID of the node as known by the
+     * address book. Valid node IDs are in the range 0..2^63-1, inclusive.
+     */
+    int64 node_id = 1;
+
+    /**
+     * The AccountID of the payer of the transaction. This may be the same as the account ID within the Transaction ID
+     * of the record, or it may be the account ID of the node that submitted the transaction to consensus if the account
+     * ID in the Transaction ID is not able to pay.
+     */
+    AccountID payer_account_id = 2;
+
+    /**
+     * The transaction record for the transaction.
+     */
+    TransactionRecord transaction_record = 3;
+}

--- a/hapi/hedera-protobufs/services/state/schedule/schedule.proto
+++ b/hapi/hedera-protobufs/services/state/schedule/schedule.proto
@@ -1,0 +1,148 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ *
+ * Hedera Network Services Protobuf
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import "basic_types.proto";
+import "timestamp.proto";
+import "schedulable_transaction_body.proto";
+import "transaction_body.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.schedule">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Hedera Schedule entry in the network Merkle tree.
+ *
+ * As with all network entities, a schedule has a unique entity number, which is usually given along
+ * with the network's shard and realm in the form of a shard.realm.number id.
+ */
+message Schedule {
+    /**
+     * This schedule's unique ID within the global network state.
+     */
+    ScheduleID schedule_id = 1;
+
+    /**
+     * The schedule deleted flag
+     * A schedule will either be executed or deleted, but never both.
+     */
+    bool deleted = 2;
+
+    /**
+     * The schedule executed flag
+     * A schedule will either be executed or deleted, but never both.
+     */
+    bool executed = 3;
+
+    /**
+     * The schedule flag to wait for expiration
+     * A schedule will be executed immediately when all necessary signatures are gathered, unless
+     * this flag is set.  If this flag is set, the schedule will wait until the consensus time
+     * reaches expiration_time_provided, when signatures will again be verified, and if all
+     * required signatures are present at that time, the schedule will be executed.  Otherwise
+     * the schedule will expire without execution.
+     * Note that a schedule is always removed from state when it expires, regardless of whether it
+     * was executed or not.
+     */
+    bool wait_for_expiry = 4;
+
+    /**
+     * The memo associated with this schedule.
+     */
+    string memo = 5;
+
+    /**
+     * The schedule account for this schedule.  This is the account that submitted the original
+     * ScheduleCreate transaction.
+     */
+    AccountID scheduler_account_id = 6;
+
+    /**
+     * The explicit payer account for the scheduled transaction.
+     * This account is added to the accounts that must sign the schedule before it will execute.
+     */
+    AccountID payer_account_id = 7;
+
+    /**
+     * The admin key for this schedule.
+     * If this is not set, then the schedule cannot be deleted.
+     */
+    Key admin_key = 8;
+
+    /**
+     * The transaction valid start value from the transaction that created this schedule.
+     */
+    Timestamp schedule_valid_start = 9;
+
+    /**
+     * The requested expiration time of the schedule as provided by the user.
+     * The actual calculated expiration time may be "earlier" than this, but will not be later.
+     */
+    int64 provided_expiration_second = 10;
+
+    /**
+     * The calculated expiration time of the schedule.  This is calculated based on the requested
+     * expiration time from the create transaction, and the maximum expiration permitted by the
+     * network.
+     * The schedule will be removed from global network state after the network reaches a consensus
+     * time greater than or equal to this value.
+     */
+    int64 calculated_expiration_second = 11;
+
+    /**
+     * The consensus timestamp of the transaction that executed or deleted this schedule.
+     */
+    Timestamp resolution_time = 12;
+
+    /**
+     * The scheduled transaction to execute.
+     */
+    SchedulableTransactionBody scheduled_transaction = 13;
+
+    /**
+     * The full transaction that created this schedule.  This is primarily used for duplicate
+     * schedule create detection.  This is also the source of the parent transaction ID, from
+     * which the child transaction ID is derived.
+     */
+    TransactionBody original_create_transaction = 14;
+
+    /**
+     * All the primitive keys that have already signed this schedule.
+     * The scheduled transaction will not be executed before this list is
+     * sufficient to "activate" the required keys for the scheduled transaction.
+     */
+    repeated Key signatories = 15;
+}
+
+/**
+ * A message for storing a list of schedules in state.
+ * This is used to store lists of schedules that expire at a particular time or that have the same
+ * simplified hash code.
+ */
+message ScheduleList {
+  /**
+   * a list of schedules, in no particular order.
+   */
+  repeated Schedule schedules = 1;
+}

--- a/hapi/hedera-protobufs/services/state/throttles/throttle_usage_snapshots.proto
+++ b/hapi/hedera-protobufs/services/state/throttles/throttle_usage_snapshots.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.throttles">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+message ThrottleUsageSnapshots {
+  /**
+   * Snapshots for TPS throttles.
+   */
+  repeated ThrottleUsageSnapshot tps_throttles = 1;
+
+  /**
+   * Snapshots for gas throttle.
+   */
+  ThrottleUsageSnapshot gas_throttle = 2;
+}
+
+message ThrottleUsageSnapshot {
+  /**
+   * Used throttle capacity.
+   */
+  int64 used = 1;
+  /**
+   * The last time at which the capacity was updated.
+   */
+  Timestamp last_decision_time = 2;
+}

--- a/hapi/hedera-protobufs/services/state/token/account.proto
+++ b/hapi/hedera-protobufs/services/state/token/account.proto
@@ -1,0 +1,253 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "state/common.proto";
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Hedera Token Service account entity in the network Merkle tree.
+ *
+ * As with all network entities, account has a unique entity number represented as shard.realm.X.
+ * X can be an alias public key or an EVM address or a number.
+ */
+
+message Account {
+    /**
+     * The unique entity id of the account.
+     */
+    AccountID account_id = 1;
+    /**
+     * The alias to use for this account, if any.
+     */
+    bytes alias = 2;
+    /**
+     * (Optional) The key to be used to sign transactions from the account, if any.
+     * This key will not be set for hollow accounts until the account is finalized.
+     * This key should be set on all the accounts, except for immutable accounts (0.0.800 and 0.0.801).
+     */
+    Key key = 3;
+    /**
+     * The expiration time of the account, in seconds since the epoch.
+     */
+    int64 expiration_second = 4;
+    /**
+     * The balance of the account, in tiny-bars.
+     */
+    int64 tinybar_balance = 5;
+    /**
+     * An optional description of the account with UTF-8 encoding up to 100 bytes.
+     */
+    string memo = 6;
+    /**
+     * A boolean marking if the account has been deleted.
+     */
+    bool deleted = 7;
+    /**
+     * The amount of hbars staked to the account.
+     */
+    int64 staked_to_me = 8;
+    /**
+     * If this account stakes to another account, its value will be -1. It will
+     * be set to the time when the account starts staking to a node.
+     */
+    int64 stake_period_start = 9;
+
+    /**
+     * ID of the account or node to which this account is staking.
+     */
+    oneof staked_id {
+        /**
+         * ID of the new account to which this account is staking. If set to the sentinel <tt>0.0.0</tt> AccountID,
+         * this field removes this account's staked account ID.
+         */
+        AccountID staked_account_id = 10;
+
+        /**
+             * ID of the new node this account is staked to. If set to the sentinel <tt>-1</tt>, this field
+             * removes this account's staked node ID.
+         */
+        int64 staked_node_id = 11;
+    }
+    /**
+     * A boolean marking if the account declines rewards.
+     */
+    bool decline_reward = 12;
+    /**
+     * A boolean marking if the account requires a receiver signature.
+     */
+    bool receiver_sig_required = 13;
+    /**
+     * The token ID of the head of the linked list from token relations map for the account.
+     */
+    TokenID head_token_id = 14;
+    /**
+     * The NftID of the head of the linked list from unique tokens map for the account.
+     */
+    NftID head_nft_id = 15;
+    /**
+      * The serial number of the head NftID of the linked list from unique tokens map for the account.
+      */
+    int64 head_nft_serial_number = 16;
+    /**
+     * The number of NFTs owned by the account.
+     */
+    int64 number_owned_nfts = 17;
+    /**
+     * The maximum number of tokens that can be auto-associated with the account.
+     */
+    int32 max_auto_associations = 18;
+    /**
+     * The number of used auto-association slots.
+     */
+    int32 used_auto_associations = 19;
+    /**
+     * The number of tokens associated with the account. This number is used for
+     * fee calculation during renewal of the account.
+     */
+    int32 number_associations = 20;
+    /**
+     * A boolean marking if the account is a smart contract.
+     */
+    bool smart_contract = 21;
+    /**
+     * The number of tokens with a positive balance associated with the account.
+     * If the account has positive balance in a token, it can not be deleted.
+     */
+    int32 number_positive_balances = 22;
+    /**
+     * The nonce of the account, used for Ethereum interoperability.
+     */
+    int64 ethereum_nonce = 23;
+    /**
+     * The amount of hbars staked to the account at the start of the last rewarded period.
+     */
+    int64 stake_at_start_of_last_rewarded_period = 24;
+    /**
+     * (Optional) The id of an auto-renew account, in the same shard and realm as the account, that
+     * has signed a transaction allowing the network to use its balance to automatically extend the account's
+     * expiration time when it passes.
+     */
+    AccountID auto_renew_account_id = 25;
+    /**
+     * The number of seconds the network should automatically extend the account's expiration by, if the
+     * account has a valid auto-renew account, and is not deleted upon expiration.
+     * If this is not provided in an allowed range on account creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+     * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+     */
+    int64 auto_renew_seconds = 26;
+    /**
+     * If this account is a smart-contract, number of key-value pairs stored on the contract.
+     * This is used to determine the storage rent for the contract.
+     */
+    int32 contract_kv_pairs_number = 27;
+    /**
+     * (Optional) List of crypto allowances approved by the account.
+     * It contains account number for which the allowance is approved to and
+     * the amount approved for that account.
+     */
+    repeated AccountCryptoAllowance crypto_allowances = 28;
+    /**
+     * (Optional) List of non-fungible token allowances approved for all by the account.
+     * It contains account number approved for spending all serial numbers for the given
+     * NFT token number using approved_for_all flag.
+     * Allowances for a specific serial number is stored in the NFT itself in state.
+     */
+    repeated AccountApprovalForAllAllowance approve_for_all_nft_allowances = 29;
+
+    /**
+     * (Optional) List of fungible token allowances approved by the account.
+     * It contains account number for which the allowance is approved to and  the token number.
+     * It also contains and the amount approved for that account.
+     */
+    repeated AccountFungibleTokenAllowance token_allowances = 30;
+    /**
+     * The number of tokens for which this account is treasury
+     */
+    uint32 number_treasury_titles = 31;
+    /**
+     * A flag indicating if the account is expired and pending removal.
+     * Only the entity expiration system task toggles this flag when it reaches this account
+     * and finds it expired. Before setting the flag the system task checks if the account has
+     * an auto-renew account with balance. This is done to prevent a zero-balance account with a funded
+     * auto-renew account from being treated as expired in the interval between its expiration
+     * and the time the system task actually auto-renews it.
+     */
+    bool expired_and_pending_removal = 32;
+    /**
+     * The first key in the doubly-linked list of this contract's storage mappings;
+     * It will be null if if the account is not a contract or the contract has no storage mappings.
+     */
+    bytes first_contract_storage_key = 33;
+
+    /**
+     * A pending airdrop ID at the head of the linked list for this account
+     * from the account airdrops map.<br/>
+     * The account airdrops are connected by including the "next" and "previous"
+     * `PendingAirdropID` in each `AccountAirdrop` message.
+     * <p>
+     * This value SHALL NOT be empty if this account is "sender" for any
+     * pending airdrop, and SHALL be empty otherwise.
+     */
+    PendingAirdropId head_pending_airdrop_id = 34;
+
+    /**
+     * The number of pending airdrops owned by the account. This number is used to collect rent
+     * for the account.
+     */
+    uint64 number_pending_airdrops = 35;
+}
+
+/**
+ * Allowance granted by this account to a spender for a specific non-fungible token
+ * using ApproveForAll. This allows spender to spend all serial numbers for the given
+ * non-fungible token id.
+ */
+message AccountApprovalForAllAllowance {
+    TokenID token_id = 1;
+    AccountID spender_id = 2;
+}
+
+/**
+ * Allowance granted by this account to another account for a specific fungible token.
+ * This also contains the amount of the token that is approved for the account.
+ * This allows spender to spend the amount of tokens approved for the account.
+ */
+message AccountFungibleTokenAllowance {
+    TokenID token_id = 1;
+    AccountID spender_id = 2;
+    int64 amount = 3;
+}
+
+/**
+ * Allowance granted by this account to another account for an amount of hbars.
+ * This allows spender to spend the amount of hbars approved for the account.
+ */
+message AccountCryptoAllowance {
+    AccountID spender_id = 1;
+    int64 amount = 2;
+}

--- a/hapi/hedera-protobufs/services/state/token/account_pending_airdrop.proto
+++ b/hapi/hedera-protobufs/services/state/token/account_pending_airdrop.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+
+/**
+ * A node within a doubly linked list of pending airdrop references.<br/>
+ * This internal state message forms the entries in a doubly-linked list
+ * of references to pending airdrop entries that are "owed" by a particular
+ * account as "sender".
+ *
+ * Each entry in this list MUST refer to an existing pending airdrop.<br/>
+ * The pending airdrop MUST NOT be claimed.<br/>
+ * The pending airdrop MUST NOT be canceled.<br/>
+ * The pending airdrop `sender` account's `head_pending_airdrop_id` field
+ * MUST match the `pending_airdrop_id` field in this message.
+ *
+ * ### Record Stream Effects
+ * This value is not currently published in the record stream.
+ */
+message AccountPendingAirdrop {
+  /**
+   * The value of the current airdrop id. SHALL NOT be set for non fungible tokens
+   */
+  PendingAirdropValue pending_airdrop_value = 1;
+
+  /**
+   * A pending airdrop identifier.<br/>
+   * This identifies the specific pending airdrop that precedes this position
+   * within the doubly linked list of pending airdrops "owed" by the sending
+   * account associated with this account airdrop "list".
+   * <p>
+   * This SHALL match `pending_airdrop_id` if this is the only entry
+   * in the "list".
+   */
+  PendingAirdropId previous_airdrop = 2;
+
+  /**
+   * A pending airdrop identifier.<br/>
+   * This identifies the specific pending airdrop that follows this position
+   * within the doubly linked list of pending airdrops "owed" by the sending
+   * account associated with this account airdrop "list".
+   * <p>
+   * This SHALL match `pending_airdrop_id` if this is the only entry
+   * in the "list".
+   */
+  PendingAirdropId next_airdrop = 3;
+}

--- a/hapi/hedera-protobufs/services/state/token/network_staking_rewards.proto
+++ b/hapi/hedera-protobufs/services/state/token/network_staking_rewards.proto
@@ -1,0 +1,62 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Hedera Token Service staking reward entity in the network Merkle tree.
+ * This consists of all the information needed to calculate the staking rewards for all nodes in the network. It is
+ * calculated at the beginning of each staking period for all nodes and is needed to have same values
+ * for reconnect.
+ *
+ * As with all network entities, staking info is per node and has a unique entity number represented as shard.realm.X.
+ */
+message NetworkStakingRewards {
+
+  /**
+   * Whether staking rewards are activated on the network. This is set to true when the balance of 0.0.800
+   * reaches minimum required balance.
+   */
+  bool staking_rewards_activated = 1;
+
+  /**
+  * Total of (balance + stakedToMe) for all accounts staked to all nodes in the network with declineReward=false, at the
+  * beginning of the new staking period.
+  */
+  int64 total_staked_reward_start = 2;
+
+  /**
+  * Total of (balance + stakedToMe) for all accounts staked to all nodes in the network, at the beginning of the new
+  * staking period.
+  */
+  int64 total_staked_start = 3;
+
+  /**
+   * The total staking rewards in tinybars that COULD be collected by all accounts staking to all nodes after the end
+   * of this staking period; assuming that no account "renounces" its rewards by, for example, setting declineReward=true.
+   */
+  int64 pending_rewards = 4;
+}

--- a/hapi/hedera-protobufs/services/state/token/nft.proto
+++ b/hapi/hedera-protobufs/services/state/token/nft.proto
@@ -1,0 +1,77 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "timestamp.proto";
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Hedera Token Service NFT in the network Merkle tree.
+ */
+message Nft {
+
+    /**
+     * The id of this NFT.
+     */
+    NftID nft_id = 1;
+
+    /**
+     * The account or contract id that owns this NFT.
+     *
+     * If this number is zero in state, the NFT is owned by its token type's current treasury.
+     */
+    AccountID owner_id = 2;
+
+    /**
+     * The account or contract id approved to spend this NFT.
+     *
+     * If this number is zero, there is no approved spender.
+     */
+    AccountID spender_id = 3;
+
+    /**
+     * The consensus time of the TokenMint that created this NFT.
+     */
+    Timestamp mint_time = 4;
+
+    /**
+     * The metadata of this NFT, up to 100 bytes; usually the UTF-8 encoding of a URI.
+     */
+    bytes metadata = 5;
+
+    /**
+     * If the owner of this NFT is not its token treasury, the id of the previous NFT 
+     * in the owner's "doubly-linked list" of owned NFTs (if any).
+     */
+    NftID owner_previous_nft_id = 6;
+
+    /**
+     * If the owner of this NFT is not its token treasury, the id of the next NFT in 
+     * the owner's "doubly-linked list" of owned NFTs (if any).
+     */
+    NftID owner_next_nft_id = 7;
+}

--- a/hapi/hedera-protobufs/services/state/token/staking_node_info.proto
+++ b/hapi/hedera-protobufs/services/state/token/staking_node_info.proto
@@ -1,0 +1,102 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "state/common.proto";
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Hedera Token Service staking info entity in the network Merkle tree.
+ *
+ * As with all network entities, staking info is per node and has a unique entity number represented as shard.realm.X.
+ */
+message StakingNodeInfo {
+    /**
+     * The unique entity number of the node. The shard and realm numbers are implied, based on the network
+     * this entity came from.
+     */
+    int64 node_number = 1;
+    /**
+     * The minimum stake on this node that is required for this node to have a non-zero weight to
+     * participate in the network consensus.
+     */
+    int64 min_stake = 2;
+    /**
+     * The maximum stake on this node that is considered to calculate its weight to participate in the network consensus.
+     */
+    int64 max_stake = 3;
+    /**
+     * The sum of balances of all accounts staked to this node who have opted to receive rewards.
+     */
+    int64 stake_to_reward = 4;
+    /**
+     * The sum of balances of all accounts staked to this node who have opted to decline rewards.
+     */
+    int64 stake_to_not_reward = 5;
+    /**
+     * The snapshot of stake_to_reward value at the beginning of the current staking period.
+     * This is needed for calculating rewards for current staking period without considering changes to
+     * stake_to_reward in the current staking period. It is reset at the beginning of every period.
+     */
+    int64 stake_reward_start = 6;
+    /**
+     * Tracks how much stake from stakeRewardStart will have unclaimed rewards due to accounts changing their staking
+     * metadata in a way that disqualifies them for the current period; It is reset at the beginning of every period
+     */
+    int64 unclaimed_stake_reward_start = 7;
+    /**
+     * The total amount of effective hbar staked to this node. This is sum of stake_to_reward and stake_to_not_reward.
+     * If the sum is greater than max_stake, then the effective stake is max_stake.
+     * If the sum is less than min_stake, then the effective stake is 0.
+     */
+    int64 stake = 8;
+    /**
+     * An running sum of reward rates per hbar for the last 365+1 staking periods. The first element is the
+     * is the reward up to and including the last full period that finished before the present. Second element is
+     * the reward up to and including the period before that
+     */
+    repeated int64 reward_sum_history = 9;
+    /**
+     * The consensus weight of this node in the network. This is computed based on the stake of this node
+     * at midnight UTC of the current day. If the stake of this node is less than minStake, then the weight is 0.
+     * Sum of all weights of nodes in the network should be less than 500.
+     * If the stake of this node A is greater than minStake, then the weight of this node A is calculated as:
+     * (node A stake * 500/ total stake of all nodes)
+     */
+    int32 weight = 10;
+    /**
+     * The total staking rewards in tinybars that COULD be collected by all accounts staking to the current node after the end
+     * of this staking period; assuming that no account "renounces" its rewards by, for example, setting declineReward=true.
+     * When the current node is deleted, this amount will be subtracted from the total pending rewards of all accounts staking
+     * to all nodes in the network in NetworkStakingRewards.
+     */
+    int64 pending_rewards = 11;
+    /**
+     * True if this node has been deleted from network.
+     */
+    bool deleted = 12;
+}

--- a/hapi/hedera-protobufs/services/state/token/token.proto
+++ b/hapi/hedera-protobufs/services/state/token/token.proto
@@ -1,0 +1,175 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+import "custom_fees.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Representation of a Hedera Token Service token entity in the network Merkle tree.
+ *
+ * As with all network entities, a token has a unique entity number, which is usually given along
+ * with the network's shard and realm in the form of a shard.realm.number id.
+ */
+
+message Token {
+    /**
+     * The unique entity id of this token.
+     */
+    TokenID token_id = 1;
+    /**
+     * The human-readable name of this token. Need not be unique. Maximum length allowed is 100 bytes.
+     */
+    string name = 2;
+    /**
+     * The human-readable symbol for the token. It is not necessarily unique. Maximum length allowed is 100 bytes.
+     */
+    string symbol = 3;
+    /**
+     * The number of decimal places of this token. If decimals are 8 or 11, then the number of whole
+     * tokens can be at most a few billions or millions, respectively. For example, it could match
+     * Bitcoin (21 million whole tokens with 8 decimals) or hbars (50 billion whole tokens with 8 decimals).
+     * It could even match Bitcoin with milli-satoshis (21 million whole tokens with 11 decimals).
+     */
+    int32 decimals = 4;
+    /**
+     * The total supply of this token.
+     */
+    int64 total_supply = 5;
+    /**
+     * The treasury account id of this token. This account receives the initial supply of
+     * tokens as well as the tokens from the Token Mint operation once executed. The balance
+     * of the treasury account is decreased when the Token Burn operation is executed.
+     */
+    AccountID treasury_account_id = 6;
+    /**
+     * (Optional) The admin key of this token. If this key is set, the token is mutable.
+     * A mutable token can be modified.
+     * If this key is not set on token creation, it cannot be modified.
+     */
+    Key admin_key = 7;
+    /**
+     * (Optional) The kyc key of this token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key kyc_key = 8;
+    /**
+     * (Optional) The freeze key of this token. This key is needed for freezing the token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key freeze_key = 9;
+    /**
+     * (Optional) The wipe key of this token. This key is needed for wiping the token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key wipe_key = 10;
+    /**
+     * (Optional) The supply key of this token. This key is needed for minting or burning token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key supply_key = 11;
+    /**
+     * (Optional) The fee schedule key of this token. This key should be set, in order to make any
+     * changes to the custom fee schedule.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key fee_schedule_key = 12;
+    /**
+     * (Optional) The pause key of this token. This key is needed for pausing the token.
+     * If this key is not set on token creation, it can only be set if the token has admin key set.
+     */
+    Key pause_key = 13;
+    /**
+     * The last used serial number of this token.
+     */
+    int64 last_used_serial_number = 14;
+    /**
+     * The flag indicating if this token is deleted.
+     */
+    bool deleted = 15;
+    /**
+     * The type of this token. A token can be either FUNGIBLE_COMMON or NON_FUNGIBLE_UNIQUE.
+     * If it has been omitted during token creation, FUNGIBLE_COMMON type is used.
+     */
+    TokenType token_type = 16;
+    /**
+     * The supply type of this token.A token can have either INFINITE or FINITE supply type.
+     * If it has been omitted during token creation, INFINITE type is used.
+     */
+    TokenSupplyType supply_type = 17;
+    /**
+     * The id of the account (if any) that the network will attempt to charge for the
+     * token's auto-renewal upon expiration.
+     */
+    AccountID auto_renew_account_id = 18;
+    /**
+     * The number of seconds the network should automatically extend the token's expiration by, if the
+     * token has a valid auto-renew account, and is not deleted upon expiration.
+     * If this is not provided in a allowed range on token creation, the transaction will fail with INVALID_AUTO_RENEWAL_PERIOD.
+     * The default values for the minimum period and maximum period are 30 days and 90 days, respectively.
+     */
+    int64 auto_renew_seconds = 19;
+    /**
+     * The expiration time of the token, in seconds since the epoch.
+     */
+    int64 expiration_second = 20;
+    /**
+     * An optional description of the token with UTF-8 encoding up to 100 bytes.
+     */
+    string memo = 21;
+    /**
+     * The maximum supply of this token.
+     */
+    int64 max_supply = 22;
+    /**
+     * The flag indicating if this token is paused.
+     */
+    bool paused = 23;
+    /**
+     * The flag indicating if this token has accounts associated to it that are frozen by default.
+     */
+    bool accounts_frozen_by_default = 24;
+    /**
+      * The flag indicating if this token has accounts associated with it that are KYC granted by default.
+     */
+    bool accounts_kyc_granted_by_default = 25;
+    /**
+     * (Optional) The custom fees of this token.
+     */
+    repeated CustomFee custom_fees = 26;
+
+    /**
+     * Metadata of the created token definition
+     */
+    bytes metadata = 27;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition and individual NFTs).
+     */
+    Key metadata_key = 28;
+}

--- a/hapi/hedera-protobufs/services/state/token/token_relation.proto
+++ b/hapi/hedera-protobufs/services/state/token/token_relation.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+import "basic_types.proto";
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.state.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+/**
+ * Representation of a Hedera Token Service token relationship entity in the network Merkle tree.
+ *
+ * As with all network entities, a token relationship has a unique entity number pair, which is represented
+ * with the account and the token involved in the relationship.
+ */
+message TokenRelation {
+    /**
+     * The token involved in this relation.It takes only positive
+     */
+    TokenID token_id = 1;
+    /**
+     * The account involved in this association.
+     */
+    AccountID account_id = 2;
+    /**
+     * The balance of the token relationship.
+     */
+    int64 balance = 3;
+    /**
+     * The flags specifying the token relationship is frozen or not.
+     */
+    bool frozen = 4;
+    /**
+     * The flag indicating if the token relationship has been granted KYC.
+     */
+    bool kyc_granted = 5;
+    /**
+     * The flag indicating if the token relationship was created using automatic association.
+     */
+    bool automatic_association = 6;
+    /**
+     * The previous token id of account's association linked list
+     */
+    TokenID previous_token = 7;
+    /**
+     * The next token id of account's association linked list
+     */
+    TokenID next_token = 8;
+}

--- a/hapi/hedera-protobufs/services/system_delete.proto
+++ b/hapi/hedera-protobufs/services/system_delete.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+/**
+ * Delete a file or smart contract - can only be done with a Hedera administrative multisignature.
+ * When it is deleted, it immediately disappears from the system as seen by the user, but is still
+ * stored internally until the expiration time, at which time it is truly and permanently deleted.
+ * Until that time, it can be undeleted by the Hedera administrative multisignature. When a smart
+ * contract is deleted, the cryptocurrency account within it continues to exist, and is not affected
+ * by the expiration time here. 
+ */
+message SystemDeleteTransactionBody {
+    oneof id {
+        /**
+         * The file ID of the file to delete, in the format used in transactions
+         */
+        FileID fileID = 1;
+
+        /**
+         * The contract ID instance to delete, in the format used in transactions
+         */
+        ContractID contractID = 2;
+    }
+
+    /**
+     * The timestamp in seconds at which the "deleted" file should truly be permanently deleted
+     */
+    TimestampSeconds expirationTime = 3;
+}

--- a/hapi/hedera-protobufs/services/system_undelete.proto
+++ b/hapi/hedera-protobufs/services/system_undelete.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.file">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Undelete a file or smart contract that was deleted by SystemDelete; requires a Hedera
+ * administrative multisignature. 
+ */
+message SystemUndeleteTransactionBody {
+    oneof id {
+        /**
+         * The file ID to undelete, in the format used in transactions
+         */
+        FileID fileID = 1;
+
+        /**
+         * The contract ID instance to undelete, in the format used in transactions
+         */
+        ContractID contractID = 2;
+    }
+}

--- a/hapi/hedera-protobufs/services/throttle_definitions.proto
+++ b/hapi/hedera-protobufs/services/throttle_definitions.proto
@@ -1,0 +1,86 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * For details behind this throttling design, please see the <i>docs/throttle-design.md</i> document
+ * in the <a href="https://github.com/hashgraph/hedera-services">Hedera Services</a> repository.
+ */
+
+/**
+ * A set of operations which should be collectively throttled at a given milli-ops-per-second limit.
+ */
+message ThrottleGroup {
+  /**
+   * The operations to be throttled
+   */
+  repeated HederaFunctionality operations = 1;
+
+  /**
+   * The number of total operations per second across the entire network, multiplied by 1000. So, to
+   * choose 3 operations per second (which on a network of 30 nodes is a tenth of an operation per
+   * second for each node), set milliOpsPerSec = 3000. And to choose 3.6 ops per second, use
+   * milliOpsPerSec = 3600. Minimum allowed value is 1, and maximum allowed value is 9223372.
+   */
+  uint64 milliOpsPerSec = 2;
+}
+
+/**
+ * A list of throttle groups that should all compete for the same internal bucket.
+ */
+message ThrottleBucket {
+  /**
+   * A name for this bucket (primarily for use in logs)
+   */
+  string name = 1;
+
+  /**
+   * The number of milliseconds required for this bucket to drain completely when full. The product
+   * of this number and the least common multiple of the milliOpsPerSec values in this bucket must
+   * not exceed 9223372036.
+   */
+  uint64 burstPeriodMs = 2;
+
+  /**
+   * The throttle groups competing for this bucket
+   */
+  repeated ThrottleGroup throttleGroups = 3;
+}
+
+/**
+ * A list of throttle buckets which, simultaneously enforced, define the system's throttling policy.
+ * <ol>
+ * <li> When an operation appears in more than one throttling bucket, all its buckets must have room
+ * or it will be throttled.</li> 
+ * <li>An operation assigned to no buckets is always throttled.</li>
+ * </ol> 
+ */
+message ThrottleDefinitions {
+  repeated ThrottleBucket throttleBuckets = 1;
+}

--- a/hapi/hedera-protobufs/services/timestamp.proto
+++ b/hapi/hedera-protobufs/services/timestamp.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * An exact date and time. This is the same data structure as the protobuf Timestamp.proto (see the
+ * comments in https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto)
+ */
+message Timestamp {
+    /**
+     * Number of complete seconds since the start of the epoch
+     */
+    int64 seconds = 1;
+
+    /**
+     * Number of nanoseconds since the start of the last second
+     */
+    int32 nanos = 2;
+}
+
+/**
+ * An exact date and time,  with a resolution of one second (no nanoseconds).
+ */
+message TimestampSeconds {
+    /**
+     * Number of complete seconds since the start of the epoch
+     */
+    int64 seconds = 1;
+}
+

--- a/hapi/hedera-protobufs/services/token_airdrop.proto
+++ b/hapi/hedera-protobufs/services/token_airdrop.proto
@@ -1,0 +1,100 @@
+/**
+ * # Token Airdrop
+ * Messages used to implement a transaction to "airdrop" tokens.<br/>
+ * An "airdrop" is a distribution of tokens from a funding account
+ * to one or more recipient accounts, ideally with no action required
+ * by the recipient account(s).
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Airdrop one or more tokens to one or more accounts.
+ *
+ * ### Effects
+ * This distributes tokens from the balance of one or more sending account(s) to the balance
+ * of one or more recipient accounts. Accounts MAY receive the tokens in one of four ways.
+ *
+ *  - An account already associated to the token to be distributed SHALL receive the
+ *    airdropped tokens immediately to the recipient account balance.<br/>
+ *    The fee for this transfer SHALL include the transfer, the airdrop fee, and any custom fees.
+ *  - An account with available automatic association slots SHALL be automatically
+ *    associated to the token, and SHALL immediately receive the airdropped tokens to the
+ *    recipient account balance.<br/>
+ *    The fee for this transfer SHALL include the transfer, the association, the cost to renew
+ *    that association once, the airdrop fee, and any custom fees.
+ *  - An account with "receiver signature required" set SHALL have a "Pending Airdrop" created
+ *    and must claim that airdrop with a `claimAirdrop` transaction.<br/>
+ *    The fee for this transfer SHALL include the transfer, the association, the cost to renew
+ *    that association once, the airdrop fee, and any custom fees. If the pending airdrop is not
+ *    claimed immediately, the `sender` SHALL pay the cost to renew the token association, and
+ *    the cost to maintain the pending airdrop, until the pending airdrop is claimed or cancelled.
+ *  - An account with no available automatic association slots SHALL have a "Pending Airdrop"
+ *    created and must claim that airdrop with a `claimAirdrop` transaction.<br/>
+ *    The fee for this transfer SHALL include the transfer, the association, the cost to renew
+ *    that association once, the airdrop fee, and any custom fees. If the pending airdrop is not
+ *    claimed immediately, the `sender` SHALL pay the cost to renew the token association, and
+ *    the cost to maintain the pending airdrop, until the pending airdrop is claimed or cancelled.
+ *
+ * If an airdrop would create a pending airdrop for a fungible/common token, and a pending airdrop
+ * for the same sender, receiver, and token already exists, the existing pending airdrop
+ * SHALL be updated to add the new amount to the existing airdrop, rather than creating a new
+ * pending airdrop.
+ *
+ * Any airdrop that completes immediately SHALL be irreversible. Any airdrop that results in a
+ * "Pending Airdrop" MAY be canceled via a `cancelAirdrop` transaction.
+ *
+ * All transfer fees (including custom fees and royalties), as well as the rent cost for the
+ * first auto-renewal period for any automatic-association slot occupied by the airdropped
+ * tokens, SHALL be charged to the account paying for this transaction.
+ *
+ * ### Record Stream Effects
+ * - Each successful transfer SHALL be recorded in `token_transfer_list` for the transaction record.
+ * - Each successful transfer that consumes an automatic association slot SHALL populate the
+ *   `automatic_association` field for the record.
+ * - Each pending transfer _created_ SHALL be added to the `pending_airdrops` field for the record.
+ * - Each pending transfer _updated_ SHALL be added to the `pending_airdrops` field for the record.
+ */
+message TokenAirdropTransactionBody {
+  /**
+   * A list of token transfers representing one or more airdrops.
+   * The sender for each transfer MUST have sufficient balance to complete the transfers.
+   *
+   * All token transfers MUST successfully transfer tokens or create a pending airdrop
+   * for this transaction to succeed.
+   * This list MUST contain between 1 and 10 transfers, inclusive.
+   *
+   * Note that each transfer of fungible/common tokens requires both a debit and
+   * a credit, so each _fungible_ token transfer MUST have _balanced_ entries in the
+   * TokenTransferList for that transfer.
+   */
+  repeated TokenTransferList token_transfers = 1;
+}

--- a/hapi/hedera-protobufs/services/token_associate.proto
+++ b/hapi/hedera-protobufs/services/token_associate.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Associates the provided account with the provided tokens. Must be signed by the provided
+ * Account's key.
+ * If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ * If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ * If any of the provided tokens is not found, the transaction will resolve to INVALID_TOKEN_REF.
+ * If any of the provided tokens has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If an association between the provided account and any of the tokens already exists, the
+ * transaction will resolve to TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT.
+ * If the provided account's associations count exceed the constraint of maximum token associations
+ * per account, the transaction will resolve to TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED.
+ * On success, associations between the provided account and tokens are made and the account is
+ * ready to interact with the tokens.
+ */
+message TokenAssociateTransactionBody {
+    /**
+     * The account to be associated with the provided tokens
+     */
+    AccountID account = 1;
+
+    /**
+     * The tokens to be associated with the provided account. In the case of NON_FUNGIBLE_UNIQUE
+     * Type, once an account is associated, it can hold any number of NFTs (serial numbers) of that
+     * token type
+     */
+    repeated TokenID tokens = 2;
+}

--- a/hapi/hedera-protobufs/services/token_burn.proto
+++ b/hapi/hedera-protobufs/services/token_burn.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Burns tokens from the Token's treasury Account. If no Supply Key is defined, the transaction will
+ * resolve to TOKEN_HAS_NO_SUPPLY_KEY.
+ * The operation decreases the Total Supply of the Token. Total supply cannot go below zero.
+ * The amount provided must be in the lowest denomination possible. Example:
+ * Token A has 2 decimals. In order to burn 100 tokens, one must provide amount of 10000. In order
+ * to burn 100.55 tokens, one must provide amount of 10055.
+ * For non fungible tokens the transaction body accepts serialNumbers list of integers as a parameter.
+ * 
+ * If the serialNumbers don't get filled for non-fungible token type, a INVALID_TOKEN_BURN_AMOUNT response
+ * code will be returned.
+ * If a zero amount is provided for a fungible token type, it will be treated as a regular transaction.
+ * If both amount and serialNumbers get filled, a INVALID_TRANSACTION_BODY response code will be
+ * returned.
+ * If the serialNumbers' list count is greater than the batch size limit global dynamic property, a
+ * BATCH_SIZE_LIMIT_EXCEEDED response code will be returned.
+ * If the serialNumbers list contains a non-positive integer as a serial number, a INVALID_NFT_ID
+ * response code will be returned.
+ */
+message TokenBurnTransactionBody {
+    /**
+     * The token for which to burn tokens. If token does not exist, transaction results in
+     * INVALID_TOKEN_ID
+     */
+    TokenID token = 1;
+
+    /**
+     * Applicable to tokens of type FUNGIBLE_COMMON. The amount to burn from the Treasury Account.
+     * Amount must be a positive non-zero number, not bigger than the token balance of the treasury
+     * account (0; balance], represented in the lowest denomination.
+     */
+    uint64 amount = 2;
+
+    /**
+     * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be burned.
+     */
+    repeated int64 serialNumbers = 3;
+}

--- a/hapi/hedera-protobufs/services/token_cancel_airdrop.proto
+++ b/hapi/hedera-protobufs/services/token_cancel_airdrop.proto
@@ -1,0 +1,60 @@
+/**
+ * # Token Cancel Airdrop
+ * Messages used to implement a transaction to cancel a pending airdrop.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Token cancel airdrop<br/>
+ * Remove one or more pending airdrops from state on behalf of the sender(s)
+ * for each airdrop.
+ *
+ * Each pending airdrop canceled SHALL be removed from state and SHALL NOT be available to claim.<br/>
+ * Each cancellation SHALL be represented in the transaction body and SHALL NOT be restated
+ * in the record file.<br/>
+ * All cancellations MUST succeed for this transaction to succeed.
+ */
+message TokenCancelAirdropTransactionBody {
+  /**
+   * A list of one or more pending airdrop identifiers.<br/>
+   * This list declares the set of pending airdrop entries that the client
+   * wishes to cancel; on success all listed pending airdrop entries
+   * will be removed.
+   * <p>
+   * This transaction MUST be signed by the account referenced by a `sender_id` for
+   * each entry in this list.<br/>
+   * This list MUST NOT have any duplicate entries.<br/>
+   * This list MUST contain between 1 and 10 entries, inclusive.
+   */
+  repeated PendingAirdropId pending_airdrops = 1;
+}

--- a/hapi/hedera-protobufs/services/token_claim_airdrop.proto
+++ b/hapi/hedera-protobufs/services/token_claim_airdrop.proto
@@ -1,0 +1,64 @@
+/**
+ * # Token Claim Airdrop
+ * Messages used to implement a transaction to claim a pending airdrop.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Token claim airdrop<br/>
+ * Complete one or more pending transfers on behalf of the
+ * recipient(s) for an airdrop.
+ *
+ * The sender MUST have sufficient balance to fulfill the airdrop at the
+ * time of claim. If the sender does not have sufficient balance, the
+ * claim SHALL fail.<br/>
+ * Each pending airdrop successfully claimed SHALL be removed from state and
+ * SHALL NOT be available to claim again.<br/>
+ * Each claim SHALL be represented in the transaction body and
+ * SHALL NOT be restated in the record file.<br/>
+ * All claims MUST succeed for this transaction to succeed.
+ *
+ * ### Record Stream Effects
+ * The completed transfers SHALL be present in the transfer list.
+ */
+message TokenClaimAirdropTransactionBody {
+  /**
+   * A list of one or more pending airdrop identifiers.
+   * <p>
+   * This transaction MUST be signed by the account identified by
+   * the `receiver_id` for each entry in this list.<br/>
+   * This list MUST contain between 1 and 10 entries, inclusive.<br/>
+   * This list MUST NOT have any duplicate entries.
+   */
+  repeated PendingAirdropId pending_airdrops = 1;
+}

--- a/hapi/hedera-protobufs/services/token_create.proto
+++ b/hapi/hedera-protobufs/services/token_create.proto
@@ -1,0 +1,212 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "duration.proto";
+import "basic_types.proto";
+import "custom_fees.proto";
+import "timestamp.proto";
+
+/**
+ * Create a new token. After the token is created, the Token ID for it is in the receipt.
+ * The specified Treasury Account is receiving the initial supply of tokens as-well as the tokens
+ * from the Token Mint operation once executed. The balance of the treasury account is decreased
+ * when the Token Burn operation is executed.
+ * 
+ * The <tt>initialSupply</tt> is the initial supply of the smallest parts of a token (like a
+ * tinybar, not an hbar). These are the smallest units of the token which may be transferred.
+ * 
+ * The supply can change over time. If the total supply at some moment is <i>S</i> parts of tokens,
+ * and the token is using <i>D</i> decimals, then <i>S</i> must be less than or equal to
+ * 2<sup>63</sup>-1, which is 9,223,372,036,854,775,807. The number of whole tokens (not parts) will
+ * be <i>S / 10<sup>D</sup></i>.
+ * 
+ * If decimals is 8 or 11, then the number of whole tokens can be at most a few billions or
+ * millions, respectively. For example, it could match Bitcoin (21 million whole tokens with 8
+ * decimals) or hbars (50 billion whole tokens with 8 decimals). It could even match Bitcoin with
+ * milli-satoshis (21 million whole tokens with 11 decimals).
+ * 
+ * Note that a created token is <i>immutable</i> if the <tt>adminKey</tt> is omitted. No property of
+ * an immutable token can ever change, with the sole exception of its expiry. Anyone can pay to
+ * extend the expiry time of an immutable token.
+ * 
+ * A token can be either <i>FUNGIBLE_COMMON</i> or <i>NON_FUNGIBLE_UNIQUE</i>, based on its
+ * <i>TokenType</i>. If it has been omitted, <i>FUNGIBLE_COMMON</i> type is used.
+ * 
+ * A token can have either <i>INFINITE</i> or <i>FINITE</i> supply type, based on its
+ * <i>TokenType</i>. If it has been omitted, <i>INFINITE</i> type is used.
+ * 
+ * If a <i>FUNGIBLE</i> TokenType is used, <i>initialSupply</i> should explicitly be set to a
+ * non-negative. If not, the transaction will resolve to INVALID_TOKEN_INITIAL_SUPPLY.
+ * 
+ * If a <i>NON_FUNGIBLE_UNIQUE</i> TokenType is used, <i>initialSupply</i> should explicitly be set
+ * to 0. If not, the transaction will resolve to INVALID_TOKEN_INITIAL_SUPPLY.
+ * 
+ * If an <i>INFINITE</i> TokenSupplyType is used, <i>maxSupply</i> should explicitly be set to 0. If
+ * it is not 0, the transaction will resolve to INVALID_TOKEN_MAX_SUPPLY.
+ * 
+ * If a <i>FINITE</i> TokenSupplyType is used, <i>maxSupply</i> should be explicitly set to a
+ * non-negative value. If it is not, the transaction will resolve to INVALID_TOKEN_MAX_SUPPLY.
+ */
+message TokenCreateTransactionBody {
+    /**
+     * The publicly visible name of the token. The token name is specified as a Unicode string. 
+     * Its UTF-8 encoding cannot exceed 100 bytes, and cannot contain the 0 byte (NUL).
+     */
+    string name = 1;
+
+    /**
+     * The publicly visible token symbol. The token symbol is specified as a Unicode string. 
+     * Its UTF-8 encoding cannot exceed 100 bytes, and cannot contain the 0 byte (NUL).
+     */
+    string symbol = 2;
+
+    /**
+     * For tokens of type FUNGIBLE_COMMON - the number of decimal places a
+     * token is divisible by. For tokens of type NON_FUNGIBLE_UNIQUE - value
+     * must be 0
+     */
+    uint32 decimals = 3;
+
+    /**
+     * Specifies the initial supply of tokens to be put in circulation. The
+     * initial supply is sent to the Treasury Account. The supply is in the
+     * lowest denomination possible. In the case for NON_FUNGIBLE_UNIQUE Type
+     * the value must be 0
+     */
+    uint64 initialSupply = 4;
+
+    /**
+     * The account which will act as a treasury for the token. This account
+     * will receive the specified initial supply or the newly minted NFTs in
+     * the case for NON_FUNGIBLE_UNIQUE Type
+     */
+    AccountID treasury = 5;
+
+    /**
+     * The key which can perform update/delete operations on the token. If empty, the token can be
+     * perceived as immutable (not being able to be updated/deleted)
+     */
+    Key adminKey = 6;
+
+    /**
+     * The key which can grant or revoke KYC of an account for the token's transactions. If empty,
+     * KYC is not required, and KYC grant or revoke operations are not possible.
+     */
+    Key kycKey = 7;
+
+    /**
+     * The key which can sign to freeze or unfreeze an account for token transactions. If empty,
+     * freezing is not possible
+     */
+    Key freezeKey = 8;
+
+    /**
+     * The key which can wipe the token balance of an account. If empty, wipe is not possible
+     */
+    Key wipeKey = 9;
+
+    /**
+     * The key which can change the supply of a token. The key is used to sign Token Mint/Burn
+     * operations
+     */
+    Key supplyKey = 10;
+
+    /**
+     * The default Freeze status (frozen or unfrozen) of Hedera accounts relative to this token. If
+     * true, an account must be unfrozen before it can receive the token
+     */
+    bool freezeDefault = 11;
+
+    /**
+     * The epoch second at which the token should expire; if an auto-renew account and period are
+     * specified, this is coerced to the current epoch second plus the autoRenewPeriod
+     */
+    Timestamp expiry = 13;
+
+    /**
+     * An account which will be automatically charged to renew the token's expiration, at
+     * autoRenewPeriod interval
+     */
+    AccountID autoRenewAccount = 14;
+
+    /**
+     * The interval at which the auto-renew account will be charged to extend the token's expiry
+     */
+    Duration autoRenewPeriod = 15;
+
+    /**
+     * The memo associated with the token (UTF-8 encoding max 100 bytes)
+     */
+    string memo = 16;
+
+    /**
+     * IWA compatibility. Specifies the token type. Defaults to FUNGIBLE_COMMON
+     */
+    TokenType tokenType = 17;
+
+    /**
+     * IWA compatibility. Specified the token supply type. Defaults to INFINITE
+     */
+    TokenSupplyType supplyType = 18;
+
+    /**
+     * IWA Compatibility. Depends on TokenSupplyType. For tokens of type FUNGIBLE_COMMON - the
+     * maximum number of tokens that can be in circulation. For tokens of type NON_FUNGIBLE_UNIQUE -
+     * the maximum number of NFTs (serial numbers) that can be minted. This field can never be
+     * changed!
+     */
+    int64 maxSupply = 19;
+
+    /**
+     * The key which can change the token's custom fee schedule; must sign a TokenFeeScheduleUpdate
+     * transaction
+     */
+    Key fee_schedule_key = 20;
+
+    /**
+     * The custom fees to be assessed during a CryptoTransfer that transfers units of this token
+     */
+    repeated CustomFee custom_fees = 21;
+
+    /**
+     * The Key which can pause and unpause the Token.
+     * If Empty the token pause status defaults to PauseNotApplicable, otherwise Unpaused.
+     */
+    Key pause_key = 22;
+
+    /**
+     * Metadata of the created token definition.
+     */
+    bytes metadata = 23;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition, partition definition, and individual NFTs).
+     */
+    Key metadata_key = 24;
+}

--- a/hapi/hedera-protobufs/services/token_delete.proto
+++ b/hapi/hedera-protobufs/services/token_delete.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Marks a token as deleted, though it will remain in the ledger.
+ * The operation must be signed by the specified Admin Key of the Token. If
+ * admin key is not set, Transaction will result in TOKEN_IS_IMMUTABlE.
+ * Once deleted update, mint, burn, wipe, freeze, unfreeze, grant kyc, revoke
+ * kyc and token transfer transactions will resolve to TOKEN_WAS_DELETED.
+ */
+message TokenDeleteTransactionBody {
+    /**
+     * The token to be deleted. If invalid token is specified, transaction will
+     * result in INVALID_TOKEN_ID
+     */
+    TokenID token = 1;
+}

--- a/hapi/hedera-protobufs/services/token_dissociate.proto
+++ b/hapi/hedera-protobufs/services/token_dissociate.proto
@@ -1,0 +1,58 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Dissociates the provided account with the provided tokens. Must be signed by the provided
+ * Account's key.
+ * If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ * If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ * If any of the provided tokens is not found, the transaction will resolve to INVALID_TOKEN_REF.
+ * If any of the provided tokens has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If an association between the provided account and any of the tokens does not exist, the
+ * transaction will resolve to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ * If a token has not been deleted and has not expired, and the user has a nonzero balance, the
+ * transaction will resolve to TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES.
+ * If a <b>fungible token</b> has expired, the user can disassociate even if their token balance is
+ * not zero.
+ * If a <b>non fungible token</b> has expired, the user can <b>not</b> disassociate if their token
+ * balance is not zero. The transaction will resolve to TRANSACTION_REQUIRED_ZERO_TOKEN_BALANCES.
+ * On success, associations between the provided account and tokens are removed.
+ */
+message TokenDissociateTransactionBody {
+    /**
+     * The account to be dissociated with the provided tokens
+     */
+    AccountID account = 1;
+
+    /**
+     * The tokens to be dissociated with the provided account
+     */
+    repeated TokenID tokens = 2;
+}

--- a/hapi/hedera-protobufs/services/token_fee_schedule_update.proto
+++ b/hapi/hedera-protobufs/services/token_fee_schedule_update.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "custom_fees.proto";
+
+/**
+ * At consensus, updates a token type's fee schedule to the given list of custom fees. 
+ * 
+ * If the target token type has no fee_schedule_key, resolves to TOKEN_HAS_NO_FEE_SCHEDULE_KEY.
+ * Otherwise this transaction must be signed to the fee_schedule_key, or the transaction will 
+ * resolve to INVALID_SIGNATURE.
+ * 
+ * If the custom_fees list is empty, clears the fee schedule or resolves to 
+ * CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES if the fee schedule was already empty.
+ */
+message TokenFeeScheduleUpdateTransactionBody {
+    /**
+     * The token whose fee schedule is to be updated
+     */
+    TokenID token_id = 1;
+
+    /**
+     * The new custom fees to be assessed during a CryptoTransfer that transfers units of this token
+     */
+    repeated CustomFee custom_fees = 2;
+}

--- a/hapi/hedera-protobufs/services/token_freeze_account.proto
+++ b/hapi/hedera-protobufs/services/token_freeze_account.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Freezes transfers of the specified token for the account. Must be signed by the Token's freezeKey.
+ * If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ * If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ * If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ * If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If an Association between the provided token and account is not found, the transaction will
+ * resolve to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ * If no Freeze Key is defined, the transaction will resolve to TOKEN_HAS_NO_FREEZE_KEY.
+ * Once executed the Account is marked as Frozen and will not be able to receive or send tokens
+ * unless unfrozen. The operation is idempotent.
+ */
+message TokenFreezeAccountTransactionBody {
+    /**
+     * The token for which this account will be frozen. If token does not exist, transaction results
+     * in INVALID_TOKEN_ID
+     */
+    TokenID token = 1;
+
+    /**
+     * The account to be frozen
+     */
+    AccountID account = 2;
+}

--- a/hapi/hedera-protobufs/services/token_get_account_nft_infos.proto
+++ b/hapi/hedera-protobufs/services/token_get_account_nft_infos.proto
@@ -1,0 +1,92 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "token_get_nft_info.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Applicable only to tokens of type NON_FUNGIBLE_UNIQUE. Gets info on NFTs N through M owned by the
+ * specified accountId.
+ * Example: If Account A owns 5 NFTs (might be of different Token Entity), having start=0 and end=5
+ * will return all of the NFTs
+ *
+ * INVALID_QUERY_RANGE response code will be returned if:
+ * 1) Start > End
+ * 2) Start and End indices are non-positive
+ * 3) Start and End indices are out of boundaries for the retrieved nft list
+ * 4) The range between Start and End is bigger than the global dynamic property for maximum query
+ *    range
+ *
+ * NOT_SUPPORTED response code will be returned if the queried token is of type FUNGIBLE_COMMON
+ *
+ * INVALID_ACCOUNT_ID response code will be returned if the queried account does not exist
+ *
+ * ACCOUNT_DELETED response code will be returned if the queried account has been deleted
+ */
+message TokenGetAccountNftInfosQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The Account for which information is requested
+     */
+    AccountID accountID = 2;
+
+    /**
+     * Specifies the start index (inclusive) of the range of NFTs to query for. Value must be in the
+     * range [0; ownedNFTs-1]
+     */
+    int64 start = 3;
+
+    /**
+     * Specifies the end index (exclusive) of the range of NFTs to query for. Value must be in the
+     * range (start; ownedNFTs]
+     */
+    int64 end = 4;
+}
+
+/**
+ * UNDOCUMENTED
+ */
+message TokenGetAccountNftInfosResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * List of NFTs associated to the account
+     */
+    repeated TokenNftInfo nfts = 2;
+}

--- a/hapi/hedera-protobufs/services/token_get_info.proto
+++ b/hapi/hedera-protobufs/services/token_get_info.proto
@@ -1,0 +1,228 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "custom_fees.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "timestamp.proto";
+import "duration.proto";
+
+/**
+ * Gets information about Token instance
+ */
+message TokenGetInfoQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither)
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The token for which information is requested. If invalid token is provided, INVALID_TOKEN_ID
+     * response is returned.
+     */
+    TokenID token = 2;
+}
+
+/**
+ * The metadata about a Token instance
+ */
+message TokenInfo {
+    /**
+     * ID of the token instance
+     */
+    TokenID tokenId = 1;
+
+    /**
+     * The name of the token. It is a string of ASCII only characters
+     */
+    string name = 2;
+
+    /**
+     * The symbol of the token. It is a UTF-8 capitalized alphabetical string
+     */
+    string symbol = 3;
+
+    /**
+     * The number of decimal places a token is divisible by. Always 0 for tokens of type
+     * NON_FUNGIBLE_UNIQUE
+     */
+    uint32 decimals = 4;
+
+    /**
+     * For tokens of type FUNGIBLE_COMMON - the total supply of tokens that are currently in
+     * circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the number of NFTs created of this
+     * token instance
+     */
+    uint64 totalSupply = 5;
+
+    /**
+     * The ID of the account which is set as Treasury
+     */
+    AccountID treasury = 6;
+
+    /**
+     * The key which can perform update/delete operations on the token. If empty, the token can be
+     * perceived as immutable (not being able to be updated/deleted)
+     */
+    Key adminKey = 7;
+
+    /**
+     * The key which can grant or revoke KYC of an account for the token's transactions. If empty,
+     * KYC is not required, and KYC grant or revoke operations are not possible.
+     */
+    Key kycKey = 8;
+
+    /**
+     * The key which can freeze or unfreeze an account for token transactions. If empty, freezing is
+     * not possible
+     */
+    Key freezeKey = 9;
+
+    /**
+     * The key which can wipe token balance of an account. If empty, wipe is not possible
+     */
+    Key wipeKey = 10;
+
+    /**
+     * The key which can change the supply of a token. The key is used to sign Token Mint/Burn
+     * operations
+     */
+    Key supplyKey = 11;
+
+    /**
+     * The default Freeze status (not applicable, frozen or unfrozen) of Hedera accounts relative to
+     * this token. FreezeNotApplicable is returned if Token Freeze Key is empty. Frozen is returned
+     * if Token Freeze Key is set and defaultFreeze is set to true. Unfrozen is returned if Token
+     * Freeze Key is set and defaultFreeze is set to false
+     */
+    TokenFreezeStatus defaultFreezeStatus = 12;
+
+    /**
+     * The default KYC status (KycNotApplicable or Revoked) of Hedera accounts relative to this
+     * token. KycNotApplicable is returned if KYC key is not set, otherwise Revoked
+     */
+    TokenKycStatus defaultKycStatus = 13;
+
+    /**
+     * Specifies whether the token was deleted or not
+     */
+    bool deleted = 14;
+
+    /**
+     * An account which will be automatically charged to renew the token's expiration, at
+     * autoRenewPeriod interval
+     */
+    AccountID autoRenewAccount = 15;
+
+    /**
+     * The interval at which the auto-renew account will be charged to extend the token's expiry
+     */
+    Duration autoRenewPeriod = 16;
+
+    /**
+     * The epoch second at which the token will expire
+     */
+    Timestamp expiry = 17;
+
+    /**
+     * The memo associated with the token
+     */
+    string memo = 18;
+
+    /**
+     * The token type
+     */
+    TokenType tokenType = 19;
+
+    /**
+     * The token supply type
+     */
+    TokenSupplyType supplyType = 20;
+
+    /**
+     * For tokens of type FUNGIBLE_COMMON - The Maximum number of fungible tokens that can be in
+     * circulation. For tokens of type NON_FUNGIBLE_UNIQUE - the maximum number of NFTs (serial
+     * numbers) that can be in circulation
+     */
+    int64 maxSupply = 21;
+
+    /**
+     * The key which can change the custom fee schedule of the token; if not set, the fee schedule
+     * is immutable
+     */
+    Key fee_schedule_key = 22;
+
+    /**
+     * The custom fees to be assessed during a CryptoTransfer that transfers units of this token
+     */
+    repeated CustomFee custom_fees = 23;
+
+    /**
+     * The Key which can pause and unpause the Token.
+     */
+    Key pause_key = 24;
+
+    /**
+     * Specifies whether the token is paused or not. PauseNotApplicable is returned if pauseKey is not set.
+     */
+    TokenPauseStatus pause_status = 25;
+
+    /**
+     * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+     */
+    bytes ledger_id = 26;
+
+    /**
+     * Represents the metadata of the token definition.
+     */
+    bytes metadata = 27;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition and individual NFTs).
+     */
+    Key metadata_key = 28;
+}
+
+/**
+ * Response when the client sends the node TokenGetInfoQuery
+ */
+message TokenGetInfoResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The information requested about this token instance
+     */
+    TokenInfo tokenInfo = 2;
+}

--- a/hapi/hedera-protobufs/services/token_get_nft_info.proto
+++ b/hapi/hedera-protobufs/services/token_get_nft_info.proto
@@ -1,0 +1,100 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+import "timestamp.proto";
+
+/**
+ * Applicable only to tokens of type NON_FUNGIBLE_UNIQUE. Gets info on a NFT for a given TokenID (of
+ * type NON_FUNGIBLE_UNIQUE) and serial number
+ */
+message TokenGetNftInfoQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The ID of the NFT
+     */
+    NftID nftID = 2;
+}
+
+/**
+ * UNDOCUMENTED
+ */
+message TokenNftInfo {
+    /**
+     * The ID of the NFT
+     */
+    NftID nftID = 1;
+
+    /**
+     * The current owner of the NFT
+     */
+    AccountID accountID = 2;
+
+    /**
+     * The effective consensus timestamp at which the NFT was minted
+     */
+    Timestamp creationTime = 3;
+
+    /**
+     * Represents the unique metadata of the NFT
+     */
+    bytes metadata = 4;
+
+    /**
+     * The ledger ID the response was returned from; please see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/master/HIP/hip-198.md">HIP-198</a> for the network-specific IDs. 
+     */
+    bytes ledger_id = 5;
+
+    /**
+     * If an allowance is granted for the NFT, its corresponding spender account
+     */
+    AccountID spender_id = 6;
+}
+
+/**
+ * UNDOCUMENTED
+ */
+message TokenGetNftInfoResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The information about this NFT
+     */
+    TokenNftInfo nft = 2;
+}

--- a/hapi/hedera-protobufs/services/token_get_nft_infos.proto
+++ b/hapi/hedera-protobufs/services/token_get_nft_infos.proto
@@ -1,0 +1,92 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "token_get_nft_info.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Applicable only to tokens of type NON_FUNGIBLE_UNIQUE. Gets info on NFTs N through M on the list
+ * of NFTs associated with a given NON_FUNGIBLE_UNIQUE Token.
+ * Example: If there are 10 NFTs issued, having start=0 and end=5 will query for the first 5 NFTs.
+ * Querying +all 10 NFTs will require start=0 and end=10
+ *
+ * INVALID_QUERY_RANGE response code will be returned if:
+ * 1) Start > End
+ * 2) Start and End indices are non-positive
+ * 3) Start and End indices are out of boundaries for the retrieved nft list
+ * 4) The range between Start and End is bigger than the global dynamic property for maximum query
+ * range
+ *
+ * NOT_SUPPORTED response code will be returned if the queried token is of type FUNGIBLE_COMMON
+ *
+ * INVALID_TOKEN_ID response code will be returned if the queried token does not exist
+ */
+message TokenGetNftInfosQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The ID of the token for which information is requested
+     */
+    TokenID tokenID = 2;
+
+    /**
+     * Specifies the start index (inclusive) of the range of NFTs to query for. Value must be in the
+     * range [0; ownedNFTs-1]
+     */
+    int64 start = 3;
+
+    /**
+     * Specifies the end index (exclusive) of the range of NFTs to query for. Value must be in the
+     * range (start; ownedNFTs]
+     */
+    int64 end = 4;
+}
+
+message TokenGetNftInfosResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The Token with type NON_FUNGIBLE that this record is for
+     */
+    TokenID tokenID = 2;
+
+    /**
+     * List of NFTs associated to the specified token
+     */
+    repeated TokenNftInfo nfts = 3;
+}

--- a/hapi/hedera-protobufs/services/token_grant_kyc.proto
+++ b/hapi/hedera-protobufs/services/token_grant_kyc.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Grants KYC to the account for the given token. Must be signed by the Token's kycKey.
+ * If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ * If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ * If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ * If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If an Association between the provided token and account is not found, the transaction will
+ * resolve to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ * If no KYC Key is defined, the transaction will resolve to TOKEN_HAS_NO_KYC_KEY.
+ * Once executed the Account is marked as KYC Granted.
+ */
+message TokenGrantKycTransactionBody {
+    /**
+     * The token for which this account will be granted KYC. If token does not exist, transaction
+     * results in INVALID_TOKEN_ID
+     */
+    TokenID token = 1;
+
+    /**
+     * The account to be KYCed
+     */
+    AccountID account = 2;
+}

--- a/hapi/hedera-protobufs/services/token_mint.proto
+++ b/hapi/hedera-protobufs/services/token_mint.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Mints tokens to the Token's treasury Account. If no Supply Key is defined, the transaction will
+ * resolve to TOKEN_HAS_NO_SUPPLY_KEY.
+ * The operation increases the Total Supply of the Token. The maximum total supply a token can have
+ * is 2^63-1.
+ * The amount provided must be in the lowest denomination possible. Example:
+ * Token A has 2 decimals. In order to mint 100 tokens, one must provide amount of 10000. In order
+ * to mint 100.55 tokens, one must provide amount of 10055.
+ * If both amount and metadata list get filled, a INVALID_TRANSACTION_BODY response code will be
+ * returned.
+ * If the metadata list contains metadata which is too large, a METADATA_TOO_LONG response code will
+ * be returned.
+ * If the metadata list is not filled for a non-fungible token type, a INVALID_TOKEN_MINT_AMOUNT response
+ * code will be returned.
+ * If a zero amount is provided for a fungible token type, it will be treated as a regular transaction.
+ * If the metadata list count is greater than the batch size limit global dynamic property, a
+ * BATCH_SIZE_LIMIT_EXCEEDED response code will be returned.
+ */
+message TokenMintTransactionBody {
+    /**
+     * The token for which to mint tokens. If token does not exist, transaction results in
+     * INVALID_TOKEN_ID
+     */
+    TokenID token = 1;
+
+    /**
+     * Applicable to tokens of type FUNGIBLE_COMMON. The amount to mint to the Treasury Account.
+     * Amount must be a positive non-zero number represented in the lowest denomination of the
+     * token. The new supply must be lower than 2^63.
+     */
+    uint64 amount = 2;
+
+    /**
+     * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. A list of metadata that are being created.
+     * Maximum allowed size of each metadata is 100 bytes
+     */
+    repeated bytes metadata = 3;
+}

--- a/hapi/hedera-protobufs/services/token_pause.proto
+++ b/hapi/hedera-protobufs/services/token_pause.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Pauses the Token from being involved in any kind of Transaction until it is unpaused.
+ * Must be signed with the Token's pause key.
+ * If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ * If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If no Pause Key is defined, the transaction will resolve to TOKEN_HAS_NO_PAUSE_KEY.
+ * Once executed the Token is marked as paused and will be not able to be a part of any transaction.
+ * The operation is idempotent - becomes a no-op if the Token is already Paused.
+ */
+message TokenPauseTransactionBody {
+  /**
+   * The token to be paused.
+   */
+  TokenID token = 1;
+}

--- a/hapi/hedera-protobufs/services/token_reject.proto
+++ b/hapi/hedera-protobufs/services/token_reject.proto
@@ -1,0 +1,89 @@
+/**
+ * # Token Reject
+ * Messages used to implement a transaction to reject a token type from an
+ * account.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119).
+ */
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Reject undesired token(s).<br/>
+ * Transfer one or more token balances held by the requesting account to the treasury for each
+ * token type.<br/>
+ * Each transfer SHALL be one of the following
+ * - A single non-fungible/unique token.
+ * - The full balance held for a fungible/common token type.
+ *
+ * A single tokenReject transaction SHALL support a maximum of 10 transfers.
+ *
+ * ### Transaction Record Effects
+ * - Each successful transfer from `payer` to `treasury` SHALL be recorded in `token_transfer_list` for the transaction record.
+ */
+message TokenRejectTransactionBody {
+  /**
+   * An account holding the tokens to be rejected.<br/>
+   * If set, this account MUST sign this transaction.
+   * If not set, the payer for this transaction SHALL be the account rejecting tokens.
+   */
+  AccountID owner = 1;
+
+  /**
+   * A list of one or more token rejections.<br/>
+   * On success each rejected token serial number or balance SHALL be transferred from
+   * the requesting account to the treasury account for that token type.<br/>
+   * After rejection the requesting account SHALL continue to be associated with the token.<br/>
+   * if dissociation is desired then a separate TokenDissociate transaction MUST be submitted to remove the association.
+   */
+  repeated TokenReference rejections = 2;
+}
+
+/**
+ * A union token identifier.
+ *
+ * Identify a fungible/common token type, or a single non-fungible/unique token serial.
+ */
+message TokenReference {
+  oneof token_identifier {
+    /**
+     * A fungible/common token type.
+     */
+    TokenID fungible_token = 1;
+
+    /**
+     * A single specific serialized non-fungible/unique token.
+     */
+    NftID nft = 2;
+  }
+}

--- a/hapi/hedera-protobufs/services/token_revoke_kyc.proto
+++ b/hapi/hedera-protobufs/services/token_revoke_kyc.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+option java_multiple_files = true;
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+
+import "basic_types.proto";
+
+/**
+ * Revokes KYC to the account for the given token. Must be signed by the Token's kycKey.
+ * If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ * If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ * If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ * If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If an Association between the provided token and account is not found, the transaction will
+ * resolve to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ * If no KYC Key is defined, the transaction will resolve to TOKEN_HAS_NO_KYC_KEY.
+ * Once executed the Account is marked as KYC Revoked
+ */
+message TokenRevokeKycTransactionBody {
+    /**
+     * The token for which this account will get his KYC revoked. If token does not exist,
+     * transaction results in INVALID_TOKEN_ID
+     */
+    TokenID token = 1;
+
+    /**
+     * The account to be KYC Revoked
+     */
+    AccountID account = 2;
+}

--- a/hapi/hedera-protobufs/services/token_service.proto
+++ b/hapi/hedera-protobufs/services/token_service.proto
@@ -1,0 +1,195 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+
+import "query.proto";
+import "response.proto";
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * Transactions and queries for the Token Service
+ */
+service TokenService {
+    /**
+     * Creates a new Token by submitting the transaction
+     */
+    rpc createToken (Transaction) returns (TransactionResponse);
+
+    /**
+     * Updates the account by submitting the transaction
+     */
+    rpc updateToken (Transaction) returns (TransactionResponse);
+
+    /**
+     * Mints an amount of the token to the defined treasury account
+     */
+    rpc mintToken (Transaction) returns (TransactionResponse);
+
+    /**
+     * Burns an amount of the token from the defined treasury account
+     */
+    rpc burnToken (Transaction) returns (TransactionResponse);
+
+    /**
+     * Deletes a Token
+     */
+    rpc deleteToken (Transaction) returns (TransactionResponse);
+
+    /**
+     * Wipes the provided amount of tokens from the specified Account ID
+     */
+    rpc wipeTokenAccount (Transaction) returns (TransactionResponse);
+
+    /**
+     * Freezes the transfer of tokens to or from the specified Account ID
+     */
+    rpc freezeTokenAccount (Transaction) returns (TransactionResponse);
+
+    /**
+     * Unfreezes the transfer of tokens to or from the specified Account ID
+     */
+    rpc unfreezeTokenAccount (Transaction) returns (TransactionResponse);
+
+    /**
+     * Flags the provided Account ID as having gone through KYC
+     */
+    rpc grantKycToTokenAccount (Transaction) returns (TransactionResponse);
+
+    /**
+     * Removes the KYC flag of the provided Account ID
+     */
+    rpc revokeKycFromTokenAccount (Transaction) returns (TransactionResponse);
+
+    /**
+     * Associates tokens to an account
+     */
+    rpc associateTokens (Transaction) returns (TransactionResponse);
+
+    /**
+     * Dissociates tokens from an account
+     */
+    rpc dissociateTokens (Transaction) returns (TransactionResponse);
+
+    /**
+     * Updates the custom fee schedule on a token
+     */
+    rpc updateTokenFeeSchedule (Transaction) returns (TransactionResponse);
+
+    /**
+     * Retrieves the metadata of a token
+     */
+    rpc getTokenInfo (Query) returns (Response);
+
+    /**
+     * (DEPRECATED) Gets info on NFTs N through M on the list of NFTs associated with a given account
+     */
+    rpc getAccountNftInfos (Query) returns (Response) {
+         option deprecated = true;
+    };
+
+    /**
+     * Retrieves the metadata of an NFT by TokenID and serial number
+     */
+    rpc getTokenNftInfo (Query) returns (Response);
+
+    /**
+     * (DEPRECATED) Gets info on NFTs N through M on the list of NFTs associated with a given Token of type NON_FUNGIBLE
+     */
+    rpc getTokenNftInfos (Query) returns (Response) {
+         option deprecated = true;
+    };
+
+    // Pause the token
+    rpc pauseToken (Transaction) returns (TransactionResponse);
+
+    //  Unpause the token
+    rpc unpauseToken (Transaction) returns (TransactionResponse);
+
+    /**
+     * Updates the NFTs in a collection by TokenID and serial number
+     */
+    rpc updateNfts (Transaction) returns (TransactionResponse);
+
+    /**
+     * Reject one or more tokens.<br/>
+     * This transaction SHALL transfer the full balance of one or more tokens from the requesting
+     * account to the treasury for each token. This transfer SHALL NOT charge any custom fee or
+     * royalty defined for the token(s) to be rejected.<br/>
+     * <h3>Effects on success</h3>
+     * <ul>
+     *   <li>If the rejected token is fungible/common, the requesting account SHALL have a balance
+     *       of 0 for the rejected token. The treasury balance SHALL increase by the amount that
+     *       the requesting account decreased.</li>
+     *   <li>If the rejected token is non-fungible/unique the requesting account SHALL NOT hold
+     *       the specific serialized token that is rejected. The treasury account SHALL hold each
+     *       specific serialized token that was rejected.</li>
+     * </li>
+     */
+    rpc rejectToken (Transaction) returns (TransactionResponse);
+
+    /**
+     * Airdrop one or more tokens to one or more accounts.<br/>
+     * This distributes tokens from the balance of one or more sending account(s) to the balance
+     * of one or more recipient accounts. Accounts will receive the tokens in one of four ways.
+     * <ul>
+     *   <li>An account already associated to the token to be distributed SHALL receive the
+     *       airdropped tokens immediately to the recipient account balance.</li>
+     *   <li>An account with available automatic association slots SHALL be automatically
+     *       associated to the token, and SHALL immediately receive the airdropped tokens to the
+     *       recipient account balance.</li>
+     *   <li>An account with "receiver signature required" set SHALL have a "Pending Airdrop"
+     *       created and MUST claim that airdrop with a `claimAirdrop` transaction.</li>
+     *   <li>An account with no available automatic association slots SHALL have a
+     *       "Pending Airdrop" created and MUST claim that airdrop with a `claimAirdrop`
+     *       transaction. </li>
+     * </ul>
+     * Any airdrop that completes immediately SHALL be irreversible. Any airdrop that results in a
+     * "Pending Airdrop" MAY be canceled via a `cancelAirdrop` transaction.<br/>
+     * All transfer fees (including custom fees and royalties), as well as the rent cost for the
+     * first auto-renewal period for any automatic-association slot occupied by the airdropped
+     * tokens, SHALL be charged to the account submitting this transaction.
+     */
+    rpc airdropTokens (Transaction) returns (TransactionResponse);
+
+    /**
+     * Cancel one or more pending airdrops.
+     * <p>
+     * This transaction MUST be signed by _each_ account *sending* an airdrop to be canceled.
+     */
+    rpc cancelAirdrop (Transaction) returns (TransactionResponse);
+
+    /**
+     * Claim one or more pending airdrops.
+     * <p>
+     * This transaction MUST be signed by _each_ account **receiving** an
+     * airdrop to be claimed.<br>
+     * If a "Sender" lacks sufficient balance to fulfill the airdrop at the
+     * time the claim is made, that claim SHALL fail.
+     */
+    rpc claimAirdrop (Transaction) returns (TransactionResponse);
+
+}

--- a/hapi/hedera-protobufs/services/token_unfreeze_account.proto
+++ b/hapi/hedera-protobufs/services/token_unfreeze_account.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Unfreezes transfers of the specified token for the account. Must be signed by the Token's
+ * freezeKey.
+ * If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ * If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ * If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ * If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If an Association between the provided token and account is not found, the transaction will
+ * resolve to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ * If no Freeze Key is defined, the transaction will resolve to TOKEN_HAS_NO_FREEZE_KEY.
+ * Once executed the Account is marked as Unfrozen and will be able to receive or send tokens. The
+ * operation is idempotent.
+ */
+message TokenUnfreezeAccountTransactionBody {
+    /**
+     * The token for which this account will be unfrozen. If token does not exist, transaction
+     * results in INVALID_TOKEN_ID
+     */
+    TokenID token = 1;
+
+    /**
+     * The account to be unfrozen
+     */
+    AccountID account = 2;
+}

--- a/hapi/hedera-protobufs/services/token_unpause.proto
+++ b/hapi/hedera-protobufs/services/token_unpause.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Unpauses the Token. Must be signed with the Token's pause key.
+ * If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ * If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If no Pause Key is defined, the transaction will resolve to TOKEN_HAS_NO_PAUSE_KEY.
+ * Once executed the Token is marked as Unpaused and can be used in Transactions.
+ * The operation is idempotent - becomes a no-op if the Token is already unpaused.
+ */
+message TokenUnpauseTransactionBody {
+  /**
+   * The token to be unpaused.
+   */
+  TokenID token = 1;
+}

--- a/hapi/hedera-protobufs/services/token_update.proto
+++ b/hapi/hedera-protobufs/services/token_update.proto
@@ -1,0 +1,163 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "duration.proto";
+import "timestamp.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * At consensus, updates an already created token to the given values.
+ * 
+ * If no value is given for a field, that field is left unchanged. For an immutable tokens (that is,
+ * a token without an admin key), only the expiry may be updated. Setting any other field in that
+ * case will cause the transaction status to resolve to TOKEN_IS_IMMUTABLE.
+ * 
+ * --- Signing Requirements ---
+ * 1. Whether or not a token has an admin key, its expiry can be extended with only the transaction
+ *    payer's signature.
+ * 2. Updating any other field of a mutable token requires the admin key's signature.
+ * 3. If a new admin key is set, this new key must sign <b>unless</b> it is exactly an empty
+ *    <tt>KeyList</tt>. This special sentinel key removes the existing admin key and causes the
+ *    token to become immutable. (Other <tt>Key</tt> structures without a constituent
+ *    <tt>Ed25519</tt> key will be rejected with <tt>INVALID_ADMIN_KEY</tt>.)
+ * 4. If a new treasury is set, the new treasury account's key must sign the transaction.
+ * 
+ * --- Nft Requirements ---
+ * 1. If a non fungible token has a positive treasury balance, the operation will abort with
+ *    CURRENT_TREASURY_STILL_OWNS_NFTS.
+ */
+message TokenUpdateTransactionBody {
+    /**
+     * The Token to be updated
+     */
+    TokenID token = 1;
+
+    /**
+     * The new publicly visible token symbol. The token symbol is specified as a Unicode string. 
+     * Its UTF-8 encoding cannot exceed 100 bytes, and cannot contain the 0 byte (NUL).
+     */
+    string symbol = 2;
+
+    /**
+     * The new publicly visible name of the token. The token name is specified as a Unicode string. 
+     * Its UTF-8 encoding cannot exceed 100 bytes, and cannot contain the 0 byte (NUL).
+     */
+    string name = 3;
+
+    /**
+     * The new Treasury account of the Token. If the provided treasury account is not existing or
+     * deleted, the response will be INVALID_TREASURY_ACCOUNT_FOR_TOKEN. If successful, the Token
+     * balance held in the previous Treasury Account is transferred to the new one.
+     */
+    AccountID treasury = 4;
+
+    /**
+     * The new admin key of the Token. If Token is immutable, transaction will resolve to
+     * TOKEN_IS_IMMUTABlE.
+     */
+    Key adminKey = 5;
+
+    /**
+     * The new KYC key of the Token. If Token does not have currently a KYC key, transaction will
+     * resolve to TOKEN_HAS_NO_KYC_KEY.
+     */
+    Key kycKey = 6;
+
+    /**
+     * The new Freeze key of the Token. If the Token does not have currently a Freeze key,
+     * transaction will resolve to TOKEN_HAS_NO_FREEZE_KEY.
+     */
+    Key freezeKey = 7;
+
+    /**
+     * The new Wipe key of the Token. If the Token does not have currently a Wipe key, transaction
+     * will resolve to TOKEN_HAS_NO_WIPE_KEY.
+     */
+    Key wipeKey = 8;
+
+    /**
+     * The new Supply key of the Token. If the Token does not have currently a Supply key,
+     * transaction will resolve to TOKEN_HAS_NO_SUPPLY_KEY.
+     */
+    Key supplyKey = 9;
+
+    /**
+     * The new account which will be automatically charged to renew the token's expiration, at
+     * autoRenewPeriod interval.
+     */
+    AccountID autoRenewAccount = 10;
+
+    /**
+     * The new interval at which the auto-renew account will be charged to extend the token's
+     * expiry.
+     */
+    Duration autoRenewPeriod = 11;
+
+    /**
+     * The new expiry time of the token. Expiry can be updated even if admin key is not set. If the
+     * provided expiry is earlier than the current token expiry, transaction wil resolve to
+     * INVALID_EXPIRATION_TIME
+     */
+    Timestamp expiry = 12;
+
+    /**
+     * If set, the new memo to be associated with the token (UTF-8 encoding max 100 bytes)
+     */
+    google.protobuf.StringValue memo = 13;
+
+    /**
+     * If set, the new key to use to update the token's custom fee schedule; if the token does not
+     * currently have this key, transaction will resolve to TOKEN_HAS_NO_FEE_SCHEDULE_KEY
+     */
+    Key fee_schedule_key = 14;
+
+    /**
+     * The Key which can pause and unpause the Token. If the Token does not currently have a pause key,
+     * transaction will resolve to TOKEN_HAS_NO_PAUSE_KEY
+     */
+    Key pause_key = 15;
+
+    /**
+     * Metadata of the created token definition
+     */
+    google.protobuf.BytesValue metadata = 16;
+
+    /**
+     * The key which can change the metadata of a token
+     * (token definition, partition definition, and individual NFTs).
+     * If the Token does not have currently a Metadata key,
+     * transaction will resolve to TOKEN_HAS_NO_METADATA_KEY
+     */
+    Key metadata_key = 17;
+
+    /**
+     * Determines whether the system should check the validity of the passed keys for update.
+     */
+    TokenKeyValidation key_verification_mode = 18;
+}

--- a/hapi/hedera-protobufs/services/token_update_nfts.proto
+++ b/hapi/hedera-protobufs/services/token_update_nfts.proto
@@ -1,0 +1,55 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "google/protobuf/wrappers.proto";
+
+/**
+ * At consensus, updates an already created Non Fungible Token to the given values.
+ *
+ * If no value is given for a field, that field is left unchanged.
+ * Only certain fields such as metadata can be updated.
+ *
+ * Updating the metadata of an NFT does not affect its ownership or transferability.
+ * This operation is intended for updating attributes of individual NFTs in a collection.
+ *
+ * --- Signing Requirements ---
+ * 1. To update metadata of an NFT, the metadata_key of the token should sign the transaction.
+ */
+message TokenUpdateNftsTransactionBody {
+    /**
+     * The token for which to update NFTs.
+     */
+    TokenID token = 1;
+
+    /**
+     * The list of serial numbers to be updated.
+     */
+    repeated int64 serial_numbers = 2;
+
+    /**
+     * The new metadata of the NFT(s)
+     */
+    google.protobuf.BytesValue metadata = 3;
+}

--- a/hapi/hedera-protobufs/services/token_wipe_account.proto
+++ b/hapi/hedera-protobufs/services/token_wipe_account.proto
@@ -1,0 +1,83 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.token">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+/**
+ * Wipes the provided amount of tokens from the specified Account. Must be signed by the Token's
+ * Wipe key.
+ * If the provided account is not found, the transaction will resolve to INVALID_ACCOUNT_ID.
+ * If the provided account has been deleted, the transaction will resolve to ACCOUNT_DELETED.
+ * If the provided token is not found, the transaction will resolve to INVALID_TOKEN_ID.
+ * If the provided token has been deleted, the transaction will resolve to TOKEN_WAS_DELETED.
+ * If an Association between the provided token and account is not found, the transaction will
+ * resolve to TOKEN_NOT_ASSOCIATED_TO_ACCOUNT.
+ * If Wipe Key is not present in the Token, transaction results in TOKEN_HAS_NO_WIPE_KEY.
+ * If the provided account is the Token's Treasury Account, transaction results in
+ * CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT
+ * On success, tokens are removed from the account and the total supply of the token is decreased by
+ * the wiped amount.
+ * 
+ * If both amount and serialNumbers get filled, a INVALID_TRANSACTION_BODY response code will be
+ * returned.
+ * If the serialNumbers don't get filled for a non-fungible token type, a INVALID_WIPING_AMOUNT response
+ * code will be returned.
+ * If a zero amount is provided for a fungible token type, it will be treated as a regular transaction.
+ * If the serialNumbers list contains a non-positive integer as a serial number, a INVALID_NFT_ID
+ * response code will be returned.
+ * If the serialNumbers' list count is greater than the batch size limit global dynamic property, a
+ * BATCH_SIZE_LIMIT_EXCEEDED response code will be returned.
+ * 
+ * The amount provided is in the lowest denomination possible. Example:
+ * Token A has 2 decimals. In order to wipe 100 tokens from account, one must provide amount of
+ * 10000. In order to wipe 100.55 tokens, one must provide amount of 10055.
+ */
+message TokenWipeAccountTransactionBody {
+    /**
+     * The token for which the account will be wiped. If token does not exist, transaction results
+     * in INVALID_TOKEN_ID
+     */
+    TokenID token = 1;
+
+    /**
+     * The account to be wiped
+     */
+    AccountID account = 2;
+
+    /**
+     * Applicable to tokens of type FUNGIBLE_COMMON. The amount of tokens to wipe from the specified
+     * account. Amount must be a positive non-zero number in the lowest denomination possible, not
+     * bigger than the token balance of the account (0; balance]
+     */
+    uint64 amount = 3;
+
+    /**
+     * Applicable to tokens of type NON_FUNGIBLE_UNIQUE. The list of serial numbers to be wiped.
+     */
+    repeated int64 serialNumbers = 4;
+}

--- a/hapi/hedera-protobufs/services/transaction.proto
+++ b/hapi/hedera-protobufs/services/transaction.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.base">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "transaction_body.proto";
+
+/**
+ * A single signed transaction, including all its signatures. The SignatureList will have a
+ * Signature for each Key in the transaction, either explicit or implicit, in the order that they
+ * appear in the transaction. For example, a CryptoTransfer will first have a Signature
+ * corresponding to the Key for the paying account, followed by a Signature corresponding to the Key
+ * for each account that is sending or receiving cryptocurrency in the transfer. Each Transaction
+ * should not have more than 50 levels. 
+ * The SignatureList field is deprecated and succeeded by SignatureMap.
+ */
+message Transaction {
+    /**
+     * The body of the transaction, which needs to be signed
+     */
+    TransactionBody body = 1 [deprecated = true];
+
+    /**
+     * The signatures on the body, to authorize the transaction; deprecated and to be succeeded by
+     * SignatureMap field
+     */
+    SignatureList sigs = 2 [deprecated = true];
+    
+    /**
+     * The signatures on the body with the new format, to authorize the transaction
+     */
+    SignatureMap sigMap = 3 [deprecated = true];
+    
+    /**
+     * TransactionBody serialized into bytes, which needs to be signed
+     */
+    bytes bodyBytes = 4 [deprecated = true];
+
+    /**
+     * SignedTransaction serialized into bytes
+     */
+    bytes signedTransactionBytes = 5;
+}

--- a/hapi/hedera-protobufs/services/transaction_body.proto
+++ b/hapi/hedera-protobufs/services/transaction_body.proto
@@ -1,0 +1,422 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "system_delete.proto";
+import "system_undelete.proto";
+import "freeze.proto";
+
+import "contract_call.proto";
+import "contract_create.proto";
+import "contract_update.proto";
+
+import "crypto_add_live_hash.proto";
+import "crypto_create.proto";
+import "crypto_delete.proto";
+import "crypto_delete_live_hash.proto";
+import "crypto_transfer.proto";
+import "crypto_update.proto";
+import "crypto_approve_allowance.proto";
+import "crypto_delete_allowance.proto";
+
+import "ethereum_transaction.proto";
+
+import "file_append.proto";
+import "file_create.proto";
+import "file_delete.proto";
+import "file_update.proto";
+
+import "duration.proto";
+import "basic_types.proto";
+import "contract_delete.proto";
+
+import "consensus_create_topic.proto";
+import "consensus_update_topic.proto";
+import "consensus_delete_topic.proto";
+import "consensus_submit_message.proto";
+
+import "unchecked_submit.proto";
+
+import "token_create.proto";
+import "token_freeze_account.proto";
+import "token_unfreeze_account.proto";
+import "token_grant_kyc.proto";
+import "token_revoke_kyc.proto";
+import "token_delete.proto";
+import "token_update.proto";
+import "token_mint.proto";
+import "token_burn.proto";
+import "token_wipe_account.proto";
+import "token_associate.proto";
+import "token_dissociate.proto";
+import "token_fee_schedule_update.proto";
+import "token_pause.proto";
+import "token_unpause.proto";
+import "token_update_nfts.proto";
+import "token_reject.proto";
+import "token_airdrop.proto";
+import "token_cancel_airdrop.proto";
+import "token_claim_airdrop.proto";
+
+import "schedule_create.proto";
+import "schedule_delete.proto";
+import "schedule_sign.proto";
+
+import "node_stake_update.proto";
+import "util_prng.proto";
+
+import "node_create.proto";
+import "node_update.proto";
+import "node_delete.proto";
+
+/**
+ * A single transaction. All transaction types are possible here.
+ */
+message TransactionBody {
+    /**
+     * The ID for this transaction, which includes the payer's account (the account paying the
+     * transaction fee). If two transactions have the same transactionID, they won't both have an
+     * effect
+     */
+    TransactionID transactionID = 1;
+
+    /**
+     * The account of the node that submits the client's transaction to the network
+     */
+    AccountID nodeAccountID = 2;
+
+    /**
+     * The maximum transaction fee the client is willing to pay
+     */
+    uint64 transactionFee = 3;
+
+    /**
+     * The transaction is invalid if consensusTimestamp > transactionID.transactionValidStart +
+     * transactionValidDuration
+     */
+    Duration transactionValidDuration = 4;
+
+    /**
+     * Should a record of this transaction be generated? (A receipt is always generated, but the
+     * record is optional)
+     */
+    bool generateRecord = 5 [deprecated = true];
+
+    /**
+     * Any notes or descriptions that should be put into the record (max length 100)
+     */
+    string memo = 6;
+
+    /**
+     * The choices here are arranged by service in roughly lexicographical order. The field ordinals are non-sequential, and a result of the historical order of implementation.
+     */
+    oneof data {
+        /**
+         * Calls a function of a contract instance
+         */
+        ContractCallTransactionBody contractCall = 7;
+
+        /**
+         * Creates a contract instance
+         */
+        ContractCreateTransactionBody contractCreateInstance = 8;
+
+        /**
+         * Updates a contract
+         */
+        ContractUpdateTransactionBody contractUpdateInstance = 9;
+
+        /**
+         * Attach a new livehash to an account
+         */
+        CryptoAddLiveHashTransactionBody cryptoAddLiveHash = 10;
+
+        /**
+         * Create a new cryptocurrency account
+         */
+        CryptoCreateTransactionBody cryptoCreateAccount = 11;
+
+        /**
+         * Delete a cryptocurrency account (mark as deleted, and transfer hbars out)
+         */
+        CryptoDeleteTransactionBody cryptoDelete = 12;
+
+        /**
+         * Remove a livehash from an account
+         */
+        CryptoDeleteLiveHashTransactionBody cryptoDeleteLiveHash = 13;
+
+        /**
+         * Transfer amount between accounts
+         */
+        CryptoTransferTransactionBody cryptoTransfer = 14;
+
+        /**
+         * Modify information such as the expiration date for an account
+         */
+        CryptoUpdateTransactionBody cryptoUpdateAccount = 15;
+
+        /**
+         * Add bytes to the end of the contents of a file
+         */
+        FileAppendTransactionBody fileAppend = 16;
+
+        /**
+         * Create a new file
+         */
+        FileCreateTransactionBody fileCreate = 17;
+
+        /**
+         * Delete a file (remove contents and mark as deleted until it expires)
+         */
+        FileDeleteTransactionBody fileDelete = 18;
+
+        /**
+         * Modify information such as the expiration date for a file
+         */
+        FileUpdateTransactionBody fileUpdate = 19;
+
+        /**
+         * Hedera administrative deletion of a file or smart contract
+         */
+        SystemDeleteTransactionBody systemDelete = 20;
+
+        /**
+         * To undelete an entity deleted by SystemDelete
+         */
+        SystemUndeleteTransactionBody systemUndelete = 21;
+
+        /**
+         * Delete contract and transfer remaining balance into specified account
+         */
+        ContractDeleteTransactionBody contractDeleteInstance = 22;
+
+        /**
+         * Freeze the nodes
+         */
+        FreezeTransactionBody freeze = 23;
+
+        /**
+         * Creates a topic
+         */
+        ConsensusCreateTopicTransactionBody consensusCreateTopic = 24;
+
+        /**
+         * Updates a topic
+         */
+        ConsensusUpdateTopicTransactionBody consensusUpdateTopic = 25;
+
+        /**
+         * Deletes a topic
+         */
+        ConsensusDeleteTopicTransactionBody consensusDeleteTopic = 26;
+
+        /**
+         * Submits message to a topic
+         */
+        ConsensusSubmitMessageTransactionBody consensusSubmitMessage = 27;
+
+        /**
+         * UNDOCUMENTED
+         */
+        UncheckedSubmitBody uncheckedSubmit = 28;
+
+        /**
+         * Creates a token instance
+         */
+        TokenCreateTransactionBody tokenCreation = 29;
+
+        /**
+         * Freezes account not to be able to transact with a token
+         */
+        TokenFreezeAccountTransactionBody tokenFreeze = 31;
+
+        /**
+         * Unfreezes account for a token
+         */
+        TokenUnfreezeAccountTransactionBody tokenUnfreeze = 32;
+
+        /**
+         * Grants KYC to an account for a token
+         */
+        TokenGrantKycTransactionBody tokenGrantKyc = 33;
+
+        /**
+         * Revokes KYC of an account for a token
+         */
+        TokenRevokeKycTransactionBody tokenRevokeKyc = 34;
+
+        /**
+         * Deletes a token instance
+         */
+        TokenDeleteTransactionBody tokenDeletion = 35;
+
+        /**
+         * Updates a token instance
+         */
+        TokenUpdateTransactionBody tokenUpdate = 36;
+
+        /**
+         * Mints new tokens to a token's treasury account
+         */
+        TokenMintTransactionBody tokenMint = 37;
+
+        /**
+         * Burns tokens from a token's treasury account
+         */
+        TokenBurnTransactionBody tokenBurn = 38;
+
+        /**
+         * Wipes amount of tokens from an account
+         */
+        TokenWipeAccountTransactionBody tokenWipe = 39;
+
+        /**
+         * Associate tokens to an account
+         */
+        TokenAssociateTransactionBody tokenAssociate = 40;
+
+        /**
+         * Dissociate tokens from an account
+         */
+        TokenDissociateTransactionBody tokenDissociate = 41;
+
+        /**
+         * Creates a schedule in the network's action queue
+         */
+        ScheduleCreateTransactionBody scheduleCreate = 42;
+
+        /**
+         * Deletes a schedule from the network's action queue
+         */
+        ScheduleDeleteTransactionBody scheduleDelete = 43;
+
+        /**
+         * Adds one or more Ed25519 keys to the affirmed signers of a scheduled transaction
+         */
+        ScheduleSignTransactionBody scheduleSign = 44;
+
+        /**
+         * Updates a token's custom fee schedule
+         */
+        TokenFeeScheduleUpdateTransactionBody token_fee_schedule_update = 45;
+
+        /**
+         * Pauses the Token
+         */
+        TokenPauseTransactionBody token_pause = 46;
+
+        /**
+         * Unpauses the Token
+         */
+        TokenUnpauseTransactionBody token_unpause = 47;
+
+        /**
+         * Adds one or more approved allowances for spenders to transfer the paying account's hbar or tokens.
+         */
+        CryptoApproveAllowanceTransactionBody cryptoApproveAllowance = 48;
+
+        /**
+         * Deletes one or more of the specific approved NFT serial numbers on an owner account.
+         */
+        CryptoDeleteAllowanceTransactionBody cryptoDeleteAllowance = 49;
+
+        /**
+         * An Ethereum encoded transaction.
+         */
+        EthereumTransactionBody ethereumTransaction = 50;
+
+        /**
+         * Updates the staking info at the end of staking period to indicate new staking period has started.
+         */
+        NodeStakeUpdateTransactionBody node_stake_update = 51;
+
+        /**
+         * Generates a pseudorandom number.
+         */
+        UtilPrngTransactionBody util_prng = 52;
+
+        /**
+         * Update the metadata of one or more NFT's of a specific token type.
+         */
+        TokenUpdateNftsTransactionBody token_update_nfts = 53;
+
+        /**
+         * A transaction body for a `createNode` request.
+         * <p>
+         * This transaction SHALL create a new consensus node record and add
+         * that record to the network address book.
+         */
+        com.hedera.hapi.node.addressbook.NodeCreateTransactionBody nodeCreate = 54;
+
+        /**
+         * A transaction body for an `updateNode` request.
+         * <p>
+         * This transaction SHALL update an existing consensus node record in
+         * the network address book.
+         */
+        com.hedera.hapi.node.addressbook.NodeUpdateTransactionBody nodeUpdate = 55;
+
+        /**
+         * A transaction body for a `deleteNode` request.
+         * <p>
+         * This transaction SHALL remove an existing consensus node record from
+         * the network address book.
+         */
+        com.hedera.hapi.node.addressbook.NodeDeleteTransactionBody nodeDelete = 56;
+
+        /**
+         * A transaction body to "reject" undesired tokens.<br/>
+         * This transaction will transfer one or more tokens or token
+         * balances held by the requesting account to the treasury
+         * for each token type.
+         * <p>
+         * Each transfer MUST be one of the following:
+         * <ul>
+         *   <li>A single non-fungible/unique token.</li>
+         *   <li>The full balance held for a fungible/common
+         *       token type.</li>
+         * </ul>
+         * When complete, the requesting account SHALL NOT hold the
+         * rejected tokens.<br/>
+         * Custom fees and royalties defined for the tokens rejected
+         * SHALL NOT be charged for this transaction.
+         */
+        TokenRejectTransactionBody tokenReject = 57;
+
+        /**
+         * A transaction body for a `tokenAirdrop` request.
+         */
+        TokenAirdropTransactionBody tokenAirdrop = 58;
+
+        /**
+        * A transaction body for a `cancelAirdrop` request.
+        */
+        TokenCancelAirdropTransactionBody tokenCancelAirdrop = 59;
+
+        /**
+        * A transaction body for a `claimAirdrop` request.
+         */
+        TokenClaimAirdropTransactionBody tokenClaimAirdrop = 60;
+    }
+}

--- a/hapi/hedera-protobufs/services/transaction_contents.proto
+++ b/hapi/hedera-protobufs/services/transaction_contents.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+message SignedTransaction {
+    /**
+     * TransactionBody serialized into bytes, which needs to be signed
+     */
+    bytes bodyBytes = 1;
+
+    /**
+     * The signatures on the body with the new format, to authorize the transaction
+     */
+    SignatureMap sigMap = 2;
+}

--- a/hapi/hedera-protobufs/services/transaction_get_fast_record.proto
+++ b/hapi/hedera-protobufs/services/transaction_get_fast_record.proto
@@ -1,0 +1,71 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "transaction_record.proto";
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get the tx record of a transaction, given its transaction ID. Once a transaction reaches
+ * consensus, then information about whether it succeeded or failed will be available until the end
+ * of the receipt period.  Before and after the receipt period, and for a transaction that was never
+ * submitted, the receipt is unknown.  This query is free (the payment field is left empty).
+ */
+message TransactionGetFastRecordQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The ID of the transaction for which the record is requested.
+     */
+    TransactionID transactionID = 2;
+}
+
+/**
+ * Response when the client sends the node TransactionGetFastRecordQuery. If it created a new entity
+ * (account, file, or smart contract instance) then one of the three ID fields will be filled in
+ * with the ID of the new entity. Sometimes a single transaction will create more than one new
+ * entity, such as when a new contract instance is created, and this also creates the new account
+ * that it owned by that instance.
+ */
+message TransactionGetFastRecordResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * The requested transaction records
+     */
+    TransactionRecord transactionRecord = 2;
+}

--- a/hapi/hedera-protobufs/services/transaction_get_receipt.proto
+++ b/hapi/hedera-protobufs/services/transaction_get_receipt.proto
@@ -1,0 +1,101 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "transaction_receipt.proto";
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get the receipt of a transaction, given its transaction ID. Once a transaction reaches consensus,
+ * then information about whether it succeeded or failed will be available until the end of the
+ * receipt period.  Before and after the receipt period, and for a transaction that was never
+ * submitted, the receipt is unknown.  This query is free (the payment field is left empty). No
+ * State proof is available for this response
+ */
+message TransactionGetReceiptQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The ID of the transaction for which the receipt is requested.
+     */
+    TransactionID transactionID = 2;
+
+    /**
+     * Whether receipts of processing duplicate transactions should be returned along with the
+     * receipt of processing the first consensus transaction with the given id whose status was
+     * neither <tt>INVALID_NODE_ACCOUNT</tt> nor <tt>INVALID_PAYER_SIGNATURE</tt>; <b>or</b>, if no
+     * such receipt exists, the receipt of processing the first transaction to reach consensus with
+     * the given transaction id.
+     */
+    bool includeDuplicates = 3;
+
+    /**
+     * Whether the response should include the receipts of any child transactions spawned by the 
+     * top-level transaction with the given transactionID. 
+     */
+    bool include_child_receipts = 4;
+}
+
+/**
+ * Response when the client sends the node TransactionGetReceiptQuery. If it created a new entity
+ * (account, file, or smart contract instance) then one of the three ID fields will be filled in
+ * with the ID of the new entity. Sometimes a single transaction will create more than one new
+ * entity, such as when a new contract instance is created, and this also creates the new account
+ * that it owned by that instance. No State proof is available for this response
+ */
+message TransactionGetReceiptResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * Either the receipt of processing the first consensus transaction with the given id whose
+     * status was neither <tt>INVALID_NODE_ACCOUNT</tt> nor <tt>INVALID_PAYER_SIGNATURE</tt>;
+     * <b>or</b>, if no such receipt exists, the receipt of processing the first transaction to
+     * reach consensus with the given transaction id.
+     */
+    TransactionReceipt receipt = 2;
+
+    /**
+     * The receipts of processing all transactions with the given id, in consensus time order.
+     */
+    repeated TransactionReceipt duplicateTransactionReceipts = 4;
+
+    /**
+     * The receipts (if any) of all child transactions spawned by the transaction with the 
+     * given top-level id, in consensus order. Always empty if the top-level status is UNKNOWN.
+     */
+    repeated TransactionReceipt child_transaction_receipts = 5;
+}

--- a/hapi/hedera-protobufs/services/transaction_get_record.proto
+++ b/hapi/hedera-protobufs/services/transaction_get_record.proto
@@ -1,0 +1,101 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "transaction_record.proto";
+import "basic_types.proto";
+import "query_header.proto";
+import "response_header.proto";
+
+/**
+ * Get the record for a transaction. If the transaction requested a record, then the record lasts
+ * for one hour, and a state proof is available for it. If the transaction created an account, file,
+ * or smart contract instance, then the record will contain the ID for what it created. If the
+ * transaction called a smart contract function, then the record contains the result of that call.
+ * If the transaction was a cryptocurrency transfer, then the record includes the TransferList which
+ * gives the details of that transfer. If the transaction didn't return anything that should be in
+ * the record, then the results field will be set to nothing.
+ */
+message TransactionGetRecordQuery {
+    /**
+     * Standard info sent from client to node, including the signed payment, and what kind of
+     * response is requested (cost, state proof, both, or neither).
+     */
+    QueryHeader header = 1;
+
+    /**
+     * The ID of the transaction for which the record is requested.
+     */
+    TransactionID transactionID = 2;
+
+    /**
+     * Whether records of processing duplicate transactions should be returned along with the record
+     * of processing the first consensus transaction with the given id whose status was neither
+     * <tt>INVALID_NODE_ACCOUNT</tt> nor <tt>INVALID_PAYER_SIGNATURE</tt>; <b>or</b>, if no such
+     * record exists, the record of processing the first transaction to reach consensus with the
+     * given transaction id..
+     */
+    bool includeDuplicates = 3;
+
+    /**
+     * Whether the response should include the records of any child transactions spawned by the 
+     * top-level transaction with the given transactionID. 
+     */
+    bool include_child_records = 4;
+}
+
+/**
+ * Response when the client sends the node TransactionGetRecordQuery
+ */
+message TransactionGetRecordResponse {
+    /**
+     * Standard response from node to client, including the requested fields: cost, or state proof,
+     * or both, or neither.
+     */
+    ResponseHeader header = 1;
+
+    /**
+     * Either the record of processing the first consensus transaction with the given id whose
+     * status was neither <tt>INVALID_NODE_ACCOUNT</tt> nor <tt>INVALID_PAYER_SIGNATURE</tt>;
+     * <b>or</b>, if no such record exists, the record of processing the first transaction to reach
+     * consensus with the given transaction id.
+     */
+    TransactionRecord transactionRecord = 3;
+
+    /**
+     * The records of processing all consensus transaction with the same id as the distinguished
+     * record above, in chronological order.
+     */
+    repeated TransactionRecord duplicateTransactionRecords = 4;
+
+    /**
+     * The records of processing all child transaction spawned by the transaction with the given 
+     * top-level id, in consensus order. Always empty if the top-level status is UNKNOWN.
+     */
+    repeated TransactionRecord child_transaction_records = 5;
+}
+

--- a/hapi/hedera-protobufs/services/transaction_receipt.proto
+++ b/hapi/hedera-protobufs/services/transaction_receipt.proto
@@ -1,0 +1,179 @@
+syntax = "proto3";
+
+package proto;
+
+/*
+ * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "response_code.proto";
+import "exchange_rate.proto";
+
+/**
+ * The summary of a transaction's result so far. If the transaction has not reached consensus, this
+ * result will be necessarily incomplete.
+ */
+message TransactionReceipt {
+    /**
+     * The consensus status of the transaction; is UNKNOWN if consensus has not been reached, or if
+     * the associated transaction did not have a valid payer signature
+     */
+    ResponseCodeEnum status = 1;
+
+    /**
+     * In the receipt of a CryptoCreate, the id of the newly created account
+     */
+    AccountID accountID = 2;
+
+    /**
+     * In the receipt of a FileCreate, the id of the newly created file
+     */
+    FileID fileID = 3;
+
+    /**
+     * In the receipt of a ContractCreate, the id of the newly created contract
+     */
+    ContractID contractID = 4;
+
+    /**
+     * The exchange rates in effect when the transaction reached consensus
+     */
+    ExchangeRateSet exchangeRate = 5;
+
+    /**
+     * In the receipt of a ConsensusCreateTopic, the id of the newly created topic.
+     */
+    TopicID topicID = 6;
+
+    /**
+     * In the receipt of a ConsensusSubmitMessage, the new sequence number of the topic that
+     * received the message
+     */
+    uint64 topicSequenceNumber = 7;
+
+    /**
+     * In the receipt of a `ConsensusSubmitMessage`, the new running hash of the topic that
+     * received the message.<br/>
+     * This 48-byte field is the output of a SHA-384 digest with input data determined by the
+     * value of the `topicRunningHashVersion` field.<br/>
+     * All new transactions SHALL use `topicRunningHashVersion` `3`.<br/>
+     * The bytes of each uint64 or uint32 encoded for the hash input MUST be in Big-Endian format.
+     * <p>
+     * <hr/>
+     * If the `topicRunningHashVersion` is '0' or '1', then the input data to the SHA-384 digest are,
+     * in order:
+     * <ol>
+     *   <li>The previous running hash of the topic (48 bytes)</li>
+     *   <li>The topic's shard (8 bytes)</li>
+     *   <li>The topic's realm (8 bytes)</li>
+     *   <li>The topic's number (8 bytes)</li>
+     *   <li>The number of seconds since the epoch when the `ConsensusSubmitMessage` reached
+     *    consensus (8 bytes)</li>
+     *   <li>The number of nanoseconds within the second when the `ConsensusSubmitMessage` reached
+     *    consensus (4 bytes)</li>
+     *   <li>The `topicSequenceNumber` (8 bytes)</li>
+     *   <li>The message bytes from the `ConsensusSubmitMessage` (variable).</li>
+     * </ol>
+     * <hr/>
+     * If the `topicRunningHashVersion` is '2', then the input data to the SHA-384 digest are, in
+     * order:
+     * <ol>
+     *   <li>The previous running hash of the topic (48 bytes)</li>
+     *   <li>The `topicRunningHashVersion` (8 bytes)</li>
+     *   <li>The topic's shard (8 bytes)</li>
+     *   <li>The topic's realm (8 bytes)</li>
+     *   <li>The topic's number (8 bytes)</li>
+     *   <li>The number of seconds since the epoch when the `ConsensusSubmitMessage` reached
+     *    consensus (8 bytes)</li>
+     *   <li>The number of nanoseconds within the second when the `ConsensusSubmitMessage` reached
+     *    consensus (4 bytes)</li>
+     *   <li>The `topicSequenceNumber` (8 bytes)</li>
+     *   <li>The output of a SHA-384 digest of the message bytes from the `ConsensusSubmitMessage`
+     *    (48 bytes)</li>
+     * </ol>
+     * <hr/>
+     * If the `topicRunningHashVersion` is '3', then the input data to the SHA-384 digest
+     * are, in order:
+     * <ol>
+     *   <li>The previous running hash of the topic (48 bytes)</li>
+     *   <li>The `topicRunningHashVersion` (8 bytes)</li>
+     *   <li>The payer account's shard (8 bytes)</li>
+     *   <li>The payer account's realm (8 bytes)</li>
+     *   <li>The payer account's number (8 bytes)</li>
+     *   <li>The topic's shard (8 bytes)</li>
+     *   <li>The topic's realm (8 bytes)</li>
+     *   <li>The topic's number (8 bytes)</li>
+     *   <li>The number of seconds since the epoch when the `ConsensusSubmitMessage` reached
+     *    consensus (8 bytes)</li>
+     *   <li>The number of nanoseconds within the second when the `ConsensusSubmitMessage` reached
+     *     consensus (4 bytes)</li>
+     *   <li>The `topicSequenceNumber` (8 bytes)</li>
+     *   <li>The output of a SHA-384 digest of the message bytes from the `ConsensusSubmitMessage`
+     *     (48 bytes)</li>
+     * </ol>
+     */
+    bytes topicRunningHash = 8;
+
+    /**
+     * In the receipt of a ConsensusSubmitMessage, the version of the SHA-384 digest used to update
+     * the running hash.
+     */
+    uint64 topicRunningHashVersion = 9;
+
+    /**
+     * In the receipt of a CreateToken, the id of the newly created token
+     */
+    TokenID tokenID = 10;
+
+    /**
+     * In the receipt of TokenMint, TokenWipe, TokenBurn, For fungible tokens - the current total
+     * supply of this token. For non fungible tokens - the total number of NFTs issued for a given
+     * tokenID
+     */
+    uint64 newTotalSupply = 11;
+
+    /**
+     * In the receipt of a ScheduleCreate, the id of the newly created Scheduled Entity
+     */
+    ScheduleID scheduleID = 12;
+
+    /**
+     * In the receipt of a ScheduleCreate or ScheduleSign that resolves to SUCCESS, the
+     * TransactionID that should be used to query for the receipt or record of the relevant
+     * scheduled transaction
+     */
+    TransactionID scheduledTransactionID = 13;
+
+    /**
+     * In the receipt of a TokenMint for tokens of type NON_FUNGIBLE_UNIQUE, the serial numbers of
+     * the newly created NFTs
+     */
+    repeated int64 serialNumbers = 14;
+
+    /**
+     * In the receipt of a NodeCreate, NodeUpdate, NodeDelete, the id of the newly created node.
+     * An affected node identifier.<br/>
+     * This value SHALL be set following a `createNode` transaction.<br/>
+     * This value SHALL be set following a `updateNode` transaction.<br/>
+     * This value SHALL be set following a `deleteNode` transaction.<br/>
+     * This value SHALL NOT be set following any other transaction.
+     */
+    uint64 node_id = 15;
+}

--- a/hapi/hedera-protobufs/services/transaction_record.proto
+++ b/hapi/hedera-protobufs/services/transaction_record.proto
@@ -1,0 +1,188 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "timestamp.proto";
+import "basic_types.proto";
+import "custom_fees.proto";
+import "transaction_receipt.proto";
+import "crypto_transfer.proto";
+import "contract_call_local.proto";
+
+/**
+ * Response when the client sends the node TransactionGetRecordResponse
+ */
+message TransactionRecord {
+    /**
+     * The status (reach consensus, or failed, or is unknown) and the ID of any new
+     * account/file/instance created.
+     */
+    TransactionReceipt receipt = 1;
+
+    /**
+     * The hash of the Transaction that executed (not the hash of any Transaction that failed for
+     * having a duplicate TransactionID)
+     */
+    bytes transactionHash = 2;
+
+    /**
+     * The consensus timestamp (or null if didn't reach consensus yet)
+     */
+    Timestamp consensusTimestamp = 3;
+
+    /**
+     * The ID of the transaction this record represents
+     */
+    TransactionID transactionID = 4;
+
+    /**
+     * The memo that was submitted as part of the transaction (max 100 bytes)
+     */
+    string memo = 5;
+
+    /**
+     * The actual transaction fee charged, not the original transactionFee value from
+     * TransactionBody
+     */
+    uint64 transactionFee = 6;
+
+    oneof body {
+        /**
+         * Record of the value returned by the smart contract function (if it completed and didn't
+         * fail) from ContractCallTransaction
+         */
+        ContractFunctionResult contractCallResult = 7;
+
+        /**
+         * Record of the value returned by the smart contract constructor (if it completed and
+         * didn't fail) from ContractCreateTransaction
+         */
+        ContractFunctionResult contractCreateResult = 8;
+    }
+
+    /**
+     * All hbar transfers as a result of this transaction, such as fees, or transfers performed by
+     * the transaction, or by a smart contract it calls, or by the creation of threshold records
+     * that it triggers.
+     */
+    TransferList transferList = 10;
+
+    /**
+     * All Token transfers as a result of this transaction
+     */
+    repeated TokenTransferList tokenTransferLists = 11;
+
+    /**
+     * Reference to the scheduled transaction ID that this transaction record represent
+     */
+    ScheduleID scheduleRef = 12;
+
+    /**
+     * All custom fees that were assessed during a CryptoTransfer, and must be paid if the
+     * transaction status resolved to SUCCESS
+     */
+    repeated AssessedCustomFee assessed_custom_fees = 13;
+
+    /**
+     * All token associations implicitly created while handling this transaction
+     */
+    repeated TokenAssociation automatic_token_associations = 14;
+
+    /**
+     * In the record of an internal transaction, the consensus timestamp of the user
+     * transaction that spawned it.
+     */
+    Timestamp parent_consensus_timestamp = 15;
+
+    /**
+     * In the record of a CryptoCreate transaction triggered by a user transaction with a
+     * (previously unused) alias, the new account's alias. 
+     */
+     bytes alias = 16;
+
+    /**
+     * The keccak256 hash of the ethereumData. This field will only be populated for 
+     * EthereumTransaction.
+     */
+    bytes ethereum_hash = 17;
+
+    /**
+     * List of accounts with the corresponding staking rewards paid as a result of a transaction.
+     */
+    repeated AccountAmount paid_staking_rewards = 18;
+
+    oneof entropy {
+        /**
+         * In the record of a UtilPrng transaction with no output range, a pseudorandom 384-bit string.
+         */
+        bytes prng_bytes = 19;
+
+        /**
+         * In the record of a PRNG transaction with an output range, the output of a PRNG whose input was a 384-bit string.
+         */
+        int32 prng_number = 20;
+    }
+
+    /**
+     * The new default EVM address of the account created by this transaction.
+     * This field is populated only when the EVM address is not specified in the related transaction body.
+     */
+    bytes evm_address = 21;
+
+    /**
+     * A list of pending token airdrops.
+     * Each pending airdrop represents a single requested transfer from a
+     * sending account to a recipient account. These pending transfers are
+     * issued unilaterally by the sending account, and MUST be claimed by the
+     * recipient account before the transfer MAY complete.
+     * A sender MAY cancel a pending airdrop before it is claimed.
+     * An airdrop transaction SHALL emit a pending airdrop when the recipient has no
+     * available automatic association slots available or when the recipient
+     * has set `receiver_sig_required`.
+     */
+    repeated PendingAirdropRecord new_pending_airdrops = 22;
+}
+
+/**
+ * A record of a new pending airdrop.
+ */
+message PendingAirdropRecord {
+    /**
+     * A unique, composite, identifier for a pending airdrop.
+     * This field is REQUIRED.
+     */
+    PendingAirdropId pending_airdrop_id = 1;
+
+    /**
+     * A single pending airdrop amount.
+     * If the pending airdrop is for a fungible/common token this field is REQUIRED
+     * and SHALL be the current amount of tokens offered.
+     * If the pending airdrop is for a non-fungible/unique token, this field SHALL NOT
+     * be set.
+     */
+    PendingAirdropValue pending_airdrop_value = 2;
+}

--- a/hapi/hedera-protobufs/services/transaction_response.proto
+++ b/hapi/hedera-protobufs/services/transaction_response.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "response_code.proto";
+
+
+/**
+ * When the client sends the node a transaction of any kind, the node replies with this, which
+ * simply says that the transaction passed the precheck (so the node will submit it to the network)
+ * or it failed (so it won't). If the fee offered was insufficient, this will also contain the
+ * amount of the required fee. To learn the consensus result, the client should later obtain a
+ * receipt (free), or can buy a more detailed record (not free).
+ */
+message TransactionResponse {
+	/**
+	 * The response code that indicates the current status of the transaction.
+	 */
+	ResponseCodeEnum nodeTransactionPrecheckCode = 1;
+
+	/**
+     * If the response code was INSUFFICIENT_TX_FEE, the actual transaction fee that would be
+     * required to execute the transaction.
+	 */
+	uint64 cost = 2;
+}

--- a/hapi/hedera-protobufs/services/unchecked_submit.proto
+++ b/hapi/hedera-protobufs/services/unchecked_submit.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.transaction">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Submit an arbitrary (serialized) Transaction to the network without prechecks. Requires superuser
+ * privileges. 
+ */
+message UncheckedSubmitBody {
+    /**
+     * The serialized bytes of the Transaction to be submitted without prechecks
+     */
+    bytes transactionBytes = 1;
+}

--- a/hapi/hedera-protobufs/services/util_prng.proto
+++ b/hapi/hedera-protobufs/services/util_prng.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.api.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.util">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * Generates a pseudorandom number
+ */
+message UtilPrngTransactionBody {
+  /**
+   * If provided and is positive, returns a 32-bit pseudorandom number from the given range in the transaction record.
+   * If not set or set to zero, will return a 384-bit pseudorandom number in the record.
+   */
+  int32 range = 1;
+}

--- a/hapi/hedera-protobufs/services/util_service.proto
+++ b/hapi/hedera-protobufs/services/util_service.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Utility Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hederahashgraph.service.proto.java";
+// <<<pbj.java_package = "com.hedera.hapi.node.util">>> This comment is special code for setting PBJ Compiler java package
+
+import "transaction_response.proto";
+import "transaction.proto";
+
+/**
+ * The requests and responses for different utility services.
+ */
+service UtilService {
+  /**
+   * Generates a pseudorandom number.
+   */
+  rpc prng (Transaction) returns (TransactionResponse);
+}

--- a/hapi/hedera-protobufs/streams/account_balance_file.proto
+++ b/hapi/hedera-protobufs/streams/account_balance_file.proto
@@ -1,0 +1,80 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hedera.services.stream.proto";
+// <<<pbj.java_package = "com.hedera.hapi.streams">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+
+message TokenUnitBalance {
+    /**
+     * A unique token id
+     */
+    TokenID tokenId = 1;
+
+    /**
+     * Number of transferable units of the identified token. For token of type FUNGIBLE_COMMON -
+     * balance in the smallest denomination. For token of type NON_FUNGIBLE_UNIQUE - the number of
+     * NFTs held by the account
+     */
+    uint64 balance = 2;
+}
+
+/**
+ * Includes all currency balances (both hbar and token) of a single account in the ledger.
+ */
+message SingleAccountBalances {
+    /**
+     * The account
+     */
+    AccountID accountID = 1;
+
+    /**
+     * The account's hbar balance
+     */
+    uint64 hbarBalance = 2;
+
+    /**
+     * The list of the account's token balances
+     */
+    repeated TokenUnitBalance tokenUnitBalances = 3;
+}
+
+/**
+ * Includes all currency balances (both hbar and token) of all accounts in the ledger.
+ */
+message AllAccountBalances {
+    /**
+     * An instant in consensus time 
+     */
+    Timestamp consensusTimestamp = 1;
+
+    /**
+     * The list of account balances for all accounts, after handling all transactions with consensus
+     * timestamp up to and including the above instant
+     */
+    repeated SingleAccountBalances allAccounts = 2;
+}

--- a/hapi/hedera-protobufs/streams/contract_action.proto
+++ b/hapi/hedera-protobufs/streams/contract_action.proto
@@ -1,0 +1,212 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hedera.services.stream.proto";
+// <<<pbj.java_package = "com.hedera.hapi.streams">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+
+message ContractActions {
+  repeated ContractAction contract_actions = 1;
+}
+
+/**
+ * The type of action described by the action proto.
+ */
+enum ContractActionType {
+  /**
+   * default non-value.
+   */
+  NO_ACTION = 0;
+
+  /**
+   * Most CALL, CALLCODE, DELEGATECALL, and STATICCALL, and first action of ContractCall/ContractCallLocal to deployed
+   * contracts. This does not include calls to system or precompiled contracts.
+   */
+  CALL = 1;
+
+  /**
+   * CREATE, CREATE2, and first action of ContractCreate.
+   */
+
+  CREATE = 2;
+
+  /**
+   * like Call, but to precompiled contracts (0x1 to 0x9 as of Berlin)
+   */
+  PRECOMPILE = 3;
+
+  /**
+   * Call, but to system contract like HTS or ERC20 facades over Token accounts
+   */
+  SYSTEM = 4;
+}
+
+/**
+ * The specific operation type of a call. The OP prefix has been added to avoid name collisions for
+ * the CALL and CREATE operation types since both ContractActionType and CallOperationType enums are
+ * used in ContractAction
+ */
+enum CallOperationType {
+  /**
+   * default operation type is UNKNOWN
+   */
+  OP_UNKNOWN = 0;
+
+  /**
+   * CALL operation type.
+   */
+  OP_CALL = 1;
+
+  /**
+   * CALLCODE operation type
+   */
+  OP_CALLCODE = 2;
+
+  /**
+   * DELEGATECALL operation type
+   */
+  OP_DELEGATECALL = 3;
+
+  /**
+   * STATICCALL operation type
+   */
+  OP_STATICCALL = 4;
+
+  /**
+   * CREATE operation type
+   */
+  OP_CREATE = 5;
+
+  /**
+   * CREATE2 operation type
+   */
+  OP_CREATE2 = 6;
+}
+
+/**
+ * A finer grained action with a function result. Sometimes called "internal transactions." The function call itself
+ * will be the first action in a list, followed by sub-action in the order they were executed.
+ */
+message ContractAction {
+
+  /**
+   * The type of this action.
+   */
+  ContractActionType call_type = 1;
+
+  /**
+   * Only the first action can come from an account, the rest will come from contracts.  Because of DELEGATECALL
+   * and CALLCODE the caller of actions whose parent is an account may also be an account.
+   */
+  oneof caller {
+    /**
+     * If the caller was a regular account, the AccountID.
+     */
+    AccountID calling_account = 2;
+
+    /**
+     * If the caller was a smart contract account, the ContractID.
+     */
+    ContractID calling_contract = 3;
+  }
+
+  /**
+   * The upper limit of gas this action can spend.
+   */
+  int64 gas = 4;
+
+  /**
+   * Bytes passed in as input data to this action.
+   */
+  bytes input = 5;
+
+  /**
+   * Who this action is directed to.
+   */
+  oneof recipient {
+    /**
+     * The AccountID of the recipient if the recipient is an account. Only HBars will be transferred, no other side
+     * effects should be expected.
+     */
+    AccountID recipient_account = 6;
+
+    /**
+     * The ContractID of the recipient if the recipient is a smart contract.
+     */
+    ContractID recipient_contract = 7;
+
+    /**
+     * The bytes of the targeted by the action address.
+     * Only set on failed executions. If set, denotes that the address did not
+     * correspond to any account or contract at the time of finalization of
+     * this action.
+     * An example would be a failed lazy create as per HIP-583.
+     */
+    bytes targeted_address = 8;
+  }
+
+  /**
+   * The value (in tinybars) that is associated with this action.
+   */
+  int64 value = 9;
+
+  /**
+   * The actual gas spent by this action.
+   */
+  int64 gas_used = 10;
+
+  /**
+   * The result data of the action.
+   */
+  oneof result_data {
+
+    /**
+     * If successful, the output bytes of the action.
+     */
+    bytes output = 11;
+
+    /**
+     * The contract itself caused the transaction to fail via the `REVERT` operation
+     */
+    bytes revert_reason = 12;
+
+    /**
+     * The transaction itself failed without an explicit `REVERT`
+     */
+    bytes error = 13;
+  }
+
+  /**
+   * The nesting depth of this call. The original action is at depth=0.
+   */
+  int32 call_depth = 14;
+
+  /**
+   * The call operation type
+   */
+  CallOperationType call_operation_type = 15;
+}

--- a/hapi/hedera-protobufs/streams/contract_bytecode.proto
+++ b/hapi/hedera-protobufs/streams/contract_bytecode.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hedera.services.stream.proto";
+// <<<pbj.java_package = "com.hedera.hapi.streams">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+message ContractBytecode {
+  /**
+  * The contract to which the bytecodes apply to
+  */
+  ContractID contract_id = 1;
+
+  /**
+  * Contract bytecode during deployment
+  */
+  bytes initcode = 2;
+
+  /**
+  * Contract bytecode after deployment
+  */
+  bytes runtime_bytecode = 3;
+}

--- a/hapi/hedera-protobufs/streams/contract_state_change.proto
+++ b/hapi/hedera-protobufs/streams/contract_state_change.proto
@@ -1,0 +1,78 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hedera.services.stream.proto";
+// <<<pbj.java_package = "com.hedera.hapi.streams">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+
+import "google/protobuf/wrappers.proto";
+
+
+message ContractStateChanges {
+  repeated ContractStateChange contract_state_changes = 1;
+}
+
+/**
+ * The storage changes to a smart contract's storage as a side effect of the function call.
+ */
+message ContractStateChange {
+
+  /**
+   * The contract to which the storage changes apply to
+   */
+  ContractID contract_id = 1;
+
+  /**
+   * The list of storage changes.
+   */
+  repeated StorageChange storage_changes = 2;
+}
+
+/**
+ * A storage slot change description.
+ */
+message StorageChange {
+  /**
+   * The storage slot changed.  Up to 32 bytes, big-endian, zero bytes left trimmed.
+   */
+  bytes slot = 1;
+
+  /**
+   * The value read from the storage slot.  Up to 32 bytes, big-endian, zero bytes left trimmed.
+   *
+   * Because of the way SSTORE operations are charged the slot is always read before being written to.
+   */
+  bytes value_read = 2;
+
+  /**
+   * The new value written to the slot.  Up to 32 bytes, big-endian, zero bytes left trimmed.
+   *
+   * If a value of zero is written the valueWritten will be present but the inner value will be absent.
+   *
+   * If a value was read and not written this value will not be present.
+   */
+  google.protobuf.BytesValue value_written = 3;
+}

--- a/hapi/hedera-protobufs/streams/hash_object.proto
+++ b/hapi/hedera-protobufs/streams/hash_object.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hedera.services.stream.proto";
+// <<<pbj.java_package = "com.hedera.hapi.streams">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+/**
+ * List of hash algorithms
+ */
+enum HashAlgorithm {
+  HASH_ALGORITHM_UNKNOWN = 0;
+  SHA_384 = 1;
+}
+
+/**
+ * Encapsulates an object hash so that additional hash algorithms
+ * can be added in the future without requiring a breaking change.
+ */
+message HashObject {
+
+  /**
+   * Specifies the hashing algorithm
+   */
+  HashAlgorithm algorithm = 1;
+
+  /**
+   * Hash length
+   */
+  int32 length = 2;
+
+  /**
+   * Specifies the result of the hashing operation in bytes
+   */
+  bytes hash = 3;
+}

--- a/hapi/hedera-protobufs/streams/record_stream_file.proto
+++ b/hapi/hedera-protobufs/streams/record_stream_file.proto
@@ -1,0 +1,109 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hedera.services.stream.proto";
+// <<<pbj.java_package = "com.hedera.hapi.streams">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "transaction.proto";
+import "transaction_record.proto";
+import "hash_object.proto";
+
+/**
+ * RecordStreamFile is used to serialize all RecordStreamItems that are part of the
+ * same period into record stream files.
+ * This structure represents a block in Hedera (HIP-415).
+ */
+message RecordStreamFile {
+  /**
+   * Version of HAPI that was used to serialize the file.
+   */
+  SemanticVersion hapi_proto_version = 1;
+
+  /**
+   * Running Hash of all RecordStreamItems before writing this file.
+   */
+  HashObject start_object_running_hash = 2;
+
+  /**
+   * List of all the record stream items from that period.
+   */
+  repeated RecordStreamItem record_stream_items = 3;
+
+  /**
+   * Running Hash of all RecordStreamItems before closing this file.
+   */
+  HashObject end_object_running_hash = 4;
+
+  /**
+   * The block number associated with this period.
+   */
+  int64 block_number = 5;
+
+  /**
+   * List of the hashes of all the sidecar record files created for the same period.
+   * Allows multiple sidecar files to be linked to this RecordStreamFile.
+   */
+  repeated SidecarMetadata sidecars = 6;
+}
+
+/**
+ * A RecordStreamItem consists of a Transaction and a TransactionRecord,
+ * which are already defined protobuf messages.
+ */
+message RecordStreamItem {
+  Transaction transaction = 1;
+  TransactionRecord record = 2;
+}
+
+/**
+ * Information about a single sidecar file.
+ */
+message SidecarMetadata {
+  /**
+   * The hash of the entire file.
+   */
+  HashObject hash = 1;
+
+  /**
+   * The id of the sidecar record file
+   */
+  int32 id = 2;
+
+  /**
+   * The types of sidecar records that will be included in the file.
+   */
+  repeated SidecarType types = 3;
+}
+
+/**
+ * The type of sidecar records contained in the sidecar record file
+ */
+enum SidecarType {
+  SIDECAR_TYPE_UNKNOWN = 0;
+  CONTRACT_STATE_CHANGE = 1;
+  CONTRACT_ACTION = 2;
+  CONTRACT_BYTECODE = 3;
+}

--- a/hapi/hedera-protobufs/streams/sidecar_file.proto
+++ b/hapi/hedera-protobufs/streams/sidecar_file.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hedera.services.stream.proto";
+// <<<pbj.java_package = "com.hedera.hapi.streams">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "timestamp.proto";
+import "contract_state_change.proto";
+import "contract_action.proto";
+import "contract_bytecode.proto";
+
+/**
+ * A SidecarFile contains a list of TransactionSidecarRecords that are all created
+ * in the same period and related to the same RecordStreamFile.
+ */
+message SidecarFile {
+
+  /**
+   * List of sidecar records
+   */
+  repeated TransactionSidecarRecord sidecar_records = 1;
+}
+
+/**
+ * TransactionSidecarRecord is used to create sidecar records complementing
+ * TransactionRecord and storing additional information about a transaction's execution.
+ */
+message TransactionSidecarRecord {
+  /**
+   * Consensus timestamp will be the same as the consensus timestamp of the
+   * transaction the side car is related to. This offers a convenient
+   * way to match record to sidecar.
+   */
+  Timestamp consensus_timestamp = 1;
+
+  /**
+  * Whether sidecar is from migration.
+   */
+  bool migration = 2;
+
+  /*
+  * List of sidecar types.
+  * In future there will be other categories.
+  */
+  oneof sidecar_records {
+    ContractStateChanges state_changes = 3;
+    ContractActions actions = 4;
+    ContractBytecode bytecode = 5;
+  }
+}

--- a/hapi/hedera-protobufs/streams/signature_file.proto
+++ b/hapi/hedera-protobufs/streams/signature_file.proto
@@ -1,0 +1,85 @@
+syntax = "proto3";
+
+package proto;
+
+/*-
+ * ‌
+ * Hedera Network Services Protobuf
+ * ​
+ * Copyright (C) 2018 - 2022 Hedera Hashgraph, LLC
+ * ​
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ‍
+ */
+
+option java_package = "com.hedera.services.stream.proto";
+// <<<pbj.java_package = "com.hedera.hapi.streams">>> This comment is special code for setting PBJ Compiler java package
+option java_multiple_files = true;
+
+import "basic_types.proto";
+import "hash_object.proto";
+
+/**
+ * The record signature file which is created for each record stream file
+ * that signs the hash of the entire corresponding stream file.
+ */
+message SignatureFile {
+
+  /**
+   * Signature for the file
+   */
+  SignatureObject file_signature = 1;
+
+  /**
+   * Metadata signature
+   */
+  SignatureObject metadata_signature = 2;
+}
+
+/**
+ * A Signature defined by its type, length, checksum and signature bytes and the hash that is signed
+ */
+message SignatureObject {
+  /**
+   * The signature type
+   */
+  SignatureType type = 1;
+
+  /**
+   * Signature length
+   */
+  int32 length = 2;
+
+  /**
+   * Signature checksum
+   */
+  int32 checksum = 3;
+
+  /**
+   * Signature bytes
+   */
+  bytes signature = 4;
+
+  /**
+   * The hash that is signed by this signature
+   */
+  HashObject hash_object = 5;
+}
+
+/**
+ * The signature type
+ */
+enum SignatureType {
+  SIGNATURE_TYPE_UNKNOWN = 0;
+  SHA_384_WITH_RSA = 1;
+}


### PR DESCRIPTION
**Description**:
 - Adds the latest block stream protobuf files as effectively documentation (**NOT** integrated into the build) so the diff for preview block streams PR https://github.com/hashgraph/hedera-services/pull/14579 can become manageable.