### PR TITLE
build: grpc update / avoid mergeJar

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.java.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.java.gradle.kts
@@ -74,8 +74,6 @@ jvmDependencyConflicts {
     }
 }
 
-configurations.javaModulesMergeJars { extendsFrom(configurations["internal"]) }
-
 tasks.buildDependents { setGroup(null) }
 
 tasks.buildNeeded { setGroup(null) }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-modules.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-modules.gradle.kts
@@ -112,10 +112,7 @@ extraJavaModuleInfo {
     module("io.grpc:grpc-protobuf", "io.grpc.protobuf")
     module("io.grpc:grpc-protobuf-lite", "io.grpc.protobuf.lite")
     module("com.github.spotbugs:spotbugs-annotations", "com.github.spotbugs.annotations")
-    module("com.google.code.findbugs:jsr305", "java.annotation") {
-        exportAllPackages()
-        mergeJar("javax.annotation:javax.annotation-api")
-    }
+    module("com.google.code.findbugs:jsr305", "java.annotation")
     module("com.google.errorprone:error_prone_annotations", "com.google.errorprone.annotations")
     module("com.google.j2objc:j2objc-annotations", "com.google.j2objc.annotations")
     module("com.google.protobuf:protobuf-java", "com.google.protobuf") {

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.protobuf.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.protobuf.gradle.kts
@@ -31,7 +31,9 @@ protobuf {
             artifact = "io.grpc:protoc-gen-grpc-java:" + libs.findVersion("grpc-proto").get()
         }
     }
-    generateProtoTasks { ofSourceSet("main").forEach { it.plugins { id("grpc") } } }
+    generateProtoTasks {
+        all().configureEach { plugins { id("grpc") { option("@generated=omit") } } }
+    }
 }
 
 sourceSets.all {

--- a/hapi/src/main/java/module-info.java
+++ b/hapi/src/main/java/module-info.java
@@ -71,5 +71,4 @@ module com.hedera.node.hapi {
     requires io.grpc.protobuf;
     requires org.antlr.antlr4.runtime;
     requires static com.github.spotbugs.annotations;
-    requires static java.annotation;
 }

--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -56,10 +56,10 @@ dependencies.constraints {
     api("com.google.jimfs:jimfs:1.2") {
         because("com.google.jimfs")
     }
-    api("com.google.protobuf:protobuf-java:3.21.7") {
+    api("com.google.protobuf:protobuf-java:3.25.4") {
         because("com.google.protobuf")
     }
-    api("com.google.protobuf:protobuf-java-util:3.21.7") {
+    api("com.google.protobuf:protobuf-java-util:3.25.4") {
         because("com.google.protobuf.util")
     }
     api("com.hedera.cryptography:hedera-cryptography-pairings-api:0.1.0-SNAPSHOT") {
@@ -121,9 +121,6 @@ dependencies.constraints {
     }
     api("jakarta.inject:jakarta.inject-api:2.0.1") {
         because("jakarta.inject")
-    }
-    api("javax.annotation:javax.annotation-api:1.3.2") {
-        because("java.annotation")
     }
     api("javax.inject:javax.inject:1") {
         because("javax.inject")
@@ -227,10 +224,4 @@ dependencies.constraints {
     api("uk.org.webcompere:system-stubs-jupiter:2.1.5") {
         because("uk.org.webcompere.systemstubs.jupiter")
     }
-}
-
-dependencies.constraints {
-    // required to merge 'javax.annotation-api' into 'com.google.code.findbugs:jsr305'
-    // to have all annotations on the classpath available at compile time
-    api("javax.annotation:javax.annotation-api:1.3.2")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -97,8 +97,8 @@ val hapiProtoVersion = "0.54.0"
 dependencyResolutionManagement {
     // Protobuf tool versions
     versionCatalogs.create("libs") {
-        version("google-proto", "3.19.4")
-        version("grpc-proto", "1.45.1")
+        version("google-proto", "3.25.4")
+        version("grpc-proto", "1.66.0")
         version("hapi-proto", hapiProtoVersion)
 
         plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.9.2")


### PR DESCRIPTION
**Description**:

Right now, we need to merge these two Jars because of the overlapping `org.javax.annotations` package:
- `com.google.code.findbugs:jsr305` - this is needed at annotation processing time, because is is a transitive dependency of libraries we currently use (like Guava) that uses annotation from there.
- `javax.annotation:javax.annotation-api` - this is only needed because the protobuf GRPC plugin (NOT our own PBJ) is using `javax.annotation.Generated`. This PR remove this!

By updating Protobuf GRPC to the latest version, we can omit using the annotation by `option("@generated=omit")`.

See:
- https://github.com/grpc/grpc-java/issues/9179
- https://github.com/DanielLiu1123/grpc-starter/pull/54/files#diff-b6f0dd6ddbdb3c9e619b2f7e79181d562aa8379c06880bf5257b629bf8c7109c
- https://github.com/grpc/grpc-java/pull/11086

**Note:** This generated code is intended to eventually only be used for testing. Right now, there are still some references in the production code that needs adjustment. See: https://github.com/hashgraph/hedera-services/pull/14026


**Related issue(s)**:

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
