### PR TITLE
feat: introduce NodeId.of(long)

### DIFF
--- a/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/info/FakeNetworkInfo.java
+++ b/hedera-node/hedera-app-spi/src/testFixtures/java/com/hedera/node/app/spi/fixtures/info/FakeNetworkInfo.java
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class FakeNetworkInfo implements NetworkInfo {
     private static final Bytes DEV_LEDGER_ID = Bytes.wrap(new byte[] {0x03});
-    private static final List<NodeId> FAKE_NODE_INFO_IDS = List.of(new NodeId(2), new NodeId(4), new NodeId(8));
+    private static final List<NodeId> FAKE_NODE_INFO_IDS = List.of(NodeId.of(2), NodeId.of(4), NodeId.of(8));
     private static final List<NodeInfo> FAKE_NODE_INFOS = List.of(
             fakeInfoWith(
                     2L,
@@ -81,7 +81,7 @@ public class FakeNetworkInfo implements NetworkInfo {
 
     @Override
     public boolean containsNode(final long nodeId) {
-        return FAKE_NODE_INFO_IDS.contains(new NodeId(nodeId));
+        return FAKE_NODE_INFO_IDS.contains(NodeId.of(nodeId));
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
@@ -142,7 +142,7 @@ public class MerkleStateLifecyclesImpl implements MerkleStateLifecycles {
         // service schema's restart() hook. Here we only update the address book weights
         // based on the staking info in the state.
         weightUpdateVisitor.accept(stakingInfoVMap, (node, info) -> {
-            final var nodeId = new NodeId(node.number());
+            final var nodeId = NodeId.of(node.number());
             // If present in the address book, remove this node id from the
             // set of node ids left to update and update its weight
             if (nodeIdsLeftToUpdate.remove(nodeId)) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/ServicesMainTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/ServicesMainTest.java
@@ -171,8 +171,8 @@ final class ServicesMainTest {
                 .thenReturn(legacyConfigProperties);
 
         List<NodeId> nodeIds = new ArrayList<>();
-        nodeIds.add(new NodeId(1));
-        nodeIds.add(new NodeId(2));
+        nodeIds.add(NodeId.of(1));
+        nodeIds.add(NodeId.of(2));
 
         bootstrapUtilsMockedStatic
                 .when(() -> BootstrapUtils.getNodesToRun(any(), any()))

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/MerkleStateLifecyclesImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/MerkleStateLifecyclesImplTest.java
@@ -114,8 +114,8 @@ class MerkleStateLifecyclesImplTest extends MerkleTestBase {
 
     @Test
     void updatesAddressBookWithZeroWeightOnGenesisStart() {
-        final var node0 = new NodeId(0);
-        final var node1 = new NodeId(1);
+        final var node0 = NodeId.of(0);
+        final var node1 = NodeId.of(1);
         given(platform.getSelfId()).willReturn(node0);
 
         final var pretendAddressBook = createPretendBookFrom(platform, true);
@@ -133,8 +133,8 @@ class MerkleStateLifecyclesImplTest extends MerkleTestBase {
 
     @Test
     void updatesAddressBookWithZeroWeightForNewNodes() {
-        final var node0 = new NodeId(0);
-        final var node1 = new NodeId(1);
+        final var node0 = NodeId.of(0);
+        final var node1 = NodeId.of(1);
         given(platform.getSelfId()).willReturn(node0);
         final var pretendAddressBook = createPretendBookFrom(platform, true);
         given(merkleStateRoot.findNodeIndex(TokenService.NAME, STAKING_INFO_KEY))
@@ -163,9 +163,9 @@ class MerkleStateLifecyclesImplTest extends MerkleTestBase {
 
     @Test
     void doesntUpdateAddressBookIfNodeIdFromStateDoesntExist() {
-        final var node0 = new NodeId(0);
-        final var node1 = new NodeId(1);
-        final var node2 = new NodeId(2);
+        final var node0 = NodeId.of(0);
+        final var node1 = NodeId.of(1);
+        final var node2 = NodeId.of(2);
         given(platform.getSelfId()).willReturn(node0);
 
         final var pretendAddressBook = createPretendBookFrom(platform, true);
@@ -214,8 +214,8 @@ class MerkleStateLifecyclesImplTest extends MerkleTestBase {
 
     @Test
     void updatesAddressBookWithNonZeroWeightsOnGenesisStartIfStakesExist() {
-        final var node0 = new NodeId(0);
-        final var node1 = new NodeId(1);
+        final var node0 = NodeId.of(0);
+        final var node1 = NodeId.of(1);
         given(platform.getSelfId()).willReturn(node0);
 
         final var pretendAddressBook = createPretendBookFrom(platform, true);
@@ -278,8 +278,8 @@ class MerkleStateLifecyclesImplTest extends MerkleTestBase {
                 .when(weightUpdateVisitor)
                 .accept(any(), any());
 
-        final var node0 = new NodeId(0);
-        final var node1 = new NodeId(1);
+        final var node0 = NodeId.of(0);
+        final var node1 = NodeId.of(1);
 
         given(platform.getSelfId()).willReturn(node0);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/test/grpc/GrpcTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/test/grpc/GrpcTestBase.java
@@ -87,7 +87,7 @@ abstract class GrpcTestBase extends TestBase {
     /**
      * Represents "this node" in our tests.
      */
-    private final NodeId nodeSelfId = new NodeId(7);
+    private final NodeId nodeSelfId = NodeId.of(7);
 
     /**
      * This {@link NettyGrpcServerManager} is used to handle the wire protocol tasks and delegate to our gRPC handlers

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/utils/TestUtils.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/utils/TestUtils.java
@@ -49,7 +49,7 @@ public class TestUtils {
                 HederaTestConfigBuilder.createConfig().getConfigData(MetricsConfig.class);
 
         return new DefaultPlatformMetrics(
-                new NodeId(DEFAULT_NODE_ID),
+                NodeId.of(DEFAULT_NODE_ID),
                 new MetricKeyRegistry(),
                 Executors.newSingleThreadScheduledExecutor(),
                 new PlatformMetricsFactoryImpl(metricsConfig),

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -191,8 +191,8 @@ class HandleWorkflowTest {
 
     @Test
     void onlySkipsEventWithMissingCreator() {
-        final var presentCreatorId = new NodeId(1L);
-        final var missingCreatorId = new NodeId(2L);
+        final var presentCreatorId = NodeId.of(1L);
+        final var missingCreatorId = NodeId.of(2L);
         final var eventFromPresentCreator = mock(ConsensusEvent.class);
         final var eventFromMissingCreator = mock(ConsensusEvent.class);
         given(round.iterator())

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/ValidationReporterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/ValidationReporterTest.java
@@ -87,7 +87,7 @@ class ValidationReporterTest {
             AccountID.newBuilder().accountNum(1_234).build();
     private static final AccountID CREATOR_ACCOUNT_ID =
             AccountID.newBuilder().accountNum(3).build();
-    private static final NodeId CREATOR_NODE_ID = new NodeId(0L);
+    private static final NodeId CREATOR_NODE_ID = NodeId.of(0L);
 
     @Mock
     private NodeInfo creatorInfo;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
@@ -328,7 +328,7 @@ class TransactionExecutorsTest {
 
             @Override
             public boolean containsNode(final long nodeId) {
-                return addressBook.contains(new NodeId(nodeId));
+                return addressBook.contains(NodeId.of(nodeId));
             }
 
             @Override

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
@@ -136,7 +136,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
     private final SemanticVersion hapiVersion =
             SemanticVersion.newBuilder().major(1).minor(2).patch(3).build();
     /** Represents "this node" in our tests. */
-    protected final NodeId nodeSelfId = new NodeId(7);
+    protected final NodeId nodeSelfId = NodeId.of(7);
     /** The AccountID of "this node" in our tests. */
     protected final AccountID nodeSelfAccountId =
             AccountID.newBuilder().shardNum(0).realmNum(0).accountNum(8).build();
@@ -337,7 +337,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
             final ConfigProvider configProvider = () -> new VersionedConfigImpl(configBuilder.getOrCreateConfig(), 1);
             final var addresses = nodes.stream()
                     .map(nodeInfo -> new Address()
-                            .copySetNodeId(new NodeId(nodeInfo.nodeId()))
+                            .copySetNodeId(NodeId.of(nodeInfo.nodeId()))
                             .copySetWeight(nodeInfo.zeroStake() ? 0 : 10))
                     .toList();
             final var addressBook = new AddressBook(addresses);

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakePlatform.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakePlatform.java
@@ -57,7 +57,7 @@ public final class FakePlatform implements Platform {
      * Constructor for Embedded Hedera that uses a single node network
      */
     public FakePlatform() {
-        this.selfNodeId = new NodeId(0L);
+        this.selfNodeId = NodeId.of(0L);
         final var addressBuilder = RandomAddressBuilder.create(random);
         final var address =
                 addressBuilder.withNodeId(selfNodeId).withWeight(500L).build();
@@ -73,7 +73,7 @@ public final class FakePlatform implements Platform {
      * @param addresses the address book
      */
     public FakePlatform(final long nodeId, final AddressBook addresses) {
-        this.selfNodeId = new NodeId(nodeId);
+        this.selfNodeId = NodeId.of(nodeId);
         this.addressBook = addresses;
         this.context = createPlatformContext();
         this.notificationEngine = NotificationEngine.buildEngine(getStaticThreadManager());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -83,7 +83,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     private static final SemanticVersion LATER_SEMVER =
             SemanticVersion.newBuilder().major(999).build();
 
-    protected static final NodeId MISSING_NODE_ID = new NodeId(666L);
+    protected static final NodeId MISSING_NODE_ID = NodeId.of(666L);
     protected static final int MAX_PLATFORM_TXN_SIZE = 1024 * 6;
     protected static final int MAX_QUERY_RESPONSE_SIZE = 1024 * 1024 * 2;
     protected static final Hash FAKE_START_OF_STATE_HASH = new Hash(new byte[48]);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/AddressBookUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/AddressBookUtils.java
@@ -170,6 +170,6 @@ public class AddressBookUtils {
      */
     public static Address nodeAddressFrom(@NonNull final AddressBook addressBook, final long nodeId) {
         requireNonNull(addressBook);
-        return addressBook.getAddress(new NodeId(nodeId));
+        return addressBook.getAddress(NodeId.of(nodeId));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
@@ -249,7 +249,7 @@ public class StateChangesValidator implements BlockStreamValidator {
         final var lifecycles = newPlatformInitLifecycle(bootstrapConfig, currentVersion, migrator, servicesRegistry);
         this.state = new MerkleStateRoot(lifecycles, version -> new ServicesSoftwareVersion(version, configVersion));
         initGenesisPlatformState(
-                new FakePlatformContext(new NodeId(0), Executors.newSingleThreadScheduledExecutor()),
+                new FakePlatformContext(NodeId.of(0), Executors.newSingleThreadScheduledExecutor()),
                 this.state.getWritablePlatformState(),
                 addressBook,
                 currentVersion);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/DabEnabledUpgradeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/DabEnabledUpgradeTest.java
@@ -326,11 +326,11 @@ public class DabEnabledUpgradeTest implements LifecycleTest {
 
     private static void validateMultipartEdits(@NonNull final AddressBook addressBook) {
         assertThat(nodeIdsFrom(addressBook)).containsExactlyInAnyOrder(0L, 2L, 5L);
-        final var node0 = addressBook.getAddress(new NodeId(0L));
+        final var node0 = addressBook.getAddress(NodeId.of(0L));
         assertEquals(classicFeeCollectorIdLiteralFor(0), node0.getMemo());
-        final var node2 = addressBook.getAddress(new NodeId(2L));
+        final var node2 = addressBook.getAddress(NodeId.of(2L));
         assertEquals(classicFeeCollectorIdLiteralFor(902), node2.getMemo());
-        final var node5 = addressBook.getAddress(new NodeId(5L));
+        final var node5 = addressBook.getAddress(NodeId.of(5L));
         assertEquals(classicFeeCollectorIdLiteralFor(905), node5.getMemo());
         assertEquals("127.0.0.1", node5.getHostnameInternal());
         assertEquals(33000, node5.getPortInternal());

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedIss.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedIss.java
@@ -218,7 +218,7 @@ public class PlannedIss implements SelfSerializable, PlannedIncident {
 
             final List<NodeId> nodes = new ArrayList<>();
             for (final String nodeString : nodeStrings) {
-                final NodeId nodeId = new NodeId(Long.parseLong(nodeString));
+                final NodeId nodeId = NodeId.of(Long.parseLong(nodeString));
                 nodes.add(nodeId);
                 if (!uniqueNodeIds.add(nodeId)) {
                     logger.error(EXCEPTION.getMarker(), "Node {} appears more than once in ISS description!", nodeId);

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedLogError.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/PlannedLogError.java
@@ -119,7 +119,7 @@ public class PlannedLogError implements SelfSerializable, PlannedIncident {
 
         final List<NodeId> nodeIds = new ArrayList<>();
         for (final String nodeIdString : nodeIdsStrings) {
-            nodeIds.add(new NodeId(Integer.parseInt(nodeIdString)));
+            nodeIds.add(NodeId.of(Integer.parseInt(nodeIdString)));
         }
 
         return new PlannedLogError(Duration.ofSeconds(elapsedSeconds), nodeIds);

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolMain.java
@@ -710,7 +710,7 @@ public class PlatformTestingToolMain implements SwirldMain {
     }
 
     private void initializeAppClient(final String[] pars, final ObjectMapper objectMapper) throws IOException {
-        if ((pars == null) || (pars.length < 2) || !selfId.equals(new NodeId(0L))) {
+        if ((pars == null) || (pars.length < 2) || !selfId.equals(NodeId.of(0L))) {
             return;
         }
 
@@ -785,7 +785,7 @@ public class PlatformTestingToolMain implements SwirldMain {
 
             // if single mode only node 0 can submit transactions
             // if not single mode anyone can submit transactions
-            if (!submitConfig.isSingleNodeSubmit() || selfId.equals(new NodeId(0L))) {
+            if (!submitConfig.isSingleNodeSubmit() || selfId.equals(NodeId.of(0L))) {
 
                 if (submitConfig.isSubmitInTurn()) {
                     // Delay the start of transactions by interval multiply by node id

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PttTransactionPool.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PttTransactionPool.java
@@ -172,7 +172,7 @@ public class PttTransactionPool implements FastCopyable {
 
         /** If the startFreezeAfterMin is 0, we don't send freeze transaction */
         if (freezeConfig != null
-                && Objects.equals(platform.getSelfId(), new NodeId(0L))
+                && Objects.equals(platform.getSelfId(), NodeId.of(0L))
                 && freezeConfig.getStartFreezeAfterMin() > 0) {
             this.freezeConfig = freezeConfig;
             this.needToSubmitFreezeTx = true;

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/internal/ExpectedFCMFamilyTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/merkle/map/internal/ExpectedFCMFamilyTest.java
@@ -150,7 +150,7 @@ class ExpectedFCMFamilyTest {
 
     static {
         platform = Mockito.mock(Platform.class);
-        Mockito.when(platform.getSelfId()).thenReturn(new NodeId(0L));
+        Mockito.when(platform.getSelfId()).thenReturn(NodeId.of(0L));
     }
 
     @BeforeAll

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/timingSensitive/java/com/swirlds/demo/merkle/map/MapValueFCQTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/timingSensitive/java/com/swirlds/demo/merkle/map/MapValueFCQTests.java
@@ -79,7 +79,7 @@ public class MapValueFCQTests {
         mapKey = new MapKey(0, 0, random.nextLong());
         state = Mockito.spy(PlatformTestingToolState.class);
         final Platform platform = Mockito.mock(Platform.class);
-        when(platform.getSelfId()).thenReturn(new NodeId(0L));
+        when(platform.getSelfId()).thenReturn(NodeId.of(0L));
         AddressBook addressBook = Mockito.spy(AddressBook.class);
         when(addressBook.getNumberWithWeight()).thenReturn(4);
         when(platform.getAddressBook()).thenReturn(addressBook);

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/timingSensitive/java/com/swirlds/demo/platform/PttTransactionPoolTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/timingSensitive/java/com/swirlds/demo/platform/PttTransactionPoolTest.java
@@ -69,7 +69,7 @@ public class PttTransactionPoolTest {
 
     static {
         platform = Mockito.mock(Platform.class);
-        Mockito.when(platform.getSelfId()).thenReturn(new NodeId(myID));
+        Mockito.when(platform.getSelfId()).thenReturn(NodeId.of(myID));
         System.arraycopy(payload, 0, payloadWithSig, 0, payload.length);
         expectedFCMFamily = new DummyExpectedFCMFamily(myID);
         fCMFamily = new FCMFamily(true);

--- a/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogProcessor.java
+++ b/platform-sdk/swirlds-cli/src/main/java/com/swirlds/cli/logging/LogProcessor.java
@@ -81,7 +81,7 @@ public class LogProcessor {
 
                 final Path logFile = subdirectory.resolve("swirlds.log");
                 if (Files.exists(logFile)) {
-                    final NodeId nodeId = new NodeId(Integer.parseInt(subdirectoryName.substring(4)));
+                    final NodeId nodeId = NodeId.of(Integer.parseInt(subdirectoryName.substring(4)));
                     logFilesByNode.put(nodeId, logFile);
 
                     logger.info(LogMarker.CLI.getMarker(), "Found log file: {}", logFile);

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/NoOpMetrics.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/NoOpMetrics.java
@@ -46,7 +46,7 @@ public class NoOpMetrics implements PlatformMetrics {
 
     @Override
     public NodeId getNodeId() {
-        return new NodeId(42L);
+        return NodeId.of(42L);
     }
 
     @Override

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeId.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeId.java
@@ -76,7 +76,7 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
      * @param id the ID number
      * @throws IllegalArgumentException if the ID number is negative
      */
-    public NodeId(final long id) {
+    protected NodeId(final long id) {
         if (id < LOWEST_NODE_NUMBER) {
             throw new IllegalArgumentException("id must be non-negative");
         }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeId.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeId.java
@@ -48,10 +48,22 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
     public static final long LOWEST_NODE_NUMBER = 0L;
 
     /** The first NodeId. */
-    public static final NodeId FIRST_NODE_ID = new NodeId(LOWEST_NODE_NUMBER);
+    public static final NodeId FIRST_NODE_ID = NodeId.of(LOWEST_NODE_NUMBER);
 
     /** The ID number. */
     private long id;
+
+    /**
+     * Return a potentially cached NodeId instance for a given node id value.
+     * The caller MUST NOT mutate the returned object even though the NodeId class is technically mutable.
+     * If the caller needs to mutate the instance, then it must use the regular NodeId(long) constructor instead.
+     *
+     * @param id a node id value
+     * @return a NodeId instance
+     */
+    public static NodeId of(final long id) {
+        return NodeIdCache.getOrCreate(id);
+    }
 
     /**
      * Constructs an empty NodeId objects, used in deserialization only.
@@ -116,7 +128,7 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
             throw new IllegalArgumentException("the new NodeId, %d, must not be below the minimum value of %d."
                     .formatted(newValue, LOWEST_NODE_NUMBER));
         }
-        return new NodeId(newValue);
+        return NodeId.of(newValue);
     }
 
     /**
@@ -168,7 +180,7 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
             }
             throw new IOException("id must be non-negative");
         }
-        return new NodeId(longValue);
+        return NodeId.of(longValue);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeIdCache.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeIdCache.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.common.platform;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * A cache for NodeId objects.
+ *
+ * It's useful to support code that uses long values to identify nodes (e.g. the Roster)
+ * and needs to interact with code that uses NodeId objects for the same purpose
+ * as it helps prevent creating many duplicate NodeId instances for the same long id value.
+ */
+final class NodeIdCache {
+    private NodeIdCache() {}
+
+    /** Minimum node id to cache. MUST BE non-negative. */
+    private static final int MIN = 0;
+    /** Maximum node id to cache. MUST BE non-negative, &gt;= MIN, and reasonably small. */
+    private static final int MAX = 63;
+
+    private static NodeId[] CACHE = new NodeId[MAX - MIN + 1];
+
+    static {
+        for (int id = MIN; id <= MAX; id++) {
+            CACHE[id - MIN] = new NodeId(id);
+        }
+    }
+
+    /**
+     * Fetch a NodeId value from the cache, or create a NodeId.of object.
+     * The caller MUST NOT mutate the returned object even though the NodeId class is technically mutable.
+     *
+     * @param id a node id value
+     * @return a NodeId object
+     */
+    @NonNull
+    static NodeId getOrCreate(final long id) {
+        if (id >= MIN && id <= MAX) {
+            return CACHE[(int) id - MIN];
+        }
+        return new NodeId(id);
+    }
+}

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeIdCache.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeIdCache.java
@@ -44,6 +44,8 @@ final class NodeIdCache {
     /**
      * Fetch a NodeId value from the cache, or create a new NodeId object.
      * The caller MUST NOT mutate the returned object even though the NodeId class is technically mutable.
+     * Note that whilst this class allows creation of NodeId with IDs beyond the boundary defined in this class,
+     * it does not cache such NodeId instances as these are expected to be used for testing purposes only.
      *
      * @param id a node id value
      * @return a NodeId object

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeIdCache.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeIdCache.java
@@ -33,7 +33,7 @@ final class NodeIdCache {
     /** Maximum node id to cache. MUST BE non-negative, &gt;= MIN, and reasonably small. */
     private static final int MAX = 63;
 
-    private static NodeId[] CACHE = new NodeId[MAX - MIN + 1];
+    private static final NodeId[] CACHE = new NodeId[MAX - MIN + 1];
 
     static {
         for (int id = MIN; id <= MAX; id++) {

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeIdCache.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeIdCache.java
@@ -42,7 +42,7 @@ final class NodeIdCache {
     }
 
     /**
-     * Fetch a NodeId value from the cache, or create a NodeId.of object.
+     * Fetch a NodeId value from the cache, or create a new NodeId object.
      * The caller MUST NOT mutate the returned object even though the NodeId class is technically mutable.
      *
      * @param id a node id value

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/context/internal/DefaultPlatformContextTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/context/internal/DefaultPlatformContextTest.java
@@ -41,7 +41,7 @@ class DefaultPlatformContextTest {
     void testNoNullServices() {
         // given
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
-        final NodeId nodeId = new NodeId(3256733545L);
+        final NodeId nodeId = NodeId.of(3256733545L);
         final PlatformMetricsProvider metricsProvider = new DefaultMetricsProvider(configuration);
         metricsProvider.createGlobalMetrics();
         final MerkleCryptography merkleCryptography = mock(MerkleCryptography.class);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/LegacyCsvWriterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/LegacyCsvWriterTest.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 class LegacyCsvWriterTest {
 
-    private static final NodeId NODE_ID = new NodeId(42L);
+    private static final NodeId NODE_ID = NodeId.of(42L);
     private Metrics metrics;
     private MetricsConfig metricsConfig;
     private Configuration configuration;

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/MetricKeyRegistrationTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/MetricKeyRegistrationTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 class MetricKeyRegistrationTest {
 
-    private static final NodeId NODE_ID = new NodeId(1L);
+    private static final NodeId NODE_ID = NodeId.of(1L);
     private static final String METRIC_KEY = calculateMetricKey("CaTeGoRy", "NaMe");
 
     @Test
@@ -98,7 +98,7 @@ class MetricKeyRegistrationTest {
         registry.register(NODE_ID, METRIC_KEY, Counter.class);
 
         // when
-        final boolean result = registry.register(new NodeId(111L), METRIC_KEY, Counter.class);
+        final boolean result = registry.register(NodeId.of(111L), METRIC_KEY, Counter.class);
 
         // then
         assertThat(result).isTrue();
@@ -187,7 +187,7 @@ class MetricKeyRegistrationTest {
     @Test
     void testAddingGlobalMetricWhenOnlyOnePlatformMetricWasDeleted() {
         // given
-        final NodeId nodeId2 = new NodeId(111L);
+        final NodeId nodeId2 = NodeId.of(111L);
         final MetricKeyRegistry registry = new MetricKeyRegistry();
         registry.register(NODE_ID, METRIC_KEY, Counter.class);
         registry.register(nodeId2, METRIC_KEY, Counter.class);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/SnapshotServiceTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/SnapshotServiceTest.java
@@ -57,8 +57,8 @@ import org.mockito.stubbing.Answer;
 @ExtendWith(MockitoExtension.class)
 class SnapshotServiceTest {
 
-    private static final NodeId NODE_ID_1 = new NodeId(1L);
-    private static final NodeId NODE_ID_2 = new NodeId(2L);
+    private static final NodeId NODE_ID_1 = NodeId.of(1L);
+    private static final NodeId NODE_ID_2 = NodeId.of(2L);
 
     @Mock
     private SnapshotableMetric globalMetric;

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/BooleanAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/BooleanAdapterTest.java
@@ -141,7 +141,7 @@ class BooleanAdapterTest {
         final BooleanAdapter adapter = new BooleanAdapter(registry, metric, PLATFORM);
 
         // when
-        adapter.update(Snapshot.of(metric), new NodeId(1L));
+        adapter.update(Snapshot.of(metric), NodeId.of(1L));
 
         // then
         assertThat(registry.getSampleValue(MAPPING_NAME, NODE_LABEL, NODE_VALUE))
@@ -155,7 +155,7 @@ class BooleanAdapterTest {
         final PlatformFunctionGauge<Boolean> metric =
                 new PlatformFunctionGauge<>(new FunctionGauge.Config<>(CATEGORY, NAME, Boolean.class, () -> true));
         final BooleanAdapter adapter = new BooleanAdapter(registry, metric, PLATFORM);
-        final NodeId nodeId = new NodeId(1L);
+        final NodeId nodeId = NodeId.of(1L);
 
         // then
         assertThatThrownBy(() -> adapter.update(null, null)).isInstanceOf(NullPointerException.class);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/CounterAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/CounterAdapterTest.java
@@ -138,7 +138,7 @@ class CounterAdapterTest {
         final CounterAdapter adapter = new CounterAdapter(registry, metric, PLATFORM);
 
         // when
-        adapter.update(Snapshot.of(metric), new NodeId(1L));
+        adapter.update(Snapshot.of(metric), NodeId.of(1L));
 
         // then
         assertThat(registry.getSampleValue(MAPPING_NAME + "_total", NODE_LABEL, NODE_VALUE))
@@ -151,7 +151,7 @@ class CounterAdapterTest {
         final CollectorRegistry registry = new CollectorRegistry();
         final DefaultCounter metric = new DefaultCounter(new Counter.Config(CATEGORY, NAME));
         final CounterAdapter adapter = new CounterAdapter(registry, metric, PLATFORM);
-        final NodeId nodeId = new NodeId(1L);
+        final NodeId nodeId = NodeId.of(1L);
 
         // then
         assertThatThrownBy(() -> adapter.update(null, null)).isInstanceOf(NullPointerException.class);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/DistributionAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/DistributionAdapterTest.java
@@ -155,7 +155,7 @@ class DistributionAdapterTest {
         final DistributionAdapter adapter = new DistributionAdapter(registry, metric, PLATFORM);
 
         // when
-        adapter.update(Snapshot.of(metric), new NodeId(1L));
+        adapter.update(Snapshot.of(metric), NodeId.of(1L));
 
         // then
         assertThat(registry.getSampleValue(MAPPING_NAME, NODE_LABEL, new String[] {"1", "mean"}))
@@ -175,7 +175,7 @@ class DistributionAdapterTest {
         final PlatformRunningAverageMetric metric =
                 new PlatformRunningAverageMetric(new RunningAverageMetric.Config(CATEGORY, NAME));
         final DistributionAdapter adapter = new DistributionAdapter(registry, metric, PLATFORM);
-        final NodeId nodeId = new NodeId(1L);
+        final NodeId nodeId = NodeId.of(1L);
 
         // then
         assertThatThrownBy(() -> adapter.update(null, null)).isInstanceOf(NullPointerException.class);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/NumberAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/NumberAdapterTest.java
@@ -141,7 +141,7 @@ class NumberAdapterTest {
         final NumberAdapter adapter = new NumberAdapter(registry, metric, PLATFORM);
 
         // when
-        adapter.update(Snapshot.of(metric), new NodeId(1L));
+        adapter.update(Snapshot.of(metric), NodeId.of(1L));
 
         // then
         assertThat(registry.getSampleValue(MAPPING_NAME, NODE_LABEL, NODE_VALUE))
@@ -154,7 +154,7 @@ class NumberAdapterTest {
         final CollectorRegistry registry = new CollectorRegistry();
         final DefaultIntegerGauge metric = new DefaultIntegerGauge(new IntegerGauge.Config(CATEGORY, NAME));
         final NumberAdapter adapter = new NumberAdapter(registry, metric, PLATFORM);
-        final NodeId nodeId = new NodeId(1L);
+        final NodeId nodeId = NodeId.of(1L);
 
         // then
         assertThatThrownBy(() -> adapter.update(null, null)).isInstanceOf(NullPointerException.class);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/PrometheusEndpointTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/PrometheusEndpointTest.java
@@ -81,9 +81,9 @@ class PrometheusEndpointTest {
 
     private static final String CATEGORY = "CaTeGoRy";
     private static final String NAME = "NaMe";
-    private static final NodeId NODE_ID_1 = new NodeId(1L);
+    private static final NodeId NODE_ID_1 = NodeId.of(1L);
     private static final String LABEL_1 = NODE_ID_1.toString();
-    private static final NodeId NODE_ID_2 = new NodeId(2L);
+    private static final NodeId NODE_ID_2 = NodeId.of(2L);
     private static final String LABEL_2 = NODE_ID_2.toString();
 
     private static final InetSocketAddress ADDRESS = new InetSocketAddress(0);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/StringAdapterTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/prometheus/StringAdapterTest.java
@@ -144,7 +144,7 @@ class StringAdapterTest {
         final StringAdapter adapter = new StringAdapter(registry, metric, PLATFORM);
 
         // when
-        adapter.update(Snapshot.of(metric), new NodeId(1L));
+        adapter.update(Snapshot.of(metric), NodeId.of(1L));
 
         // then
         assertThat(registry.getSampleValue(MAPPING_NAME + "_info", NODE_LABEL, new String[] {"1", "Hello World"}))
@@ -158,7 +158,7 @@ class StringAdapterTest {
         final PlatformFunctionGauge<String> metric = new PlatformFunctionGauge<>(
                 new FunctionGauge.Config<>(CATEGORY, NAME, String.class, () -> "Hello World"));
         final StringAdapter adapter = new StringAdapter(registry, metric, PLATFORM);
-        final NodeId nodeId = new NodeId(1L);
+        final NodeId nodeId = NodeId.of(1L);
 
         // then
         assertThatThrownBy(() -> adapter.update(null, null)).isInstanceOf(NullPointerException.class);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ThreadTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/ThreadTests.java
@@ -284,7 +284,7 @@ class ThreadTests {
                 Thread.currentThread().getContextClassLoader().getParent();
 
         final ThreadFactory factory = new ThreadConfiguration(getStaticThreadManager())
-                .setNodeId(new NodeId(1234L))
+                .setNodeId(NodeId.of(1234L))
                 .setComponent("pool1")
                 .setThreadName("thread1")
                 .setDaemon(false)
@@ -333,7 +333,7 @@ class ThreadTests {
                 .setRunnable(() -> {})
                 .setComponent("foo")
                 .setThreadName("bar")
-                .setNodeId(new NodeId(1234L))
+                .setNodeId(NodeId.of(1234L))
                 .build();
         assertEquals("<foo: bar 1234>", thread3.getName(), "unexpected thread name");
 
@@ -341,8 +341,8 @@ class ThreadTests {
                 .setRunnable(() -> {})
                 .setComponent("foo")
                 .setThreadName("bar")
-                .setNodeId(new NodeId(1234L))
-                .setOtherNodeId(new NodeId(4321L))
+                .setNodeId(NodeId.of(1234L))
+                .setOtherNodeId(NodeId.of(4321L))
                 .build();
         assertEquals("<foo: bar 1234 to 4321>", thread4.getName(), "unexpected thread name");
 
@@ -350,8 +350,8 @@ class ThreadTests {
                 .setRunnable(() -> {})
                 .setComponent("foo")
                 .setThreadName("bar")
-                .setNodeId(new NodeId(1234L))
-                .setOtherNodeId(new NodeId(4321L))
+                .setNodeId(NodeId.of(1234L))
+                .setOtherNodeId(NodeId.of(4321L))
                 .buildFactory();
 
         assertEquals("<foo: bar 1234 to 4321 #0>", factory.newThread(null).getName(), "unexpected thread name");
@@ -460,7 +460,7 @@ class ThreadTests {
 
         assertThrows(
                 MutabilityException.class,
-                () -> configuration0.setNodeId(new NodeId(0L)),
+                () -> configuration0.setNodeId(NodeId.of(0L)),
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
@@ -476,7 +476,7 @@ class ThreadTests {
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
-                () -> configuration0.setOtherNodeId(new NodeId(0L)),
+                () -> configuration0.setOtherNodeId(NodeId.of(0L)),
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
@@ -510,7 +510,7 @@ class ThreadTests {
 
         assertThrows(
                 MutabilityException.class,
-                () -> configuration1.setNodeId(new NodeId(0L)),
+                () -> configuration1.setNodeId(NodeId.of(0L)),
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
@@ -526,7 +526,7 @@ class ThreadTests {
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
-                () -> configuration1.setOtherNodeId(new NodeId(0L)),
+                () -> configuration1.setOtherNodeId(NodeId.of(0L)),
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
@@ -560,7 +560,7 @@ class ThreadTests {
 
         assertThrows(
                 MutabilityException.class,
-                () -> configuration2.setNodeId(new NodeId(0L)),
+                () -> configuration2.setNodeId(NodeId.of(0L)),
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
@@ -576,7 +576,7 @@ class ThreadTests {
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
-                () -> configuration2.setOtherNodeId(new NodeId(0L)),
+                () -> configuration2.setOtherNodeId(NodeId.of(0L)),
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
@@ -648,7 +648,7 @@ class ThreadTests {
         final Runnable runnable = () -> {};
 
         final ThreadConfiguration configuration = new ThreadConfiguration(getStaticThreadManager())
-                .setNodeId(new NodeId(1234L))
+                .setNodeId(NodeId.of(1234L))
                 .setComponent("component")
                 .setThreadName("name")
                 .setThreadGroup(group)

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/framework/internal/AbstractQueueThreadConfigurationTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/threading/framework/internal/AbstractQueueThreadConfigurationTest.java
@@ -72,7 +72,7 @@ class AbstractQueueThreadConfigurationTest {
         }
     }
 
-    static final NodeId NODE_ID = new NodeId(1L);
+    static final NodeId NODE_ID = NodeId.of(1L);
     static final String THREAD_POOL_NAME = "myThreadPool";
     static final String THREAD_NAME = "myThread";
     static final int MAX_BUFFER_SIZE = 50;

--- a/platform-sdk/swirlds-common/src/timingSensitive/java/com/swirlds/common/metrics/platform/DefaultMetricsTest.java
+++ b/platform-sdk/swirlds-common/src/timingSensitive/java/com/swirlds/common/metrics/platform/DefaultMetricsTest.java
@@ -55,7 +55,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class DefaultMetricsTest {
 
-    private static final NodeId NODE_ID = new NodeId(42L);
+    private static final NodeId NODE_ID = NodeId.of(42L);
     private static final String CATEGORY_1 = "CaTeGoRy1";
     private static final String CATEGORY_1a = "CaTeGoRy1.a";
     private static final String CATEGORY_1b = "CaTeGoRy1.b";

--- a/platform-sdk/swirlds-common/src/timingSensitive/java/com/swirlds/common/threading/StoppableThreadTests.java
+++ b/platform-sdk/swirlds-common/src/timingSensitive/java/com/swirlds/common/threading/StoppableThreadTests.java
@@ -555,7 +555,7 @@ class StoppableThreadTests {
 
         assertThrows(
                 MutabilityException.class,
-                () -> configuration.setNodeId(new NodeId(0L)),
+                () -> configuration.setNodeId(NodeId.of(0L)),
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
@@ -571,7 +571,7 @@ class StoppableThreadTests {
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,
-                () -> configuration.setOtherNodeId(new NodeId(0L)),
+                () -> configuration.setOtherNodeId(NodeId.of(0L)),
                 "configuration should be immutable");
         assertThrows(
                 MutabilityException.class,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/CommandLineArgs.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/CommandLineArgs.java
@@ -49,7 +49,7 @@ public record CommandLineArgs(@NonNull Set<NodeId> localNodesToStart) {
                 currentOption = arg;
             } else if (currentOption != null) {
                 try {
-                    localNodesToStart.add(new NodeId(Integer.parseInt(arg)));
+                    localNodesToStart.add(NodeId.of(Integer.parseInt(arg)));
                 } catch (final NumberFormatException ex) {
                     // Intentionally suppress the NumberFormatException
                 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/BrowseCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/BrowseCommand.java
@@ -57,7 +57,7 @@ public class BrowseCommand extends AbstractCommand {
                     + "specified by repeating the parameter `-l #1 -l #2 -l #3`.")
     private void setLocalNodes(@NonNull final Long... localNodes) {
         for (final Long nodeId : localNodes) {
-            this.localNodes.add(new NodeId(nodeId));
+            this.localNodes.add(NodeId.of(nodeId));
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamRecoverCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamRecoverCommand.java
@@ -93,7 +93,7 @@ public final class EventStreamRecoverCommand extends AbstractCommand {
             description = "The ID of the node that is being used to recover the state. "
                     + "This node's keys should be available locally.")
     private void setSelfId(final long selfId) {
-        this.selfId = new NodeId(selfId);
+        this.selfId = NodeId.of(selfId);
     }
 
     @CommandLine.Option(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/PcesRecoveryCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/PcesRecoveryCommand.java
@@ -37,7 +37,7 @@ public class PcesRecoveryCommand extends AbstractCommand {
 
     @Override
     public Integer call() throws IOException, InterruptedException {
-        Browser.launch(new CommandLineArgs(Set.of(new NodeId(nodeId))), true);
+        Browser.launch(new CommandLineArgs(Set.of(NodeId.of(nodeId))), true);
         return null;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PbjConverter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PbjConverter.java
@@ -207,7 +207,7 @@ public final class PbjConverter {
                 .collect(toList()));
         result.setRound(addressBook.round());
         if (addressBook.nextNodeId() != null) {
-            result.setNextNodeId(new NodeId(addressBook.nextNodeId().id()));
+            result.setNextNodeId(NodeId.of(addressBook.nextNodeId().id()));
         }
         return result;
     }
@@ -302,7 +302,7 @@ public final class PbjConverter {
     private static Address fromPbjAddress(@NonNull final com.hedera.hapi.platform.state.Address address) {
         requireNonNull(address.id());
         return new Address(
-                new NodeId(address.id().id()),
+                NodeId.of(address.id().id()),
                 address.nickname(),
                 address.selfName(),
                 address.weight(),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SigSet.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SigSet.java
@@ -200,7 +200,7 @@ public class SigSet implements FastCopyable, Iterable<NodeId>, SelfSerializable 
         for (int index = 0; index < signatureCount; index++) {
             final NodeId nodeId;
             if (version < ClassVersion.SELF_SERIALIZABLE_NODE_ID) {
-                nodeId = new NodeId(in.readLong());
+                nodeId = NodeId.of(in.readLong());
             } else {
                 nodeId = in.readSerializable(false, NodeId::new);
             }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SavedStateMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SavedStateMetadata.java
@@ -124,7 +124,7 @@ public record SavedStateMetadata(
     /**
      * Use this constant for the node ID if the thing writing the state is not a node.
      */
-    public static final NodeId NO_NODE_ID = new NodeId(Long.MAX_VALUE);
+    public static final NodeId NO_NODE_ID = NodeId.of(Long.MAX_VALUE);
 
     private static final Logger logger = LogManager.getLogger(SavedStateMetadata.class);
 
@@ -147,7 +147,7 @@ public record SavedStateMetadata(
                 parsePrimitiveLong(data, MINIMUM_GENERATION_NON_ANCIENT),
                 parseNonNullString(data, SOFTWARE_VERSION),
                 parseNonNullInstant(data, WALL_CLOCK_TIME),
-                new NodeId(parsePrimitiveLong(data, NODE_ID)),
+                NodeId.of(parsePrimitiveLong(data, NODE_ID)),
                 parseNodeIdList(data, SIGNING_NODES),
                 parsePrimitiveLong(data, SIGNING_WEIGHT_SUM),
                 parsePrimitiveLong(data, TOTAL_WEIGHT));
@@ -485,7 +485,7 @@ public record SavedStateMetadata(
 
         for (final String part : parts) {
             try {
-                list.add(new NodeId(Long.parseLong(part.strip())));
+                list.add(NodeId.of(Long.parseLong(part.strip())));
             } catch (final NumberFormatException e) {
                 throwInvalidRequiredField(field, value, e);
                 return null;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBook.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBook.java
@@ -563,7 +563,7 @@ public class AddressBook implements Iterable<Address>, SelfSerializable, Hashabl
 
         round = in.readLong();
         if (version < ClassVersion.SELF_SERIALIZABLE_NODE_ID) {
-            nextNodeId = new NodeId(in.readLong());
+            nextNodeId = NodeId.of(in.readLong());
         } else {
             nextNodeId = in.readSerializable(false, NodeId::new);
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -164,7 +164,7 @@ public class AddressBookUtils {
         }
         final NodeId nodeId;
         try {
-            nodeId = new NodeId(Long.parseLong(parts[1]));
+            nodeId = NodeId.of(Long.parseLong(parts[1]));
         } catch (final Exception e) {
             throw new ParseException("Cannot parse node id from '" + parts[1] + "'", 1);
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventDescriptorWrapper.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventDescriptorWrapper.java
@@ -62,7 +62,7 @@ public record EventDescriptorWrapper(
     }
 
     public EventDescriptorWrapper(@NonNull EventDescriptor eventDescriptor) {
-        this(eventDescriptor, new Hash(eventDescriptor.hash()), new NodeId(eventDescriptor.creatorNodeId()));
+        this(eventDescriptor, new Hash(eventDescriptor.hash()), NodeId.of(eventDescriptor.creatorNodeId()));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventMetadata.java
@@ -106,7 +106,7 @@ public class EventMetadata extends AbstractHashable {
      */
     public EventMetadata(@NonNull final GossipEvent gossipEvent) {
         Objects.requireNonNull(gossipEvent.eventCore(), "The eventCore must not be null");
-        this.creatorId = new NodeId(gossipEvent.eventCore().creatorNodeId());
+        this.creatorId = NodeId.of(gossipEvent.eventCore().creatorNodeId());
         this.allParents = gossipEvent.eventCore().parents().stream()
                 .map(EventDescriptorWrapper::new)
                 .toList();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -76,7 +76,7 @@ class AddressBookInitializerTest {
         final AddressBook configAddressBook = getRandomAddressBook(randotron);
         final SignedState signedState = getMockSignedState7WeightRandomAddressBook(randotron);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                new NodeId(0),
+                NodeId.of(0),
                 getMockSoftwareVersion(2),
                 // no software upgrade
                 false,
@@ -106,7 +106,7 @@ class AddressBookInitializerTest {
         // initial state has no address books set.
         final SignedState signedState = getMockSignedState(10, null, null, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                new NodeId(0),
+                NodeId.of(0),
                 getMockSoftwareVersion(2),
                 // no software upgrade
                 false,
@@ -133,7 +133,7 @@ class AddressBookInitializerTest {
         // genesis state address book is set to null to test the code path where it may be null.
         final SignedState signedState = getMockSignedState(10, null, null, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                new NodeId(0),
+                NodeId.of(0),
                 getMockSoftwareVersion(2),
                 // no software upgrade
                 false,
@@ -159,7 +159,7 @@ class AddressBookInitializerTest {
         final AddressBook configAddressBook = getRandomAddressBook(randotron);
         final SignedState signedState = getMockSignedState(7, configAddressBook, null, true);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                new NodeId(0),
+                NodeId.of(0),
                 getMockSoftwareVersion(2),
                 // no software upgrade
                 false,
@@ -189,7 +189,7 @@ class AddressBookInitializerTest {
                 getMockSignedState(2, getRandomAddressBook(randotron), getRandomAddressBook(randotron), false);
         final AddressBook configAddressBook = copyWithWeightChanges(signedState.getAddressBook(), 10);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                new NodeId(0),
+                NodeId.of(0),
                 getMockSoftwareVersion(2),
                 // no software upgrade
                 false,
@@ -220,7 +220,7 @@ class AddressBookInitializerTest {
                 getMockSignedState(0, getRandomAddressBook(randotron), getRandomAddressBook(randotron), false);
         final AddressBook configAddressBook = copyWithWeightChanges(signedState.getAddressBook(), 10);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                new NodeId(0),
+                NodeId.of(0),
                 getMockSoftwareVersion(3),
                 // software upgrade
                 true,
@@ -250,7 +250,7 @@ class AddressBookInitializerTest {
                 getMockSignedState(2, getRandomAddressBook(randotron), getRandomAddressBook(randotron), false);
         final AddressBook configAddressBook = copyWithWeightChanges(signedState.getAddressBook(), 3);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                new NodeId(0),
+                NodeId.of(0),
                 getMockSoftwareVersion(3),
                 // software upgrade
                 true,
@@ -279,7 +279,7 @@ class AddressBookInitializerTest {
         final SignedState signedState = getMockSignedState7WeightRandomAddressBook(randotron);
         final AddressBook configAddressBook = copyWithWeightChanges(signedState.getAddressBook(), 5);
         final AddressBookInitializer initializer = new AddressBookInitializer(
-                new NodeId(0),
+                NodeId.of(0),
                 getMockSoftwareVersion(3),
                 // software upgrade
                 true,

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ReconnectThrottleTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ReconnectThrottleTest.java
@@ -52,11 +52,11 @@ class ReconnectThrottleTest {
     void simultaneousReconnectTest() {
         final ReconnectThrottle reconnectThrottle = new ReconnectThrottle(buildSettings("10m"), Time.getCurrent());
 
-        assertTrue(reconnectThrottle.initiateReconnect(new NodeId(0)), "reconnect should be allowed");
-        assertFalse(reconnectThrottle.initiateReconnect(new NodeId(1)), "reconnect should be blocked");
+        assertTrue(reconnectThrottle.initiateReconnect(NodeId.of(0)), "reconnect should be allowed");
+        assertFalse(reconnectThrottle.initiateReconnect(NodeId.of(1)), "reconnect should be blocked");
         reconnectThrottle.reconnectAttemptFinished();
 
-        assertTrue(reconnectThrottle.initiateReconnect(new NodeId(1)), "reconnect should be allowed");
+        assertTrue(reconnectThrottle.initiateReconnect(NodeId.of(1)), "reconnect should be allowed");
     }
 
     @Test
@@ -66,19 +66,19 @@ class ReconnectThrottleTest {
         final ReconnectThrottle reconnectThrottle = new ReconnectThrottle(buildSettings("1s"), Time.getCurrent());
         reconnectThrottle.setCurrentTime(() -> Instant.ofEpochMilli(0));
 
-        assertTrue(reconnectThrottle.initiateReconnect(new NodeId(0)), "reconnect should be allowed");
+        assertTrue(reconnectThrottle.initiateReconnect(NodeId.of(0)), "reconnect should be allowed");
         reconnectThrottle.reconnectAttemptFinished();
-        assertFalse(reconnectThrottle.initiateReconnect(new NodeId(0)), "reconnect should be blocked");
+        assertFalse(reconnectThrottle.initiateReconnect(NodeId.of(0)), "reconnect should be blocked");
 
-        assertTrue(reconnectThrottle.initiateReconnect(new NodeId(1)), "reconnect should be allowed");
+        assertTrue(reconnectThrottle.initiateReconnect(NodeId.of(1)), "reconnect should be allowed");
         reconnectThrottle.reconnectAttemptFinished();
-        assertFalse(reconnectThrottle.initiateReconnect(new NodeId(1)), "reconnect should be blocked");
+        assertFalse(reconnectThrottle.initiateReconnect(NodeId.of(1)), "reconnect should be blocked");
 
         reconnectThrottle.setCurrentTime(() -> Instant.ofEpochMilli(2000));
 
-        assertTrue(reconnectThrottle.initiateReconnect(new NodeId(0)), "reconnect should be allowed");
+        assertTrue(reconnectThrottle.initiateReconnect(NodeId.of(0)), "reconnect should be allowed");
         reconnectThrottle.reconnectAttemptFinished();
-        assertTrue(reconnectThrottle.initiateReconnect(new NodeId(1)), "reconnect should be allowed");
+        assertTrue(reconnectThrottle.initiateReconnect(NodeId.of(1)), "reconnect should be allowed");
         reconnectThrottle.reconnectAttemptFinished();
     }
 
@@ -99,7 +99,7 @@ class ReconnectThrottleTest {
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 100; j++) {
                 // Each request is for a unique node
-                reconnectThrottle.initiateReconnect(new NodeId((i + 1000) * (j + 1)));
+                reconnectThrottle.initiateReconnect(NodeId.of((i + 1000) * (j + 1)));
                 reconnectThrottle.reconnectAttemptFinished();
 
                 assertTrue(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
@@ -90,7 +90,7 @@ class SavedStateMetadataTests {
     /** generates a random non-negative node id. */
     private NodeId generateRandomNodeId(@NonNull final Random random) {
         Objects.requireNonNull(random, "random must not be null");
-        return new NodeId(random.nextLong(Long.MAX_VALUE));
+        return NodeId.of(random.nextLong(Long.MAX_VALUE));
     }
 
     @Test
@@ -217,11 +217,11 @@ class SavedStateMetadataTests {
         when(platformState.getAddressBook()).thenReturn(addressBook);
         when(signedState.getSigSet()).thenReturn(sigSet);
         when(sigSet.getSigningNodes())
-                .thenReturn(new ArrayList<>(List.of(new NodeId(3L), new NodeId(1L), new NodeId(2L))));
+                .thenReturn(new ArrayList<>(List.of(NodeId.of(3L), NodeId.of(1L), NodeId.of(2L))));
 
-        final SavedStateMetadata metadata = SavedStateMetadata.create(signedState, new NodeId(1234), Instant.now());
+        final SavedStateMetadata metadata = SavedStateMetadata.create(signedState, NodeId.of(1234), Instant.now());
 
-        assertEquals(List.of(new NodeId(1L), new NodeId(2L), new NodeId(3L)), metadata.signingNodes());
+        assertEquals(List.of(NodeId.of(1L), NodeId.of(2L), NodeId.of(3L)), metadata.signingNodes());
     }
 
     @Test

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -163,7 +163,7 @@ class SignedStateFileReadWriteTest {
                 .build();
 
         writeSignedStateToDisk(
-                platformContext, new NodeId(0), directory, signedState, StateToDiskReason.PERIODIC_SNAPSHOT);
+                platformContext, NodeId.of(0), directory, signedState, StateToDiskReason.PERIODIC_SNAPSHOT);
 
         assertTrue(exists(stateFile), "state file should exist");
         assertTrue(exists(hashInfoFile), "hash info file should exist");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -84,7 +84,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class StateFileManagerTests {
 
-    private static final NodeId SELF_ID = new NodeId(1234);
+    private static final NodeId SELF_ID = NodeId.of(1234);
     private static final String MAIN_CLASS_NAME = "com.swirlds.foobar";
     private static final String SWIRLD_NAME = "mySwirld";
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/EventDeduplicatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/EventDeduplicatorTests.java
@@ -159,7 +159,7 @@ class EventDeduplicatorTests {
         for (int i = 0; i < TEST_EVENT_COUNT; i++) {
             if (submittedEvents.isEmpty() || random.nextBoolean()) {
                 // submit a brand new event half the time
-                final NodeId creatorId = new NodeId(random.nextInt(NODE_ID_COUNT));
+                final NodeId creatorId = NodeId.of(random.nextInt(NODE_ID_COUNT));
                 final long eventGeneration = Math.max(0, minimumGenerationNonAncient + random.nextInt(-1, 10));
                 final long eventBirthRound =
                         Math.max(ConsensusConstants.ROUND_FIRST, minimumRoundNonAncient + random.nextLong(-1, 4));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/FutureEventBufferTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/FutureEventBufferTests.java
@@ -76,7 +76,7 @@ class FutureEventBufferTests {
         for (int i = 0; i < count; i++) {
             final PlatformEvent event = new TestingEventBuilder(random)
                     .setBirthRound(random.nextLong(1, maxFutureRound))
-                    .setCreatorId(new NodeId(random.nextInt(100)))
+                    .setCreatorId(NodeId.of(random.nextInt(100)))
                     .setTimeCreated(randomInstant(random))
                     .build();
             events.add(event);
@@ -161,7 +161,7 @@ class FutureEventBufferTests {
         for (int i = 0; i < count; i++) {
             final PlatformEvent event = new TestingEventBuilder(random)
                     .setBirthRound(random.nextLong(1, maxFutureRound))
-                    .setCreatorId(new NodeId(random.nextInt(100)))
+                    .setCreatorId(NodeId.of(random.nextInt(100)))
                     .setTimeCreated(randomInstant(random))
                     .build();
             events.add(event);
@@ -220,7 +220,7 @@ class FutureEventBufferTests {
         final long eventBirthRound = pendingConsensusRound + roundsUntilRelease;
         final PlatformEvent event = new TestingEventBuilder(random)
                 .setBirthRound(eventBirthRound)
-                .setCreatorId(new NodeId(random.nextInt(100)))
+                .setCreatorId(NodeId.of(random.nextInt(100)))
                 .setTimeCreated(randomInstant(random))
                 .build();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/ConsensusEventLinkerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/ConsensusEventLinkerTests.java
@@ -73,7 +73,7 @@ class ConsensusEventLinkerTests {
                 new StandardEventSource());
 
         final List<EventImpl> linkedEvents = new LinkedList<>();
-        final InOrderLinker linker = new ConsensusLinker(platformContext, new NodeId(0));
+        final InOrderLinker linker = new ConsensusLinker(platformContext, NodeId.of(0));
 
         EventWindow eventWindow = EventWindow.getGenesisEventWindow(ancientMode);
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/InOrderLinkerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/linking/InOrderLinkerTests.java
@@ -54,8 +54,8 @@ class InOrderLinkerTests {
 
     private FakeTime time;
 
-    private NodeId selfId = new NodeId(0);
-    private NodeId otherId = new NodeId(1);
+    private NodeId selfId = NodeId.of(0);
+    private NodeId otherId = NodeId.of(1);
 
     /**
      * Set up the in order linker for testing

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/orphan/OrphanBufferTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/orphan/OrphanBufferTests.java
@@ -129,7 +129,7 @@ class OrphanBufferTests {
     private PlatformEvent createRandomEvent(
             @NonNull final List<PlatformEvent> parentCandidates, @NonNull final Map<NodeId, PlatformEvent> tips) {
 
-        final NodeId eventCreator = new NodeId(random.nextInt(NODE_ID_COUNT));
+        final NodeId eventCreator = NodeId.of(random.nextInt(NODE_ID_COUNT));
 
         final PlatformEvent selfParent =
                 tips.computeIfAbsent(eventCreator, creator -> createBootstrapEvent(creator, parentCandidates));
@@ -283,13 +283,13 @@ class OrphanBufferTests {
         final Random random = Randotron.create();
 
         final PlatformEvent selfParent =
-                new TestingEventBuilder(random).setCreatorId(new NodeId(0)).build();
+                new TestingEventBuilder(random).setCreatorId(NodeId.of(0)).build();
         final PlatformEvent otherParent1 =
-                new TestingEventBuilder(random).setCreatorId(new NodeId(1)).build();
+                new TestingEventBuilder(random).setCreatorId(NodeId.of(1)).build();
         final PlatformEvent otherParent2 =
-                new TestingEventBuilder(random).setCreatorId(new NodeId(2)).build();
+                new TestingEventBuilder(random).setCreatorId(NodeId.of(2)).build();
         final PlatformEvent otherParent3 =
-                new TestingEventBuilder(random).setCreatorId(new NodeId(3)).build();
+                new TestingEventBuilder(random).setCreatorId(NodeId.of(3)).build();
 
         final PlatformEvent event = new TestingEventBuilder(random)
                 .setSelfParent(selfParent)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stale/StaleEventDetectorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stale/StaleEventDetectorTests.java
@@ -104,7 +104,7 @@ class StaleEventDetectorTests {
     @Test
     void throwIfInitialEventWindowNotSetTest() {
         final Randotron randotron = Randotron.create();
-        final NodeId selfId = new NodeId(randotron.nextPositiveLong());
+        final NodeId selfId = NodeId.of(randotron.nextPositiveLong());
 
         final Configuration configuration = new TestConfigBuilder()
                 .withValue(EventConfig_.USE_BIRTH_ROUND_ANCIENT_THRESHOLD, true)
@@ -122,7 +122,7 @@ class StaleEventDetectorTests {
     @Test
     void eventIsStaleBeforeAddedTest() {
         final Randotron randotron = Randotron.create();
-        final NodeId selfId = new NodeId(randotron.nextPositiveLong());
+        final NodeId selfId = NodeId.of(randotron.nextPositiveLong());
 
         final Configuration configuration = new TestConfigBuilder()
                 .withValue(EventConfig_.USE_BIRTH_ROUND_ANCIENT_THRESHOLD, true)
@@ -184,7 +184,7 @@ class StaleEventDetectorTests {
     @Test
     void randomEventsTest() {
         final Randotron randotron = Randotron.create();
-        final NodeId selfId = new NodeId(randotron.nextPositiveLong());
+        final NodeId selfId = NodeId.of(randotron.nextPositiveLong());
 
         final Configuration configuration = new TestConfigBuilder()
                 .withValue(EventConfig_.USE_BIRTH_ROUND_ANCIENT_THRESHOLD, true)
@@ -207,7 +207,7 @@ class StaleEventDetectorTests {
 
         for (int i = 0; i < 10_000; i++) {
             final boolean selfEvent = randotron.nextBoolean(0.25);
-            final NodeId eventCreator = selfEvent ? selfId : new NodeId(randotron.nextPositiveLong());
+            final NodeId eventCreator = selfEvent ? selfId : NodeId.of(randotron.nextPositiveLong());
 
             final TestingEventBuilder eventBuilder = new TestingEventBuilder(randotron).setCreatorId(eventCreator);
 
@@ -263,7 +263,7 @@ class StaleEventDetectorTests {
     @Test
     void clearTest() {
         final Randotron randotron = Randotron.create();
-        final NodeId selfId = new NodeId(randotron.nextPositiveLong());
+        final NodeId selfId = NodeId.of(randotron.nextPositiveLong());
 
         final Configuration configuration = new TestConfigBuilder()
                 .withValue(EventConfig_.USE_BIRTH_ROUND_ANCIENT_THRESHOLD, true)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/EventSignatureValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/EventSignatureValidatorTests.java
@@ -112,8 +112,8 @@ class EventSignatureValidatorTests {
                 .eventExitedIntakePipeline(any());
 
         // create two addresses, one for the previous address book and one for the current address book
-        previousNodeAddress = generateMockAddress(new NodeId(66));
-        currentNodeAddress = generateMockAddress(new NodeId(77));
+        previousNodeAddress = generateMockAddress(NodeId.of(66));
+        currentNodeAddress = generateMockAddress(NodeId.of(77));
 
         final AddressBook previousAddressBook = new AddressBook(List.of(previousNodeAddress));
         currentAddressBook = new AddressBook(List.of(currentNodeAddress));
@@ -180,7 +180,7 @@ class EventSignatureValidatorTests {
     @Test
     @DisplayName("Node has a null public key")
     void missingPublicKey() {
-        final NodeId nodeId = new NodeId(88);
+        final NodeId nodeId = NodeId.of(88);
         final Address nodeAddress = new Address(nodeId, "", "", 10, null, 77, null, 88, null, null, "");
 
         currentAddressBook.add(nodeAddress);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/InternalEventValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/InternalEventValidatorTests.java
@@ -277,55 +277,55 @@ class InternalEventValidatorTests {
     @DisplayName("An event must have a birth round greater than or equal to the max of all parent birth rounds.")
     void invalidBirthRound() {
         final PlatformEvent selfParent1 = new TestingEventBuilder(random)
-                .setCreatorId(new NodeId(0))
+                .setCreatorId(NodeId.of(0))
                 .setBirthRound(5)
                 .build();
         final PlatformEvent otherParent1 = new TestingEventBuilder(random)
-                .setCreatorId(new NodeId(1))
+                .setCreatorId(NodeId.of(1))
                 .setBirthRound(7)
                 .build();
         final PlatformEvent selfParent2 = new TestingEventBuilder(random)
-                .setCreatorId(new NodeId(0))
+                .setCreatorId(NodeId.of(0))
                 .setBirthRound(7)
                 .build();
         final PlatformEvent otherParent2 = new TestingEventBuilder(random)
-                .setCreatorId(new NodeId(1))
+                .setCreatorId(NodeId.of(1))
                 .setBirthRound(5)
                 .build();
 
         for (final InternalEventValidator validator : List.of(multinodeValidator, singleNodeValidator)) {
             assertNull(validator.validateEvent(new TestingEventBuilder(random)
-                    .setCreatorId(new NodeId(0))
+                    .setCreatorId(NodeId.of(0))
                     .setSelfParent(selfParent1)
                     .setOtherParent(otherParent1)
                     .setBirthRound(6)
                     .build()));
             assertNull(validator.validateEvent(new TestingEventBuilder(random)
-                    .setCreatorId(new NodeId(0))
+                    .setCreatorId(NodeId.of(0))
                     .setSelfParent(selfParent2)
                     .setOtherParent(otherParent2)
                     .setBirthRound(6)
                     .build()));
             assertNull(validator.validateEvent(new TestingEventBuilder(random)
-                    .setCreatorId(new NodeId(0))
+                    .setCreatorId(NodeId.of(0))
                     .setSelfParent(selfParent1)
                     .setOtherParent(otherParent1)
                     .setBirthRound(4)
                     .build()));
             assertNull(validator.validateEvent(new TestingEventBuilder(random)
-                    .setCreatorId(new NodeId(0))
+                    .setCreatorId(NodeId.of(0))
                     .setSelfParent(selfParent2)
                     .setOtherParent(otherParent2)
                     .setBirthRound(4)
                     .build()));
             assertNotNull(validator.validateEvent(new TestingEventBuilder(random)
-                    .setCreatorId(new NodeId(0))
+                    .setCreatorId(NodeId.of(0))
                     .setSelfParent(selfParent1)
                     .setOtherParent(otherParent1)
                     .setBirthRound(7)
                     .build()));
             assertNotNull(validator.validateEvent(new TestingEventBuilder(random)
-                    .setCreatorId(new NodeId(0))
+                    .setCreatorId(NodeId.of(0))
                     .setSelfParent(selfParent2)
                     .setOtherParent(otherParent2)
                     .setBirthRound(7)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/DefaultIntakeEventCounterTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/DefaultIntakeEventCounterTests.java
@@ -32,8 +32,8 @@ import org.mockito.Mockito;
 class DefaultIntakeEventCounterTests {
     private IntakeEventCounter intakeCounter;
 
-    final NodeId nodeId1 = new NodeId(1);
-    final NodeId nodeId2 = new NodeId(2);
+    final NodeId nodeId1 = NodeId.of(1);
+    final NodeId nodeId2 = NodeId.of(2);
 
     @BeforeEach
     void setup() {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/heartbeat/HeartbeatProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/heartbeat/HeartbeatProtocolTests.java
@@ -55,7 +55,7 @@ class HeartbeatProtocolTests {
 
     @BeforeEach
     void setup() {
-        peerId = new NodeId(1);
+        peerId = NodeId.of(1);
         heartbeatPeriod = Duration.ofMillis(1000);
         networkMetrics = mock(NetworkMetrics.class);
         time = new FakeTime();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
@@ -83,7 +83,7 @@ class NetworkPeerIdentifierTest {
                 throw new RuntimeException("Invalid node name " + name);
             }
             final int id = Integer.parseInt(nameMatcher.group(1)) - 1;
-            final NodeId node = new NodeId(id);
+            final NodeId node = NodeId.of(id);
             final PeerInfo peer;
             try {
                 peer = new PeerInfo(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/proof/StateProofTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/proof/StateProofTests.java
@@ -378,7 +378,7 @@ class StateProofTests {
         final List<MerkleLeaf> payloads = leafNodes.subList(0, payloadCount);
         final Map<NodeId, Signature> signatures = new HashMap<>();
         for (int i = 0; i < signatureCount; i++) {
-            final NodeId nodeId = new NodeId(random.nextLong(1, 1000));
+            final NodeId nodeId = NodeId.of(random.nextLong(1, 1000));
             final Signature signature = randomSignature(random);
             signatures.put(nodeId, signature);
         }
@@ -426,7 +426,7 @@ class StateProofTests {
         final List<MerkleLeaf> payloads = leafNodes.subList(0, payloadCount);
         final Map<NodeId, Signature> signatures = new HashMap<>();
         for (int i = 0; i < signatureCount; i++) {
-            final NodeId nodeId = new NodeId(random.nextLong(1, 1000));
+            final NodeId nodeId = NodeId.of(random.nextLong(1, 1000));
             final Signature signature = randomSignature(random);
             signatures.put(nodeId, signature);
         }
@@ -549,7 +549,7 @@ class StateProofTests {
         assertFalse(stateProofA.isValid(cryptography, addressBook, SUPER_MAJORITY, signatureBuilder));
 
         // Adding a signature for a node not in the address book should not change the result.
-        final NodeId nodeId = new NodeId(10000000);
+        final NodeId nodeId = NodeId.of(10000000);
         assertFalse(addressBook.contains(nodeId));
         final Signature signature = randomSignature(random);
         signatures.put(nodeId, signature);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
@@ -143,7 +143,7 @@ class DefaultSignedStateValidatorTests {
             // Allow zero-weight
             final int weight = r.nextInt(MAX_WEIGHT_PER_NODE);
             final boolean hasValidSig = r.nextBoolean();
-            nodes.add(new Node(new NodeId(i), weight, hasValidSig));
+            nodes.add(new Node(NodeId.of(i), weight, hasValidSig));
         }
         return nodes;
     }
@@ -213,13 +213,13 @@ class DefaultSignedStateValidatorTests {
         }
 
         final List<Node> nodes = new ArrayList<>(NUM_NODES_IN_STATIC_TESTS);
-        nodes.add(new Node(new NodeId(0L), 5L, isValidSigList.get(0)));
-        nodes.add(new Node(new NodeId(1L), 5L, isValidSigList.get(1)));
-        nodes.add(new Node(new NodeId(2L), 8L, isValidSigList.get(2)));
-        nodes.add(new Node(new NodeId(3L), 15L, isValidSigList.get(3)));
-        nodes.add(new Node(new NodeId(4L), 17L, isValidSigList.get(4)));
-        nodes.add(new Node(new NodeId(5L), 10L, isValidSigList.get(5)));
-        nodes.add(new Node(new NodeId(6L), 30L, isValidSigList.get(6)));
+        nodes.add(new Node(NodeId.of(0L), 5L, isValidSigList.get(0)));
+        nodes.add(new Node(NodeId.of(1L), 5L, isValidSigList.get(1)));
+        nodes.add(new Node(NodeId.of(2L), 8L, isValidSigList.get(2)));
+        nodes.add(new Node(NodeId.of(3L), 15L, isValidSigList.get(3)));
+        nodes.add(new Node(NodeId.of(4L), 17L, isValidSigList.get(4)));
+        nodes.add(new Node(NodeId.of(5L), 10L, isValidSigList.get(5)));
+        nodes.add(new Node(NodeId.of(6L), 30L, isValidSigList.get(6)));
         return nodes;
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
@@ -71,7 +71,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 class ReconnectProtocolTests {
     private final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
-    private static final NodeId PEER_ID = new NodeId(1L);
+    private static final NodeId PEER_ID = NodeId.of(1L);
 
     private ReconnectController reconnectController;
     private ReconnectThrottle teacherThrottle;
@@ -145,7 +145,7 @@ class ReconnectProtocolTests {
 
         final List<NodeId> neighborsForReconnect = LongStream.range(0L, 10L)
                 .filter(id -> id != PEER_ID.id() || params.isReconnectNeighbor)
-                .mapToObj(NodeId::new)
+                .mapToObj(NodeId::of)
                 .toList();
 
         final FallenBehindManager fallenBehindManager = mock(FallenBehindManager.class);
@@ -281,8 +281,8 @@ class ReconnectProtocolTests {
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
 
-        final NodeId node1 = new NodeId(1L);
-        final NodeId node2 = new NodeId(2L);
+        final NodeId node1 = NodeId.of(1L);
+        final NodeId node2 = NodeId.of(2L);
         final ReconnectProtocol peer1 = new ReconnectProtocol(
                 platformContext,
                 getStaticThreadManager(),
@@ -362,7 +362,7 @@ class ReconnectProtocolTests {
                 fallenBehindManager,
                 () -> ACTIVE,
                 configuration);
-        final Protocol protocol = reconnectProtocolFactory.build(new NodeId(0));
+        final Protocol protocol = reconnectProtocolFactory.build(NodeId.of(0));
         assertTrue(protocol.shouldInitiate());
         protocol.initiateFailed();
 
@@ -407,7 +407,7 @@ class ReconnectProtocolTests {
                 () -> ACTIVE,
                 configuration);
 
-        final Protocol protocol = reconnectProtocolFactory.build(new NodeId(0));
+        final Protocol protocol = reconnectProtocolFactory.build(NodeId.of(0));
         assertTrue(protocol.shouldAccept());
         protocol.acceptFailed();
 
@@ -444,7 +444,7 @@ class ReconnectProtocolTests {
                 fallenBehindManager,
                 () -> ACTIVE,
                 configuration);
-        final Protocol protocol = reconnectProtocolFactory.build(new NodeId(0));
+        final Protocol protocol = reconnectProtocolFactory.build(NodeId.of(0));
         assertFalse(protocol.shouldAccept());
     }
 
@@ -474,7 +474,7 @@ class ReconnectProtocolTests {
                 fallenBehindManager,
                 () -> PlatformStatus.CHECKING,
                 configuration);
-        final Protocol protocol = reconnectProtocolFactory.build(new NodeId(0));
+        final Protocol protocol = reconnectProtocolFactory.build(NodeId.of(0));
         assertFalse(protocol.shouldAccept());
     }
 
@@ -500,7 +500,7 @@ class ReconnectProtocolTests {
                 mock(FallenBehindManager.class),
                 () -> ACTIVE,
                 configuration);
-        final Protocol protocol = reconnectProtocolFactory.build(new NodeId(0));
+        final Protocol protocol = reconnectProtocolFactory.build(NodeId.of(0));
         assertTrue(protocol.shouldAccept());
 
         verify(reconnectController, times(1)).blockLearnerPermit();
@@ -546,7 +546,7 @@ class ReconnectProtocolTests {
                 mock(FallenBehindManager.class),
                 () -> ACTIVE,
                 configuration);
-        final Protocol protocol = reconnectProtocolFactory.build(new NodeId(0));
+        final Protocol protocol = reconnectProtocolFactory.build(NodeId.of(0));
         assertFalse(protocol.shouldAccept());
 
         verify(reconnectController, times(1)).blockLearnerPermit();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -109,7 +109,7 @@ final class ReconnectTest {
         final long weightPerNode = 100L;
         final int numNodes = 4;
         final List<NodeId> nodeIds =
-                IntStream.range(0, numNodes).mapToObj(NodeId::new).toList();
+                IntStream.range(0, numNodes).mapToObj(NodeId::of).toList();
         final Random random = RandomUtils.getRandomPrintSeed();
 
         final AddressBook addressBook = RandomAddressBookBuilder.create(random)
@@ -158,7 +158,7 @@ final class ReconnectTest {
         for (int i = 0; i < numAddresses; i++) {
             final Address address = mock(Address.class);
             when(address.getSigPublicKey()).thenReturn(publicKey);
-            when(address.getNodeId()).thenReturn(new NodeId(i));
+            when(address.getNodeId()).thenReturn(NodeId.of(i));
             addresses.add(address);
         }
         return new AddressBook(addresses);
@@ -173,8 +173,8 @@ final class ReconnectTest {
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
 
-        final NodeId selfId = new NodeId(0);
-        final NodeId otherId = new NodeId(3);
+        final NodeId selfId = NodeId.of(0);
+        final NodeId otherId = NodeId.of(3);
         final long lastRoundReceived = 100;
         return new ReconnectTeacher(
                 platformContext,

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/RecoveryTestUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/RecoveryTestUtils.java
@@ -80,10 +80,10 @@ public final class RecoveryTestUtils {
                 .setTransactionSize(random.nextInt(10) + 1)
                 .setSystemTransactionCount(0)
                 .setSelfParent(new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(random.nextLong(0, Long.MAX_VALUE)))
+                        .setCreatorId(NodeId.of(random.nextLong(0, Long.MAX_VALUE)))
                         .build())
                 .setOtherParent(new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(random.nextLong(0, Long.MAX_VALUE)))
+                        .setCreatorId(NodeId.of(random.nextLong(0, Long.MAX_VALUE)))
                         .build())
                 .setTimeCreated(now)
                 .setConsensusTimestamp(now)
@@ -163,7 +163,7 @@ public final class RecoveryTestUtils {
                 .build();
 
         final DefaultConsensusEventStream eventStreamManager = new DefaultConsensusEventStream(
-                platformContext, new NodeId(0L), x -> randomSignature(random), "test", x -> false);
+                platformContext, NodeId.of(0L), x -> randomSignature(random), "test", x -> false);
 
         // The event stream writer has flaky asynchronous behavior,
         // so we need to be extra careful when waiting for it to finish.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/scratchpad/ScratchpadTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/scratchpad/ScratchpadTests.java
@@ -58,7 +58,7 @@ class ScratchpadTests {
 
     private PlatformContext platformContext;
 
-    private final NodeId selfId = new NodeId(0);
+    private final NodeId selfId = NodeId.of(0);
 
     @BeforeEach
     void beforeEach() throws IOException {
@@ -120,7 +120,7 @@ class ScratchpadTests {
         assertEquals(long1, scratchpad.get(TestScratchpadType.BAR));
         assertNull(scratchpad.get(TestScratchpadType.BAZ));
 
-        final NodeId nodeId1 = new NodeId(random.nextInt(0, 1000));
+        final NodeId nodeId1 = NodeId.of(random.nextInt(0, 1000));
         assertNull(scratchpad.set(TestScratchpadType.BAZ, nodeId1));
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash1, scratchpad.get(TestScratchpadType.FOO));
@@ -143,7 +143,7 @@ class ScratchpadTests {
         assertEquals(long2, scratchpad.get(TestScratchpadType.BAR));
         assertEquals(nodeId1, scratchpad.get(TestScratchpadType.BAZ));
 
-        final NodeId nodeId2 = new NodeId(random.nextInt(1001, 2000));
+        final NodeId nodeId2 = NodeId.of(random.nextInt(1001, 2000));
         assertEquals(nodeId1, scratchpad.set(TestScratchpadType.BAZ, nodeId2));
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash2, scratchpad.get(TestScratchpadType.FOO));
@@ -174,7 +174,7 @@ class ScratchpadTests {
         assertEquals(long3, scratchpad.get(TestScratchpadType.BAR));
         assertNull(scratchpad.get(TestScratchpadType.BAZ));
 
-        final NodeId nodeId3 = new NodeId(random.nextInt(2001, 3000));
+        final NodeId nodeId3 = NodeId.of(random.nextInt(2001, 3000));
         assertNull(scratchpad.set(TestScratchpadType.BAZ, nodeId3));
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash3, scratchpad.get(TestScratchpadType.FOO));
@@ -269,7 +269,7 @@ class ScratchpadTests {
 
         final Hash hash1 = randomHash(random);
         final SerializableLong long1 = new SerializableLong(random.nextLong());
-        final NodeId nodeId1 = new NodeId(random.nextInt(0, 1000));
+        final NodeId nodeId1 = NodeId.of(random.nextInt(0, 1000));
 
         scratchpad.atomicOperation(map -> {
             assertNull(map.put(TestScratchpadType.FOO, hash1));
@@ -287,7 +287,7 @@ class ScratchpadTests {
 
         final Hash hash2 = randomHash(random);
         final SerializableLong long2 = new SerializableLong(random.nextLong());
-        final NodeId nodeId2 = new NodeId(random.nextInt(1001, 2000));
+        final NodeId nodeId2 = NodeId.of(random.nextInt(1001, 2000));
 
         scratchpad.atomicOperation(map -> {
             assertEquals(hash1, map.put(TestScratchpadType.FOO, hash2));
@@ -320,7 +320,7 @@ class ScratchpadTests {
 
         final Hash hash3 = randomHash(random);
         final SerializableLong long3 = new SerializableLong(random.nextLong());
-        final NodeId nodeId3 = new NodeId(random.nextInt(2001, 3000));
+        final NodeId nodeId3 = NodeId.of(random.nextInt(2001, 3000));
 
         scratchpad.atomicOperation(map -> {
             assertNull(map.put(TestScratchpadType.FOO, hash3));
@@ -375,7 +375,7 @@ class ScratchpadTests {
 
         final Hash hash1 = randomHash(random);
         final SerializableLong long1 = new SerializableLong(random.nextLong());
-        final NodeId nodeId1 = new NodeId(random.nextInt(0, 1000));
+        final NodeId nodeId1 = NodeId.of(random.nextInt(0, 1000));
 
         scratchpad.atomicOperation(map -> {
             assertNull(map.put(TestScratchpadType.FOO, hash1));
@@ -398,7 +398,7 @@ class ScratchpadTests {
 
         final Hash hash2 = randomHash(random);
         final SerializableLong long2 = new SerializableLong(random.nextLong());
-        final NodeId nodeId2 = new NodeId(random.nextInt(1001, 2000));
+        final NodeId nodeId2 = NodeId.of(random.nextInt(1001, 2000));
 
         scratchpad.atomicOperation(map -> {
             assertEquals(hash1, map.put(TestScratchpadType.FOO, hash2));
@@ -441,7 +441,7 @@ class ScratchpadTests {
 
         final Hash hash3 = randomHash(random);
         final SerializableLong long3 = new SerializableLong(random.nextLong());
-        final NodeId nodeId3 = new NodeId(random.nextInt(2001, 3000));
+        final NodeId nodeId3 = NodeId.of(random.nextInt(2001, 3000));
 
         scratchpad.atomicOperation(map -> {
             assertNull(map.put(TestScratchpadType.FOO, hash3));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SigSetTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SigSetTests.java
@@ -56,7 +56,7 @@ class SigSetTests {
 
         for (int i = 0; i < 1_000; i++) {
             // There will be a few duplicates, but that doesn't really matter
-            final NodeId nodeId = new NodeId(random.nextLong(0, 10_000));
+            final NodeId nodeId = NodeId.of(random.nextLong(0, 10_000));
             final Signature signature = randomSignature(random);
             signatures.put(nodeId, signature);
         }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -57,7 +57,7 @@ class SwirldStateManagerTests {
         swirldStateManager = new SwirldStateManager(
                 platformContext,
                 addressBook,
-                new NodeId(0L),
+                NodeId.of(0L),
                 mock(StatusActionSubmitter.class),
                 new BasicSoftwareVersion(1));
         swirldStateManager.setInitialState(initialState);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PbjConverterTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PbjConverterTest.java
@@ -57,8 +57,8 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("removal")
 class PbjConverterTest {
 
-    public static final NodeId NODE_ID_1 = new NodeId(1);
-    public static final NodeId NODE_ID_2 = new NodeId(2);
+    public static final NodeId NODE_ID_1 = NodeId.of(1);
+    public static final NodeId NODE_ID_2 = NodeId.of(2);
     private Randotron randotron;
 
     @BeforeEach

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -76,7 +76,7 @@ public class StartupStateUtilsTests {
 
     private SignedStateFilePath signedStateFilePath;
 
-    private final NodeId selfId = new NodeId(0);
+    private final NodeId selfId = NodeId.of(0);
     private final String mainClassName = "mainClassName";
     private final String swirldName = "swirldName";
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/protocol/SyncProtocolFactoryTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/protocol/SyncProtocolFactoryTests.java
@@ -85,7 +85,7 @@ class SyncProtocolFactoryTests {
 
     @BeforeEach
     void setup() {
-        peerId = new NodeId(1);
+        peerId = NodeId.of(1);
         shadowGraphSynchronizer = mock(ShadowgraphSynchronizer.class);
         fallenBehindManager = mock(FallenBehindManager.class);
 
@@ -101,7 +101,7 @@ class SyncProtocolFactoryTests {
         // node is not fallen behind
         Mockito.when(fallenBehindManager.hasFallenBehind()).thenReturn(false);
         // only peer with ID 1 is needed for fallen behind
-        Mockito.when(fallenBehindManager.getNeededForFallenBehind()).thenReturn(List.of(new NodeId(1L)));
+        Mockito.when(fallenBehindManager.getNeededForFallenBehind()).thenReturn(List.of(NodeId.of(1L)));
     }
 
     @Test
@@ -294,7 +294,7 @@ class SyncProtocolFactoryTests {
                 sleepAfterSync,
                 syncMetrics,
                 () -> ACTIVE);
-        final Protocol protocol = syncProtocolFactory.build(new NodeId(6));
+        final Protocol protocol = syncProtocolFactory.build(NodeId.of(6));
 
         assertEquals(2, countAvailablePermits(permitProvider));
         assertTrue(protocol.shouldInitiate());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/address/AddressBookTests.java
@@ -162,7 +162,7 @@ class AddressBookTests {
     @NonNull
     private static Address buildNextAddress(@NonNull final Random random, @NonNull final AddressBook addressBook) {
         return RandomAddressBuilder.create(random)
-                .withNodeId(new NodeId(addressBook.getNextAvailableNodeId().id() + random.nextInt(0, 3)))
+                .withNodeId(NodeId.of(addressBook.getNextAvailableNodeId().id() + random.nextInt(0, 3)))
                 .build();
     }
 
@@ -283,8 +283,8 @@ class AddressBookTests {
                         "this.is.a.really.long.host.name.that.should.be.able.to.fit.in.the.address.book"));
 
         // make sure that certs are part of the round trip test.
-        assertNotNull(original.getAddress(new NodeId(0)).getSigCert());
-        assertNotNull(original.getAddress(new NodeId(0)).getAgreeCert());
+        assertNotNull(original.getAddress(NodeId.of(0)).getSigCert());
+        assertNotNull(original.getAddress(NodeId.of(0)).getAgreeCert());
 
         validateAddressBookConsistency(original);
 
@@ -356,9 +356,9 @@ class AddressBookTests {
         // The address book has gaps. Make sure we can't insert anything into those gaps.
         for (int i = 0; i < addressBook.getNextAvailableNodeId().id(); i++) {
 
-            final Address address = buildNextAddress(randotron, addressBook).copySetNodeId(new NodeId(i));
+            final Address address = buildNextAddress(randotron, addressBook).copySetNodeId(NodeId.of(i));
 
-            if (addressBook.contains(new NodeId(i))) {
+            if (addressBook.contains(NodeId.of(i))) {
                 // It's ok to update an existing address
                 addressBook.add(address);
             } else {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/events/BirthRoundMigrationShimTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/events/BirthRoundMigrationShimTests.java
@@ -43,7 +43,7 @@ class BirthRoundMigrationShimTests {
             final long generation,
             final long birthRound) {
 
-        final NodeId creatorId = new NodeId(random.nextLong(1, 10));
+        final NodeId creatorId = NodeId.of(random.nextLong(1, 10));
         final PlatformEvent selfParent = new TestingEventBuilder(random)
                 .setCreatorId(creatorId)
                 .setBirthRound(random.nextLong(birthRound - 2, birthRound + 1)) /* realistic range */

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
@@ -285,7 +285,7 @@ class UptimeTests {
         final NodeId nodeToRemove = addressBook.getNodeId(0);
         newAddressBook.remove(nodeToRemove);
         final Address newAddress =
-                addressBook.getAddress(addressBook.getNodeId(0)).copySetNodeId(new NodeId(12345));
+                addressBook.getAddress(addressBook.getNodeId(0)).copySetNodeId(NodeId.of(12345));
         newAddressBook.add(newAddress);
         final Set<NodeId> noSecondRoundEvents = Set.of();
         final Set<NodeId> noSecondRoundJudges = Set.of();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/AddressBookNetworkUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/AddressBookNetworkUtilsTests.java
@@ -99,10 +99,10 @@ class AddressBookNetworkUtilsTests {
                 "swirldName",
                 new BasicSoftwareVersion(1),
                 ReservedSignedState.createNullReservation(),
-                new NodeId(0));
+                NodeId.of(0));
 
-        final Address address1 = new Address(new NodeId(1), "", "", 10, null, 77, null, 88, null, null, "");
-        final Address address2 = new Address(new NodeId(2), "", "", 10, null, 77, null, 88, null, null, "");
+        final Address address1 = new Address(NodeId.of(1), "", "", 10, null, 77, null, 88, null, null, "");
+        final Address address2 = new Address(NodeId.of(2), "", "", 10, null, 77, null, 88, null, null, "");
         final AddressBook addressBook = new AddressBook();
         addressBook.add(address1);
         addressBook.add(address2);
@@ -130,7 +130,7 @@ class AddressBookNetworkUtilsTests {
                 "swirldName",
                 new BasicSoftwareVersion(1),
                 ReservedSignedState.createNullReservation(),
-                new NodeId(0));
+                NodeId.of(0));
         final AddressBook addressBook = new AddressBook();
         platformBuilder.withAddressBook(addressBook);
         final Roster roster = AddressBookUtils.createRoster(addressBook);

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/addressbook/AddresBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/addressbook/AddresBookUtils.java
@@ -46,7 +46,7 @@ public class AddresBookUtils {
                 new SerializableX509Certificate(cert),
                 "");
         final var address2 = new Address(
-                new NodeId(1),
+                NodeId.of(1),
                 "",
                 "",
                 10L,

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/addressbook/RandomAddressBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/addressbook/RandomAddressBuilder.java
@@ -74,7 +74,7 @@ public class RandomAddressBuilder {
         // Future work: use randotron utility methods once randotron changes merge
 
         if (nodeId == null) {
-            nodeId = new NodeId(random.nextLong(0, Long.MAX_VALUE));
+            nodeId = NodeId.of(random.nextLong(0, Long.MAX_VALUE));
         }
 
         if (weight == null) {

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/crypto/PreGeneratedX509Certs.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/crypto/PreGeneratedX509Certs.java
@@ -147,7 +147,7 @@ public class PreGeneratedX509Certs {
             }
         }
         long index = nodeId % sigCerts.size();
-        return sigCerts.get(new NodeId(index));
+        return sigCerts.get(NodeId.of(index));
     }
 
     /**
@@ -164,7 +164,7 @@ public class PreGeneratedX509Certs {
             }
         }
         long index = nodeId % agreeCerts.size();
-        return agreeCerts.get(new NodeId(index));
+        return agreeCerts.get(NodeId.of(index));
     }
 
     /**
@@ -196,7 +196,7 @@ public class PreGeneratedX509Certs {
             for (int i = 0; i < numSigCerts; i++) {
                 SerializableX509Certificate sigCert =
                         sigCertDis.readSerializable(false, SerializableX509Certificate::new);
-                sigCerts.put(new NodeId(i), sigCert);
+                sigCerts.put(NodeId.of(i), sigCert);
             }
 
             // load agreement certs
@@ -204,7 +204,7 @@ public class PreGeneratedX509Certs {
             for (int i = 0; i < numAgreeCerts; i++) {
                 SerializableX509Certificate agreeCert =
                         agreeCertDis.readSerializable(false, SerializableX509Certificate::new);
-                agreeCerts.put(new NodeId(i), agreeCert);
+                agreeCerts.put(NodeId.of(i), agreeCert);
             }
         } catch (final IOException e) {
             throw new IllegalStateException("critical failure in loading certificates", e);

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/TestingEventBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/TestingEventBuilder.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
 public class TestingEventBuilder {
     private static final Instant DEFAULT_TIMESTAMP = Instant.ofEpochMilli(1588771316678L);
     private static final SoftwareVersion DEFAULT_SOFTWARE_VERSION = new BasicSoftwareVersion(1);
-    private static final NodeId DEFAULT_CREATOR_ID = new NodeId(0);
+    private static final NodeId DEFAULT_CREATOR_ID = NodeId.of(0);
     private static final int DEFAULT_APP_TRANSACTION_COUNT = 2;
     private static final int DEFAULT_SYSTEM_TRANSACTION_COUNT = 0;
     private static final int DEFAULT_TRANSACTION_SIZE = 4;

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
@@ -197,7 +197,7 @@ public class StandardGraphGenerator extends AbstractGraphGenerator<StandardGraph
 
     private void initializeInternalConsensus() {
         consensus = new ConsensusImpl(platformContext, new NoOpConsensusMetrics(), addressBook);
-        inOrderLinker = new ConsensusLinker(platformContext, new NodeId(0));
+        inOrderLinker = new ConsensusLinker(platformContext, NodeId.of(0));
     }
 
     /**

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
@@ -70,7 +70,7 @@ public class TestIntake {
      * @param addressBook     the address book used by this intake
      */
     public TestIntake(@NonNull final PlatformContext platformContext, @NonNull final AddressBook addressBook) {
-        final NodeId selfId = new NodeId(0);
+        final NodeId selfId = NodeId.of(0);
         roundsNonAncient = platformContext
                 .getConfiguration()
                 .getConfigData(ConsensusConfig.class)

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/MapBuilder.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/simulated/config/MapBuilder.java
@@ -63,7 +63,7 @@ public class MapBuilder<T> {
      */
     public @NonNull MapBuilder<T> times(final int num) {
         for (int i = 0; i < num; i++) {
-            map.put(new NodeId(lastIndex++), lastElement);
+            map.put(NodeId.of(lastIndex++), lastElement);
         }
         return this;
     }
@@ -75,7 +75,7 @@ public class MapBuilder<T> {
      */
     public @NonNull Map<NodeId, T> build() {
         if (map.isEmpty()) {
-            map.put(new NodeId(lastIndex++), lastElement);
+            map.put(NodeId.of(lastIndex++), lastElement);
         }
         return map;
     }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SocketConnectionTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SocketConnectionTests.java
@@ -51,8 +51,8 @@ class SocketConnectionTests {
 
     private final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
 
-    private NodeId selfId = new NodeId(0L);
-    private NodeId otherId = new NodeId(1L);
+    private NodeId selfId = NodeId.of(0L);
+    private NodeId otherId = NodeId.of(1L);
     private Socket socket;
     private SyncInputStream dis;
     private SyncOutputStream dos;

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/GraphGeneratorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/consensus/GraphGeneratorTests.java
@@ -673,16 +673,16 @@ public class GraphGeneratorTests {
         events = generator.generateEvents(numberOfEvents);
 
         final HashSet<NodeId> excludedNodes = new HashSet<>();
-        excludedNodes.add(new NodeId(3L));
+        excludedNodes.add(NodeId.of(3L));
         eventAges = gatherOtherParentAges(events, excludedNodes);
         assertAgeRatio(eventAges, 0, 0.95, 0.05);
         assertAgeRatio(eventAges, 1, 0.05 * 0.95, 0.05);
         assertAgeRatio(eventAges, 2, 0.05 * 0.05 * 0.95, 0.2);
 
         excludedNodes.clear();
-        excludedNodes.add(new NodeId(0L));
-        excludedNodes.add(new NodeId(1L));
-        excludedNodes.add(new NodeId(2L));
+        excludedNodes.add(NodeId.of(0L));
+        excludedNodes.add(NodeId.of(1L));
+        excludedNodes.add(NodeId.of(2L));
         eventAges = gatherOtherParentAges(events, excludedNodes);
         assertAgeRatio(eventAges, 0, 0.5, 0.05);
         assertAgeRatio(eventAges, 1, 0.5 * 0.5, 0.05);
@@ -704,7 +704,7 @@ public class GraphGeneratorTests {
         events = generator.generateEvents(numberOfEvents);
 
         excludedNodes.clear();
-        excludedNodes.add(new NodeId(3L));
+        excludedNodes.add(NodeId.of(3L));
         eventAges = gatherOtherParentAges(events, excludedNodes);
         assertAgeRatio(eventAges, 0, 0.666666, 0.05);
         assertAgeRatio(eventAges, 1, 0.0, 0.0);
@@ -712,9 +712,9 @@ public class GraphGeneratorTests {
         assertAgeRatio(eventAges, 3, 0.333333, 0.05);
 
         excludedNodes.clear();
-        excludedNodes.add(new NodeId(0L));
-        excludedNodes.add(new NodeId(1L));
-        excludedNodes.add(new NodeId(2L));
+        excludedNodes.add(NodeId.of(0L));
+        excludedNodes.add(NodeId.of(1L));
+        excludedNodes.add(NodeId.of(2L));
         eventAges = gatherOtherParentAges(events, excludedNodes);
         assertAgeRatio(eventAges, 0, 1.0, 0.0);
         assertAgeRatio(eventAges, 1, 0.0, 0.0);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesBirthRoundMigrationTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesBirthRoundMigrationTests.java
@@ -261,7 +261,7 @@ class PcesBirthRoundMigrationTests {
         final long migrationRound = random.nextLong(100, 1000);
 
         PcesBirthRoundMigration.migratePcesToBirthRoundMode(
-                platformContext, new NodeId(0), migrationRound, middleGeneration);
+                platformContext, NodeId.of(0), migrationRound, middleGeneration);
 
         // We should not find any generation based PCES files in the database directory.
         assertTrue(findPcesFiles(pcesPath, GENERATION_THRESHOLD).isEmpty());
@@ -313,7 +313,7 @@ class PcesBirthRoundMigrationTests {
         }
 
         PcesBirthRoundMigration.migratePcesToBirthRoundMode(
-                platformContext, new NodeId(0), migrationRound, middleGeneration);
+                platformContext, NodeId.of(0), migrationRound, middleGeneration);
 
         final Set<Path> allFilesAfterSecondMigration = new HashSet<>();
         try (final Stream<Path> stream = Files.walk(testDirectory)) {
@@ -346,7 +346,7 @@ class PcesBirthRoundMigrationTests {
                 .build();
 
         // should not throw
-        PcesBirthRoundMigration.migratePcesToBirthRoundMode(platformContext, new NodeId(0), ROUND_FIRST, -1);
+        PcesBirthRoundMigration.migratePcesToBirthRoundMode(platformContext, NodeId.of(0), ROUND_FIRST, -1);
     }
 
     @Test
@@ -382,7 +382,7 @@ class PcesBirthRoundMigrationTests {
         final long migrationRound = random.nextLong(1, 1000);
 
         PcesBirthRoundMigration.migratePcesToBirthRoundMode(
-                platformContext, new NodeId(0), migrationRound, middleGeneration);
+                platformContext, NodeId.of(0), migrationRound, middleGeneration);
 
         // Some funny business: copy the original files back into the PCES database directory.
         // This simulates a crash in the middle of the migration process after we have created
@@ -402,7 +402,7 @@ class PcesBirthRoundMigrationTests {
 
         // Run migration again.
         PcesBirthRoundMigration.migratePcesToBirthRoundMode(
-                platformContext, new NodeId(0), migrationRound, middleGeneration);
+                platformContext, NodeId.of(0), migrationRound, middleGeneration);
 
         // We should not find any generation based PCES files in the database directory.
         assertTrue(findPcesFiles(pcesPath, GENERATION_THRESHOLD).isEmpty());
@@ -455,7 +455,7 @@ class PcesBirthRoundMigrationTests {
         }
 
         PcesBirthRoundMigration.migratePcesToBirthRoundMode(
-                platformContext, new NodeId(0), migrationRound, middleGeneration);
+                platformContext, NodeId.of(0), migrationRound, middleGeneration);
 
         final Set<Path> allFilesAfterSecondMigration = new HashSet<>();
         try (final Stream<Path> stream = Files.walk(testDirectory)) {

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesFileManagerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesFileManagerTests.java
@@ -117,7 +117,7 @@ class PcesFileManagerTests {
         Instant timestamp = Instant.now();
 
         final PcesFileManager generatingManager =
-                new PcesFileManager(platformContext, new PcesFileTracker(ancientMode), new NodeId(0), 0);
+                new PcesFileManager(platformContext, new PcesFileTracker(ancientMode), NodeId.of(0), 0);
 
         for (int i = 0; i < fileCount; i++) {
             final PcesFile file = generatingManager.getNextFileDescriptor(lowerBound, upperBound);
@@ -183,7 +183,7 @@ class PcesFileManagerTests {
 
         final PcesFileTracker fileTracker =
                 PcesFileReader.readFilesFromDisk(platformContext, fileDirectory, 0, false, ancientMode);
-        final PcesFileManager manager = new PcesFileManager(platformContext, fileTracker, new NodeId(0), 0);
+        final PcesFileManager manager = new PcesFileManager(platformContext, fileTracker, NodeId.of(0), 0);
 
         assertIteratorEquality(files.iterator(), fileTracker.getFileIterator(NO_LOWER_BOUND, 0));
 
@@ -296,7 +296,7 @@ class PcesFileManagerTests {
 
         final PcesFileTracker fileTracker =
                 PcesFileReader.readFilesFromDisk(platformContext, fileDirectory, 0, false, ancientMode);
-        final PcesFileManager manager = new PcesFileManager(platformContext, fileTracker, new NodeId(0), 0);
+        final PcesFileManager manager = new PcesFileManager(platformContext, fileTracker, NodeId.of(0), 0);
 
         assertIteratorEquality(files.iterator(), fileTracker.getFileIterator(NO_LOWER_BOUND, 0));
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesWriterTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesWriterTests.java
@@ -102,7 +102,7 @@ class PcesWriterTests {
     @TempDir
     Path testDirectory;
 
-    private final NodeId selfId = new NodeId(0);
+    private final NodeId selfId = NodeId.of(0);
     private final int numEvents = 1_000;
 
     protected static Stream<Arguments> buildArguments() {

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/ChildlessEventTrackerTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/ChildlessEventTrackerTests.java
@@ -72,7 +72,7 @@ class ChildlessEventTrackerTests {
         // Adding some event with no parents
         final List<EventDescriptorWrapper> batch1 = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final EventDescriptorWrapper descriptor = newEventDescriptor(randomHash(random), new NodeId(i), 0);
+            final EventDescriptorWrapper descriptor = newEventDescriptor(randomHash(random), NodeId.of(i), 0);
             tracker.addEvent(descriptor, List.of());
             batch1.add(descriptor);
         }
@@ -85,13 +85,13 @@ class ChildlessEventTrackerTests {
 
         final List<EventDescriptorWrapper> batch2 = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            final NodeId nonExistentParentId = new NodeId(i + 100);
+            final NodeId nonExistentParentId = NodeId.of(i + 100);
             final EventDescriptorWrapper nonExistentParent =
                     newEventDescriptor(randomHash(random), nonExistentParentId, 0);
             final int oddParentId = (i * 2 + 1) % 10;
             final EventDescriptorWrapper oddParent = batch1.get(oddParentId);
 
-            final EventDescriptorWrapper descriptor = newEventDescriptor(randomHash(), new NodeId(i), 1);
+            final EventDescriptorWrapper descriptor = newEventDescriptor(randomHash(), NodeId.of(i), 1);
             tracker.addEvent(descriptor, List.of(nonExistentParent, oddParent));
             batch2.add(descriptor);
         }
@@ -120,9 +120,9 @@ class ChildlessEventTrackerTests {
 
         final ChildlessEventTracker tracker = new ChildlessEventTracker();
 
-        final EventDescriptorWrapper e0 = newEventDescriptor(randomHash(random), new NodeId(0), 0);
-        final EventDescriptorWrapper e1 = newEventDescriptor(randomHash(random), new NodeId(0), 1);
-        final EventDescriptorWrapper e2 = newEventDescriptor(randomHash(random), new NodeId(0), 2);
+        final EventDescriptorWrapper e0 = newEventDescriptor(randomHash(random), NodeId.of(0), 0);
+        final EventDescriptorWrapper e1 = newEventDescriptor(randomHash(random), NodeId.of(0), 1);
+        final EventDescriptorWrapper e2 = newEventDescriptor(randomHash(random), NodeId.of(0), 2);
 
         tracker.addEvent(e0, List.of());
         tracker.addEvent(e1, List.of(e0));
@@ -132,8 +132,8 @@ class ChildlessEventTrackerTests {
         assertEquals(1, batch1.size());
         assertEquals(e2, batch1.get(0));
 
-        final EventDescriptorWrapper e3 = newEventDescriptor(randomHash(random), new NodeId(0), 3);
-        final EventDescriptorWrapper e3Branch = newEventDescriptor(randomHash(random), new NodeId(0), 3);
+        final EventDescriptorWrapper e3 = newEventDescriptor(randomHash(random), NodeId.of(0), 3);
+        final EventDescriptorWrapper e3Branch = newEventDescriptor(randomHash(random), NodeId.of(0), 3);
 
         // Branch with the same generation, existing event should not be discarded.
         tracker.addEvent(e3, List.of(e2));
@@ -144,14 +144,14 @@ class ChildlessEventTrackerTests {
         assertEquals(e3, batch2.get(0));
 
         // Branch with a lower generation, existing event should not be discarded.
-        final EventDescriptorWrapper e2Branch = newEventDescriptor(randomHash(random), new NodeId(0), 2);
+        final EventDescriptorWrapper e2Branch = newEventDescriptor(randomHash(random), NodeId.of(0), 2);
         tracker.addEvent(e2Branch, List.of(e1));
 
         assertEquals(1, batch2.size());
         assertEquals(e3, batch2.get(0));
 
         // Branch with a higher generation, existing event should be discarded.
-        final EventDescriptorWrapper e99Branch = newEventDescriptor(randomHash(random), new NodeId(0), 99);
+        final EventDescriptorWrapper e99Branch = newEventDescriptor(randomHash(random), NodeId.of(0), 99);
         tracker.addEvent(e99Branch, List.of());
 
         final List<EventDescriptorWrapper> batch3 = tracker.getChildlessEvents();

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetEventCreatorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/tipset/TipsetEventCreatorTests.java
@@ -253,7 +253,7 @@ class TipsetEventCreatorTests {
             @NonNull final UnsignedEvent event) {
 
         eventCreators
-                .get(new NodeId(event.getEventCore().creatorNodeId()))
+                .get(NodeId.of(event.getEventCore().creatorNodeId()))
                 .tipsetTracker
                 .addEvent(event.getDescriptor(), event.getMetadata().getAllParents());
 
@@ -952,7 +952,7 @@ class TipsetEventCreatorTests {
         final NodeId nodeC = addressBook.getNodeId(2);
         final NodeId nodeD = addressBook.getNodeId(3);
         // Node 4 (E) is not in the address book.
-        final NodeId nodeE = new NodeId(nodeD.id() + 1);
+        final NodeId nodeE = NodeId.of(nodeD.id() + 1);
 
         // All nodes except for node 0 are fully mocked. This test is testing how node 0 behaves.
         final EventCreator eventCreator = buildEventCreator(random, time, addressBook, nodeA, Collections::emptyList);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/SimpleGraphs.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/graph/SimpleGraphs.java
@@ -40,20 +40,20 @@ public class SimpleGraphs {
      */
     public static List<PlatformEvent> graph5e2n(final Random random) {
         final PlatformEvent e0 =
-                new TestingEventBuilder(random).setCreatorId(new NodeId(1)).build();
+                new TestingEventBuilder(random).setCreatorId(NodeId.of(1)).build();
         final PlatformEvent e1 =
-                new TestingEventBuilder(random).setCreatorId(new NodeId(2)).build();
+                new TestingEventBuilder(random).setCreatorId(NodeId.of(2)).build();
         final PlatformEvent e2 = new TestingEventBuilder(random)
-                .setCreatorId(new NodeId(1))
+                .setCreatorId(NodeId.of(1))
                 .setSelfParent(e0)
                 .setOtherParent(e1)
                 .build();
         final PlatformEvent e3 = new TestingEventBuilder(random)
-                .setCreatorId(new NodeId(1))
+                .setCreatorId(NodeId.of(1))
                 .setSelfParent(e2)
                 .build();
         final PlatformEvent e4 = new TestingEventBuilder(random)
-                .setCreatorId(new NodeId(2))
+                .setCreatorId(NodeId.of(2))
                 .setSelfParent(e1)
                 .setOtherParent(e2)
                 .build();
@@ -85,7 +85,7 @@ public class SimpleGraphs {
         // generation 0
         final EventImpl e0 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(1))
+                        .setCreatorId(NodeId.of(1))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.680Z")),
                 null,
                 null);
@@ -93,7 +93,7 @@ public class SimpleGraphs {
 
         final EventImpl e1 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(2))
+                        .setCreatorId(NodeId.of(2))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.681Z")),
                 null,
                 null);
@@ -101,7 +101,7 @@ public class SimpleGraphs {
 
         final EventImpl e2 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(3))
+                        .setCreatorId(NodeId.of(3))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.682Z")),
                 null,
                 null);
@@ -109,14 +109,14 @@ public class SimpleGraphs {
         // generation 1
         final EventImpl e3 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(1))
+                        .setCreatorId(NodeId.of(1))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.683Z")),
                 e0,
                 e1);
 
         final EventImpl e4 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(3))
+                        .setCreatorId(NodeId.of(3))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.686Z")),
                 e2,
                 null);
@@ -124,21 +124,21 @@ public class SimpleGraphs {
         // generation 2
         final EventImpl e5 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(1))
+                        .setCreatorId(NodeId.of(1))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.685Z")),
                 e3,
                 null);
 
         final EventImpl e6 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(2))
+                        .setCreatorId(NodeId.of(2))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.686Z")),
                 e1,
                 e3);
 
         final EventImpl e7 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(3))
+                        .setCreatorId(NodeId.of(3))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.690Z")),
                 e4,
                 e1);
@@ -146,7 +146,7 @@ public class SimpleGraphs {
         // generation 3
         final EventImpl e8 = createEventImpl(
                 new TestingEventBuilder(random)
-                        .setCreatorId(new NodeId(3))
+                        .setCreatorId(NodeId.of(3))
                         .setTimeCreated(Instant.parse("2020-05-06T13:21:56.694Z")),
                 e7,
                 e6);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/FakeConnection.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/FakeConnection.java
@@ -29,7 +29,7 @@ public class FakeConnection implements Connection {
     private final NodeId peerId;
 
     public FakeConnection() {
-        this(new NodeId(0L), new NodeId(1));
+        this(NodeId.of(0L), NodeId.of(1));
     }
 
     public FakeConnection(final NodeId selfId, final NodeId peerId) {

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionManagerTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionManagerTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 class OutboundConnectionManagerTest {
     @Test
     void createConnectionTest() {
-        final NodeId nodeId = new NodeId(0L);
+        final NodeId nodeId = NodeId.of(0L);
         ;
         final Connection connection1 = new FakeConnection();
         final Connection connection2 = new FakeConnection();
@@ -74,7 +74,7 @@ class OutboundConnectionManagerTest {
     @Test
     void concurrencyTest() throws InterruptedException {
         final int numThreads = 10;
-        final NodeId nodeId = new NodeId(0L);
+        final NodeId nodeId = NodeId.of(0L);
         final OutboundConnectionCreator creator = mock(OutboundConnectionCreator.class);
         final Connection connection = new FakeConnection();
         final CountDownLatch waitingForConnection = new CountDownLatch(1);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/HashHandshakeTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/HashHandshakeTests.java
@@ -63,7 +63,7 @@ class HashHandshakeTests {
         registry.registerConstructable(new ClassConstructorPair(SerializableLong.class, SerializableLong::new));
 
         final Pair<Connection, Connection> connections =
-                ConnectionFactory.createLocalConnections(new NodeId(0L), new NodeId(1));
+                ConnectionFactory.createLocalConnections(NodeId.of(0L), NodeId.of(1));
         myConnection = connections.left();
         theirConnection = connections.right();
     }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/VersionHandshakeTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/handshake/VersionHandshakeTests.java
@@ -66,7 +66,7 @@ class VersionHandshakeTests {
         registry.registerConstructable(new ClassConstructorPair(SerializableLong.class, SerializableLong::new));
 
         final Pair<Connection, Connection> connections =
-                ConnectionFactory.createLocalConnections(new NodeId(0L), new NodeId(1));
+                ConnectionFactory.createLocalConnections(NodeId.of(0L), NodeId.of(1));
         myConnection = connections.left();
         theirConnection = connections.right();
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/NegotiatorMultithreadedTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/NegotiatorMultithreadedTest.java
@@ -47,7 +47,7 @@ class NegotiatorMultithreadedTest {
     @Test
     void keepalive() throws Exception {
         final Pair<Connection, Connection> connections =
-                ConnectionFactory.createLocalConnections(new NodeId(0L), new NodeId(1));
+                ConnectionFactory.createLocalConnections(NodeId.of(0L), NodeId.of(1));
         final NegotiatorPair pair = new NegotiatorPair(
                 new TestProtocol().setShouldInitiate(false),
                 Pair.of(new ExpiringConnection(connections.left(), 1), new ExpiringConnection(connections.right(), 1)));

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/NegotiatorPair.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/NegotiatorPair.java
@@ -39,7 +39,7 @@ class NegotiatorPair {
     }
 
     public NegotiatorPair(final TestProtocol protocol) throws IOException {
-        this(protocol, ConnectionFactory.createLocalConnections(new NodeId(0L), new NodeId(1)));
+        this(protocol, ConnectionFactory.createLocalConnections(NodeId.of(0L), NodeId.of(1)));
     }
 
     public void start() {

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/reconnect/FallenBehindManagerTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/reconnect/FallenBehindManagerTest.java
@@ -64,32 +64,32 @@ class FallenBehindManagerTest {
         assertFallenBehind(false, 0, "default should be none report fallen behind");
 
         // node 1 reports fallen behind
-        manager.reportFallenBehind(new NodeId(1));
+        manager.reportFallenBehind(NodeId.of(1));
         assertFallenBehind(false, 1, "one node only reported fallen behind");
 
         // if the same node reports again, nothing should change
-        manager.reportFallenBehind(new NodeId(1));
+        manager.reportFallenBehind(NodeId.of(1));
         assertFallenBehind(false, 1, "if the same node reports again, nothing should change");
 
-        manager.reportFallenBehind(new NodeId(2));
-        manager.reportFallenBehind(new NodeId(3));
-        manager.reportFallenBehind(new NodeId(4));
-        manager.reportFallenBehind(new NodeId(5));
+        manager.reportFallenBehind(NodeId.of(2));
+        manager.reportFallenBehind(NodeId.of(3));
+        manager.reportFallenBehind(NodeId.of(4));
+        manager.reportFallenBehind(NodeId.of(5));
         assertFallenBehind(false, 5, "we should still be missing one for fallen behind");
 
-        manager.reportFallenBehind(new NodeId(6));
+        manager.reportFallenBehind(NodeId.of(6));
         assertFallenBehind(true, 6, "we should be fallen behind");
 
-        manager.reportFallenBehind(new NodeId(1));
-        manager.reportFallenBehind(new NodeId(2));
-        manager.reportFallenBehind(new NodeId(3));
-        manager.reportFallenBehind(new NodeId(4));
-        manager.reportFallenBehind(new NodeId(5));
-        manager.reportFallenBehind(new NodeId(6));
+        manager.reportFallenBehind(NodeId.of(1));
+        manager.reportFallenBehind(NodeId.of(2));
+        manager.reportFallenBehind(NodeId.of(3));
+        manager.reportFallenBehind(NodeId.of(4));
+        manager.reportFallenBehind(NodeId.of(5));
+        manager.reportFallenBehind(NodeId.of(6));
         assertFallenBehind(true, 6, "if the same nodes report again, nothing should change");
 
-        manager.reportFallenBehind(new NodeId(7));
-        manager.reportFallenBehind(new NodeId(8));
+        manager.reportFallenBehind(NodeId.of(7));
+        manager.reportFallenBehind(NodeId.of(8));
         assertFallenBehind(true, 8, "more nodes reported, but the status should be the same");
 
         manager.resetFallenBehind();

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/ConsensusHashFinderTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/ConsensusHashFinderTests.java
@@ -88,7 +88,7 @@ class ConsensusHashFinderTests {
                         (averageWeight + random.nextGaussian() * standardDeviationWeight)));
 
                 nodes.add(new NodeToAdd(nextNodeId, nextNodeWeight, partition.hash));
-                nextNodeId = new NodeId(nextNodeId.id() + 1);
+                nextNodeId = NodeId.of(nextNodeId.id() + 1);
                 remainingWeight -= nextNodeWeight;
             }
         }
@@ -111,11 +111,11 @@ class ConsensusHashFinderTests {
             final List<PartitionDescription> partitions) {
 
         final List<NodeToAdd> nodes = new ArrayList<>();
-        NodeId nextNodeId = new NodeId(0);
+        NodeId nextNodeId = NodeId.of(0);
         for (final PartitionDescription partition : partitions) {
             final List<NodeToAdd> partitionNodes =
                     getPartitionNodes(random, averageWeight, standardDeviationWeight, nextNodeId, partition);
-            nextNodeId = new NodeId(nextNodeId.id() + partitionNodes.size());
+            nextNodeId = NodeId.of(nextNodeId.id() + partitionNodes.size());
             nodes.addAll(partitionNodes);
         }
         return nodes;
@@ -137,7 +137,7 @@ class ConsensusHashFinderTests {
         assertEquals(0, hashFinder.getPartitionMap().size(), "there shouldn't be any partitions yet");
 
         // Add weight up until >1/2, but as soon as we meet or exceed 1/2 exit the loop
-        NodeId nextNodeId = new NodeId(0L);
+        NodeId nextNodeId = NodeId.of(0L);
         while (!MAJORITY.isSatisfiedBy(hashFinder.getHashReportedWeight(), totalWeight)) {
             assertEquals(UNDECIDED, hashFinder.getStatus(), "status should not yet be decided");
 
@@ -154,7 +154,7 @@ class ConsensusHashFinderTests {
             hashFinder.addHash(nextNodeId, nextNodeWeight, randomHash(random));
             assertEquals(currentAccumulatedWeight, hashFinder.getHashReportedWeight(), "duplicates should be no-ops");
 
-            nextNodeId = new NodeId(nextNodeId.id() + 1L);
+            nextNodeId = NodeId.of(nextNodeId.id() + 1L);
 
             assertEquals(1, hashFinder.getPartitionMap().size(), "there should only be 1 partition");
             assertTrue(hashFinder.getPartitionMap().containsKey(hash), "invalid partition map");
@@ -163,7 +163,7 @@ class ConsensusHashFinderTests {
                     hashFinder.getPartitionMap().get(hash).getNodes().size(),
                     "incorrect partition size");
             assertTrue(
-                    hashFinder.getPartitionMap().get(hash).getNodes().contains(new NodeId(nextNodeId.id() - 1)),
+                    hashFinder.getPartitionMap().get(hash).getNodes().contains(NodeId.of(nextNodeId.id() - 1)),
                     "could not find node that was just added");
         }
 
@@ -322,14 +322,14 @@ class ConsensusHashFinderTests {
             smallPartitions.add(new PartitionDescription(randomHash(random), partitionWeight));
         }
 
-        NodeId nextNodeId = new NodeId(0);
+        NodeId nextNodeId = NodeId.of(0);
         final List<NodeToAdd> nodes = new ArrayList<>();
 
         // Add the nodes from the small partitions
         for (final PartitionDescription partition : smallPartitions) {
             final List<NodeToAdd> partitionNodes =
                     getPartitionNodes(random, averageWeight, standardDeviationWeight, nextNodeId, partition);
-            nextNodeId = new NodeId(nextNodeId.id() + partitionNodes.size());
+            nextNodeId = NodeId.of(nextNodeId.id() + partitionNodes.size());
             nodes.addAll(partitionNodes);
         }
 
@@ -373,14 +373,14 @@ class ConsensusHashFinderTests {
             smallPartitions.add(new PartitionDescription(randomHash(random), partitionWeight));
         }
 
-        NodeId nextNodeId = new NodeId(0);
+        NodeId nextNodeId = NodeId.of(0);
         final List<NodeToAdd> nodes = new ArrayList<>();
 
         // Add the nodes from the small partitions
         for (final PartitionDescription partition : smallPartitions) {
             final List<NodeToAdd> partitionNodes =
                     getPartitionNodes(random, averageWeight, standardDeviationWeight, nextNodeId, partition);
-            nextNodeId = new NodeId(nextNodeId.id() + partitionNodes.size());
+            nextNodeId = NodeId.of(nextNodeId.id() + partitionNodes.size());
             nodes.addAll(partitionNodes);
         }
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssMetricsTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssMetricsTests.java
@@ -49,7 +49,7 @@ class IssMetricsTests {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> issMetrics.stateHashValidityObserver(
-                        0L, new NodeId(Integer.MAX_VALUE), randomHash(), randomHash()),
+                        0L, NodeId.of(Integer.MAX_VALUE), randomHash(), randomHash()),
                 "should not be able to update stats for non-existent node");
     }
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncNode.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/sync/SyncNode.java
@@ -120,7 +120,7 @@ public class SyncNode {
 
         this.ancientMode = Objects.requireNonNull(ancientMode);
         this.numNodes = numNodes;
-        this.nodeId = new NodeId(nodeId);
+        this.nodeId = NodeId.of(nodeId);
         this.eventEmitter = eventEmitter;
 
         syncManager = new TestingSyncManager();


### PR DESCRIPTION
**Description**:
Introducing a `NodeId.of(long)` static factory method for NodeId objects that uses a pre-built cache implemented in the `NodeIdCache` class which pre-constructs NodeId objects for node ids from 0 to 63. For node ids outside of this range, new NodeId objects will be created at all times.

This optimization is required to support a refactoring to replace `AddressBook` usages with `Roster` in Platform code. The `Roster` uses simple `long` values to represent node ids, and the code that uses the Roster and then needs to interact with the existing code that currently uses `NodeId` objects has to keep creating new `NodeId` objects over and over again. Having a cache helps avoid these unnecessary duplicate objects for the same, most frequently used node id values.

**Related issue(s)**:

Fixes #15939

**Notes for reviewer**:
There's no any logic changes (other than the construction of NodeId objects.) Tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
