### PR TITLE
refactor: 15413 Split `PlatformStateAccessor` into two interfaces

### DIFF
--- a/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/com/swirlds/demo/crypto/CryptocurrencyDemoState.java
+++ b/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/com/swirlds/demo/crypto/CryptocurrencyDemoState.java
@@ -33,7 +33,7 @@ import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.SwirldsPlatform;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -200,7 +200,7 @@ public class CryptocurrencyDemoState extends PartialMerkleLeaf implements Swirld
     }
 
     @Override
-    public void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {
         throwIfImmutable();
         round.forEachEventTransaction((event, transaction) -> handleTransaction(event.getCreatorId(), transaction));
     }

--- a/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/com/swirlds/demo/hello/HelloSwirldDemoState.java
+++ b/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/com/swirlds/demo/hello/HelloSwirldDemoState.java
@@ -30,7 +30,7 @@ import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.SwirldState;
 import com.swirlds.platform.system.transaction.Transaction;
@@ -99,7 +99,7 @@ public class HelloSwirldDemoState extends PartialMerkleLeaf implements SwirldSta
     }
 
     @Override
-    public synchronized void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {
+    public synchronized void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {
         throwIfImmutable();
         round.forEachTransaction(this::handleTransaction);
     }

--- a/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/com/swirlds/demo/stats/StatsDemoState.java
+++ b/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/com/swirlds/demo/stats/StatsDemoState.java
@@ -30,7 +30,7 @@ import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.SwirldState;
 
@@ -69,7 +69,7 @@ public class StatsDemoState extends PartialMerkleLeaf implements SwirldState, Me
     }
 
     @Override
-    public void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {}
+    public void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {}
 
     /**
      * {@inheritDoc}

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -45,6 +45,7 @@ import com.swirlds.common.utility.ByteUtils;
 import com.swirlds.common.utility.StackTrace;
 import com.swirlds.platform.config.AddressBookConfig;
 import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -182,7 +183,7 @@ public class AddressBookTestingToolState extends PartialMerkleLeaf implements Sw
      * {@inheritDoc}
      */
     @Override
