### PR TITLE
fix: 15385 Used `MerkleStateRoot.getReadablePlatformState` where possible to prevent race conditions (cherry-pick)

### DIFF
--- a/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
+++ b/hedera-node/cli-clients/src/main/java/com/hedera/services/cli/signedstate/SignedStateHolder.java
@@ -159,7 +159,7 @@ public class SignedStateHolder implements AutoCloseableNonThrowing {
             rss = SignedStateFileReader.readStateFile(platformContext, swhPath, SignedStateFileUtils::readState)
                     .reservedSignedState();
             StaticSoftwareVersion.setSoftwareVersion(
-                    rss.get().getState().getPlatformState().getCreationSoftwareVersion());
+                    rss.get().getState().getReadablePlatformState().getCreationSoftwareVersion());
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
@@ -236,7 +236,8 @@ public class StateChangesValidator implements BlockStreamValidator {
         final var currentVersion = new ServicesSoftwareVersion(servicesVersion, configVersion);
         final var lifecycles = newPlatformInitLifecycle(bootstrapConfig, currentVersion, migrator, servicesRegistry);
         state = new MerkleStateRoot(lifecycles, version -> new ServicesSoftwareVersion(version, configVersion));
-        state.getPlatformState();
+        // initialize the platform state
+        state.getWritablePlatformState();
         migrator.doMigrations(
                 state,
                 servicesRegistry,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
@@ -107,7 +107,7 @@ public class ReconnectStateLoader {
                     .init(
                             platform,
                             InitTrigger.RECONNECT,
-                            signedState.getState().getPlatformState().getCreationSoftwareVersion());
+                            signedState.getState().getReadablePlatformState().getCreationSoftwareVersion());
             if (!Objects.equals(signedState.getState().getHash(), reconnectHash)) {
                 throw new IllegalStateException(
                         "State hash is not permitted to change during a reconnect init() call. Previous hash was "
@@ -136,13 +136,13 @@ public class ReconnectStateLoader {
                     .getSignatureCollectorStateInput()
                     .put(signedState.reserve("loading reconnect state into sig collector"));
             platformWiring.consensusSnapshotOverride(Objects.requireNonNull(
-                    signedState.getState().getPlatformState().getSnapshot()));
+                    signedState.getState().getReadablePlatformState().getSnapshot()));
 
             platformWiring
                     .getAddressBookUpdateInput()
                     .inject(new AddressBookUpdate(
-                            signedState.getState().getPlatformState().getPreviousAddressBook(),
-                            signedState.getState().getPlatformState().getAddressBook()));
+                            signedState.getState().getReadablePlatformState().getPreviousAddressBook(),
+                            signedState.getState().getReadablePlatformState().getAddressBook()));
 
             final AncientMode ancientMode = platformContext
                     .getConfiguration()
@@ -151,12 +151,12 @@ public class ReconnectStateLoader {
 
             platformWiring.updateEventWindow(new EventWindow(
                     signedState.getRound(),
-                    signedState.getState().getPlatformState().getAncientThreshold(),
-                    signedState.getState().getPlatformState().getAncientThreshold(),
+                    signedState.getState().getReadablePlatformState().getAncientThreshold(),
+                    signedState.getState().getReadablePlatformState().getAncientThreshold(),
                     ancientMode));
 
             final RunningEventHashOverride runningEventHashOverride = new RunningEventHashOverride(
-                    signedState.getState().getPlatformState().getLegacyRunningEventHash(), true);
+                    signedState.getState().getReadablePlatformState().getLegacyRunningEventHash(), true);
             platformWiring.updateRunningHash(runningEventHashOverride);
             platformWiring.getPcesWriterRegisterDiscontinuityInput().inject(signedState.getRound());
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
@@ -65,7 +65,8 @@ public final class StateInitializer {
             previousSoftwareVersion = NO_VERSION;
             trigger = GENESIS;
         } else {
-            previousSoftwareVersion = signedState.getState().getPlatformState().getCreationSoftwareVersion();
+            previousSoftwareVersion =
+                    signedState.getState().getReadablePlatformState().getCreationSoftwareVersion();
             trigger = RESTART;
         }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -200,7 +200,10 @@ public class SwirldsPlatform implements Platform {
                         platformContext,
                         blocks.selfId(),
                         initialState.getRound(),
-                        initialState.getState().getPlatformState().getLowestJudgeGenerationBeforeBirthRoundMode());
+                        initialState
+                                .getState()
+                                .getReadablePlatformState()
+                                .getLowestJudgeGenerationBeforeBirthRoundMode());
             } catch (final IOException e) {
                 throw new UncheckedIOException("Birth round migration failed during PCES migration.", e);
             }
@@ -288,9 +291,9 @@ public class SwirldsPlatform implements Platform {
                 publisher);
 
         final Hash legacyRunningEventHash =
-                initialState.getState().getPlatformState().getLegacyRunningEventHash() == null
+                initialState.getState().getReadablePlatformState().getLegacyRunningEventHash() == null
                         ? platformContext.getCryptography().getNullHash()
-                        : initialState.getState().getPlatformState().getLegacyRunningEventHash();
+                        : initialState.getState().getReadablePlatformState().getLegacyRunningEventHash();
         final RunningEventHashOverride runningEventHashOverride =
                 new RunningEventHashOverride(legacyRunningEventHash, false);
         platformWiring.updateRunningHash(runningEventHashOverride);
