### PR TITLE
ci: Fix bug with deleting xts-candidate tag prior to creation or use 

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -64,16 +64,31 @@ jobs:
       - name: Check for tags
         id: check-tags-exist
         run: |
-          XTS_COMMIT=$(git rev-list -n 1 "${XTS_CANDIDATE_TAG}")
+          # Check if the tag exists and if so grab its commit id
+          set +e
+          XTS_COMMIT=$(git rev-list -n 1 "${XTS_CANDIDATE_TAG}") >/dev/null 2>&1
+          XTS_COMMIT_FOUND="${?}"
+          set -e
+
+          # Cancel out if the tag does not exist
+          if [[ "${XTS_COMMIT_FOUND}" -ne 0 ]] then;
+            gh run cancel ${{ github.run_id }}
+          fi
+
+          # Check if the tag exists on the develop branch
           set +e
           git branch --contains "${XTS_COMMIT}" | grep --quiet develop >/dev/null 2>&1
           BRANCH_ON_DEVELOP="${?}"
           set -e
-          if [[ -n "${XTS_COMMIT}" && "${BRANCH_ON_DEVELOP}" -eq 0 ]]; then
+
+          # If the tag exists on the Develop Branch set the output variables as appropriate
+          # Otherwise cancel out
+          if [[ "${BRANCH_ON_DEVELOP}" -eq 0 ]]; then
             echo "xts-tag-exists=true" >> $GITHUB_OUTPUT
             echo "xts-tag-commit=${XTS_COMMIT}" >> $GITHUB_OUTPUT
             echo "### Commit has been tagged as an XTS-Candidate" >>  $GITHUB_STEP_SUMMARY
             echo "xts-tag-commit=${XTS_COMMIT}" >> $GITHUB_STEP_SUMMARY
+
             git push --delete origin "${XTS_CANDIDATE_TAG}"
             git tag -d "${XTS_CANDIDATE_TAG}"
           else

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -167,14 +167,13 @@ jobs:
     name: Tag as XTS-Passing
     runs-on: network-node-linux-medium
     needs:
-#      - abbreviated-panel
+      - abbreviated-panel
       - extended-test-suite
       - fetch-xts-candidate
-#      - hedera-node-jrs-panel
-#    if: ${{ needs.abbreviated-panel.result == 'success' ||
-#            needs.extended-test-suite.result == 'success' ||
-#            needs.hedera-node-jrs-panel.result == 'success' }}
-    if: ${{ needs.extended-test-suite.result == 'success' }}
+      - hedera-node-jrs-panel
+    if: ${{ needs.abbreviated-panel.result == 'success' ||
+            needs.extended-test-suite.result == 'success' ||
+            needs.hedera-node-jrs-panel.result == 'success' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -71,7 +71,7 @@ jobs:
           set -e
 
           # Cancel out if the tag does not exist
-          if [[ "${XTS_COMMIT_FOUND}" -ne 0 ]] then;
+          if [[ "${XTS_COMMIT_FOUND}" -ne 0 ]]; then
             gh run cancel ${{ github.run_id }}
           fi
 

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -89,7 +89,7 @@ jobs:
           set -e
 
           # Delete the tag if it does exist
-          if [[ "${XTS_COMMIT_FOUND}" -eq 0 ]] then;
+          if [[ "${XTS_COMMIT_FOUND}" -eq 0 ]]; then
             git push --delete origin "${XTS_CANDIDATE_TAG}"
             git tag -d "${XTS_CANDIDATE_TAG}"
           fi

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -82,17 +82,19 @@ jobs:
       # move the tag if successful
       - name: Tag Code and push
         run: |
-          XTS_COMMIT=$(git rev-list -n 1 "${XTS_CANDIDATE_TAG}")
+          # Check if the tag exists
           set +e
-          git branch --contains "${XTS_COMMIT}" | grep --quiet develop >/dev/null 2>&1
-          BRANCH_ON_DEVELOP="${?}"
+          git rev-list -n 1 "${XTS_CANDIDATE_TAG}" >/dev/null 2>&1
+          XTS_COMMIT_FOUND="${?}"
           set -e
 
-          if [[ -n "${XTS_COMMIT}" && "${BRANCH_ON_DEVELOP}" -eq 0 ]]; then
+          # Delete the tag if it does exist
+          if [[ "${XTS_COMMIT_FOUND}" -eq 0 ]] then;
             git push --delete origin "${XTS_CANDIDATE_TAG}"
             git tag -d "${XTS_CANDIDATE_TAG}"
           fi
 
+          # Create the new tag
           git tag --annotate "${XTS_CANDIDATE_TAG}" --message "chore: tagging commit for XTS promotion"
           git push --set-upstream origin --tags
 


### PR DESCRIPTION
**Description**:

xts-candidate tag was failing to be deleted if it did not exist

**Related Issue(s)**:

Fixes: #16156

**Checklist**

- [x] Documented in Code comments
- [x] Tested 
  - [x] locally in shell
  - [x] through manually triggered github actions
    - Prepare XTS: https://github.com/hashgraph/hedera-services/actions/runs/11506585644
    - Execute XTS: https://github.com/hashgraph/hedera-services/actions/runs/11506615363
