### PR TITLE
fix: 13901: VirtualPipeline back-pressure is too harsh

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -232,8 +232,10 @@ public class VirtualPipeline {
         }
 
         try {
+            final long sleepStartTime = System.currentTimeMillis();
             logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flush backpressure: {} ms", sleepTimeMillis);
             MILLISECONDS.sleep(sleepTimeMillis);
+            statistics.recordFlushBackpressureMs((int) (System.currentTimeMillis() - sleepStartTime));
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
         }
@@ -254,9 +256,7 @@ public class VirtualPipeline {
 
         final Duration maxSleepTime = config.maximumFlushThrottlePeriod();
         final Duration sleepTime = CompareTo.min(computedSleepTime, maxSleepTime);
-        final int sleepTimeMillis = (int) sleepTime.toMillis();
-        statistics.recordFlushBackpressureMs(sleepTimeMillis);
-        return sleepTimeMillis;
+        return sleepTime.toMillis();
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -225,27 +225,27 @@ public class VirtualPipeline {
      * Slow down the fast copy operation if there are too many copies that need to be flushed.
      */
     private void applyFlushBackpressure() {
-        final Duration sleepTime = calculateFlushBackpressurePause();
-        if (sleepTime == null) {
+        final long sleepTimeMillis = calculateFlushBackpressurePause();
+        if (sleepTimeMillis <= 0) {
             // no backpressure needed
             return;
         }
 
         try {
-            logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flush backpressure: {} ms", sleepTime.toMillis());
-            MILLISECONDS.sleep(sleepTime.toMillis());
+            logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flush backpressure: {} ms", sleepTimeMillis);
+            MILLISECONDS.sleep(sleepTimeMillis);
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
         }
     }
 
-    Duration calculateFlushBackpressurePause() {
+    long calculateFlushBackpressurePause() {
         final int backlogSize = flushBacklog.size();
         statistics.recordFlushBacklogSize(backlogSize);
 
         final int backlogExcess = backlogSize - config.preferredFlushQueueSize();
         if (backlogExcess <= 0) {
-            return null;
+            return 0;
         }
 
         // Sleep time grows quadratically.
@@ -256,7 +256,7 @@ public class VirtualPipeline {
         final Duration sleepTime = CompareTo.min(computedSleepTime, maxSleepTime);
         final int sleepTimeMillis = (int) sleepTime.toMillis();
         statistics.recordFlushBackpressureMs(sleepTimeMillis);
-        return sleepTime;
+        return sleepTimeMillis;
     }
 
     /**
@@ -264,31 +264,47 @@ public class VirtualPipeline {
      * in this pipeline exceeds {@link VirtualMapConfig#familyThrottleThreshold()}.
      */
     private void applyFamilySizeBackpressure() {
-        final Duration sleepTime = calculateFamilySizeBackpressurePause();
-        if (sleepTime == null) return;
+        final long sleepTimeMillis = calculateFamilySizeBackpressurePause();
+        if (sleepTimeMillis <= 0) {
+            return;
+        }
+        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Total size backpressure: {} ms", sleepTimeMillis);
 
         try {
-            logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Total size backpressure: {} ms", sleepTime.toMillis());
-            MILLISECONDS.sleep(sleepTime.toMillis());
+            final long sleepStartTime = System.currentTimeMillis();
+            long timeSleptSoFar = 0;
+            do {
+                MILLISECONDS.sleep(1);
+                timeSleptSoFar = System.currentTimeMillis() - sleepStartTime;
+                // Virtual map copy may be flushing on the lifecycle thread, while this thread is
+                // sleeping. After any flush, total family size is reduced, and the current thread
+                // may not sleep any longer. Re-calculate backpressure duration as of now and
+                // check it against the time this thread has slept so far
+                final long currentSleepTimeMillis = calculateFamilySizeBackpressurePause();
+                if ((currentSleepTimeMillis <= 0) || (timeSleptSoFar >= currentSleepTimeMillis)) {
+                    break;
+                }
+            } while (timeSleptSoFar < sleepTimeMillis);
+
+            // Record actual sleep time
+            statistics.recordFamilySizeBackpressureMs((int) (System.currentTimeMillis() - sleepStartTime));
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
         }
     }
 
-    Duration calculateFamilySizeBackpressurePause() {
+    long calculateFamilySizeBackpressurePause() {
         final long sizeThreshold = config.familyThrottleThreshold();
         if (sizeThreshold <= 0) {
-            return null;
+            return 0;
         }
         final long totalSize = currentTotalSize();
         final double ratio = (double) totalSize / sizeThreshold;
         final int over100percentExcess = (int) Math.round((ratio - 1.0) * 100);
         if (over100percentExcess <= 0) {
-            return null;
+            return 0;
         }
-        final Duration sleepTime = Duration.ofMillis((long) over100percentExcess * over100percentExcess);
-        statistics.recordFamilySizeBackpressureMs((int) sleepTime.toMillis());
-        return sleepTime;
+        return (long) over100percentExcess * over100percentExcess;
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
@@ -825,13 +825,13 @@ class VirtualPipelineTests {
             final Deque<DummyVirtualRoot> copies, final int expectedTimeMs) {
         final DummyVirtualRoot copy = copies.getLast().copy();
         copies.add(copy);
-        final Duration duration = copy.getPipeline().calculateFlushBackpressurePause();
-        if (duration == null) {
+        final long duration = copy.getPipeline().calculateFlushBackpressurePause();
+        if (duration <= 0) {
             // no backpressure applied
             return;
         }
 
-        assertEquals(expectedTimeMs, duration.toMillis());
+        assertEquals(expectedTimeMs, duration);
     }
 
     /**
@@ -841,13 +841,13 @@ class VirtualPipelineTests {
             final Deque<DummyVirtualRoot> copies, final int expectedTimeMs) {
         final DummyVirtualRoot copy = copies.getLast().copy();
         copies.add(copy);
-        final Duration duration = copy.getPipeline().calculateFamilySizeBackpressurePause();
-        if (duration == null) {
+        final long duration = copy.getPipeline().calculateFamilySizeBackpressurePause();
+        if (duration <= 0) {
             // no backpressure applied
             return;
         }
 
-        assertEquals(expectedTimeMs, duration.toMillis());
+        assertEquals(expectedTimeMs, duration);
     }
 
     @Test


### PR DESCRIPTION
Fix summary: changed `VirtualPipeline.applyFamilySizeBackpressure()` to be a set of small sleeps rather a single long sleep. After each small sleep, it checks the current backpressure (which may have changed, if a virtual map copy is flushed in a parallel thread) and compares it with total time slept so far.

Fixes: https://github.com/hashgraph/hedera-services/issues/13901
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
