### PR TITLE
ci: Add skipped status as possible triggering conclusion

### DIFF
--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -38,7 +38,7 @@ jobs:
   tag-for-xts:
     name: Tag for XTS promotion
     runs-on: network-node-linux-medium
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.ref_type == 'branch' }}
+    if: ${{ (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'skipped') && github.event.workflow_run.ref_type == 'branch' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0


### PR DESCRIPTION
**Description**:

The status of the triggering job is set to `skipped` need to include that status as a valid conclusion to trigger the XTS job.

**Related issue(s)**:

Relates to: #15955 
