### PR TITLE
fix: Airdrop transfer list size validation

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
@@ -98,7 +98,7 @@ public class TokenAirdropValidator {
             @NonNull final ReadableTokenStore tokenStore,
             @NonNull final ReadableTokenRelationStore tokenRelStore,
             @NonNull final ReadableNftStore nftStore) {
-        var legerConfig = context.configuration().getConfigData(LedgerConfig.class);
+        var ledgerConfig = context.configuration().getConfigData(LedgerConfig.class);
         var totalFungibleTransfers = 0;
         var totalNftTransfers = 0;
         for (final var xfers : op.tokenTransfers()) {
@@ -121,7 +121,7 @@ public class TokenAirdropValidator {
 
                 // Verify that the current total number of (counted) fungible transfers does not exceed the limit
                 validateTrue(
-                        totalFungibleTransfers <= legerConfig.tokenTransfersMaxLen(),
+                        totalFungibleTransfers <= ledgerConfig.tokenTransfersMaxLen(),
                         TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED);
             }
 
@@ -146,7 +146,7 @@ public class TokenAirdropValidator {
 
                 totalNftTransfers += xfers.nftTransfers().size();
                 // Verify that the current total number of (counted) nft transfers does not exceed the limit
-                validateTrue(totalNftTransfers <= legerConfig.nftTransfersMaxLen(), BATCH_SIZE_LIMIT_EXCEEDED);
+                validateTrue(totalNftTransfers <= ledgerConfig.nftTransfersMaxLen(), BATCH_SIZE_LIMIT_EXCEEDED);
             }
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -482,23 +482,13 @@ public class TokenAirdropTest extends TokenAirdropBase {
                                 createTokenWithName("FT2"),
                                 createTokenWithName("FT3"),
                                 createTokenWithName("FT4"),
-                                createTokenWithName("FT5"),
-                                createTokenWithName("FT6"),
-                                createTokenWithName("FT7"),
-                                createTokenWithName("FT8"),
-                                createTokenWithName("FT9"),
-                                createTokenWithName("FT10"))
+                                createTokenWithName("FT5"))
                         .when(tokenAirdrop(
                                         defaultMovementOfToken("FT1"),
                                         defaultMovementOfToken("FT2"),
                                         defaultMovementOfToken("FT3"),
                                         defaultMovementOfToken("FT4"),
-                                        defaultMovementOfToken("FT5"),
-                                        defaultMovementOfToken("FT6"),
-                                        defaultMovementOfToken("FT7"),
-                                        defaultMovementOfToken("FT8"),
-                                        defaultMovementOfToken("FT9"),
-                                        defaultMovementOfToken("FT10"))
+                                        defaultMovementOfToken("FT5"))
                                 .payingWith(OWNER)
                                 .via("fungible airdrop"))
                         .then(
@@ -512,17 +502,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
                                 getAccountBalance(RECEIVER_WITH_UNLIMITED_AUTO_ASSOCIATIONS)
                                         .hasTokenBalance("FT4", 10),
                                 getAccountBalance(RECEIVER_WITH_UNLIMITED_AUTO_ASSOCIATIONS)
-                                        .hasTokenBalance("FT5", 10),
-                                getAccountBalance(RECEIVER_WITH_UNLIMITED_AUTO_ASSOCIATIONS)
-                                        .hasTokenBalance("FT6", 10),
-                                getAccountBalance(RECEIVER_WITH_UNLIMITED_AUTO_ASSOCIATIONS)
-                                        .hasTokenBalance("FT7", 10),
-                                getAccountBalance(RECEIVER_WITH_UNLIMITED_AUTO_ASSOCIATIONS)
-                                        .hasTokenBalance("FT8", 10),
-                                getAccountBalance(RECEIVER_WITH_UNLIMITED_AUTO_ASSOCIATIONS)
-                                        .hasTokenBalance("FT9", 10),
-                                getAccountBalance(RECEIVER_WITH_UNLIMITED_AUTO_ASSOCIATIONS)
-                                        .hasTokenBalance("FT10", 10));
+                                        .hasTokenBalance("FT5", 10));
             }
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenClaimAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenClaimAirdropTest.java
@@ -374,7 +374,9 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                 inParallel(
                         mapNTokens(token -> createFT(token, DEFAULT_PAYER, 1000L), SpecOperation.class, "ft", 1, 10)),
                 tokenAirdrop(mapNTokens(
-                        token -> moving(1, token).between(DEFAULT_PAYER, recipient), TokenMovement.class, "ft", 1, 10)),
+                        token -> moving(1, token).between(DEFAULT_PAYER, recipient), TokenMovement.class, "ft", 1, 5)),
+                tokenAirdrop(mapNTokens(
+                        token -> moving(1, token).between(DEFAULT_PAYER, recipient), TokenMovement.class, "ft", 6, 10)),
                 claimAndFailToReclaim(() -> tokenClaimAirdrop(mapNTokens(
                                 token -> pendingAirdrop(DEFAULT_PAYER, recipient, token), Function.class, "ft", 1, 10))
                         .payingWith(recipient)),
@@ -407,7 +409,8 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                         moving(1, FUNGIBLE_TOKEN_2).between(DEFAULT_PAYER, BOB),
                         moving(1, FUNGIBLE_TOKEN_3).between(DEFAULT_PAYER, BOB),
                         moving(1, FUNGIBLE_TOKEN_4).between(DEFAULT_PAYER, BOB),
-                        movingUnique(NON_FUNGIBLE_TOKEN, 1).between(DEFAULT_PAYER, BOB),
+                        movingUnique(NON_FUNGIBLE_TOKEN, 1).between(DEFAULT_PAYER, BOB)),
+                tokenAirdrop(
                         moving(1, FUNGIBLE_TOKEN_6).between(DEFAULT_PAYER, CAROL),
                         moving(1, FUNGIBLE_TOKEN_7).between(DEFAULT_PAYER, CAROL),
                         moving(1, FUNGIBLE_TOKEN_8).between(DEFAULT_PAYER, CAROL),
@@ -476,7 +479,9 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                                 moving(1, FUNGIBLE_TOKEN_2).between(ALICE, CAROL),
                                 moving(1, FUNGIBLE_TOKEN_3).between(ALICE, YULIA),
                                 moving(1, FUNGIBLE_TOKEN_4).between(ALICE, TOM),
-                                moving(1, FUNGIBLE_TOKEN_5).between(ALICE, STEVE),
+                                moving(1, FUNGIBLE_TOKEN_5).between(ALICE, STEVE))
+                        .payingWith(ALICE),
+                tokenAirdrop(
                                 moving(1, FUNGIBLE_TOKEN_6).between(ALICE, BOB),
                                 moving(1, FUNGIBLE_TOKEN_7).between(ALICE, CAROL),
                                 moving(1, FUNGIBLE_TOKEN_8).between(ALICE, YULIA),


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Replaces the current transfer list size validation with one that complies with the CryptoTransfer behaviour.

**Related issue(s)**:

Fixes #15906

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
PR, that replaces the current transfer list size validation with one that complies with the CryptoTransfer behavior :
1. Allowing no more than 10 fungible token **balance adjustments**.
- In case of one fungible token airdrop, it is possible up to 9 receivers (1 adjustment for the sender and 9 for receivers)
- In case of multiple fungible tokens, it is possible to make up to 5 token transfers (5 x 2 adjustments of the sender and the receiver balances)
2. Allowing no more than 10 NFT transfers

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
