### PR TITLE
chore: Update tests to use latest valid block stream info protobuf

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockStreamServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockStreamServiceTest.java
@@ -87,8 +87,7 @@ final class BlockStreamServiceTest {
             schema.migrate(migrationContext);
 
             verify(blockStreamState).put(blockInfoCapture.capture());
-            assertEquals(
-                    new BlockStreamInfo(0, Bytes.EMPTY, null, Bytes.EMPTY, Bytes.EMPTY), blockInfoCapture.getValue());
+            assertEquals(new BlockStreamInfo(0, null, Bytes.EMPTY, Bytes.EMPTY), blockInfoCapture.getValue());
             return null;
         });
         final var testConfig = HederaTestConfigBuilder.create()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/schemas/V0540BlockStreamSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/schemas/V0540BlockStreamSchemaTest.java
@@ -87,6 +87,6 @@ public class V0540BlockStreamSchemaTest {
         verify(mockBlockStreamInfo).put(captor.capture());
 
         BlockStreamInfo blockInfoCapture = captor.getValue();
-        assertEquals(new BlockStreamInfo(0, Bytes.EMPTY, null, Bytes.EMPTY, Bytes.EMPTY), blockInfoCapture);
+        assertEquals(new BlockStreamInfo(0, null, Bytes.EMPTY, Bytes.EMPTY), blockInfoCapture);
     }
 }


### PR DESCRIPTION
The `BlockStreamInfo` definition, generated from `block_stream_info.proto`, has changed. This PR removes the extra param from any test instantiations of `BlockStreamInfo`