### PR TITLE
chore: cherry-pick, Do not update file 102 during the first transaction after a freeze upgrade when DAB is disabled

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemSetup.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemSetup.java
@@ -54,6 +54,7 @@ import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.NetworkAdminConfig;
+import com.hedera.node.config.data.NodesConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.system.InitTrigger;
@@ -134,15 +135,18 @@ public class SystemSetup {
      */
     public void doPostUpgradeSetup(@NonNull final Dispatch dispatch) {
         final var systemContext = systemContextFor(dispatch);
+        final var config = dispatch.config();
 
         // We update the node details file from the address book that resulted from all pre-upgrade HAPI node changes
-        final var nodeStore = dispatch.handleContext().storeFactory().readableStore(ReadableNodeStore.class);
-        fileService.updateAddressBookAndNodeDetailsAfterFreeze(systemContext, nodeStore);
-        dispatch.stack().commitFullStack();
+        final var nodesConfig = config.getConfigData(NodesConfig.class);
+        if (nodesConfig.enableDAB()) {
+            final var nodeStore = dispatch.handleContext().storeFactory().readableStore(ReadableNodeStore.class);
+            fileService.updateAddressBookAndNodeDetailsAfterFreeze(systemContext, nodeStore);
+            dispatch.stack().commitFullStack();
+        }
 
         // And then we update the system files for fees schedules, throttles, override properties, and override
         // permissions from any upgrade files that are present in the configured directory
-        final var config = dispatch.config();
         final var filesConfig = config.getConfigData(FilesConfig.class);
         final var adminConfig = config.getConfigData(NetworkAdminConfig.class);
         final List<AutoSysFileUpdate> autoUpdates = List.of(

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemSetupTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemSetupTest.java
@@ -152,6 +152,7 @@ class SystemSetupTest {
     void successfulAutoUpdatesAreDispatchedWithFilesAvailable() throws IOException {
         final var config = HederaTestConfigBuilder.create()
                 .withValue("networkAdmin.upgradeSysFilesLoc", tempDir.toString())
+                .withValue("nodes.enableDAB", true)
                 .getOrCreateConfig();
         final var adminConfig = config.getConfigData(NetworkAdminConfig.class);
         Files.writeString(tempDir.resolve(adminConfig.upgradePropertyOverridesFile()), validPropertyOverrides());
@@ -162,10 +163,10 @@ class SystemSetupTest {
         given(dispatch.config()).willReturn(config);
         given(dispatch.consensusNow()).willReturn(CONSENSUS_NOW);
         given(dispatch.handleContext()).willReturn(handleContext);
-        given(handleContext.storeFactory()).willReturn(storeFactory);
-        given(storeFactory.readableStore(ReadableNodeStore.class)).willReturn(readableNodeStore);
         given(handleContext.dispatchPrecedingTransaction(any(), any(), any(), any()))
                 .willReturn(streamBuilder);
+        given(handleContext.storeFactory()).willReturn(storeFactory);
+        given(storeFactory.readableStore(ReadableNodeStore.class)).willReturn(readableNodeStore);
 
         subject.doPostUpgradeSetup(dispatch);
 
@@ -182,6 +183,7 @@ class SystemSetupTest {
     void onlyAddressBookAndNodeDetailsAutoUpdateIsDispatchedWithNoFilesAvailable() {
         final var config = HederaTestConfigBuilder.create()
                 .withValue("networkAdmin.upgradeSysFilesLoc", tempDir.toString())
+                .withValue("nodes.enableDAB", true)
                 .getOrCreateConfig();
         given(dispatch.stack()).willReturn(stack);
         given(dispatch.config()).willReturn(config);
@@ -206,6 +208,7 @@ class SystemSetupTest {
     void onlyAddressBookAndNodeDetailsAutoUpdateIsDispatchedWithInvalidFilesAvailable() throws IOException {
         final var config = HederaTestConfigBuilder.create()
                 .withValue("networkAdmin.upgradeSysFilesLoc", tempDir.toString())
+                .withValue("nodes.enableDAB", true)
                 .getOrCreateConfig();
         final var adminConfig = config.getConfigData(NetworkAdminConfig.class);
         Files.writeString(tempDir.resolve(adminConfig.upgradePropertyOverridesFile()), invalidPropertyOverrides());


### PR DESCRIPTION


**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This fix was in release/0.54 and not cherry-picked into develop branch because the DAB was going to be enabled in releases after 0.54. DAB might be disable after 0.55, this needs to be cherry-picked in deveop.

**Related issue(s)**:

Fixes #15466 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
