### PR TITLE
ci: Update the XTS workflows to prevent double tagging on commits

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -67,6 +67,8 @@ jobs:
         id: check-tags-exist
         env:
           GH_TOKEN: ${{ github.token }}
+          XTS_PASS_PATTERN: ${{ env.XTS_PASS_GREP_PATTERN }}
+          BUILD_PROMO_PATTERN: ${{ env.PROMOTED_GREP_PATTERN }}
         run: |
           # Check if the tag exists and if so grab its commit id
           set +e
@@ -76,6 +78,15 @@ jobs:
 
           # Cancel out if the tag does not exist
           if [[ "${XTS_COMMIT_FOUND}" -ne 0 ]]; then
+            gh run cancel ${{ github.run_id }}
+          fi
+
+          # Check if this commit has already been tagged xts-pass-* or build-*
+          XTS_PASS_TAGGED=$(git tag --contains ${XTS_COMMIT} | grep -E "${XTS_PASS_PATTERN}")
+          BUILD_PROMOTED_TAGGED=$(git tag --contains ${XTS_COMMIT} | grep -E "${BUILD_PROMO_PATTERN}")
+
+          # Use -n; if the BUILD_PROMOTED_TAGGED/XTS_PASS_TAGGED flags are not empty than the commit has been tagged.
+          if [[ -n XTS_PASS_TAGGED || -n BUILD_PROMOTED_TAGGED ]]; then
             gh run cancel ${{ github.run_id }}
           fi
 

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -82,8 +82,10 @@ jobs:
           fi
 
           # Check if this commit has already been tagged xts-pass-* or build-*
+          set +e
           XTS_PASS_TAGGED=$(git tag --contains "${XTS_COMMIT}" | grep -E "${XTS_PASS_PATTERN}")
           BUILD_PROMOTED_TAGGED=$(git tag --contains "${XTS_COMMIT}" | grep -E "${BUILD_PROMO_PATTERN}")
+          set -e
 
           # Use -n; if the BUILD_PROMOTED_TAGGED/XTS_PASS_TAGGED flags are not empty than the commit has been tagged.
           if [[ -n "${XTS_PASS_TAGGED}" || -n "${BUILD_PROMOTED_TAGGED}" ]]; then

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -82,11 +82,11 @@ jobs:
           fi
 
           # Check if this commit has already been tagged xts-pass-* or build-*
-          XTS_PASS_TAGGED=$(git tag --contains ${XTS_COMMIT} | grep -E "${XTS_PASS_PATTERN}")
-          BUILD_PROMOTED_TAGGED=$(git tag --contains ${XTS_COMMIT} | grep -E "${BUILD_PROMO_PATTERN}")
+          XTS_PASS_TAGGED=$(git tag --contains "${XTS_COMMIT}" | grep -E "${XTS_PASS_PATTERN}")
+          BUILD_PROMOTED_TAGGED=$(git tag --contains "${XTS_COMMIT}" | grep -E "${BUILD_PROMO_PATTERN}")
 
           # Use -n; if the BUILD_PROMOTED_TAGGED/XTS_PASS_TAGGED flags are not empty than the commit has been tagged.
-          if [[ -n ${XTS_PASS_TAGGED} || -n ${BUILD_PROMOTED_TAGGED} ]]; then
+          if [[ -n "${XTS_PASS_TAGGED}" || -n "${BUILD_PROMOTED_TAGGED}" ]]; then
             gh run cancel ${{ github.run_id }}
           fi
 

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -86,7 +86,7 @@ jobs:
           BUILD_PROMOTED_TAGGED=$(git tag --contains ${XTS_COMMIT} | grep -E "${BUILD_PROMO_PATTERN}")
 
           # Use -n; if the BUILD_PROMOTED_TAGGED/XTS_PASS_TAGGED flags are not empty than the commit has been tagged.
-          if [[ -n XTS_PASS_TAGGED || -n BUILD_PROMOTED_TAGGED ]]; then
+          if [[ -n ${XTS_PASS_TAGGED} || -n ${BUILD_PROMOTED_TAGGED} ]]; then
             gh run cancel ${{ github.run_id }}
           fi
 

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -35,6 +35,8 @@ defaults:
 
 env:
   XTS_CANDIDATE_TAG: "xts-candidate"
+  XTS_PASS_GREP_PATTERN: "xts-pass-*"
+  PROMOTED_GREP_PATTERN: "build-.{5}"
 
 jobs:
   fetch-xts-candidate:

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -31,7 +31,6 @@ defaults:
     shell: bash
 
 env:
-  XTS_CANDIDATE_TAG: "xts-candidate"
   XTS_PASS_GREP_PATTERN: "xts-pass-*"
   PROMOTED_GREP_PATTERN: "build-.{5}"
 
