### PR TITLE
fix: immediately finalize transfer lists for scheduled crypto transfer

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/ChildDispatchFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/ChildDispatchFactory.java
@@ -282,7 +282,10 @@ public class ChildDispatchFactory {
                         new WritableStoreFactory(stack, TokenService.NAME, config, storeMetricsService),
                         recordBuilder,
                         consensusNow,
-                        config),
+                        config,
+                        txnInfo.functionality(),
+                        category,
+                        recordListBuilder),
                 recordListBuilder,
                 platformState,
                 preHandleResult);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/TriggeredFinalizeContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/TriggeredFinalizeContextTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.workflows.handle.record;
+
+import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_TRANSFER;
+import static com.hedera.hapi.node.base.HederaFunctionality.TOKEN_MINT;
+import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.CHILD;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.SCHEDULED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.TransferList;
+import com.hedera.node.app.service.token.records.ChildRecordBuilder;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.store.ReadableStoreFactory;
+import com.hedera.node.app.store.WritableStoreFactory;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Instant;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TriggeredFinalizeContextTest {
+    private static final Instant NOW = Instant.ofEpochSecond(1_234_567L);
+
+    @Mock
+    private RecordListBuilder recordListBuilder;
+
+    @Mock
+    private ReadableStoreFactory readableStoreFactory;
+
+    @Mock
+    private WritableStoreFactory writableStoreFactory;
+
+    @Mock
+    private SingleTransactionRecordBuilderImpl recordBuilder;
+
+    @Mock
+    private SingleTransactionRecordBuilderImpl childNoAdjustments;
+
+    @Mock
+    private SingleTransactionRecordBuilderImpl childWithAdjustments;
+
+    @Mock
+    private Consumer<ChildRecordBuilder> consumer;
+
+    private TriggeredFinalizeContext subject;
+
+    @Test
+    void nonScheduledChildrenHaveNoSelfChildren() {
+        subject = subjectWith(CHILD, CRYPTO_TRANSFER);
+        subject.forEachChildRecord(ChildRecordBuilder.class, consumer);
+
+        assertThat(subject.hasChildOrPrecedingRecords()).isFalse();
+        verifyNoInteractions(recordListBuilder);
+        verifyNoInteractions(consumer);
+    }
+
+    @Test
+    void scheduledMintChildrenHaveNoSelfChildren() {
+        subject = subjectWith(SCHEDULED, TOKEN_MINT);
+        subject.forEachChildRecord(ChildRecordBuilder.class, consumer);
+
+        assertThat(subject.hasChildOrPrecedingRecords()).isFalse();
+        verifyNoInteractions(recordListBuilder);
+        verifyNoInteractions(consumer);
+    }
+
+    @Test
+    void scheduledCryptoTransferHasChildrenIfBalancesChange() {
+        given(childNoAdjustments.transferList()).willReturn(TransferList.DEFAULT);
+        given(childWithAdjustments.transferList())
+                .willReturn(new TransferList(List.of(AccountAmount.DEFAULT, AccountAmount.DEFAULT)));
+        given(recordListBuilder.precedingRecordBuilders())
+                .willReturn(List.of(childNoAdjustments, childWithAdjustments));
+        subject = subjectWith(SCHEDULED, CRYPTO_TRANSFER);
+        subject.forEachChildRecord(ChildRecordBuilder.class, consumer);
+
+        assertThat(subject.hasChildOrPrecedingRecords()).isTrue();
+        verify(consumer).accept(childWithAdjustments);
+        verify(consumer, never()).accept(childNoAdjustments);
+    }
+
+    private TriggeredFinalizeContext subjectWith(
+            @NonNull final HandleContext.TransactionCategory category,
+            @NonNull final HederaFunctionality functionality) {
+        return new TriggeredFinalizeContext(
+                readableStoreFactory,
+                writableStoreFactory,
+                recordBuilder,
+                NOW,
+                DEFAULT_CONFIG,
+                functionality,
+                category,
+                recordListBuilder);
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransferListAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/TransferListAsserts.java
@@ -24,8 +24,10 @@ import static java.util.stream.Collectors.toSet;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.TinyBarTransfers;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TransferList;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -64,6 +66,15 @@ public class TransferListAsserts extends BaseErroringAssertsProvider<TransferLis
     @SafeVarargs
     public static TransferListAsserts including(Function<HapiSpec, TransferList>... providers) {
         return new ExplicitTransferAsserts(Arrays.asList(providers));
+    }
+
+    public static Function<HapiSpec, TransferList> adjustment(@NonNull final String account, final long amount) {
+        return spec -> TransferList.newBuilder()
+                .addAccountAmounts(AccountAmount.newBuilder()
+                        .setAccountID(asId(account, spec))
+                        .setAmount(amount)
+                        .build())
+                .build();
     }
 
     public static TransferListAsserts includingDeduction(LongSupplier from, long amount) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -20,8 +20,12 @@ import static com.hedera.services.bdd.junit.ContextRequirement.PROPERTY_OVERRIDE
 import static com.hedera.services.bdd.junit.TestTags.NOT_REPEATABLE;
 import static com.hedera.services.bdd.spec.HapiSpec.customHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.HapiSpec.propertyPreservingHapiSpec;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.assertions.TransferListAsserts.adjustment;
+import static com.hedera.services.bdd.spec.assertions.TransferListAsserts.including;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
@@ -108,6 +112,56 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 public class ScheduleCreateSpecs {
+    @HapiTest
+    final Stream<DynamicTest> scheduledAutoCreationWithCustomPayerHasExpectedRecords() {
+        final var customPayer = "customPayer";
+        return hapiTest(
+                newKeyNamed(ALIAS),
+                cryptoCreate(PAYER).balance(10 * ONE_HUNDRED_HBARS),
+                cryptoCreate(customPayer).payingWith(PAYER).balance(20 * ONE_HBAR),
+                scheduleCreate(
+                                "autoCreationWithCustomPayer",
+                                cryptoTransfer(tinyBarsFromToWithAlias(PAYER, ALIAS, ONE_HBAR)))
+                        .designatingPayer(customPayer)
+                        .payingWith(PAYER)
+                        .via("autoCreationWithCustomPayer")
+                        .fee(ONE_HBAR),
+                scheduleSign("autoCreationWithCustomPayer")
+                        .payingWith(customPayer)
+                        .via("signTxn"),
+                getTxnRecord("signTxn")
+                        .andAllChildRecords()
+                        .hasPriority(recordWith()
+                                .transfers(including(
+                                        adjustment("0.0.3", 25768),
+                                        adjustment("0.0.98", 391354),
+                                        adjustment("0.0.800", 48919),
+                                        adjustment("0.0.801", 48919),
+                                        adjustment(customPayer, -514960)))));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> scheduledTransferWithCustomPayerHasExpectedRecords() {
+        final var customPayer = "customPayer";
+        return hapiTest(
+                cryptoCreate(PAYER).balance(10 * ONE_HUNDRED_HBARS),
+                cryptoCreate(customPayer).payingWith(PAYER).balance(20 * ONE_HBAR),
+                scheduleCreate(
+                                "transferWithCustomPayer",
+                                cryptoTransfer(tinyBarsFromToWithAlias(PAYER, FUNDING, ONE_HBAR)))
+                        .designatingPayer(customPayer)
+                        .payingWith(PAYER)
+                        .via("transferWithCustomPayer")
+                        .fee(ONE_HBAR),
+                getScheduleInfo("transferWithCustomPayer")
+                        .hasPayerAccountID(customPayer)
+                        .logged(),
+                scheduleSign("transferWithCustomPayer").payingWith(customPayer).via("signTxn"),
+                getScheduleInfo("transferWithCustomPayer").logged(),
+                getTxnRecord("signTxn").andAllChildRecords().logged(),
+                getTxnRecord("transferWithCustomPayer").scheduled().logged());
+    }
+
     @HapiTest
     final Stream<DynamicTest> aliasNotAllowedAsPayer() {
         return defaultHapiSpec("BodyAndPayerCreation")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateSpecs.java
@@ -141,28 +141,6 @@ public class ScheduleCreateSpecs {
     }
 
     @HapiTest
-    final Stream<DynamicTest> scheduledTransferWithCustomPayerHasExpectedRecords() {
-        final var customPayer = "customPayer";
-        return hapiTest(
-                cryptoCreate(PAYER).balance(10 * ONE_HUNDRED_HBARS),
-                cryptoCreate(customPayer).payingWith(PAYER).balance(20 * ONE_HBAR),
-                scheduleCreate(
-                                "transferWithCustomPayer",
-                                cryptoTransfer(tinyBarsFromToWithAlias(PAYER, FUNDING, ONE_HBAR)))
-                        .designatingPayer(customPayer)
-                        .payingWith(PAYER)
-                        .via("transferWithCustomPayer")
-                        .fee(ONE_HBAR),
-                getScheduleInfo("transferWithCustomPayer")
-                        .hasPayerAccountID(customPayer)
-                        .logged(),
-                scheduleSign("transferWithCustomPayer").payingWith(customPayer).via("signTxn"),
-                getScheduleInfo("transferWithCustomPayer").logged(),
-                getTxnRecord("signTxn").andAllChildRecords().logged(),
-                getTxnRecord("transferWithCustomPayer").scheduled().logged());
-    }
-
-    @HapiTest
     final Stream<DynamicTest> aliasNotAllowedAsPayer() {
         return defaultHapiSpec("BodyAndPayerCreation")
                 .given(


### PR DESCRIPTION
**Description**:
 - Without the complete HIP-993 implementation, we need a special case to finalize the transfer list in a scheduled `CryptoTransfer` that triggers an auto-creation.
 - Note this special case was eliminated by the completion of HIP-993 changes in `release/0.53`. 