### PR TITLE
build: update Java Module patching

### DIFF
--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -206,7 +206,7 @@ jobs:
       - name: Unit Testing
         id: gradle-test
         if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        run: ${GRADLE_EXEC} :reports:testCodeCoverageReport -x :test-clients:test --continue --scan
+        run: ${GRADLE_EXEC} :aggregation:testCodeCoverageReport -x :test-clients:test --continue --scan
 
 
       - name: Publish Unit Test Report
@@ -538,13 +538,13 @@ jobs:
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:
           token: ${{ secrets.codecov-token }}
-          files: gradle/reports/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          files: gradle/aggregation/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
 
       - name: Publish to Codacy
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.codacy-project-token }}
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
-        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Java -r gradle/reports/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Java -r gradle/aggregation/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
 
       - name: Upload Test Reports
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("com.hedera.gradle.reports") }
+
+dependencies {
+    implementation(project(":app"))
+    implementation(project(":swirlds-platform-base-example"))
+    implementation(project(":AddressBookTestingTool"))
+    implementation(project(":ConsistencyTestingTool"))
+    implementation(project(":ISSTestingTool"))
+    implementation(project(":MigrationTestingTool"))
+    implementation(project(":PlatformTestingTool"))
+    implementation(project(":StatsSigningTestingTool"))
+    implementation(project(":StressTestingTool"))
+    implementation(project(":test-clients"))
+}
+
+// As the standard 'src/test' folder of 'test-clients' does not contain unit tests,
+// do not include it in the aggregated code coverage report.
+configurations.aggregateCodeCoverageReportResults { exclude(module = "test-clients") }

--- a/gradle/modules.properties
+++ b/gradle/modules.properties
@@ -5,3 +5,4 @@
 # Consider contributing the missing entry back to the plugin by creating a PR for the 'modules.properties' linked above.
 com.hedera.cryptography.pairings.api=com.hedera.cryptography:hedera-cryptography-pairings-api
 com.hedera.cryptography.pairings.signatures=com.hedera.cryptography:hedera-cryptography-pairings-signatures
+jmh.core=org.openjdk.jmh:jmh-core

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
     implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.2")
     implementation("net.swiftzer.semver:semver:1.3.0")
-    implementation("org.gradlex:extra-java-module-info:1.8")
+    implementation("org.gradlex:extra-java-module-info:1.9")
     implementation("org.gradlex:jvm-dependency-conflict-resolution:2.1.2")
     implementation("org.gradlex:java-module-dependencies:1.7")
 }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.java.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.java.gradle.kts
@@ -69,9 +69,35 @@ configurations.all {
 
 jvmDependencyConflicts {
     consistentResolution {
-        providesVersions(":app")
+        providesVersions(":aggregation")
         platform(":hedera-dependency-versions")
     }
+}
+
+val consistentResolutionAttribute = Attribute.of("consistent-resolution", String::class.java)
+
+configurations.create("allDependencies") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    sourceSets.all {
+        extendsFrom(
+            configurations[this.implementationConfigurationName],
+            configurations[this.compileOnlyConfigurationName],
+            configurations[this.runtimeOnlyConfigurationName],
+            configurations[this.annotationProcessorConfigurationName]
+        )
+    }
+    attributes {
+        attribute(consistentResolutionAttribute, "global")
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+        attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, objects.named(LibraryElements.JAR))
+        attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
+    }
+}
+
+configurations.getByName("mainRuntimeClasspath") {
+    attributes.attribute(consistentResolutionAttribute, "global")
 }
 
 tasks.buildDependents { setGroup(null) }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-modules.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.jpms-modules.gradle.kts
