### PR TITLE
feat: Readable and Writable Roster state stores

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -77,7 +77,7 @@ import com.hedera.node.app.info.CurrentPlatformStatusImpl;
 import com.hedera.node.app.info.GenesisNetworkInfo;
 import com.hedera.node.app.info.StateNetworkInfo;
 import com.hedera.node.app.records.BlockRecordService;
-import com.hedera.node.app.roster.RosterServiceImpl;
+import com.hedera.node.app.roster.RosterService;
 import com.hedera.node.app.service.addressbook.impl.AddressBookServiceImpl;
 import com.hedera.node.app.service.consensus.impl.ConsensusServiceImpl;
 import com.hedera.node.app.service.contract.impl.ContractServiceImpl;
@@ -115,6 +115,7 @@ import com.hedera.node.config.data.NetworkAdminConfig;
 import com.hedera.node.config.data.VersionConfig;
 import com.hedera.node.config.types.StreamMode;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.RosterStateId;
 import com.swirlds.common.constructable.ClassConstructorPair;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
@@ -400,7 +401,7 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
                         new CongestionThrottleService(),
                         new NetworkServiceImpl(),
                         new AddressBookServiceImpl(),
-                        new RosterServiceImpl(),
+                        new RosterService(),
                         PLATFORM_STATE_SERVICE)
                 .forEach(servicesRegistry::register);
         try {
@@ -487,7 +488,7 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
         final var deserializedVersion = serviceMigrator.creationVersionOf(state);
         return serviceMigrator.doMigrations(
                 state,
-                servicesRegistry.subRegistryFor(EntityIdService.NAME, PlatformStateService.NAME),
+                servicesRegistry.subRegistryFor(EntityIdService.NAME, PlatformStateService.NAME, RosterStateId.NAME),
                 deserializedVersion == null ? null : new ServicesSoftwareVersion(deserializedVersion),
                 version,
                 bootstrapConfigProvider.getConfiguration(),

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/RosterService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/RosterService.java
@@ -18,7 +18,8 @@ package com.hedera.node.app.roster;
 
 import static java.util.Objects.requireNonNull;
 
-import com.hedera.node.app.roster.schemas.V0540RosterSchema;
+import com.swirlds.common.RosterStateId;
+import com.swirlds.platform.state.service.schemas.V0540RosterSchema;
 import com.swirlds.state.spi.SchemaRegistry;
 import com.swirlds.state.spi.Service;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -28,14 +29,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Registers the roster schemas with the {@link SchemaRegistry}.
  * Not exposed outside `hedera-app`.
  */
-public class RosterServiceImpl implements Service {
-    /** The name of this service */
-    public static final String NAME = "RosterService";
+public class RosterService implements Service {
 
     @NonNull
     @Override
     public String getServiceName() {
-        return NAME;
+        return RosterStateId.NAME;
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -21,6 +21,7 @@ import static com.hedera.node.app.state.merkle.SchemaApplicationType.RESTART;
 import static com.hedera.node.app.state.merkle.SchemaApplicationType.STATE_DEFINITIONS;
 import static com.hedera.node.app.state.merkle.VersionUtils.alreadyIncludesStateDefs;
 import static com.hedera.node.app.state.merkle.VersionUtils.isSoOrdered;
+import static com.hedera.node.app.workflows.handle.metric.UnavailableMetrics.UNAVAILABLE_METRICS;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
@@ -346,7 +347,15 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
                                             new VirtualMap<>(label, keySerializer, valueSerializer, dsBuilder);
                                     return virtualMap;
                                 },
-                                virtualMap -> virtualMap.registerMetrics(metrics));
+                                // Register the metrics for the virtual map if they are available.
+                                // Early rounds of migration done by services such as PlatformStateService,
+                                // EntityIdService and RosterService will not have metrics available yet, but their
+                                // later rounds of migration will.
+                                // Therefore, for the first round of migration, we will not register the metrics for
+                                // virtual maps.
+                                UNAVAILABLE_METRICS.equals(metrics)
+                                        ? virtualMap -> {}
+                                        : virtualMap -> virtualMap.registerMetrics(metrics));
                     }
                 });
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/ReadableStoreFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/ReadableStoreFactory.java
@@ -57,9 +57,12 @@ import com.hedera.node.app.service.token.impl.ReadableNftStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableStakingInfoStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenRelationStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenStoreImpl;
+import com.swirlds.common.RosterStateId;
 import com.swirlds.platform.state.MerkleStateRoot;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.ReadablePlatformStateStore;
