### PR TITLE
fix: ConsensusSubmitMessage StreamValidation diffs from SubmitMessageSuite

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
@@ -1032,8 +1032,6 @@ public class BlockStreamBuilder
         transactionResultBuilder.scheduleRef((ScheduleID) null);
         transactionResultBuilder.automaticTokenAssociations(emptyList());
         transactionResultBuilder.congestionPricingMultiplier(0);
-        transactionResultBuilder.status(ResponseCodeEnum.OK);
-        transactionResultBuilder.parentConsensusTimestamp(Timestamp.DEFAULT);
 
         transactionOutputBuilder.cryptoTransfer((CryptoTransferOutput) null);
         transactionOutputBuilder.utilPrng((UtilPrngOutput) null);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/ConsensusSubmitMessageTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/ConsensusSubmitMessageTranslator.java
@@ -23,9 +23,9 @@ import com.hedera.hapi.block.stream.output.StateChanges;
 import com.hedera.hapi.node.transaction.TransactionReceipt;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.state.SingleTransactionRecord;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 
 public class ConsensusSubmitMessageTranslator implements TransactionRecordTranslator<SingleTransactionBlockItems> {
     // For explanation about this constant value, see
@@ -34,7 +34,7 @@ public class ConsensusSubmitMessageTranslator implements TransactionRecordTransl
 
     @Override
     public SingleTransactionRecord translate(
-            @NotNull SingleTransactionBlockItems transaction, @Nullable StateChanges stateChanges) {
+            @NonNull SingleTransactionBlockItems transaction, @Nullable StateChanges stateChanges) {
         final var receiptBuilder = TransactionReceipt.newBuilder();
         if (transaction.result().status().equals(SUCCESS)) {
             receiptBuilder.topicRunningHashVersion(RUNNING_HASH_VERSION);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/UtilPrngTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/UtilPrngTranslator.java
@@ -22,13 +22,14 @@ import static com.hedera.hapi.block.stream.output.UtilPrngOutput.EntropyOneOfTyp
 import com.hedera.hapi.block.stream.output.StateChanges;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.state.SingleTransactionRecord;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
-import org.jetbrains.annotations.NotNull;
 
 public class UtilPrngTranslator implements TransactionRecordTranslator<SingleTransactionBlockItems> {
     @Override
     public SingleTransactionRecord translate(
-            @NotNull SingleTransactionBlockItems transaction, @NotNull StateChanges stateChanges) {
+            @NonNull SingleTransactionBlockItems transaction, @Nullable StateChanges stateChanges) {
         final var recordBuilder = TransactionRecord.newBuilder();
         final var txOutput = transaction.output();
         if (txOutput != null && txOutput.hasUtilPrng()) {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

For tests resulting in `HandleException` we'll end up rolling back the save point stack and which invokes `BlockStreamBuilder.nullOutSideEffectFields()`.
Removed the reset for `status` and `parentConsensusTimestamp` from there in order to have the similar behavior as in `RecordStreamBuilder.nullOutSideEffectFields()`.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/14852

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
