### PR TITLE
chore: replace usages of AddressBook with Roster in event.validation

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
@@ -26,9 +26,10 @@ import com.swirlds.platform.components.AppNotifier;
 import com.swirlds.platform.components.SavedStateController;
 import com.swirlds.platform.consensus.EventWindow;
 import com.swirlds.platform.event.AncientMode;
-import com.swirlds.platform.event.validation.AddressBookUpdate;
+import com.swirlds.platform.event.validation.RosterUpdate;
 import com.swirlds.platform.eventhandling.EventConfig;
 import com.swirlds.platform.listeners.ReconnectCompleteNotification;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.nexus.SignedStateNexus;
 import com.swirlds.platform.state.signed.SignedState;
@@ -139,10 +140,16 @@ public class ReconnectStateLoader {
                     signedState.getState().getReadablePlatformState().getSnapshot()));
 
             platformWiring
-                    .getAddressBookUpdateInput()
-                    .inject(new AddressBookUpdate(
-                            signedState.getState().getReadablePlatformState().getPreviousAddressBook(),
-                            signedState.getState().getReadablePlatformState().getAddressBook()));
+                    .getRosterUpdateInput()
+                    .inject(new RosterUpdate(
+                            RosterRetriever.buildRoster(signedState
+                                    .getState()
+                                    .getReadablePlatformState()
+                                    .getPreviousAddressBook()),
+                            RosterRetriever.buildRoster(signedState
+                                    .getState()
+                                    .getReadablePlatformState()
+                                    .getAddressBook())));
 
             final AncientMode ancientMode = platformContext
                     .getConfiguration()

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
@@ -101,6 +101,7 @@ import com.swirlds.platform.system.status.StatusStateMachine;
 import com.swirlds.platform.util.MetricsDocUtils;
 import com.swirlds.platform.wiring.components.Gossip;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Objects;
