### PR TITLE
chore: Use protos v0.54.0 for release 0.54

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -93,7 +93,7 @@ javaModules {
 }
 
 // The HAPI API version to use for Protobuf sources.
-val hapiProtoVersion = "0.53.0"
+val hapiProtoVersion = "0.54.0"
 
 dependencyResolutionManagement {
     // Protobuf tool versions


### PR DESCRIPTION
Required proto version update in order to issue 0.54 tags