### PR TITLE
ci: resolves release issue preventing the publication of the docker images

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -452,7 +452,7 @@ jobs:
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
       - name: Setup Docker Buildx Support
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
         with:
           version: v0.16.2
           driver-opts: network=host

--- a/.github/workflows/zxc-publish-production-image.yaml
+++ b/.github/workflows/zxc-publish-production-image.yaml
@@ -145,56 +145,6 @@ jobs:
 
           echo "docker-tag-base=${DOCKER_TAG_BASE}" >>"${GITHUB_OUTPUT}"
 
-      - name: Install KillAll
-        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends psmisc
-
-      - name: Create Docker Working Directory
-        run: |
-          USER="$(id -un)"
-          GROUP="$(id -gn)"
-          sudo mkdir -p /x
-          sudo chown -vR ${USER}:${GROUP} /x
-          sudo ls -lah /x
-
-      - name: Remove Docker from Self Hosted Runners
-        run: |
-          set -x
-          sudo killall dockerd || true
-          sudo killall containerd || true
-          sudo rm -rvf /usr/bin/*containerd* || true
-          sudo rm -rvf /usr/bin/docker* || true
-          sudo rm -rvf /usr/local/bin/docker* || true
-          sudo rm -rvf /usr/local/bin/*lima* || true
-
-      - name: Setup Containerd Support
-        uses: crazy-max/ghaction-setup-containerd@60acbf31e6572da7b83a4ed6b428ed92a35ff4d7 # v3.0.0
-        with:
-          containerd-version: v1.7.2
-
-      - name: Setup Docker Support
-        uses: crazy-max/ghaction-setup-docker@d9be6cade441568ba10037bce5221b8f564981f1 # v3.0.0
-        env:
-          HOME: /x
-        with:
-          version: v25.0.5
-          daemon-config: |
-            {
-              "registry-mirrors": [
-                "https://hub.mirror.docker.lat.ope.eng.hashgraph.io"
-              ]
-            }
-
-      - name: Configure Default Docker Context
-        run: |
-          set -x
-          if grep setup-docker-action < <(docker context ls --format '{{ .Name }}') >/dev/null; then
-            docker context rm -f setup-docker-action
-          fi
-
-          DOCKER_CONTEXT_PATH="$(sudo find /x -name docker.sock | tr -d '[:space:]')"
-          docker context create setup-docker-action --docker "host=unix://${DOCKER_CONTEXT_PATH}"
-          docker context use setup-docker-action
-
       - name: Setup QEmu Support
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 

--- a/.github/workflows/zxc-publish-production-image.yaml
+++ b/.github/workflows/zxc-publish-production-image.yaml
@@ -149,7 +149,7 @@ jobs:
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
       - name: Setup Docker Buildx Support
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
         with:
           version: v0.16.2
           driver-opts: network=host

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -191,7 +191,7 @@ jobs:
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
 
       - name: Setup Docker Buildx Support
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         with:
           version: v0.16.2
@@ -411,7 +411,7 @@ jobs:
         uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
       - name: Setup Docker Buildx Support
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
         with:
           version: v0.16.2
           driver-opts: network=host


### PR DESCRIPTION
## Description

This pull request changes the following:

- Cherry picks #15157 into the `release/0.52` branch

### Related Issue

- Closes #15156 