### PR TITLE
feat: 15146 Added `calculateHash`, `setHash` and `getHash` methods to `State` interface

### DIFF
--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakePlatform.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakePlatform.java
@@ -26,6 +26,7 @@ import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.io.filesystem.FileSystemManager;
 import com.swirlds.common.io.utility.NoOpRecycleBin;
+import com.swirlds.common.merkle.crypto.MerkleCryptographyFactory;
 import com.swirlds.common.metrics.config.MetricsConfig;
 import com.swirlds.common.metrics.platform.DefaultPlatformMetrics;
 import com.swirlds.common.metrics.platform.MetricKeyRegistry;
@@ -97,7 +98,8 @@ public final class FakePlatform implements Platform {
                 metrics,
                 CryptographyHolder.get(),
                 FileSystemManager.create(configuration),
-                new NoOpRecycleBin());
+                new NoOpRecycleBin(),
+                MerkleCryptographyFactory.create(configuration, CryptographyHolder.get()));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakePlatformContext.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakePlatformContext.java
@@ -23,8 +23,11 @@ import com.swirlds.common.concurrent.ExecutorFactory;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.Cryptography;
 import com.swirlds.common.crypto.CryptographyHolder;
+import com.swirlds.common.crypto.config.CryptoConfig;
 import com.swirlds.common.io.filesystem.FileSystemManager;
 import com.swirlds.common.io.utility.RecycleBin;
+import com.swirlds.common.merkle.crypto.MerkleCryptography;
+import com.swirlds.common.merkle.crypto.MerkleCryptographyFactory;
 import com.swirlds.common.metrics.config.MetricsConfig;
 import com.swirlds.common.metrics.platform.DefaultPlatformMetrics;
 import com.swirlds.common.metrics.platform.MetricKeyRegistry;
