### PR TITLE
fix: DefaultKycStatusCall correct returned values from System Contract

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCall.java
@@ -50,10 +50,8 @@ public class DefaultKycStatusCall extends AbstractNonRevertibleTokenViewCall {
     @Override
     protected @NonNull PricedResult resultOfViewingToken(@Nullable final Token token) {
         requireNonNull(token);
-        return gasOnly(
-                fullResultsFor(SUCCESS, gasCalculator.viewGasRequirement(), token.accountsKycGrantedByDefault()),
-                SUCCESS,
-                true);
+        final boolean kycStatus = !token.hasKycKey() || token.accountsKycGrantedByDefault();
+        return gasOnly(fullResultsFor(SUCCESS, gasCalculator.viewGasRequirement(), kycStatus), SUCCESS, true);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCallTest.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_EVERYTHING_TOKEN;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.revertOutputFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -44,6 +45,25 @@ class DefaultKycStatusCallTest extends CallTestBase {
                 Bytes.wrap(DefaultKycStatusTranslator.DEFAULT_KYC_STATUS
                         .getOutputs()
                         .encodeElements(SUCCESS.protoOrdinal(), true)
+                        .array()),
+                result.getOutput());
+    }
+
+    @Test
+    void returnsDefaultKycStatusForPresentTokenWithKey() {
+        final var token = FUNGIBLE_EVERYTHING_TOKEN
+                .copyBuilder()
+                .accountsKycGrantedByDefault(false)
+                .build();
+        final var subject = new DefaultKycStatusCall(gasCalculator, mockEnhancement(), false, token);
+
+        final var result = subject.execute().fullResult().result();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
+        assertEquals(
+                Bytes.wrap(DefaultKycStatusTranslator.DEFAULT_KYC_STATUS
+                        .getOutputs()
+                        .encodeElements(SUCCESS.protoOrdinal(), false)
                         .array()),
                 result.getOutput());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusCallTest.java
@@ -43,7 +43,7 @@ class DefaultKycStatusCallTest extends CallTestBase {
         assertEquals(
                 Bytes.wrap(DefaultKycStatusTranslator.DEFAULT_KYC_STATUS
                         .getOutputs()
-                        .encodeElements(SUCCESS.protoOrdinal(), false)
+                        .encodeElements(SUCCESS.protoOrdinal(), true)
                         .array()),
                 result.getOutput());
     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
@@ -269,8 +269,8 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
                 op.maxSupply(),
                 false,
                 op.freezeDefault(),
-                // We should set the default kyc status to true if there is KYC key provided
-                op.hasKycKey(),
+                // We should set the default kyc status to true if there is no KYC key provided `KycNotApplicable`
+                !op.hasKycKey(),
                 modifyCustomFeesWithSentinelValues(op.customFees(), newTokenNum),
                 op.metadata(),
                 op.metadataKey());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
@@ -269,8 +269,7 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
                 op.maxSupply(),
                 false,
                 op.freezeDefault(),
-                // We should set the default kyc status to true if there is no KYC key provided `KycNotApplicable`
-                !op.hasKycKey(),
+                false,
                 modifyCustomFeesWithSentinelValues(op.customFees(), newTokenNum),
                 op.metadata(),
                 op.metadataKey());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
@@ -269,7 +269,8 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
                 op.maxSupply(),
                 false,
                 op.freezeDefault(),
-                false,
+                // We should set the default kyc status to true if there is KYC key provided
+                op.hasKycKey(),
                 modifyCustomFeesWithSentinelValues(op.customFees(), newTokenNum),
                 op.metadata(),
                 op.metadataKey());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -387,7 +387,7 @@ public class HapiSpecRegistry {
     }
 
     public Key getKycKey(String name) {
-        return get(name + "Kyc", Key.class);
+        return getOrElse(name + "Kyc", Key.class, null);
     }
 
     public Long getExpiry(String name) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DefaultTokenStatusSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DefaultTokenStatusSuite.java
