### PR TITLE
fix: match genesis schema changes in `StateChangesValidator`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.junit.support.validators.block;
 
 import static com.hedera.node.app.info.UnavailableNetworkInfo.UNAVAILABLE_NETWORK_INFO;
-import static com.hedera.node.app.workflows.handle.metric.UnavailableMetrics.UNAVAILABLE_METRICS;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.APPLICATION_PROPERTIES;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.SAVED_STATES_DIR;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.SWIRLDS_LOG;
@@ -77,6 +76,7 @@ import com.hedera.services.bdd.junit.hedera.subprocess.SubProcessNetwork;
 import com.hedera.services.bdd.junit.support.BlockStreamAccess;
 import com.hedera.services.bdd.junit.support.BlockStreamValidator;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.swirlds.common.RosterStateId;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
@@ -151,7 +151,7 @@ public class StateChangesValidator implements BlockStreamValidator {
                 .normalize();
         final var validator = new StateChangesValidator(
                 Bytes.fromHex(
-                        "8fcceb3f724d5b765d96c9e27cbf20ac6a158eb5f06b8c5f71c3369ef5a0f1a6a01f6500dc3c464795cfa9fd5837dec8"),
+                        "bc49350852851a2c737ef6b5db24da8ba108401952ec207a1a5a4230de8d8a626da1f3663f0560bd6cf401c601b08896"),
                 node0Dir.resolve("output/swirlds.log"),
                 node0Dir.resolve("config.txt"),
                 node0Dir.resolve("data/config/application.properties"));
@@ -234,7 +234,9 @@ public class StateChangesValidator implements BlockStreamValidator {
         final var configVersion =
                 bootstrapConfig.getConfigData(HederaConfig.class).configVersion();
         final var currentVersion = new ServicesSoftwareVersion(servicesVersion, configVersion);
-        final var lifecycles = newPlatformInitLifecycle(bootstrapConfig, currentVersion, migrator, servicesRegistry);
+        final var metrics = new NoOpMetrics();
+        final var lifecycles =
+                newPlatformInitLifecycle(bootstrapConfig, currentVersion, migrator, servicesRegistry, metrics);
         state = new MerkleStateRoot(lifecycles, version -> new ServicesSoftwareVersion(version, configVersion));
         // initialize the platform state
         state.getWritablePlatformState();
@@ -245,7 +247,7 @@ public class StateChangesValidator implements BlockStreamValidator {
                 new ServicesSoftwareVersion(servicesVersion, configVersion),
                 new ConfigProviderImpl().getConfiguration(),
                 networkInfo,
-                new NoOpMetrics());
+                metrics);
 
         logger.info("Registered all Service and migrated state definitions to version {}", servicesVersion);
     }
@@ -620,19 +622,21 @@ public class StateChangesValidator implements BlockStreamValidator {
             @NonNull final Configuration bootstrapConfig,
             @NonNull final SoftwareVersion currentVersion,
             @NonNull final OrderedServiceMigrator serviceMigrator,
-            @NonNull final ServicesRegistryImpl servicesRegistry) {
+            @NonNull final ServicesRegistryImpl servicesRegistry,
+            @NonNull final NoOpMetrics metrics) {
         return new MerkleStateLifecycles() {
             @Override
             public List<StateChanges.Builder> initPlatformState(@NonNull final State state) {
                 final var deserializedVersion = serviceMigrator.creationVersionOf(state);
                 return serviceMigrator.doMigrations(
                         state,
-                        servicesRegistry.subRegistryFor(EntityIdService.NAME, PlatformStateService.NAME),
+                        servicesRegistry.subRegistryFor(
+                                EntityIdService.NAME, PlatformStateService.NAME, RosterStateId.NAME),
                         deserializedVersion == null ? null : new ServicesSoftwareVersion(deserializedVersion),
                         currentVersion,
                         bootstrapConfig,
                         UNAVAILABLE_NETWORK_INFO,
-                        UNAVAILABLE_METRICS);
+                        metrics);
             }
 
             @Override


### PR DESCRIPTION
**Description**:
 - Updates `StateChangesValidator` to follow the new order of service schema initializations in https://github.com/hashgraph/hedera-services/pull/15442