### PR TITLE
fix: fix hollow payer paying for transaction with unlimitedAssociationsEnabled

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -317,7 +317,7 @@ public class BaseTokenHandler {
      * @return the new token relation added
      */
     protected TokenRelation autoAssociate(
-            @NonNull final Account account,
+            @NonNull final AccountID accountId,
             @NonNull final Token token,
             @NonNull final WritableAccountStore accountStore,
             @NonNull final WritableTokenRelationStore tokenRelStore,
@@ -325,7 +325,6 @@ public class BaseTokenHandler {
         final var tokensConfig = config.getConfigData(TokensConfig.class);
         final var entitiesConfig = config.getConfigData(EntitiesConfig.class);
 
-        final var accountId = account.accountIdOrThrow();
         final var tokenId = token.tokenIdOrThrow();
         // If token is already associated, no need to associate again
         final var existingRel = tokenRelStore.get(accountId, tokenId);
@@ -334,6 +333,7 @@ public class BaseTokenHandler {
                 tokenRelStore.sizeOfState() + 1 < tokensConfig.maxAggregateRels(),
                 MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED);
 
+        final var account = accountStore.get(accountId);
         // Check is number of used associations is less than maxAutoAssociations
         final var numAssociations = account.numberAssociations();
         validateFalse(

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/BaseTokenHandler.java
@@ -309,7 +309,7 @@ public class BaseTokenHandler {
     /**
      * Creates a new {@link TokenRelation} with the account and token. This is called when there is
      * no association yet, but have open slots for maxAutoAssociations on the account.
-     * @param account the account to link the tokens to
+     * @param accountId the accountId to link the tokens to
      * @param token the token to link to the account
      * @param accountStore the account store
      * @param tokenRelStore the token relation store

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -161,7 +161,8 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
             // If there is no treasury relationship, then we need to create one if auto associations are available.
             // If not fail
             if (newTreasuryRel == null) {
-                final var newRelation = autoAssociate(newTreasuryAccount, token, accountStore, tokenRelStore, config);
+                final var newRelation = autoAssociate(
+                        newTreasuryAccount.accountIdOrThrow(), token, accountStore, tokenRelStore, config);
                 recordBuilder.addAutomaticTokenAssociation(
                         asTokenAssociation(newRelation.tokenId(), newRelation.accountId()));
                 newTreasuryAccount = requireNonNull(accountStore.getForModify(newTreasury));

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
@@ -208,7 +208,8 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
                     }
                 }
             }
-            final var newRelation = autoAssociate(account, token, accountStore, tokenRelStore, config);
+            final var newRelation =
+                    autoAssociate(account.accountIdOrThrow(), token, accountStore, tokenRelStore, config);
             return asTokenAssociation(newRelation.tokenId(), newRelation.accountId());
         } else {
             validateTrue(tokenRel != null, TOKEN_NOT_ASSOCIATED_TO_ACCOUNT);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -259,6 +259,27 @@ public class HollowAccountFinalizationSuite {
     }
 
     @HapiTest
+    final Stream<DynamicTest> hollowAccountCompletionWithHollowPayer() {
+        return defaultHapiSpec("hollowAccountCompletionWithHollowPayer")
+                .given(
+                        newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                        cryptoCreate(LAZY_CREATE_SPONSOR).balance(INITIAL_BALANCE * ONE_HBAR),
+                        cryptoCreate(TOKEN_TREASURY).balance(0L),
+                        tokenCreate(VANILLA_TOKEN).treasury(TOKEN_TREASURY),
+                        cryptoCreate("test"))
+                .when(createHollowAccountFrom(SECP_256K1_SOURCE_KEY))
+                .then(
+                        getAliasedAccountInfo(SECP_256K1_SOURCE_KEY)
+                                .has(accountWith().maxAutoAssociations(-1).hasEmptyKey()),
+                        cryptoTransfer(moving(1, VANILLA_TOKEN).between(TOKEN_TREASURY, SECP_256K1_SOURCE_KEY))
+                                .signedBy(SECP_256K1_SOURCE_KEY, TOKEN_TREASURY)
+                                .payingWith(SECP_256K1_SOURCE_KEY)
+                                .sigMapPrefixes(uniqueWithFullPrefixesFor(SECP_256K1_SOURCE_KEY)),
+                        getAliasedAccountInfo(SECP_256K1_SOURCE_KEY)
+                                .has(accountWith().hasNonEmptyKey()));
+    }
+
+    @HapiTest
     final Stream<DynamicTest> hollowAccountCompletionWithTokenAssociation() {
         return defaultHapiSpec("HollowAccountCompletionWithTokenAssociation")
                 .given(


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/15118

When hollow payer pays for CryptoTransfer that does an autoAssociation to itself with unlimitedAssociationsEnabled = true the changes to state are not committed correctly. This PR fixes that case that was causing a FAIL_INVALID record.
Added a HapiTest validating the behavior