### PR TITLE
fix: invalid `feeSchedules.json`

### DIFF
--- a/hedera-node/configuration/mainnet/upgrade/feeSchedules.json
+++ b/hedera-node/configuration/mainnet/upgrade/feeSchedules.json
@@ -1687,7 +1687,10 @@
                 "min": 0,
                 "max": 1000000000000000
               }
-            },
+            }
+          ]
+        }
+      },
       {
         "transactionFeeSchedule": {
           "hederaFunctionality": "TokenReject",

--- a/hedera-node/configuration/testnet/upgrade/feeSchedules.json
+++ b/hedera-node/configuration/testnet/upgrade/feeSchedules.json
@@ -1378,8 +1378,7 @@
                 }
             } ]
         }
-    },
-        {
+    }, {
             "transactionFeeSchedule": {
                 "hederaFunctionality": "TokenReject",
                 "fees": [
@@ -1690,6 +1689,9 @@
                             "min": 0,
                             "max": 1000000000000000
                         }
+                    }
+                ]
+            }
         },
         {
         "transactionFeeSchedule" : {


### PR DESCRIPTION
Fixed invalid feeSchedules.json in both testnet and mainnet directories