### PR TITLE
fix: resolve issues with isLocal flakiness due to DNS resolution

### DIFF
--- a/hedera-node/infrastructure/docker/containers/production-next/consensus-node/Dockerfile
+++ b/hedera-node/infrastructure/docker/containers/production-next/consensus-node/Dockerfile
@@ -242,6 +242,11 @@ ADD entrypoint.sh /opt/hgcapp/services-hedera/HapiApp2.0/
 RUN chmod -R +x /opt/hgcapp/services-hedera/HapiApp2.0/entrypoint.sh && \
     chown -R 2000:2000 /opt/hgcapp/services-hedera/HapiApp2.0
 
+# Patch the Java DNS Cache settings
+RUN sed -e '/networkaddress.cache.ttl/c networkaddress.cache.ttl=10' -i "${JAVA_HOME}/conf/security/java.security" && \
+    sed -e '/networkaddress.cache.stale.ttl/c networkaddress.cache.stale.ttl=0' -i "${JAVA_HOME}/conf/security/java.security" && \
+    sed -e '/networkaddress.cache.negative.ttl/c networkaddress.cache.negative.ttl=0' -i "${JAVA_HOME}/conf/security/java.security"
+
 ########################################
 ####    Deterministic Build Hack    ####
 ########################################

--- a/hedera-node/infrastructure/docker/containers/production-next/consensus-node/entrypoint.sh
+++ b/hedera-node/infrastructure/docker/containers/production-next/consensus-node/entrypoint.sh
@@ -176,6 +176,8 @@ while true; do
     printf "\n\n############# Retrying system initialization - DNS or Address Book Failure (Exit Code: %s) #############\n\n" "${EC}"
     ATTEMPTS=$(( ATTEMPTS + 1 ))
     sleep 6
