### PR TITLE
chore: Fix ownership of services protobufs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 #########################
 
 /hapi/                                          @hashgraph/hedera-base @hashgraph/hedera-services @hashgraph/hedera-smart-contracts-core @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects
+/hapi/hedera-protobufs/services                 @hashgraph/hedera-base @hashgraph/hedera-services @hashgraph/hedera-smart-contracts-core @jsync-swirlds
 
 
 #########################


### PR DESCRIPTION
**Description**:

Fix the ownership of services protobufs because we modify them in the `hedera-services` repository.

**Related issue(s)**:

Fixes #16014 
