### PR TITLE
ci: Fix issue with zxf prepare extended test suite

### DIFF
--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -38,7 +38,7 @@ jobs:
   tag-for-xts:
     name: Tag for XTS promotion
     runs-on: network-node-linux-medium
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && !github.event.workflow_run.head_repository.fork && github.event.workflow_run.head_branch == 'develop'}}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0


### PR DESCRIPTION
**Details**:

Add checks at the job level to prove we are on the develop branch of the hashgraph/hedera-services repository and not on a fork

**Related Issue(s)**:

Fixes: #15973

**Note(s)**:
- Only testable on merge
