### PR TITLE
fix(0.53): cherrypick selfdestruct fix

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/AbstractCustomCreateOperation.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/operations/AbstractCustomCreateOperation.java
@@ -177,6 +177,7 @@ public abstract class AbstractCustomCreateOperation extends AbstractOperation {
         frame.setState(MessageFrame.State.CODE_EXECUTING);
         frame.incrementRemainingGas(childFrame.getRemainingGas());
         frame.addLogs(childFrame.getLogs());
+        frame.addCreates(childFrame.getCreates());
         frame.addSelfDestructs(childFrame.getSelfDestructs());
         frame.incrementGasRefund(childFrame.getGasRefund());
         frame.popStackItems(getStackItemsConsumed());

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomContractCreationProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomContractCreationProcessor.java
@@ -99,6 +99,7 @@ public class CustomContractCreationProcessor extends ContractCreationProcessor {
                 halt(frame, tracer, maybeReasonToHalt);
             } else {
                 contract.setNonce(INITIAL_CONTRACT_NONCE);
+                frame.addCreate(addressToCreate);
                 frame.setState(MessageFrame.State.CODE_EXECUTING);
             }
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/SpecEntity.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/SpecEntity.java
@@ -72,6 +72,28 @@ public interface SpecEntity {
     }
 
     /**
+     * Given a list of entities, create them (if not already created) and register them all, in
+     * the order listed.  That is, perform {@link SpecEntity#registerOrCreateWith} for each entity given, in order.
+     *
+     * <p>Useful to force entities to be created at a specific time and in a specific order, if you need
+     * to predict the Hedera entity numbers of entities dynamically created during a test; e.g., by
+     * smart contracts which themselves create contracts, or which use HTS.
+     *
+     * <p>Always use with <code>&#64;LeakyHapiTest(requirement = NO_CONCURRENT_CREATIONS)</code>.
+     *
+     * <p>(See, e.g., {@link com.hedera.services.bdd.suites.contract.opcodes.SelfDestructSuite#selfDestructedContractIsDeletedInSameTx(String,SpecAccount,SpecContract,SpecContract)}.)
+     *
+     * @param spec the spec to use to create an entity if it is not already created
+     * @param entities - the entities to create, in order
+     */
+    static void forceCreateAndRegister(@NonNull final HapiSpec spec, final SpecEntity... entities) {
+        requireNonNull(spec);
+        for (final var entity : entities) {
+            requireNonNull(entity).registerOrCreateWith(spec);
+        }
+    }
+
+    /**
      * Creates this entity with the given {@link HapiSpec}, returning the registrar
      * for the spec's target network.
      *


### PR DESCRIPTION
**Description**:

Cherry pick of #14863 - SELFDESTRUCT now deletes contracts properly - in case it is needed in some 0.53 point release.

**Related issue(s)**:

Fixes #14835

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