+import com.swirlds.platform.state.service.ReadableRosterStore;
+import com.swirlds.platform.state.service.ReadableRosterStoreImpl;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableStates;
@@ -111,9 +114,11 @@ public class ReadableStoreFactory {
         newMap.put(
                 ReadableBlockRecordStore.class, new StoreEntry(BlockRecordService.NAME, ReadableBlockRecordStore::new));
         newMap.put(ReadableNodeStore.class, new StoreEntry(AddressBookService.NAME, ReadableNodeStoreImpl::new));
+        // Platform
         newMap.put(
                 ReadablePlatformStateStore.class,
                 new StoreEntry(PlatformStateService.NAME, ReadablePlatformStateStore::new));
+        newMap.put(ReadableRosterStore.class, new StoreEntry(RosterStateId.NAME, ReadableRosterStoreImpl::new));
         return Collections.unmodifiableMap(newMap);
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/WritableStoreFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/WritableStoreFactory.java
@@ -43,7 +43,9 @@ import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
+import com.swirlds.common.RosterStateId;
 import com.swirlds.config.api.Configuration;
+import com.swirlds.platform.state.service.WritableRosterStore;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -103,7 +105,10 @@ public class WritableStoreFactory {
                 new StoreEntry(EntityIdService.NAME, (states, config, metrics) -> new WritableEntityIdStore(states)));
         // Schedule Service
         newMap.put(WritableScheduleStore.class, new StoreEntry(ScheduleService.NAME, WritableScheduleStoreImpl::new));
-        newMap.put(WritableNodeStore.class, new StoreEntry(AddressBookService.NAME, WritableNodeStore::new));
+        // Roster Service
+        newMap.put(
+                WritableRosterStore.class,
+                new StoreEntry(RosterStateId.NAME, (states, config, metrics) -> new WritableRosterStore(states)));
         return Collections.unmodifiableMap(newMap);
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/RosterServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/RosterServiceTest.java
@@ -21,7 +21,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.hedera.node.app.roster.schemas.V0540RosterSchema;
+import com.swirlds.common.RosterStateId;
+import com.swirlds.platform.state.service.schemas.V0540RosterSchema;
 import com.swirlds.state.spi.Schema;
 import com.swirlds.state.spi.SchemaRegistry;
 import org.assertj.core.api.Assertions;
@@ -30,19 +31,19 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 /**
- * Unit tests for {@link RosterServiceImpl}.
+ * Unit tests for {@link RosterService}.
  */
-class RosterServiceImplTest {
-    private RosterServiceImpl rosterService;
+class RosterServiceTest {
+    private RosterService rosterService;
 
     @BeforeEach
     void setUp() {
-        rosterService = new RosterServiceImpl();
+        rosterService = new RosterService();
     }
 
     @Test
     void defaultConstructor() {
-        assertThat(new RosterServiceImpl()).isNotNull();
+        assertThat(new RosterService()).isNotNull();
     }
 
     @Test
@@ -65,6 +66,6 @@ class RosterServiceImplTest {
 
     @Test
     void testServiceNameReturnsCorrectName() {
-        assertThat(rosterService.getServiceName()).isEqualTo(RosterServiceImpl.NAME);
+        assertThat(rosterService.getServiceName()).isEqualTo(RosterStateId.NAME);
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
@@ -16,8 +16,8 @@
 
 package com.hedera.node.app.roster.schemas;
 
-import static com.hedera.node.app.roster.schemas.V0540RosterSchema.ROSTER_KEY;
-import static com.hedera.node.app.roster.schemas.V0540RosterSchema.ROSTER_STATES_KEY;
+import static com.swirlds.common.RosterStateId.ROSTER_KEY;
+import static com.swirlds.common.RosterStateId.ROSTER_STATES_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.roster.RosterState;
 import com.hedera.node.app.spi.fixtures.util.LoggingSubject;
+import com.swirlds.platform.state.service.schemas.V0540RosterSchema;
 import com.swirlds.state.spi.MigrationContext;
 import com.swirlds.state.spi.StateDefinition;
 import com.swirlds.state.spi.WritableSingletonState;
@@ -68,8 +69,7 @@ class V0540RosterSchemaTest {
     @DisplayName("For this version, migrate from existing state version returns default.")
     void testMigrateFromNullRosterStateReturnsDefault() {
         when(migrationContext.newStates()).thenReturn(mock(WritableStates.class));
-        when(migrationContext.newStates().getSingleton(V0540RosterSchema.ROSTER_STATES_KEY))
-                .thenReturn(rosterState);
+        when(migrationContext.newStates().getSingleton(ROSTER_STATES_KEY)).thenReturn(rosterState);
 
         subject.migrate(migrationContext);
         verify(rosterState, times(1)).put(RosterState.DEFAULT);
@@ -79,8 +79,7 @@ class V0540RosterSchemaTest {
     @DisplayName("Migrate from older state version returns default.")
     void testMigrateFromPreviousStateVersion() {
         when(migrationContext.newStates()).thenReturn(mock(WritableStates.class));
-        when(migrationContext.newStates().getSingleton(V0540RosterSchema.ROSTER_STATES_KEY))
-                .thenReturn(rosterState);
+        when(migrationContext.newStates().getSingleton(ROSTER_STATES_KEY)).thenReturn(rosterState);
         when(migrationContext.previousVersion())
                 .thenReturn(
                         SemanticVersion.newBuilder().major(0).minor(53).patch(0).build());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
@@ -21,7 +21,6 @@ import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
 import static com.hedera.node.app.info.UnavailableNetworkInfo.UNAVAILABLE_NETWORK_INFO;
 import static com.hedera.node.app.spi.AppContext.Gossip.UNAVAILABLE_GOSSIP;
-import static com.hedera.node.app.workflows.handle.metric.UnavailableMetrics.UNAVAILABLE_METRICS;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.APPLICATION_PROPERTIES;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.SAVED_STATES_DIR;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.SWIRLDS_LOG;
@@ -64,7 +63,7 @@ import com.hedera.node.app.fees.FeeService;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.info.GenesisNetworkInfo;
 import com.hedera.node.app.records.BlockRecordService;
-import com.hedera.node.app.roster.RosterServiceImpl;
+import com.hedera.node.app.roster.RosterService;
 import com.hedera.node.app.service.addressbook.impl.AddressBookServiceImpl;
 import com.hedera.node.app.service.consensus.impl.ConsensusServiceImpl;
 import com.hedera.node.app.service.contract.impl.ContractServiceImpl;
@@ -93,6 +92,7 @@ import com.hedera.services.bdd.junit.hedera.subprocess.SubProcessNetwork;
 import com.hedera.services.bdd.junit.support.BlockStreamAccess;
 import com.hedera.services.bdd.junit.support.BlockStreamValidator;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.swirlds.common.RosterStateId;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.Hash;
@@ -164,7 +164,7 @@ public class StateChangesValidator implements BlockStreamValidator {
                 .normalize();
         final var validator = new StateChangesValidator(
                 Bytes.fromHex(
-                        "f31a2b563cbe3fef1242bd94bc610fc5134267faa7f3fefc5de176cc1f4032f28d5b27f084bbc388c5a766e4d057acdd"),
+                        "bc49350852851a2c737ef6b5db24da8ba108401952ec207a1a5a4230de8d8a626da1f3663f0560bd6cf401c601b08896"),
                 node0Dir.resolve("output/swirlds.log"),
                 node0Dir.resolve("genesis-config.txt"),
                 node0Dir.resolve("data/config/application.properties"),
@@ -251,7 +251,9 @@ public class StateChangesValidator implements BlockStreamValidator {
         final var configVersion =
                 bootstrapConfig.getConfigData(HederaConfig.class).configVersion();
         final var currentVersion = new ServicesSoftwareVersion(servicesVersion, configVersion);
-        final var lifecycles = newPlatformInitLifecycle(bootstrapConfig, currentVersion, migrator, servicesRegistry);
+        final var metrics = new NoOpMetrics();
+        final var lifecycles =
+                newPlatformInitLifecycle(bootstrapConfig, currentVersion, migrator, servicesRegistry, metrics);
         this.state = new MerkleStateRoot(lifecycles, version -> new ServicesSoftwareVersion(version, configVersion));
         initGenesisPlatformState(
                 new FakePlatformContext(NodeId.of(0), Executors.newSingleThreadScheduledExecutor()),
@@ -270,7 +272,7 @@ public class StateChangesValidator implements BlockStreamValidator {
                 new ServicesSoftwareVersion(servicesVersion, configVersion),
                 new ConfigProviderImpl().getConfiguration(),
                 networkInfo,
-                new NoOpMetrics());
+                metrics);
 
         logger.info("Registered all Service and migrated state definitions to version {}", servicesVersion);
     }
@@ -544,7 +546,7 @@ public class StateChangesValidator implements BlockStreamValidator {
                         new CongestionThrottleService(),
                         new NetworkServiceImpl(),
                         new AddressBookServiceImpl(),
-                        new RosterServiceImpl(),
+                        new RosterService(),
                         PLATFORM_STATE_SERVICE)
                 .forEach(servicesRegistry::register);
     }
@@ -648,19 +650,21 @@ public class StateChangesValidator implements BlockStreamValidator {
             @NonNull final Configuration bootstrapConfig,
             @NonNull final SoftwareVersion currentVersion,
             @NonNull final OrderedServiceMigrator serviceMigrator,
-            @NonNull final ServicesRegistryImpl servicesRegistry) {
+            @NonNull final ServicesRegistryImpl servicesRegistry,
+            @NonNull final NoOpMetrics metrics) {
         return new MerkleStateLifecycles() {
             @Override
             public List<StateChanges.Builder> initPlatformState(@NonNull final State state) {
                 final var deserializedVersion = serviceMigrator.creationVersionOf(state);
                 return serviceMigrator.doMigrations(
                         state,
-                        servicesRegistry.subRegistryFor(EntityIdService.NAME, PlatformStateService.NAME),
+                        servicesRegistry.subRegistryFor(
+                                EntityIdService.NAME, PlatformStateService.NAME, RosterStateId.NAME),
                         deserializedVersion == null ? null : new ServicesSoftwareVersion(deserializedVersion),
                         currentVersion,
                         bootstrapConfig,
                         UNAVAILABLE_NETWORK_INFO,
-                        UNAVAILABLE_METRICS);
+                        metrics);
             }
 
             @Override

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadableRosterStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadableRosterStore.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.state.service;
+
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Read-only implementation for accessing rosters states.
+ */
+public interface ReadableRosterStore {
+    /**
+     * Gets the candidate roster if found in state or null otherwise.
+     * Note that state commits are buffered,
+     * so it is possible that a recently stored candidate roster is still in the batched changes and not yet committed.
+     * Therefore, callers of this API must bear in mind that an immediate call after storing a candidate roster may return null.
+     *
+     * @return the candidate roster
+     */
+    @Nullable
+    Roster getCandidateRoster();
+
+    /**
+     * Gets the active roster.
+     * Returns the active roster iff:
+     *      the roster state singleton is not null
+     *      the list of round roster pairs is not empty
+     *      the first round roster pair exists
+     *      the active roster hash is present in the roster map
+     * otherwise returns null.
+     * @return the active roster
+     */
+    @Nullable
+    Roster getActiveRoster();
+
+    /**
+     * Get the roster based on roster hash
+     *
+     * @param rosterHash The roster hash
+     * @return The roster.
+     */
+    @Nullable
+    Roster get(@NonNull Bytes rosterHash);
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadableRosterStoreImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadableRosterStoreImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.state.service;
+
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterState;
+import com.hedera.hapi.node.state.roster.RoundRosterPair;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.RosterStateId;
+import com.swirlds.state.spi.ReadableKVState;
+import com.swirlds.state.spi.ReadableSingletonState;
+import com.swirlds.state.spi.ReadableStates;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Provides read-only methods for interacting with the underlying data storage mechanisms for
+ * working with Rosters.
+ */
+public class ReadableRosterStoreImpl implements ReadableRosterStore {
+
+    /**
+     * The roster state singleton. This is the state that holds the candidate roster hash and the list of pairs of round
+     * and active roster hashes.
+     */
+    private final ReadableSingletonState<RosterState> rosterState;
+
+    /**
+     * The key-value map of roster hashes and rosters.
+     */
+    private final ReadableKVState<ProtoBytes, Roster> rosterMap;
+
+    /**
+     * Create a new {@link ReadableRosterStore} instance.
+     *
+     * @param readableStates The state to use.
+     */
+    public ReadableRosterStoreImpl(@NonNull final ReadableStates readableStates) {
+        Objects.requireNonNull(readableStates);
+        this.rosterState = readableStates.getSingleton(RosterStateId.ROSTER_STATES_KEY);
+        this.rosterMap = readableStates.get(RosterStateId.ROSTER_KEY);
+    }
+
+    /** {@inheritDoc} */
+    @Nullable
+    @Override
+    public Roster getCandidateRoster() {
+        final RosterState rosterStateSingleton = rosterState.get();
+        if (rosterStateSingleton == null) {
+            return null;
+        }
+        final Bytes candidateRosterHash = rosterStateSingleton.candidateRosterHash();
+        return rosterMap.get(ProtoBytes.newBuilder().value(candidateRosterHash).build());
+    }
+
+    /** {@inheritDoc} */
+    @Nullable
+    @Override
+    public Roster getActiveRoster() {
+        final RosterState rosterStateSingleton = rosterState.get();
+        if (rosterStateSingleton == null) {
+            return null;
+        }
+        final List<RoundRosterPair> rostersAndRounds = rosterStateSingleton.roundRosterPairs();
+        if (rostersAndRounds.isEmpty()) {
+            return null;
+        }
+        // by design, the first round roster pair is the active roster
+        // this may need to be revisited when we reach DAB
+        final RoundRosterPair latestRoundRosterPair = rostersAndRounds.getFirst();
+        final Bytes activeRosterHash = latestRoundRosterPair.activeRosterHash();
+        return rosterMap.get(ProtoBytes.newBuilder().value(activeRosterHash).build());
+    }
+
+    /** {@inheritDoc} */
+    @Nullable
+    @Override
+    public Roster get(@NonNull final Bytes rosterHash) {
+        return rosterMap.get(ProtoBytes.newBuilder().value(rosterHash).build());
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritableRosterStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritableRosterStore.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.state.service;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterState;
+import com.hedera.hapi.node.state.roster.RosterState.Builder;
+import com.hedera.hapi.node.state.roster.RoundRosterPair;
+import com.hedera.hapi.platform.state.PlatformState;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.RosterStateId;
+import com.swirlds.platform.roster.RosterUtils;
+import com.swirlds.platform.roster.RosterValidator;
+import com.swirlds.state.spi.WritableKVState;
+import com.swirlds.state.spi.WritableSingletonState;
+import com.swirlds.state.spi.WritableStates;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Read-write implementation for accessing rosters states.
+ */
+public class WritableRosterStore extends ReadableRosterStoreImpl {
+
+    /**
+     * The maximum number of active rosters to keep in the roster state.
+     */
+    public static final int MAXIMUM_ROSTER_HISTORY_SIZE = 2;
+
+    /**
+     * The roster state singleton. This is the state that holds the candidate roster hash and the list of pairs of
+     * active roster hashes and the round number in which those rosters became active.
+     *
+     * @implNote the use of {@link ReadablePlatformStateStore} and {@link WritablePlatformStateStore} to provide access
+     * to the roster states (beyond just the {@link PlatformState}) is deliberate, for convenience.
+     */
+    private final WritableSingletonState<RosterState> rosterState;
+
+    private final WritableKVState<ProtoBytes, Roster> rosterMap;
+
+    /**
+     * Constructs a new {@link WritableRosterStore} instance.
+     *
+     * @param writableStates the readable states
+     */
+    public WritableRosterStore(@NonNull final WritableStates writableStates) {
+        super(writableStates);
+        requireNonNull(writableStates);
+        this.rosterState = writableStates.getSingleton(RosterStateId.ROSTER_STATES_KEY);
+        this.rosterMap = writableStates.get(RosterStateId.ROSTER_KEY);
+    }
+
+    /**
+     * Sets the candidate roster in state.
+     * Setting the candidate roster indicates that this roster should be adopted as the active roster when required.
+     *
+     * @param candidateRoster a candidate roster to set. It must be a valid roster.
+     */
+    public void putCandidateRoster(@NonNull final Roster candidateRoster) {
+        requireNonNull(candidateRoster);
+        RosterValidator.validate(candidateRoster);
+
+        final Bytes incomingCandidateRosterHash =
+                RosterUtils.hash(candidateRoster).getBytes();
+
+        // update the roster state/map
+        final RosterState previousRosterState = rosterStateOrThrow();
+        final Bytes previousCandidateRosterHash = previousRosterState.candidateRosterHash();
+        final Builder newRosterStateBuilder =
+                previousRosterState.copyBuilder().candidateRosterHash(incomingCandidateRosterHash);
+        removeRoster(previousCandidateRosterHash);
+
+        rosterState.put(newRosterStateBuilder.build());
+        rosterMap.put(ProtoBytes.newBuilder().value(incomingCandidateRosterHash).build(), candidateRoster);
+    }
+
+    /**
+     * Sets the Active roster.
+     * This will be called to store a new Active Roster in the state.
+     * The roster must be valid according to rules codified in {@link com.swirlds.platform.roster.RosterValidator}.
+     *
+     * @param roster an active roster to set
+     * @param round the round number in which the roster became active.
+     *              It must be a positive number greater than the round number of the current active roster.
+     */
+    public void putActiveRoster(@NonNull final Roster roster, final long round) {
+        requireNonNull(roster);
+        RosterValidator.validate(roster);
+
+        // update the roster state
+        final RosterState previousRosterState = rosterStateOrThrow();
+        final List<RoundRosterPair> roundRosterPairs = new LinkedList<>(previousRosterState.roundRosterPairs());
+        if (!roundRosterPairs.isEmpty()) {
+            final RoundRosterPair activeRosterPair = roundRosterPairs.getFirst();
+            if (round < 0 || round <= activeRosterPair.roundNumber()) {
+                throw new IllegalArgumentException(
+                        "incoming round number must be greater than the round number of the current active roster.");
+            }
+        }
+        final Bytes activeRosterHash = RosterUtils.hash(roster).getBytes();
+        roundRosterPairs.addFirst(new RoundRosterPair(round, activeRosterHash));
+
+        if (roundRosterPairs.size() > MAXIMUM_ROSTER_HISTORY_SIZE) {
+            final RoundRosterPair lastRemovedRoster = roundRosterPairs.removeLast();
+            removeRoster(lastRemovedRoster.activeRosterHash());
+
+            // At this phase of the implementation, the roster state has a fixed size limit for active rosters.
+            // Future implementations (e.g. DAB) can modify this.
+            if (roundRosterPairs.size() > MAXIMUM_ROSTER_HISTORY_SIZE) {
+                // additional safety check to ensure that the roster state does not contain more than set limit.
+                throw new IllegalStateException(
+                        "Active rosters in the Roster state cannot be more than  " + MAXIMUM_ROSTER_HISTORY_SIZE);
+            }
+        }
+
+        final Builder newRosterStateBuilder = previousRosterState
+                .copyBuilder()
+                .candidateRosterHash(Bytes.EMPTY)
+                .roundRosterPairs(roundRosterPairs);
+        // since a new active roster is being set, the existing candidate roster is no longer valid
+        // so we remove it if it meets removal criteria.
+        removeRoster(previousRosterState.candidateRosterHash());
+        rosterState.put(newRosterStateBuilder.build());
+        rosterMap.put(ProtoBytes.newBuilder().value(activeRosterHash).build(), roster);
+    }
+
+    /**
+     * Returns the roster state or throws an exception if the state is null.
+     * @return the roster state
+     * @throws NullPointerException if the roster state is null
+     */
+    @NonNull
+    private RosterState rosterStateOrThrow() {
+        return requireNonNull(rosterState.get());
+    }
+
+    /**
+     * Removes a roster from the roster map, but only if it doesn't match any of the active roster hashes in
+     * the roster state. The check ensures we don't inadvertently remove a roster still in use.
+     *
+     * @param rosterHash the hash of the roster
+     */
+    private void removeRoster(@NonNull final Bytes rosterHash) {
+        final List<RoundRosterPair> activeRosterHistory = rosterStateOrThrow().roundRosterPairs();
+        if (activeRosterHistory.stream()
+                .noneMatch(rosterPair -> rosterPair.activeRosterHash().equals(rosterHash))) {
+            this.rosterMap.remove(ProtoBytes.newBuilder().value(rosterHash).build());
+        }
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/schemas/V0540RosterSchema.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/schemas/V0540RosterSchema.java
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-package com.hedera.node.app.roster.schemas;
+package com.swirlds.platform.state.service.schemas;
+
+import static com.swirlds.common.RosterStateId.ROSTER_KEY;
+import static com.swirlds.common.RosterStateId.ROSTER_STATES_KEY;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
@@ -33,8 +36,6 @@ import org.apache.logging.log4j.Logger;
  */
 public class V0540RosterSchema extends Schema {
     private static final Logger log = LogManager.getLogger(V0540RosterSchema.class);
-    public static final String ROSTER_KEY = "ROSTERS";
-    public static final String ROSTER_STATES_KEY = "ROSTER_STATE";
     /** this can't be increased later so we pick some number large enough, 2^16. */
     private static final long MAX_ROSTERS = 65_536L;
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/WritableRosterStoreTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/WritableRosterStoreTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.state.service;
+
+import static com.swirlds.platform.state.service.WritableRosterStore.MAXIMUM_ROSTER_HISTORY_SIZE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.base.ServiceEndpoint;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import com.hedera.hapi.node.state.roster.RosterState;
+import com.hedera.hapi.node.state.roster.RosterState.Builder;
+import com.hedera.hapi.node.state.roster.RoundRosterPair;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.RosterStateId;
+import com.swirlds.platform.roster.InvalidRosterException;
+import com.swirlds.platform.roster.RosterUtils;
+import com.swirlds.state.merkle.singleton.SingletonNode;
+import com.swirlds.state.merkle.singleton.WritableSingletonStateImpl;
+import com.swirlds.state.spi.WritableKVState;
+import com.swirlds.state.spi.WritableSingletonState;
+import com.swirlds.state.spi.WritableStates;
+import com.swirlds.state.test.fixtures.MapWritableKVState;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link WritableRosterStore} class.
+ */
+class WritableRosterStoreTest {
+
+    private final WritableStates writableStates = mock(WritableStates.class);
+    private WritableRosterStore writableRosterStore;
+    private ReadableRosterStore readableRosterStore;
+
+    @BeforeEach
+    void setUp() {
+        final SingletonNode<RosterState> rosterStateSingleton = new SingletonNode<>(
+                PlatformStateService.NAME,
+                RosterStateId.ROSTER_STATES_KEY,
+                0,
+                RosterState.PROTOBUF,
+                new RosterState(null, new LinkedList<>()));
+        final WritableKVState<ProtoBytes, Roster> rosters = MapWritableKVState.<ProtoBytes, Roster>builder(
+                        RosterStateId.ROSTER_KEY)
+                .build();
+        when(writableStates.<ProtoBytes, Roster>get(RosterStateId.ROSTER_KEY)).thenReturn(rosters);
+        when(writableStates.<RosterState>getSingleton(RosterStateId.ROSTER_STATES_KEY))
+                .thenReturn(new WritableSingletonStateImpl<>(RosterStateId.ROSTER_STATES_KEY, rosterStateSingleton));
+
+        readableRosterStore = new ReadableRosterStoreImpl(writableStates);
+        writableRosterStore = new WritableRosterStore(writableStates);
+    }
+
+    @Test
+    void testGetReturnsCorrectRoster() {
+        final Roster expectedRoster = createValidTestRoster(1);
+        writableRosterStore.putCandidateRoster(expectedRoster);
+        final Bytes rosterHash = RosterUtils.hash(expectedRoster).getBytes();
+
+        final Roster actualRoster = readableRosterStore.get(rosterHash);
+
+        assertEquals(expectedRoster, actualRoster, "The returned roster should match the expected roster");
+    }
+
+    @Test
+    void testGetReturnsNullForInvalidHash() {
+        final Roster expectedRoster = createValidTestRoster(1);
+        writableRosterStore.putCandidateRoster(expectedRoster);
+        final Bytes rosterHash = Bytes.EMPTY;
+
+        final Roster actualRoster = readableRosterStore.get(rosterHash);
+
+        assertNull(actualRoster, "The returned roster should be null for an invalid hash");
+    }
+
+    @Test
+    void testSetCandidateRosterReturnsSame() {
+        final Roster roster1 = createValidTestRoster(1);
+        writableRosterStore.putCandidateRoster(roster1);
+        assertEquals(
+                readableRosterStore.getCandidateRoster(),
+                roster1,
+                "Candidate roster should be the same as the one set");
+
+        final Roster roster2 = createValidTestRoster(2);
+        writableRosterStore.putCandidateRoster(roster2);
+        assertEquals(roster2, readableRosterStore.getCandidateRoster(), "Candidate roster should be roster2");
+    }
+
+    @Test
+    void testInvalidRosterThrowsException() {
+        assertThrows(NullPointerException.class, () -> writableRosterStore.putCandidateRoster(null));
+        assertThrows(InvalidRosterException.class, () -> writableRosterStore.putCandidateRoster(Roster.DEFAULT));
+        assertThrows(InvalidRosterException.class, () -> writableRosterStore.putActiveRoster(Roster.DEFAULT, 1));
+    }
+
+    @Test
+    void testInvalidRoundNumberThrowsException() {
+        writableRosterStore.putActiveRoster(createValidTestRoster(2), 1);
+        final Roster roster = createValidTestRoster(1);
+        assertThrows(IllegalArgumentException.class, () -> writableRosterStore.putActiveRoster(roster, 0));
+        assertThrows(IllegalArgumentException.class, () -> writableRosterStore.putActiveRoster(roster, -1));
+    }
+
+    /**
+     * Tests that setting an active roster returns the active roster when getActiveRoster is called.
+     */
+    @Test
+    void testGetCandidateRosterWithValidCandidateRoster() {
+        final Roster activeRoster = createValidTestRoster(1);
+        assertNull(readableRosterStore.getActiveRoster(), "Active roster should be null initially");
+        writableRosterStore.putActiveRoster(activeRoster, 2);
+        assertSame(
+                readableRosterStore.getActiveRoster(),
+                activeRoster,
+                "Returned active roster should be the same as the one set");
+    }
+
+    @Test
+    void testSetActiveRosterRemovesExistingCandidateRoster() {
+        final Roster activeRoster = createValidTestRoster(1);
+        final Roster candidateRoster = createValidTestRoster(2);
+        writableRosterStore.putCandidateRoster(candidateRoster);
+        assertSame(
+                readableRosterStore.getCandidateRoster(),
+                candidateRoster,
+                "Candidate roster should be the same as one we've just set");
+        writableRosterStore.putActiveRoster(activeRoster, 1);
+        assertSame(
+                readableRosterStore.getActiveRoster(),
+                activeRoster,
+                "Returned active roster should be the same as we've just set");
+        assertNull(
+                readableRosterStore.getCandidateRoster(),
+                "No candidate roster should exist in the state immediately after setting a new active roster");
+    }
+
+    /**
+     * Test that the oldest roster is removed when a third roster is set
+     */
+    @Test
+    @DisplayName("Test Oldest Active Roster Cleanup")
+    void testOldestActiveRosterRemoved() throws NoSuchFieldException, IllegalAccessException {
+        final Roster roster1 = createValidTestRoster(3);
+        writableRosterStore.putActiveRoster(roster1, 1);
+        assertSame(readableRosterStore.getActiveRoster(), roster1, "Returned active roster should be roster1");
+
+        final Roster roster2 = createValidTestRoster(1);
+        writableRosterStore.putActiveRoster(roster2, 2);
+        assertSame(readableRosterStore.getActiveRoster(), roster2, "Returned active roster should be roster2");
+
+        // set a 3rd candidate roster and adopt it
+        final Roster roster3 = createValidTestRoster(2);
+        writableRosterStore.putActiveRoster(roster3, 3);
+        final WritableSingletonState<RosterState> rosterState = getRosterState();
+        assertEquals(
+                2,
+                Objects.requireNonNull(rosterState.get()).roundRosterPairs().size(),
+                "Only 2 round roster pairs should exist");
+        assertFalse(
+                Objects.requireNonNull(rosterState.get())
+                        .roundRosterPairs()
+                        .contains(
+                                new RoundRosterPair(2, RosterUtils.hash(roster1).getBytes())),
+                "Oldest roster should be removed");
+    }
+
+    /**
+     * Test that an exception is thrown if stored active rosters are ever > MAXIMUM_ROSTER_HISTORY_SIZE
+     */
+    @Test
+    @DisplayName("Test Max Roster List Size Exceeded")
+    void testMaximumRostersMoreThan2ThrowsException() throws NoSuchFieldException, IllegalAccessException {
+        final List<RoundRosterPair> activeRosters = new ArrayList<>();
+        activeRosters.add(new RoundRosterPair(
+                1, RosterUtils.hash(createValidTestRoster(1)).getBytes()));
+        activeRosters.add(new RoundRosterPair(
+                2, RosterUtils.hash(createValidTestRoster(2)).getBytes()));
+        activeRosters.add(new RoundRosterPair(
+                3, RosterUtils.hash(createValidTestRoster(3)).getBytes()));
+
+        final Builder rosterStateBuilder =
+                RosterState.newBuilder().candidateRosterHash(Bytes.EMPTY).roundRosterPairs(activeRosters);
+        final WritableSingletonState<RosterState> rosterState = getRosterState();
+        rosterState.put(rosterStateBuilder.build());
+
+        final Roster roster = createValidTestRoster(4);
+        final Exception exception =
+                assertThrows(IllegalStateException.class, () -> writableRosterStore.putActiveRoster(roster, 4));
+        assertEquals(
+                "Active rosters in the Roster state cannot be more than  " + MAXIMUM_ROSTER_HISTORY_SIZE,
+                exception.getMessage());
+    }
+
+    /**
+     * Test that when a roster hash collision occurs between a newly set active roster and another active roster in
+     * history, the other roster isn't removed from the state when remove is called
+     */
+    @Test
+    @DisplayName("Duplicate Roster Hash")
+    void testRosterHashCollisions() {
+        final Roster roster1 = createValidTestRoster(3);
+        writableRosterStore.putActiveRoster(roster1, 1);
+        assertSame(
+                readableRosterStore.getActiveRoster(),
+                roster1,
+                "Returned active roster should be the same as the one set");
+
+        final Roster roster2 = createValidTestRoster(1);
+        writableRosterStore.putActiveRoster(roster2, 2);
+        assertSame(
+                readableRosterStore.getActiveRoster(),
+                roster2,
+                "Returned active roster should be the same as the one set");
+
+        writableRosterStore.putActiveRoster(roster1, 3);
+        assertSame(
+                readableRosterStore.getActiveRoster(),
+                roster1,
+                "3rd active roster with hash collision with first returns the first roster");
+    }
+
+    /**
+     * Creates a valid test roster with the given number of entries.
+     *
+     * @param entries the number of entries
+     * @return a valid roster
+     */
+    private Roster createValidTestRoster(final int entries) {
+        final List<RosterEntry> entriesList = new LinkedList<>();
+        for (int i = 0; i < entries; i++) {
+            entriesList.add(RosterEntry.newBuilder()
+                    .nodeId(i)
+                    .weight(i + 1) // weight must be > 0
+                    .gossipCaCertificate(Bytes.wrap("test" + i))
+                    .tssEncryptionKey(Bytes.wrap("test" + i))
+                    .gossipEndpoint(ServiceEndpoint.newBuilder()
+                            .domainName("domain.com" + i)
+                            .port(666)
+                            .build())
+                    .build());
+        }
+        return Roster.newBuilder().rosterEntries(entriesList).build();
+    }
+
+    /**
+     * Gets the roster state from the WritableRosterStore via reflection for testing purposes only.
+     *
+     * @return the roster state
+     * @throws NoSuchFieldException   if the field is not found
+     * @throws IllegalAccessException if the field is not accessible
+     */
+    private WritableSingletonState<RosterState> getRosterState() throws NoSuchFieldException, IllegalAccessException {
+        final Field field = WritableRosterStore.class.getDeclaredField("rosterState");
+        field.setAccessible(true);
+        return (WritableSingletonState<RosterState>) field.get(writableRosterStore);
+    }
+}


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
`ReadableRosterStore` and `WritableRosterStore` have been introduced as Roster stores and this PR includes changes to register Services/Schema/State/Migration registrations.

### Refactoring and Renaming:

* [`hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/RosterService.java`](diffhunk://#diff-b57d421270a96d2d6595715a37c98dbb725e503c6947dca9209c9f2adb16b81fL21-R22): Renamed from `RosterServiceImpl.java` and updated to use `RosterStateId`. [[1]](diffhunk://#diff-b57d421270a96d2d6595715a37c98dbb725e503c6947dca9209c9f2adb16b81fL21-R22) [[2]](diffhunk://#diff-b57d421270a96d2d6595715a37c98dbb725e503c6947dca9209c9f2adb16b81fL31-R37)
* [`hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/RosterServiceTest.java`](diffhunk://#diff-9e740aed933ba8752261fee71c5ee11303c92520b4ab41192e16e36a9a28f387L24-R25): Renamed from `RosterServiceImplTest.java` and updated references to `RosterService`. [[1]](diffhunk://#diff-9e740aed933ba8752261fee71c5ee11303c92520b4ab41192e16e36a9a28f387L24-R25) [[2]](diffhunk://#diff-9e740aed933ba8752261fee71c5ee11303c92520b4ab41192e16e36a9a28f387L33-R46) [[3]](diffhunk://#diff-9e740aed933ba8752261fee71c5ee11303c92520b4ab41192e16e36a9a28f387L68-R69)

### Import and Reference Updates:

* [`hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java`](diffhunk://#diff-3b8bc9e23b0714c170d11ec4d1b0c82d9111ba30793a554eb047d2afeec06425L80-R80): Updated imports and references to use `RosterService` and `RosterStateId`. [[1]](diffhunk://#diff-3b8bc9e23b0714c170d11ec4d1b0c82d9111ba30793a554eb047d2afeec06425L80-R80) [[2]](diffhunk://#diff-3b8bc9e23b0714c170d11ec4d1b0c82d9111ba30793a554eb047d2afeec06425R118) [[3]](diffhunk://#diff-3b8bc9e23b0714c170d11ec4d1b0c82d9111ba30793a554eb047d2afeec06425L403-R404) [[4]](diffhunk://#diff-3b8bc9e23b0714c170d11ec4d1b0c82d9111ba30793a554eb047d2afeec06425L490-R491)
* [`hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/ReadableStoreFactory.java`](diffhunk://#diff-52c702a50d0931d33d55efabd393ed175400e9df2a3e573117f1f0f357398b78R60-R65): Added import and reference for `ReadableRosterStore` and `RosterStateId`. [[1]](diffhunk://#diff-52c702a50d0931d33d55efabd393ed175400e9df2a3e573117f1f0f357398b78R60-R65) [[2]](diffhunk://#diff-52c702a50d0931d33d55efabd393ed175400e9df2a3e573117f1f0f357398b78R117-R121)
* [`hedera-node/hedera-app/src/main/java/com/hedera/node/app/store/WritableStoreFactory.java`](diffhunk://#diff-e3b361135691538cb0149824e55bd93813a97a1093f47fd62cb69e6fb0bea0c4R46-R48): Added import and reference for `WritableRosterStore` and `RosterStateId`. [[1]](diffhunk://#diff-e3b361135691538cb0149824e55bd93813a97a1093f47fd62cb69e6fb0bea0c4R46-R48) [[2]](diffhunk://#diff-e3b361135691538cb0149824e55bd93813a97a1093f47fd62cb69e6fb0bea0c4L106-R111)

### Schema and Metrics Updates:

* [`hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java`](diffhunk://#diff-4835c025371ac957e7e48d727c66b4f131c243e88f91b34c8bf5405948e6f3a1R24): Modified to conditionally register metrics based on availability. [[1]](diffhunk://#diff-4835c025371ac957e7e48d727c66b4f131c243e88f91b34c8bf5405948e6f3a1R24) [[2]](diffhunk://#diff-4835c025371ac957e7e48d727c66b4f131c243e88f91b34c8bf5405948e6f3a1L349-R358)
* [`hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java`](diffhunk://#diff-d6a8af922d9929ac86dc362165a3b33df1b6b9c49e45e76cdd8597e86a5456b5L19-R20): Updated to use `RosterStateId` for schema keys. [[1]](diffhunk://#diff-d6a8af922d9929ac86dc362165a3b33df1b6b9c49e45e76cdd8597e86a5456b5L19-R20) [[2]](diffhunk://#diff-d6a8af922d9929ac86dc362165a3b33df1b6b9c49e45e76cdd8597e86a5456b5R31) [[3]](diffhunk://#diff-d6a8af922d9929ac86dc362165a3b33df1b6b9c49e45e76cdd8597e86a5456b5L71-R72) [[4]](diffhunk://#diff-d6a8af922d9929ac86dc362165a3b33df1b6b9c49e45e76cdd8597e86a5456b5L82-R82)

### Test Client Updates:

* [`hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java`](diffhunk://#diff-27aeeed8d01c0c40855b43cc8540a9336c613c10c62b7fbc4a9ec0b13611695dL24): Updated to use `RosterService` and added metrics handling. [[1]](diffhunk://#diff-27aeeed8d01c0c40855b43cc8540a9336c613c10c62b7fbc4a9ec0b13611695dL24) [[2]](diffhunk://#diff-27aeeed8d01c0c40855b43cc8540a9336c613c10c62b7fbc4a9ec0b13611695dL67-R66) [[3]](diffhunk://#diff-27aeeed8d01c0c40855b43cc8540a9336c613c10c62b7fbc4a9ec0b13611695dR95) [[4]](diffhunk://#diff-27aeeed8d01c0c40855b43cc8540a9336c613c10c62b7fbc4a9ec0b13611695dL167-R167) [[5]](diffhunk://#diff-27aeeed8d01c0c40855b43cc8540a9336c613c10c62b7fbc4a9ec0b13611695dL254-R256) [[6]](diffhunk://#diff-27aeeed8d01c0c40855b43cc8540a9336c613c10c62b7fbc4a9ec0b13611695dL273-R275) [[7]](diffhunk://#diff-27aeeed8d01c0c40855b43cc8540a9336c613c10c62b7fbc4a9ec0b13611695dL547-R549)


**Related issue(s)**:

Fixes #14711

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
