### PR TITLE
chore: improve `noStakingInteractionsForExtendedPeriodIsFine()` spec

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUtils.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUtils.java
@@ -80,11 +80,11 @@ public final class EndOfStakingPeriodUtils {
             final boolean requireMinStakeToReward) {
         final var currRewardSumHistory = currentInfo.rewardSumHistory();
         final var newRewardSumHistory = new ArrayList<>(currRewardSumHistory);
-        final var droppedRewardSum = currRewardSumHistory.get(currRewardSumHistory.size() - 1);
+        final var droppedRewardSum = currRewardSumHistory.getLast();
         for (int i = currRewardSumHistory.size() - 1; i > 0; i--) {
             newRewardSumHistory.set(i, currRewardSumHistory.get(i - 1) - droppedRewardSum);
         }
-        newRewardSumHistory.set(0, currRewardSumHistory.get(0) - droppedRewardSum);
+        newRewardSumHistory.set(0, currRewardSumHistory.getFirst() - droppedRewardSum);
 
         long perHbarRateThisNode = 0;
         // If this node was "active"---i.e., node.numRoundsWithJudge / numRoundsInPeriod >= activeThreshold---and it had
@@ -108,7 +108,7 @@ public final class EndOfStakingPeriodUtils {
             }
         }
         perHbarRateThisNode = Math.min(perHbarRateThisNode, maxPerHbarRate);
-        newRewardSumHistory.set(0, newRewardSumHistory.get(0) + perHbarRateThisNode);
+        newRewardSumHistory.set(0, newRewardSumHistory.getFirst() + perHbarRateThisNode);
 
         return new RewardSumHistory(newRewardSumHistory, perHbarRateThisNode);
     }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakePeriodManagerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakePeriodManagerTest.java
@@ -197,7 +197,7 @@ class StakePeriodManagerTest {
 
         final var expectedEffectivePeriod = LocalDate.ofInstant(Instant.ofEpochSecond(12345678910L), ZONE_UTC)
                 .toEpochDay();
-        assertEquals(expectedEffectivePeriod - 365, period);
+        assertEquals(expectedEffectivePeriod - 366, period);
         assertEquals(expectedEffectivePeriod - 10, subject.effectivePeriod(stakePeriod - 10));
     }
 

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/StakingRewardsApi.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/api/StakingRewardsApi.java
@@ -190,7 +190,7 @@ public interface StakingRewardsApi {
     static long clampedStakePeriodStart(
             final long stakePeriodStart, final long currentStakePeriod, final int numStoredPeriods) {
         if (stakePeriodStart > -1 && stakePeriodStart < currentStakePeriod - numStoredPeriods) {
-            return currentStakePeriod - numStoredPeriods;
+            return currentStakePeriod - numStoredPeriods - 1;
         }
         return stakePeriodStart;
     }
@@ -205,7 +205,7 @@ public interface StakingRewardsApi {
             return 0;
         }
 
-        final var firstRewardSum = rewardSumHistory.get(0);
+        final var firstRewardSum = rewardSumHistory.getFirst();
         final var rewardFromSum = rewardSumHistory.get(rewardFrom);
         if (account.stakeAtStartOfLastRewardedPeriod() != -1) {
             final var rewardFromMinus1Sum = rewardSumHistory.get(rewardFrom - 1);


### PR DESCRIPTION
**Description**:
 - Add assertion that exactly `staking.rewardHistory.numStoredPeriods=365` periods of rewards are collected by a staker who did not collect rewards for over a year.
 - Replace e.g. `List.get(0)` with `List.getFirst()`.