### PR TITLE
chore: tolerate nextNodeId field in config.txt

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/LegacyConfigPropertiesLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/LegacyConfigPropertiesLoader.java
@@ -125,6 +125,11 @@ public final class LegacyConfigPropertiesLoader {
                                 onError(ERROR_ADDRESS_NOT_ENOUGH_PARAMETERS);
                             }
                         }
+                        case "nextnodeid" -> {
+                            // As of release 0.56, nextNodeId is not used and ignored.
+                            // CI/CD pipelines need to be updated to remove this field from files.
+                            // Future Work: remove this case when nextNodeId is no longer present in CI/CD pipelines.
+                        }
                         default -> onError(ERROR_PROPERTY_NOT_KNOWN.formatted(pars[0]));
                     }
                 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -120,6 +120,10 @@ public class AddressBookUtils {
                 if (address != null) {
                     addressBook.add(address);
                 }
+            } else if (trimmedLine.startsWith("nextNodeId")) {
+                // As of release 0.56, nextNodeId is not used and ignored.
+                // CI/CD pipelines need to be updated to remove this field from files.
+                // Future Work: remove this case and hard fail when nextNodeId is no longer present in CI/CD pipelines.
             } else {
                 throw new ParseException(
                         "The line [%s] does not start with `%s`."


### PR DESCRIPTION
**Description**:
In PR https://github.com/hashgraph/hedera-services/pull/15791, `nextNodeId` was completely removed from config.txt.  DevOps indicated that a hard removal of the field would make things more complicated as they switch back and forth between software version in test environments.  The decision was made to allow the field to be present until all test environments and CI/CD pipelines were on a version of the software that did not require the field to be present, then it could be removed from the format. 

Fixes #15934 

A new issue was created to undo the effects of this PR when we can completely remove the field.  https://github.com/hashgraph/hedera-services/issues/16049