### PR TITLE
fix: 15994: Need more logging in AbstractHashListener

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/FullLeafRehashHashListener.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/FullLeafRehashHashListener.java
@@ -23,6 +23,7 @@ import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
 import com.swirlds.virtualmap.internal.hash.VirtualHashListener;
 import com.swirlds.virtualmap.serialize.KeySerializer;
 import com.swirlds.virtualmap.serialize.ValueSerializer;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.stream.Stream;
 
 /**
@@ -64,14 +65,17 @@ public class FullLeafRehashHashListener<K extends VirtualKey, V extends VirtualV
      * 		The last leaf path. Must be a valid path.
      * @param dataSource
      * 		The data source. Cannot be null.
+     * @param statistics
+     *      Virtual map stats. Cannot be null.
      */
     public FullLeafRehashHashListener(
             final long firstLeafPath,
             final long lastLeafPath,
             final KeySerializer<K> keySerializer,
             final ValueSerializer<V> valueSerializer,
-            final VirtualDataSource dataSource) {
-        super(firstLeafPath, lastLeafPath, keySerializer, valueSerializer, dataSource);
+            @NonNull final VirtualDataSource dataSource,
+            @NonNull final VirtualMapStatistics statistics) {
+        super(firstLeafPath, lastLeafPath, keySerializer, valueSerializer, dataSource, statistics);
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNode.java
@@ -500,7 +500,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
                 lastLeafPath,
                 getRoute());
         final FullLeafRehashHashListener<K, V> hashListener = new FullLeafRehashHashListener<>(
-                firstLeafPath, lastLeafPath, keySerializer, valueSerializer, dataSource);
+                firstLeafPath, lastLeafPath, keySerializer, valueSerializer, dataSource, statistics);
 
         // This background thread will be responsible for hashing the tree and sending the
         // data to the hash listener to flush.
@@ -1591,6 +1591,7 @@ public final class VirtualRootNode<K extends VirtualKey, V extends VirtualValue>
                 keySerializer,
                 valueSerializer,
                 reconnectRecords.getDataSource(),
+                statistics,
                 nodeRemover);
 
         // This background thread will be responsible for hashing the tree and sending the

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListener.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListener.java
@@ -22,8 +22,11 @@ import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
 import com.swirlds.virtualmap.internal.hash.VirtualHashListener;
 import com.swirlds.virtualmap.internal.merkle.AbstractHashListener;
+import com.swirlds.virtualmap.internal.merkle.VirtualMapStatistics;
 import com.swirlds.virtualmap.serialize.KeySerializer;
 import com.swirlds.virtualmap.serialize.ValueSerializer;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -65,16 +68,19 @@ public class ReconnectHashListener<K extends VirtualKey, V extends VirtualValue>
      * 		The last leaf path. Must be a valid path.
      * @param dataSource
      * 		The data source. Cannot be null.
+     * @param statistics
+     *      Virtual map stats. Cannot be null.
      */
     public ReconnectHashListener(
             final long firstLeafPath,
             final long lastLeafPath,
             final KeySerializer<K> keySerializer,
             final ValueSerializer<V> valueSerializer,
-            final VirtualDataSource dataSource,
-            final ReconnectNodeRemover<K, V> nodeRemover) {
-        super(firstLeafPath, lastLeafPath, keySerializer, valueSerializer, dataSource);
-        this.nodeRemover = nodeRemover;
+            @NonNull final VirtualDataSource dataSource,
+            @NonNull final VirtualMapStatistics statistics,
+            @NonNull final ReconnectNodeRemover<K, V> nodeRemover) {
+        super(firstLeafPath, lastLeafPath, keySerializer, valueSerializer, dataSource, statistics);
+        this.nodeRemover = Objects.requireNonNull(nodeRemover);
     }
 
     /**


### PR DESCRIPTION
Fix summary:
* Two log statements are added to `AbstractHashListener`: to log flush time and to log leaves/hashes counters
* Flush duration is also reported as a virtual map metric

Fixes: https://github.com/hashgraph/hedera-services/issues/15994
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
