### PR TITLE
chore: Use 0.54 protobufs on release branch

### DIFF
--- a/hapi/build.gradle.kts
+++ b/hapi/build.gradle.kts
@@ -32,9 +32,9 @@ tasks.withType<JavaCompile>().configureEach {
 // Add downloaded HAPI repo protobuf files into build directory and add to sources to build them
 tasks.cloneHederaProtobufs {
     // uncomment below to use a specific tag
-    // tag = "v0.53.0"
+    tag = "v0.54.0"
     // uncomment below to use a specific branch
-    branch = "main"
+    // branch = "main"
 }
 
 sourceSets {

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java
@@ -93,7 +93,7 @@ public final class UnzipUtility {
                     }
                     log.info(" - Extracted update file {}", filePath);
                 } else {
-                    if (!fileOrDir.mkdirs()) {
+                    if (!fileOrDir.exists() && !fileOrDir.mkdirs()) {
                         throw new IOException("Unable to create assets sub-directory: " + fileOrDir);
                     }
                     log.info(" - Created assets sub-directory {}", fileOrDir);


### PR DESCRIPTION
Setting the release branch to use the specific protobufs 0.54 tag, so as not to depend on the head of `main`. 