### PR TITLE
chore: Allow injection of CacheWarmer's Executor

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflowModule.java
@@ -28,6 +28,8 @@ import com.hedera.node.app.service.token.impl.handlers.TokenHandlers;
 import com.hedera.node.app.service.util.impl.handlers.UtilHandlers;
 import com.hedera.node.app.state.WorkingStateAccessor;
 import com.hedera.node.app.workflows.dispatcher.TransactionHandlers;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.data.CacheConfig;
 import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.state.State;
 import dagger.Module;
@@ -60,6 +62,14 @@ public interface HandleWorkflowModule {
     static Supplier<AutoCloseableWrapper<State>> provideStateSupplier(
             @NonNull final WorkingStateAccessor workingStateAccessor) {
         return () -> new AutoCloseableWrapper<>(workingStateAccessor.getState(), NO_OP);
+    }
+
+    @Provides
+    @Named("CacheWarmer")
+    static Executor provideCacheWarmerExecutor(@NonNull final ConfigProvider configProvider) {
+        final var config = configProvider.getConfiguration();
+        final int parallelism = config.getConfigData(CacheConfig.class).warmThreads();
+        return new ForkJoinPool(parallelism);
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/cache/CacheWarmer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/cache/CacheWarmer.java
@@ -30,8 +30,6 @@ import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.prehandle.PreHandleResult;
-import com.hedera.node.config.ConfigProvider;
-import com.hedera.node.config.data.CacheConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.events.ConsensusEvent;
@@ -40,8 +38,8 @@ import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
@@ -60,14 +58,10 @@ public class CacheWarmer {
     public CacheWarmer(
             @NonNull final TransactionChecker checker,
             @NonNull final TransactionDispatcher dispatcher,
-            @NonNull final ConfigProvider configProvider) {
+            @NonNull @Named("CacheWarmer") final Executor executor) {
         this.checker = checker;
         this.dispatcher = requireNonNull(dispatcher);
-        final int parallelism = configProvider
-                .getConfiguration()
-                .getConfigData(CacheConfig.class)
-                .warmThreads();
-        this.executor = new ForkJoinPool(parallelism);
+        this.executor = requireNonNull(executor);
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/cache/CacheWarmerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/cache/CacheWarmerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.workflows.handle.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.node.app.workflows.TransactionChecker;
+import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CacheWarmerTest {
+
+    @Mock
+    TransactionChecker checker;
+
+    @Mock
+    TransactionDispatcher dispatcher;
+
+    @Test
+    @DisplayName("Instantiation test")
+    void testInstantiation() {
+        final var cacheWarmer = new CacheWarmer(checker, dispatcher, Runnable::run);
+        assertThat(cacheWarmer).isInstanceOf(CacheWarmer.class);
+    }
+}


### PR DESCRIPTION
**Description**:

- Restored CacheWarmer() constructor with provided Executor erroneously removed in https://github.com/hashgraph/hedera-services/pull/12753.
- Added a unit test to keep it used.

**Related issue(s)**:

Fixes #12815 
