### PR TITLE
chore: remove hapiProtoVersion

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -165,7 +165,10 @@ val cleanRun =
 
 tasks.clean { dependsOn(cleanRun) }
 
-tasks.register("showHapiVersion") { doLast { println(libs.versions.hapi.proto.get()) } }
+tasks.register("showHapiVersion") {
+    inputs.property("version", project.version)
+    doLast { println(inputs.properties["version"]) }
+}
 
 var updateDockerEnvTask =
     tasks.register<Exec>("updateDockerEnv") {

--- a/hedera-node/hedera-network-admin-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-network-admin-service-impl/build.gradle.kts
@@ -23,7 +23,7 @@ description = "Default Hedera Network Admin Service Implementation"
 
 val writeSemanticVersionProperties =
     tasks.register<WriteProperties>("writeSemanticVersionProperties") {
-        property("hapi.proto.version", libs.versions.hapi.proto.get())
+        property("hapi.proto.version", project.version)
         property("hedera.services.version", project.version)
 
         destinationFile.set(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -86,15 +86,11 @@ javaModules {
     versions("hedera-dependency-versions")
 }
 
-// The HAPI API version to use for Protobuf sources.
-val hapiProtoVersion = "0.54.0"
-
 dependencyResolutionManagement {
     // Protobuf tool versions
     versionCatalogs.create("libs") {
         version("google-proto", "3.25.4")
         version("grpc-proto", "1.66.0")
-        version("hapi-proto", hapiProtoVersion)
 
         plugin("pbj", "com.hedera.pbj.pbj-compiler").version("0.9.2")
     }


### PR DESCRIPTION
**Description**:

Remove 'hapiProtoVersion' as this is now the same as the version of hedera services itself.

**Related issue(s)**:

Related to #15324

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
