### PR TITLE
fix: Validate `CustomFees` input arrays in `UpdateTokenCustomFeesDecoder`

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/updatetokencustomfees/UpdateTokenCustomFeesDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/updatetokencustomfees/UpdateTokenCustomFeesDecoderTest.java
@@ -23,12 +23,15 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_FUN
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.base.Fraction;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.transaction.CustomFee;
 import com.hedera.hapi.node.transaction.FixedFee;
 import com.hedera.hapi.node.transaction.FractionalFee;
@@ -37,6 +40,9 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.Addres
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.updatetokencustomfees.UpdateTokenCustomFeesDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.updatetokencustomfees.UpdateTokenCustomFeesTranslator;
+import com.hedera.node.app.spi.workflows.HandleException;
+import com.hedera.node.config.data.TokensConfig;
+import com.swirlds.config.api.Configuration;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +58,12 @@ class UpdateTokenCustomFeesDecoderTest {
 
     @Mock
     private AddressIdConverter addressIdConverter;
+
+    @Mock
+    Configuration configuration;
+
+    @Mock
+    private TokensConfig tokensConfig;
 
     private UpdateTokenCustomFeesDecoder subject;
 
@@ -122,7 +134,7 @@ class UpdateTokenCustomFeesDecoderTest {
     @BeforeEach
     void setUp() {
         subject = new UpdateTokenCustomFeesDecoder();
-        given(attempt.addressIdConverter()).willReturn(addressIdConverter);
+        lenient().when(attempt.addressIdConverter()).thenReturn(addressIdConverter);
     }
 
     @Test
@@ -136,6 +148,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateFungibleTokenCustomFees(attempt);
@@ -158,6 +171,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateFungibleTokenCustomFees(attempt);
@@ -185,6 +199,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateFungibleTokenCustomFees(attempt);
@@ -219,6 +234,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateFungibleTokenCustomFees(attempt);
@@ -228,6 +244,35 @@ class UpdateTokenCustomFeesDecoderTest {
         assertEquals(updateTokenCustomFees.tokenId(), FUNGIBLE_TOKEN_ID);
         assertEquals(updateTokenCustomFees.customFees().size(), 10);
         assertTrue(updateTokenCustomFees.customFees().contains(FIXED_HBAR_FEES));
+    }
+
+    @Test
+    void decodeValidUpdateFungibleTokenCustom11FixedFeesRequest() {
+        // Given a valid encoded update token custom fees request
+        final var encoded = Bytes.wrapByteBuffer(
+                        UpdateTokenCustomFeesTranslator.UPDATE_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION.encodeCallWithArgs(
+                                FUNGIBLE_TOKEN_HEADLONG_ADDRESS,
+                                new Tuple[] {
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE,
+                                    FIXED_HBAR_FEE_TUPLE
+                                },
+                                EMPTY_TOKEN_FEES_TUPLE_ARR))
+                .toArray();
+        given(attempt.inputBytes()).willReturn(encoded);
+        setConfiguration();
+
+        final var error =
+                assertThrows(HandleException.class, () -> subject.decodeUpdateFungibleTokenCustomFees(attempt));
+        assertEquals(ResponseCodeEnum.CUSTOM_FEES_LIST_TOO_LONG, error.getStatus());
     }
 
     @Test
@@ -241,6 +286,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateFungibleTokenCustomFees(attempt);
@@ -263,6 +309,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateFungibleTokenCustomFees(attempt);
@@ -285,6 +332,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateFungibleTokenCustomFees(attempt);
@@ -308,6 +356,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateNonFungibleTokenCustomFees(attempt);
@@ -317,6 +366,65 @@ class UpdateTokenCustomFeesDecoderTest {
         assertEquals(updateTokenCustomFees.tokenId(), NON_FUNGIBLE_TOKEN_ID);
         assertEquals(updateTokenCustomFees.customFees().size(), 1);
         assertEquals(updateTokenCustomFees.customFees().get(0), ROYALTY_FEE);
+    }
+
+    @Test
+    void decodeValidUpdateNonFungibleTokenCustom11RoyaltyFeesRequest() {
+        // Given a valid encoded update token custom fees request
+        final var encoded = Bytes.wrapByteBuffer(
+                        UpdateTokenCustomFeesTranslator.UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION
+                                .encodeCallWithArgs(
+                                        NON_FUNGIBLE_TOKEN_HEADLONG_ADDRESS, EMPTY_TOKEN_FEES_TUPLE_ARR, new Tuple[] {
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE
+                                        }))
+                .toArray();
+        given(attempt.inputBytes()).willReturn(encoded);
+        setConfiguration();
+
+        final var error =
+                assertThrows(HandleException.class, () -> subject.decodeUpdateNonFungibleTokenCustomFees(attempt));
+        assertEquals(ResponseCodeEnum.CUSTOM_FEES_LIST_TOO_LONG, error.getStatus());
+    }
+
+    @Test
+    void decodeValidUpdateNonFungibleTokenCustom11MixedFeesRequest() {
+        // Given a valid encoded update token custom fees request
+        final var encoded = Bytes.wrapByteBuffer(
+                        UpdateTokenCustomFeesTranslator.UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION
+                                .encodeCallWithArgs(
+                                        NON_FUNGIBLE_TOKEN_HEADLONG_ADDRESS,
+                                        new Tuple[] {
+                                            FIXED_HBAR_FEE_TUPLE,
+                                            FIXED_HBAR_FEE_TUPLE,
+                                            FIXED_HBAR_FEE_TUPLE,
+                                            FIXED_HBAR_FEE_TUPLE,
+                                            FIXED_HBAR_FEE_TUPLE
+                                        },
+                                        new Tuple[] {
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE,
+                                            ROYALTY_FEE_TUPLE
+                                        }))
+                .toArray();
+        given(attempt.inputBytes()).willReturn(encoded);
+        setConfiguration();
+
+        final var error =
+                assertThrows(HandleException.class, () -> subject.decodeUpdateNonFungibleTokenCustomFees(attempt));
+        assertEquals(ResponseCodeEnum.CUSTOM_FEES_LIST_TOO_LONG, error.getStatus());
     }
 
     @Test
@@ -331,6 +439,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateNonFungibleTokenCustomFees(attempt);
@@ -354,6 +463,7 @@ class UpdateTokenCustomFeesDecoderTest {
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
         given(addressIdConverter.convert(OWNER_HEADLONG_ADDRESS)).willReturn(OWNER_ID);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateNonFungibleTokenCustomFees(attempt);
@@ -375,6 +485,7 @@ class UpdateTokenCustomFeesDecoderTest {
                                 EMPTY_TOKEN_FEES_TUPLE_ARR))
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateFungibleTokenCustomFees(attempt);
@@ -396,6 +507,7 @@ class UpdateTokenCustomFeesDecoderTest {
                                         EMPTY_TOKEN_FEES_TUPLE_ARR))
                 .toArray();
         given(attempt.inputBytes()).willReturn(encoded);
+        setConfiguration();
 
         // When decoding the request
         final var body = subject.decodeUpdateNonFungibleTokenCustomFees(attempt);
@@ -404,5 +516,11 @@ class UpdateTokenCustomFeesDecoderTest {
         // Then the result should match the expected decoded request
         assertEquals(updateTokenCustomFees.tokenId(), NON_FUNGIBLE_TOKEN_ID);
         assertEquals(updateTokenCustomFees.customFees().size(), 0);
+    }
+
+    private void setConfiguration() {
+        given(attempt.configuration()).willReturn(configuration);
+        given(configuration.getConfigData(TokensConfig.class)).willReturn(tokensConfig);
+        given(tokensConfig.maxCustomFeesAllowed()).willReturn(10);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/updatetokencustomfees/UpdateTokenCustomFeesTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/updatetokencustomfees/UpdateTokenCustomFeesTranslatorTest.java
@@ -44,6 +44,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.config.data.ContractsConfig;
+import com.hedera.node.config.data.TokensConfig;
 import com.swirlds.config.api.Configuration;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,6 +70,9 @@ class UpdateTokenCustomFeesTranslatorTest extends CallTestBase {
 
     @Mock
     private ContractsConfig contractsConfig;
+
+    @Mock
+    private TokensConfig tokensConfig;
 
     @Mock
     private HederaWorldUpdater.Enhancement enhancement;
@@ -161,6 +165,9 @@ class UpdateTokenCustomFeesTranslatorTest extends CallTestBase {
         given(addressIdConverter.convert(any())).willReturn(OWNER_ID);
         given(attempt.defaultVerificationStrategy()).willReturn(verificationStrategy);
         given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
+        given(attempt.configuration()).willReturn(configuration);
+        given(configuration.getConfigData(TokensConfig.class)).willReturn(tokensConfig);
+        given(tokensConfig.maxCustomFeesAllowed()).willReturn(10);
 
         final var call = subject.callFrom(attempt);
         assertThat(call).isInstanceOf(DispatchForResponseCodeHtsCall.class);
@@ -192,6 +199,9 @@ class UpdateTokenCustomFeesTranslatorTest extends CallTestBase {
         given(addressIdConverter.convert(any())).willReturn(OWNER_ID);
         given(attempt.defaultVerificationStrategy()).willReturn(verificationStrategy);
         given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
+        given(attempt.configuration()).willReturn(configuration);
+        given(configuration.getConfigData(TokensConfig.class)).willReturn(tokensConfig);
+        given(tokensConfig.maxCustomFeesAllowed()).willReturn(10);
 
         final var call = subject.callFrom(attempt);
         assertThat(call).isInstanceOf(DispatchForResponseCodeHtsCall.class);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/UpdateTokenFeeScheduleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/UpdateTokenFeeScheduleTest.java
@@ -32,7 +32,6 @@ import static com.hedera.services.bdd.spec.transactions.token.CustomFeeTests.roy
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEES_LIST_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_DENOMINATION_MUST_BE_FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_MUST_BE_POSITIVE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_SCHEDULE_ALREADY_HAS_NO_FEES;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/UpdateTokenFeeScheduleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/UpdateTokenFeeScheduleTest.java
@@ -394,13 +394,13 @@ public class UpdateTokenFeeScheduleTest {
                 overriding("tokens.maxCustomFeesAllowed", "10"),
                 updateTokenFeeSchedules
                         .call("updateFungibleFixedHbarFees", fungibleToken, 11, 10L, feeCollector)
-                        .andAssert(txn -> txn.hasKnownStatuses(CONTRACT_REVERT_EXECUTED, CUSTOM_FEES_LIST_TOO_LONG)),
+                        .andAssert(txn -> txn.hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
                 updateTokenFeeSchedules
                         .call("updateFungibleFractionalFees", feeToken, 11, 1L, 10L, false, feeCollector)
-                        .andAssert(txn -> txn.hasKnownStatuses(CONTRACT_REVERT_EXECUTED, CUSTOM_FEES_LIST_TOO_LONG)),
+                        .andAssert(txn -> txn.hasKnownStatus(CONTRACT_REVERT_EXECUTED)),
                 updateTokenFeeSchedules
                         .call("updateNonFungibleRoyaltyFees", nonFungibleToken, 11, 1L, 10L, feeCollector)
-                        .andAssert(txn -> txn.hasKnownStatuses(CONTRACT_REVERT_EXECUTED, CUSTOM_FEES_LIST_TOO_LONG)));
+                        .andAssert(txn -> txn.hasKnownStatus(CONTRACT_REVERT_EXECUTED)));
     }
 
     @Order(21)


### PR DESCRIPTION
**Description**:
This PR addresses a fail-fast way of handling invalid amount of fees provided in contract call.

**Related issue(s)**:

Fixes [#945](https://github.com/hashgraph/hedera-smart-contracts/issues/945)

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