-    public void handleConsensusRound(@NonNull final Round round, @NonNull final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(@NonNull final Round round, @NonNull final PlatformStateModifier platformState) {
         Objects.requireNonNull(round, "the round cannot be null");
         Objects.requireNonNull(platformState, "the platform state cannot be null");
         throwIfImmutable();

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolState.java
@@ -27,6 +27,7 @@ import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import com.swirlds.common.utility.NonCryptographicHashing;
 import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -249,7 +250,7 @@ public class ConsistencyTestingToolState extends PartialMerkleLeaf implements Sw
      * Writes the round and its contents to a log on disk
      */
     @Override
-    public void handleConsensusRound(final @NonNull Round round, final @NonNull PlatformStateAccessor platformState) {
+    public void handleConsensusRound(final @NonNull Round round, final @NonNull PlatformStateModifier platformState) {
         Objects.requireNonNull(round);
         Objects.requireNonNull(platformState);
 

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolState.java
@@ -40,7 +40,7 @@ import com.swirlds.common.merkle.utility.SerializableLong;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.utility.ByteUtils;
 import com.swirlds.platform.scratchpad.Scratchpad;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -172,7 +172,7 @@ public class ISSTestingToolState extends PartialMerkleLeaf implements SwirldStat
      * {@inheritDoc}
      */
     @Override
-    public void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {
         throwIfImmutable();
         final Iterator<ConsensusEvent> eventIterator = round.iterator();
 

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolState.java
@@ -32,7 +32,7 @@ import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.MerkleDbTableConfig;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -249,7 +249,7 @@ public class MigrationTestingToolState extends PartialNaryMerkleInternal impleme
      * {@inheritDoc}
      */
     @Override
-    public void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {
         throwIfImmutable();
         for (final Iterator<ConsensusEvent> eventIt = round.iterator(); eventIt.hasNext(); ) {
             final ConsensusEvent event = eventIt.next();

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
@@ -83,7 +83,7 @@ import com.swirlds.merkle.test.fixtures.map.lifecycle.TransactionType;
 import com.swirlds.merkle.test.fixtures.map.pta.MapKey;
 import com.swirlds.platform.ParameterProvider;
 import com.swirlds.platform.Utilities;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -1071,7 +1071,7 @@ public class PlatformTestingToolState extends PartialNaryMerkleInternal implemen
      * Handle the freeze transaction type.
      */
     private void handleFreezeTransaction(
-            final TestTransaction testTransaction, final PlatformStateAccessor platformState) {
+            final TestTransaction testTransaction, final PlatformStateModifier platformState) {
         final FreezeTransaction freezeTx = testTransaction.getFreezeTransaction();
         FreezeTransactionHandler.freeze(freezeTx, platformState);
     }
@@ -1093,7 +1093,7 @@ public class PlatformTestingToolState extends PartialNaryMerkleInternal implemen
     }
 
     @Override
-    public synchronized void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {
+    public synchronized void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {
         throwIfImmutable();
         if (!initialized.get()) {
             throw new IllegalStateException("handleConsensusRound() called before init()");
@@ -1125,7 +1125,7 @@ public class PlatformTestingToolState extends PartialNaryMerkleInternal implemen
     private void handleConsensusTransaction(
             final ConsensusEvent event,
             final ConsensusTransaction trans,
-            final PlatformStateAccessor platformState,
+            final PlatformStateModifier platformState,
             final long roundNum) {
         if (trans.isSystem()) {
             return;
@@ -1164,7 +1164,7 @@ public class PlatformTestingToolState extends PartialNaryMerkleInternal implemen
             @NonNull final Instant timeCreated,
             @NonNull final Instant timestamp,
             @NonNull final ConsensusTransaction trans,
-            @NonNull final PlatformStateAccessor platformState) {
+            @NonNull final PlatformStateModifier platformState) {
         if (getConfig().isAppendSig()) {
             try {
                 final TestTransactionWrapper testTransactionWrapper = TestTransactionWrapper.parseFrom(

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/freeze/FreezeTransactionHandler.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/freeze/FreezeTransactionHandler.java
@@ -17,7 +17,7 @@
 package com.swirlds.demo.platform.freeze;
 
 import com.swirlds.demo.platform.fs.stresstest.proto.FreezeTransaction;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import java.time.Instant;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -28,7 +28,7 @@ public class FreezeTransactionHandler {
     private static final Logger logger = LogManager.getLogger(FreezeTransactionHandler.class);
     private static final Marker LOGM_FREEZE = MarkerManager.getMarker("FREEZE");
 
-    public static boolean freeze(final FreezeTransaction transaction, final PlatformStateAccessor platformState) {
+    public static boolean freeze(final FreezeTransaction transaction, final PlatformStateModifier platformState) {
         logger.debug(LOGM_FREEZE, "Handling FreezeTransaction: " + transaction);
         try {
             platformState.setFreezeTime(Instant.ofEpochSecond(transaction.getStartTimeEpochSecond()));

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/StatsSigningTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/StatsSigningTestingToolState.java
@@ -37,7 +37,7 @@ import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.SwirldState;
 import com.swirlds.platform.system.events.Event;
@@ -129,7 +129,7 @@ public class StatsSigningTestingToolState extends PartialMerkleLeaf implements S
      * {@inheritDoc}
      */
     @Override
-    public void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {
         throwIfImmutable();
         round.forEachTransaction(this::handleTransaction);
     }

--- a/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolState.java
@@ -31,7 +31,7 @@ import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import com.swirlds.common.utility.ByteUtils;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -99,7 +99,7 @@ public class StressTestingToolState extends PartialMerkleLeaf implements SwirldS
      * {@inheritDoc}
      */
     @Override
-    public void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {
         throwIfImmutable();
         round.forEachTransaction(this::handleTransaction);
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
@@ -29,6 +29,7 @@ import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.platform.config.DefaultConfiguration;
 import com.swirlds.platform.consensus.SyntheticSnapshot;
 import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
 import com.swirlds.platform.state.snapshot.SignedStateFileReader;
@@ -75,7 +76,7 @@ public class GenesisPlatformStateCommand extends AbstractCommand {
         final DeserializedSignedState deserializedSignedState =
                 SignedStateFileReader.readStateFile(platformContext, statePath, SignedStateFileUtils::readState);
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
-            final PlatformStateAccessor platformState =
+            final PlatformStateModifier platformState =
                     reservedSignedState.get().getState().getWritablePlatformState();
             platformState.bulkUpdate(v -> {
                 System.out.printf("Replacing platform data %n");

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -37,7 +37,7 @@ import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.metrics.RoundHandlingMetrics;
 import com.swirlds.platform.state.MerkleRoot;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -215,12 +215,12 @@ public class DefaultTransactionHandler implements TransactionHandler {
     }
 
     /**
-     * Populate the {@link PlatformStateAccessor} with all needed data for this round.
+     * Populate the {@link PlatformStateModifier} with all needed data for this round.
      *
      * @param round the consensus round
      */
     private void updatePlatformState(@NonNull final ConsensusRound round) {
-        final PlatformStateAccessor platformState =
+        final PlatformStateModifier platformState =
                 swirldStateManager.getConsensusState().getWritablePlatformState();
         platformState.bulkUpdate(v -> {
             v.setRound(round.getRoundNum());
@@ -238,7 +238,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
      * @throws InterruptedException if this thread is interrupted
      */
     private void updateRunningEventHash(@NonNull final ConsensusRound round) throws InterruptedException {
-        final PlatformStateAccessor platformState =
+        final PlatformStateModifier platformState =
                 swirldStateManager.getConsensusState().getWritablePlatformState();
 
         if (writeLegacyRunningEventHash) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -53,6 +53,7 @@ import com.swirlds.platform.recovery.internal.RecoveryPlatform;
 import com.swirlds.platform.recovery.internal.StreamedRound;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.SignedStateFileReader;
@@ -380,7 +381,7 @@ public final class EventRecoveryWorkflow {
         new DefaultEventHasher().hashEvent(lastEvent);
 
         final PlatformStateAccessor newReadablePlatformState = newState.getReadablePlatformState();
-        final PlatformStateAccessor newWritablePlatformState = newState.getWritablePlatformState();
+        final PlatformStateModifier newWritablePlatformState = newState.getWritablePlatformState();
         final PlatformStateAccessor previousReadablePlatformState =
                 previousState.get().getState().getReadablePlatformState();
 
@@ -478,7 +479,7 @@ public final class EventRecoveryWorkflow {
     static void applyTransactions(
             final SwirldState immutableState,
             final SwirldState mutableState,
-            final PlatformStateAccessor platformState,
+            final PlatformStateModifier platformState,
             final Round round) {
 
         mutableState.throwIfImmutable();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
@@ -64,7 +64,7 @@ public final class BirthRoundStateMigration {
         }
 
         final MerkleRoot state = initialState.getState();
-        final PlatformStateAccessor writablePlatformState = state.getWritablePlatformState();
+        final PlatformStateModifier writablePlatformState = state.getWritablePlatformState();
 
         final boolean alreadyMigrated = writablePlatformState.getFirstVersionInBirthRoundMode() != null;
         if (alreadyMigrated) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/GenesisStateBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/GenesisStateBuilder.java
@@ -39,7 +39,7 @@ public final class GenesisStateBuilder {
      */
     public static void initGenesisPlatformState(
             final PlatformContext platformContext,
-            final PlatformStateAccessor platformState,
+            final PlatformStateModifier platformState,
             final AddressBook addressBook,
             final SoftwareVersion appVersion) {
         platformState.bulkUpdate(v -> {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
@@ -33,6 +33,14 @@ public interface MerkleRoot extends MerkleInternal {
     SwirldState getSwirldState();
 
     /**
+     * This method makes sure that the platform state is initialized.
+     * If it's already initialized, it does nothing.
+     */
+    default void initPlatformState() {
+        // do nothing
+    }
+
+    /**
      * Get readable platform state.
      * Works on both - mutable and immutable {@link MerkleRoot} and, therefore, this method should be preferred.
      *
@@ -48,14 +56,14 @@ public interface MerkleRoot extends MerkleInternal {
      * @return mutable platform state
      */
     @NonNull
-    PlatformStateAccessor getWritablePlatformState();
+    PlatformStateModifier getWritablePlatformState();
 
     /**
      * Set the platform state.
      *
      * @param platformState the platform state
      */
-    void updatePlatformState(@NonNull final PlatformStateAccessor platformState);
+    void updatePlatformState(@NonNull final PlatformStateModifier platformState);
 
     /**
      * Generate a string that describes this state.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleRoot.java
@@ -36,9 +36,7 @@ public interface MerkleRoot extends MerkleInternal {
      * This method makes sure that the platform state is initialized.
      * If it's already initialized, it does nothing.
      */
-    default void initPlatformState() {
-        // do nothing
-    }
+    void initPlatformState();
 
     /**
      * Get readable platform state.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public interface MerkleStateLifecycles {
     /**
-     * Called when a {@link MerkleStateRoot} needs to ensure its {@link PlatformStateAccessor} implementation
+     * Called when a {@link MerkleStateRoot} needs to ensure its {@link PlatformStateModifier} implementation
      * is initialized.
      *
      * @param state the root of the state to be initialized

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
@@ -390,7 +390,7 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
      * {@inheritDoc}
      */
     @Override
-    public void handleConsensusRound(@NonNull final Round round, @NonNull final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(@NonNull final Round round, @NonNull final PlatformStateModifier platformState) {
         throwIfImmutable();
         lifecycles.onHandleConsensusRound(round, this);
     }
@@ -1014,7 +1014,7 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
      */
     @NonNull
     @Override
-    public PlatformStateAccessor getWritablePlatformState() {
+    public PlatformStateModifier getWritablePlatformState() {
         if (isImmutable()) {
             throw new IllegalStateException("Cannot get writable platform state when state is immutable");
         }
@@ -1022,12 +1022,20 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
     }
 
     /**
-     * Updates the platform state with the values from the provided instance of {@link PlatformStateAccessor}
+     * {@inheritDoc}
+     */
+    @Override
+    public void initPlatformState() {
+        writablePlatformStateStore();
+    }
+
+    /**
+     * Updates the platform state with the values from the provided instance of {@link PlatformStateModifier}
      *
      * @param accessor a source of values
      */
     @Override
-    public void updatePlatformState(@NonNull final PlatformStateAccessor accessor) {
+    public void updatePlatformState(@NonNull final PlatformStateModifier accessor) {
         writablePlatformStateStore().setAllFrom(accessor);
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
@@ -1026,7 +1026,7 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
      */
     @Override
     public void initPlatformState() {
-        writablePlatformStateStore();
+        getWritableStates(PlatformStateService.NAME);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateRoot.java
@@ -1026,7 +1026,9 @@ public class MerkleStateRoot extends PartialNaryMerkleInternal
      */
     @Override
     public void initPlatformState() {
-        getWritableStates(PlatformStateService.NAME);
+        if (!services.containsKey(PlatformStateService.NAME)) {
+            platformStateInitChanges = lifecycles.initPlatformState(this);
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformState.java
@@ -35,11 +35,11 @@ import java.util.function.Consumer;
 
 /**
  * State managed and used by the platform.
- * @deprecated Implementation of {@link PlatformStateAccessor} before moving platform state into State API. This class
+ * @deprecated Implementation of {@link PlatformStateModifier} before moving platform state into State API. This class
  * should be moved to the platform test fixtures after migration to 0.54.0.
  */
 @Deprecated(since = "0.54.0", forRemoval = true)
-public class PlatformState extends PartialMerkleLeaf implements MerkleLeaf, PlatformStateAccessor {
+public class PlatformState extends PartialMerkleLeaf implements MerkleLeaf, PlatformStateModifier {
 
     public static final long CLASS_ID = 0x52cef730a11cb6dfL;
 
@@ -560,7 +560,7 @@ public class PlatformState extends PartialMerkleLeaf implements MerkleLeaf, Plat
      * {@inheritDoc}
      */
     @Override
-    public void bulkUpdate(@NonNull Consumer<PlatformStateAccessor> updater) {
+    public void bulkUpdate(@NonNull Consumer<PlatformStateModifier> updater) {
         updater.accept(this);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateAccessor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateAccessor.java
@@ -24,11 +24,7 @@ import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
-import java.util.function.Consumer;
 
-/**
- * This interface represents the platform state and provide access to the state's properties.
- */
 public interface PlatformStateAccessor {
     /**
      * The round of the genesis state.
@@ -44,13 +40,6 @@ public interface PlatformStateAccessor {
     SoftwareVersion getCreationSoftwareVersion();
 
     /**
-     * Set the software version of the application that created this state.
-     *
-     * @param creationVersion the creation version
-     */
-    void setCreationSoftwareVersion(@NonNull SoftwareVersion creationVersion);
-
-    /**
      * Get the address book.
      * @return an address book
      */
@@ -58,32 +47,11 @@ public interface PlatformStateAccessor {
     AddressBook getAddressBook();
 
     /**
-     * Set the address book.
-     *
-     * @param addressBook an address book
-     */
-    void setAddressBook(@Nullable AddressBook addressBook);
-
-    /**
      * Get the previous address book.
      * @return a previous address book
      */
     @Nullable
     AddressBook getPreviousAddressBook();
-
-    /**
-     * Set the previous address book.
-     *
-     * @param addressBook an address book
-     */
-    void setPreviousAddressBook(@Nullable AddressBook addressBook);
-
-    /**
-     * Set the round when this state was generated.
-     *
-     * @param round a round number
-     */
-    void setRound(long round);
 
     /**
      * Get the round when this state was generated.
@@ -101,13 +69,6 @@ public interface PlatformStateAccessor {
     Hash getLegacyRunningEventHash();
 
     /**
-     * Set the legacy running event hash. Used by the consensus event stream.
-     *
-     * @param legacyRunningEventHash a running hash of events
-     */
-    void setLegacyRunningEventHash(@Nullable Hash legacyRunningEventHash);
-
-    /**
      * Get the consensus timestamp for this state, defined as the timestamp of the first transaction that was applied in
      * the round that created the state.
      *
@@ -115,14 +76,6 @@ public interface PlatformStateAccessor {
      */
     @Nullable
     Instant getConsensusTimestamp();
-
-    /**
-     * Set the consensus timestamp for this state, defined as the timestamp of the first transaction that was applied in
-     * the round that created the state.
-     *
-     * @param consensusTimestamp a consensus timestamp
-     */
-    void setConsensusTimestamp(@NonNull Instant consensusTimestamp);
 
     /**
      * For the oldest non-ancient round, get the lowest ancient indicator out of all of those round's judges. This is
@@ -139,13 +92,6 @@ public interface PlatformStateAccessor {
     long getAncientThreshold();
 
     /**
-     * Sets the number of non-ancient rounds.
-     *
-     * @param roundsNonAncient the number of non-ancient rounds
-     */
-    void setRoundsNonAncient(int roundsNonAncient);
-
-    /**
      * Gets the number of non-ancient rounds.
      *
      * @return the number of non-ancient rounds
@@ -159,11 +105,6 @@ public interface PlatformStateAccessor {
     ConsensusSnapshot getSnapshot();
 
     /**
-     * @param snapshot the consensus snapshot for this round
-     */
-    void setSnapshot(@NonNull ConsensusSnapshot snapshot);
-
-    /**
      * Gets the time when the next freeze is scheduled to start. If null then there is no freeze scheduled.
      *
      * @return the time when the freeze starts
@@ -172,28 +113,12 @@ public interface PlatformStateAccessor {
     Instant getFreezeTime();
 
     /**
-     * Sets the instant after which the platform will enter FREEZING status. When consensus timestamp of a signed state
-     * is after this instant, the platform will stop creating events and accepting transactions. This is used to safely
-     * shut down the platform for maintenance.
-     *
-     * @param freezeTime an Instant in UTC
-     */
-    void setFreezeTime(@Nullable Instant freezeTime);
-
-    /**
      * Gets the last freezeTime based on which the nodes were frozen. If null then there has never been a freeze.
      *
      * @return the last freezeTime based on which the nodes were frozen
      */
     @Nullable
     Instant getLastFrozenTime();
-
-    /**
-     * Sets the last freezeTime based on which the nodes were frozen.
-     *
-     * @param lastFrozenTime the last freezeTime based on which the nodes were frozen
-     */
-    void setLastFrozenTime(@Nullable Instant lastFrozenTime);
 
     /**
      * Get the first software version where the birth round migration happened, or null if birth round migration has not
@@ -205,26 +130,11 @@ public interface PlatformStateAccessor {
     SoftwareVersion getFirstVersionInBirthRoundMode();
 
     /**
-     * Set the first software version where the birth round migration happened.
-     *
-     * @param firstVersionInBirthRoundMode the first software version where the birth round migration happened
-     */
-    @NonNull
-    void setFirstVersionInBirthRoundMode(SoftwareVersion firstVersionInBirthRoundMode);
-
-    /**
      * Get the last round before the birth round mode was enabled, or -1 if birth round mode has not yet been enabled.
      *
      * @return the last round before the birth round mode was enabled
      */
     long getLastRoundBeforeBirthRoundMode();
-
-    /**
-     * Set the last round before the birth round mode was enabled.
-     *
-     * @param lastRoundBeforeBirthRoundMode the last round before the birth round mode was enabled
-     */
-    void setLastRoundBeforeBirthRoundMode(long lastRoundBeforeBirthRoundMode);
 
     /**
      * Get the lowest judge generation before the birth round mode was enabled, or -1 if birth round mode has not yet
@@ -233,18 +143,4 @@ public interface PlatformStateAccessor {
      * @return the lowest judge generation before the birth round mode was enabled
      */
     long getLowestJudgeGenerationBeforeBirthRoundMode();
-
-    /**
-     * Set the lowest judge generation before the birth round mode was enabled.
-     *
-     * @param lowestJudgeGenerationBeforeBirthRoundMode the lowest judge generation before the birth round mode was
-     *                                                  enabled
-     */
-    void setLowestJudgeGenerationBeforeBirthRoundMode(long lowestJudgeGenerationBeforeBirthRoundMode);
-
-    /**
-     * This is a convenience method to update multiple fields in the platform state in a single operation.
-     * @param updater a consumer that updates the platform state
-     */
-    void bulkUpdate(@NonNull Consumer<PlatformStateAccessor> updater);
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateAccessor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateAccessor.java
@@ -25,6 +25,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 
+/**
+ * This interface represents the platform state and provide access to the state's properties.
+ */
 public interface PlatformStateAccessor {
     /**
      * The round of the genesis state.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateModifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateModifier.java
@@ -26,7 +26,7 @@ import java.time.Instant;
 import java.util.function.Consumer;
 
 /**
- * This interface represents the platform state and provide access to the state's properties.
+ * This interface represents the platform state and provide methods for modifying the state.
  */
 public interface PlatformStateModifier extends PlatformStateAccessor {
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateModifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateModifier.java
@@ -106,7 +106,6 @@ public interface PlatformStateModifier extends PlatformStateAccessor {
      *
      * @param firstVersionInBirthRoundMode the first software version where the birth round migration happened
      */
-    @NonNull
     void setFirstVersionInBirthRoundMode(SoftwareVersion firstVersionInBirthRoundMode);
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateModifier.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformStateModifier.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.state;
+
+import com.swirlds.common.crypto.Hash;
+import com.swirlds.platform.consensus.ConsensusSnapshot;
+import com.swirlds.platform.system.SoftwareVersion;
+import com.swirlds.platform.system.address.AddressBook;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+import java.util.function.Consumer;
+
+/**
+ * This interface represents the platform state and provide access to the state's properties.
+ */
+public interface PlatformStateModifier extends PlatformStateAccessor {
+
+    /**
+     * Set the software version of the application that created this state.
+     *
+     * @param creationVersion the creation version
+     */
+    void setCreationSoftwareVersion(@NonNull SoftwareVersion creationVersion);
+
+    /**
+     * Set the address book.
+     *
+     * @param addressBook an address book
+     */
+    void setAddressBook(@Nullable AddressBook addressBook);
+
+    /**
+     * Set the previous address book.
+     *
+     * @param addressBook an address book
+     */
+    void setPreviousAddressBook(@Nullable AddressBook addressBook);
+
+    /**
+     * Set the round when this state was generated.
+     *
+     * @param round a round number
+     */
+    void setRound(long round);
+
+    /**
+     * Set the legacy running event hash. Used by the consensus event stream.
+     *
+     * @param legacyRunningEventHash a running hash of events
+     */
+    void setLegacyRunningEventHash(@Nullable Hash legacyRunningEventHash);
+
+    /**
+     * Set the consensus timestamp for this state, defined as the timestamp of the first transaction that was applied in
+     * the round that created the state.
+     *
+     * @param consensusTimestamp a consensus timestamp
+     */
+    void setConsensusTimestamp(@NonNull Instant consensusTimestamp);
+
+    /**
+     * Sets the number of non-ancient rounds.
+     *
+     * @param roundsNonAncient the number of non-ancient rounds
+     */
+    void setRoundsNonAncient(int roundsNonAncient);
+
+    /**
+     * @param snapshot the consensus snapshot for this round
+     */
+    void setSnapshot(@NonNull ConsensusSnapshot snapshot);
+
+    /**
+     * Sets the instant after which the platform will enter FREEZING status. When consensus timestamp of a signed state
+     * is after this instant, the platform will stop creating events and accepting transactions. This is used to safely
+     * shut down the platform for maintenance.
+     *
+     * @param freezeTime an Instant in UTC
+     */
+    void setFreezeTime(@Nullable Instant freezeTime);
+
+    /**
+     * Sets the last freezeTime based on which the nodes were frozen.
+     *
+     * @param lastFrozenTime the last freezeTime based on which the nodes were frozen
+     */
+    void setLastFrozenTime(@Nullable Instant lastFrozenTime);
+
+    /**
+     * Set the first software version where the birth round migration happened.
+     *
+     * @param firstVersionInBirthRoundMode the first software version where the birth round migration happened
+     */
+    @NonNull
+    void setFirstVersionInBirthRoundMode(SoftwareVersion firstVersionInBirthRoundMode);
+
+    /**
+     * Set the last round before the birth round mode was enabled.
+     *
+     * @param lastRoundBeforeBirthRoundMode the last round before the birth round mode was enabled
+     */
+    void setLastRoundBeforeBirthRoundMode(long lastRoundBeforeBirthRoundMode);
+
+    /**
+     * Set the lowest judge generation before the birth round mode was enabled.
+     *
+     * @param lowestJudgeGenerationBeforeBirthRoundMode the lowest judge generation before the birth round mode was
+     *                                                  enabled
+     */
+    void setLowestJudgeGenerationBeforeBirthRoundMode(long lowestJudgeGenerationBeforeBirthRoundMode);
+
+    /**
+     * This is a convenience method to update multiple fields in the platform state in a single operation.
+     * @param updater a consumer that updates the platform state
+     */
+    void bulkUpdate(@NonNull Consumer<PlatformStateModifier> updater);
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
@@ -164,14 +164,14 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
      * @param platformStateAccessor the platform state
      */
     @Override
-    public void updatePlatformState(@NonNull final PlatformStateAccessor platformStateAccessor) {
+    public void updatePlatformState(@NonNull final PlatformStateModifier platformStateAccessor) {
         if (platformStateAccessor instanceof PlatformState platformState) {
             setChild(ChildIndices.PLATFORM_STATE, platformState);
         } else {
             throw new UnsupportedOperationException("%s implementation of %s is not supported"
                     .formatted(
                             platformStateAccessor.getClass().getSimpleName(),
-                            PlatformStateAccessor.class.getSimpleName()));
+                            PlatformStateModifier.class.getSimpleName()));
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
@@ -111,6 +111,11 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
         return this;
     }
 
+    @Override
+    public void initPlatformState() {
+        // no initialization required
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/State.java
@@ -166,17 +166,15 @@ public class State extends PartialNaryMerkleInternal implements MerkleRoot {
     /**
      * Updates the platform state.
      *
-     * @param platformStateAccessor the platform state
+     * @param modifier the platform state
      */
     @Override
-    public void updatePlatformState(@NonNull final PlatformStateModifier platformStateAccessor) {
-        if (platformStateAccessor instanceof PlatformState platformState) {
+    public void updatePlatformState(@NonNull final PlatformStateModifier modifier) {
+        if (modifier instanceof PlatformState platformState) {
             setChild(ChildIndices.PLATFORM_STATE, platformState);
         } else {
             throw new UnsupportedOperationException("%s implementation of %s is not supported"
-                    .formatted(
-                            platformStateAccessor.getClass().getSimpleName(),
-                            PlatformStateModifier.class.getSimpleName()));
+                    .formatted(modifier.getClass().getSimpleName(), PlatformStateModifier.class.getSimpleName()));
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -118,7 +118,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
 
     /**
      * Handles the events in a consensus round. Implementations are responsible for invoking
-     * {@link SwirldState#handleConsensusRound(Round, PlatformStateAccessor)}.
+     * {@link SwirldState#handleConsensusRound(Round, PlatformStateModifier)}.
      *
      * @param round the round to handle
      */

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PbjConverter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PbjConverter.java
@@ -29,6 +29,7 @@ import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.crypto.SerializableX509Certificate;
 import com.swirlds.platform.state.MinimumJudgeInfo;
 import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
@@ -52,7 +53,7 @@ import java.util.Optional;
  */
 public final class PbjConverter {
     /**
-     * Converts an instance of {@link PlatformStateAccessor} to PBJ representation (an instance of {@link com.hedera.hapi.platform.state.PlatformState}.)
+     * Converts an instance of {@link PlatformStateModifier} to PBJ representation (an instance of {@link com.hedera.hapi.platform.state.PlatformState}.)
      * @param accessor the source of the data
      * @return the platform state as PBJ object
      */
@@ -79,7 +80,7 @@ public final class PbjConverter {
     }
 
     /**
-     * Converts an instance of {@link PlatformStateAccessor} to PBJ representation (an instance of {@link com.hedera.hapi.platform.state.PlatformState}.)
+     * Converts an instance of {@link PlatformStateModifier} to PBJ representation (an instance of {@link com.hedera.hapi.platform.state.PlatformState}.)
      * @param accumulator the source of the data
      * @return the platform state as PBJ object
      */

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateValueAccumulator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateValueAccumulator.java
@@ -20,7 +20,7 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.event.AncientMode;
 import com.swirlds.platform.state.MinimumJudgeInfo;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -36,7 +36,7 @@ import java.util.function.Consumer;
  * It's not meant to be used for other purposes. This class tracks the changes to the fields to prevent resetting original
  * platform state fields to null if they are not updated.
  */
-public class PlatformStateValueAccumulator implements PlatformStateAccessor {
+public class PlatformStateValueAccumulator implements PlatformStateModifier {
 
     /**
      * The address book for this round.
@@ -478,7 +478,7 @@ public class PlatformStateValueAccumulator implements PlatformStateAccessor {
     }
 
     @Override
-    public void bulkUpdate(@NonNull Consumer<PlatformStateAccessor> updater) {
+    public void bulkUpdate(@NonNull Consumer<PlatformStateModifier> updater) {
         updater.accept(this);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadablePlatformStateStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadablePlatformStateStore.java
@@ -24,7 +24,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.state.PlatformState;
-import com.swirlds.base.state.MutabilityException;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.state.PlatformStateAccessor;
@@ -35,7 +34,6 @@ import com.swirlds.state.spi.ReadableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -213,118 +211,6 @@ public class ReadablePlatformStateStore implements PlatformStateAccessor {
     @Override
     public long getLowestJudgeGenerationBeforeBirthRoundMode() {
         return stateOrThrow().lowestJudgeGenerationBeforeBirthRoundMode();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setCreationSoftwareVersion(@NonNull final SoftwareVersion creationVersion) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setAddressBook(@Nullable AddressBook addressBook) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setPreviousAddressBook(@Nullable AddressBook addressBook) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setRound(long round) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setLegacyRunningEventHash(@Nullable Hash legacyRunningEventHash) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setConsensusTimestamp(@NonNull Instant consensusTimestamp) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setRoundsNonAncient(int roundsNonAncient) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setSnapshot(@NonNull ConsensusSnapshot snapshot) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setFreezeTime(@Nullable Instant freezeTime) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setLastFrozenTime(@Nullable Instant lastFrozenTime) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setFirstVersionInBirthRoundMode(SoftwareVersion firstVersionInBirthRoundMode) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setLastRoundBeforeBirthRoundMode(long lastRoundBeforeBirthRoundMode) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void setLowestJudgeGenerationBeforeBirthRoundMode(long lowestJudgeGenerationBeforeBirthRoundMode) {
-        throw new MutabilityException("Platform state is read-only");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void bulkUpdate(@NonNull Consumer<PlatformStateAccessor> updater) {
-        throw new MutabilityException("Platform state is read-only");
     }
 
     private @NonNull PlatformState stateOrThrow() {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritablePlatformStateStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritablePlatformStateStore.java
@@ -75,8 +75,8 @@ public class WritablePlatformStateStore extends ReadablePlatformStateStore imple
     /**
      * Overwrite the current platform state with the provided state.
      */
-    public void setAllFrom(@NonNull final PlatformStateModifier accessor) {
-        this.update(toPbjPlatformState(accessor));
+    public void setAllFrom(@NonNull final PlatformStateModifier modifier) {
+        this.update(toPbjPlatformState(modifier));
     }
 
     private void setAllFrom(@NonNull final PlatformStateValueAccumulator accumulator) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritablePlatformStateStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritablePlatformStateStore.java
@@ -27,7 +27,7 @@ import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.crypto.Hash;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
@@ -43,7 +43,7 @@ import java.util.function.Function;
 /**
  * Extends the read-only platform state store to provide write access to the platform state.
  */
-public class WritablePlatformStateStore extends ReadablePlatformStateStore {
+public class WritablePlatformStateStore extends ReadablePlatformStateStore implements PlatformStateModifier {
     private final WritableStates writableStates;
     private final WritableSingletonState<PlatformState> state;
 
@@ -75,7 +75,7 @@ public class WritablePlatformStateStore extends ReadablePlatformStateStore {
     /**
      * Overwrite the current platform state with the provided state.
      */
-    public void setAllFrom(@NonNull final PlatformStateAccessor accessor) {
+    public void setAllFrom(@NonNull final PlatformStateModifier accessor) {
         this.update(toPbjPlatformState(accessor));
     }
 
@@ -229,7 +229,7 @@ public class WritablePlatformStateStore extends ReadablePlatformStateStore {
      * {@inheritDoc}
      */
     @Override
-    public void bulkUpdate(@NonNull final Consumer<PlatformStateAccessor> updater) {
+    public void bulkUpdate(@NonNull final Consumer<PlatformStateModifier> updater) {
         final var accumulator = new PlatformStateValueAccumulator();
         updater.accept(accumulator);
         setAllFrom(accumulator);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -241,8 +241,7 @@ public class SignedState implements SignedStateInfo {
     public void setSigSet(@NonNull final SigSet sigSet) {
         this.sigSet = Objects.requireNonNull(sigSet);
         signingWeight = 0;
-        // init
-        state.getWritablePlatformState();
+        state.initPlatformState();
         if (!isGenesisState()) {
             // Only non-genesis states will have signing weight
             final AddressBook addressBook = getAddressBook();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldState.java
@@ -18,7 +18,7 @@ package com.swirlds.platform.system;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.system.transaction.Transaction;
@@ -77,7 +77,7 @@ public interface SwirldState extends MerkleNode {
      * @param round         the round to apply
      * @param platformState the platform state
      */
-    void handleConsensusRound(final Round round, final PlatformStateAccessor platformState);
+    void handleConsensusRound(final Round round, final PlatformStateModifier platformState);
 
     /**
      * Called by the platform after it has made all its changes to this state for the given round.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -26,7 +26,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.formatting.TextTable;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.state.MerkleRoot;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.address.AddressBookInitializer;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -405,7 +405,7 @@ public class AddressBookUtils {
             // Update the address book with the current address book read from config.txt.
             // Eventually we will not do this, and only transactions will be capable of
             // modifying the address book.
-            final PlatformStateAccessor platformState = state.getWritablePlatformState();
+            final PlatformStateModifier platformState = state.getWritablePlatformState();
             platformState.bulkUpdate(v -> {
                 v.setAddressBook(addressBookInitializer.getCurrentAddressBook().copy());
                 v.setPreviousAddressBook(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.swirlds.platform.state.MerkleRoot;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.events.EventConstants;
 import java.util.HashMap;
@@ -70,7 +70,7 @@ class RoundCalculationUtilsTest {
                 LongStream.range(1, 50).collect(HashMap::new, (m, l) -> m.put(l, l * 10), HashMap::putAll);
         final SignedState signedState = mock(SignedState.class);
         final MerkleRoot state = mock(MerkleRoot.class);
-        final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
+        final PlatformStateModifier platformState = mock(PlatformStateModifier.class);
         when(signedState.getState()).thenReturn(state);
         when(state.getReadablePlatformState()).thenReturn(platformState);
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
@@ -25,7 +25,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.state.MerkleRoot;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.service.PlatformStateValueAccumulator;
 import com.swirlds.platform.system.BasicSoftwareVersion;
@@ -42,7 +42,7 @@ import java.util.List;
  * A helper class for testing the {@link DefaultTransactionHandler}.
  */
 public class TransactionHandlerTester {
-    private final PlatformStateAccessor platformState;
+    private final PlatformStateModifier platformState;
     private final SwirldStateManager swirldStateManager;
     private final DefaultTransactionHandler defaultTransactionHandler;
     private final List<PlatformStatusAction> submittedActions = new ArrayList<>();
@@ -87,9 +87,9 @@ public class TransactionHandlerTester {
     }
 
     /**
-     * @return the {@link PlatformStateAccessor} used by this tester
+     * @return the {@link PlatformStateModifier} used by this tester
      */
-    public PlatformStateAccessor getPlatformState() {
+    public PlatformStateModifier getPlatformState() {
         return platformState;
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventRecoveryWorkflowTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventRecoveryWorkflowTests.java
@@ -40,7 +40,7 @@ import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.recovery.emergencyfile.EmergencyRecoveryFile;
 import com.swirlds.platform.recovery.internal.StreamedRound;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.SwirldState;
 import com.swirlds.platform.system.events.CesEvent;
@@ -107,7 +107,7 @@ class EventRecoveryWorkflowTests {
     @Test
     @DisplayName("applyTransactions() Test")
     void applyTransactionsTest() {
-        final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
+        final PlatformStateModifier platformState = mock(PlatformStateModifier.class);
 
         final List<ConsensusEvent> events = new ArrayList<>();
         for (int i = 0; i < 100; i++) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
@@ -113,12 +113,10 @@ class BirthRoundStateMigrationTests {
         ;
         final SoftwareVersion newSoftwareVersion = createNextVersion(previousSoftwareVersion);
 
-        signedState
-                .getState()
-                .getWritablePlatformState()
-                .setLastRoundBeforeBirthRoundMode(signedState.getRound() - 100);
-        signedState.getState().getWritablePlatformState().setFirstVersionInBirthRoundMode(previousSoftwareVersion);
-        signedState.getState().getWritablePlatformState().setLowestJudgeGenerationBeforeBirthRoundMode(100);
+        PlatformStateModifier writablePlatformState = signedState.getState().getWritablePlatformState();
+        writablePlatformState.setLastRoundBeforeBirthRoundMode(signedState.getRound() - 100);
+        writablePlatformState.setFirstVersionInBirthRoundMode(previousSoftwareVersion);
+        writablePlatformState.setLowestJudgeGenerationBeforeBirthRoundMode(100);
         rehashTree(signedState.getState());
         final Hash originalHash = signedState.getState().getHash();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/MerkleStateRootTest.java
@@ -779,7 +779,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @DisplayName("Notifications are sent to onHandleConsensusRound when handleConsensusRound is called")
         void handleConsensusRoundCallback() {
             final var round = Mockito.mock(Round.class);
-            final var platformState = Mockito.mock(PlatformStateAccessor.class);
+            final var platformState = Mockito.mock(PlatformStateModifier.class);
             final var state = new MerkleStateRoot(lifecycles, softwareVersionSupplier);
 
             state.handleConsensusRound(round, platformState);
@@ -797,7 +797,7 @@ class MerkleStateRootTest extends MerkleTestBase {
 
             // The original no longer has the listener
             final var round = Mockito.mock(Round.class);
-            final var platformState = Mockito.mock(PlatformStateAccessor.class);
+            final var platformState = Mockito.mock(PlatformStateModifier.class);
             assertThrows(MutabilityException.class, () -> stateRoot.handleConsensusRound(round, platformState));
 
             // But the copy does
@@ -933,7 +933,7 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Test access to the platform state")
         void testAccessToPlatformStateData() {
-            PlatformStateAccessor randomPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
+            PlatformStateModifier randomPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
             stateRoot.updatePlatformState(randomPlatformState);
             ReadableSingletonState<PlatformState> readableSingletonState = stateRoot
                     .getReadableStates(PlatformStateService.NAME)
@@ -949,12 +949,12 @@ class MerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Test update of the platform state")
         void testUpdatePlatformStateData() {
-            PlatformStateAccessor randomPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
+            PlatformStateModifier randomPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
             stateRoot.updatePlatformState(randomPlatformState);
             WritableStates writableStates = stateRoot.getWritableStates(PlatformStateService.NAME);
             WritableSingletonState<PlatformState> writableSingletonState =
                     writableStates.getSingleton(V0540PlatformStateSchema.PLATFORM_STATE_KEY);
-            PlatformStateAccessor newPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
+            PlatformStateModifier newPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
             writableSingletonState.put(toPbjPlatformState(newPlatformState));
             ((CommittableWritableStates) writableStates).commit();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -64,7 +64,7 @@ class SignedStateTests {
         final MerkleStateRoot state = spy(new MerkleStateRoot(
                 FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major())));
 
-        final PlatformStateAccessor platformState = new PlatformState();
+        final PlatformStateModifier platformState = new PlatformState();
         platformState.setAddressBook(mock(AddressBook.class));
         when(state.getWritablePlatformState()).thenReturn(platformState);
         if (reserveCallback != null) {
@@ -208,9 +208,8 @@ class SignedStateTests {
     void alternateConstructorReservationsTest() {
         final MerkleRoot state = spy(new MerkleStateRoot(
                 FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major())));
-        final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
-        // init state first
-        state.getWritablePlatformState();
+        final PlatformStateModifier platformState = mock(PlatformStateModifier.class);
+        state.initPlatformState();
         when(state.getReadablePlatformState()).thenReturn(platformState);
         when(platformState.getRound()).thenReturn(0L);
         final SignedState signedState = new SignedState(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -123,7 +123,7 @@ class SwirldStateManagerTests {
         final MerkleStateRoot state =
                 new MerkleStateRoot(FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
 
-        final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
+        final PlatformStateModifier platformState = mock(PlatformStateModifier.class);
         when(platformState.getCreationSoftwareVersion()).thenReturn(new BasicSoftwareVersion(nextInt(1, 100)));
 
         state.updatePlatformState(platformState);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PbjConverterTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PbjConverterTest.java
@@ -39,7 +39,7 @@ import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.crypto.SerializableX509Certificate;
 import com.swirlds.platform.state.MinimumJudgeInfo;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.Address;
@@ -68,7 +68,7 @@ class PbjConverterTest {
 
     @Test
     void testToPbjPlatformState() {
-        final PlatformStateAccessor platformState = randomPlatformState(randotron);
+        final PlatformStateModifier platformState = randomPlatformState(randotron);
 
         final com.hedera.hapi.platform.state.PlatformState pbjPlatformState =
                 PbjConverter.toPbjPlatformState(platformState);
@@ -467,7 +467,7 @@ class PbjConverterTest {
         assertEquals(toPbjAddressBook(newValue.getAddressBook()), pbjState.addressBook());
     }
 
-    static PlatformStateAccessor randomPlatformState(Randotron randotron) {
+    static PlatformStateModifier randomPlatformState(Randotron randotron) {
         final PlatformStateValueAccumulator platformState = new PlatformStateValueAccumulator();
         platformState.setCreationSoftwareVersion(randomSoftwareVersion());
         platformState.setRoundsNonAncient(nextInt());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTestingToolState.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTestingToolState.java
@@ -22,7 +22,7 @@ import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import com.swirlds.common.utility.NonCryptographicHashing;
 import com.swirlds.platform.state.MerkleRoot;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.State;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.SwirldState;
@@ -82,7 +82,7 @@ public class TurtleTestingToolState extends PartialMerkleLeaf implements SwirldS
      * {@inheritDoc}
      */
     @Override
-    public void handleConsensusRound(@NonNull final Round round, @NonNull final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(@NonNull final Round round, @NonNull final PlatformStateModifier platformState) {
         state = NonCryptographicHashing.hash64(
                 state,
                 round.getRoundNum(),

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/BlockingSwirldState.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/BlockingSwirldState.java
@@ -26,7 +26,7 @@ import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.MerkleStateRoot;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.SwirldState;
@@ -77,7 +77,7 @@ public class BlockingSwirldState extends MerkleStateRoot {
     }
 
     @Override
-    public void handleConsensusRound(final Round round, final PlatformStateAccessor platformState) {
+    public void handleConsensusRound(final Round round, final PlatformStateModifier platformState) {
         // intentionally does nothing
     }
 

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
@@ -37,7 +37,7 @@ import com.swirlds.platform.crypto.SignatureVerifier;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.MerkleStateRoot;
 import com.swirlds.platform.state.MinimumJudgeInfo;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -186,7 +186,7 @@ public class RandomSignedStateGenerator {
             consensusSnapshotInstance = consensusSnapshot;
         }
 
-        final PlatformStateAccessor platformState = stateInstance.getWritablePlatformState();
+        final PlatformStateModifier platformState = stateInstance.getWritablePlatformState();
 
         platformState.bulkUpdate(v -> {
             v.setSnapshot(consensusSnapshotInstance);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/PlatformStateUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/PlatformStateUtils.java
@@ -22,7 +22,7 @@ import static com.swirlds.common.test.fixtures.RandomUtils.randomInstant;
 
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.state.MinimumJudgeInfo;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
@@ -38,14 +38,14 @@ public final class PlatformStateUtils {
     /**
      * Generate a randomized PlatformState object. Values contained internally may be nonsensical.
      */
-    public static PlatformStateAccessor randomPlatformState(PlatformStateAccessor platformState) {
+    public static PlatformStateModifier randomPlatformState(PlatformStateModifier platformState) {
         return randomPlatformState(new Random(), platformState);
     }
 
     /**
      * Generate a randomized PlatformState object. Values contained internally may be nonsensical.
      */
-    public static PlatformStateAccessor randomPlatformState(final Random random, PlatformStateAccessor platformState) {
+    public static PlatformStateModifier randomPlatformState(final Random random, PlatformStateModifier platformState) {
         final AddressBook addressBook = RandomAddressBookBuilder.create(random)
                 .withSize(4)
                 .withWeightDistributionStrategy(WeightDistributionStrategy.BALANCED)


### PR DESCRIPTION
**Description**:

This is a follow-up for https://github.com/hashgraph/hedera-services/pull/15389 This PR introduce a new interface: `PlatformStateModifier`. Now, `PlatformStateAccessor` has only getters and `PlatformStateModifier` has modifying methods. 

Also, this PR introduces `initPlatformState` to get rid of confusing usages of `getWritablePlatformState` for the sake of initialization. 

**Related issue(s)**:

Fixes #15413 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
