### PR TITLE
fix(container): adds resiliency to the deterministic image entrypoint script

### DIFF
--- a/hedera-node/infrastructure/docker/containers/production-next/consensus-node/Dockerfile
+++ b/hedera-node/infrastructure/docker/containers/production-next/consensus-node/Dockerfile
@@ -226,6 +226,8 @@ ENV JAVA_VERSION "jdk-21.0.4+7"
 ENV JAVA_HOME /usr/local/java
 ENV PATH ${JAVA_HOME}/bin:${PATH}
 
+ENV CONTAINER_TSR_ENABLED "true"
+
 # Install Java
 COPY --from=java-builder ${JAVA_HOME}/ ${JAVA_HOME}/
 

--- a/hedera-node/infrastructure/docker/containers/production-next/consensus-node/entrypoint.sh
+++ b/hedera-node/infrastructure/docker/containers/production-next/consensus-node/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/command/with-contenv bash
+# shellcheck shell=bash
 
 ########################################################################################################################
 # Copyright 2016-2022 Hedera Hashgraph, LLC                                                                            #
@@ -21,6 +22,53 @@ set -eo pipefail
 SCRIPT_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd "${SCRIPT_PATH}" || exit 64
 
+### Utility method to wait for the presence of a file with size > 0
+function waitForFile() {
+  local fileName="${1}"
+  local attempts
+  local size
+
+  [[ -z "${fileName}" ]] && return 1
+  for (( attempts = 0; attempts < 20; attempts++ )); do
+    if [[ -f "${fileName}" ]]; then
+      size="$(stat -f '+%z' "${fileName}")"
+      [[ -n "${size}" && "${size}" -gt 0 ]] && return 0
+    fi
+    sleep 6
+  done
+
+  return 1
+}
+
+## Extended waitForFile method which adds stdout output facilities and support for optionally present files
+function waitForFileEx() {
+  local fileName="${1}"
+  local message="${2}"
+  local optional="${3}"
+
+  [[ -z "${optional}" ]] && optional="false"
+
+  local rc="0"
+  printf "%s ..... " "${message}"
+  set +e
+  waitForFile "${fileName}"
+  rc="${?}"
+  set -e
+
+  if [[ "${rc}" -ne 0 ]]; then
+    if [[ "${optional}" != true ]]; then
+      printf "ERROR (exit code: %s)\n" "${rc}"
+    else
+      printf "NOT PRESENT\n"
+      rc=0
+    fi
+  else
+    printf "OK\n"
+  fi
+
+  return "${rc}"
+}
+
 if [[ -z "${JAVA_OPTS}" ]]; then
   JAVA_OPTS=""
 fi
@@ -36,19 +84,19 @@ if [[ -n "${JAVA_HEAP_MAX}" ]]; then
   JAVA_HEAP_OPTS="${JAVA_HEAP_OPTS} -Xmx${JAVA_HEAP_MAX}"
 fi
 
-# Setup Main Class
-[[ -z "${JAVA_MAIN_CLASS}" ]] && JAVA_MAIN_CLASS="com.swirlds.platform.Browser"
+# Setup Main Class - Updated to default to the new ServicesMain entrypoint class
+[[ -z "${JAVA_MAIN_CLASS}" ]] && JAVA_MAIN_CLASS="com.hedera.node.app.ServicesMain"
 
 # Setup Classpath
 JCP_OVERRIDDEN="false"
 if [[ -z "${JAVA_CLASS_PATH}" ]]; then
-  JAVA_CLASS_PATH="data/lib/*"
+  JAVA_CLASS_PATH="data/lib/*:data/apps/*"
 else
   JCP_OVERRIDDEN="true"
 fi
 
-if [[ "${JCP_OVERRIDDEN}" != true && "${JAVA_MAIN_CLASS}" != "com.swirlds.platform.Browser" ]]; then
-  JAVA_CLASS_PATH="${JAVA_CLASS_PATH}:data/apps/*"
+if [[ "${JCP_OVERRIDDEN}" != true && "${JAVA_MAIN_CLASS}" == "com.swirlds.platform.Browser" ]]; then
+  JAVA_CLASS_PATH="data/lib/*"
 fi
 
 # Override Log Directory Name (if provided)
@@ -98,10 +146,37 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> BEGIN JAVA VERSION >>>>>>>>>>>>>
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END JAVA VERSION   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 echo
 
+echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> BEGIN WAITING FOR FILES >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+## In Kubernetes environments intermittent failures have been observed due to the fragile config.txt/settings.txt loading
+## code when the file is not immediately available. This can occur due to various reasons including Persistent Volumes
+## being slow to bind and attach or projected Config Maps/Secrets not being fully initialized when the container starts.
+
+## This is a permanent belt and suspenders type of fix in addition to any resiliency which may also be added to the
+## Platform configuration loading mechanism.
+waitForFileEx "log4j2.xml" "Checking for log4j2.xml presence"
+waitForFileEx "config.txt" "Checking for config.txt presence"
+waitForFileEx "settings.txt" "Checking for settings.txt presence"
+waitForFileEx "data/config/application.properties" "Checking for application.properties presence"
+waitForFileEx "data/config/api-permission.properties" "Checking for api-permission.properties presence"
+waitForFileEx "hedera.crt" "Checking for hedera.crt presence (optional)" "true"
+waitForFileEx "hedera.key" "Checking for hedera.key presence (optional)" "true"
+echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END WAITING FOR FILES   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
+echo
+
 set +e
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> BEGIN NODE OUTPUT >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-/usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}"
-EC="${?}"
+## Due to a current bug in CoreDNS combined with the Platform config loading brittleness, it is necessary to retry
+## starting the platform software if the exit code is 205 which indicates a config.txt/address book loading issue.
+ATTEMPTS=0
+while true; do
+  /usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}"
+  EC="${?}"
+  if [[ "${EC}" -eq 205 && "${ATTEMPTS}" -lt 20 ]]; then
+    printf "\n\n############# Retrying system initialization - DNS or Address Book Failure (Exit Code: %s) #############\n\n" "${EC}"
+    ATTEMPTS=$(( ATTEMPTS + 1 ))
+    sleep 6
+  fi
+done
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END NODE OUTPUT   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 
 echo
@@ -110,3 +185,14 @@ printf "Process Exit Code: %s\n" "${EC}"
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END EXIT CODE   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 
 printf "\n\n#### Hedera Services Node Software Stopped ####\n\n"
+
+## Explicitly & intentionally using GNU sleep here - Not using the shell built-in due to lack of and/or buggy infinity
+## support depending on the shell version
+if [[ -n "${CONTAINER_TSR_ENABLED}" ]] && \
+    [[ "${CONTAINER_TSR_ENABLED}" == true || "${CONTAINER_TSR_ENABLED}" -gt 0 ]]; then
+  printf "#### Container TSR is ENABLED - Entering infinite sleep ####\n\n"
+  /usr/bin/env sleep infinity
+else
+  printf "#### Container TSR is DISABLED - Exiting with Final Disposition (Exit Code: %s) ####\n\n" "${EC}"
+  exit "${EC}"
+fi


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the `entrypoint.sh` script for the `production-next` deterministic image
   - Adds retry logic to properly handle DNS being unavailable during the first few seconds of the container startup sequence
   - Adds waitFor logic to properly handle persistent/projected volumes not being immediately available during the container startup sequence
   - Adds a configurable `sleep infinity` to keep the container running after the Java process has died

### Related Issues

- Closes #15913  