### PR TITLE
fix: node exits after repeating unsuccessful reconnects

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/internal/AbstractMerkleNode.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/impl/internal/AbstractMerkleNode.java
@@ -105,7 +105,8 @@ public abstract sealed class AbstractMerkleNode extends AbstractReservable
             // allowed to proceed, a node in multiple trees would have the incorrect route in at least one of those
             // trees. Instead of moving the node, make a copy and move the copy.
             throw new MerkleRouteException("Routes can not be set unless the reservation count is 0 or 1. (type = "
-                    + this.getClass().getName() + ", reservation count = " + getReservationCount() + ")");
+                    + this.getClass().getName() + ", reservation count = " + getReservationCount() + ", route = "
+                    + getRoute() + ", new route = " + route + ")");
         }
         this.route = route;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
@@ -21,6 +21,7 @@ import static com.swirlds.platform.state.MerkleStateUtils.createInfoString;
 import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
+import com.swirlds.common.merkle.route.MerkleRouteFactory;
 import com.swirlds.common.utility.RuntimeObjectRecord;
 import com.swirlds.common.utility.RuntimeObjectRegistry;
 import com.swirlds.platform.system.SwirldState;
@@ -106,6 +107,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
             PlatformState platformState = getPlatformState().copy();
             setChild(ChildIndices.PLATFORM_STATE, null);
             merkleStateRoot.setPlatformState(platformState);
+            merkleStateRoot.setRoute(MerkleRouteFactory.getEmptyRoute());
 
             return merkleStateRoot.copy();
         }


### PR DESCRIPTION
**Description**:
The failed check in `AbstractMerkleNode.setRoute()` and the exception were bogus due to incorrect route of the Merkle tree root migrated from 0.52.

**Related issue(s)**:

Fixes #14851

**Notes for reviewer**:
Cherry-picked from release/0.53 (#14858, #14880)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