@@ -320,7 +323,8 @@ public class SwirldsPlatform implements Platform {
             startingRound = 0;
             platformWiring.updateEventWindow(EventWindow.getGenesisEventWindow(ancientMode));
         } else {
-            initialAncientThreshold = initialState.getState().getPlatformState().getAncientThreshold();
+            initialAncientThreshold =
+                    initialState.getState().getReadablePlatformState().getAncientThreshold();
             startingRound = initialState.getRound();
 
             platformWiring.sendStateToHashLogger(initialState);
@@ -331,7 +335,7 @@ public class SwirldsPlatform implements Platform {
             savedStateController.registerSignedStateFromDisk(initialState);
 
             platformWiring.consensusSnapshotOverride(Objects.requireNonNull(
-                    initialState.getState().getPlatformState().getSnapshot()));
+                    initialState.getState().getReadablePlatformState().getSnapshot()));
 
             // We only load non-ancient events during start up, so the initial expired threshold will be
             // equal to the ancient threshold when the system first starts. Over time as we get more events,
@@ -378,7 +382,7 @@ public class SwirldsPlatform implements Platform {
         }
 
         final MerkleRoot state = initialState.getState();
-        final PlatformStateAccessor platformState = state.getPlatformState();
+        final PlatformStateAccessor platformState = state.getReadablePlatformState();
 
         return new DefaultBirthRoundMigrationShim(
                 platformContext,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -556,7 +556,7 @@ public final class PlatformBuilder {
             // Update the address book with the current address book read from config.txt.
             // Eventually we will not do this, and only transactions will be capable of
             // modifying the address book.
-            final PlatformStateAccessor platformState = state.getPlatformState();
+            final PlatformStateAccessor platformState = state.getWritablePlatformState();
             platformState.bulkUpdate(v -> {
                 v.setAddressBook(addressBookInitializer.getCurrentAddressBook().copy());
                 v.setPreviousAddressBook(
@@ -570,7 +570,7 @@ public final class PlatformBuilder {
 
         // At this point the initial state must have the current address book set.  If not, something is wrong.
         final AddressBook addressBook =
-                initialState.get().getState().getPlatformState().getAddressBook();
+                initialState.get().getState().getReadablePlatformState().getAddressBook();
         if (addressBook == null) {
             throw new IllegalStateException("The current address book of the initial state is null.");
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
@@ -129,6 +129,6 @@ public record PlatformBuildingBlocks(
      */
     @NonNull
     public AddressBook initialAddressBook() {
-        return initialState.get().getState().getPlatformState().getAddressBook();
+        return initialState.get().getState().getReadablePlatformState().getAddressBook();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
@@ -360,7 +360,11 @@ public class PlatformComponentBuilder {
                     blocks.platformContext(),
                     CryptoStatic::verifySignature,
                     blocks.appVersion().getPbjSemanticVersion(),
-                    blocks.initialState().get().getState().getPlatformState().getPreviousAddressBook(),
+                    blocks.initialState()
+                            .get()
+                            .getState()
+                            .getReadablePlatformState()
+                            .getPreviousAddressBook(),
                     blocks.initialAddressBook(),
                     blocks.intakeEventCounter());
         }
@@ -859,7 +863,11 @@ public class PlatformComponentBuilder {
 
             issDetector = new DefaultIssDetector(
                     blocks.platformContext(),
-                    blocks.initialState().get().getState().getPlatformState().getAddressBook(),
+                    blocks.initialState()
+                            .get()
+                            .getState()
+                            .getReadablePlatformState()
+                            .getAddressBook(),
                     blocks.appVersion().getPbjSemanticVersion(),
                     ignorePreconsensusSignatures,
                     roundToIgnore);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
@@ -76,7 +76,7 @@ public class GenesisPlatformStateCommand extends AbstractCommand {
                 SignedStateFileReader.readStateFile(platformContext, statePath, SignedStateFileUtils::readState);
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
             final PlatformStateAccessor platformState =
-                    reservedSignedState.get().getState().getPlatformState();
+                    reservedSignedState.get().getState().getWritablePlatformState();
             platformState.bulkUpdate(v -> {
                 System.out.printf("Replacing platform data %n");
                 v.setRound(PlatformStateAccessor.GENESIS_ROUND);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
@@ -82,7 +82,7 @@ public class ValidateAddressBookStateCommand extends AbstractCommand {
         final AddressBook stateAddressBook;
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
             final PlatformStateAccessor platformState =
-                    reservedSignedState.get().getState().getPlatformState();
+                    reservedSignedState.get().getState().getReadablePlatformState();
             System.out.printf("Extracting the state address book for comparison %n");
             stateAddressBook = platformState.getAddressBook();
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -221,7 +221,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
      */
     private void updatePlatformState(@NonNull final ConsensusRound round) {
         final PlatformStateAccessor platformState =
-                swirldStateManager.getConsensusState().getPlatformState();
+                swirldStateManager.getConsensusState().getWritablePlatformState();
         platformState.bulkUpdate(v -> {
             v.setRound(round.getRoundNum());
             v.setConsensusTimestamp(round.getConsensusTimestamp());
@@ -239,7 +239,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
      */
     private void updateRunningEventHash(@NonNull final ConsensusRound round) throws InterruptedException {
         final PlatformStateAccessor platformState =
-                swirldStateManager.getConsensusState().getPlatformState();
+                swirldStateManager.getConsensusState().getWritablePlatformState();
 
         if (writeLegacyRunningEventHash) {
             // Update the running hash object. If there are no events, the running hash does not change.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/DefaultSignedStateValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/DefaultSignedStateValidator.java
@@ -67,10 +67,10 @@ public class DefaultSignedStateValidator implements SignedStateValidator {
     private void throwIfOld(final SignedState signedState, final SignedStateValidationData previousStateData)
             throws SignedStateInvalidException {
 
-        if (signedState.getState().getPlatformState().getRound() < previousStateData.round()
+        if (signedState.getState().getReadablePlatformState().getRound() < previousStateData.round()
                 || signedState
                         .getState()
-                        .getPlatformState()
+                        .getReadablePlatformState()
                         .getConsensusTimestamp()
                         .isBefore(previousStateData.consensusTimestamp())) {
             logger.error(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
@@ -104,7 +104,7 @@ public class ReconnectLearner {
         this.statistics = Objects.requireNonNull(statistics);
 
         // Save some of the current state data for validation
-        this.stateValidationData = new SignedStateValidationData(currentState.getPlatformState(), addressBook);
+        this.stateValidationData = new SignedStateValidationData(currentState.getReadablePlatformState(), addressBook);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -153,7 +153,7 @@ public final class EventRecoveryWorkflow {
                         platformContext, signedStateFile, SignedStateFileUtils::readState)
                 .reservedSignedState()) {
             StaticSoftwareVersion.setSoftwareVersion(
-                    initialState.get().getState().getPlatformState().getCreationSoftwareVersion());
+                    initialState.get().getState().getReadablePlatformState().getCreationSoftwareVersion());
 
             logger.info(
                     STARTUP.getMarker(),
@@ -314,7 +314,7 @@ public final class EventRecoveryWorkflow {
                 .init(
                         platform,
                         InitTrigger.EVENT_STREAM_RECOVERY,
-                        initialState.get().getState().getPlatformState().getCreationSoftwareVersion());
+                        initialState.get().getState().getReadablePlatformState().getCreationSoftwareVersion());
 
         appMain.init(platform, platform.getSelfId());
 
@@ -379,32 +379,33 @@ public final class EventRecoveryWorkflow {
         final PlatformEvent lastEvent = ((CesEvent) getLastEvent(round)).getPlatformEvent();
         new DefaultEventHasher().hashEvent(lastEvent);
 
-        final PlatformStateAccessor platformState = newState.getPlatformState();
+        final PlatformStateAccessor newReadablePlatformState = newState.getReadablePlatformState();
+        final PlatformStateAccessor newWritablePlatformState = newState.getWritablePlatformState();
+        final PlatformStateAccessor previousReadablePlatformState =
+                previousState.get().getState().getReadablePlatformState();
 
-        platformState.bulkUpdate(v -> {
+        newWritablePlatformState.bulkUpdate(v -> {
             v.setRound(round.getRoundNum());
-            v.setLegacyRunningEventHash(getHashEventsCons(
-                    previousState.get().getState().getPlatformState().getLegacyRunningEventHash(), round));
+            v.setLegacyRunningEventHash(
+                    getHashEventsCons(previousReadablePlatformState.getLegacyRunningEventHash(), round));
             v.setConsensusTimestamp(currentRoundTimestamp);
             v.setSnapshot(SyntheticSnapshot.generateSyntheticSnapshot(
                     round.getRoundNum(), lastEvent.getConsensusOrder(), currentRoundTimestamp, config, lastEvent));
-            v.setCreationSoftwareVersion(
-                    previousState.get().getState().getPlatformState().getCreationSoftwareVersion());
+            v.setCreationSoftwareVersion(previousReadablePlatformState.getCreationSoftwareVersion());
         });
 
         applyTransactions(
                 previousState.get().getSwirldState().cast(),
                 newState.getSwirldState().cast(),
-                newState.getPlatformState(),
+                newState.getWritablePlatformState(),
                 round);
 
         final boolean isFreezeState = isFreezeState(
                 previousState.get().getConsensusTimestamp(),
                 currentRoundTimestamp,
-                newState.getPlatformState().getFreezeTime());
+                newReadablePlatformState.getFreezeTime());
         if (isFreezeState) {
-            newState.getPlatformState()
-                    .setLastFrozenTime(newState.getPlatformState().getFreezeTime());
+            newWritablePlatformState.setLastFrozenTime(newReadablePlatformState.getFreezeTime());
         }
 
         final ReservedSignedState signedState = new SignedState(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
@@ -53,7 +53,7 @@ public final class BirthRoundStateMigration {
             @NonNull final SoftwareVersion appVersion) {
 
         if (ancientMode == AncientMode.GENERATION_THRESHOLD) {
-            if (initialState.getState().getPlatformState().getFirstVersionInBirthRoundMode() != null) {
+            if (initialState.getState().getReadablePlatformState().getFirstVersionInBirthRoundMode() != null) {
                 throw new IllegalStateException(
                         "Cannot revert to generation mode after birth round migration has been completed.");
             }
@@ -64,18 +64,18 @@ public final class BirthRoundStateMigration {
         }
 
         final MerkleRoot state = initialState.getState();
-        final PlatformStateAccessor platformState = state.getPlatformState();
+        final PlatformStateAccessor writablePlatformState = state.getWritablePlatformState();
 
-        final boolean alreadyMigrated = platformState.getFirstVersionInBirthRoundMode() != null;
+        final boolean alreadyMigrated = writablePlatformState.getFirstVersionInBirthRoundMode() != null;
         if (alreadyMigrated) {
             // Birth round migration was completed at a prior time, no action needed.
             logger.info(STARTUP.getMarker(), "Birth round state migration has already been completed.");
             return;
         }
 
-        final long lastRoundBeforeMigration = platformState.getRound();
+        final long lastRoundBeforeMigration = writablePlatformState.getRound();
 
-        final ConsensusSnapshot consensusSnapshot = Objects.requireNonNull(platformState.getSnapshot());
+        final ConsensusSnapshot consensusSnapshot = Objects.requireNonNull(writablePlatformState.getSnapshot());
         final List<MinimumJudgeInfo> judgeInfoList = consensusSnapshot.getMinimumJudgeInfoList();
         final long lowestJudgeGenerationBeforeMigration =
                 judgeInfoList.getLast().minimumJudgeAncientThreshold();
@@ -88,9 +88,9 @@ public final class BirthRoundStateMigration {
                 lastRoundBeforeMigration,
                 lowestJudgeGenerationBeforeMigration);
 
-        platformState.setFirstVersionInBirthRoundMode(appVersion);
-        platformState.setLastRoundBeforeBirthRoundMode(lastRoundBeforeMigration);
-        platformState.setLowestJudgeGenerationBeforeBirthRoundMode(lowestJudgeGenerationBeforeMigration);
+        writablePlatformState.setFirstVersionInBirthRoundMode(appVersion);
+        writablePlatformState.setLastRoundBeforeBirthRoundMode(lastRoundBeforeMigration);
+        writablePlatformState.setLowestJudgeGenerationBeforeBirthRoundMode(lowestJudgeGenerationBeforeMigration);
 
         final List<MinimumJudgeInfo> modifiedJudgeInfoList = new ArrayList<>(judgeInfoList.size());
         for (final MinimumJudgeInfo judgeInfo : judgeInfoList) {
@@ -102,7 +102,7 @@ public final class BirthRoundStateMigration {
                 modifiedJudgeInfoList,
                 consensusSnapshot.nextConsensusNumber(),
                 consensusSnapshot.consensusTimestamp());
-        platformState.setSnapshot(modifiedConsensusSnapshot);
+        writablePlatformState.setSnapshot(modifiedConsensusSnapshot);
 
         state.invalidateHash();
         MerkleCryptoFactory.getInstance().digestTreeSync(state);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/GenesisStateBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/GenesisStateBuilder.java
@@ -73,7 +73,7 @@ public final class GenesisStateBuilder {
             @NonNull final SoftwareVersion appVersion,
             @NonNull final MerkleRoot stateRoot) {
 
-        initGenesisPlatformState(platformContext, stateRoot.getPlatformState(), addressBook, appVersion);
+        initGenesisPlatformState(platformContext, stateRoot.getWritablePlatformState(), addressBook, appVersion);
 
         final SignedState signedState = new SignedState(
                 platformContext, CryptoStatic::verifySignature, stateRoot, "genesis state", false, false, false);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
@@ -33,12 +33,23 @@ public interface MerkleRoot extends MerkleInternal {
     SwirldState getSwirldState();
 
     /**
-     * Get the platform state.
+     * Get readable platform state.
+     * Works on both - mutable and immutable {@link MerkleRoot} and, therefore, this method should be preferred.
      *
-     * @return the platform state
+     * @return immutable platform state
      */
     @NonNull
-    PlatformStateAccessor getPlatformState();
+    PlatformStateAccessor getReadablePlatformState();
+
+    /**
+     * Get writable platform state. Works only on mutable {@link MerkleRoot}.
+     * Call this method only if you need to modify the platform state.
+     *
+     * @return mutable platform state
+     */
+    @NonNull
+    PlatformStateAccessor getWritablePlatformState();
+
     /**
      * Set the platform state.
      *

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
@@ -1000,8 +1000,20 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
      */
     @NonNull
     @Override
-    public PlatformStateAccessor getPlatformState() {
-        return !isImmutable() ? writablePlatformStateStore() : readablePlatformStateStore();
+    public PlatformStateAccessor getReadablePlatformState() {
+        return readablePlatformStateStore();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public PlatformStateAccessor getWritablePlatformState() {
+        if (isImmutable()) {
+            throw new IllegalStateException("Cannot get writable platform state when state is immutable");
+        }
+        return writablePlatformStateStore();
     }
 
     /**
@@ -1020,7 +1032,7 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
     @NonNull
     @Override
     public String getInfoString(final int hashDepth) {
-        return createInfoString(hashDepth, getPlatformState(), getHash(), this);
+        return createInfoString(hashDepth, readablePlatformStateStore(), getHash(), this);
     }
 
     private ReadablePlatformStateStore readablePlatformStateStore() {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
@@ -84,8 +84,8 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
         if (that.getSwirldState() != null) {
             this.setSwirldState(that.getSwirldState().copy());
         }
-        if (that.getPlatformState() != null) {
-            this.updatePlatformState(that.getPlatformState().copy());
+        if (that.getWritablePlatformState() != null) {
+            this.updatePlatformState(that.getWritablePlatformState().copy());
         }
     }
 
@@ -101,7 +101,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
 
         if (version < ClassVersion.MIGRATE_PLATFORM_STATE
                 && getSwirldState() instanceof MerkleStateRoot merkleStateRoot) {
-            PlatformState platformState = getPlatformState().copy();
+            PlatformState platformState = getWritablePlatformState().copy();
             setChild(ChildIndices.PLATFORM_STATE, null);
             merkleStateRoot.updatePlatformState(platformState);
             merkleStateRoot.setRoute(MerkleRouteFactory.getEmptyRoute());
@@ -140,13 +140,21 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
     }
 
     /**
+     * Immutable platform state is not supported by this class.
+     */
+    @NonNull
+    @Override
+    public PlatformStateAccessor getReadablePlatformState() {
+        return getChild(ChildIndices.PLATFORM_STATE);
+    }
+
+    /**
      * Get the platform state.
-     *
      * @return the platform state
      */
     @NonNull
     @Override
-    public PlatformState getPlatformState() {
+    public PlatformState getWritablePlatformState() {
         return getChild(ChildIndices.PLATFORM_STATE);
     }
 
@@ -214,7 +222,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
             return false;
         }
         final MerkleRoot state = (MerkleRoot) other;
-        return Objects.equals(getPlatformState(), state.getPlatformState())
+        return Objects.equals(getReadablePlatformState(), state.getReadablePlatformState())
                 && Objects.equals(getSwirldState(), state.getSwirldState());
     }
 
@@ -223,7 +231,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(getPlatformState(), getSwirldState());
+        return Objects.hash(getReadablePlatformState(), getSwirldState());
     }
 
     /**
@@ -234,7 +242,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
     @NonNull
     @Override
     public String getInfoString(final int hashDepth) {
-        final PlatformStateAccessor platformState = getPlatformState();
+        final PlatformStateAccessor platformState = getReadablePlatformState();
         return createInfoString(hashDepth, platformState, getHash(), this);
     }
 
@@ -244,7 +252,7 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .append("platformState", getPlatformState())
+                .append("platformState", getReadablePlatformState())
                 .append("swirldState", getSwirldState())
                 .toString();
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -125,7 +125,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
     public void handleConsensusRound(final ConsensusRound round) {
         final MerkleRoot state = stateRef.get();
 
-        uptimeTracker.handleRound(round, state.getPlatformState().getAddressBook());
+        uptimeTracker.handleRound(round, state.getReadablePlatformState().getAddressBook());
         transactionHandler.handleRound(round, state);
     }
 
@@ -157,8 +157,8 @@ public class SwirldStateManager implements FreezePeriodChecker {
     public void savedStateInFreezePeriod() {
         // set current DualState's lastFrozenTime to be current freezeTime
         stateRef.get()
-                .getPlatformState()
-                .setLastFrozenTime(stateRef.get().getPlatformState().getFreezeTime());
+                .getWritablePlatformState()
+                .setLastFrozenTime(stateRef.get().getReadablePlatformState().getFreezeTime());
     }
 
     /**
@@ -213,7 +213,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
      */
     @Override
     public boolean isInFreezePeriod(final Instant timestamp) {
-        final PlatformStateAccessor platformState = getConsensusState().getPlatformState();
+        final PlatformStateAccessor platformState = getConsensusState().getReadablePlatformState();
         return SwirldStateManagerUtils.isInFreezePeriod(
                 timestamp, platformState.getFreezeTime(), platformState.getLastFrozenTime());
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
@@ -52,7 +52,7 @@ public final class SwirldStateManagerUtils {
 
         // Create a fast copy
         final MerkleRoot copy = state.copy();
-        final var platformState = copy.getPlatformState();
+        final var platformState = copy.getWritablePlatformState();
         platformState.setCreationSoftwareVersion(softwareVersion);
 
         // Increment the reference count because this reference becomes the new value

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/TransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/TransactionHandler.java
@@ -56,7 +56,7 @@ public class TransactionHandler {
             final Instant timeOfHandle = Instant.now();
             final long startTime = System.nanoTime();
 
-            state.getSwirldState().handleConsensusRound(round, state.getPlatformState());
+            state.getSwirldState().handleConsensusRound(round, state.getWritablePlatformState());
 
             final double secondsElapsed = (System.nanoTime() - startTime) * NANOSECONDS_TO_SECONDS;
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
@@ -130,7 +130,8 @@ public class AddressBookInitializer {
                 platformContext.getConfiguration().getConfigData(AddressBookConfig.class);
         this.initialState = Objects.requireNonNull(initialState, "The initialState must not be null.");
 
-        this.stateAddressBook = initialState.getState().getPlatformState().getAddressBook();
+        this.stateAddressBook =
+                initialState.getState().getReadablePlatformState().getAddressBook();
         if (stateAddressBook == null && !initialState.isGenesisState()) {
             throw new IllegalStateException("Only genesis states can have null address books.");
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateService.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateService.java
@@ -21,7 +21,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.state.PlatformState;
-import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.MerkleStateRoot;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.state.merkle.singleton.SingletonNode;
@@ -33,8 +32,8 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * A service that provides the schema for the platform state, used by {@link MerkleStateRoot} to implement
- * {@link MerkleRoot#getPlatformState()}.
+ * A service that provides the schema for the platform state, used by {@link MerkleStateRoot}
+ * to implement accessors to the platform state.
  */
 public enum PlatformStateService implements Service {
     PLATFORM_STATE_SERVICE;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -213,7 +213,7 @@ public class SignedState implements SignedStateInfo {
      */
     @Override
     public long getRound() {
-        return state.getPlatformState().getRound();
+        return state.getReadablePlatformState().getRound();
     }
 
     /**
@@ -222,7 +222,7 @@ public class SignedState implements SignedStateInfo {
      * @return true if this is the genesis state
      */
     public boolean isGenesisState() {
-        return state.getPlatformState().getRound() == GENESIS_ROUND;
+        return state.getReadablePlatformState().getRound() == GENESIS_ROUND;
     }
 
     /**
@@ -241,6 +241,8 @@ public class SignedState implements SignedStateInfo {
     public void setSigSet(@NonNull final SigSet sigSet) {
         this.sigSet = Objects.requireNonNull(sigSet);
         signingWeight = 0;
+        // init
+        state.getWritablePlatformState();
         if (!isGenesisState()) {
             // Only non-genesis states will have signing weight
             final AddressBook addressBook = getAddressBook();
@@ -258,7 +260,7 @@ public class SignedState implements SignedStateInfo {
     @Override
     public @NonNull AddressBook getAddressBook() {
         return Objects.requireNonNull(
-                getState().getPlatformState().getAddressBook(),
+                getState().getReadablePlatformState().getAddressBook(),
                 "address book stored in this signed state is null, this should never happen");
     }
 
@@ -455,7 +457,7 @@ public class SignedState implements SignedStateInfo {
      * @return the consensus timestamp for this signed state.
      */
     public @NonNull Instant getConsensusTimestamp() {
-        return state.getPlatformState().getConsensusTimestamp();
+        return state.getReadablePlatformState().getConsensusTimestamp();
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -273,7 +273,7 @@ public final class StartupStateUtils {
         final Hash oldHash = deserializedSignedState.originalHash();
         final Hash newHash = rehashTree(state);
 
-        final SoftwareVersion loadedVersion = state.getPlatformState().getCreationSoftwareVersion();
+        final SoftwareVersion loadedVersion = state.getReadablePlatformState().getCreationSoftwareVersion();
 
         if (oldHash.equals(newHash)) {
             logger.info(STARTUP.getMarker(), "Loaded state's hash is the same as when it was saved.");

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SavedStateMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SavedStateMetadata.java
@@ -167,7 +167,7 @@ public record SavedStateMetadata(
         Objects.requireNonNull(signedState.getState().getHash(), "state must be hashed");
         Objects.requireNonNull(now, "now must not be null");
 
-        final PlatformStateAccessor platformState = signedState.getState().getPlatformState();
+        final PlatformStateAccessor platformState = signedState.getState().getReadablePlatformState();
 
         final List<NodeId> signingNodes = signedState.getSigSet().getSigningNodes();
         Collections.sort(signingNodes);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
@@ -169,7 +169,7 @@ public final class SignedStateFileWriter {
                     platformContext,
                     selfId,
                     directory,
-                    signedState.getState().getPlatformState().getAncientThreshold(),
+                    signedState.getState().getReadablePlatformState().getAncientThreshold(),
                     signedState.getRound());
         }
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
@@ -45,6 +45,7 @@ import com.swirlds.platform.health.clock.OSClockSpeedSourceChecker;
 import com.swirlds.platform.health.entropy.OSEntropyChecker;
 import com.swirlds.platform.health.filesystem.OSFileSystemChecker;
 import com.swirlds.platform.network.Network;
+import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.address.AddressBookNetworkUtils;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.swirldapp.AppLoaderException;
@@ -192,9 +193,13 @@ public final class BootstrapUtils {
             @NonNull final SoftwareVersion appVersion, @Nullable final SignedState loadedSignedState) {
         Objects.requireNonNull(appVersion, "The app version must not be null.");
 
-        final SoftwareVersion loadedSoftwareVersion = loadedSignedState == null
-                ? null
-                : loadedSignedState.getState().getPlatformState().getCreationSoftwareVersion();
+        final SoftwareVersion loadedSoftwareVersion;
+        if (loadedSignedState == null) {
+            loadedSoftwareVersion = null;
+        } else {
+            MerkleRoot state = loadedSignedState.getState();
+            loadedSoftwareVersion = state.getReadablePlatformState().getCreationSoftwareVersion();
+        }
         final int versionComparison = loadedSoftwareVersion == null ? 1 : appVersion.compareTo(loadedSoftwareVersion);
         final boolean softwareUpgrade;
         if (versionComparison < 0) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -379,7 +379,7 @@ class AddressBookInitializerTest {
         when(platformState.getAddressBook()).thenReturn(currentAddressBook);
         when(platformState.getPreviousAddressBook()).thenReturn(previousAddressBook);
         final MerkleRoot state = mock(MerkleRoot.class);
-        when(state.getPlatformState()).thenReturn(platformState);
+        when(state.getReadablePlatformState()).thenReturn(platformState);
         when(signedState.getState()).thenReturn(state);
         when(signedState.isGenesisState()).thenReturn(fromGenesis);
         when(signedState.getAddressBook()).thenReturn(currentAddressBook);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
@@ -213,7 +213,7 @@ class SavedStateMetadataTests {
         final AddressBook addressBook = mock(AddressBook.class);
 
         when(signedState.getState()).thenReturn(state);
-        when(state.getPlatformState()).thenReturn(platformState);
+        when(state.getReadablePlatformState()).thenReturn(platformState);
         when(platformState.getAddressBook()).thenReturn(addressBook);
         when(signedState.getSigSet()).thenReturn(sigSet);
         when(sigSet.getSigningNodes())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
@@ -72,7 +72,7 @@ class RoundCalculationUtilsTest {
         final MerkleRoot state = mock(MerkleRoot.class);
         final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
         when(signedState.getState()).thenReturn(state);
-        when(state.getPlatformState()).thenReturn(platformState);
+        when(state.getReadablePlatformState()).thenReturn(platformState);
 
         final AtomicLong lastRoundDecided = new AtomicLong();
         when(signedState.getRound()).thenAnswer(a -> lastRoundDecided.get());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
@@ -63,7 +63,8 @@ public class TransactionHandlerTester {
         final SwirldState swirldState = mock(SwirldState.class);
         when(consensusState.getSwirldState()).thenReturn(swirldState);
         when(consensusState.copy()).thenReturn(consensusState);
-        when(consensusState.getPlatformState()).thenReturn(platformState);
+        when(consensusState.getReadablePlatformState()).thenReturn(platformState);
+        when(consensusState.getWritablePlatformState()).thenReturn(platformState);
         doAnswer(i -> {
                     handledRounds.add(i.getArgument(0));
                     return null;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
@@ -258,7 +258,7 @@ class DefaultSignedStateValidatorTests {
 
         final SignedState signedState = stateSignedByNodes(signingNodes);
         final SignedStateValidationData originalData =
-                new SignedStateValidationData(signedState.getState().getPlatformState(), addressBook);
+                new SignedStateValidationData(signedState.getState().getReadablePlatformState(), addressBook);
 
         final boolean shouldSucceed = stateHasEnoughWeight(nodes, signingNodes);
         if (shouldSucceed) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
@@ -84,7 +84,7 @@ class BirthRoundStateMigrationTests {
         final Hash originalHash = signedState.getState().getHash();
 
         final SoftwareVersion previousSoftwareVersion =
-                signedState.getState().getPlatformState().getCreationSoftwareVersion();
+                signedState.getState().getWritablePlatformState().getCreationSoftwareVersion();
 
         final SoftwareVersion newSoftwareVersion = createNextVersion(previousSoftwareVersion);
 
@@ -108,14 +108,17 @@ class BirthRoundStateMigrationTests {
         final SignedState signedState = generateSignedState(random, platformContext);
 
         final SoftwareVersion previousSoftwareVersion =
-                signedState.getState().getPlatformState().getCreationSoftwareVersion();
+                signedState.getState().getReadablePlatformState().getCreationSoftwareVersion();
 
         ;
         final SoftwareVersion newSoftwareVersion = createNextVersion(previousSoftwareVersion);
 
-        signedState.getState().getPlatformState().setLastRoundBeforeBirthRoundMode(signedState.getRound() - 100);
-        signedState.getState().getPlatformState().setFirstVersionInBirthRoundMode(previousSoftwareVersion);
-        signedState.getState().getPlatformState().setLowestJudgeGenerationBeforeBirthRoundMode(100);
+        signedState
+                .getState()
+                .getWritablePlatformState()
+                .setLastRoundBeforeBirthRoundMode(signedState.getRound() - 100);
+        signedState.getState().getWritablePlatformState().setFirstVersionInBirthRoundMode(previousSoftwareVersion);
+        signedState.getState().getWritablePlatformState().setLowestJudgeGenerationBeforeBirthRoundMode(100);
         rehashTree(signedState.getState());
         final Hash originalHash = signedState.getState().getHash();
 
@@ -145,13 +148,13 @@ class BirthRoundStateMigrationTests {
         final Hash originalHash = signedState.getState().getHash();
 
         final SoftwareVersion previousSoftwareVersion =
-                signedState.getState().getPlatformState().getCreationSoftwareVersion();
+                signedState.getState().getReadablePlatformState().getCreationSoftwareVersion();
 
         final SoftwareVersion newSoftwareVersion = createNextVersion(previousSoftwareVersion);
 
         final long lastRoundMinimumJudgeGeneration = signedState
                 .getState()
-                .getPlatformState()
+                .getReadablePlatformState()
                 .getSnapshot()
                 .getMinimumJudgeInfoList()
                 .getLast()
@@ -167,19 +170,19 @@ class BirthRoundStateMigrationTests {
                 newSoftwareVersion.getPbjSemanticVersion(),
                 signedState
                         .getState()
-                        .getPlatformState()
+                        .getReadablePlatformState()
                         .getFirstVersionInBirthRoundMode()
                         .getPbjSemanticVersion());
         assertEquals(
                 lastRoundMinimumJudgeGeneration,
-                signedState.getState().getPlatformState().getLowestJudgeGenerationBeforeBirthRoundMode());
+                signedState.getState().getReadablePlatformState().getLowestJudgeGenerationBeforeBirthRoundMode());
         assertEquals(
                 signedState.getRound(),
-                signedState.getState().getPlatformState().getLastRoundBeforeBirthRoundMode());
+                signedState.getState().getReadablePlatformState().getLastRoundBeforeBirthRoundMode());
 
         // All of the judge info objects should now be using a birth round equal to the round of the state
         for (final MinimumJudgeInfo minimumJudgeInfo :
-                signedState.getState().getPlatformState().getSnapshot().getMinimumJudgeInfoList()) {
+                signedState.getState().getReadablePlatformState().getSnapshot().getMinimumJudgeInfoList()) {
             assertEquals(signedState.getRound(), minimumJudgeInfo.minimumJudgeAncientThreshold());
         }
     }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
@@ -46,6 +46,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.platform.state.service.PlatformStateService;
+import com.swirlds.platform.state.service.ReadablePlatformStateStore;
 import com.swirlds.platform.state.service.WritablePlatformStateStore;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.system.InitTrigger;
@@ -919,13 +920,13 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Platform state should be registered by default")
         void platformStateIsRegisteredByDefault() {
-            assertThat(stateRoot.getPlatformState()).isNotNull();
+            assertThat(stateRoot.getWritablePlatformState()).isNotNull();
         }
 
         @Test
         @DisplayName("Test access to the platform state")
         void testAccessToPlatformStateData() {
-            PlatformStateAccessor randomPlatformState = randomPlatformState(stateRoot.getPlatformState());
+            PlatformStateAccessor randomPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
             stateRoot.updatePlatformState(randomPlatformState);
             ReadableSingletonState<PlatformState> readableSingletonState = stateRoot
                     .getReadableStates(PlatformStateService.NAME)
@@ -941,16 +942,16 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Test update of the platform state")
         void testUpdatePlatformStateData() {
-            PlatformStateAccessor randomPlatformState = randomPlatformState(stateRoot.getPlatformState());
+            PlatformStateAccessor randomPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
             stateRoot.updatePlatformState(randomPlatformState);
             WritableStates writableStates = stateRoot.getWritableStates(PlatformStateService.NAME);
             WritableSingletonState<PlatformState> writableSingletonState =
                     writableStates.getSingleton(V0540PlatformStateSchema.PLATFORM_STATE_KEY);
-            PlatformStateAccessor newPlatformState = randomPlatformState(stateRoot.getPlatformState());
+            PlatformStateAccessor newPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
             writableSingletonState.put(toPbjPlatformState(newPlatformState));
             ((CommittableWritableStates) writableStates).commit();
 
-            PlatformStateAccessor stateAccessor = stateRoot.getPlatformState();
+            PlatformStateAccessor stateAccessor = stateRoot.getReadablePlatformState();
             assertThat(stateAccessor.getAddressBook()).isEqualTo(newPlatformState.getAddressBook());
             assertThat(stateAccessor.getRound())
                     .isEqualTo(newPlatformState.getSnapshot().round());
@@ -1013,8 +1014,10 @@ class MerkleStateRootTest extends MerkleTestBase {
             assertFalse(stateRoot.isImmutable());
 
             // MerkleStateRoot registers the platform state as a singleton upon the first request to it
-            assertInstanceOf(WritablePlatformStateStore.class, stateRoot.getPlatformState());
-            assertEquals(toPbjPlatformState(platformState), toPbjPlatformState(stateRoot.getPlatformState()));
+            assertInstanceOf(WritablePlatformStateStore.class, stateRoot.getWritablePlatformState());
+            assertInstanceOf(ReadablePlatformStateStore.class, stateRoot.getReadablePlatformState());
+            assertEquals(toPbjPlatformState(platformState), toPbjPlatformState(stateRoot.getWritablePlatformState()));
+            assertEquals(toPbjPlatformState(platformState), toPbjPlatformState(stateRoot.getReadablePlatformState()));
         }
 
         @Test
@@ -1052,8 +1055,8 @@ class MerkleStateRootTest extends MerkleTestBase {
             assertFalse(stateRoot.isImmutable());
 
             // MerkleStateRoot registers the platform state as a singleton upon the first request to it
-            assertInstanceOf(WritablePlatformStateStore.class, stateRoot.getPlatformState());
-            assertEquals(toPbjPlatformState(platformState), toPbjPlatformState(stateRoot.getPlatformState()));
+            assertInstanceOf(WritablePlatformStateStore.class, stateRoot.getWritablePlatformState());
+            assertEquals(toPbjPlatformState(platformState), toPbjPlatformState(stateRoot.getWritablePlatformState()));
         }
 
         @Test

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -66,7 +66,7 @@ class SignedStateTests {
 
         final PlatformStateAccessor platformState = new PlatformState();
         platformState.setAddressBook(mock(AddressBook.class));
-        when(state.getPlatformState()).thenReturn(platformState);
+        when(state.getWritablePlatformState()).thenReturn(platformState);
         if (reserveCallback != null) {
             doAnswer(invocation -> {
                         reserveCallback.run();
@@ -209,7 +209,9 @@ class SignedStateTests {
         final MerkleRoot state = spy(new MerkleStateRoot(
                 FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major())));
         final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
-        when(state.getPlatformState()).thenReturn(platformState);
+        // init state first
+        state.getWritablePlatformState();
+        when(state.getReadablePlatformState()).thenReturn(platformState);
         when(platformState.getRound()).thenReturn(0L);
         final SignedState signedState = new SignedState(
                 TestPlatformContextBuilder.create().build(),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateRegistryTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateRegistryTests.java
@@ -108,7 +108,7 @@ class StateRegistryTests {
         // Deserialize a state
         final MerkleStateRoot stateToSerialize =
                 new MerkleStateRoot(FAKE_MERKLE_STATE_LIFECYCLES, softwareVersionSupplier);
-        final var platformState = stateToSerialize.getPlatformState();
+        final var platformState = stateToSerialize.getWritablePlatformState();
         platformState.bulkUpdate(v -> {
             v.setCreationSoftwareVersion(new BasicSoftwareVersion(version.minor()));
             v.setLegacyRunningEventHash(new Hash());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
@@ -318,7 +318,7 @@ class StateSigningTests {
         final NodeId nodeRemovedFromAddressBook = nodes.get(0).getNodeId();
         final long weightRemovedFromAddressBook = nodes.get(0).getWeight();
         final AddressBook updatedAddressBook = signedState.getAddressBook().remove(nodeRemovedFromAddressBook);
-        signedState.getState().getPlatformState().setAddressBook(updatedAddressBook);
+        signedState.getState().getWritablePlatformState().setAddressBook(updatedAddressBook);
 
         // Tamper with a node's signature
         final long weightWithModifiedSignature = nodes.get(1).getWeight();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
@@ -157,7 +157,7 @@ public class HashLoggerTest {
         when(platformState.getRound()).thenReturn(round);
         when(platformState.getAddressBook()).thenReturn(addressBook);
 
-        when(state.getPlatformState()).thenReturn(platformState);
+        when(state.getReadablePlatformState()).thenReturn(platformState);
         when(state.getRoute()).thenReturn(merkleNode.getRoute());
         when(state.getHash()).thenReturn(merkleNode.getHash());
 

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/BlockingSwirldState.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/BlockingSwirldState.java
@@ -102,8 +102,8 @@ public class BlockingSwirldState extends MerkleStateRoot {
             return false;
         }
         return Objects.equals(
-                this.getPlatformState().getAddressBook(),
-                that.getPlatformState().getAddressBook());
+                this.getReadablePlatformState().getAddressBook(),
+                that.getReadablePlatformState().getAddressBook());
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
@@ -186,7 +186,7 @@ public class RandomSignedStateGenerator {
             consensusSnapshotInstance = consensusSnapshot;
         }
 
-        final PlatformStateAccessor platformState = stateInstance.getPlatformState();
+        final PlatformStateAccessor platformState = stateInstance.getWritablePlatformState();
 
         platformState.bulkUpdate(v -> {
             v.setSnapshot(consensusSnapshotInstance);

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/merkle/StateUtils.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/merkle/StateUtils.java
@@ -30,13 +30,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Objects;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /** Utility class for working with states. */
 public final class StateUtils {
-
-    private static final Logger logger = LogManager.getLogger();
 
     /** Prevent instantiation */
     private StateUtils() {}

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/SignedStateUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/SignedStateUtils.java
@@ -36,7 +36,7 @@ public class SignedStateUtils {
     public static SignedState randomSignedState(Random random) {
         MerkleStateRoot root =
                 new MerkleStateRoot(FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.minor()));
-        randomPlatformState(random, root.getPlatformState());
+        randomPlatformState(random, root.getWritablePlatformState());
         boolean shouldSaveToDisk = random.nextBoolean();
         SignedState signedState = new SignedState(
                 TestPlatformContextBuilder.create().build(),


### PR DESCRIPTION
**Description**:

This is a cherry-pick of https://github.com/hashgraph/hedera-services/pull/15389

**Related issue(s)**:

Fixes #15385 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
