### PR TITLE
chore: Add codeowners for the /hapi directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,13 @@
 
 
 #########################
+##### HAPI protobuf #####
+#########################
+
+/hapi/                                          @hashgraph/hedera-base @hashgraph/hedera-services @hashgraph/hedera-smart-contracts-core @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects
+
+
+#########################
 ##### Hedera Node  ######
 #########################
 


### PR DESCRIPTION
**Description**:
Add codeowners for the /hapi directory. Previously this was not specified and defaulted to devops-ci and release-engineering-managers

**Related issue(s)**:

Fixes #14724
