### PR TITLE
build: add 'timeConsuming' test set

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.feature.test-time-consuming.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.feature.test-time-consuming.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("java") }
+
+// Tests that could be in the default "test" set but take more than 100ms to execute.
+@Suppress("UnstableApiUsage")
+testing.suites {
+    register<JvmTestSuite>("timeConsuming") {
+        testType = "timing-consuming"
+        targets.all {
+            testTask {
+                group = "build"
+                maxHeapSize = "4g"
+            }
+        }
+    }
+}

--- a/platform-sdk/swirlds-logging/build.gradle.kts
+++ b/platform-sdk/swirlds-logging/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     id("com.hedera.gradle.platform-publish")
     id("com.hedera.gradle.feature.benchmark")
     id("com.hedera.gradle.feature.test-fixtures")
+    id("com.hedera.gradle.feature.test-time-consuming")
     id("com.hedera.gradle.feature.test-timing-sensitive")
 }
 


### PR DESCRIPTION
**Description**:

Adds the `timeConsuming` test set as something projects may use if necessary.

- Will run regularly once #15363 is in
- Can then be filled by moving long running tests from `test` to `timeConsuming` where

For reference, here is a recent scan, that show which tests are above the `100ms` threshold and should be moved once the setup is complete: https://scans.gradle.com/s/fasvtpqbn54tq/tests/slowest-tests

**Related issue(s)**:

#14407

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
