### PR TITLE
chore: migrate cryptography from .pfx files to .pem files

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -530,6 +530,7 @@ public final class CryptoStatic {
                 if (cryptoConfig.enableNewKeyStoreModel()) {
                     logger.debug(STARTUP.getMarker(), "Reading keys using the enhanced key loader");
                     keysAndCerts = EnhancedKeyStoreLoader.using(addressBook, configuration)
+                            .migrate()
                             .scan()
                             .generateIfNecessary()
                             .verify()

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
@@ -113,6 +113,7 @@ class EnhancedKeyStoreLoaderTest {
         assertThat(keyDirectory).exists().isDirectory().isReadable().isNotEmptyDirectory();
 
         assertThat(loader).isNotNull();
+        assertThatCode(loader::migrate).doesNotThrowAnyException();
         assertThatCode(loader::scan).doesNotThrowAnyException();
         assertThatCode(loader::generateIfNecessary).doesNotThrowAnyException();
         assertThatCode(loader::verify).doesNotThrowAnyException();
@@ -159,6 +160,7 @@ class EnhancedKeyStoreLoaderTest {
         assertThat(keyDirectory).exists().isDirectory().isReadable().isNotEmptyDirectory();
 
         assertThat(loader).isNotNull();
+        assertThatCode(loader::migrate).doesNotThrowAnyException();
         assertThatCode(loader::scan).doesNotThrowAnyException();
         assertThatCode(loader::verify).isInstanceOf(KeyLoadingException.class);
         assertThatCode(loader::injectInAddressBook).isInstanceOf(KeyLoadingException.class);
@@ -183,6 +185,7 @@ class EnhancedKeyStoreLoaderTest {
         assertThat(keyDirectory).exists().isDirectory().isReadable().isNotEmptyDirectory();
 
         assertThat(loader).isNotNull();
+        assertThatCode(loader::migrate).doesNotThrowAnyException();
         assertThatCode(loader::scan).doesNotThrowAnyException();
         assertThatCode(loader::verify).isInstanceOf(KeyLoadingException.class);
         assertThatCode(loader::injectInAddressBook).doesNotThrowAnyException();


### PR DESCRIPTION
**Description**:
This PR migrates  the cryptography from pfx files to pem files.    Merge targeting .55,  may need to go to develop instead since DAB was delayed to 56.  

Behavior Of Note: 
* This runs at every startup before loading cryptography from disk. 
* If successful, pfx files are moved to an `OLD_PFX_KEYS` subdirectory. 
* Success is determined by loading the PEM keys and comparing their encoding to the PFX keys
* If not successful, all created PEM files are deleted (no pre-existing PEM files are deleted) and pfx files remain unmoved. 
* All agreement key material is permanently deleted regardless of success or failure. 


Fixes #15827 


- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
