### PR TITLE
chore: Fix compiler warnings in `hedera-config`

### DIFF
--- a/hedera-node/hedera-config/build.gradle.kts
+++ b/hedera-node/hedera-config/build.gradle.kts
@@ -22,10 +22,6 @@ plugins {
 
 description = "Hedera Configuration"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
-
 testModuleInfo {
     requires("com.hedera.node.config")
     requires("com.swirlds.config.extensions.test.fixtures")

--- a/hedera-node/hedera-config/src/testFixtures/java/module-info.java
+++ b/hedera-node/hedera-config/src/testFixtures/java/module-info.java
@@ -1,10 +1,10 @@
 module com.hedera.node.config.test.fixtures {
     exports com.hedera.node.config.testfixtures;
 
+    requires transitive com.hedera.node.config;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.config.extensions.test.fixtures;
     requires com.hedera.node.app.hapi.utils;
-    requires com.hedera.node.config;
     requires com.hedera.node.hapi;
     requires com.swirlds.common;
     requires com.swirlds.merkledb;


### PR DESCRIPTION
**Description**:
Removed `tasks.withType<>...` line from `build.gradle.kts` files in `hedera-config` which disables warnings for those packages.

- Inside test `module-info.java` file `com.hedera.node.config` is changed to `transitive` because of `ConfigProvider`

**Related issue(s)**:

Fixes #15239 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
