### PR TITLE
fix: 15036: IndexOutOfBoundsException when flushing an empty virtual map to MerkleDb

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
@@ -62,7 +62,8 @@ public class KeyValueStoreBench extends BaseBench {
         // Write files
         long start = System.currentTimeMillis();
         for (int i = 0; i < numFiles; i++) {
-            store.startWriting(0, maxKey);
+            store.updateValidKeyRange(0, maxKey);
+            store.startWriting();
             resetKeys();
             for (int j = 0; j < numRecords; ++j) {
                 long id = nextAscKey();

--- a/platform-sdk/swirlds-jasperdb/src/hammer/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreCompactionHammerTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/hammer/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreCompactionHammerTest.java
@@ -362,7 +362,8 @@ class MemoryIndexDiskKeyValueStoreCompactionHammerTest {
          * @throws IOException in case of emergency
          */
         private void save(final Map<Long, Long> cache) throws IOException {
-            coll.startWriting(firstPath, lastPath);
+            coll.updateValidKeyRange(firstPath, lastPath);
+            coll.startWriting();
             final List<Long> sortedKeys = cache.keySet().stream().sorted().toList();
             for (final long key : sortedKeys) {
                 if (key < firstPath || key > lastPath || key == DELETED) {

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
@@ -53,7 +53,7 @@ public abstract class AbstractLongList<C> implements LongList {
     public static final String MAX_CHUNKS_EXCEEDED_MSG = "The maximum number of memory chunks should not exceed %s. "
             + "Either increase numLongsPerChunk or decrease maxLongs";
     public static final String CHUNK_SIZE_EXCEEDED_MSG = "Cannot store %d per chunk (max is %d)";
-    public static final String MIN_VALID_INDEX_NON_NEGATIVE_MSG = "Min valid index %d must be non-negative";
+    public static final String INVALID_RANGE_MSG = "Invalid range %d - %d";
     public static final String MAX_VALID_INDEX_LIMIT = "Max valid index %d must be less than max capacity %d";
 
     static {
@@ -126,8 +126,11 @@ public abstract class AbstractLongList<C> implements LongList {
      */
     protected final long maxLongs;
 
-    /** Min valid index of the list. All the indices to the left of this index have {@code IMPERMISSIBLE_VALUE}-s */
-    protected final AtomicLong minValidIndex = new AtomicLong(0);
+    /** Min valid index of the list. All indices to the left of this index have {@code IMPERMISSIBLE_VALUE}-s */
+    protected final AtomicLong minValidIndex = new AtomicLong(-1);
+
+    /** Max valid index of the list. All indices to the right of this index have {@code IMPERMISSIBLE_VALUE}-s */
+    protected final AtomicLong maxValidIndex = new AtomicLong(-1);
 
     /** Atomic reference array of our memory chunks */
     protected final AtomicReferenceArray<C> chunkList;
@@ -222,8 +225,10 @@ public abstract class AbstractLongList<C> implements LongList {
                     // "inflating" the size by number of indices that are to the left of the min valid index
                     size.set(minValidIndex.get() + (fileChannel.size() - currentFileHeaderSize) / Long.BYTES);
                 } else {
+                    minValidIndex.set(0);
                     size.set((fileChannel.size() - FILE_HEADER_SIZE_V1) / Long.BYTES);
                 }
+                maxValidIndex.set(size.get() - 1);
                 chunkList = new AtomicReferenceArray<>(calculateNumberOfChunks(maxLongs));
                 readBodyFromFileChannelOnInit(file.getName(), fileChannel);
             }
@@ -302,6 +307,8 @@ public abstract class AbstractLongList<C> implements LongList {
     private void putImpl(final long index, final long value) {
         assert index >= minValidIndex.get()
                 : String.format("Index %d is less than min valid index %d", index, minValidIndex.get());
+        assert index <= maxValidIndex.get()
+                : String.format("Index %d is greater than max valid index %d", index, maxValidIndex.get());
         final C chunk = createOrGetChunk(index);
         final int subIndex = toIntExact(index % numLongsPerChunk);
         putToChunk(chunk, subIndex, value);
@@ -434,6 +441,7 @@ public abstract class AbstractLongList<C> implements LongList {
         headerBuffer.putInt(getNumLongsPerChunk());
         headerBuffer.putLong(maxLongs);
         headerBuffer.putLong(minValidIndex.get());
+        // maxValidIndex is not written. On loading, it will be set automatically based on the size
         headerBuffer.flip();
         // always write at start of file
         MerkleDbFileUtils.completelyWrite(fc, headerBuffer, 0);
@@ -460,21 +468,30 @@ public abstract class AbstractLongList<C> implements LongList {
     /** {@inheritDoc} */
     @Override
     public final void updateValidRange(final long newMinValidIndex, final long newMaxValidIndex) {
-        if (newMinValidIndex < 0) {
-            throw new IndexOutOfBoundsException(MIN_VALID_INDEX_NON_NEGATIVE_MSG.formatted(newMinValidIndex));
+        if ((newMinValidIndex < -1) || (newMinValidIndex > newMaxValidIndex)) {
+            throw new IndexOutOfBoundsException(INVALID_RANGE_MSG.formatted(newMinValidIndex, newMaxValidIndex));
         }
-
         if (newMaxValidIndex > maxLongs - 1) {
             throw new IndexOutOfBoundsException(MAX_VALID_INDEX_LIMIT.formatted(newMaxValidIndex, maxLongs));
         }
 
         minValidIndex.set(newMinValidIndex);
-        long oldMaxValidIndex = size.getAndUpdate(v -> min(newMaxValidIndex + 1, v)) - 1;
+        final long oldMaxValidIndex = maxValidIndex.getAndSet(newMaxValidIndex);
+        size.updateAndGet(v -> min(v, newMaxValidIndex + 1));
 
         shrinkLeftSideIfNeeded(newMinValidIndex);
         shrinkRightSideIfNeeded(oldMaxValidIndex, newMaxValidIndex);
         // everything to the right of the newMaxValidIndex is going to be discarded, adjust the size accordingly
+    }
 
+    @Override
+    public long getMinValidIndex() {
+        return minValidIndex.get();
+    }
+
+    @Override
+    public long getMaxValidIndex() {
+        return maxValidIndex.get();
     }
 
     /**
@@ -627,8 +644,8 @@ public abstract class AbstractLongList<C> implements LongList {
     /** {@inheritDoc} */
     @Override
     public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
-        final long max = size();
-        for (long i = minValidIndex.get(); i < max; i++) {
+        final long max = maxValidIndex.get();
+        for (long i = minValidIndex.get(); i <= max; i++) {
             final long value = get(i);
             if (value != IMPERMISSIBLE_VALUE) {
                 action.handle(i, value);

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongList.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongList.java
@@ -119,14 +119,17 @@ public interface LongList extends CASableLongIndex, Closeable {
     void writeToFile(Path file) throws IOException;
 
     /**
-     * After invocation of this method, {@link LongList#get(long)}) calls
+     * Updates min and max valid indexes in this list. If both values are -1, this indicates
+     * the list is empty.
+     *
+     * <p>After invocation of this method, {@link LongList#get(long)}) calls
      * will return {@link LongList#IMPERMISSIBLE_VALUE} for indices that
      * are before {@code newMinValidIndex} and after {@code newMaxValidIndex}
      * Also, a call to this method releases memory taken by unused chunks.
      * For in-memory implementation it means the chunk clean up and memory release,
      * while file-based reuse the file space in further writes.
-     * <p>
-     * Note that {@code newMinValidIndex} is allowed to exceed the current size of the list.
+     *
+     * <p>Note that {@code newMinValidIndex} is allowed to exceed the current size of the list.
      * If {@code newMaxValidIndex} exceeds the current size of the list, there will be no effect.
      *
      * @param newMinValidIndex minimal valid index of the list
@@ -135,6 +138,20 @@ public interface LongList extends CASableLongIndex, Closeable {
      * {@code newMaxValidIndex} exceeds max number of chunks allowed.
      */
     void updateValidRange(long newMinValidIndex, long newMaxValidIndex);
+
+    /**
+     * Min valid index in this list. If the list is empty, the min index is -1.
+     *
+     * @return min valid index
+     */
+    long getMinValidIndex();
+
+    /**
+     * Max valid index in this list. If the list is empty, the max index is -1;
+     *
+     * @return max valid index
+     */
+    long getMaxValidIndex();
 
     /** {@inheritDoc} */
     @Override

--- a/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
+++ b/platform-sdk/swirlds-jasperdb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
@@ -97,6 +97,10 @@ public final class LongListOffHeap extends AbstractLongList<ByteBuffer> implemen
     /** {@inheritDoc} */
     @Override
     protected void readBodyFromFileChannelOnInit(String sourceFileName, FileChannel fileChannel) throws IOException {
+        if (minValidIndex.get() < 0) {
+            // Empty list, nothing to read
+            return;
+        }
         final int totalNumberOfChunks = calculateNumberOfChunks(size());
         final int firstChunkWithDataIndex = toIntExact(minValidIndex.get() / numLongsPerChunk);
         final int minValidIndexInChunk = toIntExact(minValidIndex.get() % numLongsPerChunk);

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -105,6 +105,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 () -> longList.putIfEqual(capacity, 1, -1),
                 "Capacity should not be a valid index");
 
+        longList.updateValidRange(0, getSampleSize());
         for (int i = 1; i < getSampleSize(); i++) {
             longList.put(i, i);
         }
@@ -155,6 +156,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
     @Test
     @Order(3)
     void testOffEndExpand() {
+        longList.updateValidRange(0, OUT_OF_SAMPLE_INDEX);
         longList.put(OUT_OF_SAMPLE_INDEX, OUT_OF_SAMPLE_INDEX);
         assertEquals(
                 OUT_OF_SAMPLE_INDEX,

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListDiskTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListDiskTest.java
@@ -302,6 +302,7 @@ class LongListDiskTest {
         longListDisk.updateValidRange(0, HALF_SAMPLE_SIZE);
 
         // using the freed up chunks
+        longListDisk.updateValidRange(0, SAMPLE_SIZE - 1);
         for (int i = HALF_SAMPLE_SIZE; i < SAMPLE_SIZE; i++) {
             longListDisk.put(i, i + 100);
         }
@@ -347,6 +348,7 @@ class LongListDiskTest {
     }
 
     private static <T extends LongList> T populateList(T longList) {
+        longList.updateValidRange(0, SAMPLE_SIZE - 1);
         for (int i = 0; i < SAMPLE_SIZE; i++) {
             longList.put(i, i + 100);
         }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListOffHeapTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListOffHeapTest.java
@@ -80,6 +80,7 @@ class LongListOffHeapTest extends AbstractLongListTest<LongListOffHeap> {
     void testCustomNumberOfLongs() throws IOException {
         try (final LongListOffHeap list =
                 createFullyParameterizedLongListWith(DEFAULT_NUM_LONGS_PER_CHUNK, getSampleSize())) {
+            list.updateValidRange(0, getSampleSize() - 1);
             for (int i = 0; i < getSampleSize(); i++) {
                 list.put(i, i + 1);
             }
@@ -95,6 +96,7 @@ class LongListOffHeapTest extends AbstractLongListTest<LongListOffHeap> {
     @Test
     void testInsertAtTheEndOfTheList() {
         final LongListOffHeap list = createLongList();
+        list.updateValidRange(0, DEFAULT_MAX_LONGS_TO_STORE - 1);
         assertDoesNotThrow(() -> list.put(DEFAULT_MAX_LONGS_TO_STORE - 1, 1));
     }
 
@@ -102,6 +104,7 @@ class LongListOffHeapTest extends AbstractLongListTest<LongListOffHeap> {
     void testInsertAtTheEndOfTheListCustomConfigured() {
         final int maxLongs = 10;
         final LongListOffHeap list = createFullyParameterizedLongListWith(10, maxLongs);
+        list.updateValidRange(0, maxLongs - 1);
         assertDoesNotThrow(() -> list.put(maxLongs - 1, 1));
     }
 
@@ -111,6 +114,7 @@ class LongListOffHeapTest extends AbstractLongListTest<LongListOffHeap> {
         try (final LongListOffHeap list = createFullyParameterizedLongListWith(
                 getSampleSize() / 100, // 100 chunks
                 getSampleSize())) {
+            list.updateValidRange(0, getSampleSize() - 1);
             for (int i = 1; i < getSampleSize(); i++) {
                 list.put(i, i);
             }
@@ -135,6 +139,7 @@ class LongListOffHeapTest extends AbstractLongListTest<LongListOffHeap> {
         try (final LongListOffHeap list = createFullyParameterizedLongListWith(
                 getSampleSize() / 100, // 100 chunks
                 getSampleSize())) {
+            list.updateValidRange(0, getSampleSize() - 1);
             for (int i = 1; i < getSampleSize(); i++) {
                 list.put(i, i);
             }
@@ -159,6 +164,7 @@ class LongListOffHeapTest extends AbstractLongListTest<LongListOffHeap> {
         try (final LongListOffHeap list = createFullyParameterizedLongListWith(
                 sampleSize / 100, // 100 chunks, 100 longs each
                 sampleSize + DEFAULT_NUM_LONGS_PER_CHUNK)) {
+            list.updateValidRange(0, getSampleSize() - 1);
             for (int i = 0; i < getSampleSize(); i++) {
                 list.put(i, i + 1);
             }
@@ -192,6 +198,7 @@ class LongListOffHeapTest extends AbstractLongListTest<LongListOffHeap> {
         try (final LongListOffHeap list = createFullyParameterizedLongListWith(
                 sampleSize / 100, // 100 chunks, 100 longs each
                 sampleSize + DEFAULT_NUM_LONGS_PER_CHUNK)) {
+            list.updateValidRange(0, getSampleSize() - 1);
             for (int i = 1; i < getSampleSize(); i++) {
                 list.put(i, i + 1);
             }

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/collections/LongListTest.java
@@ -56,6 +56,7 @@ class LongListTest {
         final LongConsumer secondConsumer = mock(LongConsumer.class);
 
         final LongListHeap list = new LongListHeap(32, 32, 0);
+        list.updateValidRange(0, 3);
         for (int i = 1; i <= 3; i++) {
             list.put(i, i);
         }
@@ -89,6 +90,7 @@ class LongListTest {
     @ParameterizedTest
     @MethodSource("provideLongLists")
     void test4089(final AbstractLongList<?> list) {
+        list.updateValidRange(0, list.maxLongs - 1);
         // Issue #4089: ArrayIndexOutOfBoundsException from VirtualMap.put()
         final long maxLongs = list.maxLongs;
         final int defaultValue = -1;

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
@@ -63,6 +63,7 @@ class DataFileReaderCloseTest {
         final int COUNT = 100;
         collection.startWriting();
         final LongList index = new LongListOffHeap();
+        index.updateValidRange(0, COUNT);
         for (int i = 0; i < COUNT; i++) {
             index.put(i, collection.storeDataItem(new long[] {i, i + 1}));
         }
@@ -117,6 +118,7 @@ class DataFileReaderCloseTest {
                 filePath = writer.getPath();
                 final DataFileMetadata metadata = writer.getMetadata();
                 final LongList index = new LongListOffHeap();
+                index.updateValidRange(0, i);
                 index.put(0, writer.storeDataItem(new long[] {i, i * 2 + 1}));
                 final DataFileReader<long[]> reader = new DataFileReader<>(dbConfig, filePath, serializer, metadata);
                 final int fi = i;

--- a/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreTest.java
+++ b/platform-sdk/swirlds-jasperdb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreTest.java
@@ -109,7 +109,8 @@ class MemoryIndexDiskKeyValueStoreTest {
             final long lastLeafPath,
             final int valueAddition)
             throws IOException {
-        store.startWriting(0, lastLeafPath);
+        store.updateValidKeyRange(0, lastLeafPath);
+        store.startWriting();
         writeDataBatch(testType, store, start, count, valueAddition);
         store.endWriting();
     }


### PR DESCRIPTION
Fix summary:

* A new field is introduced to `AbstractLongList` and its subclasses: max valid index. Previously there was only a field for min valid index, and list size was used as max valid index
* Both min and max valid indices can be -1, which indicates that the long list is empty
* Before a long list can be used, `updateValidKeyRange()` method must be called. All updates to the list outside the current range will result in an exception

Testing:

* A new unit test is provided. It failed before the fix, and passes with the fix
* Existing unit tests are updated to call `updateValidKeyRange()` when needed

Fixes: https://github.com/hashgraph/hedera-services/issues/15036
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
