### PR TITLE
fix: RosterSchema should provide default roster for existing states from previous versions AND genesis.

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
@@ -61,12 +61,9 @@ public class V0540RosterSchema extends Schema {
 
     @Override
     public void migrate(@NonNull final MigrationContext ctx) {
-        if (ctx.previousVersion() == null) {
-            log.info("Creating genesis roster and roster state");
-            // This migration code is really, for now, a default value provider.
-            // At genesis we put empty roster state into the state
-            // as serialization/deserialization fails on null.
-            final var rosterState = ctx.newStates().getSingleton(ROSTER_STATES_KEY);
+        final var rosterState = ctx.newStates().getSingleton(ROSTER_STATES_KEY);
+        if (rosterState.get() == null) {
+            log.info("Creating default roster state");
             rosterState.put(RosterState.DEFAULT);
         }
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.SemanticVersion;
@@ -34,6 +33,7 @@ import com.swirlds.state.spi.StateDefinition;
 import com.swirlds.state.spi.WritableSingletonState;
 import com.swirlds.state.spi.WritableStates;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -65,8 +65,8 @@ class V0540RosterSchemaTest {
     }
 
     @Test
-    void testMigrateFromNullPreviousVersion() {
-        when(migrationContext.previousVersion()).thenReturn(null);
+    @DisplayName("For this version, migrate from existing state version returns default.")
+    void testMigrateFromNullRosterStateReturnsDefault() {
         when(migrationContext.newStates()).thenReturn(mock(WritableStates.class));
         when(migrationContext.newStates().getSingleton(V0540RosterSchema.ROSTER_STATES_KEY))
                 .thenReturn(rosterState);
@@ -76,11 +76,15 @@ class V0540RosterSchemaTest {
     }
 
     @Test
-    void testMigrateFromNonNullPreviousVersion() {
+    @DisplayName("Migrate from older state version returns default.")
+    void testMigrateFromPreviousStateVersion() {
+        when(migrationContext.newStates()).thenReturn(mock(WritableStates.class));
+        when(migrationContext.newStates().getSingleton(V0540RosterSchema.ROSTER_STATES_KEY))
+                .thenReturn(rosterState);
         when(migrationContext.previousVersion())
                 .thenReturn(
                         SemanticVersion.newBuilder().major(0).minor(53).patch(0).build());
         subject.migrate(migrationContext);
-        verifyNoInteractions(rosterState);
+        verify(rosterState, times(1)).put(RosterState.DEFAULT);
     }
 }


### PR DESCRIPTION
RosterSchema only provides default for Genesis state. That's a bug, as it must also provide default for existing state created in previous versions. This PR fixes that bug. 