### PR TITLE
ci: Fix invalid workflow introduced by 15928

### DIFF
--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -95,7 +95,6 @@ jobs:
       sdk-gpg-key-contents: ${{ secrets.PLATFORM_GPG_KEY_CONTENTS }}
       sdk-gpg-key-passphrase: ${{ secrets.PLATFORM_GPG_KEY_PASSPHRASE }}
       slack-webhook-url: ${{ secrets.PLATFORM_SLACK_RELEASE_WEBHOOK }}
-      jenkins-integration-url: ${{ secrets.RELEASE_JENKINS_INTEGRATION_URL }}
       jf-url: ${{ vars.JF_URL }}
       jf-docker-registry: ${{ vars.JF_DOCKER_REGISTRY }}
       jf-user-name: ${{ vars.JF_USER_NAME }}
@@ -122,7 +121,6 @@ jobs:
       sdk-gpg-key-contents: ${{ secrets.PLATFORM_GPG_KEY_CONTENTS }}
       sdk-gpg-key-passphrase: ${{ secrets.PLATFORM_GPG_KEY_PASSPHRASE }}
       slack-webhook-url: ${{ secrets.PLATFORM_SLACK_RELEASE_WEBHOOK }}
-      jenkins-integration-url: ${{ secrets.RELEASE_JENKINS_INTEGRATION_URL }}
       jf-url: ${{ vars.JF_URL }}
       jf-docker-registry: ${{ vars.JF_DOCKER_REGISTRY }}
       jf-user-name: ${{ vars.JF_USER_NAME }}


### PR DESCRIPTION
**Description**:

PR #15928 moved the jenkins notify steps in
`node-zxc-build-release-artifact.yaml` to its own file, `node-zxf-deploy-integration.yaml` This file triggers off of the completion of `node-zxc-build-release-artifact.yaml`. However, the file `node-flow-deploy-release-artifact.yaml` which calls build-release-artifact maintained its original calling signature.

This PR removes the `jenkins-integration-url` entry from the `node-flow-deploy-release-artifact.yaml` file. Which was causing the workflow to be marked as invalid.

This change should enable the `ZXF: Deploy Production Release` job to complete.

**Related Issue(s)**:

Relates to: #15947
