### PR TITLE
chore: replace usages of AddressBook with Roster in DefaultConsensusE…

### DIFF
--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/BlockStreamManagerBenchmark.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/BlockStreamManagerBenchmark.java
@@ -35,6 +35,7 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
+import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.node.app.blocks.impl.BlockStreamManagerImpl;
 import com.hedera.node.app.blocks.impl.BoundaryStateChangeListener;
@@ -54,7 +55,6 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.system.Round;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.state.notifications.StateHashedNotification;
 import com.swirlds.state.spi.Schema;
@@ -291,7 +291,7 @@ public class BlockStreamManagerBenchmark {
 
         @NonNull
         @Override
-        public AddressBook getConsensusRoster() {
+        public Roster getConsensusRoster() {
             throw new UnsupportedOperationException();
         }
 

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/StandaloneRoundManagement.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/StandaloneRoundManagement.java
@@ -35,6 +35,7 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
+import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.node.app.blocks.impl.BlockStreamManagerImpl;
 import com.hedera.node.app.blocks.impl.BoundaryStateChangeListener;
@@ -55,7 +56,6 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.system.Round;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.state.notifications.StateHashedNotification;
 import com.swirlds.state.spi.Schema;
@@ -291,7 +291,7 @@ public class StandaloneRoundManagement {
 
         @NonNull
         @Override
-        public AddressBook getConsensusRoster() {
+        public Roster getConsensusRoster() {
             throw new UnsupportedOperationException();
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -30,6 +30,7 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.StreamSupport.stream;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.node.app.Hedera;
 import com.hedera.node.app.fixtures.state.FakeServiceMigrator;
@@ -51,6 +52,7 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader;
 import com.swirlds.platform.listeners.PlatformStatusChangeNotification;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.Address;
@@ -100,6 +102,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     protected final FakeState state = new FakeState();
     protected final AccountID defaultNodeAccountId;
     protected final AddressBook addressBook;
+    protected final Roster roster;
     protected final NodeId defaultNodeId;
     protected final AtomicInteger nextNano = new AtomicInteger(0);
     protected final Hedera hedera;
@@ -111,6 +114,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     protected AbstractEmbeddedHedera(@NonNull final EmbeddedNode node) {
         requireNonNull(node);
         addressBook = loadAddressBook(node.getExternalPath(ADDRESS_BOOK));
+        roster = RosterRetriever.buildRoster(addressBook);
         nodeIds = stream(spliteratorUnknownSize(addressBook.iterator(), 0), false)
                 .collect(toMap(AbstractEmbeddedHedera::accountIdOf, Address::getNodeId));
         accountIds = stream(spliteratorUnknownSize(addressBook.iterator(), 0), false)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
@@ -159,7 +159,7 @@ class ConcurrentEmbeddedHedera extends AbstractEmbeddedHedera implements Embedde
                                         event.getSoftwareVersion());
                             })
                             .toList();
-                    final var round = new FakeRound(roundNo.getAndIncrement(), addressBook, consensusEvents);
+                    final var round = new FakeRound(roundNo.getAndIncrement(), roster, consensusEvents);
                     hedera.handleWorkflow().handleRound(state, round);
                     hedera.onSealConsensusRound(round, state);
                     notifyBlockStreamManagerIfEnabled(round.getRoundNum());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
@@ -152,7 +152,7 @@ class RepeatableEmbeddedHedera extends AbstractEmbeddedHedera implements Embedde
                     consensusOrder.getAndIncrement(),
                     firstRoundTime,
                     lastCreatedEvent.getSoftwareVersion()));
-            return new FakeRound(roundNo.getAndIncrement(), addressBook, consensusEvents);
+            return new FakeRound(roundNo.getAndIncrement(), roster, consensusEvents);
         }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeRound.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeRound.java
