### PR TITLE
ci: Update github token permissions

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -23,7 +23,7 @@ on:
 
 permissions:
   id-token: write
-  actions: read
+  actions: write
   pull-requests: write
   statuses: write
   checks: write
@@ -88,7 +88,7 @@ jobs:
           if [[ "${BRANCH_ON_DEVELOP}" -eq 0 ]]; then
             echo "xts-tag-exists=true" >> $GITHUB_OUTPUT
             echo "xts-tag-commit=${XTS_COMMIT}" >> $GITHUB_OUTPUT
-            echo "### Commit has been tagged as an XTS-Candidate" >>  $GITHUB_STEP_SUMMARY
+            echo "### XTS-Candidate commit found" >>  $GITHUB_STEP_SUMMARY
             echo "xts-tag-commit=${XTS_COMMIT}" >> $GITHUB_STEP_SUMMARY
 
             git push --delete origin "${XTS_CANDIDATE_TAG}"

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -22,7 +22,7 @@ on:
     - cron: '0 20 * * *'
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   statuses: write
 

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -27,6 +27,7 @@ defaults:
     shell: bash
 
 permissions:
+  actions: write
   contents: write
 
 env:


### PR DESCRIPTION
**Description**:

Need `actions:write` in order to enable the cancel action by the GH token

**Related issue(s)**:

Fixes #16212 

