### PR TITLE
chore: Updates to match recent changes to the Block Stream definition

### DIFF
--- a/hapi/hedera-protobufs/block/block_service.proto
+++ b/hapi/hedera-protobufs/block/block_service.proto
@@ -2,39 +2,6 @@
  * # Block Service
  * The Service API exposed by the Block Nodes.
  *
- * ## Workarounds
- * > There are incorrect elements in this file to work around bugs in the
- * > PBJ Compiler.
- * >> Issues 262, 263, 240, 218, 217, and 216 are related.
- * >
- * > Issue 263
- * >> A number of fields reference child messages, these _should_ specify
- * >> the parent message (i.e. `Parent.child field = #;`) but do not do
- * >> so due to issue 263.
- * >
- * > Issue 262
- * >> Some fields reference messages defined in other packages that share
- * >> a common prefix (e.g. `com.hedera.hapi.block.stream`). These fields
- * >> specify the entire package instead of the shorter and clearer suffix
- * >> due to issue 262
- * >
- * > Issue 240
- * >> These files currently cause PBJ integration tests to fail if included
- * >> due to issue 240.
- * >
- * > Issue 218
- * >> These files have the same value for package and java_package. Ideally
- * >> we would not specify `java_package` or the pbj comment in that situation,
- * >> but Issue 218 prevents eliding the unnecessary directives.
- * >
- * > Issue 217
- * >> These files may cause PBJ to fail compilation due to comments preceeding
- * >> the `syntax` keyword.
- * >
- * > Issue 216
- * >> These files would do well with validation support, but cannot make
- * >> use of validation, even as an advisory element, due to Issue 216.
- *
  * ### Keywords
  * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
  * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
@@ -71,23 +38,117 @@ import "stream/block.proto";
 import "stream/block_item.proto";
 
 /**
- * Publish a stream of blocks.
+ * Publish a stream of block items.
  *
- * Each item in the stream MUST contain one `BlockItem`.<br/>
+ * Each request in the stream MUST contain at least one `BlockItem`.<br/>
+ * Each request MAY contain more than one `BlockItem`.<br/>
+ * A single request MUST NOT contain `BlockItem`s from more than one block.<br/>
+ * Each request MAY contain a variable number of `BlockItem`s.<br/>
  * Each Block MUST begin with a single `BlockHeader` block item.<br/>
+ * If a `BlockHeader` is present in a request, it MUST be the first `BlockItem`
+ * in the `block_items` list.<br/>
  * The block node SHALL append each `BlockItem` to an internal structure
  * to reconstruct full blocks.<br/>
  * The block node MUST verify the block proof for each block before sending a
  * response message acknowledging that block.<br/>
- * Each Block MUST end with a single `BlockStateProof` block item.<br/>
- * The block node MUST verify the Block using the `BlockStateProof` to
- * ensure all data was received and processed correctly.<br/>
+ * Each Block MUST end with a single `BlockProof` block item.<br/>
+ * If a `BlockProof` is present in a request, it MUST be the last `BlockItem`
+ * in the `block_items` list.<br/>
+ * The block node MUST verify each Block using the `BlockProof` to
+ * ensure all data was received and processed correctly.
  */
 message PublishStreamRequest {
+    oneof request {
+        /**
+         * A stream item containing one or more `BlockItem`s.
+         * <p>
+         * The full stream SHALL consist of many `block_items` messages
+         * followed by a single `status` message.
+         */
+        BlockItemSet block_items = 1;
+    }
+}
+
+/**
+ * An enumeration indicating why a publisher ended a stream.
+ *
+ * This enumeration describes the reason a block stream
+ * (sent via `publishBlockStream`) was ended by the publisher.
+ */
+enum PublishStreamEndCode {
     /**
-     * A single item written to the block stream.
+     * An "unset value" flag, this value SHALL NOT be used.<br/>
+     * This status indicates the server software failed to set a
+     * status, and SHALL be considered a software defect.
      */
-    com.hedera.hapi.block.stream.BlockItem block_item = 1;
+    STREAM_END_UNKNOWN = 0;
+
+    /**
+     * The Publisher reached a reset point.<br/>
+     * No errors occurred and the source node orderly ended the stream.
+     *
+     * Publishers SHOULD use this code to end a stream and restart
+     * occasionally. Occasionally resetting the stream increases stability and
+     * allows for routine network configuration changes.
+     */
+    STREAM_END_RESET = 1;
+
+    /**
+     * The delay between items was too long.<br/>
+     * The destination system did not timely acknowledge a block.
+     * <p>
+     * The source SHALL start a new stream before the failed block.
+     */
+    STREAM_END_TIMEOUT = 2;
+
+    /**
+     * The publisher encountered an error.<br/>
+     * The publisher encountered an internal error and must try again later.
+     * <p>
+     * Publishers that encounter internal logic errors, find themselves
+     * "behind" the network, or otherwise detect an unexpected situation MUST
+     * send this code and restart the stream before the failed block.
+     */
+    STREAM_END_ERROR = 3;
+
+    /**
+     * The block node is too far behind to catch up directly.<br/>
+     * The block node responded to a block header with "BEHIND" and is
+     * too far behind the publisher.
+     * <p>
+     * The block node MUST recover and "catch up" from another trustworthy
+     * block node.<br/>
+     * The publisher MAY stream items to a different block node.<br/>
+     * The publisher MAY resume streaming to this block node later.<br/>
+     * The `EndOfStream` message MUST include the earliest and latest blocks
+     * currently available from the publisher.<br/>
+     * The block node SHOULD attempt to "catch up" to the _latest_ block
+     * available from the publisher.
+     */
+    STREAM_END_TOO_FAR_BEHIND = 4;
+}
+
+/**
+ * A wrapper around a repeated BlockItem.<br/>
+ * This message is required so that we can include ordered lists of block
+ * items as `oneof` alternatives in streams.
+ *
+ * Each `BlockItemSet` MUST contain at least one `BlockItem`,
+ * and MAY contain up to one full block.<br/>
+ * A single `BlockItemSet` SHALL NOT contain block items from
+ * more than one block.<br/>
+ * If a `BlockHeader` is present in a `BlockItemSet`, that item
+ * MUST be the first item in the list.<br/>
+ * If a `BlockProof` is present in a `BlockItemSet`, that item
+ * MUST be the last item in the list.
+ */
+message BlockItemSet {
+    /**
+     * An ordered list of `BlockItem`s.<br/>
+     * This list supports sending block items to subscribers in batches
+     * for greater channel efficiency.
+     */
+    repeated com.hedera.hapi.block.stream.BlockItem block_items = 1;
 }
 
 /**
@@ -143,24 +204,24 @@ message PublishStreamResponse {
     }
 
     /**
-     * Acknowledgement for a single `BlockItem`.<br/>
+     * Acknowledgement for a single repeated `BlockItem`.<br/>
      * Most nodes are expected to implement this acknowledgement only for
      * debugging and development purposes.
      *
      * If a node implements single item acknowledgement, the block node SHALL
-     * send one `ItemAcknowledgement` for each `BlockItem` received
+     * send one `ItemAcknowledgement` for each repeated `BlockItem` received
      * and verified.
      */
     message ItemAcknowledgement {
         /**
-         * A SHA2-384 hash of the `BlockItem` received.
+         * A SHA2-384 hash of the `BlockItem`s received.
          * <p>
          * This field is REQUIRED.<br/>
          * A source system MUST verify that this value matches its own internal
          * calculated hash value, and MUST end the stream if the values do not
          * match.
          */
-        bytes item_hash = 1;
+        bytes items_hash = 1;
     }
 
     /**
@@ -245,7 +306,7 @@ message PublishStreamResponse {
 /**
  * An enumeration indicating the status of this request.
  *
- * This enumeration describes the reason a block stream
+ * This enumeration SHALL describe the reason a block stream
  * (sent via `publishBlockStream`) ended.
  */
 enum PublishStreamResponseCode {
@@ -378,9 +439,9 @@ message SingleBlockResponse {
     com.hedera.hapi.block.stream.Block block = 2;
 }
 
-    /**
-     * An enumeration indicating the status of this request.
-     */
+/**
+ * An enumeration indicating the status of this request.
+ */
 enum SingleBlockResponseCode {
     /**
      * An "unset value" flag, this value SHALL NOT be used.<br/>
@@ -539,12 +600,12 @@ message SubscribeStreamResponse {
         SubscribeStreamResponseCode status = 1;
 
         /**
-         * A stream response item containing a single `BlockItem`.
+         * A stream response item containing one or more `BlockItem`s.
          * <p>
-         * The full response SHALL consist of many `block_item` messages
+         * The full stream SHALL consist of many `block_items` messages
          * followed by a single `status` message.
          */
-        com.hedera.hapi.block.stream.BlockItem block_item = 2;
+        BlockItemSet block_items = 2;
     }
 }
 
