### PR TITLE
feat: `BlockStreamBuilder` changes for block streams

### DIFF
--- a/hapi/src/main/java/module-info.java
+++ b/hapi/src/main/java/module-info.java
@@ -59,6 +59,8 @@ module com.hedera.node.hapi {
     exports com.hedera.hapi.platform.state;
     exports com.hedera.hapi.node.state.roster;
     exports com.hedera.hapi.block.stream.schema;
+    exports com.hedera.hapi.block.stream.output;
+    exports com.hedera.hapi.block.stream;
 
     requires transitive com.google.common;
     requires transitive com.google.protobuf;

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/DeleteCapableTransactionStreamBuilder.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/DeleteCapableTransactionStreamBuilder.java
@@ -35,7 +35,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * just-deleted account was going to receive staking rewards in the transaction, those rewards
  * should be redirected to the beneficiary account.
  */
-public interface DeleteCapableTransactionRecordBuilder extends StreamBuilder {
+public interface DeleteCapableTransactionStreamBuilder extends StreamBuilder {
     /**
      * Gets number of deleted accounts in this transaction.
      * @return number of deleted accounts in this transaction
@@ -50,7 +50,8 @@ public interface DeleteCapableTransactionRecordBuilder extends StreamBuilder {
     AccountID getDeletedAccountBeneficiaryFor(@NonNull final AccountID deletedAccountID);
 
     /**
-     * Adds a beneficiary for a deleted account.
+     * Adds a beneficiary for a deleted account into the map. This is needed while computing staking rewards.
+     * If the deleted account receives staking reward, it is transferred to the beneficiary.
      *
      * @param deletedAccountID the deleted account ID
      * @param beneficiaryForDeletedAccount the beneficiary account ID

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
@@ -1,0 +1,864 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.blocks.impl;
+
+import static com.hedera.hapi.util.HapiUtils.asTimestamp;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.output.CallContractOutput;
+import com.hedera.hapi.block.stream.output.CreateContractOutput;
+import com.hedera.hapi.block.stream.output.CreateScheduleOutput;
+import com.hedera.hapi.block.stream.output.CryptoTransferOutput;
+import com.hedera.hapi.block.stream.output.EthereumOutput;
+import com.hedera.hapi.block.stream.output.SignScheduleOutput;
+import com.hedera.hapi.block.stream.output.StateChange;
+import com.hedera.hapi.block.stream.output.StateChanges;
+import com.hedera.hapi.block.stream.output.TransactionOutput;
+import com.hedera.hapi.block.stream.output.TransactionResult;
+import com.hedera.hapi.block.stream.output.UtilPrngOutput;
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.ScheduleID;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TokenAssociation;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenTransferList;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.base.TopicID;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.base.TransferList;
+import com.hedera.hapi.node.contract.ContractFunctionResult;
+import com.hedera.hapi.node.transaction.AssessedCustomFee;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.PendingAirdropRecord;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.platform.event.EventTransaction;
+import com.hedera.hapi.streams.ContractActions;
+import com.hedera.hapi.streams.ContractBytecode;
+import com.hedera.hapi.streams.ContractStateChanges;
+import com.hedera.hapi.streams.TransactionSidecarRecord;
+import com.hedera.node.app.service.addressbook.impl.records.NodeCreateStreamBuilder;
+import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicStreamBuilder;
+import com.hedera.node.app.service.consensus.impl.records.ConsensusSubmitMessageStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractDeleteStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractUpdateStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.EthereumTransactionStreamBuilder;
+import com.hedera.node.app.service.file.impl.records.CreateFileStreamBuilder;
+import com.hedera.node.app.service.schedule.ScheduleStreamBuilder;
+import com.hedera.node.app.service.token.api.FeeStreamBuilder;
+import com.hedera.node.app.service.token.records.ChildStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoDeleteStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoUpdateStreamBuilder;
+import com.hedera.node.app.service.token.records.GenesisAccountStreamBuilder;
+import com.hedera.node.app.service.token.records.NodeStakeUpdateStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenAccountWipeStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenAirdropStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenBurnStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenCreateStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenMintStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenUpdateStreamBuilder;
+import com.hedera.node.app.service.util.impl.records.PrngStreamBuilder;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.pbj.runtime.OneOf;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An implementation of {@link BlockStreamBuilder} that produces block items for a single user or
+ * synthetic transaction; that is, the "input" block item with a {@link Transaction} and "output" block items
+ * with a {@link TransactionResult} and, optionally, {@link TransactionOutput}.
+ */
+public class BlockStreamBuilder
+        implements StreamBuilder,
+                ConsensusCreateTopicStreamBuilder,
+                ConsensusSubmitMessageStreamBuilder,
+                CreateFileStreamBuilder,
+                CryptoCreateStreamBuilder,
+                CryptoTransferStreamBuilder,
+                ChildStreamBuilder,
+                PrngStreamBuilder,
+                ScheduleStreamBuilder,
+                TokenMintStreamBuilder,
+                TokenBurnStreamBuilder,
+                TokenCreateStreamBuilder,
+                ContractCreateStreamBuilder,
+                ContractCallStreamBuilder,
+                ContractUpdateStreamBuilder,
+                EthereumTransactionStreamBuilder,
+                CryptoDeleteStreamBuilder,
+                TokenUpdateStreamBuilder,
+                NodeStakeUpdateStreamBuilder,
+                FeeStreamBuilder,
+                ContractDeleteStreamBuilder,
+                GenesisAccountStreamBuilder,
+                ContractOperationStreamBuilder,
+                TokenAccountWipeStreamBuilder,
+                CryptoUpdateStreamBuilder,
+                NodeCreateStreamBuilder,
+                TokenAirdropStreamBuilder {
+    // base transaction data
+    private Transaction transaction;
+
+    @Nullable
+    private Bytes serializedTransaction;
+
+    private Bytes transactionBytes = Bytes.EMPTY;
+    // fields needed for TransactionRecord
+    // Mutable because the provisional consensus timestamp assigned on dispatch could
+    // change when removable records appear "between" this record and the parent record
+    private Instant consensusNow;
+    private Instant parentConsensus;
+    private TransactionID transactionID;
+    private List<TokenTransferList> tokenTransferLists = new LinkedList<>();
+    private boolean hasAssessedCustomFees = false;
+    private List<AssessedCustomFee> assessedCustomFees = new LinkedList<>();
+    private List<PendingAirdropRecord> pendingAirdropRecords = new LinkedList<>();
+    private List<TokenAssociation> automaticTokenAssociations = new LinkedList<>();
+
+    private List<AccountAmount> paidStakingRewards = new LinkedList<>();
+    private TransferList transferList = TransferList.DEFAULT;
+    private final TransactionResult.Builder transactionResultBuilder = TransactionResult.newBuilder();
+
+    // fields needed for TransactionReceipt
+    private ResponseCodeEnum status = ResponseCodeEnum.OK;
+    private List<Long> serialNumbers = new LinkedList<>();
+    private long newTotalSupply = 0L;
+    // If non-null, a builder to be used to set the transaction output
+    private TransactionOutput.Builder transactionOutputBuilder = null;
+    // Sidecar data, booleans are the migration flag
+    private List<AbstractMap.SimpleEntry<ContractStateChanges, Boolean>> contractStateChanges = new LinkedList<>();
+    private List<AbstractMap.SimpleEntry<ContractActions, Boolean>> contractActions = new LinkedList<>();
+    private List<AbstractMap.SimpleEntry<ContractBytecode, Boolean>> contractBytecodes = new LinkedList<>();
+
+    // Fields that are not in TransactionRecord, but are needed for computing staking rewards
+    // These are not persisted to the record file
+    private final Map<AccountID, AccountID> deletedAccountBeneficiaries = new HashMap<>();
+
+    // A set of ids that should be explicitly considered as in a "reward situation",
+    // despite the canonical definition of a reward situation; needed for mono-service
+    // fidelity only
+    @Nullable
+    private Set<AccountID> explicitRewardReceiverIds;
+
+    // While the fee is sent to the underlying builder all the time, it is also cached here because, as of today,
+    // there is no way to get the transaction fee from the PBJ object.
+    private long transactionFee;
+    // If non-null, a contract function result
+    private ContractFunctionResult contractFunctionResult;
+    // If true, the contract function result is a call result; otherwise, a create result
+    private boolean isCreateResult;
+
+    // Used for some child records builders.
+    private final ReversingBehavior reversingBehavior;
+
+    // Category of the record
+    private final HandleContext.TransactionCategory category;
+
+    private List<StateChange> stateChanges = new ArrayList<>();
+
+    // Used to customize the externalized form of a dispatched child transaction, right before
+    // its record stream item is built; lets the contract service externalize certain dispatched
+    // CryptoCreate transactions as ContractCreate synthetic transactions
+    private final ExternalizedRecordCustomizer customizer;
+
+    private TokenID tokenID;
+    private TokenType tokenType;
+    private Bytes ethereumHash;
+    private boolean createsOrDeletesSchedule;
+    private TransactionID scheduledTransactionId;
+
+    public BlockStreamBuilder(
+            @NonNull final ReversingBehavior reversingBehavior,
+            @NonNull final ExternalizedRecordCustomizer customizer,
+            @NonNull final HandleContext.TransactionCategory category) {
+        this.reversingBehavior = requireNonNull(reversingBehavior);
+        this.customizer = requireNonNull(customizer);
+        this.category = requireNonNull(category);
+    }
+
+    @Override
+    public StreamBuilder stateChanges(@NonNull List<StateChange> stateChanges) {
+        this.stateChanges.addAll(stateChanges);
+        return this;
+    }
+
+    /**
+     * Builds the list of block items.
+     *
+     * @return the list of block items
+     */
+    public List<BlockItem> build() {
+        final var blockItems = new ArrayList<BlockItem>();
+
+        final var transactionBlockItem = BlockItem.newBuilder()
+                .eventTransaction(EventTransaction.newBuilder()
+                        .applicationTransaction(getSerializedTransaction())
+                        .build())
+                .build();
+        blockItems.add(transactionBlockItem);
+
+        final var resultBlockItem = getTransactionResultBlockItem();
+        blockItems.add(resultBlockItem);
+
+        final var output = getTransactionOutput();
+        if (output != null) {
+            blockItems.add(BlockItem.newBuilder().transactionOutput(output).build());
+        }
+
+        if (!stateChanges.isEmpty()) {
+            final var stateChangesBlockItem = BlockItem.newBuilder()
+                    .stateChanges(StateChanges.newBuilder()
+                            .consensusTimestamp(asTimestamp(consensusNow))
+                            .stateChanges(stateChanges)
+                            .build())
+                    .build();
+            blockItems.add(stateChangesBlockItem);
+        }
+        return blockItems;
+    }
+
+    @Override
+    @NonNull
+    public ReversingBehavior reversingBehavior() {
+        return reversingBehavior;
+    }
+
+    @Override
+    public int getNumAutoAssociations() {
+        return automaticTokenAssociations.size();
+    }
+
+    // ------------------------------------------------------------------------------------------------------------------------
+    // base transaction data
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder parentConsensus(@NonNull final Instant parentConsensus) {
+        this.parentConsensus = requireNonNull(parentConsensus, "parentConsensus must not be null");
+        transactionResultBuilder.parentConsensusTimestamp(Timestamp.newBuilder()
+                .seconds(parentConsensus.getEpochSecond())
+                .nanos(parentConsensus.getNano())
+                .build());
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder consensusTimestamp(@NonNull final Instant now) {
+        this.consensusNow = requireNonNull(now, "consensus time must not be null");
+        transactionResultBuilder.consensusTimestamp(Timestamp.newBuilder()
+                .seconds(now.getEpochSecond())
+                .nanos(now.getNano())
+                .build());
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder transaction(@NonNull final Transaction transaction) {
+        this.transaction = requireNonNull(transaction, "transaction must not be null");
+        return this;
+    }
+
+    @Override
+    public StreamBuilder serializedTransaction(@Nullable final Bytes serializedTransaction) {
+        this.serializedTransaction = serializedTransaction;
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder transactionBytes(@NonNull final Bytes transactionBytes) {
+        this.transactionBytes = requireNonNull(transactionBytes, "transactionBytes must not be null");
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public TransactionID transactionID() {
+        return transactionID;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder transactionID(@NonNull final TransactionID transactionID) {
+        this.transactionID = requireNonNull(transactionID, "transactionID must not be null");
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public BlockStreamBuilder syncBodyIdFromRecordId() {
+        final var newTransactionID = transactionID;
+        final var body =
+                inProgressBody().copyBuilder().transactionID(newTransactionID).build();
+        this.transaction = StreamBuilder.transactionWith(body);
+        this.transactionBytes = transaction.signedTransactionBytes();
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder memo(@NonNull final String memo) {
+        // No-op
+        return this;
+    }
+
+    // ------------------------------------------------------------------------------------------------------------------------
+    // fields needed for TransactionRecord
+
+    @Override
+    @NonNull
+    public Transaction transaction() {
+        return transaction;
+    }
+
+    @Override
+    public long transactionFee() {
+        return transactionFee;
+    }
+
+    @NonNull
+    @Override
+    public BlockStreamBuilder transactionFee(final long transactionFee) {
+        transactionResultBuilder.transactionFeeCharged(transactionFee);
+        this.transactionFee = transactionFee;
+        return this;
+    }
+
+    @Override
+    public void trackExplicitRewardSituation(@NonNull final AccountID accountId) {
+        if (explicitRewardReceiverIds == null) {
+            explicitRewardReceiverIds = new LinkedHashSet<>();
+        }
+        explicitRewardReceiverIds.add(accountId);
+    }
+
+    @Override
+    public Set<AccountID> explicitRewardSituationIds() {
+        return explicitRewardReceiverIds != null ? explicitRewardReceiverIds : emptySet();
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder contractCallResult(@Nullable final ContractFunctionResult contractCallResult) {
+        this.contractFunctionResult = contractCallResult;
+        if (contractCallResult != null) {
+            ensureOutputBuilder();
+            isCreateResult = false;
+        }
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder contractCreateResult(@Nullable ContractFunctionResult contractCreateResult) {
+        this.contractFunctionResult = contractCreateResult;
+        if (contractCreateResult != null) {
+            ensureOutputBuilder();
+            isCreateResult = true;
+        }
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public TransferList transferList() {
+        return transferList;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder transferList(@Nullable final TransferList transferList) {
+        this.transferList = transferList;
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder tokenTransferLists(@NonNull final List<TokenTransferList> tokenTransferLists) {
+        requireNonNull(tokenTransferLists, "tokenTransferLists must not be null");
+        this.tokenTransferLists = tokenTransferLists;
+        transactionResultBuilder.tokenTransferLists(tokenTransferLists);
+        return this;
+    }
+
+    @Override
+    public List<TokenTransferList> tokenTransferLists() {
+        return tokenTransferLists;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder tokenType(final @NonNull TokenType tokenType) {
+        this.tokenType = requireNonNull(tokenType);
+        return this;
+    }
+
+    @Override
+    public BlockStreamBuilder addPendingAirdrop(@NonNull final PendingAirdropRecord pendingAirdropRecord) {
+        requireNonNull(pendingAirdropRecord);
+        this.pendingAirdropRecords.add(pendingAirdropRecord);
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder scheduleRef(@NonNull final ScheduleID scheduleRef) {
+        requireNonNull(scheduleRef, "scheduleRef must not be null");
+        transactionResultBuilder.scheduleRef(scheduleRef);
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder assessedCustomFees(@NonNull final List<AssessedCustomFee> assessedCustomFees) {
+        this.assessedCustomFees = requireNonNull(assessedCustomFees);
+        ensureOutputBuilder();
+        hasAssessedCustomFees = true;
+        return this;
+    }
+
+    @NonNull
+    public BlockStreamBuilder addAutomaticTokenAssociation(@NonNull final TokenAssociation automaticTokenAssociation) {
+        requireNonNull(automaticTokenAssociation, "automaticTokenAssociation must not be null");
+        automaticTokenAssociations.add(automaticTokenAssociation);
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder ethereumHash(@NonNull final Bytes ethereumHash) {
+        this.ethereumHash = requireNonNull(ethereumHash);
+        ensureOutputBuilder();
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder paidStakingRewards(@NonNull final List<AccountAmount> paidStakingRewards) {
+        // These need not be externalized to block streams
+        requireNonNull(paidStakingRewards, "paidStakingRewards must not be null");
+        this.paidStakingRewards = paidStakingRewards;
+        transactionResultBuilder.paidStakingRewards(paidStakingRewards);
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder entropyNumber(final int num) {
+        ensureOutputBuilder()
+                .utilPrng(UtilPrngOutput.newBuilder().prngNumber(num).build());
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder entropyBytes(@NonNull final Bytes prngBytes) {
+        requireNonNull(prngBytes);
+        ensureOutputBuilder()
+                .utilPrng(UtilPrngOutput.newBuilder().prngBytes(prngBytes).build());
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder evmAddress(@NonNull final Bytes evmAddress) {
+        // No-op
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public List<AssessedCustomFee> getAssessedCustomFees() {
+        return assessedCustomFees;
+    }
+
+    // ------------------------------------------------------------------------------------------------------------------------
+    // fields needed for TransactionReceipt
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder status(@NonNull final ResponseCodeEnum status) {
+        this.status = requireNonNull(status, "status must not be null");
+        transactionResultBuilder.status(status);
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public ResponseCodeEnum status() {
+        return status;
+    }
+
+    @Override
+    public boolean hasContractResult() {
+        return this.contractFunctionResult != null;
+    }
+
+    @Override
+    public long getGasUsedForContractTxn() {
+        return this.contractFunctionResult.gasUsed();
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder accountID(@NonNull final AccountID accountID) {
+        // No-op
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder fileID(@NonNull final FileID fileID) {
+        // No-op
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder contractID(@Nullable final ContractID contractID) {
+        // No-op
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public BlockStreamBuilder exchangeRate(@NonNull final ExchangeRateSet exchangeRate) {
+        requireNonNull(exchangeRate);
+        transactionResultBuilder.exchangeRate(exchangeRate);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public BlockStreamBuilder congestionMultiplier(long congestionMultiplier) {
+        if (congestionMultiplier != 0) {
+            transactionResultBuilder.congestionPricingMultiplier(congestionMultiplier);
+        }
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder topicID(@NonNull final TopicID topicID) {
+        // No-op
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder topicSequenceNumber(final long topicSequenceNumber) {
+        // No-op
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder topicRunningHash(@NonNull final Bytes topicRunningHash) {
+        // No-op
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder topicRunningHashVersion(final long topicRunningHashVersion) {
+        // TOD0: Need to confirm what the value should be
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder tokenID(@NonNull final TokenID tokenID) {
+        requireNonNull(tokenID, "tokenID must not be null");
+        this.tokenID = tokenID;
+        return this;
+    }
+
+    @Override
+    public TokenID tokenID() {
+        return tokenID;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder nodeID(long nodeId) {
+        // No-op
+        return this;
+    }
+
+    @NonNull
+    public BlockStreamBuilder newTotalSupply(final long newTotalSupply) {
+        this.newTotalSupply = newTotalSupply;
+        return this;
+    }
+
+    @Override
+    public long getNewTotalSupply() {
+        return newTotalSupply;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder scheduleID(@NonNull final ScheduleID scheduleID) {
+        this.createsOrDeletesSchedule = true;
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder scheduledTransactionID(@NonNull final TransactionID scheduledTransactionID) {
+        this.scheduledTransactionId = requireNonNull(scheduledTransactionID);
+        ensureOutputBuilder();
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder serialNumbers(@NonNull final List<Long> serialNumbers) {
+        requireNonNull(serialNumbers, "serialNumbers must not be null");
+        this.serialNumbers = serialNumbers;
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public List<Long> serialNumbers() {
+        return serialNumbers;
+    }
+
+    // ------------------------------------------------------------------------------------------------------------------------
+    // Sidecar data, booleans are the migration flag
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder addContractStateChanges(
+            @NonNull final ContractStateChanges contractStateChanges, final boolean isMigration) {
+        requireNonNull(contractStateChanges, "contractStateChanges must not be null");
+        this.contractStateChanges.add(new AbstractMap.SimpleEntry<>(contractStateChanges, isMigration));
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder addContractActions(
+            @NonNull final ContractActions contractActions, final boolean isMigration) {
+        requireNonNull(contractActions, "contractActions must not be null");
+        this.contractActions.add(new AbstractMap.SimpleEntry<>(contractActions, isMigration));
+        return this;
+    }
+
+    @Override
+    @NonNull
+    public BlockStreamBuilder addContractBytecode(
+            @NonNull final ContractBytecode contractBytecode, final boolean isMigration) {
+        requireNonNull(contractBytecode, "contractBytecode must not be null");
+        contractBytecodes.add(new AbstractMap.SimpleEntry<>(contractBytecode, isMigration));
+        return this;
+    }
+
+    // ------------- Information needed by token service for redirecting staking rewards to appropriate accounts
+
+    @Override
+    public void addBeneficiaryForDeletedAccount(
+            @NonNull final AccountID deletedAccountID, @NonNull final AccountID beneficiaryForDeletedAccount) {
+        requireNonNull(deletedAccountID, "deletedAccountID must not be null");
+        requireNonNull(beneficiaryForDeletedAccount, "beneficiaryForDeletedAccount must not be null");
+        deletedAccountBeneficiaries.put(deletedAccountID, beneficiaryForDeletedAccount);
+    }
+
+    @Override
+    public int getNumberOfDeletedAccounts() {
+        return deletedAccountBeneficiaries.size();
+    }
+
+    @Override
+    @Nullable
+    public AccountID getDeletedAccountBeneficiaryFor(@NonNull final AccountID deletedAccountID) {
+        return deletedAccountBeneficiaries.get(deletedAccountID);
+    }
+
+    @Override
+    @NonNull
+    public ContractFunctionResult contractFunctionResult() {
+        return contractFunctionResult;
+    }
+
+    @Override
+    @NonNull
+    public TransactionBody transactionBody() {
+        return inProgressBody();
+    }
+
+    private TransactionBody inProgressBody() {
+        try {
+            final var signedTransaction = SignedTransaction.PROTOBUF.parseStrict(
+                    transaction.signedTransactionBytes().toReadableSequentialData());
+            return TransactionBody.PROTOBUF.parse(signedTransaction.bodyBytes().toReadableSequentialData());
+        } catch (Exception e) {
+            throw new IllegalStateException("Record being built for unparseable transaction", e);
+        }
+    }
+
+    @NonNull
+    @Override
+    public List<AccountAmount> getPaidStakingRewards() {
+        return paidStakingRewards;
+    }
+
+    @Override
+    @NonNull
+    public HandleContext.TransactionCategory category() {
+        return category;
+    }
+
+    @Override
+    public void nullOutSideEffectFields() {
+        serialNumbers.clear();
+        tokenTransferLists.clear();
+        automaticTokenAssociations.clear();
+        transferList = TransferList.DEFAULT;
+        paidStakingRewards.clear();
+        assessedCustomFees.clear();
+
+        newTotalSupply = 0L;
+        transactionFee = 0L;
+        contractFunctionResult = null;
+        // Note that internal contract creations are removed instead of reversed
+        transactionResultBuilder.scheduleRef((ScheduleID) null);
+        transactionResultBuilder.automaticTokenAssociations(emptyList());
+        transactionResultBuilder.congestionPricingMultiplier(0);
+
+        transactionOutputBuilder = null;
+    }
+
+    @NonNull
+    private BlockItem getTransactionResultBlockItem() {
+        if (!automaticTokenAssociations.isEmpty()) {
+            transactionResultBuilder.automaticTokenAssociations(automaticTokenAssociations);
+        }
+        return BlockItem.newBuilder()
+                .transactionResult(
+                        transactionResultBuilder.transferList(transferList).build())
+                .build();
+    }
+
+    @Nullable
+    private TransactionOutput getTransactionOutput() {
+        if (transactionOutputBuilder == null) {
+            return null;
+        }
+        if (contractFunctionResult != null) {
+            final var sidecars = getSidecars();
+            if (ethereumHash != null) {
+                transactionOutputBuilder.ethereumCall(EthereumOutput.newBuilder()
+                        .ethereumHash(ethereumHash)
+                        .sidecars(sidecars)
+                        .build());
+            } else if (!isCreateResult) {
+                transactionOutputBuilder.contractCall(CallContractOutput.newBuilder()
+                        .contractCallResult(contractFunctionResult)
+                        .sidecars(sidecars)
+                        .build());
+            } else {
+                transactionOutputBuilder.contractCreate(CreateContractOutput.newBuilder()
+                        .contractCreateResult(contractFunctionResult)
+                        .sidecars(sidecars)
+                        .build());
+            }
+        } else if (createsOrDeletesSchedule && scheduledTransactionId != null) {
+            transactionOutputBuilder.createSchedule(CreateScheduleOutput.newBuilder()
+                    .scheduledTransactionId(scheduledTransactionId)
+                    .build());
+        } else if (scheduledTransactionId != null) {
+            transactionOutputBuilder.signSchedule(SignScheduleOutput.newBuilder()
+                    .scheduledTransactionId(scheduledTransactionId)
+                    .build());
+        } else if (hasAssessedCustomFees) {
+            transactionOutputBuilder.cryptoTransfer(CryptoTransferOutput.newBuilder()
+                    .assessedCustomFees(assessedCustomFees)
+                    .build());
+        }
+        return transactionOutputBuilder.build();
+    }
+
+    private List<TransactionSidecarRecord> getSidecars() {
+        final var timestamp = asTimestamp(consensusNow);
+        // create list of sidecar records
+        final List<TransactionSidecarRecord> transactionSidecarRecords = new ArrayList<>();
+        contractStateChanges.stream()
+                .map(pair -> new TransactionSidecarRecord(
+                        timestamp,
+                        pair.getValue(),
+                        new OneOf<>(TransactionSidecarRecord.SidecarRecordsOneOfType.STATE_CHANGES, pair.getKey())))
+                .forEach(transactionSidecarRecords::add);
+        contractActions.stream()
+                .map(pair -> new TransactionSidecarRecord(
+                        timestamp,
+                        pair.getValue(),
+                        new OneOf<>(TransactionSidecarRecord.SidecarRecordsOneOfType.ACTIONS, pair.getKey())))
+                .forEach(transactionSidecarRecords::add);
+        contractBytecodes.stream()
+                .map(pair -> new TransactionSidecarRecord(
+                        timestamp,
+                        pair.getValue(),
+                        new OneOf<>(TransactionSidecarRecord.SidecarRecordsOneOfType.BYTECODE, pair.getKey())))
+                .forEach(transactionSidecarRecords::add);
+        return transactionSidecarRecords;
+    }
+
+    private Bytes getSerializedTransaction() {
+        if (customizer != null) {
+            transaction = customizer.apply(transaction);
+            transactionBytes = transaction.signedTransactionBytes();
+            return Transaction.PROTOBUF.toBytes(transaction);
+        }
+        return serializedTransaction != null ? serializedTransaction : Transaction.PROTOBUF.toBytes(transaction);
+    }
+
+    private TransactionOutput.Builder ensureOutputBuilder() {
+        if (transactionOutputBuilder == null) {
+            transactionOutputBuilder = TransactionOutput.newBuilder();
+        }
+        return transactionOutputBuilder;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/PairedStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/PairedStreamBuilder.java
@@ -1,0 +1,587 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.blocks.impl;
+
+import com.hedera.hapi.block.stream.output.StateChange;
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.ScheduleID;
+import com.hedera.hapi.node.base.TokenAssociation;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenTransferList;
+import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.base.TopicID;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.base.TransferList;
+import com.hedera.hapi.node.contract.ContractFunctionResult;
+import com.hedera.hapi.node.transaction.AssessedCustomFee;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.PendingAirdropRecord;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.streams.ContractActions;
+import com.hedera.hapi.streams.ContractBytecode;
+import com.hedera.hapi.streams.ContractStateChanges;
+import com.hedera.node.app.service.addressbook.impl.records.NodeCreateStreamBuilder;
+import com.hedera.node.app.service.consensus.impl.records.ConsensusCreateTopicStreamBuilder;
+import com.hedera.node.app.service.consensus.impl.records.ConsensusSubmitMessageStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractDeleteStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.ContractUpdateStreamBuilder;
+import com.hedera.node.app.service.contract.impl.records.EthereumTransactionStreamBuilder;
+import com.hedera.node.app.service.file.impl.records.CreateFileStreamBuilder;
+import com.hedera.node.app.service.schedule.ScheduleStreamBuilder;
+import com.hedera.node.app.service.token.api.FeeStreamBuilder;
+import com.hedera.node.app.service.token.records.ChildStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoDeleteStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
+import com.hedera.node.app.service.token.records.CryptoUpdateStreamBuilder;
+import com.hedera.node.app.service.token.records.GenesisAccountStreamBuilder;
+import com.hedera.node.app.service.token.records.NodeStakeUpdateStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenAccountWipeStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenAirdropStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenBurnStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenCreateStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenMintStreamBuilder;
+import com.hedera.node.app.service.token.records.TokenUpdateStreamBuilder;
+import com.hedera.node.app.service.util.impl.records.PrngStreamBuilder;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
+import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A temporary implementation of {@link StreamBuilder} that forwards all mutating calls to an
+ * {@link BlockStreamBuilder} and a {@link RecordStreamBuilder}.
+ */
+public class PairedStreamBuilder
+        implements StreamBuilder,
+                ConsensusCreateTopicStreamBuilder,
+                ConsensusSubmitMessageStreamBuilder,
+                CreateFileStreamBuilder,
+                CryptoCreateStreamBuilder,
+                CryptoTransferStreamBuilder,
+                ChildStreamBuilder,
+                PrngStreamBuilder,
+                ScheduleStreamBuilder,
+                TokenMintStreamBuilder,
+                TokenBurnStreamBuilder,
+                TokenCreateStreamBuilder,
+                ContractCreateStreamBuilder,
+                ContractCallStreamBuilder,
+                ContractUpdateStreamBuilder,
+                EthereumTransactionStreamBuilder,
+                CryptoDeleteStreamBuilder,
+                TokenUpdateStreamBuilder,
+                NodeStakeUpdateStreamBuilder,
+                FeeStreamBuilder,
+                ContractDeleteStreamBuilder,
+                GenesisAccountStreamBuilder,
+                ContractOperationStreamBuilder,
+                TokenAccountWipeStreamBuilder,
+                CryptoUpdateStreamBuilder,
+                NodeCreateStreamBuilder,
+                TokenAirdropStreamBuilder {
+    private final BlockStreamBuilder blockStreamBuilder;
+    private final RecordStreamBuilder recordBuilder;
+
+    public PairedStreamBuilder(
+            @NonNull final ReversingBehavior reversingBehavior,
+            @NonNull final ExternalizedRecordCustomizer customizer,
+            @NonNull final HandleContext.TransactionCategory category) {
+        recordBuilder = new RecordStreamBuilder(reversingBehavior, customizer, category);
+        blockStreamBuilder = new BlockStreamBuilder(reversingBehavior, customizer, category);
+    }
+
+    @Override
+    public StreamBuilder stateChanges(@NonNull List<StateChange> stateChanges) {
+        blockStreamBuilder.stateChanges(stateChanges);
+        return this;
+    }
+
+    public BlockStreamBuilder ioBlockItemsBuilder() {
+        return blockStreamBuilder;
+    }
+
+    public RecordStreamBuilder recordBuilder() {
+        return recordBuilder;
+    }
+
+    @Override
+    public PairedStreamBuilder transaction(@NonNull Transaction transaction) {
+        recordBuilder.transaction(transaction);
+        blockStreamBuilder.transaction(transaction);
+        return this;
+    }
+
+    @Override
+    public PairedStreamBuilder serializedTransaction(@Nullable final Bytes serializedTransaction) {
+        recordBuilder.serializedTransaction(serializedTransaction);
+        blockStreamBuilder.serializedTransaction(serializedTransaction);
+        return this;
+    }
+
+    @Override
+    public int getNumAutoAssociations() {
+        return blockStreamBuilder.getNumAutoAssociations();
+    }
+
+    @Override
+    public Transaction transaction() {
+        return recordBuilder.transaction();
+    }
+
+    @Override
+    public TokenAirdropStreamBuilder addPendingAirdrop(@NonNull final PendingAirdropRecord pendingAirdropRecord) {
+        recordBuilder.addPendingAirdrop(pendingAirdropRecord);
+        blockStreamBuilder.addPendingAirdrop(pendingAirdropRecord);
+        return this;
+    }
+
+    @Override
+    public Set<AccountID> explicitRewardSituationIds() {
+        return recordBuilder.explicitRewardSituationIds();
+    }
+
+    @Override
+    public List<AccountAmount> getPaidStakingRewards() {
+        return recordBuilder.getPaidStakingRewards();
+    }
+
+    @Override
+    public boolean hasContractResult() {
+        return recordBuilder.hasContractResult();
+    }
+
+    @Override
+    public long getGasUsedForContractTxn() {
+        return recordBuilder.getGasUsedForContractTxn();
+    }
+
+    @NonNull
+    @Override
+    public ResponseCodeEnum status() {
+        return recordBuilder.status();
+    }
+
+    @NonNull
+    @Override
+    public TransactionBody transactionBody() {
+        return recordBuilder.transactionBody();
+    }
+
+    @Override
+    public long transactionFee() {
+        return recordBuilder.transactionFee();
+    }
+
+    @Override
+    public HandleContext.TransactionCategory category() {
+        return recordBuilder.category();
+    }
+
+    @Override
+    public ReversingBehavior reversingBehavior() {
+        return recordBuilder.reversingBehavior();
+    }
+
+    @Override
+    public void nullOutSideEffectFields() {
+        recordBuilder.nullOutSideEffectFields();
+        blockStreamBuilder.nullOutSideEffectFields();
+    }
+
+    @Override
+    public StreamBuilder syncBodyIdFromRecordId() {
+        recordBuilder.syncBodyIdFromRecordId();
+        blockStreamBuilder.syncBodyIdFromRecordId();
+        return this;
+    }
+
+    @Override
+    public StreamBuilder consensusTimestamp(@NonNull final Instant now) {
+        recordBuilder.consensusTimestamp(now);
+        blockStreamBuilder.consensusTimestamp(now);
+        return this;
+    }
+
+    @Override
+    public TransactionID transactionID() {
+        return recordBuilder.transactionID();
+    }
+
+    @Override
+    public StreamBuilder transactionID(@NonNull final TransactionID transactionID) {
+        recordBuilder.transactionID(transactionID);
+        blockStreamBuilder.transactionID(transactionID);
+        return this;
+    }
+
+    @Override
+    public StreamBuilder parentConsensus(@NonNull final Instant parentConsensus) {
+        recordBuilder.parentConsensus(parentConsensus);
+        blockStreamBuilder.parentConsensus(parentConsensus);
+        return this;
+    }
+
+    @Override
+    public StreamBuilder transactionBytes(@NonNull final Bytes transactionBytes) {
+        recordBuilder.transactionBytes(transactionBytes);
+        blockStreamBuilder.transactionBytes(transactionBytes);
+        return this;
+    }
+
+    @Override
+    public StreamBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate) {
+        recordBuilder.exchangeRate(exchangeRate);
+        blockStreamBuilder.exchangeRate(exchangeRate);
+        return this;
+    }
+
+    @Override
+    public StreamBuilder congestionMultiplier(final long congestionMultiplier) {
+        return null;
+    }
+
+    @NonNull
+    @Override
+    public NodeCreateStreamBuilder nodeID(long nodeID) {
+        recordBuilder.nodeID(nodeID);
+        blockStreamBuilder.nodeID(nodeID);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ConsensusCreateTopicStreamBuilder topicID(@NonNull TopicID topicID) {
+        recordBuilder.topicID(topicID);
+        blockStreamBuilder.topicID(topicID);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ConsensusSubmitMessageStreamBuilder topicSequenceNumber(long topicSequenceNumber) {
+        recordBuilder.topicSequenceNumber(topicSequenceNumber);
+        blockStreamBuilder.topicSequenceNumber(topicSequenceNumber);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ConsensusSubmitMessageStreamBuilder topicRunningHash(@NonNull Bytes topicRunningHash) {
+        recordBuilder.topicRunningHash(topicRunningHash);
+        blockStreamBuilder.topicRunningHash(topicRunningHash);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ConsensusSubmitMessageStreamBuilder topicRunningHashVersion(long topicRunningHashVersion) {
+        recordBuilder.topicRunningHashVersion(topicRunningHashVersion);
+        blockStreamBuilder.topicRunningHashVersion(topicRunningHashVersion);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public List<AssessedCustomFee> getAssessedCustomFees() {
+        return recordBuilder.getAssessedCustomFees();
+    }
+
+    @Override
+    public ContractFunctionResult contractFunctionResult() {
+        return recordBuilder.contractFunctionResult();
+    }
+
+    @Override
+    public List<Long> serialNumbers() {
+        return recordBuilder.serialNumbers();
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder status(@NonNull ResponseCodeEnum status) {
+        recordBuilder.status(status);
+        blockStreamBuilder.status(status);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder contractID(@Nullable ContractID contractId) {
+        recordBuilder.contractID(contractId);
+        blockStreamBuilder.contractID(contractId);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder contractCreateResult(@Nullable ContractFunctionResult result) {
+        recordBuilder.contractCreateResult(result);
+        blockStreamBuilder.contractCreateResult(result);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public EthereumTransactionStreamBuilder ethereumHash(@NonNull Bytes ethereumHash) {
+        recordBuilder.ethereumHash(ethereumHash);
+        blockStreamBuilder.ethereumHash(ethereumHash);
+        return this;
+    }
+
+    @Override
+    public void trackExplicitRewardSituation(@NonNull AccountID accountId) {
+        recordBuilder.trackExplicitRewardSituation(accountId);
+        blockStreamBuilder.trackExplicitRewardSituation(accountId);
+    }
+
+    @NonNull
+    @Override
+    public ContractOperationStreamBuilder addContractActions(
+            @NonNull ContractActions contractActions, boolean isMigration) {
+        recordBuilder.addContractActions(contractActions, isMigration);
+        blockStreamBuilder.addContractActions(contractActions, isMigration);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ContractOperationStreamBuilder addContractBytecode(
+            @NonNull ContractBytecode contractBytecode, boolean isMigration) {
+        recordBuilder.addContractBytecode(contractBytecode, isMigration);
+        blockStreamBuilder.addContractBytecode(contractBytecode, isMigration);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ContractOperationStreamBuilder addContractStateChanges(
+            @NonNull ContractStateChanges contractStateChanges, boolean isMigration) {
+        recordBuilder.addContractStateChanges(contractStateChanges, isMigration);
+        blockStreamBuilder.addContractStateChanges(contractStateChanges, isMigration);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public CreateFileStreamBuilder fileID(@NonNull FileID fileID) {
+        recordBuilder.fileID(fileID);
+        blockStreamBuilder.fileID(fileID);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ScheduleStreamBuilder scheduleRef(ScheduleID scheduleRef) {
+        recordBuilder.scheduleRef(scheduleRef);
+        blockStreamBuilder.scheduleRef(scheduleRef);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ScheduleStreamBuilder scheduleID(ScheduleID scheduleID) {
+        recordBuilder.scheduleID(scheduleID);
+        blockStreamBuilder.scheduleID(scheduleID);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public ScheduleStreamBuilder scheduledTransactionID(TransactionID scheduledTransactionID) {
+        recordBuilder.scheduledTransactionID(scheduledTransactionID);
+        blockStreamBuilder.scheduledTransactionID(scheduledTransactionID);
+        return this;
+    }
+
+    @Override
+    public TransferList transferList() {
+        return recordBuilder.transferList();
+    }
+
+    @Override
+    public List<TokenTransferList> tokenTransferLists() {
+        return recordBuilder.tokenTransferLists();
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder accountID(@NonNull AccountID accountID) {
+        recordBuilder.accountID(accountID);
+        blockStreamBuilder.accountID(accountID);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public CryptoCreateStreamBuilder evmAddress(@NonNull Bytes evmAddress) {
+        recordBuilder.evmAddress(evmAddress);
+        blockStreamBuilder.evmAddress(evmAddress);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder transactionFee(@NonNull long transactionFee) {
+        recordBuilder.transactionFee(transactionFee);
+        blockStreamBuilder.transactionFee(transactionFee);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder memo(@NonNull String memo) {
+        recordBuilder.memo(memo);
+        blockStreamBuilder.memo(memo);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public CryptoTransferStreamBuilder transferList(@NonNull TransferList hbarTransfers) {
+        recordBuilder.transferList(hbarTransfers);
+        blockStreamBuilder.transferList(hbarTransfers);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public CryptoTransferStreamBuilder tokenTransferLists(@NonNull List<TokenTransferList> tokenTransferLists) {
+        recordBuilder.tokenTransferLists(tokenTransferLists);
+        blockStreamBuilder.tokenTransferLists(tokenTransferLists);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public CryptoTransferStreamBuilder assessedCustomFees(@NonNull List<AssessedCustomFee> assessedCustomFees) {
+        recordBuilder.assessedCustomFees(assessedCustomFees);
+        blockStreamBuilder.assessedCustomFees(assessedCustomFees);
+        return this;
+    }
+
+    @Override
+    public CryptoTransferStreamBuilder paidStakingRewards(@NonNull List<AccountAmount> paidStakingRewards) {
+        recordBuilder.paidStakingRewards(paidStakingRewards);
+        blockStreamBuilder.paidStakingRewards(paidStakingRewards);
+        return this;
+    }
+
+    @Override
+    public PairedStreamBuilder addAutomaticTokenAssociation(@NonNull TokenAssociation tokenAssociation) {
+        recordBuilder.addAutomaticTokenAssociation(tokenAssociation);
+        blockStreamBuilder.addAutomaticTokenAssociation(tokenAssociation);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder contractCallResult(@Nullable ContractFunctionResult result) {
+        recordBuilder.contractCallResult(result);
+        blockStreamBuilder.contractCallResult(result);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public TokenCreateStreamBuilder tokenID(@NonNull TokenID tokenID) {
+        recordBuilder.tokenID(tokenID);
+        blockStreamBuilder.tokenID(tokenID);
+        return this;
+    }
+
+    @Override
+    public TokenID tokenID() {
+        return recordBuilder.tokenID();
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder serialNumbers(@NonNull List<Long> serialNumbers) {
+        recordBuilder.serialNumbers(serialNumbers);
+        blockStreamBuilder.serialNumbers(serialNumbers);
+        return this;
+    }
+
+    @Override
+    public PairedStreamBuilder newTotalSupply(long newTotalSupply) {
+        recordBuilder.newTotalSupply(newTotalSupply);
+        blockStreamBuilder.newTotalSupply(newTotalSupply);
+        return this;
+    }
+
+    @Override
+    public long getNewTotalSupply() {
+        return recordBuilder.getNewTotalSupply();
+    }
+
+    @Override
+    public TokenBaseStreamBuilder tokenType(@NonNull TokenType tokenType) {
+        recordBuilder.tokenType(tokenType);
+        blockStreamBuilder.tokenType(tokenType);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public PrngStreamBuilder entropyNumber(int num) {
+        recordBuilder.entropyNumber(num);
+        blockStreamBuilder.entropyNumber(num);
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public PairedStreamBuilder entropyBytes(@NonNull Bytes prngBytes) {
+        recordBuilder.entropyBytes(prngBytes);
+        blockStreamBuilder.entropyBytes(prngBytes);
+        return this;
+    }
+
+    @Override
+    public int getNumberOfDeletedAccounts() {
+        return recordBuilder.getNumberOfDeletedAccounts();
+    }
+
+    @Nullable
+    @Override
+    public AccountID getDeletedAccountBeneficiaryFor(@NonNull AccountID deletedAccountID) {
+        return recordBuilder.getDeletedAccountBeneficiaryFor(deletedAccountID);
+    }
+
+    @Override
+    public void addBeneficiaryForDeletedAccount(
+            @NonNull AccountID deletedAccountID, @NonNull AccountID beneficiaryForDeletedAccount) {
+        recordBuilder.addBeneficiaryForDeletedAccount(deletedAccountID, beneficiaryForDeletedAccount);
+        blockStreamBuilder.addBeneficiaryForDeletedAccount(deletedAccountID, beneficiaryForDeletedAccount);
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeCalculatorImpl.java
@@ -24,7 +24,14 @@ import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BASIC_QUERY_RES_HEAD
 import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BASIC_TX_ID_SIZE;
 import static java.util.Objects.requireNonNull;
 
-import com.hedera.hapi.node.base.*;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.FeeData;
+import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.TransactionBody;
@@ -134,7 +141,7 @@ public class FeeCalculatorImpl implements FeeCalculator {
         this.storeFactory = storeFactory;
         try {
             this.txInfo = new TransactionInfo(
-                    Transaction.DEFAULT, txBody, SignatureMap.DEFAULT, Bytes.EMPTY, functionOf(txBody));
+                    Transaction.DEFAULT, txBody, SignatureMap.DEFAULT, Bytes.EMPTY, functionOf(txBody), null);
         } catch (UnknownHederaFunctionality e) {
             throw new IllegalStateException("Invalid transaction body " + txBody, e);
         }
@@ -172,7 +179,8 @@ public class FeeCalculatorImpl implements FeeCalculator {
                         .build(),
                 SignatureMap.DEFAULT,
                 Bytes.EMPTY,
-                functionality);
+                functionality,
+                null);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/NetworkUtilizationManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/NetworkUtilizationManagerImpl.java
@@ -70,7 +70,8 @@ public class NetworkUtilizationManagerImpl implements NetworkUtilizationManager 
                 AccountID.DEFAULT,
                 SignatureMap.DEFAULT,
                 Bytes.EMPTY,
-                CRYPTO_TRANSFER);
+                CRYPTO_TRANSFER,
+                null);
         trackTxn(chargingFeesCryptoTransfer, consensusNow, state);
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -454,7 +454,8 @@ public class ThrottleAccumulator {
                         effectivePayer,
                         SignatureMap.DEFAULT,
                         Bytes.EMPTY,
-                        scheduledFunction);
+                        scheduledFunction,
+                        null);
 
                 return shouldThrottleTxn(true, innerTxnInfo, now, state);
             }
@@ -517,7 +518,8 @@ public class ThrottleAccumulator {
                     effectivePayer,
                     SignatureMap.DEFAULT,
                     Bytes.EMPTY,
-                    scheduledFunction);
+                    scheduledFunction,
+                    null);
 
             return shouldThrottleTxn(true, innerTxnInfo, now, state);
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -145,14 +145,14 @@ public class TransactionChecker {
     @NonNull
     public TransactionInfo parseAndCheck(@NonNull final Bytes buffer) throws PreCheckException {
         final var tx = parse(buffer);
-        return check(tx);
+        return check(tx, buffer);
     }
 
     /**
      * Parse the given {@link Bytes} into a transaction.
      *
      * <p>After verifying that the number of bytes comprising the transaction does not exceed the maximum allowed, the
-     * transaction is parsed. A transaction can be checked with {@link #check(Transaction)}.
+     * transaction is parsed. A transaction can be checked with {@link #check(Transaction, Bytes)}.
      *
      * @param buffer the {@code ByteBuffer} with the serialized transaction
      * @return an {@link TransactionInfo} with the parsed and checked entities
@@ -199,12 +199,13 @@ public class TransactionChecker {
      * modules themselves).</p>
      *
      * @param tx the {@link Transaction} that needs to be checked
+     * @param serializedTx if set, the serialized transaction bytes to include in the {@link TransactionInfo}
      * @return an {@link TransactionInfo} with the parsed and checked entities
      * @throws PreCheckException if the data is not valid
      * @throws NullPointerException if one of the arguments is {@code null}
      */
     @NonNull
-    public TransactionInfo check(@NonNull final Transaction tx) throws PreCheckException {
+    public TransactionInfo check(@NonNull final Transaction tx, @Nullable Bytes serializedTx) throws PreCheckException {
         // NOTE: Since we've already parsed the transaction, we assume that the
         // transaction was not too many bytes. This is a safe assumption because
         // the code that receives the transaction bytes and parses/ the transaction
@@ -243,7 +244,7 @@ public class TransactionChecker {
                 throw new PreCheckException(PAYER_ACCOUNT_NOT_FOUND);
             }
         }
-        return checkParsed(new TransactionInfo(tx, txBody, signatureMap, bodyBytes, functionality));
+        return checkParsed(new TransactionInfo(tx, txBody, signatureMap, bodyBytes, functionality, serializedTx));
     }
 
     public TransactionInfo checkParsed(@NonNull final TransactionInfo txInfo) throws PreCheckException {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionInfo.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionInfo.java
@@ -54,14 +54,16 @@ public record TransactionInfo(
         @Nullable AccountID payerID,
         @NonNull SignatureMap signatureMap,
         @NonNull Bytes signedBytes,
-        @NonNull HederaFunctionality functionality) {
+        @NonNull HederaFunctionality functionality,
+        @Nullable Bytes serializedTransaction) {
 
     public TransactionInfo(
             @NonNull Transaction transaction,
             @NonNull TransactionBody txBody,
             @NonNull SignatureMap signatureMap,
             @NonNull Bytes signedBytes,
-            @NonNull HederaFunctionality functionality) {
+            @NonNull HederaFunctionality functionality,
+            @Nullable Bytes serializedTransaction) {
         this(
                 transaction,
                 txBody,
@@ -69,7 +71,8 @@ public record TransactionInfo(
                 txBody.transactionIDOrThrow().accountIDOrThrow(),
                 signatureMap,
                 signedBytes,
-                functionality);
+                functionality,
+                serializedTransaction);
     }
 
     public static TransactionInfo from(
@@ -87,6 +90,6 @@ public record TransactionInfo(
             }
         }
         return new TransactionInfo(
-                transaction, txBody, transactionId, payerId, signatureMap, signedBytes, functionality);
+                transaction, txBody, transactionId, payerId, signatureMap, signedBytes, functionality, null);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/ChildDispatchFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/ChildDispatchFactory.java
@@ -229,7 +229,7 @@ public class ChildDispatchFactory {
         final var entityNumGenerator = new EntityNumGeneratorImpl(
                 new WritableStoreFactory(childStack, EntityIdService.NAME, config, storeMetricsService)
                         .getStore(WritableEntityIdStore.class));
-        final var feeAccumulator =
+        final var childFeeAccumulator =
                 new FeeAccumulator(serviceApiFactory.getApi(TokenServiceApi.class), (FeeStreamBuilder) builder);
         final var dispatchHandleContext = new DispatchHandleContext(
                 consensusNow,
@@ -253,11 +253,14 @@ public class ChildDispatchFactory {
                 this,
                 dispatchProcessor,
                 throttleAdviser,
-                feeAccumulator);
+                childFeeAccumulator);
         final var childFees =
                 computeChildFees(payerId, dispatchHandleContext, category, dispatcher, topLevelFunction, txnInfo);
-        final var childFeeAccumulator =
-                new FeeAccumulator(serviceApiFactory.getApi(TokenServiceApi.class), (RecordStreamBuilder) builder);
+        final var congestionMultiplier = feeManager.congestionMultiplierFor(
+                txnInfo.txBody(), txnInfo.functionality(), storeFactory.asReadOnly());
+        if (congestionMultiplier > 1) {
+            builder.congestionMultiplier(congestionMultiplier);
+        }
         final var childTokenContext = new TokenContextImpl(config, storeMetricsService, childStack, consensusNow);
         return new RecordDispatch(
                 builder,
@@ -445,7 +448,8 @@ public class ChildDispatchFactory {
                 payerId,
                 SignatureMap.DEFAULT,
                 signedTransactionBytes,
-                functionOfTxn(txBody));
+                functionOfTxn(txBody),
+                null);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordStreamBuilder.java
@@ -17,14 +17,11 @@
 package com.hedera.node.app.workflows.handle.record;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.IDENTICAL_SCHEDULE_ALREADY_CREATED;
-import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
 import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
-import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static com.hedera.node.app.state.logging.TransactionStateLogger.logEndTransactionRecord;
 import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.node.base.AccountAmount;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
@@ -149,6 +146,10 @@ public class RecordStreamBuilder
                     .thenComparingLong(a -> a.accountIdOrThrow().accountNum());
     // base transaction data
     private Transaction transaction;
+
+    @Nullable
+    private Bytes serializedTransaction;
+
     private Bytes transactionBytes = Bytes.EMPTY;
     // fields needed for TransactionRecord
     // Mutable because the provisional consensus timestamp assigned on dispatch could
@@ -205,16 +206,6 @@ public class RecordStreamBuilder
 
     private TokenID tokenID;
     private TokenType tokenType;
-
-    /**
-     * Creates new transaction record builder where reversion will leave its record in the stream
-     * with either a failure status or {@link ResponseCodeEnum#REVERTED_SUCCESS}.
-     *
-     */
-    @VisibleForTesting
-    public RecordStreamBuilder() {
-        this(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
-    }
 
     public RecordStreamBuilder(
             @NonNull final ReversingBehavior reversingBehavior,
@@ -366,6 +357,12 @@ public class RecordStreamBuilder
     @NonNull
     public RecordStreamBuilder transaction(@NonNull final Transaction transaction) {
         this.transaction = requireNonNull(transaction, "transaction must not be null");
+        return this;
+    }
+
+    @Override
+    public StreamBuilder serializedTransaction(@Nullable final Bytes serializedTransaction) {
+        this.serializedTransaction = serializedTransaction;
         return this;
     }
 
@@ -577,8 +574,8 @@ public class RecordStreamBuilder
      * @return the builder
      */
     @Override
-    public RecordStreamBuilder addPendingAirdrop(@NonNull PendingAirdropRecord pendingAirdropRecord) {
-        requireNonNull(pendingAirdropRecords, "pendingAirdropRecords must not be null");
+    public RecordStreamBuilder addPendingAirdrop(@NonNull final PendingAirdropRecord pendingAirdropRecord) {
+        requireNonNull(pendingAirdropRecord);
         this.pendingAirdropRecords.add(pendingAirdropRecord);
         return this;
     }
@@ -856,17 +853,19 @@ public class RecordStreamBuilder
         return exchangeRate;
     }
 
-    /**
-     * Sets the receipt exchange rate.
-     *
-     * @param exchangeRate the {@link ExchangeRateSet} for the receipt
-     * @return the builder
-     */
+    /**{@inheritDoc}*/
     @NonNull
     @Override
     public RecordStreamBuilder exchangeRate(@NonNull final ExchangeRateSet exchangeRate) {
         requireNonNull(exchangeRate, "exchangeRate must not be null");
         this.exchangeRate = exchangeRate;
+        return this;
+    }
+
+    @NonNull
+    @Override
+    public StreamBuilder congestionMultiplier(long congestionMultiplier) {
+        // No-op
         return this;
     }
 
@@ -1064,20 +1063,6 @@ public class RecordStreamBuilder
     }
 
     /**
-     * Sets the contractActions which are part of sidecar records.
-     *
-     * @param contractActions the contractActions
-     * @return the builder
-     */
-    @NonNull
-    public RecordStreamBuilder contractActions(
-            @NonNull final List<AbstractMap.SimpleEntry<ContractActions, Boolean>> contractActions) {
-        requireNonNull(contractActions, "contractActions must not be null");
-        this.contractActions = contractActions;
-        return this;
-    }
-
-    /**
      * Adds contractActions to sidecar records.
      *
      * @param contractActions the contractActions to add
@@ -1093,26 +1078,13 @@ public class RecordStreamBuilder
     }
 
     /**
-     * Sets the contractBytecodes which are part of sidecar records.
-     *
-     * @param contractBytecodes the contractBytecodes
-     * @return the builder
-     */
-    @NonNull
-    public RecordStreamBuilder contractBytecodes(
-            @NonNull final List<AbstractMap.SimpleEntry<ContractBytecode, Boolean>> contractBytecodes) {
-        requireNonNull(contractBytecodes, "contractBytecodes must not be null");
-        this.contractBytecodes = contractBytecodes;
-        return this;
-    }
-
-    /**
      * Adds contractBytecodes to sidecar records.
      *
      * @param contractBytecode the contractBytecode to add
      * @param isMigration flag indicating whether sidecar is from migration
      * @return the builder
      */
+    @Override
     @NonNull
     public RecordStreamBuilder addContractBytecode(
             @NonNull final ContractBytecode contractBytecode, final boolean isMigration) {
@@ -1131,7 +1103,6 @@ public class RecordStreamBuilder
      * @param beneficiaryForDeletedAccount the beneficiary account ID
      */
     @Override
-    @NonNull
     public void addBeneficiaryForDeletedAccount(
             @NonNull final AccountID deletedAccountID, @NonNull final AccountID beneficiaryForDeletedAccount) {
         requireNonNull(deletedAccountID, "deletedAccountID must not be null");
@@ -1189,16 +1160,13 @@ public class RecordStreamBuilder
         }
     }
 
-    public EthereumTransactionStreamBuilder feeChargedToPayer(@NonNull long amount) {
-        transactionRecordBuilder.transactionFee(transactionFee + amount);
-        return this;
-    }
-
     /**
      * Returns the staking rewards paid in this transaction.
      *
      * @return the staking rewards paid in this transaction
      */
+    @Override
+    @NonNull
     public List<AccountAmount> getPaidStakingRewards() {
         return paidStakingRewards;
     }
@@ -1208,6 +1176,7 @@ public class RecordStreamBuilder
      * @return the {@link TransactionRecord.Builder} of the record
      */
     @Override
+    @NonNull
     public TransactionCategory category() {
         return category;
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -168,7 +168,7 @@ public final class IngestChecker {
         final var consensusTime = instantSource.instant();
 
         // 1. Check the syntax
-        final var txInfo = transactionChecker.check(tx);
+        final var txInfo = transactionChecker.check(tx, null);
         final var txBody = txInfo.txBody();
         final var functionality = txInfo.functionality();
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockStreamBuilderTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockStreamBuilderTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.blocks;
+
+import static com.hedera.hapi.util.HapiUtils.asTimestamp;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.ScheduleID;
+import com.hedera.hapi.node.base.TokenAssociation;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenTransferList;
+import com.hedera.hapi.node.base.TopicID;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.base.TransferList;
+import com.hedera.hapi.node.contract.ContractFunctionResult;
+import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
+import com.hedera.hapi.node.transaction.AssessedCustomFee;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.node.transaction.TransactionRecord;
+import com.hedera.hapi.streams.ContractActions;
+import com.hedera.hapi.streams.ContractBytecode;
+import com.hedera.hapi.streams.ContractStateChanges;
+import com.hedera.node.app.blocks.impl.BlockStreamBuilder;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BlockStreamBuilderTest {
+    public static final Instant CONSENSUS_TIME = Instant.now();
+    public static final Instant PARENT_CONSENSUS_TIME = CONSENSUS_TIME.plusNanos(1L);
+    public static final long TRANSACTION_FEE = 6846513L;
+    public static final int ENTROPY_NUMBER = 87372879;
+    public static final String MEMO = "Yo Memo";
+    private Transaction transaction = Transaction.newBuilder()
+            .body(TransactionBody.newBuilder()
+                    .cryptoTransfer(CryptoTransferTransactionBody.newBuilder().build())
+                    .build())
+            .build();
+    private @Mock TransactionID transactionID;
+    private final Bytes transactionBytes = Bytes.wrap("Hello Tester");
+    private @Mock ContractFunctionResult contractCallResult;
+    private @Mock ContractFunctionResult contractCreateResult;
+    private @Mock TransferList transferList;
+    private @Mock TokenTransferList tokenTransfer;
+    private @Mock ScheduleID scheduleRef;
+    private @Mock AssessedCustomFee assessedCustomFee;
+    private @Mock TokenAssociation tokenAssociation;
+    private @Mock Bytes alias;
+    private @Mock Bytes ethereumHash;
+    private @Mock Bytes prngBytes;
+    private @Mock AccountAmount accountAmount;
+    private @Mock Bytes evmAddress;
+    private @Mock ResponseCodeEnum status;
+    private @Mock AccountID accountID;
+    private @Mock FileID fileID;
+    private @Mock ContractID contractID;
+    private @Mock ExchangeRateSet exchangeRate;
+    private @Mock TopicID topicID;
+    private @Mock Bytes topicRunningHash;
+    private @Mock TokenID tokenID;
+    private @Mock ScheduleID scheduleID;
+    private @Mock TransactionID scheduledTransactionID;
+    private @Mock ContractStateChanges contractStateChanges;
+    private @Mock ContractActions contractActions;
+    private @Mock ContractBytecode contractBytecode;
+
+    @Test
+    void testBlockItemsWithCryptoTransferOutput() {
+        final var itemsBuilder = createBaseBuilder().assessedCustomFees(List.of(assessedCustomFee));
+
+        List<BlockItem> blockItems = itemsBuilder.build();
+        validateTransactionBlockItems(blockItems);
+        validateTransactionResult(blockItems);
+
+        final var outputBlockItem = blockItems.get(2);
+        assertTrue(outputBlockItem.hasTransactionOutput());
+        final var output = outputBlockItem.transactionOutput();
+        assertTrue(output.hasCryptoTransfer());
+        assertEquals(List.of(assessedCustomFee), output.cryptoTransferOrThrow().assessedCustomFees());
+    }
+
+    @ParameterizedTest
+    @EnumSource(TransactionRecord.EntropyOneOfType.class)
+    void testBlockItemsWithUtilPrngOutput(TransactionRecord.EntropyOneOfType entropyOneOfType) {
+        if (entropyOneOfType == TransactionRecord.EntropyOneOfType.UNSET) {
+            return;
+        }
+        if (entropyOneOfType == TransactionRecord.EntropyOneOfType.PRNG_BYTES) {
+            final var itemsBuilder = createBaseBuilder().entropyBytes(prngBytes);
+            List<BlockItem> blockItems = itemsBuilder.build();
+            validateTransactionBlockItems(blockItems);
+            validateTransactionResult(blockItems);
+
+            final var outputBlockItem = blockItems.get(2);
+            assertTrue(outputBlockItem.hasTransactionOutput());
+            final var output = outputBlockItem.transactionOutput();
+            assertTrue(output.hasUtilPrng());
+            assertEquals(prngBytes, output.utilPrng().prngBytes());
+        } else {
+            final var itemsBuilder = createBaseBuilder().entropyNumber(ENTROPY_NUMBER);
+            List<BlockItem> blockItems = itemsBuilder.build();
+            validateTransactionBlockItems(blockItems);
+            validateTransactionResult(blockItems);
+
+            final var outputBlockItem = blockItems.get(2);
+            assertTrue(outputBlockItem.hasTransactionOutput());
+            final var output = outputBlockItem.transactionOutput();
+            assertTrue(output.hasUtilPrng());
+            assertEquals(ENTROPY_NUMBER, output.utilPrng().prngNumber());
+        }
+    }
+
+    @Test
+    void testBlockItemsWithContractCallOutput() {
+        final var itemsBuilder = createBaseBuilder()
+                .contractCallResult(contractCallResult)
+                .addContractStateChanges(contractStateChanges, false);
+
+        List<BlockItem> blockItems = itemsBuilder.build();
+        validateTransactionBlockItems(blockItems);
+        validateTransactionResult(blockItems);
+
+        final var outputBlockItem = blockItems.get(2);
+        assertTrue(outputBlockItem.hasTransactionOutput());
+        final var output = outputBlockItem.transactionOutput();
+        assertTrue(output.hasContractCall());
+    }
+
+    private void validateTransactionResult(final List<BlockItem> blockItems) {
+        final var resultBlockItem = blockItems.get(1);
+        assertTrue(resultBlockItem.hasTransactionResult());
+        final var result = resultBlockItem.transactionResult();
+
+        assertEquals(status, result.status());
+        assertEquals(asTimestamp(CONSENSUS_TIME), result.consensusTimestamp());
+        assertEquals(asTimestamp(PARENT_CONSENSUS_TIME), result.parentConsensusTimestamp());
+        assertEquals(exchangeRate, result.exchangeRate());
+        assertEquals(scheduleRef, result.scheduleRef());
+        assertEquals(TRANSACTION_FEE, result.transactionFeeCharged());
+        assertEquals(transferList, result.transferList());
+        assertEquals(List.of(tokenTransfer), result.tokenTransferLists());
+        assertEquals(List.of(tokenAssociation), result.automaticTokenAssociations());
+        assertEquals(List.of(accountAmount), result.paidStakingRewards());
+        assertEquals(10L, result.congestionPricingMultiplier());
+    }
+
+    private void validateTransactionBlockItems(final List<BlockItem> blockItems) {
+        final var txnBlockItem = blockItems.get(0);
+        assertTrue(txnBlockItem.hasEventTransaction());
+        assertEquals(
+                Transaction.PROTOBUF.toBytes(transaction),
+                txnBlockItem.eventTransaction().applicationTransactionOrThrow());
+    }
+
+    private BlockStreamBuilder createBaseBuilder() {
+        final List<TokenTransferList> tokenTransferLists = List.of(tokenTransfer);
+        final List<AccountAmount> paidStakingRewards = List.of(accountAmount);
+        return new BlockStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER)
+                .status(status)
+                .consensusTimestamp(CONSENSUS_TIME)
+                .parentConsensus(PARENT_CONSENSUS_TIME)
+                .exchangeRate(exchangeRate)
+                .scheduleRef(scheduleRef)
+                .transactionFee(TRANSACTION_FEE)
+                .transaction(transaction)
+                .transactionBytes(transactionBytes)
+                .transactionID(transactionID)
+                .memo(MEMO)
+                .transactionFee(TRANSACTION_FEE)
+                .transferList(transferList)
+                .tokenTransferLists(tokenTransferLists)
+                .addAutomaticTokenAssociation(tokenAssociation)
+                .paidStakingRewards(paidStakingRewards)
+                .congestionMultiplier(10L);
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/UtilizationScaledThrottleMultiplierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/UtilizationScaledThrottleMultiplierTest.java
@@ -245,7 +245,8 @@ class UtilizationScaledThrottleMultiplierTest {
                         .build(),
                 SignatureMap.DEFAULT,
                 Bytes.EMPTY,
-                TOKEN_MINT);
+                TOKEN_MINT,
+                null);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
         state = new FakeState()
@@ -283,7 +284,8 @@ class UtilizationScaledThrottleMultiplierTest {
                         .build(),
                 SignatureMap.DEFAULT,
                 Bytes.EMPTY,
-                TOKEN_MINT);
+                TOKEN_MINT,
+                null);
         when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
 
         var storeFactory = new ReadableStoreFactory(new FakeState());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/AppThrottleAdviserTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/AppThrottleAdviserTest.java
@@ -51,14 +51,14 @@ class AppThrottleAdviserTest {
                     ContractCallTransactionBody.newBuilder().gas(GAS_LIMIT).build())
             .build();
     private static final TransactionInfo CONTRACT_CALL_TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, CONTRACT_CALL_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CALL);
+            Transaction.DEFAULT, CONTRACT_CALL_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CALL, null);
     private static final TransactionBody CRYPTO_TRANSFER_TXN_BODY = TransactionBody.newBuilder()
             .transactionID(
                     TransactionID.newBuilder().accountID(PAYER_ACCOUNT_ID).build())
             .cryptoTransfer(CryptoTransferTransactionBody.DEFAULT)
             .build();
     private static final TransactionInfo CRYPTO_TRANSFER_TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, CRYPTO_TRANSFER_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER);
+            Transaction.DEFAULT, CRYPTO_TRANSFER_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER, null);
 
     @Mock
     private NetworkUtilizationManager networkUtilizationManager;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
@@ -2227,7 +2227,8 @@ class ThrottleAccumulatorTest {
                 PAYER_ID,
                 SignatureMap.DEFAULT,
                 Bytes.EMPTY,
-                SCHEDULE_CREATE);
+                SCHEDULE_CREATE,
+                null);
     }
 
     private TransactionInfo scheduleSign(ScheduleID scheduleID) {
@@ -2244,7 +2245,8 @@ class ThrottleAccumulatorTest {
                 PAYER_ID,
                 SignatureMap.DEFAULT,
                 Bytes.EMPTY,
-                SCHEDULE_SIGN);
+                SCHEDULE_SIGN,
+                null);
     }
 
     private ThrottleDefinitions getThrottleDefs(String testResource) throws IOException, ParseException {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
@@ -115,7 +115,8 @@ class NetworkUtilizationManagerImplTest {
                 AccountID.DEFAULT,
                 SignatureMap.DEFAULT,
                 Bytes.EMPTY,
-                CRYPTO_TRANSFER);
+                CRYPTO_TRANSFER,
+                null);
 
         // when
         subject.trackFeePayments(consensusNow, state);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/SolvencyPreCheckTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/SolvencyPreCheckTest.java
@@ -465,7 +465,8 @@ class SolvencyPreCheckTest extends AppTestBase {
         final var transaction = Transaction.newBuilder()
                 .signedTransactionBytes(signedTransactionBytes)
                 .build();
-        return new TransactionInfo(transaction, txBody, SignatureMap.DEFAULT, signedTransactionBytes, functionality);
+        return new TransactionInfo(
+                transaction, txBody, SignatureMap.DEFAULT, signedTransactionBytes, functionality, null);
     }
 
     private static AccountAmount send(AccountID accountID, long amount) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -229,7 +229,7 @@ final class TransactionCheckerTest extends AppTestBase {
             // Given a transaction with no bytes at all
             // Then the checker should throw a PreCheckException
             final var transaction = checker.parse(Bytes.EMPTY);
-            assertThatThrownBy(() -> checker.check(transaction))
+            assertThatThrownBy(() -> checker.check(transaction, null))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(INVALID_TRANSACTION_BODY));
         }
@@ -245,7 +245,7 @@ final class TransactionCheckerTest extends AppTestBase {
         void happyPath() throws PreCheckException {
             // Given a valid serialized transaction, when we parseStrict and check
             final var transaction = checker.parse(inputBuffer);
-            final var info = checker.check(transaction);
+            final var info = checker.check(transaction, null);
 
             // Then the parsed data is as we expected
             assertThat(info.transaction()).isEqualTo(tx);
@@ -275,7 +275,7 @@ final class TransactionCheckerTest extends AppTestBase {
 
             // When we parseStrict and check
             final var transaction = checker.parse(inputBuffer);
-            final var info = checker.check(transaction);
+            final var info = checker.check(transaction, null);
 
             // Then everything works because the deprecated fields are supported
             assertThat(info.transaction()).isEqualTo(localTx);
@@ -303,7 +303,7 @@ final class TransactionCheckerTest extends AppTestBase {
 
             // When we check, then we get a PreCheckException with INVALID_TRANSACTION_BODY
             final var transaction = checker.parse(inputBuffer);
-            assertThatThrownBy(() -> checker.check(transaction))
+            assertThatThrownBy(() -> checker.check(transaction, null))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(INVALID_TRANSACTION_BODY));
 
@@ -349,7 +349,7 @@ final class TransactionCheckerTest extends AppTestBase {
         @SuppressWarnings("ConstantConditions")
         @DisplayName("`check` requires a transaction")
         void checkWithNull() {
-            assertThatThrownBy(() -> checker.check(null)).isInstanceOf(NullPointerException.class);
+            assertThatThrownBy(() -> checker.check(null, null)).isInstanceOf(NullPointerException.class);
         }
 
         @Nested
@@ -365,7 +365,7 @@ final class TransactionCheckerTest extends AppTestBase {
             @DisplayName("A valid transaction passes parseAndCheck with a BufferedData")
             void happyPath() throws PreCheckException {
                 // Given a valid serialized transaction, when we parse and check
-                final var info = checker.check(tx);
+                final var info = checker.check(tx, null);
 
                 // Then the parsed data is as we expected
                 assertThat(info.transaction()).isEqualTo(tx);
@@ -392,7 +392,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check
-                final var info = checker.check(localTx);
+                final var info = checker.check(localTx, null);
 
                 // Then everything works because the deprecated fields are supported
                 assertThat(info.transaction()).isEqualTo(localTx);
@@ -418,7 +418,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we check, then we get a PreCheckException with INVALID_TRANSACTION_BODY
-                assertThatThrownBy(() -> checker.check(localTx))
+                assertThatThrownBy(() -> checker.check(localTx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION_BODY));
 
@@ -442,7 +442,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we check
-                final var info = checker.check(localTx);
+                final var info = checker.check(localTx, null);
                 // Then the parsed data is as we expected
                 assertThat(info.transaction()).isEqualTo(localTx);
                 assertThat(info.txBody()).isEqualTo(txBody);
@@ -468,7 +468,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we check
-                final var info = checker.check(localTx);
+                final var info = checker.check(localTx, null);
                 // Then the parsed data is as we expected
                 assertThat(info.transaction()).isEqualTo(localTx);
                 assertThat(info.txBody()).isEqualTo(txBody);
@@ -493,7 +493,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we check the transaction, then we find it is invalid
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION));
 
@@ -513,7 +513,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION));
 
@@ -566,7 +566,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         txBuilder(signedTxBuilder(txBody, localSignatureMap)).build();
 
                 // When we check the transaction, we find it is invalid due to duplicate prefixes
-                assertThatThrownBy(() -> checker.check(localTx))
+                assertThatThrownBy(() -> checker.check(localTx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(KEY_PREFIX_MISMATCH));
             }
@@ -584,7 +584,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check, then the parsing fails because this is an INVALID_TRANSACTION
-                assertThatThrownBy(() -> checker.check(localTx))
+                assertThatThrownBy(() -> checker.check(localTx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION));
             }
@@ -599,7 +599,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check, then the parsing fails because has unknown fields
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(TRANSACTION_HAS_UNKNOWN_FIELDS));
             }
@@ -623,7 +623,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check, then the parsing fails because has unknown fields
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION_BODY));
             }
@@ -644,7 +644,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check, then the parsing fails because this is an TRANSACTION_HAS_UNKNOWN_FIELDS
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(TRANSACTION_HAS_UNKNOWN_FIELDS));
             }
@@ -657,7 +657,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION_ID));
             }
@@ -671,7 +671,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var body = bodyBuilder(txIdBuilder().accountID(payerId));
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(PAYER_ACCOUNT_NOT_FOUND));
             }
@@ -686,7 +686,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(PAYER_ACCOUNT_NOT_FOUND));
             }
@@ -702,7 +702,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(PAYER_ACCOUNT_NOT_FOUND));
             }
@@ -718,7 +718,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(PAYER_ACCOUNT_NOT_FOUND));
             }
@@ -730,7 +730,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(TRANSACTION_ID_FIELD_NOT_ALLOWED));
             }
@@ -742,7 +742,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(TRANSACTION_ID_FIELD_NOT_ALLOWED));
             }
@@ -756,7 +756,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .hasFieldOrPropertyWithValue("responseCode", MEMO_TOO_LONG);
             }
@@ -772,7 +772,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .hasFieldOrPropertyWithValue("responseCode", INVALID_ZERO_BYTE_IN_STRING);
             }
@@ -790,7 +790,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // When we check the transaction body
-                assertThatThrownBy(() -> checker.check(tx))
+                assertThatThrownBy(() -> checker.check(tx, null))
                         .isInstanceOf(PreCheckException.class)
                         .hasFieldOrPropertyWithValue("responseCode", INSUFFICIENT_TX_FEE);
             }
@@ -882,7 +882,7 @@ final class TransactionCheckerTest extends AppTestBase {
                     hapiUtils.when(() -> HapiUtils.functionOf(eq(txBody))).thenThrow(new UnknownHederaFunctionality());
 
                     // When we parse and check, then the parsing fails due to the exception
-                    assertThatThrownBy(() -> checker.check(tx))
+                    assertThatThrownBy(() -> checker.check(tx, null))
                             .isInstanceOf(PreCheckException.class)
                             .hasFieldOrPropertyWithValue("responseCode", INVALID_TRANSACTION_BODY);
                 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionScenarioBuilder.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionScenarioBuilder.java
@@ -117,7 +117,7 @@ public class TransactionScenarioBuilder implements Scenarios {
                 .body(body)
                 .signedTransactionBytes(asBytes(SignedTransaction.PROTOBUF, signedTx))
                 .build();
-        return new TransactionInfo(tx, body, SignatureMap.DEFAULT, signedbytes, function);
+        return new TransactionInfo(tx, body, SignatureMap.DEFAULT, signedbytes, function, null);
     }
 
     public static TransactionBody goodDefaultBody() {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
@@ -29,7 +29,9 @@ import static com.hedera.node.app.spi.workflows.HandleContext.ConsensusThrottlin
 import static com.hedera.node.app.spi.workflows.HandleContext.ConsensusThrottling.ON;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.CHILD;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.SCHEDULED;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
 import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static com.hedera.node.app.workflows.handle.steps.HollowAccountCompletionsTest.asTxn;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -165,7 +167,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
             .cryptoTransfer(CryptoTransferTransactionBody.DEFAULT)
             .build();
     private static final TransactionInfo CRYPTO_TRANSFER_TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, CRYPTO_TRANSFER_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER);
+            Transaction.DEFAULT, CRYPTO_TRANSFER_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER, null);
 
     @Mock
     private AppKeyVerifier verifier;
@@ -263,12 +265,17 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
             .build();
     private static final TransactionBody txBody = asTxn(transferBody, payerId, CONSENSUS_NOW);
     private final Configuration configuration = HederaTestConfigBuilder.createConfig();
-    private RecordStreamBuilder childRecordBuilder = new RecordStreamBuilder();
+    private RecordStreamBuilder childRecordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
     private final TransactionBody txnBodyWithoutId = TransactionBody.newBuilder()
             .consensusSubmitMessage(ConsensusSubmitMessageTransactionBody.DEFAULT)
             .build();
     private static final TransactionInfo txnInfo = new TransactionInfo(
-            Transaction.newBuilder().body(txBody).build(), txBody, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER);
+            Transaction.newBuilder().body(txBody).build(),
+            txBody,
+            SignatureMap.DEFAULT,
+            Bytes.EMPTY,
+            CRYPTO_TRANSFER,
+            null);
 
     private static final TransactionBody MISSING_PAYER_ID =
             TransactionBody.newBuilder().transactionID(TransactionID.DEFAULT).build();
@@ -740,7 +747,12 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
         }
 
         final TransactionInfo txnInfo = new TransactionInfo(
-                Transaction.newBuilder().body(txBody).build(), txBody, SignatureMap.DEFAULT, Bytes.EMPTY, function);
+                Transaction.newBuilder().body(txBody).build(),
+                txBody,
+                SignatureMap.DEFAULT,
+                Bytes.EMPTY,
+                function,
+                null);
         return new DispatchHandleContext(
                 CONSENSUS_NOW,
                 creatorInfo,

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchProcessorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchProcessorTest.java
@@ -112,16 +112,16 @@ class DispatchProcessorTest {
             .transactionID(
                     TransactionID.newBuilder().accountID(PAYER_ACCOUNT_ID).build())
             .build();
-    private static final TransactionInfo CRYPTO_TRANSFER_TXN_INFO =
-            new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER);
+    private static final TransactionInfo CRYPTO_TRANSFER_TXN_INFO = new TransactionInfo(
+            Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER, null);
     private static final TransactionInfo SYS_DEL_TXN_INFO =
-            new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, SYSTEM_DELETE);
-    private static final TransactionInfo SYS_UNDEL_TXN_INFO =
-            new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, SYSTEM_UNDELETE);
+            new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, SYSTEM_DELETE, null);
+    private static final TransactionInfo SYS_UNDEL_TXN_INFO = new TransactionInfo(
+            Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, SYSTEM_UNDELETE, null);
     private static final TransactionInfo CONTRACT_TXN_INFO =
-            new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CALL);
-    private static final TransactionInfo ETH_TXN_INFO =
-            new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, ETHEREUM_TRANSACTION);
+            new TransactionInfo(Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CALL, null);
+    private static final TransactionInfo ETH_TXN_INFO = new TransactionInfo(
+            Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, ETHEREUM_TRANSACTION, null);
 
     @Mock
     private EthereumTransactionHandler ethereumTransactionHandler;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/RecordFinalizerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/RecordFinalizerTest.java
@@ -22,6 +22,8 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.CHILD;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static com.hedera.node.app.workflows.handle.steps.HollowAccountCompletionsTest.asTxn;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -95,9 +97,10 @@ public class RecordFinalizerTest {
             TX_BODY,
             SignatureMap.DEFAULT,
             Bytes.EMPTY,
-            HederaFunctionality.CRYPTO_TRANSFER);
+            HederaFunctionality.CRYPTO_TRANSFER,
+            null);
 
-    private RecordStreamBuilder recordBuilder = new RecordStreamBuilder();
+    private RecordStreamBuilder recordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
     private RecordFinalizer subject;
 
     @BeforeEach

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/ValidationReporterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/ValidationReporterTest.java
@@ -534,7 +534,12 @@ class ValidationReporterTest {
                     TransactionID.newBuilder().accountID(PAYER_ACCOUNT_ID).build())
             .build();
     private static final TransactionInfo TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, HederaFunctionality.CRYPTO_TRANSFER);
+            Transaction.DEFAULT,
+            TXN_BODY,
+            SignatureMap.DEFAULT,
+            Bytes.EMPTY,
+            HederaFunctionality.CRYPTO_TRANSFER,
+            null);
 
     private static final Fees FEES = new Fees(1L, 2L, 3L);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/StreamBuilderTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/StreamBuilderTest.java
@@ -16,6 +16,9 @@
 
 package com.hedera.node.app.workflows.handle.record;
 
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Fail.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -114,7 +117,8 @@ public class StreamBuilderTest {
         final List<AccountAmount> paidStakingRewards = List.of(accountAmount);
         final List<Long> serialNumbers = List.of(1L, 2L, 3L);
 
-        RecordStreamBuilder singleTransactionRecordBuilder = new RecordStreamBuilder();
+        RecordStreamBuilder singleTransactionRecordBuilder =
+                new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
 
         singleTransactionRecordBuilder
                 .parentConsensus(PARENT_CONSENSUS_TIME)
@@ -149,8 +153,8 @@ public class StreamBuilderTest {
                 .scheduledTransactionID(scheduledTransactionID)
                 .serialNumbers(serialNumbers)
                 .contractStateChanges(List.of(new AbstractMap.SimpleEntry<>(contractStateChanges, false)))
-                .contractActions(List.of(new AbstractMap.SimpleEntry<>(contractActions, false)))
-                .contractBytecodes(List.of(new AbstractMap.SimpleEntry<>(contractBytecode, false)));
+                .addContractActions(contractActions, false)
+                .addContractBytecode(contractBytecode, false);
 
         if (entropyOneOfType == TransactionRecord.EntropyOneOfType.PRNG_BYTES) {
             singleTransactionRecordBuilder.entropyBytes(prngBytes);
@@ -247,7 +251,8 @@ public class StreamBuilderTest {
 
     @Test
     void testTopLevelRecordBuilder() {
-        RecordStreamBuilder singleTransactionRecordBuilder = new RecordStreamBuilder();
+        RecordStreamBuilder singleTransactionRecordBuilder =
+                new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
 
         singleTransactionRecordBuilder.transaction(transaction);
 
@@ -268,7 +273,8 @@ public class StreamBuilderTest {
 
     @Test
     void testBuilderWithAddMethods() {
-        RecordStreamBuilder singleTransactionRecordBuilder = new RecordStreamBuilder();
+        RecordStreamBuilder singleTransactionRecordBuilder =
+                new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
 
         SingleTransactionRecord singleTransactionRecord = singleTransactionRecordBuilder
                 .transaction(transaction)

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletionsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletionsTest.java
@@ -231,7 +231,8 @@ public class HollowAccountCompletionsTest {
                 txnBody,
                 SignatureMap.DEFAULT,
                 transactionBytes,
-                ETHEREUM_TRANSACTION);
+                ETHEREUM_TRANSACTION,
+                null);
 
         when(userTxn.readableStoreFactory().getStore(ReadableAccountStore.class))
                 .thenReturn(accountStore);
@@ -262,7 +263,8 @@ public class HollowAccountCompletionsTest {
                 txnBody,
                 SignatureMap.DEFAULT,
                 transactionBytes,
-                ETHEREUM_TRANSACTION);
+                ETHEREUM_TRANSACTION,
+                null);
         when(userTxn.txnInfo()).thenReturn(txnInfo);
 
         hollowAccountCompletions.completeHollowAccounts(userTxn, dispatch);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
@@ -40,7 +40,6 @@ import com.hedera.node.app.service.file.FileService;
 import com.hedera.node.app.spi.fixtures.TransactionFactory;
 import com.hedera.node.app.throttle.ThrottleServiceManager;
 import com.hedera.node.app.util.FileUtilities;
-import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.converter.BytesConverter;
 import com.hedera.node.config.converter.LongPairConverter;
@@ -129,7 +128,6 @@ class SystemFileUpdatesTest implements TransactionFactory {
         final var txBody = TransactionBody.newBuilder()
                 .cryptoTransfer(CryptoTransferTransactionBody.DEFAULT)
                 .build();
-        final var recordBuilder = new RecordStreamBuilder();
 
         // then
         assertThatCode(() -> subject.handleTxBody(state, txBody)).doesNotThrowAnyException();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManagerTest.java
@@ -113,15 +113,20 @@ class DispatchUsageManagerTest {
                     .build())
             .build();
     private static final TransactionInfo ETH_TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, ETH_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, ETHEREUM_TRANSACTION);
+            Transaction.DEFAULT, ETH_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, ETHEREUM_TRANSACTION, null);
     private static final TransactionInfo CRYPTO_TRANSFER_TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, NONDESCRIPT_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER);
+            Transaction.DEFAULT, NONDESCRIPT_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER, null);
     private static final TransactionInfo CONTRACT_CALL_TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, CONTRACT_CALL_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CALL);
+            Transaction.DEFAULT, CONTRACT_CALL_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CALL, null);
     private static final TransactionInfo CONTRACT_CREATE_TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, CONTRACT_CREATE_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CREATE);
+            Transaction.DEFAULT, CONTRACT_CREATE_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONTRACT_CREATE, null);
     private static final TransactionInfo SUBMIT_TXN_INFO = new TransactionInfo(
-            Transaction.DEFAULT, NONDESCRIPT_TXN_BODY, SignatureMap.DEFAULT, Bytes.EMPTY, CONSENSUS_SUBMIT_MESSAGE);
+            Transaction.DEFAULT,
+            NONDESCRIPT_TXN_BODY,
+            SignatureMap.DEFAULT,
+            Bytes.EMPTY,
+            CONSENSUS_SUBMIT_MESSAGE,
+            null);
 
     @Mock
     private NetworkInfo networkInfo;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
@@ -166,8 +166,13 @@ class IngestCheckerTest extends AppTestBase {
                 .build();
 
         transactionInfo = new TransactionInfo(
-                tx, txBody, MOCK_SIGNATURE_MAP, tx.signedTransactionBytes(), HederaFunctionality.UNCHECKED_SUBMIT);
-        when(transactionChecker.check(tx)).thenReturn(transactionInfo);
+                tx,
+                txBody,
+                MOCK_SIGNATURE_MAP,
+                tx.signedTransactionBytes(),
+                HederaFunctionality.UNCHECKED_SUBMIT,
+                null);
+        when(transactionChecker.check(tx, null)).thenReturn(transactionInfo);
 
         final var configProvider = HederaTestConfigBuilder.createConfigProvider();
         this.deduplicationCache = new DeduplicationCacheImpl(configProvider, instantSource);
@@ -250,7 +255,12 @@ class IngestCheckerTest extends AppTestBase {
     void testRunAllChecksSuccessfully() throws Exception {
         // given
         final var expected = new TransactionInfo(
-                tx, txBody, MOCK_SIGNATURE_MAP, tx.signedTransactionBytes(), HederaFunctionality.UNCHECKED_SUBMIT);
+                tx,
+                txBody,
+                MOCK_SIGNATURE_MAP,
+                tx.signedTransactionBytes(),
+                HederaFunctionality.UNCHECKED_SUBMIT,
+                null);
         final var verificationResultFuture = mock(SignatureVerificationFuture.class);
         final var verificationResult = mock(SignatureVerification.class);
         when(verificationResult.failed()).thenReturn(false);
@@ -282,7 +292,7 @@ class IngestCheckerTest extends AppTestBase {
         @DisplayName("If the transaction fails TransactionChecker, a failure response is returned with the right error")
         void onsetFailsWithPreCheckException(ResponseCodeEnum failureReason) throws PreCheckException {
             // Given a TransactionChecker that will throw a PreCheckException with the given failure reason
-            when(transactionChecker.check(any())).thenThrow(new PreCheckException(failureReason));
+            when(transactionChecker.check(any(), eq(null))).thenThrow(new PreCheckException(failureReason));
 
             // When the transaction is checked
             assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
@@ -294,7 +304,7 @@ class IngestCheckerTest extends AppTestBase {
         @DisplayName("If some random exception is thrown from TransactionChecker, the exception is bubbled up")
         void randomException() throws PreCheckException {
             // Given a WorkflowOnset that will throw a RuntimeException
-            when(transactionChecker.check(any())).thenThrow(new RuntimeException("check exception"));
+            when(transactionChecker.check(any(), eq(null))).thenThrow(new RuntimeException("check exception"));
 
             // When the transaction is submitted, then the exception is bubbled up
             assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
@@ -511,8 +521,9 @@ class IngestCheckerTest extends AppTestBase {
                     myTxBody,
                     MOCK_SIGNATURE_MAP,
                     myTx.signedTransactionBytes(),
-                    HederaFunctionality.UNCHECKED_SUBMIT);
-            when(transactionChecker.check(myTx)).thenReturn(myTransactionInfo);
+                    HederaFunctionality.UNCHECKED_SUBMIT,
+                    null);
+            when(transactionChecker.check(myTx, null)).thenReturn(myTransactionInfo);
             when(solvencyPreCheck.getPayerAccount(any(), eq(accountID))).thenReturn(account);
             final var verificationResultFutureAlice = mock(SignatureVerificationFuture.class);
             final var verificationResultAlice = mock(SignatureVerification.class);
@@ -563,8 +574,9 @@ class IngestCheckerTest extends AppTestBase {
                     myTxBody,
                     MOCK_SIGNATURE_MAP,
                     myTx.signedTransactionBytes(),
-                    HederaFunctionality.UNCHECKED_SUBMIT);
-            when(transactionChecker.check(myTx)).thenReturn(myTransactionInfo);
+                    HederaFunctionality.UNCHECKED_SUBMIT,
+                    null);
+            when(transactionChecker.check(myTx, null)).thenReturn(myTransactionInfo);
             when(solvencyPreCheck.getPayerAccount(any(), eq(accountID))).thenReturn(account);
             final var verificationResultFutureAlice = mock(SignatureVerificationFuture.class);
             final var verificationResultAlice = mock(SignatureVerification.class);
@@ -616,8 +628,9 @@ class IngestCheckerTest extends AppTestBase {
                     myTxBody,
                     MOCK_SIGNATURE_MAP,
                     myTx.signedTransactionBytes(),
-                    HederaFunctionality.UNCHECKED_SUBMIT);
-            when(transactionChecker.check(myTx)).thenReturn(myTransactionInfo);
+                    HederaFunctionality.UNCHECKED_SUBMIT,
+                    null);
+            when(transactionChecker.check(myTx, null)).thenReturn(myTransactionInfo);
             when(solvencyPreCheck.getPayerAccount(any(), eq(accountID))).thenReturn(account);
             final var verificationResultFutureAlice = mock(SignatureVerificationFuture.class);
             final var verificationResultAlice = mock(SignatureVerification.class);
@@ -670,8 +683,9 @@ class IngestCheckerTest extends AppTestBase {
                     myTxBody,
                     MOCK_SIGNATURE_MAP,
                     myTx.signedTransactionBytes(),
-                    HederaFunctionality.UNCHECKED_SUBMIT);
-            when(transactionChecker.check(myTx)).thenReturn(myTransactionInfo);
+                    HederaFunctionality.UNCHECKED_SUBMIT,
+                    null);
+            when(transactionChecker.check(myTx, null)).thenReturn(myTransactionInfo);
             when(solvencyPreCheck.getPayerAccount(any(), eq(accountID))).thenReturn(account);
             final var verificationResultFutureAlice = mock(SignatureVerificationFuture.class);
             final var verificationResultAlice = mock(SignatureVerification.class);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
@@ -141,7 +141,8 @@ class IngestWorkflowImplTest extends AppTestBase {
                 transactionBody,
                 SignatureMap.newBuilder().build(),
                 randomBytes(100), // Not used in this test, so random bytes is OK
-                HederaFunctionality.CONSENSUS_CREATE_TOPIC);
+                HederaFunctionality.CONSENSUS_CREATE_TOPIC,
+                null);
         when(ingestChecker.runAllChecks(state, transaction, configuration)).thenReturn(transactionInfo);
 
         // Create the workflow we are going to test with

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
@@ -137,7 +137,7 @@ class QueryCheckerTest extends AppTestBase {
         final var signatureMap = SignatureMap.newBuilder().build();
         final var transaction = Transaction.newBuilder().build();
         final var transactionInfo = new TransactionInfo(
-                transaction, txBody, signatureMap, transaction.signedTransactionBytes(), CRYPTO_TRANSFER);
+                transaction, txBody, signatureMap, transaction.signedTransactionBytes(), CRYPTO_TRANSFER, null);
 
         // when
         assertThatCode(() -> checker.validateCryptoTransfer(transactionInfo)).doesNotThrowAnyException();
@@ -153,7 +153,7 @@ class QueryCheckerTest extends AppTestBase {
         final var signatureMap = SignatureMap.newBuilder().build();
         final var transaction = Transaction.newBuilder().build();
         final var transactionInfo = new TransactionInfo(
-                transaction, txBody, signatureMap, transaction.signedTransactionBytes(), CONSENSUS_CREATE_TOPIC);
+                transaction, txBody, signatureMap, transaction.signedTransactionBytes(), CONSENSUS_CREATE_TOPIC, null);
 
         // then
         assertThatThrownBy(() -> checker.validateCryptoTransfer(transactionInfo))
@@ -171,7 +171,7 @@ class QueryCheckerTest extends AppTestBase {
         final var signatureMap = SignatureMap.newBuilder().build();
         final var transaction = Transaction.newBuilder().build();
         final var transactionInfo = new TransactionInfo(
-                transaction, txBody, signatureMap, transaction.signedTransactionBytes(), CRYPTO_TRANSFER);
+                transaction, txBody, signatureMap, transaction.signedTransactionBytes(), CRYPTO_TRANSFER, null);
         doThrow(new PreCheckException(INVALID_ACCOUNT_AMOUNTS))
                 .when(cryptoTransferHandler)
                 .pureChecks(txBody);
@@ -502,7 +502,8 @@ class QueryCheckerTest extends AppTestBase {
         final var transaction = Transaction.newBuilder()
                 .signedTransactionBytes(signedTransactionBytes)
                 .build();
-        return new TransactionInfo(transaction, txBody, SignatureMap.DEFAULT, signedTransactionBytes, CRYPTO_TRANSFER);
+        return new TransactionInfo(
+                transaction, txBody, SignatureMap.DEFAULT, signedTransactionBytes, CRYPTO_TRANSFER, null);
     }
 
     private static AccountAmount send(AccountID accountID, long amount) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -175,8 +175,8 @@ class QueryWorkflowImplTest extends AppTestBase {
         txBody = TransactionBody.newBuilder().transactionID(transactionID).build();
 
         final var signatureMap = SignatureMap.newBuilder().build();
-        transactionInfo =
-                new TransactionInfo(payment, txBody, signatureMap, payment.signedTransactionBytes(), CRYPTO_TRANSFER);
+        transactionInfo = new TransactionInfo(
+                payment, txBody, signatureMap, payment.signedTransactionBytes(), CRYPTO_TRANSFER, null);
         when(ingestChecker.runAllChecks(state, payment, configuration)).thenReturn(transactionInfo);
 
         when(handler.extractHeader(query)).thenReturn(queryHeader);

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlerTestBase.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleHandlerTestBase.java
@@ -18,6 +18,9 @@ package com.hedera.node.app.service.schedule.impl.handlers;
 
 import static com.hedera.node.app.signature.impl.SignatureVerificationImpl.failedVerification;
 import static com.hedera.node.app.signature.impl.SignatureVerificationImpl.passedVerification;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -184,11 +187,12 @@ class ScheduleHandlerTestBase extends ScheduleTestBase {
                         any(AccountID.class),
                         any(TransactionCategory.class),
                         any()))
-                .willReturn(new RecordStreamBuilder());
+                .willReturn(new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER));
 
         final var mockStack = mock(HandleContext.SavepointStack.class);
         given(mockContext.savepointStack()).willReturn(mockStack);
-        given(mockStack.getBaseBuilder(ScheduleStreamBuilder.class)).willReturn(new RecordStreamBuilder());
+        given(mockStack.getBaseBuilder(ScheduleStreamBuilder.class))
+                .willReturn(new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER));
     }
 
     private static TransactionKeys createChildKeys(

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/FrameUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/FrameUtils.java
@@ -32,7 +32,7 @@ import com.hedera.node.app.service.contract.impl.hevm.HevmPropagatedCallFailure;
 import com.hedera.node.app.service.contract.impl.infra.StorageAccessTracker;
 import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import com.hedera.node.config.data.ContractsConfig;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -143,7 +143,7 @@ public class FrameUtils {
      * @param frame the frame whose EVM transaction we are tracking beneficiaries in
      * @return the record builder able to track beneficiary ids
      */
-    public static @NonNull DeleteCapableTransactionRecordBuilder selfDestructBeneficiariesFor(
+    public static @NonNull DeleteCapableTransactionStreamBuilder selfDestructBeneficiariesFor(
             @NonNull final MessageFrame frame) {
         return requireNonNull(initialFrameOf(frame).getContextVariable(HAPI_RECORD_BUILDER_CONTEXT_VARIABLE));
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractDeleteStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractDeleteStreamBuilder.java
@@ -18,14 +18,14 @@ package com.hedera.node.app.service.contract.impl.records;
 
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.Transaction;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A {@code StreamBuilder} specialization for tracking the side effects of a {@code ContractDelete}.
  */
-public interface ContractDeleteStreamBuilder extends DeleteCapableTransactionRecordBuilder {
+public interface ContractDeleteStreamBuilder extends DeleteCapableTransactionStreamBuilder {
     /**
      * Tracks the contract id deleted by a successful top-level contract deletion.
      *

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractOperationStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractOperationStreamBuilder.java
@@ -23,11 +23,11 @@ import com.hedera.hapi.streams.ContractActions;
 import com.hedera.hapi.streams.ContractBytecode;
 import com.hedera.hapi.streams.ContractStateChanges;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
 
-public interface ContractOperationStreamBuilder extends DeleteCapableTransactionRecordBuilder {
+public interface ContractOperationStreamBuilder extends DeleteCapableTransactionStreamBuilder {
     /**
      * Sets the transaction fee.
      *

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractUpdateStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/ContractUpdateStreamBuilder.java
@@ -17,14 +17,14 @@
 package com.hedera.node.app.service.contract.impl.records;
 
 import com.hedera.hapi.node.base.ContractID;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A {@code StreamBuilder} specialization for tracking the side effects of a {@code ContractUpdate}.
  */
-public interface ContractUpdateStreamBuilder extends DeleteCapableTransactionRecordBuilder {
+public interface ContractUpdateStreamBuilder extends DeleteCapableTransactionStreamBuilder {
     /**
      * Tracks the contract id updated by a successful top-level contract update operation.
      *

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/EthereumTransactionStreamBuilder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/records/EthereumTransactionStreamBuilder.java
@@ -68,7 +68,4 @@ public interface EthereumTransactionStreamBuilder extends ContractOperationStrea
      */
     @NonNull
     EthereumTransactionStreamBuilder ethereumHash(@NonNull Bytes ethereumHash);
-
-    @NonNull
-    EthereumTransactionStreamBuilder feeChargedToPayer(@NonNull long amount);
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaNativeOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaNativeOperationsTest.java
@@ -68,7 +68,7 @@ import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.spi.ids.EntityNumGenerator;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.function.Predicate;
@@ -301,7 +301,7 @@ class HandleHederaNativeOperationsTest {
 
     @Test
     void trackDeletionUpdatesMap() {
-        final DeleteCapableTransactionRecordBuilder beneficiaries = mock(DeleteCapableTransactionRecordBuilder.class);
+        final DeleteCapableTransactionStreamBuilder beneficiaries = mock(DeleteCapableTransactionStreamBuilder.class);
         given(frame.getMessageFrameStack()).willReturn(stack);
         stack.push(frame);
         given(frame.getContextVariable(HAPI_RECORD_BUILDER_CONTEXT_VARIABLE)).willReturn(beneficiaries);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/FrameUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/FrameUtilsTest.java
@@ -55,7 +55,7 @@ import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import com.hedera.node.app.service.contract.impl.utils.OpcodeUtils;
 import com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -302,7 +302,7 @@ class FrameUtilsTest {
     void checksForBeneficiaryMapAsExpected() {
         givenNonInitialFrame();
         given(frame.getMessageFrameStack()).willReturn(stack);
-        final DeleteCapableTransactionRecordBuilder beneficiaries = mock(DeleteCapableTransactionRecordBuilder.class);
+        final DeleteCapableTransactionStreamBuilder beneficiaries = mock(DeleteCapableTransactionStreamBuilder.class);
         given(initialFrame.getContextVariable(HAPI_RECORD_BUILDER_CONTEXT_VARIABLE))
                 .willReturn(beneficiaries);
         assertSame(beneficiaries, selfDestructBeneficiariesFor(frame));

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/records/ContractOperationStreamBuilderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/records/ContractOperationStreamBuilderTest.java
@@ -52,6 +52,11 @@ class ContractOperationStreamBuilderTest {
     void withGasFeeWorksAsExpected() {
         final var subject = new ContractOperationStreamBuilder() {
             @Override
+            public StreamBuilder serializedTransaction(@Nullable Bytes serializedTransaction) {
+                return this;
+            }
+
+            @Override
             public int getNumAutoAssociations() {
                 return 0;
             }
@@ -93,6 +98,11 @@ class ContractOperationStreamBuilderTest {
 
             @Override
             public StreamBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate) {
+                return this;
+            }
+
+            @Override
+            public StreamBuilder congestionMultiplier(final long congestionMultiplier) {
                 return this;
             }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/api/TokenServiceApiImpl.java
@@ -45,7 +45,7 @@ import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.spi.validation.EntityType;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
@@ -492,7 +492,7 @@ public class TokenServiceApiImpl implements TokenServiceApi {
             @NonNull final AccountID deletedId,
             @NonNull final AccountID obtainerId,
             @NonNull final ExpiryValidator expiryValidator,
-            @NonNull final DeleteCapableTransactionRecordBuilder recordBuilder,
+            @NonNull final DeleteCapableTransactionStreamBuilder recordBuilder,
             @NonNull final FreeAliasOnDeletion freeAliasOnDeletion) {
         // validate the semantics involving dynamic properties and state.
         // Gets delete and transfer accounts from state

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsDistributor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsDistributor.java
@@ -23,7 +23,7 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.HashMap;
@@ -74,7 +74,7 @@ public class StakingRewardsDistributor {
             @NonNull final WritableNetworkStakingRewardsStore stakingRewardsStore,
             @NonNull final WritableStakingInfoStore stakingInfoStore,
             @NonNull final Instant consensusNow,
-            @NonNull final DeleteCapableTransactionRecordBuilder recordBuilder) {
+            @NonNull final DeleteCapableTransactionStreamBuilder recordBuilder) {
         requireNonNull(possibleRewardReceivers);
 
         final Map<AccountID, Long> rewardsPaid = new HashMap<>();

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
@@ -33,7 +33,7 @@ import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
 import com.hedera.node.app.service.token.records.FinalizeContext;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import com.hedera.node.config.data.AccountsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -100,7 +100,7 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
         // a SCHEDULED dispatch)
         rewardReceivers.removeAll(prePaidRewards.keySet());
         // Pay rewards to all possible reward receivers, returns all rewards paid
-        final var recordBuilder = context.userTransactionRecordBuilder(DeleteCapableTransactionRecordBuilder.class);
+        final var recordBuilder = context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class);
         final var rewardsPaid = rewardsPayer.payRewardsIfPending(
                 rewardReceivers, writableStore, stakingRewardsStore, stakingInfoStore, consensusNow, recordBuilder);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAccountWipeHandlerTest.java
@@ -82,6 +82,7 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
@@ -113,6 +114,11 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
                 .getOrCreateConfig();
         recordBuilder = new TokenAccountWipeStreamBuilder() {
             private long newTotalSupply;
+
+            @Override
+            public StreamBuilder serializedTransaction(@Nullable Bytes serializedTransaction) {
+                return this;
+            }
 
             @Override
             public int getNumAutoAssociations() {
@@ -161,6 +167,11 @@ class TokenAccountWipeHandlerTest extends ParityTestBase {
 
             @Override
             public StreamBuilder exchangeRate(@NonNull ExchangeRateSet exchangeRate) {
+                return this;
+            }
+
+            @Override
+            public StreamBuilder congestionMultiplier(final long congestionMultiplier) {
                 return this;
             }
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenBurnHandlerTest.java
@@ -37,6 +37,9 @@ import static com.hedera.node.app.service.token.impl.test.handlers.util.TestStor
 import static com.hedera.node.app.service.token.impl.test.handlers.util.TestStoreFactory.newWritableStoreWithTokens;
 import static com.hedera.node.app.service.token.impl.test.keys.KeysAndIds.TOKEN_SUPPLY_KT;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -385,7 +388,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
                     .build());
             final var txn = newBurnTxn(TOKEN_123, 8);
             final var context = mockContext(txn);
-            final var recordBuilder = new RecordStreamBuilder();
+            final var recordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
             given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
@@ -425,7 +428,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
                     .build());
             final var txn = newBurnTxn(TOKEN_123, 8);
             final var context = mockContext(txn);
-            final var recordBuilder = new RecordStreamBuilder();
+            final var recordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
             given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
@@ -706,7 +709,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L);
             final var context = mockContext(txn);
-            final var recordBuilder = new RecordStreamBuilder();
+            final var recordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
             given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
@@ -769,7 +772,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L, 3L);
             final var context = mockContext(txn);
-            final var recordBuilder = new RecordStreamBuilder();
+            final var recordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
             given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 
@@ -833,7 +836,7 @@ class TokenBurnHandlerTest extends ParityTestBase {
                             .build());
             final var txn = newBurnTxn(TOKEN_123, 0, 1L, 2L, 3L, 1L, 2L, 3L, 3L, 1L, 1L, 2L);
             final var context = mockContext(txn);
-            final var recordBuilder = new RecordStreamBuilder();
+            final var recordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
             given(context.savepointStack().getBaseBuilder(TokenBurnStreamBuilder.class))
                     .willReturn(recordBuilder);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCreateHandlerTest.java
@@ -45,6 +45,9 @@ import static com.hedera.node.app.service.token.impl.TokenServiceImpl.THREE_MONT
 import static com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTestBase.A_COMPLEX_KEY;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static com.hedera.node.app.spi.key.KeyUtils.IMMUTABILITY_SENTINEL_KEY;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -128,7 +131,7 @@ class TokenCreateHandlerTest extends CryptoTokenHandlerTestBase {
     public void setUp() {
         super.setUp();
         refreshWritableStores();
-        recordBuilder = new RecordStreamBuilder();
+        recordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
         tokenFieldsValidator = new TokenAttributesValidator();
         customFeesValidator = new CustomFeesValidator();
         tokenCreateValidator = new TokenCreateValidator(tokenFieldsValidator);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
@@ -26,6 +26,9 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_IS_PAUSED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_WAS_DELETED;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -76,7 +79,7 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
         refreshWritableStores();
         givenStoresAndConfig(handleContext);
         subject = new TokenMintHandler(new TokenSupplyChangeOpsValidator());
-        recordBuilder = new RecordStreamBuilder();
+        recordBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -42,7 +42,7 @@ import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHand
 import com.hedera.node.app.service.token.records.CryptoDeleteStreamBuilder;
 import com.hedera.node.app.service.token.records.FinalizeContext;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import com.hedera.node.config.ConfigProvider;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -492,7 +492,7 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
                         .atStartOfDay(ZoneOffset.UTC)
                         .toInstant());
         given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
-        given(context.userTransactionRecordBuilder(DeleteCapableTransactionRecordBuilder.class))
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
                 .willReturn(recordBuilder);
         given(recordBuilder.getNumberOfDeletedAccounts()).willReturn(1);
         given(recordBuilder.getDeletedAccountBeneficiaryFor(payerId)).willReturn(ownerId);
@@ -734,7 +734,7 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
                         .atStartOfDay(ZoneOffset.UTC)
                         .toInstant());
         given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
-        given(context.userTransactionRecordBuilder(DeleteCapableTransactionRecordBuilder.class))
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
                 .willReturn(recordBuilder);
         given(recordBuilder.getNumberOfDeletedAccounts()).willReturn(1);
         given(recordBuilder.getDeletedAccountBeneficiaryFor(payerId)).willReturn(ownerId);
@@ -786,7 +786,7 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
                         .atStartOfDay(ZoneOffset.UTC)
                         .toInstant());
         given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
-        given(context.userTransactionRecordBuilder(DeleteCapableTransactionRecordBuilder.class))
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
                 .willReturn(recordBuilder);
         given(recordBuilder.getNumberOfDeletedAccounts()).willReturn(1);
         given(recordBuilder.getDeletedAccountBeneficiaryFor(payerId)).willReturn(ownerId);
@@ -842,7 +842,7 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
                         .atStartOfDay(ZoneOffset.UTC)
                         .toInstant());
         given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
-        given(context.userTransactionRecordBuilder(DeleteCapableTransactionRecordBuilder.class))
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
                 .willReturn(recordBuilder);
 
         given(recordBuilder.getNumberOfDeletedAccounts()).willReturn(2);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustFungibleTokenChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustFungibleTokenChangesStepTest.java
@@ -23,6 +23,9 @@ import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.aaWith;
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.aaWithAllowance;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +46,7 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesSte
 import com.hedera.node.app.service.token.impl.handlers.transfer.ReplaceAliasesWithIDsInOp;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
 import com.hedera.node.app.spi.workflows.HandleException;
+import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.workflows.handle.record.RecordStreamBuilder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,7 +67,8 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
         associateTokenRecepientsStep = new AssociateTokenRecipientsStep(body);
         transferContext = new TransferContextImpl(handleContext);
         writableTokenStore.put(givenValidFungibleToken(ownerId, false, false, false, false, false));
-        given(handleContext.dispatchRemovablePrecedingTransaction(any(), any(), eq(null), any(), any()))
+        given(handleContext.dispatchRemovablePrecedingTransaction(
+                        any(), eq(StreamBuilder.class), eq(null), any(), any()))
                 .will((invocation) -> {
                     final var relation =
                             new TokenRelation(fungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
@@ -71,7 +76,7 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
                             new TokenRelation(nonFungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new RecordStreamBuilder().status(SUCCESS);
+                    return new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER).status(SUCCESS);
                 });
     }
 
@@ -145,7 +150,7 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
         assertThat(receiverAccountBefore.numberPositiveBalances()).isEqualTo(2);
         assertThat(senderRelBefore.balance()).isEqualTo(1000L);
         // There is an association happening during the transfer for auto creation
-        assertThat(receiverRelBefore.balance()).isEqualTo(1);
+        assertThat(receiverRelBefore.balance()).isEqualTo(0);
 
         assertThat(senderAccountBefore.tokenAllowances()).hasSize(1);
 
@@ -161,7 +166,7 @@ class AdjustFungibleTokenChangesStepTest extends StepsBase {
         assertThat(senderAccountAfter.numberPositiveBalances())
                 .isEqualTo(senderAccountBefore.numberPositiveBalances() - 1);
         assertThat(receiverAccountAfter.numberPositiveBalances())
-                .isEqualTo(receiverAccountBefore.numberPositiveBalances());
+                .isEqualTo(receiverAccountBefore.numberPositiveBalances() + 1);
         assertThat(senderRelAfter.balance()).isEqualTo(senderRelBefore.balance() - 1000);
         assertThat(receiverRelAfter.balance()).isEqualTo(receiverRelBefore.balance() + 1000);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
@@ -22,6 +22,9 @@ import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.aaWith;
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.aaWithAllowance;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -68,7 +71,7 @@ class AdjustHbarChangesStepTest extends StepsBase {
                             new TokenRelation(nonFungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new RecordStreamBuilder().status(SUCCESS);
+                    return new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER).status(SUCCESS);
                 });
         // since we can't change NFT owner with auto association if KYC key exists on token
         writableTokenStore.put(nonFungibleToken.copyBuilder().kycKey((Key) null).build());

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/CustomFeeAssessmentStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/CustomFeeAssessmentStepTest.java
@@ -20,6 +20,9 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.asAccount;
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.aaWith;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -77,7 +80,7 @@ class CustomFeeAssessmentStepTest extends StepsBase {
                             new TokenRelation(nonFungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new RecordStreamBuilder().status(SUCCESS);
+                    return new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER).status(SUCCESS);
                 });
 
         refreshWritableStores();
@@ -393,7 +396,7 @@ class CustomFeeAssessmentStepTest extends StepsBase {
                             new TokenRelation(fungibleTokenIDB, payerId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new RecordStreamBuilder().status(SUCCESS);
+                    return new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER).status(SUCCESS);
                 });
         givenDifferentTxn(body, payerId);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/NFTOwnersChangeStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/NFTOwnersChangeStepTest.java
@@ -23,6 +23,9 @@ import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.aaWith;
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.nftTransferWithAllowance;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.ExternalizedRecordCustomizer.NOOP_RECORD_CUSTOMIZER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,7 +69,7 @@ class NFTOwnersChangeStepTest extends StepsBase {
                             new TokenRelation(nonFungibleTokenId, tokenReceiverId, 1, false, true, true, null, null);
                     writableTokenRelStore.put(relation);
                     writableTokenRelStore.put(relation1);
-                    return new RecordStreamBuilder().status(SUCCESS);
+                    return new RecordStreamBuilder(REVERSIBLE, NOOP_RECORD_CUSTOMIZER, USER).status(SUCCESS);
                 });
 
         refreshWritableStores();

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/TokenServiceApi.java
@@ -24,7 +24,7 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.spi.info.NetworkInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -76,7 +76,7 @@ public interface TokenServiceApi {
             @NonNull AccountID deletedId,
             @NonNull AccountID obtainerId,
             @NonNull ExpiryValidator expiryValidator,
-            @NonNull DeleteCapableTransactionRecordBuilder recordBuilder,
+            @NonNull DeleteCapableTransactionStreamBuilder recordBuilder,
             @NonNull FreeAliasOnDeletion freeAliasOnDeletion);
 
     /**

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoDeleteStreamBuilder.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/records/CryptoDeleteStreamBuilder.java
@@ -16,10 +16,10 @@
 
 package com.hedera.node.app.service.token.records;
 
-import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionRecordBuilder;
+import com.hedera.node.app.spi.workflows.record.DeleteCapableTransactionStreamBuilder;
 
 /**
  * A {@code StreamBuilder} specialization for tracking the side effects of a {@code CryptoDelete}
  * transaction.
  */
-public interface CryptoDeleteStreamBuilder extends DeleteCapableTransactionRecordBuilder {}
+public interface CryptoDeleteStreamBuilder extends DeleteCapableTransactionStreamBuilder {}


### PR DESCRIPTION
**Description**:
Adds all `BlockStreamBuilder `changes needed for block streams. This is a sub part of the long lived branch for block streams https://github.com/hashgraph/hedera-services/pull/14579

`BlockStreamBuilder` implements the `StreamBuilder `interface and several other interfaces related to different types of transactions. It's responsible for building block items for a single user or synthetic transaction. It contains methods for setting and getting various transaction details, such as the transaction ID, consensus timestamp, transaction fee, and more.
**Related issue(s)**:

Fixes #15163 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
