### PR TITLE
fix: adding support for chain ids where the value requires a sign bit…

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -387,7 +387,7 @@ public record EthTxData(
             // after EIP155 the chain id is equal to
             // CHAIN_ID = (v - {0,1} - 35) / 2
             chainId = BigIntegers.asUnsignedByteArray(
-                vBI.subtract(BigInteger.valueOf(35)).shiftRight(1));
+                    vBI.subtract(BigInteger.valueOf(35)).shiftRight(1));
         } else if (isLegacyUnprotectedEtx(vBI)) {
             // before EIP155 the chain id is considered equal to 0
             chainId = new byte[0];

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -31,6 +31,7 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import org.apache.commons.codec.binary.Hex;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
+import org.bouncycastle.util.BigIntegers;
 
 public record EthTxData(
         byte[] rawTx,
@@ -385,7 +386,7 @@ public record EthTxData(
         if (vBI.compareTo(BigInteger.valueOf(34)) > 0) {
             // after EIP155 the chain id is equal to
             // CHAIN_ID = (v - {0,1} - 35) / 2
-            chainId = vBI.subtract(BigInteger.valueOf(35)).shiftRight(1).toByteArray();
+            chainId = BigIntegers.asUnsignedByteArray(vBI.subtract(BigInteger.valueOf(35)).shiftRight(1));
         } else if (isLegacyUnprotectedEtx(vBI)) {
             // before EIP155 the chain id is considered equal to 0
             chainId = new byte[0];

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -386,7 +386,8 @@ public record EthTxData(
         if (vBI.compareTo(BigInteger.valueOf(34)) > 0) {
             // after EIP155 the chain id is equal to
             // CHAIN_ID = (v - {0,1} - 35) / 2
-            chainId = BigIntegers.asUnsignedByteArray(vBI.subtract(BigInteger.valueOf(35)).shiftRight(1));
+            chainId = BigIntegers.asUnsignedByteArray(
+                vBI.subtract(BigInteger.valueOf(35)).shiftRight(1));
         } else if (isLegacyUnprotectedEtx(vBI)) {
             // before EIP155 the chain id is considered equal to 0
             chainId = new byte[0];

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -35,6 +35,7 @@ import com.swirlds.common.utility.CommonUtils;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
+import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -46,6 +47,8 @@ class EthTxDataTest {
     static final String SIGNATURE_PUBKEY = "033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d";
     static final String RAW_TX_TYPE_0 =
             "f864012f83018000947e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc18180827653820277a0f9fbff985d374be4a55f296915002eec11ac96f1ce2df183adf992baa9390b2fa00c1e867cc960d9c74ec2e6a662b7908ec4c8cc9f3091e886bcefbeb2290fb792";
+    static final String RAW_TX_TYPE_0_WITH_CHAIN_ID_11155111 =
+            "f86b048503ff9aca0782520f94e64fac7f3df5ab44333ad3d3eb3fb68be43f2e8c830fffff808401546d71a026cf0758fda122862a4de71a82a3210ef7c172ee13eae42997f5d32b747ec78ca03587c5c2eee373b1e45693544edcde8dde883d2be3e211b3f0f3c840d6389c8a";
     static final String RAW_TX_TYPE_0_TRIMMED_LAST_BYTES =
             "f864012f83018000947e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc18180827653820277a0f9fbff985d374be4a55f296915002eec11ac96f1ce2df183adf992baa9390b2fa00c1e867cc960d9c74ec2e6a662b7908ec4c8cc9f3091e886bcefbeb2290000";
     // {
@@ -600,5 +603,19 @@ class EthTxDataTest {
         final var populateEthTxData = EthTxData.populateEthTxData(encoded);
 
         assertEquals(bigValue, populateEthTxData.value());
+    }
+
+    @Test
+    void thatPassesOnBigIntegerByteArray() {
+        final var subject = EthTxData.populateEthTxData(Hex.decode(RAW_TX_TYPE_0_WITH_CHAIN_ID_11155111));
+        byte[] passingChainId = BigIntegers.asUnsignedByteArray(BigInteger.valueOf(11155111L));
+        assertEquals(Hex.toHexString(subject.chainId()), Hex.toHexString(passingChainId));
+    }
+
+    @Test
+    void thatFailsOnBigIntegerByteArray() {
+        final var subject = EthTxData.populateEthTxData(Hex.decode(RAW_TX_TYPE_0_WITH_CHAIN_ID_11155111));
+        byte[] failingChainId = BigInteger.valueOf(11155111L).toByteArray();
+        assertNotEquals(Hex.toHexString(subject.chainId()), Hex.toHexString(failingChainId));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/EthereumSuite.java
@@ -1081,6 +1081,42 @@ public class EthereumSuite {
                                 .hasPriority(recordWith().status(SUCCESS)))));
     }
 
+    // Test unprotected legacy Ethereum transactions (pre-EIP155).
+    // When using a `CHAIN_ID` represented as a BigInteger, an additional byte is required
+    // to store the sign information (indicating whether the value is positive or negative),
+    // if there is no free bit available for this information, as in values like 11155111.
+    @HapiTest
+    final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
+        final String DEPOSIT = "deposit";
+        final long depositAmount = 20_000L;
+        final Integer chainId = 11_155_111;
+
+        return hapiTest(
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                        .via("autoAccount"),
+                getTxnRecord("autoAccount").andAllChildRecords(),
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD),
+                ethereumCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(depositAmount))
+                        .type(EthTransactionType.LEGACY_ETHEREUM)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .payingWith(RELAYER)
+                        .via("legacyBeforeEIP155")
+                        .nonce(0)
+                        .chainId(chainId)
+                        .gasPrice(50L)
+                        .maxPriorityGas(2L)
+                        .gasLimit(1_000_000L)
+                        .sending(depositAmount),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        getTxnRecord("legacyBeforeEIP155")
+                                .logged()
+                                .hasPriority(recordWith().status(SUCCESS)))));
+    }
+
     @HapiTest
     final Stream<DynamicTest> etx007FungibleTokenCreateWithFeesHappyPath() {
         final var createdTokenNum = new AtomicLong();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
@@ -98,7 +98,7 @@ public class LeakyEthereumTestsSuite {
      * if there is no free bit available for this information, as in values like 11155111.
      */
     @LeakyHapiTest(overrides = {"contracts.chainId"})
-        /* default */ final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
+    /* default */ final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
         final String DEPOSIT = "deposit";
         final long depositAmount = 20_000L;
         final Integer chainId = 11_155_111;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
@@ -98,7 +98,7 @@ public class LeakyEthereumTestsSuite {
      * if there is no free bit available for this information, as in values like 11155111.
      */
     @LeakyHapiTest(overrides = {"contracts.chainId"})
-    final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
+        /* default */ final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
         final String DEPOSIT = "deposit";
         final long depositAmount = 20_000L;
         final Integer chainId = 11_155_111;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
@@ -91,6 +91,44 @@ public class LeakyEthereumTestsSuite {
                                 .hasPriority(recordWith().status(SUCCESS)))));
     }
 