@@ -39,6 +39,7 @@ import static com.hedera.services.bdd.suites.contract.Utils.asToken;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.VANILLA_TOKEN;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_KYC_KEY;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 
 import com.hedera.node.app.hapi.utils.contracts.ParsingConstants.FunctionType;
@@ -126,7 +127,7 @@ public class DefaultTokenStatusSuite {
                         .initialSupply(1_000)
                         .exposingCreatedIdTo(id -> noKycTokenId.set(asToken(id))),
                 tokenAssociate(ACCOUNT, "noKycToken"),
-//                grantTokenKyc("noKycToken", ACCOUNT),
+                grantTokenKyc("noKycToken", ACCOUNT).hasKnownStatus(TOKEN_HAS_NO_KYC_KEY),
                 uploadInitCode(TOKEN_DEFAULT_KYC_FREEZE_STATUS_CONTRACT),
                 contractCreate(TOKEN_DEFAULT_KYC_FREEZE_STATUS_CONTRACT),
                 withOpContext((spec, opLog) -> allRunFor(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DefaultTokenStatusSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/DefaultTokenStatusSuite.java
@@ -24,6 +24,8 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.grantTokenKyc;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
@@ -116,11 +118,15 @@ public class DefaultTokenStatusSuite {
                         .kycKey(KYC_KEY)
                         .initialSupply(1_000)
                         .exposingCreatedIdTo(id -> vanillaTokenID.set(asToken(id))),
+                tokenAssociate(ACCOUNT, VANILLA_TOKEN),
+                grantTokenKyc(VANILLA_TOKEN, ACCOUNT),
                 tokenCreate("noKycToken")
                         .tokenType(FUNGIBLE_COMMON)
                         .treasury(TOKEN_TREASURY)
                         .initialSupply(1_000)
                         .exposingCreatedIdTo(id -> noKycTokenId.set(asToken(id))),
+                tokenAssociate(ACCOUNT, "noKycToken"),
+//                grantTokenKyc("noKycToken", ACCOUNT),
                 uploadInitCode(TOKEN_DEFAULT_KYC_FREEZE_STATUS_CONTRACT),
                 contractCreate(TOKEN_DEFAULT_KYC_FREEZE_STATUS_CONTRACT),
                 withOpContext((spec, opLog) -> allRunFor(
@@ -152,7 +158,7 @@ public class DefaultTokenStatusSuite {
                                         .contractCallResult(htsPrecompileResult()
                                                 .forFunction(FunctionType.GET_TOKEN_DEFAULT_KYC_STATUS)
                                                 .withStatus(SUCCESS)
-                                                .withTokenDefaultKycStatus(true)))),
+                                                .withTokenDefaultKycStatus(false)))),
                 childRecordsCheck(
                         "defaultKycStatus",
                         SUCCESS,
@@ -162,6 +168,6 @@ public class DefaultTokenStatusSuite {
                                         .contractCallResult(htsPrecompileResult()
                                                 .forFunction(FunctionType.GET_TOKEN_DEFAULT_KYC_STATUS)
                                                 .withStatus(SUCCESS)
-                                                .withTokenDefaultKycStatus(false)))));
+                                                .withTokenDefaultKycStatus(true)))));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
@@ -87,6 +87,7 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.RoyaltyFee;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenInfo;
+import com.hederahashgraph.api.proto.java.TokenKycStatus;
 import com.hederahashgraph.api.proto.java.TokenNftInfo;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
@@ -260,7 +261,8 @@ public class TokenInfoHTSSuite {
                                                                             getTokenKeyFromSpec(
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
-                                                                            targetLedgerId.get()))))),
+                                                                            targetLedgerId.get(),
+                                                                            TokenKycStatus.Granted))))),
                             childRecordsCheck(
                                     "TOKEN_INFO_TXN_V2",
                                     SUCCESS,
@@ -281,7 +283,8 @@ public class TokenInfoHTSSuite {
                                                                             getTokenKeyFromSpec(
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
-                                                                            targetLedgerId.get()))))));
+                                                                            targetLedgerId.get(),
+                                                                            TokenKycStatus.Granted))))));
                 }));
     }
 