@@ -36,11 +39,13 @@ import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.config.TransactionConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.ScheduledExecutorService;
+import org.jetbrains.annotations.NotNull;
 
 public class FakePlatformContext implements PlatformContext {
     private final Configuration platformConfig = ConfigurationBuilder.create()
             .withConfigDataType(MetricsConfig.class)
             .withConfigDataType(TransactionConfig.class)
+            .withConfigDataType(CryptoConfig.class)
             .build();
 
     private final Metrics metrics;
@@ -98,5 +103,11 @@ public class FakePlatformContext implements PlatformContext {
     @Override
     public RecycleBin getRecycleBin() {
         throw new UnsupportedOperationException("Not used by Hedera");
+    }
+
+    @NotNull
+    @Override
+    public MerkleCryptography getMerkleCryptography() {
+        return MerkleCryptographyFactory.create(platformConfig, getCryptography());
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/DefaultPlatformContext.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/DefaultPlatformContext.java
@@ -21,6 +21,7 @@ import com.swirlds.common.concurrent.ExecutorFactory;
 import com.swirlds.common.crypto.Cryptography;
 import com.swirlds.common.io.filesystem.FileSystemManager;
 import com.swirlds.common.io.utility.RecycleBin;
+import com.swirlds.common.merkle.crypto.MerkleCryptography;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -39,6 +40,7 @@ public final class DefaultPlatformContext implements PlatformContext {
     private final ExecutorFactory executorFactory;
     private final FileSystemManager fileSystemManager;
     private final RecycleBin recycleBin;
+    private final MerkleCryptography merkleCryptography;
 
     /**
      * Constructor.
@@ -58,7 +60,8 @@ public final class DefaultPlatformContext implements PlatformContext {
             @NonNull final Time time,
             @NonNull final ExecutorFactory executorFactory,
             @NonNull final FileSystemManager fileSystemManager,
-            RecycleBin recycleBin) {
+            @NonNull final RecycleBin recycleBin,
+            @NonNull final MerkleCryptography merkleCryptography) {
         this.configuration = Objects.requireNonNull(configuration, "configuration must not be null");
         this.metrics = Objects.requireNonNull(metrics, "metrics must not be null");
         this.cryptography = Objects.requireNonNull(cryptography, "cryptography must not be null");
@@ -66,6 +69,7 @@ public final class DefaultPlatformContext implements PlatformContext {
         this.executorFactory = Objects.requireNonNull(executorFactory, "executorFactory must not be null");
         this.fileSystemManager = Objects.requireNonNull(fileSystemManager, "fileSystemManager must not be null");
         this.recycleBin = Objects.requireNonNull(recycleBin, "recycleBin must not be null");
+        this.merkleCryptography = Objects.requireNonNull(merkleCryptography, "merkleCryptography must not be null");
     }
 
     /**
@@ -120,5 +124,9 @@ public final class DefaultPlatformContext implements PlatformContext {
     @Override
     public RecycleBin getRecycleBin() {
         return recycleBin;
+    }
+
+    public MerkleCryptography getMerkleCryptography() {
+        return merkleCryptography;
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/PlatformContext.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/context/PlatformContext.java
@@ -24,6 +24,8 @@ import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.io.filesystem.FileSystemManager;
 import com.swirlds.common.io.utility.NoOpRecycleBin;
 import com.swirlds.common.io.utility.RecycleBin;
+import com.swirlds.common.merkle.crypto.MerkleCryptography;
+import com.swirlds.common.merkle.crypto.MerkleCryptographyFactory;
 import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
@@ -58,7 +60,15 @@ public interface PlatformContext {
         final Cryptography cryptography = CryptographyHolder.get();
         final FileSystemManager fileSystemManager = FileSystemManager.create(configuration);
         final Time time = Time.getCurrent();
-        return create(configuration, time, metrics, cryptography, fileSystemManager, new NoOpRecycleBin());
+        final MerkleCryptography merkleCryptography = MerkleCryptographyFactory.create(configuration, cryptography);
+        return create(
+                configuration,
+                time,
+                metrics,
+                cryptography,
+                fileSystemManager,
+                new NoOpRecycleBin(),
+                merkleCryptography);
     }
 
     /**
@@ -81,12 +91,20 @@ public interface PlatformContext {
             @NonNull final Metrics metrics,
             @NonNull final Cryptography cryptography,
             @NonNull final FileSystemManager fileSystemManager,
-            @NonNull final RecycleBin recycleBin) {
+            @NonNull final RecycleBin recycleBin,
+            @NonNull final MerkleCryptography merkleCryptography) {
 
         final UncaughtExceptionHandler handler = new PlatformUncaughtExceptionHandler();
         final ExecutorFactory executorFactory = ExecutorFactory.create("platform", null, handler);
         return new DefaultPlatformContext(
-                configuration, metrics, cryptography, time, executorFactory, fileSystemManager, recycleBin);
+                configuration,
+                metrics,
+                cryptography,
+                time,
+                executorFactory,
+                fileSystemManager,
+                recycleBin,
+                merkleCryptography);
     }
 
     /**
@@ -144,4 +162,12 @@ public interface PlatformContext {
      */
     @NonNull
     RecycleBin getRecycleBin();
+
+    /**
+     * Returns the {@link MerkleCryptography} for this node
+     *
+     * @return the {@link MerkleCryptography} for this node
+     */
+    @NonNull
+    MerkleCryptography getMerkleCryptography();
 }

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/context/internal/DefaultPlatformContextTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/context/internal/DefaultPlatformContextTest.java
@@ -17,6 +17,7 @@
 package com.swirlds.common.context.internal;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import com.swirlds.base.time.Time;
 import com.swirlds.common.concurrent.ExecutorFactory;
@@ -24,6 +25,7 @@ import com.swirlds.common.context.DefaultPlatformContext;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.io.utility.NoOpRecycleBin;
+import com.swirlds.common.merkle.crypto.MerkleCryptography;
 import com.swirlds.common.metrics.PlatformMetricsProvider;
 import com.swirlds.common.metrics.platform.DefaultMetricsProvider;
 import com.swirlds.common.platform.NodeId;
@@ -42,6 +44,7 @@ class DefaultPlatformContextTest {
         final NodeId nodeId = new NodeId(3256733545L);
         final PlatformMetricsProvider metricsProvider = new DefaultMetricsProvider(configuration);
         metricsProvider.createGlobalMetrics();
+        final MerkleCryptography merkleCryptography = mock(MerkleCryptography.class);
 
         // when
         final PlatformContext context = new DefaultPlatformContext(
@@ -51,7 +54,8 @@ class DefaultPlatformContextTest {
                 Time.getCurrent(),
                 ExecutorFactory.create("test", new PlatformUncaughtExceptionHandler()),
                 new TestFileSystemManager(Path.of("/tmp/test")),
-                new NoOpRecycleBin());
+                new NoOpRecycleBin(),
+                merkleCryptography);
 
         // then
         assertNotNull(context.getConfiguration(), "Configuration must not be null");
@@ -60,5 +64,6 @@ class DefaultPlatformContextTest {
         assertNotNull(context.getTime(), "Time must not be null");
         assertNotNull(context.getFileSystemManager(), "FileSystemManager must not be null");
         assertNotNull(context.getExecutorFactory(), "ExecutorFactory must not be null");
+        assertNotNull(context.getMerkleCryptography(), "MerkleCryptography must not be null");
     }
 }

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/platform/TestPlatformContextBuilder.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/platform/TestPlatformContextBuilder.java
@@ -27,6 +27,7 @@ import com.swirlds.common.crypto.CryptographyHolder;
 import com.swirlds.common.io.filesystem.FileSystemManager;
 import com.swirlds.common.io.utility.NoOpRecycleBin;
 import com.swirlds.common.io.utility.RecycleBin;
+import com.swirlds.common.merkle.crypto.MerkleCryptography;
 import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.common.test.fixtures.TestFileSystemManager;
 import com.swirlds.config.api.Configuration;
@@ -54,6 +55,7 @@ public final class TestPlatformContextBuilder {
     private Time time = Time.getCurrent();
     private FileSystemManager fileSystemManager;
     private RecycleBin recycleBin;
+    private MerkleCryptography merkleCryptography;
 
     private TestPlatformContextBuilder() {}
 
@@ -130,6 +132,12 @@ public final class TestPlatformContextBuilder {
         return this;
     }
 
+    @NonNull
+    public TestPlatformContextBuilder withMerkleCryptography(@NonNull final MerkleCryptography merkleCryptography) {
+        this.merkleCryptography = merkleCryptography;
+        return this;
+    }
+
     /**
      * Returns a new {@link PlatformContext} based on this builder
      *
@@ -201,6 +209,12 @@ public final class TestPlatformContextBuilder {
             @Override
             public RecycleBin getRecycleBin() {
                 return recycleBin;
+            }
+
+            @NonNull
+            @Override
+            public MerkleCryptography getMerkleCryptography() {
+                return merkleCryptography;
             }
         };
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -514,7 +514,14 @@ public final class PlatformBuilder {
         }
 
         final PlatformContext platformContext = new DefaultPlatformContext(
-                configuration, metrics, cryptography, time, executorFactory, fileSystemManager, recycleBin);
+                configuration,
+                metrics,
+                cryptography,
+                time,
+                executorFactory,
+                fileSystemManager,
+                recycleBin,
+                merkleCryptography);
 
         final boolean firstPlatform = doStaticSetup(configuration, configPath);
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,6 +44,7 @@ import com.hedera.hapi.block.stream.output.StateChanges;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.swirlds.base.state.MutabilityException;
 import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.platform.state.service.PlatformStateService;
@@ -1065,6 +1067,70 @@ class MerkleStateRootTest extends MerkleTestBase {
             stateRoot.setChild(1, node2);
 
             assertThrows(IllegalStateException.class, () -> stateRoot.migrate(CURRENT_VERSION - 1));
+        }
+    }
+
+    @Nested
+    @DisplayName("Hashing test")
+    class HashingTest {
+
+        @BeforeEach
+        void setUp() {
+            setupAnimalMerkleMap();
+            setupSingletonCountry();
+            setupSteamQueue();
+
+            add(fruitMerkleMap, fruitMetadata, A_KEY, APPLE);
+            add(fruitMerkleMap, fruitMetadata, B_KEY, BANANA);
+            add(animalMerkleMap, animalMetadata, C_KEY, CUTTLEFISH);
+            add(animalMerkleMap, animalMetadata, D_KEY, DOG);
+            add(animalMerkleMap, animalMetadata, F_KEY, FOX);
+            countrySingleton.setValue(GHANA);
+            steamQueue.add(ART);
+
+            // Given a State with the fruit and animal and country states
+            stateRoot.putServiceStateIfAbsent(fruitMetadata, () -> fruitMerkleMap);
+            stateRoot.putServiceStateIfAbsent(animalMetadata, () -> animalMerkleMap);
+            stateRoot.putServiceStateIfAbsent(countryMetadata, () -> countrySingleton);
+            stateRoot.putServiceStateIfAbsent(steamMetadata, () -> steamQueue);
+        }
+
+        @Test
+        @DisplayName("No hash by default")
+        void noHashByDefault() {
+            assertNull(stateRoot.getHash());
+        }
+
+        @Test
+        @DisplayName("calculateHash is doesn't work on mutable states")
+        void calculateHashOnMutable() {
+            assertThrows(IllegalStateException.class, stateRoot::calculateHash);
+        }
+
+        @Test
+        @DisplayName("calculateHash is doesn't work on destroyed states")
+        void calculateHashOnDestroyed() {
+            stateRoot.destroyNode();
+            assertThrows(IllegalStateException.class, stateRoot::calculateHash);
+        }
+
+        @Test
+        @DisplayName("Hash is computed after calculateHash invocation")
+        void calculateHash() {
+            stateRoot.copy();
+            stateRoot.calculateHash();
+            assertNotNull(stateRoot.getHash());
+        }
+
+        @Test
+        @DisplayName("calculateHash is idempotent")
+        void calculateHash_idempotent() {
+            stateRoot.copy();
+            stateRoot.calculateHash();
+            Hash hash1 = stateRoot.getHash();
+            stateRoot.calculateHash();
+            Hash hash2 = stateRoot.getHash();
+            assertSame(hash1, hash2);
         }
     }
 }

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
@@ -18,7 +18,6 @@ package com.swirlds.state;
 
 import com.swirlds.common.FastCopyable;
 import com.swirlds.common.crypto.Hash;
-import com.swirlds.common.crypto.Hashable;
 import com.swirlds.state.spi.CommittableWritableStates;
 import com.swirlds.state.spi.ReadableKVState;
 import com.swirlds.state.spi.ReadableStates;
@@ -32,7 +31,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * structures provided by the hashgraph platform. But most of our code doesn't need to know that
  * detail, and are happy with just the API provided by this interface.
  */
-public interface State extends FastCopyable, Hashable {
+public interface State extends FastCopyable {
 
     /**
      * Returns a {@link ReadableStates} for the given named service. If such a service doesn't
@@ -75,35 +74,26 @@ public interface State extends FastCopyable, Hashable {
         throw new UnsupportedOperationException();
     }
 
-    /***
-     * {$inheritDoc}
+    /**
+     * {@inheritDoc}
      */
     @Override
     default State copy() {
         throw new UnsupportedOperationException();
     }
 
-    /***
-     * {$inheritDoc}
+    /**
+     * Returns a calculated hash of the state.
      */
     @Nullable
-    @Override
     default Hash getHash() {
-        throw new UnsupportedOperationException();
-    }
-
-    /***
-     * {$inheritDoc}
-     */
-    @Override
-    default void setHash(@NonNull Hash hash) {
         throw new UnsupportedOperationException();
     }
 
     /**
      * Hashes the state on demand if it is not already hashed. If the state is already hashed, this method is a no-op.
      */
-    default void calculateHash() {
+    default void computeHash() {
         throw new UnsupportedOperationException();
     }
 }

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
@@ -95,6 +95,7 @@ public interface State extends FastCopyable, Hashable {
     /***
      * {$inheritDoc}
      */
+    @Override
     default void setHash(@NonNull Hash hash) {
         throw new UnsupportedOperationException();
     }

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
@@ -17,19 +17,22 @@
 package com.swirlds.state;
 
 import com.swirlds.common.FastCopyable;
+import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.crypto.Hashable;
 import com.swirlds.state.spi.CommittableWritableStates;
 import com.swirlds.state.spi.ReadableKVState;
 import com.swirlds.state.spi.ReadableStates;
 import com.swirlds.state.spi.WritableKVState;
 import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * The full state used of the app. The primary implementation is based on a merkle tree, and the data
  * structures provided by the hashgraph platform. But most of our code doesn't need to know that
  * detail, and are happy with just the API provided by this interface.
  */
-public interface State extends FastCopyable {
+public interface State extends FastCopyable, Hashable {
 
     /**
      * Returns a {@link ReadableStates} for the given named service. If such a service doesn't
@@ -72,8 +75,34 @@ public interface State extends FastCopyable {
         throw new UnsupportedOperationException();
     }
 
+    /***
+     * {$inheritDoc}
+     */
     @Override
     default State copy() {
+        throw new UnsupportedOperationException();
+    }
+
+    /***
+     * {$inheritDoc}
+     */
+    @Nullable
+    @Override
+    default Hash getHash() {
+        throw new UnsupportedOperationException();
+    }
+
+    /***
+     * {$inheritDoc}
+     */
+    default void setHash(@NonNull Hash hash) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Hashes the state on demand if it is not already hashed. If the state is already hashed, this method is a no-op.
+     */
+    default void calculateHash() {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
**Description**:

This PR adds hash-related methods to `State` interface and provides an implementation of these methods in `MerkleStateRoot`. In fact, only `calculateHash` implementation is required, as the other methods are already implemented  by a parent class (`AbstractMerkleNode`). 

**Related issue(s)**:

Fixes #15146 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
