### PR TITLE
chore: schedule 0.56 release branch creation

### DIFF
--- a/.github/workflows/config/node-release.yaml
+++ b/.github/workflows/config/node-release.yaml
@@ -1,7 +1,7 @@
 release:
   branching:
     execution:
-      time: "19:30:00"
+      time: "21:00:00"
     schedule:
       - on: "2024-10-25"
         name: release/0.56

--- a/.github/workflows/config/node-release.yaml
+++ b/.github/workflows/config/node-release.yaml
@@ -1,11 +1,11 @@
 release:
   branching:
     execution:
-      time: "17:00:00"
+      time: "19:30:00"
     schedule:
-      - on: "2024-09-30"
-        name: release/0.55
+      - on: "2024-10-25"
+        name: release/0.56
         initial-tag:
-          create: false
-          name: v0.55.0-alpha.2
+          create: true
+          name: v0.56.0
 


### PR DESCRIPTION
Schedule 0.56 release branch creation for 2:00pm Pacific / 4:00pm Central / 21:00 GMT

**Related issue(s)**:

Fixes #16183
