### PR TITLE
ci: Specify java major minor and patch versions

### DIFF
--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -296,7 +296,7 @@ jobs:
     with:
       ref: ${{ github.event.inputs.ref || '' }}
       java-distribution: temurin
-      java-version: 21
+      java-version: 21.0.4
     secrets:
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
       gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR fixes the Gradle Determinism / Verify Artifacts (windows-2019) check. It seems that when specifying only "21" as a java version, at some point the action automatically switched to java 21.0.5, which seems to be the problem.

Example with only "java-version: 21" specified - https://github.com/hashgraph/hedera-services/actions/runs/11507482709/job/32043010427?pr=16095#step:7:26

**Related issue(s)**:

N/A

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
