### PR TITLE
chore: Remove PeerInfo.nodeName

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
@@ -379,7 +379,6 @@ public final class Utilities {
                 .filter(address -> !address.getNodeId().equals(selfId))
                 .map(address -> new PeerInfo(
                         address.getNodeId(),
-                        address.getSelfName(),
                         Objects.requireNonNull(address.getHostnameExternal()),
                         Objects.requireNonNull(address.getSigCert())))
                 .toList();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
@@ -17,6 +17,7 @@
 package com.swirlds.platform.network;
 
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.platform.roster.RosterUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.cert.Certificate;
 
@@ -24,12 +25,18 @@ import java.security.cert.Certificate;
  * A record representing a peer's network information.
  *
  * @param nodeId             the ID of the peer
- * @param nodeName           the name of the peer
  * @param hostname           the hostname (or IP address) of the peer
  * @param signingCertificate the certificate used to validate the peer's TLS certificate
  */
 public record PeerInfo(
         @NonNull NodeId nodeId,
-        @NonNull String nodeName,
         @NonNull String hostname,
-        @NonNull Certificate signingCertificate) {}
+        @NonNull Certificate signingCertificate) {
+    /**
+     * Return a "node name" for the peer, e.g. "node0" for a peer with NodeId == 0.
+     * @return a "node name"
+     */
+    @NonNull public String nodeName() {
+        return RosterUtils.formatNodeName(nodeId.id());
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
@@ -28,15 +28,13 @@ import java.security.cert.Certificate;
  * @param hostname           the hostname (or IP address) of the peer
  * @param signingCertificate the certificate used to validate the peer's TLS certificate
  */
-public record PeerInfo(
-        @NonNull NodeId nodeId,
-        @NonNull String hostname,
-        @NonNull Certificate signingCertificate) {
+public record PeerInfo(@NonNull NodeId nodeId, @NonNull String hostname, @NonNull Certificate signingCertificate) {
     /**
-     * Return a "node name" for the peer, e.g. "node0" for a peer with NodeId == 0.
+     * Return a "node name" for the peer, e.g. "node1" for a peer with NodeId == 0.
      * @return a "node name"
      */
-    @NonNull public String nodeName() {
+    @NonNull
+    public String nodeName() {
         return RosterUtils.formatNodeName(nodeId.id());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -25,7 +25,7 @@ public final class RosterUtils {
     private RosterUtils() {}
 
     /**
-     * Formats a "node name" for a given node id, e.g. "node0" for nodeId == 0.
+     * Formats a "node name" for a given node id, e.g. "node1" for nodeId == 0.
      * This name can be used for logging purposes, or to support code that
      * uses strings to identify nodes.
      *
@@ -34,6 +34,6 @@ public final class RosterUtils {
      */
     @NonNull
     public static String formatNodeName(final long nodeId) {
-        return "node" + nodeId;
+        return "node" + (nodeId + 1);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.roster;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A utility class to help use Rooster and RosterEntry instances.
+ */
+public final class RosterUtils {
+    private RosterUtils() {}
+
+    /**
+     * Formats a "node name" for a given node id, e.g. "node0" for nodeId == 0.
+     * This name can be used for logging purposes, or to support code that
+     * uses strings to identify nodes.
+     *
+     * @param nodeId a node id
+     * @return a "node name"
+     */
+    @NonNull
+    public static String formatNodeName(final long nodeId) {
+        return "node" + nodeId;
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
@@ -50,7 +50,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -61,7 +60,6 @@ class NetworkPeerIdentifierTest {
     final PlatformContext platformContext = mock(PlatformContext.class);
     List<PeerInfo> peerInfoList = null;
     PublicStores publicStores = null;
-
 
     @BeforeEach
     void setUp() throws URISyntaxException, KeyLoadingException, KeyStoreException {
@@ -84,7 +82,7 @@ class NetworkPeerIdentifierTest {
             if (!nameMatcher.matches()) {
                 throw new RuntimeException("Invalid node name " + name);
             }
-            final int id = Integer.parseInt(nameMatcher.group(1));
+            final int id = Integer.parseInt(nameMatcher.group(1)) - 1;
             final NodeId node = new NodeId(id);
             final PeerInfo peer;
             try {


### PR DESCRIPTION
**Description**:
As a part of replacing usages of AddressBook with Roster, I'm removing a usage of the Address.selfName which is not present in Roster.

**Related issue(s)**:

Fixes #15440

**Notes for reviewer**:
`test` and `timingSensitive` pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