@@ -18,8 +18,8 @@ package com.hedera.services.bdd.junit.hedera.embedded.fakes;
 
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.platform.system.Round;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
@@ -28,15 +28,13 @@ import java.util.List;
 
 public class FakeRound implements Round {
     private final long roundNum;
-    private final AddressBook addressBook;
+    private final Roster roster;
     private final List<ConsensusEvent> consensusEvents;
 
     public FakeRound(
-            final long roundNum,
-            @NonNull final AddressBook addressBook,
-            @NonNull final List<ConsensusEvent> consensusEvents) {
+            final long roundNum, @NonNull final Roster roster, @NonNull final List<ConsensusEvent> consensusEvents) {
         this.roundNum = roundNum;
-        this.addressBook = requireNonNull(addressBook);
+        this.roster = requireNonNull(roster);
         this.consensusEvents = requireNonNull(consensusEvents);
     }
 
@@ -63,8 +61,8 @@ public class FakeRound implements Round {
 
     @NonNull
     @Override
-    public AddressBook getConsensusRoster() {
-        return addressBook;
+    public Roster getConsensusRoster() {
+        return roster;
     }
 
     @NonNull

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/test/java/com/swirlds/demo/consistency/ConsistencyTestingToolRoundTests.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/test/java/com/swirlds/demo/consistency/ConsistencyTestingToolRoundTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.event.EventTransaction.TransactionOneOfType;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -32,7 +33,6 @@ import com.swirlds.platform.consensus.GraphGenerations;
 import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.system.Round;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.fixtures.event.TestingEventBuilder;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -83,7 +83,7 @@ class ConsistencyTestingToolRoundTests {
         Mockito.when(mockSnapshot.round()).thenReturn(roundReceived);
 
         return new ConsensusRound(
-                mock(AddressBook.class),
+                mock(Roster.class),
                 mockEvents,
                 mock(PlatformEvent.class),
                 mock(GraphGenerations.class),

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module com.swirlds.demo.iss {
+    requires com.hedera.node.hapi;
     requires com.swirlds.base;
     requires com.swirlds.common;
     requires com.swirlds.config.api;

--- a/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
+++ b/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
@@ -23,6 +23,7 @@ import com.swirlds.platform.Consensus;
 import com.swirlds.platform.ConsensusImpl;
 import com.swirlds.platform.internal.EventImpl;
 import com.swirlds.platform.metrics.NoOpConsensusMetrics;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.event.emitter.StandardEventEmitter;
 import com.swirlds.platform.test.event.source.EventSourceFactory;
@@ -73,7 +74,8 @@ public class ConsensusBenchmark {
         events = emitter.emitEvents(numEvents);
         final AddressBook addressBook = emitter.getGraphGenerator().getAddressBook();
 
-        consensus = new ConsensusImpl(platformContext, new NoOpConsensusMetrics(), addressBook);
+        consensus = new ConsensusImpl(
+                platformContext, new NoOpConsensusMetrics(), RosterRetriever.buildRoster(addressBook));
     }
 
     @Benchmark

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
@@ -559,8 +559,7 @@ public class PlatformComponentBuilder {
     @NonNull
     public ConsensusEngine buildConsensusEngine() {
         if (consensusEngine == null) {
-            consensusEngine = new DefaultConsensusEngine(
-                    blocks.platformContext(), blocks.initialState().get().getAddressBook(), blocks.selfId());
+            consensusEngine = new DefaultConsensusEngine(blocks.platformContext(), getInitialRoster(), blocks.selfId());
         }
         return consensusEngine;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/consensus/DefaultConsensusEngine.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/consensus/DefaultConsensusEngine.java
@@ -18,6 +18,7 @@ package com.swirlds.platform.components.consensus;
 
 import static com.swirlds.platform.system.status.PlatformStatus.REPLAYING_EVENTS;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.Consensus;
@@ -35,7 +36,6 @@ import com.swirlds.platform.internal.EventImpl;
 import com.swirlds.platform.metrics.AddedEventMetrics;
 import com.swirlds.platform.metrics.ConsensusMetrics;
 import com.swirlds.platform.metrics.ConsensusMetricsImpl;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.status.PlatformStatus;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
@@ -65,16 +65,16 @@ public class DefaultConsensusEngine implements ConsensusEngine {
      * Constructor
      *
      * @param platformContext the platform context
-     * @param addressBook     the current address book
+     * @param roster     the current roster
      * @param selfId          the ID of the node
      */
     public DefaultConsensusEngine(
             @NonNull final PlatformContext platformContext,
-            @NonNull final AddressBook addressBook,
+            @NonNull final Roster roster,
             @NonNull final NodeId selfId) {
 
         final ConsensusMetrics consensusMetrics = new ConsensusMetricsImpl(selfId, platformContext.getMetrics());
-        consensus = new ConsensusImpl(platformContext, consensusMetrics, addressBook);
+        consensus = new ConsensusImpl(platformContext, consensusMetrics, roster);
 
         linker = new ConsensusLinker(platformContext, selfId);
         ancientMode = platformContext

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusRounds.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusRounds.java
@@ -16,12 +16,15 @@
 
 package com.swirlds.platform.consensus;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.logging.legacy.LogMarker;
 import com.swirlds.platform.internal.EventImpl;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MinimumJudgeInfo;
-import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.LongStream;
 import org.apache.logging.log4j.LogManager;
@@ -38,8 +41,8 @@ public class ConsensusRounds {
     private final ConsensusConfig config;
     /** stores the minimum judge ancient identifier for all decided and non-expired rounds */
     private final SequentialRingBuffer<MinimumJudgeInfo> minimumJudgeStorage;
-    /** the only address book currently in use, until address book changes are implemented */
-    private final AddressBook addressBook;
+    /** a derivative of the only roster currently in use, until roster changes are implemented */
+    private final Map<Long, RosterEntry> rosterEntryMap;
     /** The maximum round created of all the known witnesses */
     private long maxRoundCreated = ConsensusConstants.ROUND_UNDEFINED;
     /** The round we are currently voting on */
@@ -49,10 +52,10 @@ public class ConsensusRounds {
     public ConsensusRounds(
             @NonNull final ConsensusConfig config,
             @NonNull final SequentialRingBuffer<MinimumJudgeInfo> minimumJudgeStorage,
-            @NonNull final AddressBook addressBook) {
+            @NonNull final Roster roster) {
         this.config = Objects.requireNonNull(config);
         this.minimumJudgeStorage = Objects.requireNonNull(minimumJudgeStorage);
-        this.addressBook = Objects.requireNonNull(addressBook);
+        this.rosterEntryMap = RosterUtils.toMap(Objects.requireNonNull(roster));
         reset();
     }
 
@@ -87,7 +90,8 @@ public class ConsensusRounds {
         // theorem says this witness can't be famous if round R+2 exists
         // if this is true, we immediately mark this witness as not famous without any elections
         // also, if the witness is not in the AB, we decide that it's not famous
-        if (maxRoundCreated >= witness.getRoundCreated() + 2 || !addressBook.contains(witness.getCreatorId())) {
+        if (maxRoundCreated >= witness.getRoundCreated() + 2
+                || !rosterEntryMap.containsKey(witness.getCreatorId().id())) {
             witness.setFamous(false);
             witness.setFameDecided(true);
             return;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiEventStorage.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiEventStorage.java
@@ -29,6 +29,7 @@ import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
 import com.swirlds.platform.metrics.NoOpConsensusMetrics;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -61,7 +62,8 @@ public class GuiEventStorage {
         this.configuration = Objects.requireNonNull(configuration);
         final PlatformContext platformContext = PlatformContext.create(configuration);
 
-        this.consensus = new ConsensusImpl(platformContext, new NoOpConsensusMetrics(), addressBook);
+        this.consensus = new ConsensusImpl(
+                platformContext, new NoOpConsensusMetrics(), RosterRetriever.buildRoster(addressBook));
         // Future work: birth round compatibility for GUI
         this.linker = new SimpleLinker(GENERATION_THRESHOLD);
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/ConsensusRound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/internal/ConsensusRound.java
@@ -16,13 +16,13 @@
 
 package com.swirlds.platform.internal;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.consensus.EventWindow;
 import com.swirlds.platform.consensus.GraphGenerations;
 import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.system.Round;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.CesEvent;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.transaction.Transaction;
@@ -78,7 +78,7 @@ public class ConsensusRound implements Round {
     /**
      * The consensus roster for this round.
      */
-    private final AddressBook consensusRoster;
+    private final Roster consensusRoster;
 
     /**
      * True if this round reached consensus during the replaying of the preconsensus event stream.
@@ -101,7 +101,7 @@ public class ConsensusRound implements Round {
      * @param reachedConsTimestamp the local time (not consensus time) at which this round reached consensus
      */
     public ConsensusRound(
-            @NonNull final AddressBook consensusRoster,
+            @NonNull final Roster consensusRoster,
             @NonNull final List<PlatformEvent> consensusEvents,
             @NonNull final PlatformEvent keystoneEvent,
             @NonNull final GraphGenerations generations,
@@ -222,7 +222,7 @@ public class ConsensusRound implements Round {
      */
     @Override
     @NonNull
-    public AddressBook getConsensusRoster() {
+    public Roster getConsensusRoster() {
         return consensusRoster;
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -51,6 +51,7 @@ import com.swirlds.platform.recovery.internal.EventStreamRoundIterator;
 import com.swirlds.platform.recovery.internal.RecoveredState;
 import com.swirlds.platform.recovery.internal.RecoveryPlatform;
 import com.swirlds.platform.recovery.internal.StreamedRound;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformStateAccessor;
 import com.swirlds.platform.state.PlatformStateModifier;
@@ -163,7 +164,7 @@ public final class EventRecoveryWorkflow {
             logger.info(STARTUP.getMarker(), "Loading event stream at {}", eventStreamDirectory);
 
             final IOIterator<StreamedRound> roundIterator = new EventStreamRoundIterator(
-                    initialState.get().getAddressBook(),
+                    RosterRetriever.buildRoster(initialState.get().getAddressBook()),
                     eventStreamDirectory,
                     initialState.get().getRound() + 1,
                     allowPartialRounds);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamRoundIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/EventStreamRoundIterator.java
@@ -16,8 +16,8 @@
 
 package com.swirlds.platform.recovery.internal;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.io.IOIterator;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.CesEvent;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -34,7 +34,7 @@ public class EventStreamRoundIterator implements IOIterator<StreamedRound> {
 
     private final IOIterator<CesEvent> eventIterator;
     private final boolean allowPartialRound;
-    private final AddressBook consensusRoster;
+    private final Roster consensusRoster;
 
     private StreamedRound next;
     private boolean ended = false;
@@ -51,7 +51,7 @@ public class EventStreamRoundIterator implements IOIterator<StreamedRound> {
      *                             If false then do not return a round that does not have all of its events.
      */
     public EventStreamRoundIterator(
-            @NonNull final AddressBook consensusRoster,
+            @NonNull final Roster consensusRoster,
             final Path eventStreamDirectory,
             final long startingRound,
             boolean allowPartialRound)
@@ -69,7 +69,7 @@ public class EventStreamRoundIterator implements IOIterator<StreamedRound> {
      * @param eventIterator   an iterator that walks over events
      */
     public EventStreamRoundIterator(
-            @NonNull final AddressBook consensusRoster,
+            @NonNull final Roster consensusRoster,
             final IOIterator<CesEvent> eventIterator,
             boolean allowPartialRound) {
         this.consensusRoster = Objects.requireNonNull(consensusRoster);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/StreamedRound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/StreamedRound.java
@@ -16,9 +16,9 @@
 
 package com.swirlds.platform.recovery.internal;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.system.Round;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.CesEvent;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.util.iterator.TypedIterator;
@@ -36,10 +36,10 @@ public class StreamedRound implements Round {
     private final List<CesEvent> events;
     private final long roundNumber;
     private final Instant consensusTimestamp;
-    private final AddressBook consensusRoster;
+    private final Roster consensusRoster;
 
     public StreamedRound(
-            @NonNull final AddressBook consensusRoster, @NonNull final List<CesEvent> events, final long roundNumber) {
+            @NonNull final Roster consensusRoster, @NonNull final List<CesEvent> events, final long roundNumber) {
         this.events = events;
         this.roundNumber = roundNumber;
         events.stream().map(CesEvent::getPlatformEvent).forEach(PlatformEvent::setConsensusTimestampsOnTransactions);
@@ -89,7 +89,7 @@ public class StreamedRound implements Round {
      */
     @NonNull
     @Override
-    public AddressBook getConsensusRoster() {
+    public Roster getConsensusRoster() {
         return consensusRoster;
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -27,6 +27,7 @@ import java.security.cert.X509Certificate;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * A utility class to help use Rooster and RosterEntry instances.
@@ -85,7 +86,21 @@ public final class RosterUtils {
     }
 
     /**
+     * Build a map from a long nodeId to an index of the node in the roster entries list.
+     * If code needs to perform this lookup only once, then use the getIndex() instead.
+     *
+     * @param roster a roster
+     * @return {@code Map<Long, Integer>}
+     */
+    public static Map<Long, Integer> toIndicesMap(@NonNull final Roster roster) {
+        return IntStream.range(0, roster.rosterEntries().size())
+                .boxed()
+                .collect(Collectors.toMap(i -> roster.rosterEntries().get(i).nodeId(), Function.identity()));
+    }
+
+    /**
      * Return an index of a RosterEntry with a given node id.
+     * If code needs to perform this operation often, then use the toIndicesMap() instead.
      *
      * @param roster a Roster
      * @param nodeId a node id

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Round.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Round.java
@@ -16,7 +16,7 @@
 
 package com.swirlds.platform.system;
 
-import com.swirlds.platform.system.address.AddressBook;
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.transaction.ConsensusTransaction;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -74,7 +74,7 @@ public interface Round extends Iterable<ConsensusEvent> {
      * @return the roster that was used to compute consensus for this round
      */
     @NonNull
-    AddressBook getConsensusRoster();
+    Roster getConsensusRoster();
 
     /**
      * A convenience method that supplies every transaction in this round to a consumer.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ConsensusRoundTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/ConsensusRoundTests.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.test.fixtures.RandomUtils;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
@@ -28,7 +29,6 @@ import com.swirlds.platform.consensus.EventWindow;
 import com.swirlds.platform.consensus.GraphGenerations;
 import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.internal.ConsensusRound;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.fixtures.event.TestingEventBuilder;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -52,7 +52,7 @@ class ConsensusRoundTests {
                 new TestingEventBuilder(r).build());
 
         final ConsensusRound round = new ConsensusRound(
-                mock(AddressBook.class),
+                mock(Roster.class),
                 events,
                 mock(PlatformEvent.class),
                 g,
@@ -84,7 +84,7 @@ class ConsensusRoundTests {
         }
 
         final ConsensusRound round = new ConsensusRound(
-                mock(AddressBook.class),
+                mock(Roster.class),
                 events,
                 mock(PlatformEvent.class),
                 mock(GraphGenerations.class),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/preconsensus/RoundDurabilityBufferTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/preconsensus/RoundDurabilityBufferTests.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.test.fixtures.time.FakeTime;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
@@ -37,7 +38,6 @@ import com.swirlds.platform.event.preconsensus.durability.DefaultRoundDurability
 import com.swirlds.platform.event.preconsensus.durability.RoundDurabilityBuffer;
 import com.swirlds.platform.gossip.shadowgraph.Generations;
 import com.swirlds.platform.internal.ConsensusRound;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.fixtures.event.TestingEventBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jakarta.inject.Inject;
@@ -74,7 +74,7 @@ class RoundDurabilityBufferTests {
         keystoneEvent.setStreamSequenceNumber(keystoneSequenceNumber);
 
         return new ConsensusRound(
-                mock(AddressBook.class),
+                mock(Roster.class),
                 List.of(),
                 keystoneEvent,
                 mock(Generations.class),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stale/StaleEventDetectorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stale/StaleEventDetectorTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.Randotron;
@@ -35,7 +36,6 @@ import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.eventhandling.EventConfig_;
 import com.swirlds.platform.gossip.shadowgraph.Generations;
 import com.swirlds.platform.internal.ConsensusRound;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.fixtures.event.TestingEventBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
@@ -171,7 +171,7 @@ class StaleEventDetectorTests {
                 randotron.nextPositiveLong(), ancientThreshold, randotron.nextPositiveLong(), BIRTH_ROUND_THRESHOLD);
 
         return new ConsensusRound(
-                mock(AddressBook.class),
+                mock(Roster.class),
                 events,
                 mock(PlatformEvent.class),
                 mock(Generations.class),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.consensus.EventWindow;
 import com.swirlds.platform.consensus.SyntheticSnapshot;
@@ -31,6 +32,7 @@ import com.swirlds.platform.event.AncientMode;
 import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.gossip.shadowgraph.Generations;
 import com.swirlds.platform.internal.ConsensusRound;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.status.actions.FreezePeriodEnteredAction;
@@ -50,6 +52,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 class DefaultTransactionHandlerTests {
     private Randotron random;
     private AddressBook addressBook;
+    private Roster roster;
 
     @BeforeEach
     void setUp() {
@@ -58,6 +61,7 @@ class DefaultTransactionHandlerTests {
                 .withRealKeysEnabled(false)
                 .withSize(4)
                 .build();
+        roster = RosterRetriever.buildRoster(addressBook);
     }
 
     /**
@@ -88,7 +92,7 @@ class DefaultTransactionHandlerTests {
         final PlatformEvent keystone = new TestingEventBuilder(random).build();
         keystone.signalPrehandleCompletion();
         final ConsensusRound round = new ConsensusRound(
-                addressBook,
+                roster,
                 events,
                 keystone,
                 new Generations(),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamRoundIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamRoundIteratorTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.io.IOIterator;
@@ -38,7 +39,6 @@ import com.swirlds.platform.recovery.internal.EventStreamRoundIterator;
 import com.swirlds.platform.recovery.internal.StreamedRound;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.StaticSoftwareVersion;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.CesEvent;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -88,7 +88,7 @@ class EventStreamRoundIteratorTest {
         writeRandomEventStream(random, directory, secondsPerFile, events);
 
         try (final IOIterator<StreamedRound> iterator = new EventStreamRoundIterator(
-                mock(AddressBook.class), directory, EventStreamPathIterator.FIRST_ROUND_AVAILABLE, true)) {
+                mock(Roster.class), directory, EventStreamPathIterator.FIRST_ROUND_AVAILABLE, true)) {
 
             final List<CesEvent> deserializedEvents = new ArrayList<>();
 
@@ -140,7 +140,7 @@ class EventStreamRoundIteratorTest {
         writeRandomEventStream(random, directory, secondsPerFile, events);
 
         try (final IOIterator<StreamedRound> iterator =
-                new EventStreamRoundIterator(mock(AddressBook.class), directory, firstRoundToRead, true)) {
+                new EventStreamRoundIterator(mock(Roster.class), directory, firstRoundToRead, true)) {
 
             final List<CesEvent> deserializedEvents = new ArrayList<>();
 
@@ -189,7 +189,7 @@ class EventStreamRoundIteratorTest {
         boolean exception = false;
 
         try (final IOIterator<StreamedRound> iterator = new EventStreamRoundIterator(
-                mock(AddressBook.class), directory, EventStreamPathIterator.FIRST_ROUND_AVAILABLE, true)) {
+                mock(Roster.class), directory, EventStreamPathIterator.FIRST_ROUND_AVAILABLE, true)) {
 
             final List<CesEvent> deserializedEvents = new ArrayList<>();
 
@@ -247,7 +247,7 @@ class EventStreamRoundIteratorTest {
 
         assertThrows(
                 NoSuchElementException.class,
-                () -> new EventStreamRoundIterator(mock(AddressBook.class), directory, 10, true),
+                () -> new EventStreamRoundIterator(mock(Roster.class), directory, 10, true),
                 "should be unable to start at requested round");
 
         FileUtils.deleteDirectory(directory);
@@ -272,7 +272,7 @@ class EventStreamRoundIteratorTest {
         truncateFile(lastFile, false);
 
         try (final IOIterator<StreamedRound> iterator = new EventStreamRoundIterator(
-                mock(AddressBook.class), directory, EventStreamPathIterator.FIRST_ROUND_AVAILABLE, true)) {
+                mock(Roster.class), directory, EventStreamPathIterator.FIRST_ROUND_AVAILABLE, true)) {
 
             final List<CesEvent> deserializedEvents = new ArrayList<>();
 
@@ -331,7 +331,7 @@ class EventStreamRoundIteratorTest {
         truncateFile(lastFile, false);
 
         try (final IOIterator<StreamedRound> iterator = new EventStreamRoundIterator(
-                mock(AddressBook.class), directory, EventStreamPathIterator.FIRST_ROUND_AVAILABLE, false)) {
+                mock(Roster.class), directory, EventStreamPathIterator.FIRST_ROUND_AVAILABLE, false)) {
 
             final List<CesEvent> deserializedEvents = new ArrayList<>();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.test.fixtures.time.FakeTime;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
@@ -93,7 +94,7 @@ class UptimeTests {
     private static ConsensusRound mockRound(@NonNull final List<PlatformEvent> events, final long roundNum) {
         final ConsensusSnapshot snapshot = mock(ConsensusSnapshot.class);
         final ConsensusRound round = new ConsensusRound(
-                mock(AddressBook.class),
+                mock(Roster.class),
                 events,
                 mock(PlatformEvent.class),
                 mock(GraphGenerations.class),

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
@@ -29,6 +29,7 @@ import com.swirlds.platform.event.linking.ConsensusLinker;
 import com.swirlds.platform.event.linking.InOrderLinker;
 import com.swirlds.platform.internal.EventImpl;
 import com.swirlds.platform.metrics.NoOpConsensusMetrics;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
 import com.swirlds.platform.test.fixtures.event.DynamicValue;
@@ -196,7 +197,8 @@ public class StandardGraphGenerator extends AbstractGraphGenerator<StandardGraph
     }
 
     private void initializeInternalConsensus() {
-        consensus = new ConsensusImpl(platformContext, new NoOpConsensusMetrics(), addressBook);
+        consensus = new ConsensusImpl(
+                platformContext, new NoOpConsensusMetrics(), RosterRetriever.buildRoster(addressBook));
         inOrderLinker = new ConsensusLinker(platformContext, NodeId.of(0));
     }
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
@@ -45,6 +45,7 @@ import com.swirlds.platform.gossip.IntakeEventCounter;
 import com.swirlds.platform.gossip.NoOpIntakeEventCounter;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.consensus.framework.ConsensusOutput;
 import com.swirlds.platform.wiring.components.PassThroughWiring;
@@ -93,7 +94,8 @@ public class TestIntake {
         orphanBufferWiring = new ComponentWiring<>(model, OrphanBuffer.class, directScheduler("orphanBuffer"));
         orphanBufferWiring.bind(orphanBuffer);
 
-        final ConsensusEngine consensusEngine = new DefaultConsensusEngine(platformContext, addressBook, selfId);
+        final ConsensusEngine consensusEngine =
+                new DefaultConsensusEngine(platformContext, RosterRetriever.buildRoster(addressBook), selfId);
 
         consensusEngineWiring = new ComponentWiring<>(model, ConsensusEngine.class, directScheduler("consensusEngine"));
         consensusEngineWiring.bind(consensusEngine);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/ProfilingTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/ProfilingTest.java
@@ -22,6 +22,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.Consensus;
 import com.swirlds.platform.ConsensusImpl;
 import com.swirlds.platform.metrics.NoOpConsensusMetrics;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.event.emitter.StandardEventEmitter;
 import com.swirlds.platform.test.event.source.EventSourceFactory;
@@ -51,7 +52,8 @@ public class ProfilingTest {
         final StandardEventEmitter emitter = new StandardEventEmitter(generator);
         final AddressBook addressBook = emitter.getGraphGenerator().getAddressBook();
 
-        final Consensus consensus = new ConsensusImpl(platformContext, new NoOpConsensusMetrics(), addressBook);
+        final Consensus consensus = new ConsensusImpl(
+                platformContext, new NoOpConsensusMetrics(), RosterRetriever.buildRoster(addressBook));
 
         for (int i = 0; i < numEvents; i++) {
             consensus.addEvent(emitter.emitEvent());


### PR DESCRIPTION
…ngine

**Description**:
As a part of the TSS initiative, and specifically the TSS-Roster project, we're refactoring the Platform code to replace usages of `AddressBook` with `Roster`.

This fix refactors the `DefaultConsensusEngine`-related classes.

**Related issue(s)**:

Fixes #16323

**Notes for reviewer**:
Tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
