### PR TITLE
chore: Update SystemSetup to set memo in TransactionBody

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemSetup.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemSetup.java
@@ -277,8 +277,11 @@ public class SystemSetup {
             if (overrideAutoRenewPeriod != null) {
                 op.autoRenewPeriod(Duration.newBuilder().seconds(overrideAutoRenewPeriod));
             }
-            final var body =
-                    TransactionBody.newBuilder().cryptoCreateAccount(op).build();
+            final var bodyBuilder = TransactionBody.newBuilder().cryptoCreateAccount(op);
+            if (recordMemo != null) {
+                bodyBuilder.memo(recordMemo);
+            }
+            final var body = bodyBuilder.build();
             recordBuilder.transaction(transactionWith(body));
 
             final var balance = account.tinybarBalance();


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Currently the memo of "Synthetic system creation" for genesis crypto accounts are only externalized in the record stream via a TransactionRecord, the TransactionBody itself does not contain the memo. This change would put the memo in the body and then it would be available in the block stream and applicable translates converting BlockItem's to a TransactionRecord would have the memo available.

**Related issue(s)**:

Fixes #14871 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