@@ -790,9 +851,9 @@ message BlockNodeVersions {
 }
 
 /**
- * Remote procedure calls (RPCs) for the Block Node.
+ * Remote procedure calls (RPCs) for the Block Node ancillary services.
  */
-service BlockStreamService {
+service BlockNodeService {
     /**
      * Read the status of this block node server.
      * <p>
@@ -800,14 +861,25 @@ service BlockStreamService {
      * data or a state snapshot.
      */
     rpc serverStatus(ServerStatusRequest) returns (ServerStatusResponse);
+}
 
+/**
+ * Remote procedure calls (RPCs) for the Block Node block services.
+ */
+service BlockAccessService {
     /**
      * Read a single block from the block node.
      * <p>
      * The request SHALL describe the block number of the block to retrieve.
      */
     rpc singleBlock(SingleBlockRequest) returns (SingleBlockResponse);
+}
 
+/**
+ * Remote procedure calls (RPCs) for the Block Node state snapshot
+ * and query services.
+ */
+service StateService {
     /**
      * Read a state snapshot from the block node.
      * <p>
@@ -817,7 +889,12 @@ service BlockStreamService {
      * than the latest available, but MUST clearly document this behavior.
      */
     rpc stateSnapshot(StateSnapshotRequest) returns (StateSnapshotResponse);
+}
 
+/**
+ * Remote procedure calls (RPCs) for the Block Node stream services.
+ */
+service BlockStreamService {
     /**
      * Publish a stream of blocks.
      * <p>

--- a/hapi/hedera-protobufs/block/stream/output/block_header.proto
+++ b/hapi/hedera-protobufs/block/stream/output/block_header.proto
@@ -126,7 +126,7 @@ message BlockHeader {
      *               same order that the block items are encountered
      *               in the stream.</li>
      *           <li>The fourth leaf MUST be the merkle tree root hash for
-     *               network state at the end of the block, and is a single
+     *               network state at the start of the block, and is a single
      *               48-byte value.</li>
      *         </ol>
      *       </li>

--- a/hapi/hedera-protobufs/block/stream/output/consensus_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/consensus_service.proto
@@ -6,7 +6,11 @@
  * ### Topic Running Hash Calculation
  * Submitted messages include a topic running hash. This value has changed
  * over time, with the known versions detailed in the `RunningHashVersion`
- * enumeration.
+ * enumeration. The running hash version SHALL NOT be transmitted in the
+ * Block Stream, however, as it is a fixed value that can only be changed
+ * with a new release of consensus node software following a HIP to update
+ * the specification, so repeating that fixed value in the block stream is
+ * wasteful and unnecessary.
  *
  * ### Keywords
  * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",

--- a/hapi/hedera-protobufs/block/stream/output/schedule_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/schedule_service.proto
@@ -75,6 +75,7 @@ message CreateScheduleOutput {
      * other status, this value SHALL NOT be set.
      */
     proto.ScheduleID schedule_id = 1;
+
     /**
      * A scheduled transaction identifier.
      * <p>

--- a/hapi/hedera-protobufs/block/stream/output/smart_contract_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/smart_contract_service.proto
@@ -151,6 +151,7 @@ message EthereumOutput {
      * This field is not settled and MAY be removed or modified.
      */
     repeated proto.TransactionSidecarRecord sidecars = 1;
+
     /**
      * An ethereum hash value.
      * <p>

--- a/hapi/hedera-protobufs/block/stream/output/smart_contract_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/smart_contract_service.proto
@@ -50,6 +50,16 @@ import "sidecar_file.proto";
  * the original transaction.
  */
 message CallContractOutput {
+    /**
+     * A list of additional outputs.
+     * <p>
+     * This field MAY record one or more additional outputs and smart
+     * contract state changes produced during the ethereum call
+     * transaction handling.<br/>
+     * This field SHALL NOT be set if the transaction handling did not
+     * produce additional outputs.<br/>
+     * This field is not settled and MAY be removed or modified.
+     */
     repeated proto.TransactionSidecarRecord sidecars = 1;
 
     /**
@@ -68,6 +78,16 @@ message CallContractOutput {
  * the original transaction.
  */
 message CreateContractOutput {
+    /**
+     * A list of additional outputs.
+     * <p>
+     * This field MAY record one or more additional outputs and smart
+     * contract state changes produced during the ethereum call
+     * transaction handling.<br/>
+     * This field SHALL NOT be set if the transaction handling did not
+     * produce additional outputs.<br/>
+     * This field is not settled and MAY be removed or modified.
+     */
     repeated proto.TransactionSidecarRecord sidecars = 1;
 
     /**

--- a/hapi/hedera-protobufs/block/stream/output/transaction_result.proto
+++ b/hapi/hedera-protobufs/block/stream/output/transaction_result.proto
@@ -34,8 +34,6 @@ option java_package = "com.hedera.hapi.block.stream.output.protoc";
 option java_multiple_files = true;
 
 import "basic_types.proto";
-//import "custom_fees.proto";
-import "exchange_rate.proto";
 import "response_code.proto";
 import "timestamp.proto";
 
@@ -79,14 +77,6 @@ message TransactionResult {
      * part of completing a user-submitted transaction.
      */
     proto.Timestamp parent_consensus_timestamp = 3;
-
-    /**
-     * An exchange rate set.
-     * <p>
-     * This field SHALL describe the exchange rates in effect when this
-     * transaction reached consensus.
-     */
-    proto.ExchangeRateSet exchange_rate = 4;
 
     /**
      * A schedule that executed this transaction, if this transaction

--- a/hapi/hedera-protobufs/services/auxiliary/tss/tss_message.proto
+++ b/hapi/hedera-protobufs/services/auxiliary/tss/tss_message.proto
@@ -48,7 +48,7 @@ option java_multiple_files = true;
 message TssMessageTransactionBody {
 
   /**
-   * A hash of the roster containing the node generating the TssMessage.</br>
+   * A hash of the roster containing the node generating the TssMessage.<br/>
    * This hash uniquely identifies the source roster, which will include
    * an entry for the node generating this TssMessage.
    * <p>

--- a/hapi/hedera-protobufs/services/basic_types.proto
+++ b/hapi/hedera-protobufs/services/basic_types.proto
@@ -1246,7 +1246,7 @@ enum HederaFunctionality {
     TokenCancelAirdrop = 94;
 
     /**
-      * Claim one or more pending airdrops
+     * Claim one or more pending airdrops
      */
     TokenClaimAirdrop = 95;
 

--- a/hapi/hedera-protobufs/services/state/blockstream/block_stream_info.proto
+++ b/hapi/hedera-protobufs/services/state/blockstream/block_stream_info.proto
@@ -88,7 +88,7 @@ message BlockStreamInfo {
      * The latest available hash SHALL be for block N-1.<br/>
      * This is REQUIRED to implement the EVM `BLOCKHASH` opcode.
      * <p>
-     * <div style="display: block;font-size: .83em;margin-top: 1.67em;margin-bottom: 1.67em;margin-left: 0;margin-right: 0;font-weight: bold;">Field Length</div>
+     * ### Field Length
      * Each hash value SHALL be the trailing 265 bits of a SHA2-384 hash.<br/>
      * The length of this field SHALL be an integer multiple of 32 bytes.<br/>
      * This field SHALL be at least 32 bytes.<br/>
@@ -143,9 +143,9 @@ message BlockStreamInfo {
 
     /**
      * A version describing the version of application software.
-    * <p>
-    * This SHALL be the software version that created this block.
-    */
+     * <p>
+     * This SHALL be the software version that created this block.
+     */
     proto.SemanticVersion creation_software_version = 11;
 
     /**

--- a/hapi/hedera-protobufs/services/state/recordcache/recordcache.proto
+++ b/hapi/hedera-protobufs/services/state/recordcache/recordcache.proto
@@ -1,13 +1,22 @@
+/**
+ * # Record Cache
+ * The Record Cache holds transaction records for a short time, and is the
+ * source for responses to `transactionGetRecord` and `transactionGetReceipt`
+ * queries.
+ *
+ * ### Keywords
+ * The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+ * "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+ * document are to be interpreted as described in [RFC2119](https://www.ietf.org/rfc/rfc2119)
+ * and clarified in [RFC8174](https://www.ietf.org/rfc/rfc8174).
+ */
 syntax = "proto3";
 
 package proto;
 
-/*-
- * ‌
- * Hedera Network Services Protobuf
- * ​
- * Copyright (C) 2018 - 2023 Hedera Hashgraph, LLC
- * ​
+/*
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,7 +28,6 @@ package proto;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * ‍
  */
 
 import "basic_types.proto";
@@ -31,56 +39,82 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * As transactions are handled and records and receipts are created, they are stored in state for a configured time
- * limit (perhaps, for example, 3 minutes). During this time window, any client can query the node and get the record
- * or receipt for the transaction. The TransactionRecordEntry is the object stored in state with this information.
+ * As transactions are handled and records and receipts are created, they are
+ * stored in state for a configured time period (for example, 3 minutes).
+ * During this time, any client can query the node and get the record or receipt
+ * for the transaction. The `TransactionRecordEntry` is the object stored in
+ * state with this information.
  */
 message TransactionRecordEntry {
     /**
-     * The ID of the node that submitted the transaction to consensus. The ID is the ID of the node as known by the
-     * address book. Valid node IDs are in the range 0..2^63-1, inclusive.
+     * A node identifier.<br/>
+     * This identifier is the node, as known to the address book, that
+     * submitted the transaction for consensus.
+     * <p>
+     * This SHALL be a whole number.
      */
     int64 node_id = 1;
 
     /**
-     * The AccountID of the payer of the transaction. This may be the same as the account ID within the Transaction ID
-     * of the record, or it may be the account ID of the node that submitted the transaction to consensus if the account
-     * ID in the Transaction ID is not able to pay.
+     * An Account identifier for the payer for the transaction.
+     * <p>
+     * This MAY be the same as the account ID within the Transaction ID of the
+     * record, or it MAY be the account ID of the node that submitted the
+     * transaction to consensus if the account ID in the Transaction ID was
+     * not able to pay.
      */
     AccountID payer_account_id = 2;
 
     /**
-     * The transaction record for the transaction.
+     * A transaction record for the transaction.
      */
     TransactionRecord transaction_record = 3;
 }
+
 /**
- * As a single transaction is handled a receipt is created. It is stored in state for a configured time
- * limit (perhaps, for example, 3 minutes). During this time window, any client can query the node and get the
- * receipt for the transaction. The TransactionReceiptEntry is the object stored in state with this information.
+ * An entry in the record cache with the receipt for a transaction.
+ * This is the entry stored in state that enables returning the receipt
+ * information when queried by clients.
+ *
+ * When a transaction is handled a receipt SHALL be created.<br/>
+ * This receipt MUST be stored in state for a configured time limit
+ * (e.g. 3 minutes).<br/>
+ * While a receipt is stored, a client MAY query the node and retrieve
+ * the receipt.
  */
 message TransactionReceiptEntry {
     /**
-    * The ID of the node that submitted the transaction to consensus. The ID is the ID of the node as known by the
-    * address book. Valid node IDs are in the range 0..2^63-1, inclusive.
-    */
+     * A node identifier.<br/>
+     * This identifies the node that submitted the transaction to consensus.
+     * The value is the identifier as known to the current address book.
+     * <p>
+     * Valid node identifiers SHALL be between 0 and <tt>2<sup>63-1</sup></tt>,
+     * inclusive.
+     */
     uint64 node_id = 1;
 
     /**
-     * The id of the submitted transaction.
+     * A transaction identifier.<br/>
+     * This identifies the submitted transaction for this receipt.
      */
     TransactionID transaction_id = 2;
 
     /**
-     * The resulting status of handling the transaction.
+     * A status result.<br/>
+     * This is the final status after handling the transaction.
      */
     ResponseCodeEnum status = 3;
 }
+
 /**
- * As transactions are handled and receipts are created, they are stored in state for a configured time
- * limit (perhaps, for example, 3 minutes). During this time window, any client can query the node and get the
- * receipt for the transaction. The TransactionReceiptEntries is the object stored in state with this information.
- * This object contains a list of TransactionReceiptEntry objects.
+ * A cache of transaction receipts.<br/>
+ * As transactions are handled and receipts are created, they are stored in
+ * state for a configured time limit (perhaps, for example, 3 minutes).
+ * During this time window, any client can query the node and get the receipt
+ * for the transaction. The `TransactionReceiptEntries` is the object stored in
+ * state with this information.
+ *
+ * This message SHALL contain a list of `TransactionReceiptEntry` objects.
  */
 message TransactionReceiptEntries {
     repeated TransactionReceiptEntry entries = 1;

--- a/hapi/hedera-protobufs/services/state/roster/ledger_id.proto
+++ b/hapi/hedera-protobufs/services/state/roster/ledger_id.proto
@@ -83,7 +83,7 @@ message LedgerId {
   /**
    * A signature from the prior ledger key.<br/>
    * This signature is the _previous_ ledger ID signing _this_ ledger ID.<br/>
-   * This value MAY be unset, if there is no prior ledger ID.</br>
+   * This value MAY be unset, if there is no prior ledger ID.<br/>
    * This value SHOULD be set if a prior ledger ID exists
    * to generate the signature.
    */

--- a/hapi/hedera-protobufs/services/state/roster/roster.proto
+++ b/hapi/hedera-protobufs/services/state/roster/roster.proto
@@ -31,13 +31,13 @@ option java_multiple_files = true;
  */
 message Roster {
 
-  /**
-   * List of roster entries, one per consensus node.
-   * <p>
-   * This list SHALL contain roster entries in natural order of ascending node ids.
-   * This list SHALL NOT be empty.<br/>
-   */
-  repeated RosterEntry roster_entries = 1;
+    /**
+     * List of roster entries, one per consensus node.
+     * <p>
+     * This list SHALL contain roster entries in natural order of ascending node ids.
+     * This list SHALL NOT be empty.<br/>
+     */
+    repeated RosterEntry roster_entries = 1;
 }
 
 /**
@@ -49,59 +49,59 @@ message Roster {
  */
 message RosterEntry {
 
-  /**
-   * A consensus node identifier.
-   * <p>
-   * Node identifiers SHALL be unique _within_ a ledger,
-   * and MUST NOT be repeated _between_ shards and realms.
-   */
-  uint64 node_id = 1;
+    /**
+     * A consensus node identifier.
+     * <p>
+     * Node identifiers SHALL be unique _within_ a ledger,
+     * and MUST NOT be repeated _between_ shards and realms.
+     */
+    uint64 node_id = 1;
 
-  /**
-   * A consensus weight.
-   * <p>
-   * Each node SHALL have a weight of zero or more in consensus calculations.<br/>
-   * The sum of the weights of all nodes in the roster SHALL form the total weight of the system,
-   * and each node's individual weight SHALL be proportional to that sum.<br/>
-   */
-  uint64 weight = 2;
+    /**
+     * A consensus weight.
+     * <p>
+     * Each node SHALL have a weight of zero or more in consensus calculations.<br/>
+     * The sum of the weights of all nodes in the roster SHALL form the total weight of the system,
+     * and each node's individual weight SHALL be proportional to that sum.<br/>
+     */
+    uint64 weight = 2;
 
-  /**
-   * An RSA public certificate used for signing gossip events.
-   * <p>
-   * This value SHALL be a certificate of a type permitted for gossip
-   * signatures.<br/>
-   * This value SHALL be the DER encoding of the certificate presented.<br/>
-   * This field is REQUIRED and MUST NOT be empty.
-   */
-  bytes gossip_ca_certificate = 3;
+    /**
+     * An RSA public certificate used for signing gossip events.
+     * <p>
+     * This value SHALL be a certificate of a type permitted for gossip
+     * signatures.<br/>
+     * This value SHALL be the DER encoding of the certificate presented.<br/>
+     * This field is REQUIRED and MUST NOT be empty.
+     */
+    bytes gossip_ca_certificate = 3;
 
-  /**
-   * An elliptic curve public encryption key.<br/>
-   * This is currently an ALT_BN128 curve, but the elliptic curve
-   * type may change in the future. For example,
-   * if the Ethereum ecosystem creates precompiles for BLS12_381,
-   * we may switch to that curve.
-   * <p>
-   * This value SHALL be specified according to EIP-196 and EIP-197 standards,
-   * See <a href='https://eips.ethereum.org/EIPS/eip-196#encoding'>EIP-196</a> and
-   * <a href='https://eips.ethereum.org/EIPS/eip-197#encoding'>EIP-197</a><br/>
-   * This field is _initially_ OPTIONAL (i.e. it can be unset _when created_)
-   * but once set, it is REQUIRED thereafter.
-   */
-  bytes tss_encryption_key = 4;
+    /**
+     * An elliptic curve public encryption key.<br/>
+     * This is currently an ALT_BN128 curve, but the elliptic curve
+     * type may change in the future. For example,
+     * if the Ethereum ecosystem creates precompiles for BLS12_381,
+     * we may switch to that curve.
+     * <p>
+     * This value SHALL be specified according to EIP-196 and EIP-197 standards,
+     * See <a href='https://eips.ethereum.org/EIPS/eip-196#encoding'>EIP-196</a> and
+     * <a href='https://eips.ethereum.org/EIPS/eip-197#encoding'>EIP-197</a><br/>
+     * This field is _initially_ OPTIONAL (i.e. it can be unset _when created_)
+     * but once set, it is REQUIRED thereafter.
+     */
+    bytes tss_encryption_key = 4;
 
-  /**
-   * A list of service endpoints for gossip.
-   * <p>
-   * These endpoints SHALL represent the published endpoints to which other
-   * consensus nodes may _gossip_ transactions.<br/>
-   * If the network configuration value `gossipFqdnRestricted` is set, then
-   * all endpoints in this list SHALL supply only IP address.<br/>
-   * If the network configuration value `gossipFqdnRestricted` is _not_ set,
-   * then endpoints in this list MAY supply either IP address or FQDN, but
-   * SHALL NOT supply both values for the same endpoint.<br/>
-   * This list SHALL NOT be empty.<br/>
-   */
-  repeated proto.ServiceEndpoint gossip_endpoint = 5;
+    /**
+     * A list of service endpoints for gossip.
+     * <p>
+     * These endpoints SHALL represent the published endpoints to which other
+     * consensus nodes may _gossip_ transactions.<br/>
+     * If the network configuration value `gossipFqdnRestricted` is set, then
+     * all endpoints in this list SHALL supply only IP address.<br/>
+     * If the network configuration value `gossipFqdnRestricted` is _not_ set,
+     * then endpoints in this list MAY supply either IP address or FQDN, but
+     * SHALL NOT supply both values for the same endpoint.<br/>
+     * This list SHALL NOT be empty.<br/>
+     */
+    repeated proto.ServiceEndpoint gossip_endpoint = 5;
 }

--- a/hapi/hedera-protobufs/services/state/tss/tss_vote_map_key.proto
+++ b/hapi/hedera-protobufs/services/state/tss/tss_vote_map_key.proto
@@ -32,27 +32,27 @@ option java_package = "com.hedera.hapi.node.state.tss.legacy";
 // <<<pbj.java_package = "com.hedera.hapi.node.state.tss">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
- /**
-  * A key for use in the Threshold Signature Scheme (TSS) TssVoteMaps.
-  *
-  * This key SHALL be used to uniquely identify entries in the Vote Maps.
-  */
+/**
+ * A key for use in the Threshold Signature Scheme (TSS) TssVoteMaps.
+ *
+ * This key SHALL be used to uniquely identify entries in the Vote Maps.
+ */
 message TssVoteMapKey {
 
-  /**
-   * A hash of the target roster for the associated value in the map. <br/>
-   * This hash uniquely identifies the target roster.
-   * <p>
-   * This value MUST be set.<br/>
-   * This value MUST contain a valid hash.
-   */
-  bytes roster_hash = 1;
+    /**
+     * A hash of the target roster for the associated value in the map. <br/>
+     * This hash uniquely identifies the target roster.
+     * <p>
+     * This value MUST be set.<br/>
+     * This value MUST contain a valid hash.
+     */
+    bytes roster_hash = 1;
 
-  /** The node id of the node that created the TssVote.</br>
-  * This id uniquely identifies the node.
-  * <p>
-  * This value MUST be set.<br/>
-  * This value MUST be a valid node id.
-  */
-  uint64 node_id = 2;
+    /** The node id of the node that created the TssVote.<br/>
+     * This id uniquely identifies the node.
+     * <p>
+     * This value MUST be set.<br/>
+     * This value MUST be a valid node id.
+     */
+    uint64 node_id = 2;
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockItemsTranslator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockItemsTranslator.java
@@ -71,8 +71,9 @@ public class BlockItemsTranslator {
         requireNonNull(context);
         requireNonNull(result);
         requireNonNull(outputs);
-        final var receiptBuilder =
-                TransactionReceipt.newBuilder().status(result.status()).exchangeRate(result.exchangeRate());
+        final var receiptBuilder = TransactionReceipt.newBuilder()
+                .status(result.status())
+                .exchangeRate(context.transactionExchangeRates());
         final var function = context.functionality();
         switch (function) {
             case CONTRACT_CALL,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
@@ -185,6 +185,10 @@ public class BlockStreamBuilder
     @Nullable
     private HederaFunctionality functionality;
     /**
+     * The exchange rate set to add to the record stream transaction receipt.
+     */
+    private ExchangeRateSet translationContextExchangeRates;
+    /**
      * The memo from the transaction, set explicitly to avoid parsing the transaction again.
      */
     private String memo;
@@ -840,7 +844,10 @@ public class BlockStreamBuilder
     @NonNull
     @Override
     public BlockStreamBuilder exchangeRate(@Nullable final ExchangeRateSet exchangeRate) {
-        transactionResultBuilder.exchangeRate(exchangeRate);
+        // Block Stream doesn't include exchange rate in output (it's in state
+        // changes when it is updated), so store exchange rate for the
+        // translation context
+        translationContextExchangeRates = exchangeRate;
         return this;
     }
 
@@ -1171,27 +1178,58 @@ public class BlockStreamBuilder
                     CONTRACT_DELETE,
                     CONTRACT_UPDATE,
                     ETHEREUM_TRANSACTION -> new ContractOpContext(
-                    memo, transactionId, transaction, functionality, contractId);
+                    memo, translationContextExchangeRates, transactionId, transaction, functionality, contractId);
             case CRYPTO_CREATE, CRYPTO_UPDATE -> new CryptoOpContext(
-                    memo, transactionId, transaction, functionality, accountId, evmAddress);
-            case FILE_CREATE -> new FileOpContext(memo, transactionId, transaction, functionality, fileId);
-            case NODE_CREATE -> new NodeOpContext(memo, transactionId, transaction, functionality, nodeId);
-            case SCHEDULE_DELETE -> new ScheduleOpContext(memo, transactionId, transaction, functionality, scheduleId);
+                    memo,
+                    translationContextExchangeRates,
+                    transactionId,
+                    transaction,
+                    functionality,
+                    accountId,
+                    evmAddress);
+            case FILE_CREATE -> new FileOpContext(
+                    memo, translationContextExchangeRates, transactionId, transaction, functionality, fileId);
+            case NODE_CREATE -> new NodeOpContext(
+                    memo, translationContextExchangeRates, transactionId, transaction, functionality, nodeId);
+            case SCHEDULE_DELETE -> new ScheduleOpContext(
+                    memo, translationContextExchangeRates, transactionId, transaction, functionality, scheduleId);
             case CONSENSUS_SUBMIT_MESSAGE -> new SubmitOpContext(
-                    memo, transactionId, transaction, functionality, runningHash, runningHashVersion, sequenceNumber);
+                    memo,
+                    translationContextExchangeRates,
+                    transactionId,
+                    transaction,
+                    functionality,
+                    runningHash,
+                    runningHashVersion,
+                    sequenceNumber);
             case TOKEN_AIRDROP -> {
                 if (!pendingAirdropRecords.isEmpty()) {
                     pendingAirdropRecords.sort(PENDING_AIRDROP_RECORD_COMPARATOR);
                 }
-                yield new AirdropOpContext(memo, transactionId, transaction, functionality, pendingAirdropRecords);
+                yield new AirdropOpContext(
+                        memo,
+                        translationContextExchangeRates,
+                        transactionId,
+                        transaction,
+                        functionality,
+                        pendingAirdropRecords);
             }
             case TOKEN_MINT -> new MintOpContext(
-                    memo, transactionId, transaction, functionality, serialNumbers, newTotalSupply);
+                    memo,
+                    translationContextExchangeRates,
+                    transactionId,
+                    transaction,
+                    functionality,
+                    serialNumbers,
+                    newTotalSupply);
             case TOKEN_BURN, TOKEN_ACCOUNT_WIPE -> new SupplyChangeOpContext(
-                    memo, transactionId, transaction, functionality, newTotalSupply);
-            case TOKEN_CREATE -> new TokenOpContext(memo, transactionId, transaction, functionality, tokenId);
-            case CONSENSUS_CREATE_TOPIC -> new TopicOpContext(memo, transactionId, transaction, functionality, topicId);
-            default -> new BaseOpContext(memo, transactionId, transaction, functionality);
+                    memo, translationContextExchangeRates, transactionId, transaction, functionality, newTotalSupply);
+            case TOKEN_CREATE -> new TokenOpContext(
+                    memo, translationContextExchangeRates, transactionId, transaction, functionality, tokenId);
+            case CONSENSUS_CREATE_TOPIC -> new TopicOpContext(
+                    memo, translationContextExchangeRates, transactionId, transaction, functionality, topicId);
+            default -> new BaseOpContext(
+                    memo, translationContextExchangeRates, transactionId, transaction, functionality);
         };
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/GrpcBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/GrpcBlockItemWriter.java
@@ -177,10 +177,9 @@ public class GrpcBlockItemWriter implements BlockItemWriter {
         PublishStreamRequest request = PublishStreamRequest.newBuilder().build();
         try {
             BlockItemSet items = BlockItemSet.newBuilder()
-                    .addBlockItems(BlockItem.parseFrom(bytes)).build();
-            request = PublishStreamRequest.newBuilder()
-                    .setBlockItems(items)
+                    .addBlockItems(BlockItem.parseFrom(bytes))
                     .build();
+            request = PublishStreamRequest.newBuilder().setBlockItems(items).build();
             requestObserver.onNext(request);
         } catch (IOException e) {
             final String message = INVALID_MESSAGE.formatted("PublishStreamResponse", request);
@@ -202,9 +201,7 @@ public class GrpcBlockItemWriter implements BlockItemWriter {
             BlockItemSet items = BlockItemSet.newBuilder()
                     .addBlockItems(BlockItem.parseFrom(data.asInputStream()))
                     .build();
-            request = PublishStreamRequest.newBuilder()
-                    .setBlockItems(items)
-                    .build();
+            request = PublishStreamRequest.newBuilder().setBlockItems(items).build();
             requestObserver.onNext(request);
         } catch (IOException e) {
             final String message = INVALID_MESSAGE.formatted("PublishStreamResponse", request);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/GrpcBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/GrpcBlockItemWriter.java
@@ -21,6 +21,7 @@ import static io.grpc.Status.fromThrowable;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.hedera.hapi.block.protoc.BlockItemSet;
 import com.hedera.hapi.block.protoc.BlockStreamServiceGrpc;
 import com.hedera.hapi.block.protoc.PublishStreamRequest;
 import com.hedera.hapi.block.protoc.PublishStreamResponse;
@@ -175,8 +176,10 @@ public class GrpcBlockItemWriter implements BlockItemWriter {
 
         PublishStreamRequest request = PublishStreamRequest.newBuilder().build();
         try {
+            BlockItemSet items = BlockItemSet.newBuilder()
+                    .addBlockItems(BlockItem.parseFrom(bytes)).build();
             request = PublishStreamRequest.newBuilder()
-                    .setBlockItem(BlockItem.parseFrom(bytes))
+                    .setBlockItems(items)
                     .build();
             requestObserver.onNext(request);
         } catch (IOException e) {
@@ -196,8 +199,11 @@ public class GrpcBlockItemWriter implements BlockItemWriter {
 
         PublishStreamRequest request = PublishStreamRequest.newBuilder().build();
         try {
+            BlockItemSet items = BlockItemSet.newBuilder()
+                    .addBlockItems(BlockItem.parseFrom(data.asInputStream()))
+                    .build();
             request = PublishStreamRequest.newBuilder()
-                    .setBlockItem(BlockItem.parseFrom(data.asInputStream()))
+                    .setBlockItems(items)
                     .build();
             requestObserver.onNext(request);
         } catch (IOException e) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/TranslationContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/TranslationContext.java
@@ -23,6 +23,7 @@ import com.hedera.hapi.block.stream.output.TransactionResult;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 
@@ -36,6 +37,12 @@ public interface TranslationContext {
      * @return the memo
      */
     String memo();
+
+    /**
+     * The exchange rate set to include in the receipt for this transaction.
+     * @return an exchange rate set applicable to the transaction receipt.
+     */
+    ExchangeRateSet transactionExchangeRates();
 
     /**
      * Returns the transaction ID of the transaction.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/AirdropOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/AirdropOpContext.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.blocks.impl.contexts;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.hapi.node.transaction.PendingAirdropRecord;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -34,6 +35,7 @@ import java.util.List;
  */
 public record AirdropOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/BaseOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/BaseOpContext.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.blocks.impl.contexts;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -32,6 +33,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public record BaseOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/ContractOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/ContractOpContext.java
@@ -20,6 +20,7 @@ import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -34,6 +35,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  */
 public record ContractOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/CryptoOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/CryptoOpContext.java
@@ -20,6 +20,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -37,6 +38,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  */
 public record CryptoOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/FileOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/FileOpContext.java
@@ -20,6 +20,7 @@ import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -34,6 +35,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  */
 public record FileOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/MintOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/MintOpContext.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.blocks.impl.contexts;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
@@ -34,6 +35,7 @@ import java.util.List;
  */
 public record MintOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/NodeOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/NodeOpContext.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.blocks.impl.contexts;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -32,6 +33,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public record NodeOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/ScheduleOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/ScheduleOpContext.java
@@ -20,6 +20,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -33,6 +34,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public record ScheduleOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/SubmitOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/SubmitOpContext.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.blocks.impl.contexts;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -35,6 +36,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public record SubmitOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/SupplyChangeOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/SupplyChangeOpContext.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.blocks.impl.contexts;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -32,6 +33,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public record SupplyChangeOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/TokenOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/TokenOpContext.java
@@ -20,6 +20,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -33,6 +34,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public record TokenOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/TopicOpContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/contexts/TopicOpContext.java
@@ -20,6 +20,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.node.app.blocks.impl.TranslationContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -33,6 +34,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  */
 public record TopicOpContext(
         @NonNull String memo,
+        @NonNull ExchangeRateSet transactionExchangeRates,
         @NonNull TransactionID txnId,
         @NonNull Transaction transaction,
         @NonNull HederaFunctionality functionality,

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockItemsTranslatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockItemsTranslatorTest.java
@@ -142,7 +142,6 @@ class BlockItemsTranslatorTest {
             .nextRate(new ExchangeRate(3, 4, TimestampSeconds.DEFAULT))
             .build();
     private static final TransactionResult TRANSACTION_RESULT = TransactionResult.newBuilder()
-            .exchangeRate(RATES)
             .consensusTimestamp(CONSENSUS_TIME)
             .parentConsensusTimestamp(PARENT_CONSENSUS_TIME)
             .scheduleRef(SCHEDULE_REF)
@@ -216,7 +215,7 @@ class BlockItemsTranslatorTest {
                 "TOKEN_BURN",
             })
     void mostOpsUseJustUseBaseOpContextForReceipt(@NonNull final HederaFunctionality function) {
-        final var context = new BaseOpContext(MEMO, TXN_ID, Transaction.DEFAULT, function);
+        final var context = new BaseOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, function);
 
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT, actualReceipt);
@@ -233,7 +232,7 @@ class BlockItemsTranslatorTest {
                 "ETHEREUM_TRANSACTION",
             })
     void contractOpsUseContractOpContext(@NonNull final HederaFunctionality function) {
-        final var context = new ContractOpContext(MEMO, TXN_ID, Transaction.DEFAULT, function, CONTRACT_ID);
+        final var context = new ContractOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, function, CONTRACT_ID);
 
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT.copyBuilder().contractID(CONTRACT_ID).build(), actualReceipt);
@@ -247,35 +246,37 @@ class BlockItemsTranslatorTest {
                 "CRYPTO_UPDATE",
             })
     void certainCryptoOpsUseCryptoOpContext(@NonNull final HederaFunctionality function) {
-        final var context = new CryptoOpContext(MEMO, TXN_ID, Transaction.DEFAULT, function, ACCOUNT_ID, EVM_ADDRESS);
+        final var context =
+                new CryptoOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, function, ACCOUNT_ID, EVM_ADDRESS);
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT.copyBuilder().accountID(ACCOUNT_ID).build(), actualReceipt);
     }
 
     @Test
     void fileCreateUsesFileOpContext() {
-        final var context = new FileOpContext(MEMO, TXN_ID, Transaction.DEFAULT, FILE_CREATE, FILE_ID);
+        final var context = new FileOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, FILE_CREATE, FILE_ID);
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT.copyBuilder().fileID(FILE_ID).build(), actualReceipt);
     }
 
     @Test
     void nodeCreateUsesNodeOpContext() {
-        final var context = new NodeOpContext(MEMO, TXN_ID, Transaction.DEFAULT, NODE_CREATE, NODE_ID);
+        final var context = new NodeOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, NODE_CREATE, NODE_ID);
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT.copyBuilder().nodeId(NODE_ID).build(), actualReceipt);
     }
 
     @Test
     void tokenCreateUsesTokenOpContext() {
-        final var context = new TokenOpContext(MEMO, TXN_ID, Transaction.DEFAULT, TOKEN_CREATE, TOKEN_ID);
+        final var context = new TokenOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, TOKEN_CREATE, TOKEN_ID);
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT.copyBuilder().tokenID(TOKEN_ID).build(), actualReceipt);
     }
 
     @Test
     void topicCreateUsesTopicOpContext() {
-        final var context = new TopicOpContext(MEMO, TXN_ID, Transaction.DEFAULT, CONSENSUS_CREATE_TOPIC, TOPIC_ID);
+        final var context =
+                new TopicOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, CONSENSUS_CREATE_TOPIC, TOPIC_ID);
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT.copyBuilder().topicID(TOPIC_ID).build(), actualReceipt);
     }
