### PR TITLE
test: GetBalance queries

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/SteadyStateThrottlingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/SteadyStateThrottlingTest.java
@@ -83,7 +83,7 @@ public class SteadyStateThrottlingTest {
 
     private static final double PRIORITY_RESERVATIONS_CONTRACT_CALL_NETWORK_TPS = 2.0;
     private static final double CREATION_LIMITS_CRYPTO_CREATE_NETWORK_TPS = 1.0;
-    private static final double FREE_QUERY_LIMITS_GET_BALANCE_NETWORK_QPS = 100.0;
+    private static final double BALANCE_QUERY_LIMITS_QPS = 10.0;
 
     private static final int NETWORK_SIZE = REGRESSION_NETWORK_SIZE;
 
@@ -92,7 +92,7 @@ public class SteadyStateThrottlingTest {
     private static final double EXPECTED_CONTRACT_CALL_TPS =
             PRIORITY_RESERVATIONS_CONTRACT_CALL_NETWORK_TPS / NETWORK_SIZE;
     private static final double EXPECTED_CRYPTO_CREATE_TPS = CREATION_LIMITS_CRYPTO_CREATE_NETWORK_TPS / NETWORK_SIZE;
-    private static final double EXPECTED_GET_BALANCE_QPS = FREE_QUERY_LIMITS_GET_BALANCE_NETWORK_QPS / NETWORK_SIZE;
+    private static final double EXPECTED_GET_BALANCE_QPS = BALANCE_QUERY_LIMITS_QPS / NETWORK_SIZE;
     private static final double TOLERATED_PERCENT_DEVIATION = 7;
     private static final String SUPPLY = "supply";
     private static final String TOKEN = "token";

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/artificial-limits.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/artificial-limits.json
@@ -130,19 +130,17 @@
 		}
 	  ]
 	},
+    {
+	  "name": "BalanceQueryLimits",
+	  "burstPeriod": 1,
+	  "throttleGroups": [
 		{
-			"burstPeriod": 0,
-			"burstPeriodMs": 1000,
-			"name": "BalanceQueryLimits",
-			"throttleGroups": [
-				{
-					"opsPerSec": 0,
-					"milliOpsPerSec": 1000000,
-					"operations": [
-						"CryptoGetAccountBalance"
-					]
-				}
-			]
+		  "opsPerSec": 100,
+		  "operations": [
+			"CryptoGetAccountBalance"
+		  ]
+		}
+	  ]
 	}
   ]
 }

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/artificial-limits.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/artificial-limits.json
@@ -125,11 +125,24 @@
 		{
 		  "opsPerSec": 100,
 		  "operations": [
-			"CryptoGetAccountBalance",
 			"TransactionGetReceipt"
 		  ]
 		}
 	  ]
+	},
+		{
+			"burstPeriod": 0,
+			"burstPeriodMs": 1000,
+			"name": "BalanceQueryLimits",
+			"throttleGroups": [
+				{
+					"opsPerSec": 0,
+					"milliOpsPerSec": 1000000,
+					"operations": [
+						"CryptoGetAccountBalance"
+					]
+				}
+			]
 	}
   ]
 }

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/artificial-limits.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/artificial-limits.json
@@ -135,7 +135,7 @@
 	  "burstPeriod": 1,
 	  "throttleGroups": [
 		{
-		  "opsPerSec": 100,
+		  "opsPerSec": 10,
 		  "operations": [
 			"CryptoGetAccountBalance"
 		  ]


### PR DESCRIPTION
**Description**:
Based on this comment: https://github.com/hashgraph/hedera-services/pull/15930#pullrequestreview-2407720434
Adding `artificial-limits.json` for GetBalance queries in order to test it in `SteadyStateThrottlingTest`

**Related issue(s)**:

Fixes #16374