### PR TITLE
fix: LegacyConfigPropertiesLoader should not suppress ParseException

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/LegacyConfigPropertiesLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/legacy/LegacyConfigPropertiesLoader.java
@@ -56,7 +56,7 @@ public final class LegacyConfigPropertiesLoader {
     public static final String ERROR_MORE_THAN_ONE_APP =
             "config.txt had more than one line starting with 'app'. All but the last will be ignored.";
     public static final String ERROR_NO_PARAMETER = "%s needs a parameter";
-    public static final String ERROR_ADDRESS_NOT_ENOUGH_PARAMETERS = "'address' needs a minimum of 7 parameters";
+    public static final String ERROR_ADDRESS_COULD_NOT_BE_PARSED = "'address' could not be parsed";
     public static final String ERROR_PROPERTY_NOT_KNOWN =
             "'%s' in config.txt isn't a recognized first parameter for a line";
     public static final String ERROR_NEXT_NODE_NOT_GREATER_THAN_HIGHEST_ADDRESS =
@@ -115,14 +115,13 @@ public final class LegacyConfigPropertiesLoader {
                                     addressBook.add(address);
                                 }
                             } catch (final ParseException ex) {
-                                logger.error(
-                                        EXCEPTION.getMarker(),
-                                        "file {}, line {}, offset {}: {}",
-                                        configPath,
-                                        lineNumber,
-                                        ex.getErrorOffset(),
-                                        ex.getMessage());
-                                onError(ERROR_ADDRESS_NOT_ENOUGH_PARAMETERS);
+                                // if we fail to parse address, we must abort since otherwise node starts with subset
+                                // of node keys and fails to join the network eventually.
+                                throw new ConfigurationException(
+                                        String.format(
+                                                "%s [line: %d]: %s",
+                                                ERROR_ADDRESS_COULD_NOT_BE_PARSED, lineNumber, line),
+                                        ex);
                             }
                         }
                         case "nextnodeid" -> {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.system.address;
 
-import static com.swirlds.base.utility.NetworkUtils.isNameResolvable;
 import static com.swirlds.platform.util.BootstrapUtils.detectSoftwareUpgrade;
 
 import com.hedera.hapi.node.base.ServiceEndpoint;
@@ -181,9 +180,6 @@ public class AddressBookUtils {
         }
         // FQDN Support: The original string value is preserved, whether it is an IP Address or a FQDN.
         final String internalHostname = parts[5];
-        if (!isNameResolvable(internalHostname)) {
-            throw new ParseException("Cannot parse ip address from '" + internalHostname + "'", 5);
-        }
         final int internalPort;
         try {
             internalPort = Integer.parseInt(parts[6]);
@@ -192,9 +188,6 @@ public class AddressBookUtils {
         }
         // FQDN Support: The original string value is preserved, whether it is an IP Address or a FQDN.
         final String externalHostname = parts[7];
-        if (!isNameResolvable(externalHostname)) {
-            throw new ParseException("Cannot parse ip address from '" + externalHostname + "'", 7);
-        }
         final int externalPort;
         try {
             externalPort = Integer.parseInt(parts[8]);


### PR DESCRIPTION
**Description**:


**Related issue(s)**:

Fixes #16132 
Fixes https://github.com/hashgraph/solo-operator/issues/233

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
During boot time, platform shouldn't try to resolve the FQDN addresses (internal or external) in the config.txt as other nodes may not be up by the time a node starts parsing config.txt. So this PR removes FQDN resolution at config parsing time.

Also it throws exception if `config.txt` parsing fails for other reasons at the boot time.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
