### PR TITLE
ci: disable release 0.52 regression

### DIFF
--- a/.github/workflows/node-zxcron-release-fsts-regression.yaml
+++ b/.github/workflows/node-zxcron-release-fsts-regression.yaml
@@ -51,7 +51,7 @@ jobs:
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
 
-            if [[ "${major}" -eq 0 && "${minor}" -lt 52 ]]; then
+            if [[ "${major}" -eq 0 && "${minor}" -lt 53 ]]; then
               continue
             fi
 

--- a/.github/workflows/platform-zxcron-release-jrs-regression.yaml
+++ b/.github/workflows/platform-zxcron-release-jrs-regression.yaml
@@ -51,7 +51,7 @@ jobs:
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
 
-            if [[ "${major}" -eq 0 && "${minor}" -lt 52 ]]; then
+            if [[ "${major}" -eq 0 && "${minor}" -lt 53 ]]; then
               continue
             fi
 


### PR DESCRIPTION
**Description**:

disable release 0.52 regression since it is on mainnet already

**Related issue(s)**:

Fixes #15227
