### PR TITLE
chore: Fix compiler warnings in util-service and util-service-impl

### DIFF
--- a/hedera-node/hedera-util-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-util-service-impl/build.gradle.kts
@@ -21,10 +21,6 @@ plugins {
 
 description = "Default Hedera Util Service Implementation"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
-
 mainModuleInfo { annotationProcessor("dagger.compiler") }
 
 testModuleInfo {

--- a/hedera-node/hedera-util-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/module-info.java
@@ -6,12 +6,12 @@ module com.hedera.node.app.service.util.impl {
     requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
     requires transitive dagger;
+    requires transitive java.compiler; // javax.annotation.processing.Generated
     requires transitive javax.inject;
     requires com.hedera.node.config;
     requires com.swirlds.config.api;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
-    requires static java.compiler; // javax.annotation.processing.Generated
 
     provides com.hedera.node.app.service.util.UtilService with
             UtilServiceImpl;

--- a/hedera-node/hedera-util-service/build.gradle.kts
+++ b/hedera-node/hedera-util-service/build.gradle.kts
@@ -21,10 +21,6 @@ plugins {
 
 description = "Hedera Util Service API"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
-
 testModuleInfo {
     requires("org.assertj.core")
     requires("org.junit.jupiter.api")


### PR DESCRIPTION
**Description**:
Removed `tasks.withType<>...` line from `build.gradle.kts` files in `hedera-util-service` and `hedera-util-service-impl` which disables warnings for those packages.

- In service-impl `module-info.java` file java.compiler is changed from `static` to `transitive` 

**Related issue(s)**:

Fixes #14866 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
