### PR TITLE
build: add back 'platform-sdk/swirlds' as Gradle project

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,6 +35,7 @@ javaModules {
     directory("platform-sdk") {
         group = "com.swirlds"
         module("swirlds-jasperdb") { artifact = "swirlds-merkledb" }
+        module("swirlds") // not actually a Module as it has no module-info.java
         module("swirlds-benchmarks") // not actually a Module as it has no module-info.java
         module("swirlds-unit-tests/core/swirlds-platform-test") // nested module is not found automatically
     }


### PR DESCRIPTION
**Description**:

This was accidentally remove in #14245

**Related issue(s)**:

#14245

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
