### PR TITLE
test: six new hapi tests for token claim airdrop

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenClaimAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenClaimAirdropTest.java
@@ -56,8 +56,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_P
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PENDING_AIRDROP_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_PENDING_AIRDROP_ID_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PENDING_AIRDROP_ID_LIST_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PENDING_AIRDROP_ID_REPEATED;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
@@ -264,7 +263,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                                 pendingAirdrop(OWNER, RECEIVER, FUNGIBLE_TOKEN_11))
                         .payingWith(RECEIVER)
                         .via("claimTxn")
-                        .hasKnownStatus(MAX_PENDING_AIRDROP_ID_EXCEEDED));
+                        .hasKnownStatus(PENDING_AIRDROP_ID_LIST_TOO_LONG));
     }
 
     @HapiTest


### PR DESCRIPTION
Implemented 3 tests:
-TokenClaimAirdrop transaction containing duplicate entries should fail
-TokenClaimAirdrop transaction with more than 10 pending airdrops entries should fail
-TokenClaimAirdrop transaction with no pending airdrops entries should fail
-[Single Token]
Given existing pending airdrop in state when valid TokenClaimAirdrop transaction containing 1 entry for the same pending airdrop is performed then the TokenClaimAirdrop should succeed
-[Single Token]
Receiver (a normal account) signs a pending TokenClaimAirdrop transaction for FT A 
-[Single Token]
Receiver (a normal account) signs a pending TokenClaimAirdrop transaction for 1 NFT A with serial number 1
-[Single Token]
Receiver signs a TokenClaimAirdrop with not enough HBAR, then gets enough HBAR and claims the same airdrop again.
**Related issue(s)**:

Fixes #14703 
#14701 
#14700 
#14813 
#14814
#14815 
#14816 


