### PR TITLE
chore: replace usages of AddressBook with Roster in event.branching

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
@@ -1199,7 +1199,7 @@ public class PlatformComponentBuilder {
     @NonNull
     public BranchDetector buildBranchDetector() {
         if (branchDetector == null) {
-            branchDetector = new DefaultBranchDetector(blocks.initialAddressBook());
+            branchDetector = new DefaultBranchDetector(getInitialRoster());
         }
         return branchDetector;
     }
@@ -1231,7 +1231,7 @@ public class PlatformComponentBuilder {
     @NonNull
     public BranchReporter buildBranchReporter() {
         if (branchReporter == null) {
-            branchReporter = new DefaultBranchReporter(blocks.platformContext(), blocks.initialAddressBook());
+            branchReporter = new DefaultBranchReporter(blocks.platformContext(), getInitialRoster());
         }
         return branchReporter;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/branching/DefaultBranchDetector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/branching/DefaultBranchDetector.java
@@ -16,10 +16,10 @@
 
 package com.swirlds.platform.event.branching;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.consensus.EventWindow;
 import com.swirlds.platform.event.PlatformEvent;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.EventDescriptorWrapper;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -54,8 +54,10 @@ public class DefaultBranchDetector implements BranchDetector {
      *
      * @param currentRoster the current roster
      */
-    public DefaultBranchDetector(@NonNull final AddressBook currentRoster) {
-        nodes.addAll(currentRoster.getNodeIdSet());
+    public DefaultBranchDetector(@NonNull final Roster currentRoster) {
+        nodes.addAll(currentRoster.rosterEntries().stream()
+                .map(re -> NodeId.of(re.nodeId()))
+                .toList());
         Collections.sort(nodes);
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -74,7 +74,7 @@ public final class RosterUtils {
      * Build a map from a long nodeId to a RosterEntry for a given Roster.
      *
      * @param roster a roster
-     * @return Map&lt;Long, RosterEntry&gt;
+     * @return {@code Map<Long, RosterEntry>}
      */
     @Nullable
     public static Map<Long, RosterEntry> toMap(@Nullable final Roster roster) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/branching/BranchDetectorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/branching/BranchDetectorTests.java
@@ -22,12 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.consensus.EventWindow;
 import com.swirlds.platform.event.PlatformEvent;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.event.TestingEventBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -71,15 +71,14 @@ class BranchDetectorTests {
     @Test
     void requiresEventWindow() {
         final Randotron randotron = Randotron.create();
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(randotron).withSize(8).build();
+        final Roster roster = RandomRosterBuilder.create(randotron).withSize(8).build();
 
         final PlatformEvent event = new TestingEventBuilder(randotron)
-                .setCreatorId(addressBook.getNodeId(0))
+                .setCreatorId(NodeId.of(roster.rosterEntries().get(0).nodeId()))
                 .setBirthRound(1)
                 .build();
 
-        final BranchDetector branchDetector = new DefaultBranchDetector(addressBook);
+        final BranchDetector branchDetector = new DefaultBranchDetector(roster);
 
         // We expect this to throw if we haven't yet specified the event window.
         assertThrows(IllegalStateException.class, () -> branchDetector.checkForBranches(event));
@@ -91,13 +90,15 @@ class BranchDetectorTests {
 
         final int nodeCount = 8;
 
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(randotron).withSize(nodeCount).build();
+        final Roster roster =
+                RandomRosterBuilder.create(randotron).withSize(nodeCount).build();
 
         final int initialBirthRound = randotron.nextInt(1, 1000);
 
         final List<PlatformEvent> events = new ArrayList<>();
-        for (final NodeId nodeId : addressBook.getNodeIdSet()) {
+        for (final NodeId nodeId : roster.rosterEntries().stream()
+                .map(re -> NodeId.of(re.nodeId()))
+                .toList()) {
             events.addAll(generateSimpleSequenceOfEvents(randotron, nodeId, initialBirthRound, 512));
         }
 
@@ -107,7 +108,7 @@ class BranchDetectorTests {
 
         long ancientThreshold = initialBirthRound;
 
-        final BranchDetector branchDetector = new DefaultBranchDetector(addressBook);
+        final BranchDetector branchDetector = new DefaultBranchDetector(roster);
         branchDetector.updateEventWindow(
                 new EventWindow(1 /* ignored */, ancientThreshold, 1 /* ignored */, BIRTH_ROUND_THRESHOLD));
 
@@ -141,17 +142,21 @@ class BranchDetectorTests {
 
         final int nodeCount = 8;
 
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(randotron).withSize(nodeCount).build();
+        final Roster roster =
+                RandomRosterBuilder.create(randotron).withSize(nodeCount).build();
 
         final int initialBirthRound = randotron.nextInt(1, 1000);
 
-        final NodeId branchingNode = addressBook.getNodeId(randotron.nextInt(0, addressBook.getSize()));
+        final NodeId branchingNode = NodeId.of(roster.rosterEntries()
+                .get(randotron.nextInt(0, roster.rosterEntries().size()))
+                .nodeId());
         PlatformEvent branchingEvent = null;
         PlatformEvent siblingEvent = null;
 
         final List<PlatformEvent> events = new ArrayList<>();
-        for (final NodeId nodeId : addressBook.getNodeIdSet()) {
+        for (final NodeId nodeId : roster.rosterEntries().stream()
+                .map(re -> NodeId.of(re.nodeId()))
+                .toList()) {
             final List<PlatformEvent> nodeEvents =
                     generateSimpleSequenceOfEvents(randotron, nodeId, initialBirthRound, 64);
 
@@ -176,7 +181,7 @@ class BranchDetectorTests {
 
         long ancientThreshold = initialBirthRound;
 
-        final BranchDetector branchDetector = new DefaultBranchDetector(addressBook);
+        final BranchDetector branchDetector = new DefaultBranchDetector(roster);
         branchDetector.updateEventWindow(
                 new EventWindow(1 /* ignored */, ancientThreshold, 1 /* ignored */, BIRTH_ROUND_THRESHOLD));
 
@@ -231,16 +236,20 @@ class BranchDetectorTests {
 
         final int nodeCount = 8;
 
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(randotron).withSize(nodeCount).build();
+        final Roster roster =
+                RandomRosterBuilder.create(randotron).withSize(nodeCount).build();
 
         final int initialBirthRound = randotron.nextInt(1, 1000);
 
-        final NodeId branchingNode = addressBook.getNodeId(randotron.nextInt(0, addressBook.getSize()));
+        final NodeId branchingNode = NodeId.of(roster.rosterEntries()
+                .get(randotron.nextInt(0, roster.rosterEntries().size()))
+                .nodeId());
         PlatformEvent branchingEvent = null;
 
         final List<PlatformEvent> events = new ArrayList<>();
-        for (final NodeId nodeId : addressBook.getNodeIdSet()) {
+        for (final NodeId nodeId : roster.rosterEntries().stream()
+                .map(re -> NodeId.of(re.nodeId()))
+                .toList()) {
             final List<PlatformEvent> nodeEvents =
                     generateSimpleSequenceOfEvents(randotron, nodeId, initialBirthRound, 64);
 
@@ -263,7 +272,7 @@ class BranchDetectorTests {
 
         long ancientThreshold = initialBirthRound;
 
-        final BranchDetector branchDetector = new DefaultBranchDetector(addressBook);
+        final BranchDetector branchDetector = new DefaultBranchDetector(roster);
         branchDetector.updateEventWindow(
                 new EventWindow(1 /* ignored */, ancientThreshold, 1 /* ignored */, BIRTH_ROUND_THRESHOLD));
 
@@ -301,16 +310,20 @@ class BranchDetectorTests {
 
         final int nodeCount = 8;
 
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(randotron).withSize(nodeCount).build();
+        final Roster roster =
+                RandomRosterBuilder.create(randotron).withSize(nodeCount).build();
 
         final int initialBirthRound = randotron.nextInt(1, 1000);
 
-        final NodeId branchingNode = addressBook.getNodeId(randotron.nextInt(0, addressBook.getSize()));
+        final NodeId branchingNode = NodeId.of(roster.rosterEntries()
+                .get(randotron.nextInt(0, roster.rosterEntries().size()))
+                .nodeId());
         PlatformEvent branchingEvent = null;
 
         final List<PlatformEvent> events = new ArrayList<>();
-        for (final NodeId nodeId : addressBook.getNodeIdSet()) {
+        for (final NodeId nodeId : roster.rosterEntries().stream()
+                .map(re -> NodeId.of(re.nodeId()))
+                .toList()) {
             final List<PlatformEvent> nodeEvents =
                     generateSimpleSequenceOfEvents(randotron, nodeId, initialBirthRound, 64);
 
@@ -335,7 +348,7 @@ class BranchDetectorTests {
 
         long ancientThreshold = initialBirthRound;
 
-        final BranchDetector branchDetector = new DefaultBranchDetector(addressBook);
+        final BranchDetector branchDetector = new DefaultBranchDetector(roster);
         branchDetector.updateEventWindow(
                 new EventWindow(1 /* ignored */, ancientThreshold, 1 /* ignored */, BIRTH_ROUND_THRESHOLD));
 
@@ -371,16 +384,20 @@ class BranchDetectorTests {
 
         final int nodeCount = 8;
 
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(randotron).withSize(nodeCount).build();
+        final Roster roster =
+                RandomRosterBuilder.create(randotron).withSize(nodeCount).build();
 
         final int initialBirthRound = randotron.nextInt(1, 1000);
 
-        final NodeId branchingNode = addressBook.getNodeId(randotron.nextInt(0, addressBook.getSize()));
+        final NodeId branchingNode = NodeId.of(roster.rosterEntries()
+                .get(randotron.nextInt(0, roster.rosterEntries().size()))
+                .nodeId());
         PlatformEvent branchingEvent = null;
 
         final List<PlatformEvent> events = new ArrayList<>();
-        for (final NodeId nodeId : addressBook.getNodeIdSet()) {
+        for (final NodeId nodeId : roster.rosterEntries().stream()
+                .map(re -> NodeId.of(re.nodeId()))
+                .toList()) {
             final List<PlatformEvent> nodeEvents =
                     generateSimpleSequenceOfEvents(randotron, nodeId, initialBirthRound, 64);
 
@@ -402,7 +419,7 @@ class BranchDetectorTests {
 
         long ancientThreshold = initialBirthRound;
 
-        final BranchDetector branchDetector = new DefaultBranchDetector(addressBook);
+        final BranchDetector branchDetector = new DefaultBranchDetector(roster);
         branchDetector.updateEventWindow(
                 new EventWindow(1 /* ignored */, ancientThreshold, 1 /* ignored */, BIRTH_ROUND_THRESHOLD));
 
@@ -436,16 +453,20 @@ class BranchDetectorTests {
 
         final int nodeCount = 8;
 
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(randotron).withSize(nodeCount).build();
+        final Roster roster =
+                RandomRosterBuilder.create(randotron).withSize(nodeCount).build();
 
         final int initialBirthRound = randotron.nextInt(1, 1000);
 
-        final NodeId branchingNode = addressBook.getNodeId(randotron.nextInt(0, addressBook.getSize()));
+        final NodeId branchingNode = NodeId.of(roster.rosterEntries()
+                .get(randotron.nextInt(0, roster.rosterEntries().size()))
+                .nodeId());
         PlatformEvent branchingEvent = null;
 
         final List<PlatformEvent> events = new ArrayList<>();
-        for (final NodeId nodeId : addressBook.getNodeIdSet()) {
+        for (final NodeId nodeId : roster.rosterEntries().stream()
+                .map(re -> NodeId.of(re.nodeId()))
+                .toList()) {
             final List<PlatformEvent> nodeEvents =
                     generateSimpleSequenceOfEvents(randotron, nodeId, initialBirthRound, 64);
 
@@ -471,7 +492,7 @@ class BranchDetectorTests {
 
         long ancientThreshold = initialBirthRound;
 
-        final BranchDetector branchDetector = new DefaultBranchDetector(addressBook);
+        final BranchDetector branchDetector = new DefaultBranchDetector(roster);
         branchDetector.updateEventWindow(
                 new EventWindow(1 /* ignored */, ancientThreshold, 1 /* ignored */, BIRTH_ROUND_THRESHOLD));
 


### PR DESCRIPTION
**Description**:
As a part of the TSS initiative, and specifically the TSS-Roster project, we're refactoring the Platform code to replace usages of `AddressBook` with `Roster`.

This fix refactors the `event.branching`-related classes.

**Related issue(s)**:

Fixes #16235

**Notes for reviewer**:
Tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
