### PR TITLE
fix: 15167: Remove timeout from reconnect/rehash Iterators

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -35,7 +35,6 @@ import static com.swirlds.virtualmap.internal.Path.getSiblingPath;
 import static com.swirlds.virtualmap.internal.Path.isFarRight;
 import static com.swirlds.virtualmap.internal.Path.isLeft;
 import static com.swirlds.virtualmap.internal.merkle.VirtualMapState.MAX_LABEL_LENGTH;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -465,7 +464,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
         Objects.requireNonNull(records, "Records must be initialized before rehashing");
 
         final ConcurrentBlockingIterator<VirtualLeafRecord<K, V>> rehashIterator =
-                new ConcurrentBlockingIterator<>(MAX_REHASHING_BUFFER_SIZE, Integer.MAX_VALUE, MILLISECONDS);
+                new ConcurrentBlockingIterator<>(MAX_REHASHING_BUFFER_SIZE);
         final CompletableFuture<Hash> fullRehashFuture = new CompletableFuture<>();
         final CompletableFuture<Void> leafFeedFuture = new CompletableFuture<>();
         // getting a range that is relevant for the data source
@@ -1487,8 +1486,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
 
         // Set up the VirtualHasher which we will use during reconnect.
         // Initial timeout is intentionally very long, timeout is reduced once we receive the first leaf in the tree.
-        reconnectIterator =
-                new ConcurrentBlockingIterator<>(MAX_RECONNECT_HASHING_BUFFER_SIZE, Integer.MAX_VALUE, MILLISECONDS);
+        reconnectIterator = new ConcurrentBlockingIterator<>(MAX_RECONNECT_HASHING_BUFFER_SIZE);
         reconnectHashingFuture = new CompletableFuture<>();
         reconnectHashingStarted = new AtomicBoolean(false);
 
@@ -1582,10 +1580,6 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
         } catch (final Exception e) {
             throw new MerkleSynchronizationException("Failed to handle a leaf during reconnect on the learner", e);
         }
-    }
-
-    public void prepareForFirstLeaf() {
-        reconnectIterator.setMaxWaitTime(MAX_RECONNECT_HASHING_BUFFER_TIMEOUT, SECONDS);
     }
 
     public void prepareReconnectHashing(final long firstLeafPath, final long lastLeafPath) {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeView.java
@@ -107,11 +107,6 @@ public final class LearnerPullVirtualTreeView<K extends VirtualKey, V extends Vi
     private boolean firstNodeResponse = true;
 
     /**
-     * True until we have handled our first leaf
-     */
-    private boolean firstLeaf = true;
-
-    /**
      * Create a new {@link LearnerPullVirtualTreeView}.
      *
      * @param root
@@ -228,10 +223,6 @@ public final class LearnerPullVirtualTreeView<K extends VirtualKey, V extends Vi
         traversalOrder.nodeReceived(path, isClean);
 
         if (isLeaf) {
-            if (firstLeaf) {
-                root.prepareForFirstLeaf();
-                firstLeaf = false;
-            }
             if (!isClean) {
                 final VirtualLeafRecord<K, V> leaf = in.readSerializable(false, VirtualLeafRecord::new);
                 mapStats.incrementLeafData(1, 0);

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPushVirtualTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPushVirtualTreeView.java
@@ -118,11 +118,6 @@ public final class LearnerPushVirtualTreeView<K extends VirtualKey, V extends Vi
     private final ReconnectMapStats mapStats;
 
     /**
-     * True until we have handled our first leaf
-     */
-    private boolean firstLeaf = true;
-
-    /**
      * Create a new {@link LearnerPushVirtualTreeView}.
      *
      * @param root
@@ -262,11 +257,6 @@ public final class LearnerPushVirtualTreeView<K extends VirtualKey, V extends Vi
      */
     @Override
     public Long deserializeLeaf(final SerializableDataInputStream in) throws IOException {
-        if (firstLeaf) {
-            root.prepareForFirstLeaf();
-            firstLeaf = false;
-        }
-
         final VirtualLeafRecord<K, V> leaf = in.readSerializable(false, VirtualLeafRecord::new);
         nodeRemover.newLeafNode(leaf.getPath(), leaf.getKey());
         root.handleReconnectLeaf(leaf); // may block if hashing is slower than ingest


### PR DESCRIPTION
Fix summary:

* All timeouts are removed from `ConcurrentBlockingIterator`
* Rationale: when an iterator is used during reconnects, if elements (dirty leaves from the teacher) aren't provided for too long, the whole reconnect process is terminated. There is no need to have timeouts at the iterator level

Testing:

* All existing unit tests pass
* A couple new tests are provided, in particular to make sure `hasNext()` results in a runtime exception, if the thread is interrupted

Fixes: https://github.com/hashgraph/hedera-services/issues/15167
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