@@ -390,7 +393,8 @@ public class TokenInfoHTSSuite {
                                                                             getTokenKeyFromSpec(
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
-                                                                            targetLedgerId.get()))))),
+                                                                            targetLedgerId.get(),
+                                                                            TokenKycStatus.Granted))))),
                             childRecordsCheck(
                                     "FUNGIBLE_TOKEN_INFO_TXN_V2",
                                     SUCCESS,
@@ -412,7 +416,8 @@ public class TokenInfoHTSSuite {
                                                                             getTokenKeyFromSpec(
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
-                                                                            targetLedgerId.get()))))));
+                                                                            targetLedgerId.get(),
+                                                                            TokenKycStatus.Granted))))));
                 }));
     }
 
@@ -539,7 +544,8 @@ public class TokenInfoHTSSuite {
                                                                             getTokenKeyFromSpec(
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
-                                                                            targetLedgerId.get()))
+                                                                            targetLedgerId.get(),
+                                                                            TokenKycStatus.Granted))
                                                             .withNftTokenInfo(nftTokenInfo)))),
                             childRecordsCheck(
                                     "NON_FUNGIBLE_TOKEN_INFO_TXN_V2",
@@ -559,7 +565,8 @@ public class TokenInfoHTSSuite {
                                                                             getTokenKeyFromSpec(
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
-                                                                            targetLedgerId.get()))
+                                                                            targetLedgerId.get(),
+                                                                            TokenKycStatus.Granted))
                                                             .withNftTokenInfo(nftTokenInfo)))));
                 }));
     }
@@ -1211,7 +1218,8 @@ public class TokenInfoHTSSuite {
                                                                     spec.registry()
                                                                             .getKey(CONTRACT_KEY),
                                                                     expirySecond,
-                                                                    targetLedgerId.get()))))));
+                                                                    targetLedgerId.get(),
+                                                                    TokenKycStatus.Granted))))));
                 }));
     }
 
@@ -1321,7 +1329,8 @@ public class TokenInfoHTSSuite {
                                                                     spec.registry()
                                                                             .getKey(CONTRACT_KEY),
                                                                     expirySecond,
-                                                                    targetLedgerId.get()))))));
+                                                                    targetLedgerId.get(),
+                                                                    TokenKycStatus.Granted))))));
                 }));
     }
 
@@ -1443,7 +1452,8 @@ public class TokenInfoHTSSuite {
                                                                     spec.registry()
                                                                             .getKey(CONTRACT_KEY),
                                                                     expirySecond,
-                                                                    targetLedgerId.get()))
+                                                                    targetLedgerId.get(),
+                                                                    TokenKycStatus.Granted))
                                                             .withNftTokenInfo(nftTokenInfo)))));
                 }));
     }
@@ -1599,9 +1609,10 @@ public class TokenInfoHTSSuite {
             final AccountID treasury,
             final Key adminKey,
             final long expirySecond,
-            ByteString ledgerId) {
+            ByteString ledgerId,
+            final TokenKycStatus kycDefault) {
 
-        return buildBaseTokenInfo(spec, tokenName, symbol, memo, treasury, adminKey, expirySecond, ledgerId)
+        return buildBaseTokenInfo(spec, tokenName, symbol, memo, treasury, adminKey, expirySecond, ledgerId, kycDefault)
                 .build();
     }
 