@@ -61,10 +60,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_PATTERN: ${{ env.XTS_PASS_GREP_PATTERN }}
+          BUILD_PROMO_PATTERN: ${{ env.PROMOTED_GREP_PATTERN }}
         run: |
           CANDIDATE_TAG="$(git tag --list --sort=-version:refname "${TAG_PATTERN}" | head --lines 1)"
           if [[ -n "${CANDIDATE_TAG}" ]]; then
             CANDIDATE_COMMIT=$(git rev-list --max-count 1 ${CANDIDATE_TAG})
+            BUILD_PROMOTED_TAGGED=$(git tag --contains HEAD | grep -E "${BUILD_PROMO_PATTERN}")
+
+            # Use -n; if the BUILD_PROMOTED_TAGGED flag is not empty than the commit has been tagged.
+            if [[ -n BUILD_PROMOTED_TAGGED]]; then
+              gh run cancel ${{ github.run_id }}
+            fi
+
+            # Verify the commit is on develop and continue
             if git branch --contains "${CANDIDATE_COMMIT}" | grep --quiet develop >/dev/null 2>&1; then
               git push --delete origin $(git tag --list "${TAG_PATTERN}")
               git tag --delete $(git tag --list "${TAG_PATTERN}")

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -68,7 +68,7 @@ jobs:
             BUILD_PROMOTED_TAGGED=$(git tag --contains ${CANDIDATE_COMMIT} | grep -E "${BUILD_PROMO_PATTERN}")
 
             # Use -n; if the BUILD_PROMOTED_TAGGED flag is not empty than the commit has been tagged.
-            if [[ -n BUILD_PROMOTED_TAGGED ]]; then
+            if [[ -n ${BUILD_PROMOTED_TAGGED} ]]; then
               gh run cancel ${{ github.run_id }}
             fi
 

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -64,8 +64,10 @@ jobs:
         run: |
           CANDIDATE_TAG="$(git tag --list --sort=-version:refname "${TAG_PATTERN}" | head --lines 1)"
           if [[ -n "${CANDIDATE_TAG}" ]]; then
+            set +e
             CANDIDATE_COMMIT=$(git rev-list --max-count 1 ${CANDIDATE_TAG})
             BUILD_PROMOTED_TAGGED=$(git tag --contains "${CANDIDATE_COMMIT}" | grep -E "${BUILD_PROMO_PATTERN}")
+            set -e
 
             # Use -n; if the BUILD_PROMOTED_TAGGED flag is not empty than the commit has been tagged.
             if [[ -n "${BUILD_PROMOTED_TAGGED}" ]]; then

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -65,10 +65,10 @@ jobs:
           CANDIDATE_TAG="$(git tag --list --sort=-version:refname "${TAG_PATTERN}" | head --lines 1)"
           if [[ -n "${CANDIDATE_TAG}" ]]; then
             CANDIDATE_COMMIT=$(git rev-list --max-count 1 ${CANDIDATE_TAG})
-            BUILD_PROMOTED_TAGGED=$(git tag --contains ${CANDIDATE_COMMIT} | grep -E "${BUILD_PROMO_PATTERN}")
+            BUILD_PROMOTED_TAGGED=$(git tag --contains "${CANDIDATE_COMMIT}" | grep -E "${BUILD_PROMO_PATTERN}")
 
             # Use -n; if the BUILD_PROMOTED_TAGGED flag is not empty than the commit has been tagged.
-            if [[ -n ${BUILD_PROMOTED_TAGGED} ]]; then
+            if [[ -n "${BUILD_PROMOTED_TAGGED}" ]]; then
               gh run cancel ${{ github.run_id }}
             fi
 

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -65,10 +65,10 @@ jobs:
           CANDIDATE_TAG="$(git tag --list --sort=-version:refname "${TAG_PATTERN}" | head --lines 1)"
           if [[ -n "${CANDIDATE_TAG}" ]]; then
             CANDIDATE_COMMIT=$(git rev-list --max-count 1 ${CANDIDATE_TAG})
-            BUILD_PROMOTED_TAGGED=$(git tag --contains HEAD | grep -E "${BUILD_PROMO_PATTERN}")
+            BUILD_PROMOTED_TAGGED=$(git tag --contains ${CANDIDATE_COMMIT} | grep -E "${BUILD_PROMO_PATTERN}")
 
             # Use -n; if the BUILD_PROMOTED_TAGGED flag is not empty than the commit has been tagged.
