### PR TITLE
chore: Add constructor for `Bytes` in `Hash` to avoid copying

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -212,7 +212,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
                                   Starting: #{} @ {}""",
                         justFinishedBlockNumber,
                         lastBlockInfo.firstConsTimeOfCurrentBlock(),
-                        new Hash(lastBlockHashBytes.toByteArray(), DigestType.SHA_384),
+                        new Hash(lastBlockHashBytes, DigestType.SHA_384),
                         justFinishedBlockNumber + 1,
                         consensusTime);
             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/singleton/BlockInfoDumpUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/singleton/BlockInfoDumpUtils.java
@@ -107,18 +107,17 @@ public class BlockInfoDumpUtils {
                         blockInfo.firstConsTimeOfCurrentBlock().seconds(),
                         blockInfo.firstConsTimeOfCurrentBlock().nanos());
 
-        var runningHash = Bytes.EMPTY.equals(runningHashes.runningHash())
-                ? null
-                : new Hash(runningHashes.runningHash().toByteArray());
+        var runningHash =
+                Bytes.EMPTY.equals(runningHashes.runningHash()) ? null : new Hash(runningHashes.runningHash());
         var nMinus1RunningHash = Bytes.EMPTY.equals(runningHashes.nMinus1RunningHash())
                 ? null
-                : new Hash(runningHashes.nMinus1RunningHash().toByteArray());
+                : new Hash(runningHashes.nMinus1RunningHash());
         var nMinus2RunningHash = Bytes.EMPTY.equals(runningHashes.nMinus2RunningHash())
                 ? null
-                : new Hash(runningHashes.nMinus2RunningHash().toByteArray());
+                : new Hash(runningHashes.nMinus2RunningHash());
         var nMinus3RunningHash = Bytes.EMPTY.equals(runningHashes.nMinus3RunningHash())
                 ? null
-                : new Hash(runningHashes.nMinus3RunningHash().toByteArray());
+                : new Hash(runningHashes.nMinus3RunningHash());
 
         return new BBMBlockInfoAndRunningHashes(
                 blockInfo.lastBlockNumber(),

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/crypto/Hash.java
@@ -48,17 +48,31 @@ public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Seri
     }
 
     /**
-     * Same as {@link #Hash(byte[], DigestType)} but with an empty byte array.
+     * Same as {@link #Hash(Bytes, DigestType)} but with an empty byte array.
      */
     public Hash(@NonNull final DigestType digestType) {
-        this(new byte[digestType.digestLength()], digestType);
+        this(Bytes.wrap(new byte[digestType.digestLength()]), digestType);
     }
 
     /**
-     * Same as {@link #Hash(byte[], DigestType)} but with a digest type ({@link DigestType#SHA_384})
+     * Same as {@link #Hash(Bytes, DigestType)} but with a digest type ({@link DigestType#SHA_384}) and wrapping the byte array.
      */
     public Hash(@NonNull final byte[] value) {
+        this(Bytes.wrap(value), DigestType.SHA_384);
+    }
+
+    /**
+     * Same as {@link #Hash(Bytes, DigestType)} but with a digest type ({@link DigestType#SHA_384})
+     */
+    public Hash(@NonNull final Bytes value) {
         this(value, DigestType.SHA_384);
+    }
+
+    /**
+     * Same as {@link #Hash(Bytes, DigestType)} but with wrapping the byte array.
+     */
+    public Hash(@NonNull final byte[] value, @NonNull final DigestType digestType) {
+        this(Bytes.wrap(value), digestType);
     }
 
     /**
@@ -70,16 +84,16 @@ public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Seri
      * @param digestType
      * 		the digest type
      */
