### PR TITLE
fix: 15000: No need to have data file compaction running during reconnects

### DIFF
--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -396,7 +396,7 @@ public final class MerkleDb {
         final String label = dataSource.getTableName();
         final int tableId = getNextTableId();
         importDataSource(dataSource, tableId, !makeCopyPrimary, makeCopyPrimary); // import to itself == copy
-        return getDataSource(tableId, label, makeCopyPrimary);
+        return getDataSource(tableId, label, false);
     }
 
     private <K extends VirtualKey, V extends VirtualValue> void importDataSource(


### PR DESCRIPTION
Fix summary: when a MerkleDb data source copy is created, it has data compaction explicitly disabled. This conforms to the current `VirtualDataSourceBuilder.copy()` contract.

Fixes: https://github.com/hashgraph/hedera-services/issues/15000
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