-            if [[ -n BUILD_PROMOTED_TAGGED]]; then
+            if [[ -n BUILD_PROMOTED_TAGGED ]]; then
               gh run cancel ${{ github.run_id }}
             fi
 

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -23,12 +23,17 @@ on:
 
 permissions:
   actions: write
-  contents: read
+  contents: write
   statuses: write
 
 defaults:
   run:
     shell: bash
+
+env:
+  XTS_CANDIDATE_TAG: "xts-candidate"
+  XTS_PASS_GREP_PATTERN: "xts-pass-*"
+  PROMOTED_GREP_PATTERN: "build-.{5}"
 
 jobs:
   determine-build-candidate:
@@ -55,8 +60,8 @@ jobs:
         id: find-build-candidates
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG_PATTERN: ${{ env.XTS_PASS_GREP_PATTERN }}
         run: |
-          TAG_PATTERN="xts-pass-*"
           CANDIDATE_TAG="$(git tag --list --sort=-version:refname "${TAG_PATTERN}" | head --lines 1)"
           if [[ -n "${CANDIDATE_TAG}" ]]; then
             CANDIDATE_COMMIT=$(git rev-list --max-count 1 ${CANDIDATE_TAG})

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -96,7 +96,7 @@ jobs:
           BUILD_PROMOTED_TAGGED=$(git tag --contains HEAD | grep -E "${BUILD_PROMO_PATTERN}")
 
           # Use -n; if the strings are not empty than the commit has been tagged.
-          if [[ -n XTS_CANDIDATE_TAGGED || -n XTS_PASS_TAGGED || -n BUILD_PROMOTED_TAGGED]]; then
+          if [[ -n XTS_CANDIDATE_TAGGED || -n XTS_PASS_TAGGED || -n BUILD_PROMOTED_TAGGED ]]; then
             gh run cancel ${{ github.run_id }}
           fi
 

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -85,6 +85,7 @@ jobs:
 
       # Check if this commit is already tagged in the XTS flow
       - name: Check if XTS flow is required
+        id: check-xts-required
         env:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE_PATTERN: ${{ env.XTS_CANDIDATE_TAG }}
@@ -101,10 +102,13 @@ jobs:
           # if the strings are not empty than the commit has been tagged.
           if [[ -n "${XTS_CANDIDATE_TAGGED}" || -n "${XTS_PASS_TAGGED}" || -n "${BUILD_PROMOTED_TAGGED}" ]]; then
             gh run cancel ${{ github.run_id }}
+          else
+            echo "xts-checks-required=true" >> $GITHUB_OUTPUT
           fi
 
       # move the tag if successful
       - name: Tag Code and push
+        if: ${{ steps.check-xts-required.outputs.xts-checks-required == 'true' }}
         run: |
           # Check if the tag exists
           set +e

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -90,12 +90,14 @@ jobs:
           XTS_PASS_PATTERN: ${{ env.XTS_PASS_GREP_PATTERN }}
           BUILD_PROMO_PATTERN: ${{ env.PROMOTED_GREP_PATTERN }}
         run: |
+          set +e
           # Check if the HEAD ref is already tagged in the XTS workflows
           XTS_CANDIDATE_TAGGED=$(git tag --contains HEAD | grep -E "${CANDIDATE_PATTERN}")
           XTS_PASS_TAGGED=$(git tag --contains HEAD | grep -E "${XTS_PASS_PATTERN}")
           BUILD_PROMOTED_TAGGED=$(git tag --contains HEAD | grep -E "${BUILD_PROMO_PATTERN}")
+          set -e
 
-          # Use -n; if the strings are not empty than the commit has been tagged.
+          # if the strings are not empty than the commit has been tagged.
           if [[ -n "${XTS_CANDIDATE_TAGGED}" || -n "${XTS_PASS_TAGGED}" || -n "${BUILD_PROMOTED_TAGGED}" ]]; then
             gh run cancel ${{ github.run_id }}
           fi

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -96,7 +96,7 @@ jobs:
           BUILD_PROMOTED_TAGGED=$(git tag --contains HEAD | grep -E "${BUILD_PROMO_PATTERN}")
 
           # Use -n; if the strings are not empty than the commit has been tagged.
-          if [[ -n ${XTS_CANDIDATE_TAGGED} || -n ${XTS_PASS_TAGGED} || -n ${BUILD_PROMOTED_TAGGED} ]]; then
+          if [[ -n "${XTS_CANDIDATE_TAGGED}" || -n "${XTS_PASS_TAGGED}" || -n "${BUILD_PROMOTED_TAGGED}" ]]; then
             gh run cancel ${{ github.run_id }}
           fi
 

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -96,7 +96,7 @@ jobs:
           BUILD_PROMOTED_TAGGED=$(git tag --contains HEAD | grep -E "${BUILD_PROMO_PATTERN}")
 
           # Use -n; if the strings are not empty than the commit has been tagged.