@@ -202,6 +203,20 @@ public class PlatformComponentBuilder {
     @NonNull
     private Roster getInitialRoster() {
         return RosterRetriever.buildRoster(blocks.initialAddressBook());
+    }
+
+    /**
+     * Get the previous roster from the initial state in PlatformBuildingBlocks.
+     *
+     * @return the previous roster, or null
+     */
+    @Nullable
+    private Roster getPreviousRoster() {
+        return RosterRetriever.buildRoster(blocks.initialState()
+                .get()
+                .getState()
+                .getReadablePlatformState()
+                .getPreviousAddressBook());
     }
 
     /**
@@ -372,12 +387,8 @@ public class PlatformComponentBuilder {
                     blocks.platformContext(),
                     CryptoStatic::verifySignature,
                     blocks.appVersion().getPbjSemanticVersion(),
-                    blocks.initialState()
-                            .get()
-                            .getState()
-                            .getReadablePlatformState()
-                            .getPreviousAddressBook(),
-                    blocks.initialAddressBook(),
+                    getPreviousRoster(),
+                    getInitialRoster(),
                     blocks.intakeEventCounter());
         }
         return eventSignatureValidator;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/EventSignatureValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/EventSignatureValidator.java
@@ -46,10 +46,10 @@ public interface EventSignatureValidator {
     void setEventWindow(@NonNull final EventWindow eventWindow);
 
     /**
-     * Set the previous and current address books
+     * Set the previous and current rosters
      *
-     * @param addressBookUpdate the new address books
+     * @param rosterUpdate the new rosters
      */
-    @InputWireLabel("AddressBookUpdate")
-    void updateAddressBooks(@NonNull final AddressBookUpdate addressBookUpdate);
+    @InputWireLabel("RosterUpdate")
+    void updateRosters(@NonNull final RosterUpdate rosterUpdate);
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/RosterUpdate.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/RosterUpdate.java
@@ -16,13 +16,13 @@
 
 package com.swirlds.platform.event.validation;
 
-import com.swirlds.platform.system.address.AddressBook;
+import com.hedera.hapi.node.state.roster.Roster;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
- * A record representing an update to the address book.
+ * A record representing an update to the roster.
  *
- * @param previousAddressBook the previous address book
- * @param currentAddressBook  the new current address book
+ * @param previousRoster the previous roster
+ * @param currentRoster  the new current roster
  */
-public record AddressBookUpdate(@NonNull AddressBook previousAddressBook, @NonNull AddressBook currentAddressBook) {}
+public record RosterUpdate(@NonNull Roster previousRoster, @NonNull Roster currentRoster) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterRetriever.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterRetriever.java
@@ -146,8 +146,11 @@ public final class RosterRetriever {
      * @param addressBook an AddressBook
      * @return a Roster
      */
-    @NonNull
-    public static Roster buildRoster(@NonNull final AddressBook addressBook) {
+    @Nullable
+    public static Roster buildRoster(@Nullable final AddressBook addressBook) {
+        if (addressBook == null) {
+            return null;
+        }
         return Roster.newBuilder()
                 .rosterEntries(addressBook.getNodeIdSet().stream()
                         .map(addressBook::getAddress)

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -22,7 +22,11 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.util.PbjRecordHasher;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.security.cert.X509Certificate;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * A utility class to help use Rooster and RosterEntry instances.
@@ -64,6 +68,20 @@ public final class RosterUtils {
     @NonNull
     public static Hash hash(@NonNull final Roster roster) {
         return PBJ_RECORD_HASHER.hash(roster, Roster.PROTOBUF);
+    }
+
+    /**
+     * Build a map from a long nodeId to a RosterEntry for a given Roster.
+     *
+     * @param roster a roster
+     * @return Map&lt;Long, RosterEntry&gt;
+     */
+    @Nullable
+    public static Map<Long, RosterEntry> toMap(@Nullable final Roster roster) {
+        if (roster == null) {
+            return null;
+        }
+        return roster.rosterEntries().stream().collect(Collectors.toMap(RosterEntry::nodeId, Function.identity()));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -69,9 +69,9 @@ import com.swirlds.platform.event.signing.SelfEventSigner;
 import com.swirlds.platform.event.stale.StaleEventDetector;
 import com.swirlds.platform.event.stale.StaleEventDetectorOutput;
 import com.swirlds.platform.event.stream.ConsensusEventStream;
-import com.swirlds.platform.event.validation.AddressBookUpdate;
 import com.swirlds.platform.event.validation.EventSignatureValidator;
 import com.swirlds.platform.event.validation.InternalEventValidator;
+import com.swirlds.platform.event.validation.RosterUpdate;
 import com.swirlds.platform.eventhandling.EventConfig;
 import com.swirlds.platform.eventhandling.TransactionHandler;
 import com.swirlds.platform.eventhandling.TransactionPrehandler;
@@ -729,7 +729,7 @@ public class PlatformWiring {
         eventCreationManagerWiring.getInputWire(EventCreationManager::clear);
         notifierWiring.getInputWire(AppNotifier::sendReconnectCompleteNotification);
         notifierWiring.getInputWire(AppNotifier::sendPlatformStatusChangeNotification);
-        eventSignatureValidatorWiring.getInputWire(EventSignatureValidator::updateAddressBooks);
+        eventSignatureValidatorWiring.getInputWire(EventSignatureValidator::updateRosters);
         eventWindowManagerWiring.getInputWire(EventWindowManager::updateEventWindow);
         orphanBufferWiring.getInputWire(OrphanBuffer::clear);
         if (inlinePces) {
@@ -838,8 +838,8 @@ public class PlatformWiring {
      * @return the input method for the address book update
      */
     @NonNull
-    public InputWire<AddressBookUpdate> getAddressBookUpdateInput() {
-        return eventSignatureValidatorWiring.getInputWire(EventSignatureValidator::updateAddressBooks);
+    public InputWire<RosterUpdate> getRosterUpdateInput() {
+        return eventSignatureValidatorWiring.getInputWire(EventSignatureValidator::updateRosters);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/EventSignatureValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/validation/EventSignatureValidatorTests.java
@@ -24,6 +24,9 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.base.test.fixtures.time.FakeTime;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
@@ -37,12 +40,10 @@ import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.eventhandling.EventConfig;
 import com.swirlds.platform.eventhandling.EventConfig_;
 import com.swirlds.platform.gossip.IntakeEventCounter;
-import com.swirlds.platform.system.address.Address;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.EventConstants;
 import com.swirlds.platform.test.fixtures.crypto.PreGeneratedX509Certs;
 import com.swirlds.platform.test.fixtures.event.TestingEventBuilder;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.cert.CertificateEncodingException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +59,7 @@ class EventSignatureValidatorTests {
     private AtomicLong exitedIntakePipelineCount;
     private IntakeEventCounter intakeEventCounter;
 
-    private AddressBook currentAddressBook;
+    private Roster currentRoster;
 
     /**
      * A verifier that always returns true.
@@ -76,24 +77,34 @@ class EventSignatureValidatorTests {
     private SemanticVersion defaultVersion;
 
     /**
-     * This address belongs to a node that is placed in the previous address book.
+     * This address belongs to a node that is placed in the previous roster.
      */
-    private Address previousNodeAddress;
+    private RosterEntry previousNodeRosterEntry;
 
     /**
-     * This address belongs to a node that is placed in the current address book.
+     * This address belongs to a node that is placed in the current roster.
      */
-    private Address currentNodeAddress;
+    private RosterEntry currentNodeRosterEntry;
 
     /**
-     * Generate a mock address, with enough elements mocked to support the signature validation.
+     * Generate a mock RosterEntry, with enough elements mocked to support the signature validation.
      *
      * @param nodeId the node id to use for the address
-     * @return a mock address
+     * @return a mock roster entry
      */
-    private static Address generateMockAddress(final @NonNull NodeId nodeId) {
-        return new Address(
-                nodeId, "", "", 10, null, 77, null, 88, PreGeneratedX509Certs.getSigCert(nodeId.id()), null, "");
+    private static RosterEntry generateMockRosterEntry(final long nodeId) {
+        try {
+            return new RosterEntry(
+                    nodeId,
+                    10,
+                    Bytes.wrap(PreGeneratedX509Certs.getSigCert(nodeId)
+                            .getCertificate()
+                            .getEncoded()),
+                    Bytes.EMPTY,
+                    List.of());
+        } catch (CertificateEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @BeforeEach
@@ -112,36 +123,26 @@ class EventSignatureValidatorTests {
                 .eventExitedIntakePipeline(any());
 
         // create two addresses, one for the previous address book and one for the current address book
-        previousNodeAddress = generateMockAddress(NodeId.of(66));
-        currentNodeAddress = generateMockAddress(NodeId.of(77));
+        previousNodeRosterEntry = generateMockRosterEntry(66);
+        currentNodeRosterEntry = generateMockRosterEntry(77);
 
-        final AddressBook previousAddressBook = new AddressBook(List.of(previousNodeAddress));
-        currentAddressBook = new AddressBook(List.of(currentNodeAddress));
+        final Roster previousRoster = new Roster(List.of(previousNodeRosterEntry));
+        currentRoster = new Roster(List.of(currentNodeRosterEntry));
 
         defaultVersion = SemanticVersion.newBuilder().major(2).build();
 
         validatorWithTrueVerifier = new DefaultEventSignatureValidator(
-                platformContext,
-                trueVerifier,
-                defaultVersion,
-                previousAddressBook,
-                currentAddressBook,
-                intakeEventCounter);
+                platformContext, trueVerifier, defaultVersion, previousRoster, currentRoster, intakeEventCounter);
 
         validatorWithFalseVerifier = new DefaultEventSignatureValidator(
-                platformContext,
-                falseVerifier,
-                defaultVersion,
-                previousAddressBook,
-                currentAddressBook,
-                intakeEventCounter);
+                platformContext, falseVerifier, defaultVersion, previousRoster, currentRoster, intakeEventCounter);
     }
 
     @Test
     @DisplayName("Events with higher version than the app should always fail validation")
     void irreconcilableVersions() {
         final PlatformEvent event = new TestingEventBuilder(random)
-                .setCreatorId(currentNodeAddress.getNodeId())
+                .setCreatorId(NodeId.of(currentNodeRosterEntry.nodeId()))
                 .setSoftwareVersion(SemanticVersion.newBuilder().major(3).build())
                 .build();
 
@@ -153,10 +154,10 @@ class EventSignatureValidatorTests {
     @DisplayName("Lower version event with missing previous address book")
     void versionMismatchWithNullPreviousAddressBook() {
         final EventSignatureValidator signatureValidator = new DefaultEventSignatureValidator(
-                platformContext, trueVerifier, defaultVersion, null, currentAddressBook, intakeEventCounter);
+                platformContext, trueVerifier, defaultVersion, null, currentRoster, intakeEventCounter);
 
         final PlatformEvent event = new TestingEventBuilder(random)
-                .setCreatorId(previousNodeAddress.getNodeId())
+                .setCreatorId(NodeId.of(previousNodeRosterEntry.nodeId()))
                 .setSoftwareVersion(SemanticVersion.newBuilder().major(3).build())
                 .build();
 
@@ -169,7 +170,7 @@ class EventSignatureValidatorTests {
     void applicableAddressBookMissingNode() {
         // this creator isn't in the current address book, so verification will fail
         final PlatformEvent event = new TestingEventBuilder(random)
-                .setCreatorId(previousNodeAddress.getNodeId())
+                .setCreatorId(NodeId.of(previousNodeRosterEntry.nodeId()))
                 .setSoftwareVersion(defaultVersion)
                 .build();
 
@@ -181,9 +182,6 @@ class EventSignatureValidatorTests {
     @DisplayName("Node has a null public key")
     void missingPublicKey() {
         final NodeId nodeId = NodeId.of(88);
-        final Address nodeAddress = new Address(nodeId, "", "", 10, null, 77, null, 88, null, null, "");
-
-        currentAddressBook.add(nodeAddress);
 
         final PlatformEvent event = new TestingEventBuilder(random)
                 .setCreatorId(nodeId)
@@ -199,7 +197,7 @@ class EventSignatureValidatorTests {
     void validSignature() {
         // both the event and the app have the same version, so the currentAddressBook will be selected
         final PlatformEvent event1 = new TestingEventBuilder(random)
-                .setCreatorId(currentNodeAddress.getNodeId())
+                .setCreatorId(NodeId.of(currentNodeRosterEntry.nodeId()))
                 .setSoftwareVersion(defaultVersion)
                 .build();
 
@@ -208,7 +206,7 @@ class EventSignatureValidatorTests {
 
         // event2 is from a previous version, so the previous address book will be selected
         final PlatformEvent event2 = new TestingEventBuilder(random)
-                .setCreatorId(previousNodeAddress.getNodeId())
+                .setCreatorId(NodeId.of(previousNodeRosterEntry.nodeId()))
                 .setSoftwareVersion(SemanticVersion.newBuilder().major(1).build())
                 .build();
 
@@ -220,7 +218,7 @@ class EventSignatureValidatorTests {
     @DisplayName("Event fails validation if the signature does not verify")
     void verificationFails() {
         final PlatformEvent event = new TestingEventBuilder(random)
-                .setCreatorId(currentNodeAddress.getNodeId())
+                .setCreatorId(NodeId.of(currentNodeRosterEntry.nodeId()))
                 .setSoftwareVersion(defaultVersion)
                 .build();
 
@@ -240,18 +238,13 @@ class EventSignatureValidatorTests {
                         .withValue(EventConfig_.USE_BIRTH_ROUND_ANCIENT_THRESHOLD, useBirthRoundForAncientThreshold)
                         .getOrCreateConfig())
                 .build();
-        final AddressBook previousAddressBook = new AddressBook(List.of(previousNodeAddress));
+        final Roster previousRoster = new Roster(List.of(previousNodeRosterEntry));
 
         final EventSignatureValidator validator = new DefaultEventSignatureValidator(
-                platformContext,
-                trueVerifier,
-                defaultVersion,
-                previousAddressBook,
-                currentAddressBook,
-                intakeEventCounter);
+                platformContext, trueVerifier, defaultVersion, previousRoster, currentRoster, intakeEventCounter);
 
         final PlatformEvent event = new TestingEventBuilder(random)
-                .setCreatorId(currentNodeAddress.getNodeId())
+                .setCreatorId(NodeId.of(currentNodeRosterEntry.nodeId()))
                 .setBirthRound(EventConstants.MINIMUM_ROUND_CREATED)
                 .setSoftwareVersion(defaultVersion)
                 .build();


### PR DESCRIPTION
**Description**:
As a part of the TSS initiative, and specifically the TSS-Roster project, we're refactoring the Platform code to replace usages of `AddressBook` with `Roster`.

This fix refactors the `event.validation`-related classes.

**Related issue(s)**:

Fixes #16201

**Notes for reviewer**:
Tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
