### PR TITLE
feat: implement mint, burn, wipe translations; misc fixes

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/ScheduleTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/ScheduleTranslator.java
@@ -25,7 +25,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
 
-class TokenCreateTranslator implements TransactionRecordTranslator<SingleTransactionBlockItems> {
+/**
+ * Note: this class is used for both schedule creation and schedule signing translation
+ */
+class ScheduleTranslator implements TransactionRecordTranslator<SingleTransactionBlockItems> {
 
     @Override
     public SingleTransactionRecord translate(
@@ -34,7 +37,7 @@ class TokenCreateTranslator implements TransactionRecordTranslator<SingleTransac
         final var recordBuilder = TransactionRecord.newBuilder();
 
         if (stateChanges != null) {
-            maybeAssignTokenID(stateChanges, receiptBuilder);
+            maybeAssignScheduleID(stateChanges, receiptBuilder);
         }
 
         return new SingleTransactionRecord(
@@ -44,14 +47,15 @@ class TokenCreateTranslator implements TransactionRecordTranslator<SingleTransac
                 new SingleTransactionRecord.TransactionOutputs(null));
     }
 
-    private void maybeAssignTokenID(final StateChanges stateChanges, final TransactionReceipt.Builder receiptBuilder) {
+    private void maybeAssignScheduleID(
+            final StateChanges stateChanges, final TransactionReceipt.Builder receiptBuilder) {
         stateChanges.stateChanges().stream()
                 .filter(StateChange::hasMapUpdate)
                 .findFirst()
                 .ifPresent(stateChange -> {
                     if (stateChange.mapUpdate().hasKey()
-                            && stateChange.mapUpdate().key().hasTokenIdKey()) {
-                        receiptBuilder.tokenID(stateChange.mapUpdate().key().tokenIdKey());
+                            && stateChange.mapUpdate().key().hasScheduleIdKey()) {
+                        receiptBuilder.scheduleID(stateChange.mapUpdate().key().scheduleIdKey());
                     }
                 });
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/TokenMintBurnWipeTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/TokenMintBurnWipeTranslator.java
@@ -18,14 +18,19 @@ package com.hedera.services.bdd.junit.support.translators;
 
 import com.hedera.hapi.block.stream.output.StateChange;
 import com.hedera.hapi.block.stream.output.StateChanges;
+import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.transaction.TransactionReceipt;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.state.SingleTransactionRecord;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 
-class ScheduleCreateTranslator implements TransactionRecordTranslator<SingleTransactionBlockItems> {
+/**
+ * Note: this class is used for token mint, burn, and wipe translations
+ */
+class TokenMintBurnWipeTranslator implements TransactionRecordTranslator<SingleTransactionBlockItems> {
 
     @Override
     public SingleTransactionRecord translate(
@@ -34,7 +39,7 @@ class ScheduleCreateTranslator implements TransactionRecordTranslator<SingleTran
         final var recordBuilder = TransactionRecord.newBuilder();
 
         if (stateChanges != null) {
-            maybeAssignScheduleID(stateChanges, receiptBuilder);
+            maybeAssignNewSupplyAndSerialNums(stateChanges, receiptBuilder);
         }
 
         return new SingleTransactionRecord(
@@ -44,16 +49,30 @@ class ScheduleCreateTranslator implements TransactionRecordTranslator<SingleTran
                 new SingleTransactionRecord.TransactionOutputs(null));
     }
 
-    private void maybeAssignScheduleID(
+    private void maybeAssignNewSupplyAndSerialNums(
             final StateChanges stateChanges, final TransactionReceipt.Builder receiptBuilder) {
-        stateChanges.stateChanges().stream()
+        final var updatedToken = stateChanges.stateChanges().stream()
                 .filter(StateChange::hasMapUpdate)
+                .filter(stateChange -> stateChange.mapUpdate().hasValue()
+                        && stateChange.mapUpdate().value().hasTokenValue())
                 .findFirst()
-                .ifPresent(stateChange -> {
-                    if (stateChange.mapUpdate().hasKey()
-                            && stateChange.mapUpdate().key().hasScheduleIdKey()) {
-                        receiptBuilder.scheduleID(stateChange.mapUpdate().key().scheduleIdKey());
-                    }
-                });
+                .map(stateChange -> stateChange.mapUpdate().value().tokenValue())
+                .orElse(null);
+
+        if (updatedToken != null) {
+            receiptBuilder.newTotalSupply(updatedToken.totalSupply());
+
+            if (updatedToken.tokenType() == TokenType.NON_FUNGIBLE_UNIQUE) {
+                final var serialNums = new ArrayList<Long>();
+                stateChanges.stateChanges().stream()
+                        .filter(StateChange::hasMapUpdate)
+                        .filter(stateChange -> stateChange.mapUpdate().hasKey()
+                                && stateChange.mapUpdate().key().hasNftIdKey())
+                        .map(stateChange -> stateChange.mapUpdate().key().nftIdKey())
+                        .forEach(nftId -> serialNums.add(nftId.serialNumber()));
+
+                receiptBuilder.serialNumbers(serialNums);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR implements the transaction-specific translation needed for token mint, burn, and wipe translations, as well as:

* Expanding `ScheduleCreateTranslator` to also operate on `ScheduleSign`
* A few minor fixes
* Minor cleanup

Closes #14958