### PR TITLE
chore: grant code ownership for Gradle and GH workflow files to @hashgraph/devops-ci-committers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,18 +98,18 @@
 
 # Protection Rules for Github Configuration Files and Actions Workflows
 /.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/devops-ci
+/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers
 
 # Legacy Maven project files
 **/pom.xml                                      @hashgraph/devops-ci
 
 # Gradle project files and inline plugins
-/gradle/                                        @hashgraph/devops-ci
-gradlew                                         @hashgraph/devops-ci
-gradlew.bat                                     @hashgraph/devops-ci
-**/build-logic/                                 @hashgraph/devops-ci
-**/gradle.*                                     @hashgraph/devops-ci
-**/*.gradle.*                                   @hashgraph/devops-ci
+/gradle/                                        @hashgraph/devops-ci @hashgraph/devops-ci-committers
+gradlew                                         @hashgraph/devops-ci @hashgraph/devops-ci-committers
+gradlew.bat                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
+**/build-logic/                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers
+**/gradle.*                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
+**/*.gradle.*                                   @hashgraph/devops-ci @hashgraph/devops-ci-committers
 
 # Codacy Tool Configurations
 /config/                                        @hashgraph/devops-ci @hashgraph/release-engineering-managers


### PR DESCRIPTION
**Description**:
So that all `@hashgraph/devops-ci-committers` can:
- Approve Dependabot PRs
- Can approve changes from each other on Gradle and GH action workflow files

**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
