### PR TITLE
ci: disable release 0.53 regression

### DIFF
--- a/.github/workflows/node-zxcron-release-fsts-regression.yaml
+++ b/.github/workflows/node-zxcron-release-fsts-regression.yaml
@@ -57,7 +57,7 @@ jobs:
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
 
-            if [[ "${major}" -eq 0 && "${minor}" -lt 53 ]]; then
+            if [[ "${major}" -eq 0 && "${minor}" -lt 55 ]]; then
               continue
             fi
 

--- a/.github/workflows/platform-zxcron-release-jrs-regression.yaml
+++ b/.github/workflows/platform-zxcron-release-jrs-regression.yaml
@@ -59,7 +59,7 @@ jobs:
             major="${BASH_REMATCH[1]}"
             minor="${BASH_REMATCH[2]}"
 
-            if [[ "${major}" -eq 0 && "${minor}" -lt 53 ]]; then
+            if [[ "${major}" -eq 0 && "${minor}" -lt 55 ]]; then
               continue
             fi
 


### PR DESCRIPTION
**Description**:

0.54 is on mainnet , no longer need to run regression for release 0.54