### PR TITLE
ci: fix build application workflow

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -23,18 +23,8 @@ on:
         type: boolean
         required: false
         default: true
-      enable-integration-tests:
-        description: "Integration Testing Enabled"
-        type: boolean
-        required: false
-        default: false
       enable-hapi-tests:
         description: "HAPI Testing Enabled"
-        type: boolean
-        required: false
-        default: false
-      enable-e2e-tests:
-        description: "E2E Testing Enabled"
         type: boolean
         required: false
         default: false
@@ -76,7 +66,6 @@ jobs:
       java-version: ${{ github.event.inputs.java-version || '21' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
       enable-unit-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-unit-tests == 'true' }}
-      enable-integration-tests: ${{ github.event.inputs.enable-integration-tests == 'true' }}
       enable-hapi-tests-misc: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
       enable-hapi-tests-crypto: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
       enable-hapi-tests-token: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
@@ -84,7 +73,6 @@ jobs:
       enable-hapi-tests-time-consuming: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
       enable-hapi-tests-restart: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
       enable-hapi-tests-nd-reconnect: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-e2e-tests: ${{ github.event.inputs.enable-e2e-tests == 'true' }}
       enable-spotless-check: ${{ github.event.inputs.enable-spotless-check == 'true' }}
       enable-snyk-scan: ${{ github.event_name == 'push' || github.event.inputs.enable-snyk-scan == 'true' }}
       enable-network-log-capture: true


### PR DESCRIPTION
## Description

This pull request changes the following:

- Fixes the `Node: Build Application` workflow definition by removing the `enable-integration-tests` and `enabled-e2e-tests` which no longer exist in the reusable workflow being called.

### Related Issues

- Closes #15168 

### Passing Workflow Runs

- https://github.com/hashgraph/hedera-services/actions/runs/10587478941