### PR TITLE
fix: When airdrop to contract return NOT_SUPPORTED

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
@@ -17,7 +17,6 @@
 package com.hedera.node.app.service.token.impl.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PENDING_NFT_AIRDROP_ALREADY_EXISTS;
 import static com.hedera.hapi.util.HapiUtils.isHollow;
@@ -221,7 +220,7 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
             final var account = accountStore.getAliasedAccountById(receiverId);
             // Missing accounts will be treated as auto-creation attempts
             if (account != null) {
-                validateTrue(isHollow(account) || canClaimAirdrop(account.keyOrThrow()), INVALID_TRANSACTION_BODY);
+                validateTrue(isHollow(account) || canClaimAirdrop(account.keyOrThrow()), NOT_SUPPORTED);
             }
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/AirdropSigReqsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/AirdropSigReqsTest.java
@@ -32,7 +32,7 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHollow;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
@@ -96,7 +96,7 @@ public class AirdropSigReqsTest {
         return hapiTest(
                 airdropTo(mutableContract).with(txn -> txn.via("successAirdrop")),
                 getTxnRecord("successAirdrop").hasPriority(recordWith().pendingAirdropsCount(2)),
-                airdropTo(immutableContract).andAssert(txn -> txn.hasKnownStatus(INVALID_TRANSACTION_BODY)));
+                airdropTo(immutableContract).andAssert(txn -> txn.hasKnownStatus(NOT_SUPPORTED)));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -640,7 +640,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
                     tokenAirdrop(moving(10, FUNGIBLE_TOKEN).between(OWNER, testContract))
                             .signedBy(OWNER)
                             .payingWith(OWNER)
-                            .hasKnownStatus(INVALID_TRANSACTION_BODY));
+                            .hasKnownStatus(NOT_SUPPORTED));
         }
     }
 


### PR DESCRIPTION
Changing the status of the error from INVALID_TRANSACTION_BODY to NOT_SUPPORTED