### PR TITLE
fix: change `failInvalidOutsideDispatchDoesNotAttemptToChargeFees()` for refactored ScheduleService schema

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.spec;
 
 import static com.hedera.node.app.service.addressbook.AddressBookHelper.NODES_KEY;
-import static com.hedera.node.app.service.schedule.impl.schemas.V0490ScheduleSchema.SCHEDULES_BY_EXPIRY_SEC_KEY;
+import static com.hedera.node.app.service.schedule.impl.schemas.V0570ScheduleSchema.SCHEDULE_IDS_BY_EXPIRY_SEC_KEY;
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.ACCOUNTS_KEY;
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.TOKENS_KEY;
 import static com.hedera.services.bdd.junit.extensions.NetworkTargetingExtension.REPEATABLE_KEY_GENERATOR;
@@ -69,7 +69,7 @@ import com.google.common.base.MoreObjects;
 import com.hedera.hapi.node.state.addressbook.Node;
 import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.primitives.ProtoLong;
-import com.hedera.hapi.node.state.schedule.ScheduleList;
+import com.hedera.hapi.node.state.schedule.ScheduleIdList;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.fixtures.state.FakeState;
@@ -522,9 +522,9 @@ public class HapiSpec implements Runnable, Executable {
      * @return the embedded schedule expiries state
      * @throws IllegalStateException if this spec is not targeting an embedded network
      */
-    public @NonNull WritableKVState<ProtoLong, ScheduleList> embeddedScheduleExpiriesOrThrow() {
+    public @NonNull WritableKVState<ProtoLong, ScheduleIdList> embeddedScheduleExpiriesOrThrow() {
         final var state = embeddedStateOrThrow();
-        return state.getWritableStates(ScheduleService.NAME).get(SCHEDULES_BY_EXPIRY_SEC_KEY);
+        return state.getWritableStates(ScheduleService.NAME).get(SCHEDULE_IDS_BY_EXPIRY_SEC_KEY);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/EmbeddedVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/EmbeddedVerbs.java
@@ -24,7 +24,7 @@ import com.hedera.hapi.node.state.addressbook.Node;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
 import com.hedera.hapi.node.state.primitives.ProtoLong;
-import com.hedera.hapi.node.state.schedule.ScheduleList;
+import com.hedera.hapi.node.state.schedule.ScheduleIdList;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.AccountPendingAirdrop;
 import com.hedera.hapi.node.state.token.Token;
@@ -83,7 +83,7 @@ public final class EmbeddedVerbs {
      * @return the operation that will mutate the schedule expiries
      */
     public static MutateScheduleExpiries mutateScheduleExpiries(
-            @NonNull final Consumer<WritableKVState<ProtoLong, ScheduleList>> mutation) {
+            @NonNull final Consumer<WritableKVState<ProtoLong, ScheduleIdList>> mutation) {
         return new MutateScheduleExpiries(mutation);
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/embedded/MutateScheduleExpiries.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/embedded/MutateScheduleExpiries.java
@@ -19,7 +19,7 @@ package com.hedera.services.bdd.spec.utilops.embedded;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.state.primitives.ProtoLong;
-import com.hedera.hapi.node.state.schedule.ScheduleList;
+import com.hedera.hapi.node.state.schedule.ScheduleIdList;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilOp;
 import com.swirlds.state.spi.WritableKVState;
@@ -30,9 +30,9 @@ import java.util.function.Consumer;
  * An operation that allows the test author to directly mutate the schedule experies in an embedded state.
  */
 public class MutateScheduleExpiries extends UtilOp {
-    private final Consumer<WritableKVState<ProtoLong, ScheduleList>> mutation;
+    private final Consumer<WritableKVState<ProtoLong, ScheduleIdList>> mutation;
 
-    public MutateScheduleExpiries(@NonNull final Consumer<WritableKVState<ProtoLong, ScheduleList>> mutation) {
+    public MutateScheduleExpiries(@NonNull final Consumer<WritableKVState<ProtoLong, ScheduleIdList>> mutation) {
         this.mutation = requireNonNull(mutation);
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java
@@ -55,10 +55,10 @@ import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.output.TransactionResult;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
 import com.hedera.hapi.node.state.primitives.ProtoLong;
-import com.hedera.hapi.node.state.schedule.Schedule;
-import com.hedera.hapi.node.state.schedule.ScheduleList;
+import com.hedera.hapi.node.state.schedule.ScheduleIdList;
 import com.hedera.node.app.blocks.BlockStreamService;
 import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.GenesisHapiTest;
@@ -69,6 +69,7 @@ import com.hedera.services.bdd.junit.support.translators.inputs.TransactionParts
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.BlockStreamAssertion;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -168,6 +169,8 @@ public class ConcurrentIntegrationTests {
     @DisplayName("fail invalid outside dispatch does not attempt to charge fees")
     final Stream<DynamicTest> failInvalidOutsideDispatchDoesNotAttemptToChargeFees() {
         final AtomicReference<BlockStreamInfo> blockStreamInfo = new AtomicReference<>();
+        final List<ScheduleID> corruptedScheduleIds = new ArrayList<>();
+        corruptedScheduleIds.add(null);
         return hapiTest(
                 blockStreamMustIncludePassFrom(spec -> blockWithResultOf(FAIL_INVALID)),
                 cryptoCreate("civilian").balance(ONE_HUNDRED_HBARS),
@@ -183,7 +186,7 @@ public class ConcurrentIntegrationTests {
                                 .get()
                                 .lastIntervalProcessTimeOrThrow()
                                 .seconds()),
-                        new ScheduleList(List.of(Schedule.DEFAULT))))),
+                        new ScheduleIdList(corruptedScheduleIds)))),
                 cryptoTransfer(tinyBarsFromTo("civilian", FUNDING, 1))
                         .fee(ONE_HBAR)
                         .hasKnownStatus(com.hederahashgraph.api.proto.java.ResponseCodeEnum.FAIL_INVALID),


### PR DESCRIPTION
**Description**:
 - Updates the state "corruption" used in [this embedded test](https://github.com/hashgraph/hedera-services/blob/2c30a3ac0ddb31a4f2289b33ddc8ac0c20f5bb70/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java#L169) to target the updated `ScheduleService` schemas.