### PR TITLE
chore: updated the LogValidationTest to scan for exception present in swirlds.log file.

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/LogValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/LogValidationTest.java
@@ -16,11 +16,20 @@
 
 package com.hedera.services.bdd.suites.validation;
 
+import static com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils.OUTPUT_DIR;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateAllLogsAfter;
+import static java.util.Objects.requireNonNull;
 
 import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.junit.hedera.NodeMetadata;
+import com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Order;
@@ -30,9 +39,29 @@ import org.junit.jupiter.api.Tag;
 @Order(Integer.MAX_VALUE)
 public class LogValidationTest {
     private static final Duration VALIDATION_DELAY = Duration.ofSeconds(1);
+    private static final String SWIRLDS_LOG = "swirlds.log";
+    private final NodeMetadata metadata =
+            new NodeMetadata(0, "node0", null, "", 0, 0, 0, 0, WorkingDirUtils.workingDirFor(0, "EMBEDDED"));
+
+    private void validateSwirldsLog() throws IOException {
+        final Path workingDir = requireNonNull(metadata.workingDir());
+        final Path path = workingDir.resolve(OUTPUT_DIR).resolve(SWIRLDS_LOG);
+        final String fileContent = Files.readString(path);
+        final Pattern pattern = Pattern.compile(".*Exception.*", Pattern.CASE_INSENSITIVE);
+        final Matcher matcher = pattern.matcher(fileContent);
+        final StringBuilder matchedLines = new StringBuilder();
+        while (matcher.find()) {
+            matchedLines.append(matcher.group()).append(System.lineSeparator());
+        }
+        if (!matchedLines.isEmpty()) {
+            throw new AssertionError("Unexpected problem found in logs:\n" + matchedLines);
+        }
+    }
 
     @LeakyHapiTest
     final Stream<DynamicTest> logsContainNoUnexpectedProblems() {
-        return hapiTest(validateAllLogsAfter(VALIDATION_DELAY));
+        return Stream.concat(
+                hapiTest(validateAllLogsAfter(VALIDATION_DELAY)),
+                Stream.of(DynamicTest.dynamicTest("Validate swirlds.log", this::validateSwirldsLog)));
     }
 }


### PR DESCRIPTION
Description:

Added logic in the LogValidationTest to scan swirlds log.

Related issue(s):

Fixes https://github.com/hashgraph/hedera-services/issues/14017

Notes for reviewer:

Checklist

 Documented (Code comments, README, etc.)
 Tested (unit, integration, etc.)