-          if [[ -n XTS_CANDIDATE_TAGGED || -n XTS_PASS_TAGGED || -n BUILD_PROMOTED_TAGGED ]]; then
+          if [[ -n ${XTS_CANDIDATE_TAGGED} || -n ${XTS_PASS_TAGGED} || -n ${BUILD_PROMOTED_TAGGED} ]]; then
             gh run cancel ${{ github.run_id }}
           fi
 

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -86,6 +86,7 @@ jobs:
       # Check if this commit is already tagged in the XTS flow
       - name: Check if XTS flow is required
         env:
+          GH_TOKEN: ${{ github.token }}
           CANDIDATE_PATTERN: ${{ env.XTS_CANDIDATE_TAG }}
           XTS_PASS_PATTERN: ${{ env.XTS_PASS_GREP_PATTERN }}
           BUILD_PROMO_PATTERN: ${{ env.PROMOTED_GREP_PATTERN }}

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -94,7 +94,7 @@ jobs:
           XTS_CANDIDATE_TAGGED=$(git tag --contains HEAD | grep -E "${CANDIDATE_PATTERN}")
           XTS_PASS_TAGGED=$(git tag --contains HEAD | grep -E "${XTS_PASS_PATTERN}")
           BUILD_PROMOTED_TAGGED=$(git tag --contains HEAD | grep -E "${BUILD_PROMO_PATTERN}")
-          
+
           # Use -n; if the strings are not empty than the commit has been tagged.
           if [[ -n XTS_CANDIDATE_TAGGED || -n XTS_PASS_TAGGED || -n BUILD_PROMOTED_TAGGED]]; then
             gh run cancel ${{ github.run_id }}

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -29,9 +29,12 @@ defaults:
 permissions:
   actions: write
   contents: write
+  statuses: write
 
 env:
   XTS_CANDIDATE_TAG: "xts-candidate"
+  XTS_PASS_GREP_PATTERN: "xts-pass-*"
+  PROMOTED_GREP_PATTERN: "build-.{5}"
 
 jobs:
   tag-for-xts:
@@ -79,6 +82,23 @@ jobs:
           git_user_signingkey: true
           gpg_private_key: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.SVCS_GPG_KEY_PASSPHRASE }}
+
+      # Check if this commit is already tagged in the XTS flow
+      - name: Check if XTS flow is required
+        env:
+          CANDIDATE_PATTERN: ${{ env.XTS_CANDIDATE_TAG }}
+          XTS_PASS_PATTERN: ${{ env.XTS_PASS_GREP_PATTERN }}
+          BUILD_PROMO_PATTERN: ${{ env.PROMOTED_GREP_PATTERN }}
+        run: |
+          # Check if the HEAD ref is already tagged in the XTS workflows
+          XTS_CANDIDATE_TAGGED=$(git tag --contains HEAD | grep -E "${CANDIDATE_PATTERN}")
+          XTS_PASS_TAGGED=$(git tag --contains HEAD | grep -E "${XTS_PASS_PATTERN}")
+          BUILD_PROMOTED_TAGGED=$(git tag --contains HEAD | grep -E "${BUILD_PROMO_PATTERN}")
+          
+          # Use -n; if the strings are not empty than the commit has been tagged.
+          if [[ -n XTS_CANDIDATE_TAGGED || -n XTS_PASS_TAGGED || -n BUILD_PROMOTED_TAGGED]]; then
+            gh run cancel ${{ github.run_id }}
+          fi
 
       # move the tag if successful
       - name: Tag Code and push


### PR DESCRIPTION
**Description**:
Updates the following workflows to prevent duplicate tagging on a given commit:

- `zxcron-extended-test-suite.yaml`
- `zxcron-promote-build-candidate.yaml`
- `zxf-prepare-extended-test-suite.yaml`

**Related Issue(s)**:
Fixes #16329

**Testing**:
Manual Triggers: 
- [Skipped xts-candidate tag](https://github.com/hashgraph/hedera-services/actions/runs/11607212373)
- [Passed xts-candidate tag](https://github.com/hashgraph/hedera-services/actions/runs/11607189764)
- [Skipped xts-pass tag](https://github.com/hashgraph/hedera-services/actions/runs/11607302685)
- [Passed xts-pass tag](https://github.com/hashgraph/hedera-services/actions/runs/11607302685/attempts/1)
- [Skipped build promotion tag](https://github.com/hashgraph/hedera-services/actions/runs/11607252702/job/32320514864)
- [Passed build promotion tag](https://github.com/hashgraph/hedera-services/actions/runs/11607252702/attempts/1)
