### PR TITLE
chore(0.52): updates the buildkit and docker daemon configuration to use the registry mirror

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -456,6 +456,7 @@ jobs:
         with:
           version: v0.15.1
           driver-opts: network=host
+          buildkitd-config: /etc/docker/buildkitd.toml
 
       - name: Setup Local Docker Registry
         if: ${{ inputs.dry-run-enabled == true && !cancelled() && !failure() }}

--- a/.github/workflows/zxc-publish-production-image.yaml
+++ b/.github/workflows/zxc-publish-production-image.yaml
@@ -177,6 +177,12 @@ jobs:
           HOME: /x
         with:
           version: v25.0.5
+          daemon-config: |
+            {
+              "registry-mirrors": [
+                "https://hub.mirror.docker.lat.ope.eng.hashgraph.io"
+              ]
+            }
 
       - name: Configure Default Docker Context
         run: |
@@ -197,6 +203,7 @@ jobs:
         with:
           version: v0.15.1
           driver-opts: network=host
+          buildkitd-config: /etc/docker/buildkitd.toml
 
       - name: Setup Local Docker Registry
         if: ${{ inputs.dry-run-enabled == true && !cancelled() && !failure() }}

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -167,6 +167,12 @@ jobs:
           HOME: /x
         with:
           version: v25.0.5
+          daemon-config: |
+            {
+              "registry-mirrors": [
+                "https://hub.mirror.docker.lat.ope.eng.hashgraph.io"
+              ]
+            }
 
       - name: Configure Default Docker Context
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
@@ -190,6 +196,7 @@ jobs:
         with:
           version: v0.15.1
           driver-opts: network=host
+          buildkitd-config: /etc/docker/buildkitd.toml
 
       - name: Setup Local Docker Registry
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
@@ -378,6 +385,12 @@ jobs:
           HOME: ${{ runner.os == 'Linux' && '/x' || steps.home.outputs.directory }}
         with:
           version: v25.0.5
+          daemon-config: |
+            {
+              "registry-mirrors": [
+                "https://hub.mirror.docker.lat.ope.eng.hashgraph.io"
+              ]
+            }
 
       - name: Configure Default Docker Context
         env:
@@ -400,6 +413,7 @@ jobs:
         with:
           version: v0.15.1
           driver-opts: network=host
+          buildkitd-config: /etc/docker/buildkitd.toml
 
       - name: Setup Local Docker Registry
         run: docker run -d -p 5000:5000 --restart=always --name registry registry:latest


### PR DESCRIPTION
## Description

This pull request changes the following:

* Cherry picks #14774 into the `release/0.52` branch

### Related Issues 

* Closes #14774 