-    public Hash(@NonNull final byte[] value, @NonNull final DigestType digestType) {
+    public Hash(@NonNull final Bytes value, @NonNull final DigestType digestType) {
         Objects.requireNonNull(value, "value");
         Objects.requireNonNull(digestType, "digestType");
 
-        if (value.length != digestType.digestLength()) {
-            throw new IllegalArgumentException("value: " + value.length);
+        if ((int) value.length() != digestType.digestLength()) {
+            throw new IllegalArgumentException("value: " + value.length());
         }
 
         this.digestType = digestType;
-        this.bytes = Bytes.wrap(value);
+        this.bytes = value;
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/HashTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/crypto/HashTests.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.test.fixtures.RandomUtils;
@@ -58,6 +59,7 @@ public class HashTests {
 
         assertThrows(NullPointerException.class, () -> new Hash((DigestType) null));
         assertThrows(NullPointerException.class, () -> new Hash((byte[]) null));
+        assertThrows(NullPointerException.class, () -> new Hash((Bytes) null));
         assertThrows(IllegalArgumentException.class, () -> new Hash((Hash) null));
 
         assertThrows(NullPointerException.class, () -> new Hash(nonZeroHashValue, null));

--- a/platform-sdk/swirlds-merkle/src/testFixtures/java/com/swirlds/merkle/test/fixtures/map/lifecycle/SaveExpectedMapHandler.java
+++ b/platform-sdk/swirlds-merkle/src/testFixtures/java/com/swirlds/merkle/test/fixtures/map/lifecycle/SaveExpectedMapHandler.java
@@ -236,7 +236,7 @@ public class SaveExpectedMapHandler {
             final String digestString = node.get("digestType").asText();
             final DigestType digestType = DigestType.valueOf(digestString);
             final String hex = node.get("bytes").asText();
-            return new Hash(Bytes.fromHex(hex).toByteArray(), digestType);
+            return new Hash(Bytes.fromHex(hex), digestType);
         }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
@@ -364,8 +364,8 @@ public class DefaultIssDetector implements IssDetector {
             return null;
         }
 
-        final boolean decided = roundValidator.reportHashFromNetwork(
-                signerId, nodeWeight, new Hash(signaturePayload.hash().toByteArray()));
+        final boolean decided =
+                roundValidator.reportHashFromNetwork(signerId, nodeWeight, new Hash(signaturePayload.hash()));
         if (decided) {
             return checkValidity(roundValidator);
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PbjConverter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PbjConverter.java
@@ -239,9 +239,7 @@ public final class PbjConverter {
 
         return new ConsensusSnapshot(
                 consensusSnapshot.round(),
-                consensusSnapshot.judgeHashes().stream()
-                        .map(v -> new Hash(v.toByteArray()))
-                        .collect(toList()),
+                consensusSnapshot.judgeHashes().stream().map(Hash::new).collect(toList()),
                 consensusSnapshot.minimumJudgeInfoList().stream()
                         .map(PbjConverter::fromPbjMinimumJudgeInfo)
                         .collect(toList()),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadablePlatformStateStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadablePlatformStateStore.java
@@ -121,7 +121,7 @@ public class ReadablePlatformStateStore implements PlatformStateAccessor {
     @Nullable
     public Hash getLegacyRunningEventHash() {
         final var hash = stateOrThrow().legacyRunningEventHash();
-        return hash.length() == 0 ? null : new Hash(hash.toByteArray());
+        return hash.length() == 0 ? null : new Hash(hash);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventDescriptorWrapper.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventDescriptorWrapper.java
@@ -62,10 +62,7 @@ public record EventDescriptorWrapper(
     }
 
     public EventDescriptorWrapper(@NonNull EventDescriptor eventDescriptor) {
-        this(
-                eventDescriptor,
-                new Hash(eventDescriptor.hash().toByteArray()),
-                new NodeId(eventDescriptor.creatorNodeId()));
+        this(eventDescriptor, new Hash(eventDescriptor.hash()), new NodeId(eventDescriptor.creatorNodeId()));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
@@ -322,7 +322,7 @@ class DefaultSignedStateValidatorTests {
             if (signature.getByte(0) == 0) {
                 return false;
             }
-            final Hash hash = new Hash(data.toByteArray(), stateHash.getDigestType());
+            final Hash hash = new Hash(data, stateHash.getDigestType());
 
             return hash.equals(stateHash);
         };


### PR DESCRIPTION
Fix [#15542](https://github.com/hashgraph/hedera-services/issues/15542)