### PR TITLE
chore: remove unnecessary checks for value xfer to system contracts

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
@@ -63,7 +63,6 @@ public class ExchangeRateSystemContract extends AbstractFullContract implements 
         requireNonNull(messageFrame);
         try {
             validateTrue(input.size() >= 4, INVALID_TRANSACTION_BODY);
-            validateTrue(messageFrame.getValue().getAsBigInteger().equals(BigInteger.ZERO), INVALID_FEE_SUBMITTED);
             gasRequirement = contractsConfigOf(messageFrame).precompileExchangeRateGasCost();
             final var selector = input.getInt(0);
             final var amount = biValueFrom(input);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
@@ -19,19 +19,19 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts;
 import static com.hedera.node.app.hapi.utils.ValidationUtils.validateTrue;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.contractsConfigOf;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.proxyUpdaterFor;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FEE_SUBMITTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.BigIntegerType;
 import com.esaulpaugh.headlong.abi.TypeFactory;
 import com.hedera.node.app.hapi.utils.InvalidTransactionException;
-import com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.Optional;
 import javax.inject.Inject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
@@ -39,7 +39,7 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 public class ExchangeRateSystemContract extends AbstractFullContract implements HederaSystemContract {
-
+    private static final Logger log = LogManager.getLogger(ExchangeRateSystemContract.class);
     private static final String PRECOMPILE_NAME = "ExchangeRate";
     private static final BigIntegerType WORD_DECODER = TypeFactory.create("uint256");
 
@@ -78,16 +78,13 @@ public class ExchangeRateSystemContract extends AbstractFullContract implements 
             requireNonNull(result);
             return new FullResult(PrecompileContractResult.success(result), gasRequirement, null);
         } catch (InvalidTransactionException e) {
-            ExceptionalHaltReason haltReason;
-            if (e.getResponseCode() == INVALID_FEE_SUBMITTED) {
-                haltReason = CustomExceptionalHaltReason.INVALID_FEE_SUBMITTED;
-            } else {
-                haltReason = ExceptionalHaltReason.INVALID_OPERATION;
-            }
-
             return new FullResult(
-                    PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(haltReason)), gasRequirement, null);
+                    PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(ExceptionalHaltReason.INVALID_OPERATION)),
+                    gasRequirement,
+                    null);
         } catch (Exception e) {
+            // Log a warning as this error is unexpected
+            log.warn("Internal precompile failure", e);
             return new FullResult(
                     PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(ExceptionalHaltReason.INVALID_OPERATION)),
                     gasRequirement,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
@@ -24,14 +24,11 @@ import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.BigIntegerType;
 import com.esaulpaugh.headlong.abi.TypeFactory;
-import com.hedera.node.app.hapi.utils.InvalidTransactionException;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.Optional;
 import javax.inject.Inject;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
@@ -39,7 +36,6 @@ import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
 public class ExchangeRateSystemContract extends AbstractFullContract implements HederaSystemContract {
-    private static final Logger log = LogManager.getLogger(ExchangeRateSystemContract.class);
     private static final String PRECOMPILE_NAME = "ExchangeRate";
     private static final BigIntegerType WORD_DECODER = TypeFactory.create("uint256");
 
@@ -77,14 +73,7 @@ public class ExchangeRateSystemContract extends AbstractFullContract implements 
                     };
             requireNonNull(result);
             return new FullResult(PrecompileContractResult.success(result), gasRequirement, null);
-        } catch (InvalidTransactionException e) {
-            return new FullResult(
-                    PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(ExceptionalHaltReason.INVALID_OPERATION)),
-                    gasRequirement,
-                    null);
         } catch (Exception e) {
-            // Log a warning as this error is unexpected
-            log.warn("Internal precompile failure", e);
             return new FullResult(
                     PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(ExceptionalHaltReason.INVALID_OPERATION)),
                     gasRequirement,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/PrngSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/PrngSystemContract.java
@@ -23,7 +23,6 @@ import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.as
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.tuweniToPbjBytes;
 import static com.hedera.node.app.service.contract.impl.utils.SystemContractUtils.successResultOfZeroValueTraceable;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FEE_SUBMITTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static java.util.Objects.requireNonNull;
 import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INVALID_OPERATION;
@@ -40,7 +39,6 @@ import com.hedera.node.app.service.contract.impl.state.AbstractProxyEvmAccount;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.math.BigInteger;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -84,7 +82,6 @@ public class PrngSystemContract extends AbstractFullContract implements HederaSy
 
         try {
             validateTrue(input.size() >= 4, INVALID_TRANSACTION_BODY);
-            validateTrue(frame.getValue().getAsBigInteger().equals(BigInteger.ZERO), INVALID_FEE_SUBMITTED);
             // compute the pseudorandom number
             final var randomNum = generatePseudoRandomData(input, frame);
             requireNonNull(randomNum);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/ExchangeRateSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/ExchangeRateSystemContractTest.java
@@ -25,7 +25,6 @@ import static org.mockito.BDDMockito.given;
 
 import com.google.common.primitives.Longs;
 import com.hedera.hapi.node.transaction.ExchangeRate;
-import com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.ExchangeRateSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
@@ -35,7 +34,6 @@ import java.time.Instant;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
-import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -82,7 +80,6 @@ class ExchangeRateSystemContractTest {
 
     @Test
     void convertsPositiveNumberToTinybarsAsExpected() {
-        given(frame.getValue()).willReturn(Wei.ZERO);
         givenRate(someRate);
 
         final var someInput = tinycentsInput(someTinycentAmount);
@@ -93,7 +90,6 @@ class ExchangeRateSystemContractTest {
 
     @Test
     void convertsPositiveNumberToTinycentsAsExpected() {
-        given(frame.getValue()).willReturn(Wei.ZERO);
         givenRate(someRate);
 
         final var positiveInput = tinybarsInput(someTinybarAmount);
@@ -104,7 +100,6 @@ class ExchangeRateSystemContractTest {
 
     @Test
     void convertsZeroToTinybarsAsExpected() {
-        given(frame.getValue()).willReturn(Wei.ZERO);
         givenRate(someRate);
 
         final var zeroInput = tinycentsInput(0);
@@ -121,17 +116,6 @@ class ExchangeRateSystemContractTest {
         final var result = subject.computeFully(underflowInput, frame);
         assertThat(result.output()).isEqualTo(Bytes.EMPTY);
         assertThat(result.result().getHaltReason().get()).isEqualTo(ExceptionalHaltReason.INVALID_OPERATION);
-    }
-
-    @Test
-    void valueShouldNotBeSentToThePrecompile() {
-        given(frame.getValue()).willReturn(Wei.MAX_WEI);
-
-        final var zeroInput = tinycentsInput(0);
-        final var result = subject.computeFully(zeroInput, frame);
-
-        assertThat(result.output()).isEqualTo(Bytes.EMPTY);
-        assertThat(result.result().getHaltReason().get()).isEqualTo(CustomExceptionalHaltReason.INVALID_FEE_SUBMITTED);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/PrngSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/PrngSystemContractTest.java
@@ -42,7 +42,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
-import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.BlockValues;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
@@ -120,7 +119,6 @@ class PrngSystemContractTest {
         givenInitialFrame();
         given(messageFrame.isStatic()).willReturn(true);
         given(messageFrame.getWorldUpdater()).willReturn(proxyWorldUpdater);
-        given(messageFrame.getValue()).willReturn(Wei.ZERO);
         given(proxyWorldUpdater.entropy()).willReturn(EXPECTED_RANDOM_NUMBER);
 
         // when:
@@ -137,7 +135,6 @@ class PrngSystemContractTest {
         commonMocks();
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(proxyWorldUpdater);
-        given(messageFrame.getValue()).willReturn(Wei.ZERO);
         given(proxyWorldUpdater.entropy()).willReturn(EXPECTED_RANDOM_NUMBER);
         given(systemContractGasCalculator.canonicalGasRequirement(any())).willReturn(GAS_REQUIRED);
 
@@ -160,7 +157,6 @@ class PrngSystemContractTest {
         given(systemContractGasCalculator.canonicalGasRequirement(any())).willReturn(GAS_REQUIRED);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(proxyWorldUpdater);
-        given(messageFrame.getValue()).willReturn(Wei.ZERO);
         given(proxyWorldUpdater.entropy()).willReturn(Bytes.wrap(ZERO_ENTROPY.toByteArray()));
         when(systemContractOperations.externalizePreemptedDispatch(any(), any()))
                 .thenReturn(mock(ContractCallStreamBuilder.class));
@@ -180,7 +176,6 @@ class PrngSystemContractTest {
         given(systemContractGasCalculator.canonicalGasRequirement(any())).willReturn(GAS_REQUIRED);
         given(messageFrame.isStatic()).willReturn(false);
         given(messageFrame.getWorldUpdater()).willReturn(proxyWorldUpdater);
-        given(messageFrame.getValue()).willReturn(Wei.ONE);
         when(systemContractOperations.externalizePreemptedDispatch(any(), any()))
                 .thenReturn(mock(ContractCallStreamBuilder.class));
 


### PR DESCRIPTION
**Description**:
There are checks in some of the system contracts which ensure that value is not passed to the contract.  These checks have been made superfluous by this pr #14843 and thus need to be removed.

**Related issue(s)**:

Fixes #13286 
