### PR TITLE
feat: add `SwirldState#sealConsensusRound()` lifecycle

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -638,11 +638,16 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener {
 
     /**
      * Called by the platform after it has made all its changes to this state for the given round.
+     *
      * @param round the round whose platform state changes are completed
+     * @param state the state after the platform has made all its changes
      */
-    public void onSealConsensusRound(@NonNull final Round round) {
-        // FUTURE - call daggerApp.blockStreamManager.endRound(round) here
+    public void onSealConsensusRound(@NonNull final Round round, @NonNull final State state) {
+        requireNonNull(state);
+        requireNonNull(round);
+        // FUTURE - daggerApp.blockStreamManager().endRound(state, round.getRoundNum());
     }
+
     /*==================================================================================================================
     *
     * gRPC Server Lifecycle

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -636,6 +636,13 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener {
         daggerApp.handleWorkflow().handleRound(state, round);
     }
 
+    /**
+     * Called by the platform after it has made all its changes to this state for the given round.
+     * @param round the round whose platform state changes are completed
+     */
+    public void onSealConsensusRound(@NonNull final Round round) {
+        // FUTURE - call daggerApp.blockStreamManager.endRound(round) here
+    }
     /*==================================================================================================================
     *
     * gRPC Server Lifecycle

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
@@ -105,9 +105,10 @@ public class MerkleStateLifecyclesImpl implements MerkleStateLifecycles {
     }
 
     @Override
-    public void onSealConsensusRound(@NonNull final Round round) {
+    public void onSealConsensusRound(@NonNull final Round round, @NonNull final State state) {
+        requireNonNull(state);
         requireNonNull(round);
-        hedera.onSealConsensusRound(round);
+        hedera.onSealConsensusRound(round, state);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
@@ -105,6 +105,12 @@ public class MerkleStateLifecyclesImpl implements MerkleStateLifecycles {
     }
 
     @Override
+    public void onSealConsensusRound(@NonNull final Round round) {
+        requireNonNull(round);
+        hedera.onSealConsensusRound(round);
+    }
+
+    @Override
     public void onStateInitialized(
             @NonNull final State state,
             @NonNull final Platform platform,

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/MerkleStateLifecyclesImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/MerkleStateLifecyclesImplTest.java
@@ -100,9 +100,9 @@ class MerkleStateLifecyclesImplTest extends MerkleTestBase {
 
     @Test
     void delegatesOnSealConsensusRound() {
-        subject.onSealConsensusRound(round);
+        subject.onSealConsensusRound(round, merkleStateRoot);
 
-        verify(hedera).onSealConsensusRound(round);
+        verify(hedera).onSealConsensusRound(round, merkleStateRoot);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/MerkleStateLifecyclesImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/MerkleStateLifecyclesImplTest.java
@@ -30,11 +30,9 @@ import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.token.StakingNodeInfo;
 import com.hedera.node.app.Hedera;
 import com.hedera.node.app.service.token.TokenService;
-import com.hedera.node.app.spi.fixtures.state.MapWritableStates;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.state.MerkleStateRoot;
-import com.swirlds.platform.state.PlatformState;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -42,11 +40,7 @@ import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.test.fixtures.state.MerkleTestBase;
 import com.swirlds.state.merkle.disk.OnDiskKey;
 import com.swirlds.state.merkle.disk.OnDiskValue;
-import com.swirlds.state.test.fixtures.MapReadableKVState;
-import com.swirlds.state.test.fixtures.MapReadableStates;
-import com.swirlds.state.test.fixtures.MapWritableKVState;
 import com.swirlds.virtualmap.VirtualMap;
-import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.BiConsumer;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,7 +50,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class StateLifecyclesImplTest extends MerkleTestBase {
+class MerkleStateLifecyclesImplTest extends MerkleTestBase {
     private static final int PRETEND_STAKING_INFO_CHILD_INDEX = 7;
 
     @Mock
@@ -76,24 +70,6 @@ class StateLifecyclesImplTest extends MerkleTestBase {
 
     @Mock
     private MerkleStateRoot merkleStateRoot;
-
-    @Mock
-    private PlatformState platformState;
-
-    @Mock
-    private MapWritableStates writableStates;
-
-    @Mock
-    private MapWritableKVState<EntityNumber, StakingNodeInfo> mockWritableKVState;
-
-    @Mock
-    private MapReadableStates readableStates;
-
-    @Mock
-    private MapReadableKVState<EntityNumber, StakingNodeInfo> mockReadableKVState;
-
-    @Mock
-    private Iterator<EntityNumber> mockIterator;
 
     @Mock
     private BiConsumer<
@@ -120,6 +96,13 @@ class StateLifecyclesImplTest extends MerkleTestBase {
         subject.onHandleConsensusRound(round, merkleStateRoot);
 
         verify(hedera).onHandleConsensusRound(round, merkleStateRoot);
+    }
+
+    @Test
+    void delegatesOnSealConsensusRound() {
+        subject.onSealConsensusRound(round);
+
+        verify(hedera).onSealConsensusRound(round);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -80,8 +80,11 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestMethodOrder;
 
 @Tag(CRYPTO)
 @HapiTestLifecycle
@@ -378,6 +381,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
     // custom fees
     @Nested
     @DisplayName("with custom fees for")
+    @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class AirdropTokensWithCustomFees {
 
         private static long hbarFee = 1_000L;
@@ -391,6 +395,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("fungible token with fixed Hbar fee")
+        @Order(1)
         final Stream<DynamicTest> airdropFungibleWithFixedHbarCustomFee() {
             final var initialBalance = 100 * ONE_HUNDRED_HBARS;
             return defaultHapiSpec(" sender should prepay hbar custom fee")
@@ -425,6 +430,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("NFT with 2 layers fixed Hts fee")
+        @Order(2)
         final Stream<DynamicTest> transferNonFungibleWithFixedHtsCustomFees2Layers() {
             return defaultHapiSpec("sender should prepay hts custom fee")
                     .given(
@@ -463,6 +469,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("FT with fractional fee and net of transfers true")
+        @Order(3)
         final Stream<DynamicTest> ftWithFractionalFeeNetOfTransfersTre() {
             return defaultHapiSpec("should be successful transfer")
                     .given(
@@ -485,6 +492,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("FT with fractional fee with netOfTransfers=false")
+        @Order(4)
         final Stream<DynamicTest> ftWithFractionalFeeNetOfTransfersFalse() {
             return defaultHapiSpec("should be successful transfer")
                     .given(
@@ -505,6 +513,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("FT with fractional fee with netOfTransfers=false, in pending state")
+        @Order(5)
         final Stream<DynamicTest> ftWithFractionalFeeNetOfTransfersFalseInPendingState() {
             var sender = "sender";
             return defaultHapiSpec("the value should be reduced")
@@ -530,6 +539,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("FT with fractional fee with netOfTransfers=false and dissociated collector")
+        @Order(6)
         final Stream<DynamicTest> ftWithFractionalFeeNetOfTransfersFalseNotAssociatedCollector() {
             var sender = "sender";
             return defaultHapiSpec("should have 2 pending airdrops and the value should be reduced")
@@ -557,6 +567,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("NFT with royalty fee")
+        @Order(7)
         final Stream<DynamicTest> nftWithRoyaltyFeesPaidByReceiverFails() {
             return defaultHapiSpec("should fail - INVALID_TRANSACTION")
                     .given()

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -203,7 +203,9 @@ public class DefaultTransactionHandler implements TransactionHandler {
             handlerMetrics.setPhase(UPDATING_PLATFORM_STATE_RUNNING_HASH);
             updateRunningEventHash(consensusRound);
 
-            return createSignedState(consensusRound);
+            final StateAndRound stateAndRound = createSignedState(consensusRound);
+            swirldStateManager.sealConsensusRound(consensusRound);
+            return stateAndRound;
         } catch (final InterruptedException e) {
             logger.error(EXCEPTION.getMarker(), "handleConsensusRound interrupted");
             Thread.currentThread().interrupt();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -203,9 +203,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
             handlerMetrics.setPhase(UPDATING_PLATFORM_STATE_RUNNING_HASH);
             updateRunningEventHash(consensusRound);
 
-            final StateAndRound stateAndRound = createSignedState(consensusRound);
-            swirldStateManager.sealConsensusRound(consensusRound);
-            return stateAndRound;
+            return createSignedState(consensusRound);
         } catch (final InterruptedException e) {
             logger.error(EXCEPTION.getMarker(), "handleConsensusRound interrupted");
             Thread.currentThread().interrupt();
@@ -275,6 +273,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
             // Let the swirld state manager know we are about to write the saved state for the freeze period
             swirldStateManager.savedStateInFreezePeriod();
         }
+        swirldStateManager.sealConsensusRound(consensusRound);
 
         handlerMetrics.setPhase(GETTING_STATE_TO_SIGN);
         final MerkleRoot immutableStateCons = swirldStateManager.getStateForSigning();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
@@ -64,7 +64,7 @@ public interface MerkleStateLifecycles {
      * Called by the platform after it has made all its changes to this state for the given round.
      * @param round the round whose platform state changes are completed
      */
-    void onSealConsensusRound(@NonNull Round round);
+    void onSealConsensusRound(@NonNull Round round, @NonNull State state);
 
     /**
      * Called when the platform is initializing the network state.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
@@ -61,6 +61,12 @@ public interface MerkleStateLifecycles {
     void onHandleConsensusRound(@NonNull Round round, @NonNull State state);
 
     /**
+     * Called by the platform after it has made all its changes to this state for the given round.
+     * @param round the round whose platform state changes are completed
+     */
+    void onSealConsensusRound(@NonNull Round round);
+
+    /**
      * Called when the platform is initializing the network state.
      *
      * @param state the working state of the network to be initialized

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
@@ -369,7 +369,8 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
     @Override
     public void sealConsensusRound(@NonNull final Round round) {
         requireNonNull(round);
-        lifecycles.onSealConsensusRound(round);
+        throwIfImmutable();
+        lifecycles.onSealConsensusRound(round, this);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
@@ -366,6 +366,12 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
         lifecycles.onHandleConsensusRound(round, this);
     }
 
+    @Override
+    public void sealConsensusRound(@NonNull final Round round) {
+        requireNonNull(round);
+        lifecycles.onSealConsensusRound(round);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -17,6 +17,7 @@
 package com.swirlds.platform.state;
 
 import static com.swirlds.platform.state.SwirldStateManagerUtils.fastCopy;
+import static java.util.Objects.requireNonNull;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
@@ -32,7 +33,6 @@ import com.swirlds.platform.system.status.StatusActionSubmitter;
 import com.swirlds.platform.uptime.UptimeTracker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -86,12 +86,12 @@ public class SwirldStateManager implements FreezePeriodChecker {
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final SoftwareVersion softwareVersion) {
 
-        Objects.requireNonNull(platformContext);
-        Objects.requireNonNull(addressBook);
-        Objects.requireNonNull(selfId);
+        requireNonNull(platformContext);
+        requireNonNull(addressBook);
+        requireNonNull(selfId);
         this.stats = new SwirldStateMetrics(platformContext.getMetrics());
-        Objects.requireNonNull(statusActionSubmitter);
-        this.softwareVersion = Objects.requireNonNull(softwareVersion);
+        requireNonNull(statusActionSubmitter);
+        this.softwareVersion = requireNonNull(softwareVersion);
         this.transactionHandler = new TransactionHandler(selfId, stats);
         this.uptimeTracker = new UptimeTracker(
                 platformContext, addressBook, statusActionSubmitter, selfId, platformContext.getTime());
@@ -103,7 +103,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @param state the initial state
      */
     public void setInitialState(@NonNull final MerkleRoot state) {
-        Objects.requireNonNull(state);
+        requireNonNull(state);
         state.throwIfDestroyed("state must not be destroyed");
         state.throwIfImmutable("state must be mutable");
 
@@ -127,6 +127,16 @@ public class SwirldStateManager implements FreezePeriodChecker {
 
         uptimeTracker.handleRound(round, state.getPlatformState().getAddressBook());
         transactionHandler.handleRound(round, state);
+    }
+
+    /**
+     * Seals the platform's state changes for the given round.
+     * @param round the round to seal
+     */
+    public void sealConsensusRound(@NonNull final Round round) {
+        requireNonNull(round);
+        final MerkleRoot state = stateRef.get();
+        state.getSwirldState().sealConsensusRound(round);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -17,7 +17,6 @@
 package com.swirlds.platform.state;
 
 import static com.swirlds.platform.state.SwirldStateManagerUtils.fastCopy;
-import static java.util.Objects.requireNonNull;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
@@ -33,6 +32,7 @@ import com.swirlds.platform.system.status.StatusActionSubmitter;
 import com.swirlds.platform.uptime.UptimeTracker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -86,12 +86,12 @@ public class SwirldStateManager implements FreezePeriodChecker {
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final SoftwareVersion softwareVersion) {
 
-        requireNonNull(platformContext);
-        requireNonNull(addressBook);
-        requireNonNull(selfId);
+        Objects.requireNonNull(platformContext);
+        Objects.requireNonNull(addressBook);
+        Objects.requireNonNull(selfId);
         this.stats = new SwirldStateMetrics(platformContext.getMetrics());
-        requireNonNull(statusActionSubmitter);
-        this.softwareVersion = requireNonNull(softwareVersion);
+        Objects.requireNonNull(statusActionSubmitter);
+        this.softwareVersion = Objects.requireNonNull(softwareVersion);
         this.transactionHandler = new TransactionHandler(selfId, stats);
         this.uptimeTracker = new UptimeTracker(
                 platformContext, addressBook, statusActionSubmitter, selfId, platformContext.getTime());
@@ -103,7 +103,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @param state the initial state
      */
     public void setInitialState(@NonNull final MerkleRoot state) {
-        requireNonNull(state);
+        Objects.requireNonNull(state);
         state.throwIfDestroyed("state must not be destroyed");
         state.throwIfImmutable("state must be mutable");
 
@@ -134,7 +134,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      * @param round the round to seal
      */
     public void sealConsensusRound(@NonNull final Round round) {
-        requireNonNull(round);
+        Objects.requireNonNull(round);
         final MerkleRoot state = stateRef.get();
         state.getSwirldState().sealConsensusRound(round);
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldState.java
@@ -80,6 +80,14 @@ public interface SwirldState extends MerkleNode {
     void handleConsensusRound(final Round round, final PlatformStateAccessor platformState);
 
     /**
+     * Called by the platform after it has made all its changes to this state for the given round.
+     * @param round the round whose platform state changes are completed
+     */
+    default void sealConsensusRound(@NonNull final Round round) {
+        // No-op, only implemented by applications that externalize state changes
+    }
+
+    /**
      * Implementations of the SwirldState should always override this method in production.  The AddressBook returned
      * should have the same Address entries as the configuration AddressBook, but with the weight values updated.
      * <p>

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
 
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.consensus.EventWindow;
@@ -145,6 +146,8 @@ class DefaultTransactionHandlerTests {
                 pcesRound,
                 handlerOutput.reservedSignedState().get().isPcesRound(),
                 "the state should match the PCES boolean");
+        verify(tester.getSwirldStateManager().getConsensusState().getSwirldState())
+                .sealConsensusRound(consensusRound);
     }
 
     @Test

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
@@ -42,6 +42,7 @@ import java.util.List;
  */
 public class TransactionHandlerTester {
     private final PlatformState platformState;
+    private final SwirldStateManager swirldStateManager;
     private final DefaultTransactionHandler defaultTransactionHandler;
     private final List<PlatformStatusAction> submittedActions = new ArrayList<>();
     private final List<Round> handledRounds = new ArrayList<>();
@@ -69,7 +70,7 @@ public class TransactionHandlerTester {
                 .when(swirldState)
                 .handleConsensusRound(any(), any());
         final StatusActionSubmitter statusActionSubmitter = submittedActions::add;
-        final SwirldStateManager swirldStateManager = new SwirldStateManager(
+        swirldStateManager = new SwirldStateManager(
                 platformContext, addressBook, NodeId.FIRST_NODE_ID, statusActionSubmitter, new BasicSoftwareVersion(1));
         swirldStateManager.setInitialState(consensusState);
         defaultTransactionHandler = new DefaultTransactionHandler(
@@ -102,5 +103,12 @@ public class TransactionHandlerTester {
      */
     public List<Round> getHandledRounds() {
         return handledRounds;
+    }
+
+    /**
+     * @return the {@link SwirldStateManager} used by this tester
+     */
+    public SwirldStateManager getSwirldStateManager() {
+        return swirldStateManager;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
@@ -103,7 +103,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         }
 
         @Override
-        public void onSealConsensusRound(@NonNull Round round) {
+        public void onSealConsensusRound(@NonNull Round round, @NonNull State state) {
             // No-op
         }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
@@ -103,6 +103,11 @@ class MerkleStateRootTest extends MerkleTestBase {
         }
 
         @Override
+        public void onSealConsensusRound(@NonNull Round round) {
+            // No-op
+        }
+
+        @Override
         public void onPreHandle(@NonNull Event event, @NonNull State state) {
             onPreHandleCalled.set(true);
         }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -20,6 +20,7 @@ import static com.swirlds.common.test.fixtures.RandomUtils.nextInt;
 import static com.swirlds.platform.test.fixtures.state.FakeMerkleStateLifecycles.FAKE_MERKLE_STATE_LIFECYCLES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.swirlds.common.context.PlatformContext;
@@ -29,6 +30,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.SwirldsPlatform;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
+import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.status.StatusActionSubmitter;
 import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
@@ -71,6 +73,14 @@ class SwirldStateManagerTests {
                 1,
                 swirldStateManager.getConsensusState().getReservationCount(),
                 "The consensus state should have one reference.");
+    }
+
+    @Test
+    @DisplayName("Seal consensus round")
+    void sealConsensusRound() {
+        final var round = mock(Round.class);
+        swirldStateManager.sealConsensusRound(round);
+        verify(round).getRoundNum();
     }
 
     @Test

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/FakeMerkleStateLifecycles.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/FakeMerkleStateLifecycles.java
@@ -126,7 +126,7 @@ public enum FakeMerkleStateLifecycles implements MerkleStateLifecycles {
     }
 
     @Override
-    public void onSealConsensusRound(@NonNull final Round round) {
+    public void onSealConsensusRound(@NonNull Round round, @NonNull State state) {
         // Touch this round
         round.getRoundNum();
     }

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/FakeMerkleStateLifecycles.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/FakeMerkleStateLifecycles.java
@@ -126,6 +126,12 @@ public enum FakeMerkleStateLifecycles implements MerkleStateLifecycles {
     }
 
     @Override
+    public void onSealConsensusRound(@NonNull final Round round) {
+        // Touch this round
+        round.getRoundNum();
+    }
+
+    @Override
     public void onStateInitialized(
             @NonNull State state,
             @NonNull Platform platform,


### PR DESCRIPTION
**Description**:
 - Closes #15139 
 - Fixes a flake in `TokenAirdropTest`.