@@ -92,6 +92,7 @@ jvmDependencyConflicts.patch {
 // Jar needs to have this file. If it is missing, it is added by what is configured here.
 extraJavaModuleInfo {
     failOnAutomaticModules = true // Only allow Jars with 'module-info' on all module paths
+    versionsProvidingConfiguration = "mainRuntimeClasspath"
 
     module("io.grpc:grpc-api", "io.grpc")
     module("io.grpc:grpc-core", "io.grpc.internal")
@@ -106,15 +107,11 @@ extraJavaModuleInfo {
         requireAllDefinedDependencies()
         requires("java.logging")
     }
-    module("io.grpc:grpc-testing", "io.grpc.testing")
-    module("io.grpc:grpc-services", "io.grpc.services")
     module("io.grpc:grpc-util", "io.grpc.util")
     module("io.grpc:grpc-protobuf", "io.grpc.protobuf")
     module("io.grpc:grpc-protobuf-lite", "io.grpc.protobuf.lite")
     module("com.github.spotbugs:spotbugs-annotations", "com.github.spotbugs.annotations")
     module("com.google.code.findbugs:jsr305", "java.annotation")
-    module("com.google.errorprone:error_prone_annotations", "com.google.errorprone.annotations")
-    module("com.google.j2objc:j2objc-annotations", "com.google.j2objc.annotations")
     module("com.google.protobuf:protobuf-java", "com.google.protobuf") {
         exportAllPackages()
         requireAllDefinedDependencies()
@@ -131,8 +128,6 @@ extraJavaModuleInfo {
     module("io.perfmark:perfmark-api", "io.perfmark")
     module("javax.inject:javax.inject", "javax.inject")
     module("commons-codec:commons-codec", "org.apache.commons.codec")
-    module("org.apache.commons:commons-math3", "org.apache.commons.math3")
-    module("org.apache.commons:commons-collections4", "org.apache.commons.collections4")
     module("com.esaulpaugh:headlong", "headlong")
     module("org.checkerframework:checker-qual", "org.checkerframework.checker.qual")
     module("org.connid:framework", "org.connid.framework")
@@ -174,7 +169,6 @@ extraJavaModuleInfo {
         requireAllDefinedDependencies()
         requiresStatic("com.fasterxml.jackson.annotation")
     }
-    module("org.hyperledger.besu:plugin-api", "org.hyperledger.besu.plugin.api")
     module("org.hyperledger.besu:secp256k1", "org.hyperledger.besu.nativelib.secp256k1")
     module("org.hyperledger.besu:secp256r1", "org.hyperledger.besu.nativelib.secp256r1")
     module("com.goterl:resource-loader", "resource.loader")
@@ -197,11 +191,11 @@ extraJavaModuleInfo {
     // Need to use Jar file names here as there is currently no other way to address Jar with
     // classifier directly for patching
     module(
-        "netty-transport-native-epoll-4.1.110.Final-linux-x86_64.jar",
+        "io.netty:netty-transport-native-epoll|linux-x86_64",
         "io.netty.transport.epoll.linux.x86_64"
     )
     module(
-        "netty-transport-native-epoll-4.1.110.Final-linux-aarch_64.jar",
+        "io.netty:netty-transport-native-epoll|linux-aarch_64",
         "io.netty.transport.epoll.linux.aarch_64"
     )
 
@@ -227,15 +221,8 @@ extraJavaModuleInfo {
     module("uk.org.webcompere:system-stubs-core", "uk.org.webcompere.systemstubs.core")
     module("uk.org.webcompere:system-stubs-jupiter", "uk.org.webcompere.systemstubs.jupiter")
 
-    // JMH only
-    module("net.sf.jopt-simple:jopt-simple", "jopt.simple")
-    module("org.openjdk.jmh:jmh-core", "jmh.core")
-    module("org.openjdk.jmh:jmh-generator-asm", "jmh.generator.asm")
-    module("org.openjdk.jmh:jmh-generator-bytecode", "jmh.generator.bytecode")
-    module("org.openjdk.jmh:jmh-generator-reflection", "jmh.generator.reflection")
-
     // Test clients only
-    module("com.github.docker-java:docker-java-api", "com.github.docker.java.api")
+    module("com.github.docker-java:docker-java-api", "com.github.dockerjava.api")
     module("com.github.docker-java:docker-java-transport", "com.github.docker.java.transport")
     module(
         "com.github.docker-java:docker-java-transport-zerodep",
@@ -252,7 +239,6 @@ extraJavaModuleInfo {
     module("org.mockito:mockito-core", "org.mockito")
     module("org.objenesis:objenesis", "org.objenesis")
     module("org.rnorth.duct-tape:duct-tape", "org.rnorth.ducttape")
-    module("org.testcontainers:junit-jupiter", "org.testcontainers.junit.jupiter")
     module("org.testcontainers:testcontainers", "org.testcontainers")
     module("org.mockito:mockito-junit-jupiter", "org.mockito.junit.jupiter")
 }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.reports.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.reports.gradle.kts
@@ -14,36 +14,14 @@
  * limitations under the License.
  */
 
+import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesScopeCheck
+
 plugins {
-    id("jvm-ecosystem")
+    id("com.hedera.gradle.java")
     id("jacoco-report-aggregation")
-    id("com.hedera.gradle.lifecycle")
-    id("com.hedera.gradle.repositories")
-    id("com.hedera.gradle.jpms-modules")
 }
 
-dependencies {
-    rootProject.subprojects
-        // exclude the 'reports' project itself
-        .filter { prj -> prj != project }
-        // exclude 'test-clients' as it contains test sources in 'main'
-        // see also 'codecov.yml'
-        .filter { prj -> prj.name != "test-clients" }
-        .forEach {
-            if (it.name == "hedera-dependency-versions") {
-                jacocoAggregation(platform(project(it.path)))
-            } else {
-                jacocoAggregation(project(it.path))
-            }
-        }
-}
+tasks.withType<ModuleDirectivesScopeCheck> { enabled = false }
 
-// Use Gradle's 'jacoco-report-aggregation' plugin to create an aggregated report independent of the
-// platform (Codecov, Codacy, ...) that picks it up later on.
-// See:
-// https://docs.gradle.org/current/samples/sample_jvm_multi_project_with_code_coverage_standalone.html
-reporting {
-    reports.create<JacocoCoverageReport>("testCodeCoverageReport") {
-        testType = TestSuiteType.UNIT_TEST
-    }
-}
+// Make aggregation "classpath" use the platform for versions (gradle/versions)
+configurations.aggregateCodeCoverageReportResults { extendsFrom(configurations["internal"]) }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.settings.settings.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.settings.settings.gradle.kts
@@ -73,7 +73,7 @@ includeBuild(".")
 
 configure<JavaModulesExtension> {
     // Project to aggregate code coverage data for the whole repository into one report
-    module("gradle/reports")
+    module("gradle/aggregation")
 
     // "BOM" with versions of 3rd party dependencies
     versions("hedera-dependency-versions")

--- a/gradle/reports/build.gradle.kts
+++ b/gradle/reports/build.gradle.kts
@@ -1,3 +1,0 @@
-plugins {
-    id("com.hedera.gradle.reports")
-}

--- a/hedera-dependency-versions/build.gradle.kts
+++ b/hedera-dependency-versions/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies.constraints {
         because("com.github.benmanes.caffeine")
     }
     api("com.github.docker-java:docker-java-api:3.2.13") {
-        because("com.github.docker.java.api")
+        because("com.github.dockerjava.api")
     }
     api("com.github.spotbugs:spotbugs-annotations:4.7.3") {
         because("com.github.spotbugs.annotations")
@@ -52,8 +52,11 @@ dependencies.constraints {
     api("com.google.auto.service:auto-service:1.1.1") {
         because("com.google.auto.service.processor")
     }
-    api("com.google.guava:guava:31.1-jre") {
+    api("com.google.guava:guava:33.1.0-jre") {
         because("com.google.common")
+    }
+    api("com.google.j2objc:j2objc-annotations:3.0.0") {
+        because("com.google.j2objc.annotations")
     }
     api("com.google.jimfs:jimfs:1.2") {
         because("com.google.jimfs")

--- a/hedera-node/test-clients/src/main/java/module-info.java
+++ b/hedera-node/test-clients/src/main/java/module-info.java
@@ -102,7 +102,7 @@ module com.hedera.node.test.clients {
     requires com.swirlds.platform.core.test.fixtures;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;
-    requires com.github.docker.java.api;
+    requires com.github.dockerjava.api;
     requires com.sun.jna;
     requires io.grpc.netty;
     requires io.grpc.stub;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

- Update extra-java-module-info to 1.9
- Configure a consistent classpath (new feature in 1.9) to no longer do multiple transformations of the same Jar
- For the consistent/global classpath, use the 'gradle/aggregation' project to configure it (renamed from 'gradle/reports')
- Update Guava and related libraries and remove no longer needed patch rules

This fixes the problem that many Jars are transformed several times, which leads to long IntelliJ import times and the Jars showing up many times in IntelliJ (which looks like this BEFORE this change):

![363586854-2f8e8fc3-ea3d-44d2-afe4-8a0121081af2](https://github.com/user-attachments/assets/0e0bb5db-71ca-4be9-830c-371a1368b0c4)


**Related issue(s)**:

 #14255

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
