### PR TITLE
fix: write s-public-alias.pem file for each node to a configurable location

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
@@ -25,19 +25,19 @@ import com.swirlds.config.api.ConfigProperty;
  *
  * @param upgradeArtifactsPath path to the location where upgrade files are stored once uncompressed, and upgrade
  *                             marker files are written
+ * @param keysPath path to the generated public key *.pem files during freeze prepare upgrade
  * @param upgradeSysFilesLoc path to the location where post-upgrade system files are located
  * @param upgradeFeeSchedulesFile name of the file containing the post-upgrade fee schedules
  * @param upgradeThrottlesFile name of the file containing the post-upgrade throttles
  * @param upgradePropertyOverridesFile name of the file containing the post-upgrade override properties
  * @param upgradePermissionOverridesFile name of the file containing the post-upgrade override permissions
- * @param keysPath path to the generated public key *.pem files during freeze prepare upgrade
  */
 @ConfigData("networkAdmin")
 public record NetworkAdminConfig(
         @ConfigProperty(defaultValue = "data/upgrade/current") @NodeProperty String upgradeArtifactsPath,
+        @ConfigProperty(defaultValue = "data/upgrade/current/data/keys") @NodeProperty String keysPath,
         @ConfigProperty(defaultValue = "data/config") String upgradeSysFilesLoc,
         @ConfigProperty(defaultValue = "feeSchedules.json") String upgradeFeeSchedulesFile,
         @ConfigProperty(defaultValue = "throttles.json") String upgradeThrottlesFile,
         @ConfigProperty(defaultValue = "application-override.properties") String upgradePropertyOverridesFile,
-        @ConfigProperty(defaultValue = "api-permission-override.properties") String upgradePermissionOverridesFile,
-        @ConfigProperty(defaultValue = "data/upgrade/current/data/keys") @NodeProperty String keysPath) {}
+        @ConfigProperty(defaultValue = "api-permission-override.properties") String upgradePermissionOverridesFile) {}

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
@@ -30,6 +30,7 @@ import com.swirlds.config.api.ConfigProperty;
  * @param upgradeThrottlesFile name of the file containing the post-upgrade throttles
  * @param upgradePropertyOverridesFile name of the file containing the post-upgrade override properties
  * @param upgradePermissionOverridesFile name of the file containing the post-upgrade override permissions
