### PR TITLE
feat: utility to retrieve a Roster for a round

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/InvalidAddressBookException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/InvalidAddressBookException.java
@@ -17,7 +17,7 @@
 package com.swirlds.platform.roster;
 
 /**
- * An exception thrown by the RosterValidator when a given Roster is invalid.
+ * An exception thrown by the RosterRetriever.buildRoster() when a given AddressBook is invalid.
  */
 public class InvalidAddressBookException extends RuntimeException {
     /**


### PR DESCRIPTION
**Description**:
* Extending the `RosterRetriever` to be able to retrieve a Roster instance for a specific round number.
* Minor refactoring of the supporting unit test to help test the new utility.
* Addressing a minor typo identified at https://github.com/hashgraph/hedera-services/pull/15096#discussion_r1735343278

**Related issue(s)**:

Fixes #14969

**Notes for reviewer**:
Unit tests.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
