### PR TITLE
perf: increase Health Monitor invocation frequency

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/WiringConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/wiring/WiringConfig.java
@@ -46,6 +46,6 @@ public record WiringConfig(
         @ConfigProperty(defaultValue = "0") double defaultPoolMultiplier,
         @ConfigProperty(defaultValue = "8") int defaultPoolConstant,
         @ConfigProperty(defaultValue = "500") int healthMonitorSchedulerCapacity,
-        @ConfigProperty(defaultValue = "100ms") Duration healthMonitorHeartbeatPeriod,
+        @ConfigProperty(defaultValue = "1ms") Duration healthMonitorHeartbeatPeriod,
         @ConfigProperty(defaultValue = "1s") Duration healthLogThreshold,
         @ConfigProperty(defaultValue = "10m") Duration healthLogPeriod) {}


### PR DESCRIPTION
**Description**:
Decreased default health monitor period to 1ms.

**Related issue(s)**:

Fixes #15624 

**Notes for reviewer**:

Before:
```
[main] INFO NftTransferLoadTest - Finished NftTransferLoadTest: 626124014 transferred in 70614 sec, TPS: 8866
```
After:
```
[main] INFO NftTransferLoadTest - Finished NftTransferLoadTest: 647547837 transferred in 70625 sec, TPS: 9168
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