+    // test unprotected legacy ethereum transactions before EIP155
+    // When using a `CHAIN_ID` represented as a BigInteger, an additional byte is required
+    // to store the sign information (indicating whether the value is positive or negative),
+    // if there is no free bit available for this information, as in values like 11155111.
+    @LeakyHapiTest(overrides = {"contracts.chainId"})
+    final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
+        final String DEPOSIT = "deposit";
+        final long depositAmount = 20_000L;
+        final Integer chainId = 11_155_111;
+
+        return hapiTest(
+                overriding("contracts.chainId", "" + chainId),
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                        .via("autoAccount"),
+                getTxnRecord("autoAccount").andAllChildRecords(),
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD),
+                ethereumCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(depositAmount))
+                        .type(EthTransactionType.LEGACY_ETHEREUM)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .payingWith(RELAYER)
+                        .via("legacyBeforeEIP155")
+                        .nonce(0)
+                        .chainId(chainId)
+                        .gasPrice(50L)
+                        .maxPriorityGas(2L)
+                        .gasLimit(1_000_000L)
+                        .sending(depositAmount)
+                        .hasKnownStatus(ResponseCodeEnum.SUCCESS),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        getTxnRecord("legacyBeforeEIP155")
+                                .logged()
+                                .hasPriority(recordWith().status(SUCCESS)))));
+    }
+
     // test legacy ethereum transactions after EIP155
     // this tests the behaviour when the `v` field is 37 or 38
     // in this case the passed chainId = 1 so ETX is after EIP155

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
@@ -96,7 +96,7 @@ public class LeakyEthereumTestsSuite {
     // to store the sign information (indicating whether the value is positive or negative),
     // if there is no free bit available for this information, as in values like 11155111.
     @LeakyHapiTest(overrides = {"contracts.chainId"})
-    final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
+    public final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
         final String DEPOSIT = "deposit";
         final long depositAmount = 20_000L;
         final Integer chainId = 11_155_111;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/leaky/LeakyEthereumTestsSuite.java
@@ -91,12 +91,14 @@ public class LeakyEthereumTestsSuite {
                                 .hasPriority(recordWith().status(SUCCESS)))));
     }
 
-    // test unprotected legacy ethereum transactions before EIP155
-    // When using a `CHAIN_ID` represented as a BigInteger, an additional byte is required
-    // to store the sign information (indicating whether the value is positive or negative),
-    // if there is no free bit available for this information, as in values like 11155111.
+    /**
+     * test unprotected legacy ethereum transactions before EIP155
+     * When using a `CHAIN_ID` represented as a BigInteger, an additional byte is required
+     * to store the sign information (indicating whether the value is positive or negative),
+     * if there is no free bit available for this information, as in values like 11155111.
+     */
     @LeakyHapiTest(overrides = {"contracts.chainId"})
-    public final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
+    final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
         final String DEPOSIT = "deposit";
         final long depositAmount = 20_000L;
         final Integer chainId = 11_155_111;


### PR DESCRIPTION
… to be stored in a separate byte within the byte array returned by the biginteger type (#15953)

**Description**:
When using a `CHAIN_ID` represented as a BigInteger, an additional byte is required to store the sign information (indicating whether the value is positive or negative), if there is no free bit available for this information, as in values like 11155111.

As a result, the previous code caused BigInteger.toByteArray to return a value with an unexpected extra byte, leading to validation failures and other issues. For example, the message payload contained this extra byte,  which caused attempts to derive the signer from the message and signature to return an incorrect signer ID instead of the correct one.

**Related issue(s)**:

Fixes #15953 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