+ * @param keysPath path to the generated public key *.pem files during freeze prepare upgrade
  */
 @ConfigData("networkAdmin")
 public record NetworkAdminConfig(
@@ -38,4 +39,5 @@ public record NetworkAdminConfig(
         @ConfigProperty(defaultValue = "feeSchedules.json") String upgradeFeeSchedulesFile,
         @ConfigProperty(defaultValue = "throttles.json") String upgradeThrottlesFile,
         @ConfigProperty(defaultValue = "application-override.properties") String upgradePropertyOverridesFile,
-        @ConfigProperty(defaultValue = "api-permission-override.properties") String upgradePermissionOverridesFile) {}
+        @ConfigProperty(defaultValue = "api-permission-override.properties") String upgradePermissionOverridesFile,
+        @ConfigProperty(defaultValue = "data/upgrade/current/data/keys") @NodeProperty String keysPath) {}

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/ReadableFreezeUpgradeActions.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/ReadableFreezeUpgradeActions.java
@@ -270,11 +270,11 @@ public class ReadableFreezeUpgradeActions {
             if (!FileUtils.isDirectory(artifactsDir)) {
                 FileUtils.forceMkdir(artifactsDir);
             }
+            FileUtils.cleanDirectory(artifactsDir);
             if (!FileUtils.isDirectory(keysDir)) {
                 FileUtils.forceMkdir(keysDir);
             }
-            FileUtils.cleanDirectory(artifactsDir);
-            if (!keysLoc.startsWith(artifactsLoc)) FileUtils.cleanDirectory(keysDir);
+            FileUtils.cleanDirectory(keysDir);
             UnzipUtility.unzip(archiveData.toByteArray(), artifactsLoc);
             log.info("Finished unzipping {} bytes for {} update into {}", size, desc, artifactsLoc);
             if (nodes != null && nodesConfig.enableDAB()) {

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/ReadableFreezeUpgradeActions.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/ReadableFreezeUpgradeActions.java
@@ -274,7 +274,7 @@ public class ReadableFreezeUpgradeActions {
                 FileUtils.forceMkdir(keysDir);
             }
             FileUtils.cleanDirectory(artifactsDir);
-            FileUtils.cleanDirectory(keysDir);
+            if (!keysLoc.startsWith(artifactsLoc)) FileUtils.cleanDirectory(keysDir);
             UnzipUtility.unzip(archiveData.toByteArray(), artifactsLoc);
             log.info("Finished unzipping {} bytes for {} update into {}", size, desc, artifactsLoc);
             if (nodes != null && nodesConfig.enableDAB()) {

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/ReadableFreezeUpgradeActionsTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/ReadableFreezeUpgradeActionsTest.java
@@ -126,6 +126,9 @@ class ReadableFreezeUpgradeActionsTest {
     @TempDir
     private File zipOutputDir; // temp directory to place marker files and output of zip extraction
 
+    @TempDir
+    private File keysDir;
+
     @Mock
     private WritableFreezeStore writableFreezeStore;
 
@@ -196,6 +199,7 @@ class ReadableFreezeUpgradeActionsTest {
         rmIfPresent(EXEC_IMMEDIATE_MARKER);
 
         given(adminServiceConfig.upgradeArtifactsPath()).willReturn(zipOutputDir.toString());
+        given(adminServiceConfig.keysPath()).willReturn(keysDir.toString());
 
         final Bytes invalidArchive = Bytes.wrap("Not a valid zip archive".getBytes(StandardCharsets.UTF_8));
         subject.extractSoftwareUpgrade(invalidArchive).join();
@@ -214,6 +218,7 @@ class ReadableFreezeUpgradeActionsTest {
         rmIfPresent(EXEC_IMMEDIATE_MARKER);
 
         given(adminServiceConfig.upgradeArtifactsPath()).willReturn(zipOutputDir.toString());
+        given(adminServiceConfig.keysPath()).willReturn(keysDir.toString());
         given(nodesConfig.enableDAB()).willReturn(true);
 
         final Bytes realArchive = Bytes.wrap(Files.readAllBytes(zipArchivePath));
@@ -230,12 +235,13 @@ class ReadableFreezeUpgradeActionsTest {
         setupNodes();
 
         given(adminServiceConfig.upgradeArtifactsPath()).willReturn(zipOutputDir.toString());
+        given(adminServiceConfig.keysPath()).willReturn(keysDir.toString());
         given(nodesConfig.enableDAB()).willReturn(true);
 
         final Bytes realArchive = Bytes.wrap(Files.readAllBytes(zipArchivePath));
         subject.extractSoftwareUpgrade(realArchive).join();
 
-        assertDABFilesCreated(EXEC_IMMEDIATE_MARKER, zipOutputDir.toPath());
+        assertDABFilesCreated(EXEC_IMMEDIATE_MARKER, zipOutputDir.toPath(), keysDir.toPath());
         assertMarkerCreated(EXEC_IMMEDIATE_MARKER, null);
     }
 
@@ -246,12 +252,13 @@ class ReadableFreezeUpgradeActionsTest {
         setupNodes2();
 
         given(adminServiceConfig.upgradeArtifactsPath()).willReturn(zipOutputDir.toString());
+        given(adminServiceConfig.keysPath()).willReturn(keysDir.toString());
         given(nodesConfig.enableDAB()).willReturn(true);
 
         final Bytes realArchive = Bytes.wrap(Files.readAllBytes(zipArchivePath));
         subject.extractSoftwareUpgrade(realArchive).join();
 
-        assertDABFilesCreated2(EXEC_IMMEDIATE_MARKER, zipOutputDir.toPath());
+        assertDABFilesCreated2(EXEC_IMMEDIATE_MARKER, zipOutputDir.toPath(), keysDir.toPath());
         assertMarkerCreated(EXEC_IMMEDIATE_MARKER, null);
     }
 
@@ -260,6 +267,7 @@ class ReadableFreezeUpgradeActionsTest {
         rmIfPresent(EXEC_TELEMETRY_MARKER);
 
         given(adminServiceConfig.upgradeArtifactsPath()).willReturn(zipOutputDir.toString());
+        given(adminServiceConfig.keysPath()).willReturn(keysDir.toString());
 
         final Bytes realArchive = Bytes.wrap(Files.readAllBytes(zipArchivePath));
         subject.extractTelemetryUpgrade(realArchive, then).join();
@@ -481,19 +489,20 @@ class ReadableFreezeUpgradeActionsTest {
         given(stakingInfoStore.get(4)).willReturn(stakingNodeInfo4);
     }
 
-    private void assertDABFilesCreated(final String file, final Path baseDir) throws IOException, CertificateException {
+    private void assertDABFilesCreated(final String file, final Path baseDir, final Path keyDir)
+            throws IOException, CertificateException {
         final Path filePath = baseDir.resolve(file);
         final Path configFilePath = baseDir.resolve("config.txt");
         assertTrue(configFilePath.toFile().exists());
         final var configFile = Files.readString(configFilePath);
 
-        final Path pemFilePath1 = baseDir.resolve("s-public-node2.pem");
+        final Path pemFilePath1 = keyDir.resolve("s-public-node2.pem");
         assertTrue(pemFilePath1.toFile().exists());
-        final Path pemFilePath2 = baseDir.resolve("s-public-node3.pem");
+        final Path pemFilePath2 = keyDir.resolve("s-public-node3.pem");
         assertTrue(pemFilePath2.toFile().exists());
-        final Path pemFilePath3 = baseDir.resolve("s-public-node4.pem");
+        final Path pemFilePath3 = keyDir.resolve("s-public-node4.pem");
         assertFalse(pemFilePath3.toFile().exists());
-        final Path pemFilePath4 = baseDir.resolve("s-public-node5.pem");
+        final Path pemFilePath4 = keyDir.resolve("s-public-node5.pem");
         assertTrue(pemFilePath4.toFile().exists());
         final var pemFile1 = readCertificatePemFile(pemFilePath1);
         final var pemFile2 = readCertificatePemFile(pemFilePath2);
@@ -605,20 +614,20 @@ class ReadableFreezeUpgradeActionsTest {
         given(stakingInfoStore.get(2)).willReturn(stakingNodeInfo3);
     }
 
-    private void assertDABFilesCreated2(final String file, final Path baseDir)
+    private void assertDABFilesCreated2(final String file, final Path baseDir, final Path keyDir)
             throws IOException, CertificateException {
         final Path filePath = baseDir.resolve(file);
         final Path configFilePath = baseDir.resolve("config.txt");
         assertTrue(configFilePath.toFile().exists());
         final var configFile = Files.readString(configFilePath);
 
-        final Path pemFilePath1 = baseDir.resolve("s-public-node1.pem");
+        final Path pemFilePath1 = keyDir.resolve("s-public-node1.pem");
         assertTrue(pemFilePath1.toFile().exists());
-        final Path pemFilePath2 = baseDir.resolve("s-public-node2.pem");
+        final Path pemFilePath2 = keyDir.resolve("s-public-node2.pem");
         assertTrue(pemFilePath2.toFile().exists());
-        final Path pemFilePath3 = baseDir.resolve("s-public-node3.pem");
+        final Path pemFilePath3 = keyDir.resolve("s-public-node3.pem");
         assertTrue(pemFilePath3.toFile().exists());
-        final Path pemFilePath4 = baseDir.resolve("s-public-node4.pem");
+        final Path pemFilePath4 = keyDir.resolve("s-public-node4.pem");
         assertFalse(pemFilePath4.toFile().exists());
         final var pemFile1 = readCertificatePemFile(pemFilePath1);
         final var pemFile2 = readCertificatePemFile(pemFilePath2);


### PR DESCRIPTION
Add networkAdmin.keysPath property. The default value is data/upgrade/current/data/keys. Write s-public-alias.pem file for each node during freeze prepare upgrade to this directory, networkAdmin.keysPath.

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #15255 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
