### PR TITLE
fix: isAuthorizedRaw fails when given an auto-created account with EC…

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCall.java
@@ -148,7 +148,7 @@ public class IsAuthorizedRawCall extends AbstractCall {
         // Key must match signature type
         if (key.isPresent()) {
             if (!switch (signatureType) {
-                case EC -> false;
+                case EC -> key.get().hasEcdsa384();
                 case ED -> key.get().hasEd25519();
                 case INVALID -> false;
             }) return bail.apply(INVALID_SIGNATURE_TYPE_MISMATCHING_KEY);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isvalidalias/IsValidAliasCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isvalidalias/IsValidAliasCall.java
@@ -17,14 +17,17 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isvalidalias;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
+import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.MISSING_ENTITY_NUMBER;
 import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.NON_CANONICAL_REFERENCE_NUMBER;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.successResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call.PricedResult.gasOnly;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isvalidalias.IsValidAliasTranslator.IS_VALID_ALIAS;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.accountNumberForEvmReference;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.isLongZero;
 import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.Address;
+import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
@@ -49,11 +52,48 @@ public class IsValidAliasCall extends AbstractCall {
     @Override
     public @NonNull PricedResult execute() {
 
-        // It is OK if given address is long zero whether it does or doesn't have an EVM alias (which is
-        // why NON_CANONICAL_REFERENCE_NUMBER is an acceptable result).
-        final long accountNum = accountNumberForEvmReference(address, nativeOperations());
-        boolean isValidAlias = accountNum >= 0 || accountNum == NON_CANONICAL_REFERENCE_NUMBER;
+        // It is OK if given address is long zero whether it does or doesn't have an EVM alias
+
+        final var aliasKind = getAliasKindForAddressWithAccount(address, nativeOperations());
+        final boolean isValidAlias = aliasKind != AliasKind.EVM_ADDRESS_WITH_NO_ASSOCIATED_ACCOUNT;
         return gasOnly(fullResultsFor(isValidAlias), SUCCESS, true);
+    }
+
+    // FUTURE: Consider moving `AliasKind` and `getAliasKindForAddressWithAccount` to
+    // `com.hedera.node.app.service.token.AliasUtils`
+
+    public enum AliasKind {
+        ACCOUNT_NUM_ALIAS_OF_ACCOUNT_WITH_EVM_ALIAS,
+        ACCOUNT_NUM_ALIAS_OF_ACCOUNT_WITHOUT_EVM_ALIAS,
+        EVM_ALIAS_OF_ACCOUNT,
+        EVM_ADDRESS_WITH_NO_ASSOCIATED_ACCOUNT
+    };
+
+    /**
+     * Determine what kind of alias the {@link Address} is, w.r.t. current accounts known to the system
+     * @param address An EVM address
+     * @param nativeOperations Provides access to state (for Hedera accounts)
+     * @return an {@link AliasKind} describing the kind of alias this address is
+     */
+    public static @NonNull AliasKind getAliasKindForAddressWithAccount(
+            @NonNull final Address address, @NonNull final HederaNativeOperations nativeOperations) {
+        final boolean isAccountNumAlias /*aka long-zero*/ = isLongZero(address);
+        final long accountNum = accountNumberForEvmReference(address, nativeOperations);
+
+        if (accountNum == MISSING_ENTITY_NUMBER) {
+            // No account for this alias (accountNumberForEvmReference)
+            // Key alias given as protobuf but not EC key
+            // Not an EVM address (wrong size)
+            return AliasKind.EVM_ADDRESS_WITH_NO_ASSOCIATED_ACCOUNT;
+        } else if (accountNum == NON_CANONICAL_REFERENCE_NUMBER) {
+            // Account doesn't have an EVM address alias
+            return AliasKind.ACCOUNT_NUM_ALIAS_OF_ACCOUNT_WITHOUT_EVM_ALIAS;
+        } else {
+            // valid account with EVM address alias (possibly hollow?)
+            return isAccountNumAlias
+                    ? AliasKind.ACCOUNT_NUM_ALIAS_OF_ACCOUNT_WITH_EVM_ALIAS
+                    : AliasKind.EVM_ALIAS_OF_ACCOUNT;
+        }
     }
 
     private @NonNull FullResult fullResultsFor(final boolean result) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -174,16 +174,6 @@ public class ConversionUtils {
     }
 
     /**
-     * Given an entity number, returns it as a headlong address.
-     *
-     * @param anEntityNum a number (typically, last element of a shard.realm.num triplet)
-     * @return the argument represented as a Headlong address
-     */
-    public static com.esaulpaugh.headlong.abi.Address headlongAddressOf(final long anEntityNum) {
-        return asHeadlongAddress(asEvmAddress(anEntityNum));
-    }
-
-    /**
      * Given an account, returns its "priority" address as a Besu address.
      *
      * @param account the account

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -174,6 +174,16 @@ public class ConversionUtils {
     }
 
     /**
+     * Given an entity number, returns it as a headlong address.
+     *
+     * @param anEntityNum a number (typically, last element of a shard.realm.num triplet)
+     * @return the argument represented as a Headlong address
+     */
+    public static com.esaulpaugh.headlong.abi.Address headlongAddressOf(final long anEntityNum) {
+        return asHeadlongAddress(asEvmAddress(anEntityNum));
+    }
+
+    /**
      * Given an account, returns its "priority" address as a Besu address.
      *
      * @param account the account

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -410,11 +410,21 @@ public class ConversionUtils {
     /**
      * Given an EVM address, returns whether it is long-zero.
      *
-     * @param address the EVM address
+     * @param address the EVM address (as a BESU {@link org.hyperledger.besu.datatypes.Address})
      * @return whether it is long-zero
      */
     public static boolean isLongZero(@NonNull final Address address) {
         return isLongZeroAddress(address.toArrayUnsafe());
+    }
+
+    /**
+     * Given an EVM address, returns whether it is long-zero.
+     *
+     * @param address the EVM address (as a headlong {@link com.esaulpaugh.headlong.abi.Address})
+     * @return whether it is long-zero
+     */
+    public static boolean isLongZero(@NonNull final com.esaulpaugh.headlong.abi.Address address) {
+        return isLongZeroAddress(explicitFromHeadlong(address));
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
@@ -101,10 +101,6 @@ class IsAuthorizedRawCallTest extends CallTestBase {
     }
 
     @ParameterizedTest
-    @CsvSource({})
-    void noLongZeroAddressesValidIfEC(final long account, final boolean expected) {}
-
-    @ParameterizedTest
     @CsvSource({"0,27", "1,28", "27,27", "28,28", "45,27", "46,28", "18,"})
     void reverseVTest(final byte fromV, final Byte expectedV) {
         subject = getSubject(APPROVED_HEADLONG_ADDRESS);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilOp.java
@@ -18,7 +18,12 @@ package com.hedera.services.bdd.spec.utilops;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.SpecOperation;
 import com.hederahashgraph.api.proto.java.Transaction;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 
 public abstract class UtilOp extends HapiSpecOperation {
     @Override
@@ -29,5 +34,38 @@ public abstract class UtilOp extends HapiSpecOperation {
     public UtilOp logged() {
         verboseLoggingOn = true;
         return this;
+    }
+
+    /**
+     * Given an array of mixed
+     * <ul>
+     *     <li>{@link SpecOperation},</li>
+     *     <li>{@link SpecOperation}[],</li>
+     *     <li>{@link Collection}&lt;{@link SpecOperation}></li>
+     * </ul>
+     * flatten it into an {@link SpecOperation}[] with all the elements in the order iterated. (Only
+     * flattens top-level.)
+     */
+    @SuppressWarnings("rawtypes")
+    public static @NonNull SpecOperation[] flatten(@NonNull final Object... sos) {
+        final var ops = new ArrayList<SpecOperation>();
+        for (final var o : sos) {
+            switch (o) {
+                case SpecOperation so -> ops.add(so);
+                case SpecOperation[] aso -> Collections.addAll(ops, aso);
+                case Collection co -> {
+                    for (final var e : co) {
+                        if (e instanceof SpecOperation so) {
+                            ops.add(so);
+                        }
+                        // and ... silently ignore anything in the collection that's _not_ a `SpecOperation` ...
+                    }
+                }
+                default -> {
+                    /* silently ignore anything in the top-level array that's _not_ what we expect ... */
+                }
+            }
+        }
+        return ops.toArray(new SpecOperation[0]);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
@@ -222,7 +222,7 @@ public class UtilStateChange {
     }
 
     /**
-     * Like {@link #createEthereumAccountsWithECKeysAllDifferentWays(Map)} but with all default account names.
+     * Like {@link #createEthereumAccountsWithECKeysAllDifferentWays(Map)} but with all defaulted account names.
      */
     public static @NonNull List<SpecOperation> createEthereumAccountsWithECKeysAllDifferentWays() {
         return createEthereumAccountsWithECKeysAllDifferentWays(Map.of());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilStateChange.java
@@ -16,14 +16,41 @@
 
 package com.hedera.services.bdd.spec.utilops;
 
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asHeadlongAddress;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.explicitFromHeadlong;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.headlongAddressOf;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.keys.SigControl.SECP256K1_ON;
+import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.AUTO_CREATION_KEY_NAME_FN;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHip32Auto;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHollow;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.recordStreamMustIncludePassFrom;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.visibleNonSyntheticItems;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withAddressOfKey;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_CONTRACT_RECEIVER;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_CONTRACT_SENDER;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_RECEIVER_SOURCE_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoCreate;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.esaulpaugh.headlong.abi.Address;
+import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.assertions.StateChange;
@@ -32,11 +59,17 @@ import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
 import com.hedera.services.bdd.spec.utilops.inventory.NewSpecKey;
+import com.hedera.services.bdd.spec.utilops.streams.assertions.VisibleItemsValidator;
 import com.hedera.services.stream.proto.ContractStateChange;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -77,6 +110,154 @@ public class UtilStateChange {
         final var acc2 = createEthereumAccount(SECP_256K1_RECEIVER_SOURCE_KEY, DEFAULT_CONTRACT_RECEIVER);
         specToInitializedEthereumAccount.putIfAbsent(spec.getSuitePrefix() + spec.getName(), true);
         return Stream.concat(acc1.stream(), acc2.stream()).toList();
+    }
+
+    /**
+     * The four different kinds of EC-addressed accounts
+     */
+    public enum ECKind {
+        LONG_ZERO,
+        AUTO,
+        HOLLOW,
+        EXPLICIT_ALIAS;
+
+        /**
+         * Default names for each of the EC-addressed accounts
+         */
+        public static @NonNull Map<ECKind, String> defaultAccountNames() {
+            final var r = new HashMap<ECKind, String>();
+            for (final var e : ECKind.values()) {
+                r.put(e, e.name().toLowerCase());
+            }
+            return r;
+        }
+    };
+
+    /**
+     * Create (and register) 4 accounts with EC addresses - one each of the four different ways
+     * such accounts can be created: long-zero (with explicit EC key set), auto (HIP-32), hollow
+     * aka lazy (HIP-583), explicit alias provided (HIP-583).  Accounts and keys (with same name
+     * as accounts) are all registered.
+     *
+     * @param accountNamesByKind map of account kind to account name, for those accounts where
+     *                           caller wants to specify a name to override the default from {@link ECKind#defaultAccountNames()}}
+     * @return HAPI {@link com.hedera.services.bdd.spec.SpecOperation}s that create the accounts
+     * and assert their creation happened
+     */
+    public static @NonNull List<SpecOperation> createEthereumAccountsWithECKeysAllDifferentWays(
+            final @NonNull Map<ECKind, String> accountNamesByKind) {
+
+        // Merge default account names into caller-provided map of account names
+        final var accountsToCreate = new TreeMap<ECKind, String>((Comparator.comparing(Enum::ordinal)));
+        accountsToCreate.putAll(Stream.of(ECKind.defaultAccountNames(), accountNamesByKind)
+                .flatMap(m -> m.entrySet().stream())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1)));
+        final var accountCreationTxnIds = accountsToCreate.values().toArray(new String[0]);
+
+        final Map<ECKind, Address> evmAddresses = new HashMap<>(); // Collect addresses of created accounts here
+
+        final var ops = List.of(
+
+                // Validate (after all ops executed) that our accounts did get created
+                recordStreamMustIncludePassFrom(
+                        visibleNonSyntheticItems(
+                                ecAccountsValidator(evmAddresses, accountsToCreate), accountCreationTxnIds),
+                        Duration.ofSeconds(15)),
+
+                // Create the account with a long-zero EVM address
+                cryptoCreate(accountsToCreate.get(ECKind.LONG_ZERO))
+                        .via(accountsToCreate.get(ECKind.LONG_ZERO))
+                        .keyShape(SECP256K1_ON)
+                        .exposingEvmAddressTo(address -> evmAddresses.put(ECKind.LONG_ZERO, address)),
+
+                // Auto-create an account with an ECDSA key alias
+                createHip32Auto(1, KeyShape.SECP256K1, i -> accountsToCreate.get(ECKind.AUTO)),
+                withAddressOfKey(accountsToCreate.get(ECKind.AUTO), evmAddress -> {
+                    evmAddresses.put(ECKind.AUTO, evmAddress);
+                    return withOpContext((spec, opLog) -> spec.registry()
+                            .saveTxnId(
+                                    accountsToCreate.get(ECKind.AUTO),
+                                    spec.registry().getTxnId("hip32" + AUTO_CREATION_KEY_NAME_FN.apply(0))));
+                }),
+
+                // Create a hollow account and complete it
+                createHollow(
+                        1,
+                        i -> accountsToCreate.get(ECKind.HOLLOW),
+                        evmAddress -> cryptoTransfer(tinyBarsFromTo(GENESIS, evmAddress, ONE_HUNDRED_HBARS))),
+                withAddressOfKey(accountsToCreate.get(ECKind.HOLLOW), evmAddress -> {
+                    evmAddresses.put(ECKind.HOLLOW, evmAddress);
+                    return withOpContext((spec, opLog) -> {
+                        spec.registry()
+                                .saveTxnId(
+                                        accountsToCreate.get(ECKind.HOLLOW),
+                                        spec.registry()
+                                                .getTxnId(accountsToCreate.get(ECKind.AUTO)
+                                                        + "Create" /*from UtilVerbs.createHollow*/ + evmAddress));
+                    });
+                }),
+                cryptoTransfer(tinyBarsFromTo(accountsToCreate.get(ECKind.HOLLOW), FUNDING, 1))
+                        .payingWith(accountsToCreate.get(ECKind.HOLLOW))
+                        .sigMapPrefixes(uniqueWithFullPrefixesFor(accountsToCreate.get(ECKind.HOLLOW))),
+
+                // Create an account with an explicit EVM address
+                newKeyNamed(accountsToCreate.get(ECKind.EXPLICIT_ALIAS)).shape(KeyShape.SECP256K1),
+                withAddressOfKey(accountsToCreate.get(ECKind.EXPLICIT_ALIAS), evmAddress -> {
+                    evmAddresses.put(ECKind.EXPLICIT_ALIAS, evmAddress);
+                    return cryptoCreate(accountsToCreate.get(ECKind.EXPLICIT_ALIAS))
+                            .key(accountsToCreate.get(ECKind.EXPLICIT_ALIAS))
+                            .evmAddress(evmAddress)
+                            .via(accountsToCreate.get(ECKind.EXPLICIT_ALIAS));
+                }),
+                withOpContext((spec, opLog) -> {
+                    for (final var e : evmAddresses.entrySet()) {
+                        spec.registry()
+                                .saveEVMAddress(
+                                        accountsToCreate.get(e.getKey()),
+                                        e.getValue().value().toString(16));
+                    }
+                }));
+
+        return ops;
+    }
+
+    /**
+     * Like {@link #createEthereumAccountsWithECKeysAllDifferentWays(Map)} but with all default account names.
+     */
+    public static @NonNull List<SpecOperation> createEthereumAccountsWithECKeysAllDifferentWays() {
+        return createEthereumAccountsWithECKeysAllDifferentWays(Map.of());
+    }
+
+    private static @NonNull VisibleItemsValidator ecAccountsValidator(
+            @NonNull Map<ECKind, Address> evmAddresses, @NonNull Map<ECKind, String> accountNamesByKind) {
+        return (spec, records) -> {
+            for (final var e : accountNamesByKind.entrySet()) {
+                final var txnKind = e.getKey();
+                final var txnId = e.getValue();
+                final var successItems = requireNonNull(records.get(txnId), txnId + " not found");
+                final var creationEntry = successItems.entries().stream()
+                        .filter(entry -> entry.function() == CryptoCreate)
+                        .findFirst()
+                        .orElseThrow();
+                final var recordEvmAddress = creationEntry.transactionRecord().getEvmAddress();
+                final var bodyEvmAddress =
+                        creationEntry.body().getCryptoCreateAccount().getAlias();
+                final var numEvmAddresses =
+                        ((recordEvmAddress.size() == 20) ? 1 : 0) + ((bodyEvmAddress.size() == 20) ? 1 : 0);
+                assertTrue(numEvmAddresses <= 1);
+                final var evmAddress = numEvmAddresses == 0
+                        ? headlongAddressOf(creationEntry.createdAccountId())
+                        : asHeadlongAddress(
+                                (recordEvmAddress.size() == 20)
+                                        ? recordEvmAddress.toByteArray()
+                                        : bodyEvmAddress.toByteArray());
+                assertEquals(evmAddresses.get(txnKind), evmAddress);
+                allRunFor(
+                        spec,
+                        getAccountInfo("0.0." + creationEntry.createdAccountId().accountNumOrThrow())
+                                .has(accountWith().evmAddress(ByteString.copyFrom(explicitFromHeadlong(evmAddress)))));
+            }
+        };
     }
 
     private static List<SpecOperation> createEthereumAccount(final String secp256k1Key, final String txnName) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -16,9 +16,6 @@
 
 package com.hedera.services.bdd.suites.crypto;
 
-import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asHeadlongAddress;
-import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.explicitFromHeadlong;
-import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.headlongAddressOf;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
@@ -32,8 +29,6 @@ import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
 import static com.hedera.services.bdd.spec.keys.SigControl.ANY;
 import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
-import static com.hedera.services.bdd.spec.keys.SigControl.SECP256K1_ON;
-import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountDetails;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
@@ -47,13 +42,10 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
-import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
-import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.AUTO_CREATION_KEY_NAME_FN;
+import static com.hedera.services.bdd.spec.utilops.UtilOp.flatten;
+import static com.hedera.services.bdd.spec.utilops.UtilStateChange.createEthereumAccountsWithECKeysAllDifferentWays;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHip32Auto;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHollow;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doWithStartupConfigNow;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
@@ -63,18 +55,14 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.visibleNonSyntheticItems;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withAddressOfKey;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedBodyIds;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
-import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.THREE_MONTHS_IN_SECONDS;
 import static com.hedera.services.bdd.suites.HapiSuite.ZERO_BYTE_MEMO;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractUpdateSuite.ADMIN_KEY;
-import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoCreate;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoUpdate;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT;
@@ -88,10 +76,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REQUESTED_NUM_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.SpecOperation;
@@ -101,14 +87,15 @@ import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.queries.crypto.HapiGetAccountInfo;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.bdd.spec.utilops.UtilStateChange.ECKind;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.VisibleItemsValidator;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -166,9 +153,6 @@ public class CryptoUpdateSuite {
                         .newStakedAccountId("0.0.21")));
     }
 
-    private static final String[] ACCOUNTS_TO_HAVE_KEYS_ROTATED = {
-        "longZero", "autoCreated", "hollowAccount", "explicitAlias"
-    };
     private static final UnaryOperator<String> ROTATION_TXN = account -> account + "KeyRotation";
 
     /**
@@ -185,102 +169,46 @@ public class CryptoUpdateSuite {
     @HapiTest
     final Stream<DynamicTest> keyRotationDoesNotChangeEvmAddress() {
         final Map<String, Address> evmAddresses = new HashMap<>();
+
+        final var accountsToHaveKeysRotated =
+                ECKind.defaultAccountNames().values().stream().sorted().toList();
         final var allTxnIds = Stream.concat(
-                        Arrays.stream(ACCOUNTS_TO_HAVE_KEYS_ROTATED),
-                        Arrays.stream(ACCOUNTS_TO_HAVE_KEYS_ROTATED).map(ROTATION_TXN))
+                        accountsToHaveKeysRotated.stream(),
+                        accountsToHaveKeysRotated.stream().map(ROTATION_TXN))
                 .toArray(String[]::new);
-        return hapiTest(
+        return hapiTest(flatten(
                 recordStreamMustIncludePassFrom(
-                        visibleNonSyntheticItems(keyRotationsValidator(evmAddresses), allTxnIds),
+                        visibleNonSyntheticItems(
+                                keyRotationsValidator(evmAddresses, accountsToHaveKeysRotated), allTxnIds),
                         Duration.ofSeconds(10)),
                 // If the FileAlterationObserver just started the monitor, there's a chance we could miss the
                 // first couple of creations, so wait for a new record file boundary
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted),
-                // --- CREATE ACCOUNTS ---
-                // The account with a long-zero EVM address
-                cryptoCreate("longZero")
-                        .via("longZero")
-                        .keyShape(SECP256K1_ON)
-                        .exposingEvmAddressTo(address -> evmAddresses.put("longZero", address)),
-                // The auto-created account with an ECDSA key alias
-                createHip32Auto(1, KeyShape.SECP256K1, i -> "autoCreated"),
-                withAddressOfKey("autoCreated", evmAddress -> {
-                    evmAddresses.put("autoCreated", evmAddress);
-                    return withOpContext((spec, opLog) -> spec.registry()
-                            .saveTxnId(
-                                    "autoCreated",
-                                    spec.registry().getTxnId("hip32" + AUTO_CREATION_KEY_NAME_FN.apply(0))));
-                }),
-                // The hollow account - create and complete it for convenience
-                createHollow(
-                        1,
-                        i -> "hollowAccount",
-                        evmAddress -> cryptoTransfer(tinyBarsFromTo(GENESIS, evmAddress, ONE_HUNDRED_HBARS))),
-                withAddressOfKey("hollowAccount", evmAddress -> {
-                    evmAddresses.put("hollowAccount", evmAddress);
-                    return withOpContext((spec, opLog) -> spec.registry()
-                            .saveTxnId("hollowAccount", spec.registry().getTxnId("autoCreate" + evmAddress)));
-                }),
-                cryptoTransfer(tinyBarsFromTo("hollowAccount", FUNDING, 1))
-                        .payingWith("hollowAccount")
-                        .sigMapPrefixes(uniqueWithFullPrefixesFor("hollowAccount")),
-                // The account with an explicit EVM address
-                newKeyNamed("bEcdsaKey").shape(KeyShape.SECP256K1),
-                withAddressOfKey("bEcdsaKey", evmAddress -> {
-                    evmAddresses.put("explicitAlias", evmAddress);
-                    return cryptoCreate("explicitAlias")
-                            .key("bEcdsaKey")
-                            .evmAddress(evmAddress)
-                            .via("explicitAlias");
-                }),
+                createEthereumAccountsWithECKeysAllDifferentWays(),
                 // --- ROTATE KEYS ---
-                blockingOrder(IntStream.range(0, ACCOUNTS_TO_HAVE_KEYS_ROTATED.length)
+                blockingOrder(IntStream.range(0, accountsToHaveKeysRotated.size())
                         .mapToObj(i -> {
                             final var newKey = "replKey" + i;
-                            final var targetAccount = ACCOUNTS_TO_HAVE_KEYS_ROTATED[i];
+                            final var targetAccount = accountsToHaveKeysRotated.get(i);
                             return blockingOrder(
                                     newKeyNamed(newKey).shape(KeyShape.SECP256K1),
                                     cryptoUpdate(targetAccount).key(newKey).via(ROTATION_TXN.apply(targetAccount)));
                         })
-                        .toArray(SpecOperation[]::new)));
+                        .toArray(SpecOperation[]::new))));
     }
 
-    private static VisibleItemsValidator keyRotationsValidator(@NonNull final Map<String, Address> evmAddresses) {
+    private static VisibleItemsValidator keyRotationsValidator(
+            @NonNull final Map<String, Address> evmAddresses, @NonNull final List<String> accountsToHaveKeysRotated) {
         return (spec, records) -> {
-            for (final var txnId : ACCOUNTS_TO_HAVE_KEYS_ROTATED) {
-                final var successItems = requireNonNull(records.get(txnId), txnId + " not found");
-                final var creationEntry = successItems.entries().stream()
-                        .filter(entry -> entry.function() == CryptoCreate)
-                        .findFirst()
-                        .orElseThrow();
-                final var recordEvmAddress = creationEntry.transactionRecord().getEvmAddress();
-                final var bodyEvmAddress =
-                        creationEntry.body().getCryptoCreateAccount().getAlias();
-                final var numEvmAddresses =
-                        ((recordEvmAddress.size() == 20) ? 1 : 0) + ((bodyEvmAddress.size() == 20) ? 1 : 0);
-                assertTrue(numEvmAddresses <= 1);
-                final var evmAddress = numEvmAddresses == 0
-                        ? headlongAddressOf(creationEntry.createdAccountId())
-                        : asHeadlongAddress(
-                                (recordEvmAddress.size() == 20)
-                                        ? recordEvmAddress.toByteArray()
-                                        : bodyEvmAddress.toByteArray());
-                assertEquals(evmAddresses.get(txnId), evmAddress);
-                allRunFor(
-                        spec,
-                        getAccountInfo("0.0." + creationEntry.createdAccountId().accountNumOrThrow())
-                                .has(accountWith().evmAddress(ByteString.copyFrom(explicitFromHeadlong(evmAddress)))));
-            }
-            final var rotationTxnIds = Arrays.stream(ACCOUNTS_TO_HAVE_KEYS_ROTATED)
-                    .map(ROTATION_TXN)
-                    .toArray(String[]::new);
+            final var rotationTxnIds =
+                    accountsToHaveKeysRotated.stream().map(ROTATION_TXN).toArray(String[]::new);
             for (final var txnId : rotationTxnIds) {
                 final var successItems = requireNonNull(records.get(txnId), txnId + " not found");
                 final var updateEntry = successItems.entries().stream()
                         .filter(entry -> entry.function() == CryptoUpdate)
                         .findFirst()
                         .orElseThrow();
-                assertEquals(0, updateEntry.txnRecord().getEvmAddress().size());
+                assertEquals(0, updateEntry.txnRecord().getEvmAddress().size(), "for txnId " + txnId);
             }
         };
     }


### PR DESCRIPTION
**Description**:
Fix bug where `isAuthorizedRaw` fails when given an auto-created account with EC… key

Fix bug for auto-created account.  Add a HapiSpec DSL method for creating accounts all four ways they can be created with EC keys.
* The four ways are: explicitly create with EC key, auto create, completed hollow account, long-zero

**Related issue(s)**:
Fixes #15920

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
