### PR TITLE
chore: Sync latest block stream proto changes

### DIFF
--- a/hapi/hedera-protobufs/block/stream/output/state_changes.proto
+++ b/hapi/hedera-protobufs/block/stream/output/state_changes.proto
@@ -51,6 +51,8 @@ import "state/contract/bytecode.proto";
 import "state/contract/storage_slot.proto";
 import "state/file/file.proto";
 import "state/recordcache/recordcache.proto";
+import "state/roster/roster.proto";
+import "state/roster/roster_state.proto";
 import "state/schedule/schedule.proto";
 import "state/throttles/throttle_usage_snapshots.proto";
 import "state/token/account.proto";
@@ -342,6 +344,16 @@ enum StateIdentifier {
     STATE_ID_PLATFORM_STATE = 26;
 
     /**
+     * A state identifier for the roster state singleton.
+     */
+    STATE_ID_ROSTER_STATE = 27;
+
+    /**
+     * A state identifier for the rosters key/value map.
+     */
+    STATE_ID_ROSTERS = 28;
+
+    /**
      * A state identifier for the round receipts queue.
      */
     STATE_ID_TRANSACTION_RECEIPTS_QUEUE = 126;
@@ -545,6 +557,11 @@ message SingletonUpdateChange {
          * A change to the platform state singleton.
          */
         com.hedera.hapi.platform.state.PlatformState platform_state_value = 12;
+
+        /**
+         * A change to the roster state singleton.
+         */
+        com.hedera.hapi.node.state.roster.RosterState roster_state_value = 13;
     }
 }
 
@@ -774,6 +791,10 @@ message MapChangeValue {
          */
         proto.AccountPendingAirdrop account_pending_airdrop_value = 15;
 
+        /**
+         * A pending roster value.
+         */
+        com.hedera.hapi.node.state.roster.Roster roster_value = 16;
     }
 }
 

--- a/hapi/hedera-protobufs/services/state/blockstream/block_stream_info.proto
+++ b/hapi/hedera-protobufs/services/state/blockstream/block_stream_info.proto
@@ -47,37 +47,35 @@ option java_multiple_files = true;
  */
 message BlockStreamInfo {
     /**
-     * A block number.<br/>
-     * This is the block number of the last completed block.
+     * The number of the block this state has information about.
      */
-    uint64 last_block_number = 1;
+    uint64 block_number = 1;
 
     /**
-     * A block hash value.<br/>
-     * This is the hash of the last completed block.
-     */
-    bytes last_block_hash = 2;
-
-    /**
-     * A consensus time for the last completed block.
+     * The first consensus time in this block.
      * This is used to determine if this block was the first across an
      * important boundary in consensus time, such as UTC midnight.
      * This may also be used to purge entities expiring between the last
      * block time and this time.
      */
-    proto.Timestamp last_block_time = 3;
+    proto.Timestamp block_time = 2;
 
     /**
      * A concatenation of hash values.<br/>
      * This combines several trailing output block item hashes and
      * is used as a seed value for a pseudo-random number generator.
      */
-    bytes trailing_output_hashes = 4;
+    bytes trailing_output_hashes = 3;
 
     /**
      * A concatenation of hash values.<br/>
      * This combines the last 256 trailing block hashes, and is required to
      * support the EVM `BLOCKHASH` opcode.
      */
-    bytes trailing_block_hashes = 5;
+    bytes trailing_block_hashes = 4;
+
+    /**
+     * The hash of the state at the start of the block.
+     */
+    bytes starting_state_hash = 5;
 }


### PR DESCRIPTION
* Create `roster` and `roster_state` protos
* Various property updates to `block_stream_info`