### PR TITLE
chore: Use 0.54 protobufs on 0.54 release branch

### DIFF
--- a/hapi/build.gradle.kts
+++ b/hapi/build.gradle.kts
@@ -32,9 +32,9 @@ tasks.withType<JavaCompile>().configureEach {
 // Add downloaded HAPI repo protobuf files into build directory and add to sources to build them
 tasks.cloneHederaProtobufs {
     // uncomment below to use a specific tag
-    // tag = "v0.53.0"
+    tag = "v0.54.0"
     // uncomment below to use a specific branch
-    branch = "main"
+    // branch = "main"
 }
 
 sourceSets {


### PR DESCRIPTION
Setting the release branch to use the specific protobufs 0.54 tag, so as not to depend on the head of main.