+  else
+    break
   fi
 done
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END NODE OUTPUT   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/NetworkUtils.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/NetworkUtils.java
@@ -30,6 +30,9 @@ import java.util.concurrent.ExecutionException;
  */
 public final class NetworkUtils {
 
+    /**
+     * The maximum amount of time to wait for the DNS hostname to become resolvable.
+     */
     public static final Duration DNS_RESOLUTION_WAIT_TIME = Duration.ofSeconds(60);
 
     /**

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/Retry.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/Retry.java
@@ -19,6 +19,7 @@ package com.swirlds.base.utility;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -137,5 +138,106 @@ public final class Retry {
         // If the checkFn failed to resolve to a true value then we should fall
         // through to here and fail the operation.
         return false;
+    }
+
+    /**
+     * Evaluates a given {@code value} using the provided {@code resolveFn} method until a non-null result is returned
+     * and no exceptions are thrown.
+     *
+     * @param resolveFn   the function to be called to resolve the value to a result.
+     * @param value       the user value to be passed to the {@code checkFn} method.
+     * @param maxWaitTime the maximum duration to wait for the {@code checkFn} method to return true.
+     * @param retryDelay  the delay between retry attempts. must be greater than zero and less than or equal to the
+     *                    {@code maxWaitTime}.
+     * @param <T>         the type of the value argument.
+     * @param <R>         the type of the return value.
+     * @return the resolved value.
+     * @throws NullPointerException     if the {@code resolveFn} or the {@code value} arguments are a {@code null} values.
+     * @throws IllegalArgumentException if the {@code maxAttempts} argument is less than or equal to zero (0) or the
+     * @throws ExecutionException     if the resolve function fails to return a non-null value after the maximum number of attempts.
+     * @throws InterruptedException if the thread is interrupted while waiting.
+     */
+    public static <T, R> R resolve(
+            @NonNull final ThrowableFunction<T, R> resolveFn,
+            @NonNull final T value,
+            @NonNull final Duration maxWaitTime,
+            @NonNull final Duration retryDelay)
+            throws InterruptedException, ExecutionException {
+        Objects.requireNonNull(resolveFn, "resolveFn must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+        Objects.requireNonNull(maxWaitTime, "maxWaitTime must not be null");
+        Objects.requireNonNull(retryDelay, "retryDelay must not be null");
+
+        if (maxWaitTime.isNegative() || maxWaitTime.isZero()) {
+            throw new IllegalArgumentException("The maximum wait time must be greater than zero (0)");
+        }
+
+        if (retryDelay.isNegative() || retryDelay.isZero()) {
+            throw new IllegalArgumentException("The retry delay must be greater than zero (0)");
+        }
+
+        if (retryDelay.compareTo(maxWaitTime) > 0) {
+            throw new IllegalArgumentException("The retry delay must be less than or equal to the maximum wait time");
+        }
+
+        final int maxAttempts = Math.round(maxWaitTime.dividedBy(retryDelay));
+        return resolve(resolveFn, value, maxAttempts, retryDelay.toMillis());
+    }
+
+    /**
+     * Evaluates a given {@code value} using the provided {@code resolveFn} method until a non-null result is returned
+     * and no exceptions are thrown.
+     *
+     * @param resolveFn   the function to be called to resolve the value to a result.
+     * @param value       the user value to be passed to the {@code checkFn} method.
+     * @param maxAttempts the maximum number of retry attempts.
+     * @param delayMs     the delay between retry attempts. must greater than or equal to zero (0). if a zero value is
+     *                    specified then no delay will be applied.
+     * @param <T>         the type of the value argument.
+     * @param <R>         the type of the return value.
+     * @return the resolved value.
+     * @throws NullPointerException     if the {@code resolveFn} or the {@code value} arguments are a {@code null} values.
+     * @throws IllegalArgumentException if the {@code maxAttempts} argument is less than or equal to zero (0) or the
+     * @throws ExecutionException     if the resolve function fails to return a non-null value after the maximum number of attempts.
+     * @throws InterruptedException if the thread is interrupted while waiting.
+     */
+    public static <T, R> R resolve(
+            @NonNull final ThrowableFunction<T, R> resolveFn,
+            @NonNull final T value,
+            final int maxAttempts,
+            final long delayMs)
+            throws InterruptedException, ExecutionException {
+        Objects.requireNonNull(resolveFn, "resolveFn must not be null");
+        Objects.requireNonNull(value, "value must not be null");
+
+        if (maxAttempts <= 0) {
+            throw new IllegalArgumentException("The maximum number of attempts must be greater than zero (0)");
+        }
+
+        if (delayMs < 0) {
+            throw new IllegalArgumentException("The delay must be greater than or equal to zero (0)");
+        }
+
+        Throwable lastException = null;
+        for (int i = 0; i < maxAttempts; i++) {
+            try {
+                final R result = resolveFn.apply(value);
+
+                if (result != null) {
+                    return result;
+                }
+            } catch (final Throwable ex) {
+                // Ignore the exception and continue to retry while saving it for later.
+                lastException = ex;
+            }
+
+            if (delayMs > 0) {
+                TimeUnit.MILLISECONDS.sleep(delayMs);
+            }
+        }
+
+        throw new ExecutionException(
+                "The resolve function failed to return a non-null value after " + maxAttempts + " attempts",
+                lastException);
     }
 }

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/ThrowableFunction.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/utility/ThrowableFunction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.base.utility;
+
+/**
+ * Functional interface that represents a function that accepts one argument and produces a result. This variant is
+ * capable of throwing a checked exception.
+ *
+ * @param <T> the type of the input to the function.
+ * @param <R> the type of the result of the function.
+ */
+@FunctionalInterface
+public interface ThrowableFunction<T, R> {
+    /**
+     * Applies this function to the given argument.
+     *
+     * @param t the function argument.
+     * @return the function result.
+     * @throws Throwable if an error occurs.
+     */
+    R apply(T t) throws Throwable;
+}

--- a/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/utility/NetworkUtilsTest.java
+++ b/platform-sdk/swirlds-base/src/test/java/com/swirlds/base/utility/NetworkUtilsTest.java
@@ -17,9 +17,12 @@
 package com.swirlds.base.utility;
 
 import static com.swirlds.base.utility.NetworkUtils.isNameResolvable;
+import static com.swirlds.base.utility.NetworkUtils.resolveName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.Test;
@@ -33,15 +36,17 @@ public class NetworkUtilsTest {
     private static final Duration SHORT_RETRY_DELAY = Duration.of(25, ChronoUnit.MILLIS);
 
     @Test
-    void ipAddressShouldResolve() {
+    void ipAddressShouldResolve() throws UnknownHostException {
         final String ipv4 = "127.0.0.1";
         assertThat(isNameResolvable(ipv4)).isTrue();
+        assertThat(resolveName(ipv4)).isNotNull();
     }
 
     @Test
-    void validHostnameShouldResolve() {
+    void validHostnameShouldResolve() throws UnknownHostException {
         final String hostname = "localhost";
         assertThat(isNameResolvable(hostname)).isTrue();
+        assertThat(resolveName(hostname)).isNotNull();
     }
 
     @Test
@@ -49,18 +54,27 @@ public class NetworkUtilsTest {
         final String hostname = "invalid-hostname";
         assertThat(isNameResolvable(hostname, SHORT_WAIT_TIME, SHORT_RETRY_DELAY))
                 .isFalse();
+        assertThatThrownBy(() -> resolveName(hostname, SHORT_WAIT_TIME, SHORT_RETRY_DELAY))
+                .isInstanceOf(UnknownHostException.class)
+                .hasMessage("invalid-hostname: Name or service not known");
     }
 
     @Test
-    void publicHostnameShouldResolve() {
+    void publicHostnameShouldResolve() throws UnknownHostException {
         final String hostname = "google.com";
         assertThat(isNameResolvable(hostname)).isTrue();
+        assertThat(resolveName(hostname)).isNotNull().isInstanceOf(InetAddress.class);
     }
 
     @Test
     void nullHostnameShouldThrow() {
         //noinspection DataFlowIssue
         assertThatThrownBy(() -> isNameResolvable(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("name must not be null");
+
+        //noinspection DataFlowIssue
+        assertThatThrownBy(() -> resolveName(null))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("name must not be null");
     }
@@ -70,11 +84,19 @@ public class NetworkUtilsTest {
         assertThatThrownBy(() -> isNameResolvable("localhost", SHORT_WAIT_TIME, Duration.ZERO))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The retry delay must be greater than zero (0)");
+
+        assertThatThrownBy(() -> resolveName("localhost", SHORT_WAIT_TIME, Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The retry delay must be greater than zero (0)");
     }
 
     @Test
     void negativeDelayShouldThrow() {
         assertThatThrownBy(() -> isNameResolvable("localhost", SHORT_WAIT_TIME, SHORT_RETRY_DELAY.negated()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The retry delay must be greater than zero (0)");
+
+        assertThatThrownBy(() -> resolveName("localhost", SHORT_WAIT_TIME, SHORT_RETRY_DELAY.negated()))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The retry delay must be greater than zero (0)");
     }
@@ -84,11 +106,19 @@ public class NetworkUtilsTest {
         assertThatThrownBy(() -> isNameResolvable("localhost", Duration.ZERO, SHORT_RETRY_DELAY))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The maximum wait time must be greater than zero (0)");
+
+        assertThatThrownBy(() -> resolveName("localhost", Duration.ZERO, SHORT_RETRY_DELAY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The maximum wait time must be greater than zero (0)");
     }
 
     @Test
     void negativeWaitTimeShouldThrow() {
         assertThatThrownBy(() -> isNameResolvable("localhost", SHORT_WAIT_TIME.negated(), SHORT_RETRY_DELAY))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("The maximum wait time must be greater than zero (0)");
+
+        assertThatThrownBy(() -> resolveName("localhost", SHORT_WAIT_TIME.negated(), SHORT_RETRY_DELAY))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("The maximum wait time must be greater than zero (0)");
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookNetworkUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookNetworkUtils.java
@@ -16,11 +16,12 @@
 
 package com.swirlds.platform.state.address;
 
+import static com.swirlds.base.utility.NetworkUtils.resolveName;
+
 import com.swirlds.platform.network.Network;
 import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
 
@@ -41,7 +42,8 @@ public final class AddressBookNetworkUtils {
     public static boolean isLocal(@NonNull final Address address) {
         Objects.requireNonNull(address, "The address must not be null.");
         try {
-            return Network.isOwn(InetAddress.getByName(address.getHostnameInternal()));
+            assert address.getHostnameInternal() != null;
+            return Network.isOwn(resolveName(address.getHostnameInternal()));
         } catch (final UnknownHostException e) {
             throw new IllegalStateException(
                     "Not able to determine locality of address [%s] for node [%s]"


### PR DESCRIPTION
## Description

This pull request changes the following:

- Improves the `AddressBookNetworkUtils.isLocal()` method to reduce brittleness when DNS resolution is slow or fails on the first attempt. 
- Updates the `production-next` container image to resolve a bug in the `entrypoint.sh` script when retrying for address book loading issues.
- Updates the `production-next` container image to adjust the Java JVM DNS caching timeouts to behave within reasonable limits. 

### Related Issues

- Closes #16210
- Related to #16133 