### PR TITLE
fix: Small adjustments to recently added inert protobufs

### DIFF
--- a/hapi/hedera-protobufs/block/stream/output/state_changes.proto
+++ b/hapi/hedera-protobufs/block/stream/output/state_changes.proto
@@ -375,19 +375,19 @@ enum StateIdentifier {
     STATE_ID_FREEZE_TIME = 23;
 
     /**
-     * A state identifier for the block stream information.
+     * A state identifier for the block stream status singleton.
      */
     STATE_ID_BLOCK_STREAM_INFO = 24;
 
     /**
-     * A state identifier for the record cache.
-     */
-    STATE_ID_RECORD_QUEUE = 25;
-
-    /**
      * A state identifier for pending airdrops.
      */
-    STATE_ID_PENDING_AIRDROPS = 26;
+    STATE_ID_PENDING_AIRDROPS = 25;
+
+    /**
+     * A state identifier for the record cache.
+     */
+    STATE_ID_RECORD_QUEUE = 126;
 
     /**
      * A state for the `150` upgrade file data
@@ -577,9 +577,12 @@ message SingletonUpdateChange {
         proto.Timestamp timestamp_value = 10;
 
         /**
-         * A change to the block stream information singleton.
+         * A change to the block stream status singleton.
+         * <p>
+         * This MUST be updated at the beginning of a block, with the
+         * information for the immediately prior block.
          */
-        proto.BlockStreamInfo block_stream_info_value = 11;
+        com.hedera.hapi.node.state.blockstream.BlockStreamInfo block_stream_info_value = 11;
     }
 }
 

--- a/hapi/hedera-protobufs/services/state/blockstream/block_stream_info.proto
+++ b/hapi/hedera-protobufs/services/state/blockstream/block_stream_info.proto
@@ -1,13 +1,22 @@
+/**
+ * # Block Stream Info
+ * Information stored in consensus state at the beginning of each block to
+ * record the status of the immediately prior block.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in
+ * [RFC2119](https://www.ietf.org/rfc/rfc2119) and clarified in
+ * [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
 syntax = "proto3";
 
-package proto;
+package com.hedera.hapi.node.state.blockstream;
 
-/*-
- * ‌
- * Hedera Network Services Protobuf
- * ​
- * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +28,6 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
 
 import "timestamp.proto";
@@ -29,29 +37,47 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * The state required to continue constructing blocks, and the state derived from it.
+ * A message stored in state to maintain block stream parameters.
+ *
+ * This value MUST be updated for every block.<br/>
+ * This value MUST be transmitted in the "state changes" section of
+ * _each_ block, but MUST be updated at the beginning of the _next_ block.<br/>
+ * This value SHALL contain the block hash up to, and including, the
+ * immediately prior completed block.
  */
 message BlockStreamInfo {
-  /**
-   * The number of the last completed block.
-   */
-  uint64 last_block_number = 1;
-  /**
-   * The hash of the last completed block.
-   */
-  bytes last_block_hash = 2;
-  /**
-   * The consensus time of the last block, to determine if this round was the first across some distinguished boundary in 
-   * consensus time, such as UTC midnight. May also be used to purge entities expiring between the last block time and 
-   * this time.
-   */
-  Timestamp last_block_time = 3;
-  /**
-   * A concatenation of the hashes of several trailing output block item hashes, for use as a PRNG seed.
-   */
-  bytes trailing_output_hashes = 4;
-  /**
-   * A concatenation of the hashes of 256 trailing blocks, for use with EVM BLOCKHASH opcode.
-   */
-  bytes trailing_block_hashes = 5;
+    /**
+     * A block number.<br/>
+     * This is the block number of the last completed block.
+     */
+    uint64 last_block_number = 1;
+
+    /**
+     * A block hash value.<br/>
+     * This is the hash of the last completed block.
+     */
+    bytes last_block_hash = 2;
+
+    /**
+     * A consensus time for the last completed block.
+     * This is used to determine if this block was the first across an
+     * important boundary in consensus time, such as UTC midnight.
+     * This may also be used to purge entities expiring between the last
+     * block time and this time.
+     */
+    proto.Timestamp last_block_time = 3;
+
+    /**
+     * A concatenation of hash values.<br/>
+     * This combines several trailing output block item hashes and
+     * is used as a seed value for a pseudo-random number generator.
+     */
+    bytes trailing_output_hashes = 4;
+
+    /**
+     * A concatenation of hash values.<br/>
+     * This combines the last 256 trailing block hashes, and is required to
+     * support the EVM `BLOCKHASH` opcode.
+     */
+    bytes trailing_block_hashes = 5;
 }


### PR DESCRIPTION
* Fixed _protobuf_ package for blockstream file
* Added missing specification text
* Fixed bad copyright header in the recently added file
* Made some minor ordering changes to an _advisory_ enum.
