### PR TITLE
fix: remove dependencies to 'org.testcontainers' in production code

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/CertificatePemTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/CertificatePemTest.java
@@ -82,7 +82,7 @@ class CertificatePemTest {
         final var genPemPath = Path.of(tmpDir.getPath() + "/generated.pem");
         writeCertificatePemFile(genPemPath, Bytes.wrap("anyString").toByteArray());
         final var exception = assertThrows(IOException.class, () -> readCertificatePemFile(genPemPath));
-        assertThat(exception.getMessage()).contains("problem parsing cert: java.io.IOException:");
+        assertThat(exception.getMessage()).contains("problem parsing cert: java.io.EOFException:");
         final var msg = assertThrows(PreCheckException.class, () -> validateX509Certificate(Bytes.wrap("anyString")));
         assertEquals(ResponseCodeEnum.INVALID_GOSSIP_CA_CERTIFICATE, msg.responseCode());
     }

--- a/hedera-node/hedera-addressbook-service/src/main/java/com/hedera/node/app/service/addressbook/AddressBookHelper.java
+++ b/hedera-node/hedera-addressbook-service/src/main/java/com/hedera/node/app/service/addressbook/AddressBookHelper.java
@@ -37,11 +37,11 @@ import java.security.cert.X509Certificate;
 import java.util.Objects;
 import java.util.Spliterators;
 import java.util.stream.StreamSupport;
-import org.testcontainers.shaded.org.bouncycastle.cert.X509CertificateHolder;
-import org.testcontainers.shaded.org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.testcontainers.shaded.org.bouncycastle.openssl.PEMParser;
-import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemObject;
-import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
 
 /**
  * Utility class that provides static methods and constants to facilitate the Address Book Services functions.

--- a/hedera-node/hedera-addressbook-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-addressbook-service/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module com.hedera.node.app.service.addressbook {
     requires transitive com.hedera.pbj.runtime;
     requires com.hedera.node.config;
     requires com.swirlds.config.api;
-    requires org.testcontainers;
+    requires org.bouncycastle.pkix;
+    requires org.bouncycastle.provider;
     requires static com.github.spotbugs.annotations;
 }


### PR DESCRIPTION
**Description**:
We only have 'org.testcontainers' in our dependency catalog for testing. It should never be used in production, as it pulls in the complete test containers library, with a bunch of transitive dependencies, into the Hedera Services release.

Here it was mistakenly introduced instead of using the original 'org.bouncycastle' dependencies.

@iwsimon *I recommend picking this also to the `0.54` branch.*

**Related issue(s)**:

Follow up to #14568


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
