### PR TITLE
feat: always generate agreement key on startup

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -551,7 +551,7 @@ public final class CryptoStatic {
                     keysAndCerts = EnhancedKeyStoreLoader.using(addressBook, configuration)
                             .migrate()
                             .scan()
-                            .generateIfNecessary()
+                            .generate()
                             .verify()
                             .injectInAddressBook()
                             .keysAndCerts();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
@@ -298,16 +298,11 @@ public class EnhancedKeyStoreLoader {
                 localNodes.add(nodeId);
                 sigPrivateKeys.compute(
                         nodeId, (k, v) -> resolveNodePrivateKey(nodeId, nodeAlias, KeyCertPurpose.SIGNING));
-                agrPrivateKeys.compute(
-                        nodeId, (k, v) -> resolveNodePrivateKey(nodeId, nodeAlias, KeyCertPurpose.AGREEMENT));
             }
 
             sigCertificates.compute(
                     nodeId,
                     (k, v) -> resolveNodeCertificate(nodeId, nodeAlias, KeyCertPurpose.SIGNING, legacyPublicStore));
-            agrCertificates.compute(
-                    nodeId,
-                    (k, v) -> resolveNodeCertificate(nodeId, nodeAlias, KeyCertPurpose.AGREEMENT, legacyPublicStore));
         });
 
         logger.trace(STARTUP.getMarker(), "Completed key store enumeration");
@@ -315,16 +310,15 @@ public class EnhancedKeyStoreLoader {
     }
 
     /**
-     * Iterates over the local nodes and creates the agreement key and certificate for each if they do not exist.  This
-     * method should be called after {@link #scan()} and before {@link #verify()} in order to generate any missing
-     * agreement keys for local nodes to pass verification.
+     * Iterates over the local nodes and creates the agreement key and certificate for each.  This
+     * method should be called after {@link #scan()} and before {@link #verify()}.
      *
      * @return this {@link EnhancedKeyStoreLoader} instance.
      * @throws NoSuchAlgorithmException if the algorithm required to generate the key pair is not available.
      * @throws NoSuchProviderException  if the security provider required to generate the key pair is not available.
      * @throws KeyGeneratingException   if an error occurred while generating the agreement key pair.
      */
-    public EnhancedKeyStoreLoader generateIfNecessary()
+    public EnhancedKeyStoreLoader generate()
             throws NoSuchAlgorithmException, NoSuchProviderException, KeyGeneratingException {
 
         for (final NodeId node : localNodes) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
@@ -102,7 +102,7 @@ public class CryptoArgsProvider {
         final Map<NodeId, KeysAndCerts> loadedC = EnhancedKeyStoreLoader.using(
                         createdAB, configure(ResourceLoader.getFile("preGeneratedPEMKeysAndCerts/")))
                 .scan()
-                .generateIfNecessary()
+                .generate()
                 .verify()
                 .injectInAddressBook()
                 .keysAndCerts();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
@@ -117,7 +117,7 @@ class EnhancedKeyStoreLoaderTest {
         assertThat(loader).isNotNull();
         assertThatCode(loader::migrate).doesNotThrowAnyException();
         assertThatCode(loader::scan).doesNotThrowAnyException();
-        assertThatCode(loader::generateIfNecessary).doesNotThrowAnyException();
+        assertThatCode(loader::generate).doesNotThrowAnyException();
         assertThatCode(loader::verify).doesNotThrowAnyException();
         assertThatCode(loader::injectInAddressBook).doesNotThrowAnyException();
 
@@ -189,13 +189,9 @@ class EnhancedKeyStoreLoaderTest {
         assertThat(loader).isNotNull();
         assertThatCode(loader::migrate).doesNotThrowAnyException();
         assertThatCode(loader::scan).doesNotThrowAnyException();
-        assertThatCode(loader::generateIfNecessary).isInstanceOf(KeyGeneratingException.class);
+        assertThatCode(loader::generate).isInstanceOf(KeyGeneratingException.class);
         assertThatCode(loader::verify).isInstanceOf(KeyLoadingException.class);
-        if (directoryName.equals("hybrid-invalid-case-2") || directoryName.equals("enhanced-invalid-case-2")) {
-            assertThatCode(loader::injectInAddressBook).isInstanceOf(KeyLoadingException.class);
-        } else {
-            assertThatCode(loader::injectInAddressBook).doesNotThrowAnyException();
-        }
+        assertThatCode(loader::injectInAddressBook).isInstanceOf(KeyLoadingException.class);
         assertThatCode(loader::keysAndCerts).isInstanceOf(KeyLoadingException.class);
     }
 


### PR DESCRIPTION
**Description**:

This PR stops reading the agreement key from disk and always generates it on startup.  The migration code will delete the agreement key if found and force generation anyway.   This is a code cleanup operation so that when the migration code is removed, there are no potential bugs.  

Potential Bug This Avoids:  
* PFX file contains an agreement key
* Migration code is deleted and PFX files remain on disk because someone put them there again. 
* DAB has rotated the signing key and is using a new signing key in a PEM file. 
* Agreement key for old signing key is loaded from PFX file. 
* The mismatch between the old agreement key and new signing key will cause the node to fail to create mTLS connections with peers. 

Fixes #16161 

**Notes for reviewer**:
The only testing required and performed was unit testing.   The special casing on one of the negative unit tests was removed because we are no longer reading a valid agreement key in that scenario. 