@@ -1613,11 +1624,12 @@ public class TokenInfoHTSSuite {
             final AccountID treasury,
             final Key adminKey,
             final long expirySecond,
-            ByteString ledgerId) {
+            ByteString ledgerId,
+            final TokenKycStatus kycDefault) {
 
         final ByteString meta = ByteString.copyFrom("metadata".getBytes(StandardCharsets.UTF_8));
 
-        return buildBaseTokenInfo(spec, tokenName, symbol, memo, treasury, adminKey, expirySecond, ledgerId)
+        return buildBaseTokenInfo(spec, tokenName, symbol, memo, treasury, adminKey, expirySecond, ledgerId, kycDefault)
                 .setMetadata(meta)
                 .setMetadataKey(getTokenKeyFromSpec(spec, TokenKeyType.METADATA_KEY))
                 .build();
@@ -1631,7 +1643,8 @@ public class TokenInfoHTSSuite {
             final AccountID treasury,
             final Key adminKey,
             final long expirySecond,
-            ByteString ledgerId) {
+            ByteString ledgerId,
+            final TokenKycStatus kycDefault) {
 
         final var autoRenewAccount = spec.registry().getAccountID(AUTO_RENEW_ACCOUNT);
         final var customFees = getExpectedCustomFees(spec);
@@ -1657,7 +1670,8 @@ public class TokenInfoHTSSuite {
                 .setWipeKey(getTokenKeyFromSpec(spec, TokenKeyType.WIPE_KEY))
                 .setSupplyKey(getTokenKeyFromSpec(spec, TokenKeyType.SUPPLY_KEY))
                 .setFeeScheduleKey(getTokenKeyFromSpec(spec, TokenKeyType.FEE_SCHEDULE_KEY))
-                .setPauseKey(getTokenKeyFromSpec(spec, TokenKeyType.PAUSE_KEY));
+                .setPauseKey(getTokenKeyFromSpec(spec, TokenKeyType.PAUSE_KEY))
+                .setDefaultKycStatus(kycDefault);
     }
 
     @NonNull
@@ -1708,8 +1722,10 @@ public class TokenInfoHTSSuite {
             final AccountID treasury,
             final Key adminKey,
             final long expirySecond,
-            final ByteString ledgerId) {
-        return buildTokenInfo(spec, tokenName, symbol, memo, treasury, adminKey, expirySecond, ledgerId, null, false);
+            final ByteString ledgerId,
+            final TokenKycStatus kycDefault) {
+        return buildTokenInfo(
+                spec, tokenName, symbol, memo, treasury, adminKey, expirySecond, ledgerId, null, false, kycDefault);
     }
 
     private TokenInfo getTokenInfoStructForNonFungibleTokenV2(
@@ -1717,7 +1733,8 @@ public class TokenInfoHTSSuite {
             final AccountID treasury,
             final Key adminKey,
             final long expirySecond,
-            final ByteString ledgerId) {
+            final ByteString ledgerId,
+            final TokenKycStatus kycDefault) {
         final ByteString meta = ByteString.copyFrom("metadata".getBytes(StandardCharsets.UTF_8));
         return buildTokenInfo(
                 spec,
@@ -1729,7 +1746,8 @@ public class TokenInfoHTSSuite {
                 expirySecond,
                 ledgerId,
                 meta,
-                true);
+                true,
+                kycDefault);
     }
 
     private TokenInfo buildTokenInfo(
@@ -1742,7 +1760,8 @@ public class TokenInfoHTSSuite {
             final long expirySecond,
             final ByteString ledgerId,
             final ByteString metadata,
-            final boolean includeMetadataKey) {
+            final boolean includeMetadataKey,
+            final TokenKycStatus kycDefault) {
         final var autoRenewAccount = spec.registry().getAccountID(AUTO_RENEW_ACCOUNT);
 
         TokenInfo.Builder builder = TokenInfo.newBuilder()
@@ -1766,7 +1785,8 @@ public class TokenInfoHTSSuite {
                 .setWipeKey(getTokenKeyFromSpec(spec, TokenKeyType.WIPE_KEY))
                 .setSupplyKey(getTokenKeyFromSpec(spec, TokenKeyType.SUPPLY_KEY))
                 .setFeeScheduleKey(getTokenKeyFromSpec(spec, TokenKeyType.FEE_SCHEDULE_KEY))
-                .setPauseKey(getTokenKeyFromSpec(spec, TokenKeyType.PAUSE_KEY));
+                .setPauseKey(getTokenKeyFromSpec(spec, TokenKeyType.PAUSE_KEY))
+                .setDefaultKycStatus(kycDefault);
 
         if (metadata != null) {
             builder.setMetadata(metadata);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenInfoHTSSuite.java
@@ -262,7 +262,7 @@ public class TokenInfoHTSSuite {
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
                                                                             targetLedgerId.get(),
-                                                                            TokenKycStatus.Granted))))),
+                                                                            TokenKycStatus.Revoked))))),
                             childRecordsCheck(
                                     "TOKEN_INFO_TXN_V2",
                                     SUCCESS,
@@ -284,7 +284,7 @@ public class TokenInfoHTSSuite {
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
                                                                             targetLedgerId.get(),
-                                                                            TokenKycStatus.Granted))))));
+                                                                            TokenKycStatus.Revoked))))));
                 }));
     }
 