@@ -285,7 +286,7 @@ class BlockItemsTranslatorTest {
         final var output = TransactionOutput.newBuilder()
                 .createSchedule(new CreateScheduleOutput(SCHEDULE_ID, SCHEDULED_TXN_ID))
                 .build();
-        final var context = new BaseOpContext(MEMO, TXN_ID, Transaction.DEFAULT, SCHEDULE_CREATE);
+        final var context = new BaseOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, SCHEDULE_CREATE);
 
         final var actualReceiptNoOutput = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT, actualReceiptNoOutput);
@@ -306,7 +307,7 @@ class BlockItemsTranslatorTest {
         final var output = TransactionOutput.newBuilder()
                 .signSchedule(new SignScheduleOutput(SCHEDULED_TXN_ID))
                 .build();
-        final var context = new BaseOpContext(MEMO, TXN_ID, Transaction.DEFAULT, SCHEDULE_SIGN);
+        final var context = new BaseOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, SCHEDULE_SIGN);
 
         final var actualReceiptNoOutput = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT, actualReceiptNoOutput);
@@ -323,7 +324,8 @@ class BlockItemsTranslatorTest {
 
     @Test
     void scheduleDeleteUsesScheduleOpContext() {
-        final var context = new ScheduleOpContext(MEMO, TXN_ID, Transaction.DEFAULT, SCHEDULE_DELETE, SCHEDULE_ID);
+        final var context =
+                new ScheduleOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, SCHEDULE_DELETE, SCHEDULE_ID);
 
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECEIPT.copyBuilder().scheduleID(SCHEDULE_ID).build(), actualReceipt);
@@ -333,6 +335,7 @@ class BlockItemsTranslatorTest {
     void submitMessageUsesSubmitOpContext() {
         final var context = new SubmitOpContext(
                 MEMO,
+                RATES,
                 TXN_ID,
                 Transaction.DEFAULT,
                 CONSENSUS_SUBMIT_MESSAGE,
@@ -354,7 +357,7 @@ class BlockItemsTranslatorTest {
     @Test
     void tokenMintUsesMintOpContext() {
         final var context =
-                new MintOpContext(MEMO, TXN_ID, Transaction.DEFAULT, TOKEN_MINT, SERIAL_NOS, NEW_TOTAL_SUPPLY);
+                new MintOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, TOKEN_MINT, SERIAL_NOS, NEW_TOTAL_SUPPLY);
 
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(
@@ -374,7 +377,8 @@ class BlockItemsTranslatorTest {
                 "TOKEN_BURN",
             })
     void supplyChangeOpsUseSupplyChangeContext(@NonNull final HederaFunctionality function) {
-        final var context = new SupplyChangeOpContext(MEMO, TXN_ID, Transaction.DEFAULT, function, NEW_TOTAL_SUPPLY);
+        final var context =
+                new SupplyChangeOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, function, NEW_TOTAL_SUPPLY);
         final var actualReceipt = BLOCK_ITEMS_TRANSLATOR.translateReceipt(context, TRANSACTION_RESULT);
         assertEquals(
                 EXPECTED_BASE_RECEIPT
@@ -391,7 +395,7 @@ class BlockItemsTranslatorTest {
         final var output = TransactionOutput.newBuilder()
                 .contractCall(new CallContractOutput(List.of(), FUNCTION_RESULT))
                 .build();
-        final var context = new ContractOpContext(MEMO, TXN_ID, Transaction.DEFAULT, CONTRACT_CALL, CONTRACT_ID);
+        final var context = new ContractOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, CONTRACT_CALL, CONTRACT_ID);
 
         final var actualRecordNoOutput = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(
@@ -423,7 +427,8 @@ class BlockItemsTranslatorTest {
         final var output = TransactionOutput.newBuilder()
                 .contractCreate(new CreateContractOutput(List.of(), FUNCTION_RESULT))
                 .build();
-        final var context = new ContractOpContext(MEMO, TXN_ID, Transaction.DEFAULT, CONTRACT_CREATE, CONTRACT_ID);
+        final var context =
+                new ContractOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, CONTRACT_CREATE, CONTRACT_ID);
 
         final var actualRecordNoOutput = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(
@@ -458,7 +463,8 @@ class BlockItemsTranslatorTest {
                         .ethereumCallResult(FUNCTION_RESULT)
                         .build())
                 .build();
-        final var context = new ContractOpContext(MEMO, TXN_ID, Transaction.DEFAULT, ETHEREUM_TRANSACTION, CONTRACT_ID);
+        final var context =
+                new ContractOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, ETHEREUM_TRANSACTION, CONTRACT_ID);
 
         final var actualRecordNoOutput = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(
@@ -494,7 +500,8 @@ class BlockItemsTranslatorTest {
                         .ethereumCreateResult(FUNCTION_RESULT)
                         .build())
                 .build();
-        final var context = new ContractOpContext(MEMO, TXN_ID, Transaction.DEFAULT, ETHEREUM_TRANSACTION, CONTRACT_ID);
+        final var context =
+                new ContractOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, ETHEREUM_TRANSACTION, CONTRACT_ID);
 
         final var actualRecordNoOutput = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(
@@ -527,7 +534,7 @@ class BlockItemsTranslatorTest {
         final var output = TransactionOutput.newBuilder()
                 .contractCall(new CallContractOutput(List.of(), FUNCTION_RESULT))
                 .build();
-        final var context = new BaseOpContext(MEMO, TXN_ID, Transaction.DEFAULT, CRYPTO_TRANSFER);
+        final var context = new BaseOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, CRYPTO_TRANSFER);
 
         final var actualRecordNoOutput = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECORD, actualRecordNoOutput);
@@ -546,7 +553,7 @@ class BlockItemsTranslatorTest {
         final var output = TransactionOutput.newBuilder()
                 .cryptoTransfer(new CryptoTransferOutput(ASSESSED_CUSTOM_FEES))
                 .build();
-        final var context = new BaseOpContext(MEMO, TXN_ID, Transaction.DEFAULT, CRYPTO_TRANSFER);
+        final var context = new BaseOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, CRYPTO_TRANSFER);
 
         final var actualRecordNoOutput = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECORD, actualRecordNoOutput);
@@ -568,7 +575,8 @@ class BlockItemsTranslatorTest {
                 "CRYPTO_UPDATE",
             })
     void certainCryptoOpsUseEvmAddressFromContext(@NonNull final HederaFunctionality function) {
-        final var context = new CryptoOpContext(MEMO, TXN_ID, Transaction.DEFAULT, function, ACCOUNT_ID, EVM_ADDRESS);
+        final var context =
+                new CryptoOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, function, ACCOUNT_ID, EVM_ADDRESS);
         final var actualRecord = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(
                 EXPECTED_BASE_RECORD
@@ -585,7 +593,7 @@ class BlockItemsTranslatorTest {
     @Test
     void tokenAirdropUsesPendingFromContext() {
         final var context =
-                new AirdropOpContext(MEMO, TXN_ID, Transaction.DEFAULT, TOKEN_AIRDROP, PENDING_AIRDROP_RECORDS);
+                new AirdropOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, TOKEN_AIRDROP, PENDING_AIRDROP_RECORDS);
         final var actualRecord = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(
                 EXPECTED_BASE_RECORD
@@ -603,7 +611,7 @@ class BlockItemsTranslatorTest {
         final var seedOutput = TransactionOutput.newBuilder()
                 .utilPrng(UtilPrngOutput.newBuilder().prngBytes(RUNNING_HASH).build())
                 .build();
-        final var context = new BaseOpContext(MEMO, TXN_ID, Transaction.DEFAULT, UTIL_PRNG);
+        final var context = new BaseOpContext(MEMO, RATES, TXN_ID, Transaction.DEFAULT, UTIL_PRNG);
 
         final var actualRecordNoOutput = BLOCK_ITEMS_TRANSLATOR.translateRecord(context, TRANSACTION_RESULT);
         assertEquals(EXPECTED_BASE_RECORD, actualRecordNoOutput);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockStreamBuilderTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockStreamBuilderTest.java
@@ -154,7 +154,6 @@ public class BlockStreamBuilderTest {
         assertEquals(status, result.status());
         assertEquals(asTimestamp(CONSENSUS_TIME), result.consensusTimestamp());
         assertEquals(asTimestamp(PARENT_CONSENSUS_TIME), result.parentConsensusTimestamp());
-        assertEquals(exchangeRate, result.exchangeRate());
         assertEquals(scheduleRef, result.scheduleRef());
         assertEquals(TRANSACTION_FEE, result.transactionFeeCharged());
         assertEquals(transferList, result.transferList());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/TranslationContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/TranslationContextTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.node.app.blocks.impl.contexts.BaseOpContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -35,6 +36,7 @@ class TranslationContextTest {
 
         final var subject = new BaseOpContext(
                 "",
+                ExchangeRateSet.DEFAULT,
                 TransactionID.DEFAULT,
                 Transaction.newBuilder()
                         .signedTransactionBytes(signedTransactionBytes)
@@ -48,7 +50,8 @@ class TranslationContextTest {
     void hashIsOfSerializedTransactionIfMissingSignedTransactionBytes() {
         final var transactionBytes = Transaction.PROTOBUF.toBytes(Transaction.DEFAULT);
 
-        final var subject = new BaseOpContext("", TransactionID.DEFAULT, Transaction.DEFAULT, HederaFunctionality.NONE);
+        final var subject = new BaseOpContext(
+                "", ExchangeRateSet.DEFAULT, TransactionID.DEFAULT, Transaction.DEFAULT, HederaFunctionality.NONE);
 
         assertEquals(Bytes.wrap(noThrowSha384HashOf(transactionBytes.toByteArray())), subject.transactionHash());
     }


### PR DESCRIPTION
* Updated the block service definitions
   * Split one monolithic service into a few modular services
   * Modified the _publish_ service to match agreed protocol.
   * Changed the publish call to send repeated block items,
     rather than one-at-a-time.
* Merged a few other small changes

> Note.
>> This change includes a small section in the Block Node API definition that is
   removed (due to multiple PBJ bugs).  This will be restored once the relevant
   bug (`#280`) in the PBJ library is fixed.
