### PR TITLE
chore: Fix compiler warnings in `hedera-app-spi`

### DIFF
--- a/hedera-node/hedera-app-spi/build.gradle.kts
+++ b/hedera-node/hedera-app-spi/build.gradle.kts
@@ -22,10 +22,6 @@ plugins {
 
 description = "Hedera Application - SPI"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports") }
-
 testModuleInfo {
     requires("com.hedera.node.app.spi")
     requires("com.swirlds.state.api.test.fixtures")

--- a/hedera-node/hedera-app-spi/src/testFixtures/java/module-info.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/module-info.java
@@ -4,6 +4,7 @@ module com.hedera.node.app.spi.test.fixtures {
     exports com.hedera.node.app.spi.fixtures.workflows;
     exports com.hedera.node.app.spi.fixtures.util;
 
+    requires transitive com.hedera.node.app.service.token; // TMP until FakePreHandleContext can be removed
     requires transitive com.hedera.node.app.spi;
     requires transitive com.hedera.node.hapi;
     requires transitive com.swirlds.config.api;
@@ -17,6 +18,5 @@ module com.hedera.node.app.spi.test.fixtures {
     requires com.hedera.node.app.hapi.utils;
     requires com.swirlds.common;
     requires org.apache.logging.log4j.core;
-    requires static com.hedera.node.app.service.token; // TMP until FakePreHandleContext can be removed
     requires static com.github.spotbugs.annotations;
 }


### PR DESCRIPTION
**Description**:
Removed `tasks.withType<>...` line from `build.gradle.kts` files in `hedera-app-spi` which disables warnings for those packages.

- Inside test `module-info.java` file `com.hedera.node.app.service.token` is changed to `transitive` because of `FakePreHandleContext`

**Related issue(s)**:

Fixes #15241 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