@@ -394,7 +394,7 @@ public class TokenInfoHTSSuite {
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
                                                                             targetLedgerId.get(),
-                                                                            TokenKycStatus.Granted))))),
+                                                                            TokenKycStatus.Revoked))))),
                             childRecordsCheck(
                                     "FUNGIBLE_TOKEN_INFO_TXN_V2",
                                     SUCCESS,
@@ -417,7 +417,7 @@ public class TokenInfoHTSSuite {
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
                                                                             targetLedgerId.get(),
-                                                                            TokenKycStatus.Granted))))));
+                                                                            TokenKycStatus.Revoked))))));
                 }));
     }
 
@@ -545,7 +545,7 @@ public class TokenInfoHTSSuite {
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
                                                                             targetLedgerId.get(),
-                                                                            TokenKycStatus.Granted))
+                                                                            TokenKycStatus.Revoked))
                                                             .withNftTokenInfo(nftTokenInfo)))),
                             childRecordsCheck(
                                     "NON_FUNGIBLE_TOKEN_INFO_TXN_V2",
@@ -566,7 +566,7 @@ public class TokenInfoHTSSuite {
                                                                                     spec, TokenKeyType.ADMIN_KEY),
                                                                             expirySecond,
                                                                             targetLedgerId.get(),
-                                                                            TokenKycStatus.Granted))
+                                                                            TokenKycStatus.Revoked))
                                                             .withNftTokenInfo(nftTokenInfo)))));
                 }));
     }
@@ -1219,7 +1219,7 @@ public class TokenInfoHTSSuite {
                                                                             .getKey(CONTRACT_KEY),
                                                                     expirySecond,
                                                                     targetLedgerId.get(),
-                                                                    TokenKycStatus.Granted))))));
+                                                                    TokenKycStatus.Revoked))))));
                 }));
     }
 
@@ -1330,7 +1330,7 @@ public class TokenInfoHTSSuite {
                                                                             .getKey(CONTRACT_KEY),
                                                                     expirySecond,
                                                                     targetLedgerId.get(),
-                                                                    TokenKycStatus.Granted))))));
+                                                                    TokenKycStatus.Revoked))))));
                 }));
     }
 
@@ -1453,7 +1453,7 @@ public class TokenInfoHTSSuite {
                                                                             .getKey(CONTRACT_KEY),
                                                                     expirySecond,
                                                                     targetLedgerId.get(),
-                                                                    TokenKycStatus.Granted))
+                                                                    TokenKycStatus.Revoked))
                                                             .withNftTokenInfo(nftTokenInfo)))));
                 }));
     }


### PR DESCRIPTION
**Description**:
This PR aims to fix the way we return the value for DefaultKycStatusCall system contract..
Now returning the value based on kycKey present. If the related token is missing the kycKey the status is `KycNotApplicable` which is represented as a boolean true. We return false when the token has kycKey where the status is `Revoked`.
Adjusted existing tests and added a new one.

**Related issue(s)**:

Fixes #5775 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
