### PR TITLE
fix: publishToSonatype failing due to hedera.evm overwriting itself in MC

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.evm-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.evm-publish.gradle.kts
@@ -30,7 +30,6 @@ tasks.withType<PublishToMavenRepository>().configureEach {
 publishing {
     publications {
         named<MavenPublication>("maven") {
-            artifactId = "hedera-evm"
             pom.developers {
                 developer {
                     name = "Hedera Base Team"

--- a/hedera-node/hedera-evm-impl/build.gradle.kts
+++ b/hedera-node/hedera-evm-impl/build.gradle.kts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-plugins {
-    id("com.hedera.gradle.evm")
-    id("com.hedera.gradle.evm-publish")
-}
+plugins { id("com.hedera.gradle.evm") }
 
 description = "Hedera EVM - Implementation"


### PR DESCRIPTION
**Description**:

The maven central release process had two modules hedera-evm and hedera-evm-impl that were both configured to publish as hedera-evm. This led to an issue in maven central where the hedera-evm module was actually the hedera-evm-impl module, but the verification checks were looking for the hedera-evm module.

The hedera-evm  module couldn't be properly verified and caused a failure.

So this PR does two things:

- It stops the hedera-evm-publish gradle plugin from overwriting all java modules that it publishes from overwriting the hedera-evm module
- It stops publishing the empty project hedera-evm-impl

**Related issue(s)**:

Fixes #15173 

