### PR TITLE
ci: Re-enable jenkins integration flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,41 +53,41 @@
 ###############################
 ##### Hedera Cryptography #####
 ###############################
-/hedera-cryptography/                           @hashgraph/platform-cryptography
+/hedera-cryptography/                               @hashgraph/platform-cryptography
 
 #########################
 ##### Platform SDK ######
 #########################
 
 # Platform SDK Root Protections
-/platform-sdk/                                  @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects
-/platform-sdk/README.md                         @hashgraph/platform-hashgraph @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/platform-sdk/                                      @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects
+/platform-sdk/README.md                             @hashgraph/platform-hashgraph @hashgraph/devops-ci @hashgraph/release-engineering-managers
 
 # Platform SDK Modules
-/platform-sdk/platform-apps/                    @hashgraph/platform-hashgraph
-/platform-sdk/swirlds-base/                     @hashgraph/platform-base
-/platform-sdk/swirlds-benchmarks/               @hashgraph/platform-data @hashgraph/platform-architects
-/platform-sdk/swirlds-cli/                      @hashgraph/platform-hashgraph
-/platform-sdk/swirlds-common/                   @hashgraph/platform-hashgraph @hashgraph/platform-base @hashgraph/platform-data
-/platform-sdk/swirlds-config-*/                 @hashgraph/platform-base
-/platform-sdk/swirlds-fchashmap/                @hashgraph/platform-data @hashgraph/platform-architects
-/platform-sdk/swirlds-fcqueue/                  @hashgraph/platform-data @hashgraph/platform-architects
-/platform-sdk/swirlds-merkledb/                 @hashgraph/platform-data @hashgraph/platform-architects
-/platform-sdk/swirlds-logging/                  @hashgraph/platform-hashgraph @hashgraph/platform-base
-/platform-sdk/swirlds-logging-*/                @hashgraph/platform-base
-/platform-sdk/swirlds-merkle/                   @hashgraph/platform-data @hashgraph/platform-architects
-/platform-sdk/swirlds-platform-core/            @hashgraph/platform-hashgraph
-/platform-sdk/swirlds-unit-tests/common/        @hashgraph/platform-hashgraph @hashgraph/platform-base
-/platform-sdk/swirlds-unit-tests/core/          @hashgraph/platform-hashgraph @hashgraph/platform-base
-/platform-sdk/swirlds-unit-tests/structures/    @hashgraph/platform-data @hashgraph/platform-architects  @hashgraph/platform-base
-/platform-sdk/swirlds-virtualmap/               @hashgraph/platform-data @hashgraph/platform-architects
-/platform-sdk/**/module-info.java               @hashgraph/platform-hashgraph @hashgraph/platform-base @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/platform-sdk/platform-apps/                        @hashgraph/platform-hashgraph
+/platform-sdk/swirlds-base/                         @hashgraph/platform-base
+/platform-sdk/swirlds-benchmarks/                   @hashgraph/platform-data @hashgraph/platform-architects
+/platform-sdk/swirlds-cli/                          @hashgraph/platform-hashgraph
+/platform-sdk/swirlds-common/                       @hashgraph/platform-hashgraph @hashgraph/platform-base @hashgraph/platform-data
+/platform-sdk/swirlds-config-*/                     @hashgraph/platform-base
+/platform-sdk/swirlds-fchashmap/                    @hashgraph/platform-data @hashgraph/platform-architects
+/platform-sdk/swirlds-fcqueue/                      @hashgraph/platform-data @hashgraph/platform-architects
+/platform-sdk/swirlds-merkledb/                     @hashgraph/platform-data @hashgraph/platform-architects
+/platform-sdk/swirlds-logging/                      @hashgraph/platform-hashgraph @hashgraph/platform-base
+/platform-sdk/swirlds-logging-*/                    @hashgraph/platform-base
+/platform-sdk/swirlds-merkle/                       @hashgraph/platform-data @hashgraph/platform-architects
+/platform-sdk/swirlds-platform-core/                @hashgraph/platform-hashgraph
+/platform-sdk/swirlds-unit-tests/common/            @hashgraph/platform-hashgraph @hashgraph/platform-base
+/platform-sdk/swirlds-unit-tests/core/              @hashgraph/platform-hashgraph @hashgraph/platform-base
+/platform-sdk/swirlds-unit-tests/structures/        @hashgraph/platform-data @hashgraph/platform-architects  @hashgraph/platform-base
+/platform-sdk/swirlds-virtualmap/                   @hashgraph/platform-data @hashgraph/platform-architects
+/platform-sdk/**/module-info.java                   @hashgraph/platform-hashgraph @hashgraph/platform-base @hashgraph/devops-ci @hashgraph/release-engineering-managers
 
 # Documentation
-/platform-sdk/docs/platformWiki.md              @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base
-/platform-sdk/docs/base                         @hashgraph/platform-base
-/platform-sdk/docs/components                   @hashgraph/platform-hashgraph
-/platform-sdk/docs/core                         @hashgraph/platform-hashgraph
+/platform-sdk/docs/platformWiki.md                  @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base
+/platform-sdk/docs/base                             @hashgraph/platform-base
+/platform-sdk/docs/components                       @hashgraph/platform-hashgraph
+/platform-sdk/docs/core                             @hashgraph/platform-hashgraph
 
 #########################
 #####  Core Files  ######
@@ -96,38 +96,40 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/devops-ci @hashgraph/devops-ci-committers
+/.github/                                           @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/.github/workflows/                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers
+/.github/workflows/node-zxf-deploy-integration.yaml @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/devops
+/.github/workflows/node-zxf-deploy-preview.yaml     @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/devops
 
 # Legacy Maven project files
-**/pom.xml                                      @hashgraph/devops-ci
+**/pom.xml                                          @hashgraph/devops-ci @hashgraph/devops
 
 # Gradle project files and inline plugins
-/gradle/                                        @hashgraph/devops-ci @hashgraph/devops-ci-committers
-gradlew                                         @hashgraph/devops-ci @hashgraph/devops-ci-committers
-gradlew.bat                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/build-logic/                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/gradle.*                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/*.gradle.*                                   @hashgraph/devops-ci @hashgraph/devops-ci-committers
+/gradle/                                            @hashgraph/devops-ci @hashgraph/devops-ci-committers
+gradlew                                             @hashgraph/devops-ci @hashgraph/devops-ci-committers
+gradlew.bat                                         @hashgraph/devops-ci @hashgraph/devops-ci-committers
+**/build-logic/                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
+**/gradle.*                                         @hashgraph/devops-ci @hashgraph/devops-ci-committers
+**/*.gradle.*                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers
 
 # Codacy Tool Configurations
-/config/                                        @hashgraph/devops-ci @hashgraph/release-engineering-managers
-.remarkrc                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/config/                                            @hashgraph/devops-ci @hashgraph/release-engineering-managers
+.remarkrc                                           @hashgraph/devops-ci @hashgraph/release-engineering-managers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                     @hashgraph/release-engineering-managers
+/CODEOWNERS                                         @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers
-**/LICENSE                                      @hashgraph/release-engineering-managers
+/README.md                                          @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/LICENSE                                          @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                  @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/codecov.yml                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers
 
 # Git Ignore definitions
-**/.gitignore                                   @hashgraph/devops-ci @hashgraph/release-engineering-managers
-**/.gitignore.*                                 @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/.gitignore                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/.gitignore.*                                     @hashgraph/devops-ci @hashgraph/release-engineering-managers
 
 # Legacy CircleCI configuration
-.circleci.settings.xml                          @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.circleci/                                     @hashgraph/devops-ci @hashgraph/release-engineering-managers
+.circleci.settings.xml                              @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/.circleci/                                         @hashgraph/devops-ci @hashgraph/release-engineering-managers

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -102,11 +102,9 @@ jobs:
           repo: hashgraph/hedera-services # ensure we are executing in the hashgraph org
           ref: develop # ensure we are always using the workflow definition from the develop branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
-          #inputs: '{ "ref": "${{ github.ref }}" }'
           inputs: '{
             "ref": "${{ github.ref }}",
             "author": "${{ github.event.head_commit.author.name }}",
             "message": "${{ github.event.head_commit.message }}",
             "headSha": "${{ github.sha }}"
           }'
-          #inputs: '{ "event": "${{ toJSON(github.event) }}", "ref": "${{ github.ref }}" }'

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -105,6 +105,6 @@ jobs:
           inputs: '{
             "ref": "${{ github.ref }}",
             "author": "${{ github.event.head_commit.author.name }}",
-            "message": "${{ github.event.head_commit.message }}",
-            "headSha": "${{ github.sha }}"
+            "msg": "${{ github.event.head_commit.message }}",
+            "sha": "${{ github.sha }}"
           }'

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -102,5 +102,11 @@ jobs:
           repo: hashgraph/hedera-services # ensure we are executing in the hashgraph org
           ref: develop # ensure we are always using the workflow definition from the develop branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
-          inputs: '{ "ref": "${{ github.ref }}" }'
+          #inputs: '{ "ref": "${{ github.ref }}" }'
+          inputs: '{
+            "ref": "${{ github.ref }}",
+            "author": "${{ github.event.head_commit.author.name }}",
+            "message": "${{ github.event.head_commit.message }}",
+            "headSha": "${{ github.sha }}"
+          }'
           #inputs: '{ "event": "${{ toJSON(github.event) }}", "ref": "${{ github.ref }}" }'

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -23,7 +23,16 @@ on:
     inputs:
       ref:
         required: true
-        description: "The github ref that triggered the workflow"
+        description: "The github branch or tag that triggered the workflow"
+      author:
+        required: true
+        description: "The author name of the commit"
+      message:
+        required: true
+        description: "The message on the head commit"
+      headSha:
+        required: true
+        description: "The commit ID of the commit that triggered the workflow"
 #      event:
 #        required: true
 #        description: "The github event of the triggering workflow"

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -26,16 +26,13 @@ on:
         description: "The github branch or tag that triggered the workflow"
       author:
         required: true
-        description: "The author name of the commit"
+        description: "The author of the commit"
       message:
         required: true
         description: "The message on the head commit"
       headSha:
         required: true
         description: "The commit ID of the commit that triggered the workflow"
-#      event:
-#        required: true
-#        description: "The github event of the triggering workflow"
 
 defaults:
   run:
@@ -172,8 +169,8 @@ jobs:
           ref: develop # ensure we are always using the workflow definition from the develop branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
-                      "ref": "${{ inputs.ref }}",
-                      "author": "${{ inputs.author }}",
-                      "message": "${{ inputs.message }}",
-                      "headSha": "${{ inputs.headSha }}"
-                    }'
+            "ref": "${{ inputs.ref }}",
+            "author": "${{ inputs.author }}",
+            "message": "${{ inputs.message }}",
+            "headSha": "${{ inputs.headSha }}"
+          }'

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -25,14 +25,17 @@ on:
         required: true
         description: "The github branch or tag that triggered the workflow"
       author:
-        required: true
+        required: false
         description: "The author of the commit"
-      message:
-        required: true
+        default: ""
+      msg:
+        required: false
         description: "The message on the head commit"
-      headSha:
-        required: true
+        default: ""
+      sha:
+        required: false
         description: "The commit ID of the commit that triggered the workflow"
+        default: ""
 
 defaults:
   run:
@@ -171,6 +174,6 @@ jobs:
           inputs: '{
             "ref": "${{ inputs.ref }}",
             "author": "${{ inputs.author }}",
-            "message": "${{ inputs.message }}",
-            "headSha": "${{ inputs.headSha }}"
+            "message": "${{ inputs.msg }}",
+            "headSha": "${{ inputs.sha }}"
           }'

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -164,7 +164,9 @@ jobs:
           inputs: '{ "ref": "${{ inputs.ref }}" }'
 
       - name: Trigger ZXF Deploy Integration
-        if: ${{ needs.release-branch.result == 'success' }}
+        if: ${{ needs.release-branch.result == 'success' &&
+          (inputs.author != '' && inputs.message != '' && inputs.headSha != '') &&
+          !cancelled() }}
         uses: step-security/workflow-dispatch@4d1049025980f72b1327cbfdeecb07fe7a20f577 # v1.2.4
         with:
           workflow: .github/workflows/node-zxf-deploy-integration.yaml

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -176,6 +176,6 @@ jobs:
           inputs: '{
             "ref": "${{ inputs.ref }}",
             "author": "${{ inputs.author }}",
-            "message": "${{ inputs.msg }}",
-            "headSha": "${{ inputs.sha }}"
+            "msg": "${{ inputs.msg }}",
+            "sha": "${{ inputs.sha }}"
           }'

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -163,12 +163,17 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{ "ref": "${{ inputs.ref }}" }'
 
-#      - name: Trigger ZXF Deploy Integration
-#        if: ${{ needs.release-branch.result == 'success' }}
-#        uses: step-security/workflow-dispatch@4d1049025980f72b1327cbfdeecb07fe7a20f577 # v1.2.4
-#        with:
-#          workflow: .github/workflows/node-zxf-deploy-integration.yaml
-#          repo: hashgraph/hedera-services # ensure we are executing in the hashgraph org
-#          ref: develop # ensure we are always using the workflow definition from the develop branch
-#          token: ${{ secrets.GH_ACCESS_TOKEN }}
-#          inputs: '{ "event": "${{ inputs.event }}" }'
+      - name: Trigger ZXF Deploy Integration
+        if: ${{ needs.release-branch.result == 'success' }}
+        uses: step-security/workflow-dispatch@4d1049025980f72b1327cbfdeecb07fe7a20f577 # v1.2.4
+        with:
+          workflow: .github/workflows/node-zxf-deploy-integration.yaml
+          repo: hashgraph/hedera-services # ensure we are executing in the hashgraph org
+          ref: develop # ensure we are always using the workflow definition from the develop branch
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          inputs: '{
+                      "ref": "${{ inputs.ref }}",
+                      "author": "${{ inputs.author }}",
+                      "message": "${{ inputs.message }}",
+                      "headSha": "${{ inputs.headSha }}"
+                    }'

--- a/.github/workflows/node-zxf-deploy-integration.yaml
+++ b/.github/workflows/node-zxf-deploy-integration.yaml
@@ -22,14 +22,17 @@ on:
         required: true
         description: "The github branch or tag that triggered the workflow"
       author:
-        required: true
-        description: "The author name of the commit"
-      message:
-        required: true
+        required: false
+        description: "The author of the commit"
+        default: ""
+      msg:
+        required: false
         description: "The message on the head commit"
-      headSha:
-        required: true
+        default: ""
+      sha:
+        required: false
         description: "The commit ID of the commit that triggered the workflow"
+        default: ""
 
 permissions:
   contents: read
@@ -46,10 +49,11 @@ jobs:
 
       - name: Notify Jenkins of Release (Integration)
         id: jenkins-integration
+        if: ${{ (inputs.author != '' && inputs.message != '' && inputs.headSha != '') && !cancelled() }}
         uses: fjogeleit/http-request-action@bf78da14118941f7e940279dd58f67e863cbeff6 # v1.16.3
         with:
           url: ${{ secrets.RELEASE_JENKINS_INTEGRATION_URL  }}
-          data: ${{ inputs }}
+          data: ${{ toJSON(inputs) }}
 
       - name: Display Jenkins Payload
         env:

--- a/.github/workflows/node-zxf-deploy-integration.yaml
+++ b/.github/workflows/node-zxf-deploy-integration.yaml
@@ -18,9 +18,21 @@ name: "ZXF: [Node] Deploy Integration Network Release"
 on:
   workflow_dispatch:
     inputs:
-      event:
-        description: JSON representation of the triggering GitHub event
+      ref:
         required: true
+        description: "The github branch or tag that triggered the workflow"
+      author:
+        required: true
+        description: "The author name of the commit"
+      message:
+        required: true
+        description: "The message on the head commit"
+      headSha:
+        required: true
+        description: "The commit ID of the commit that triggered the workflow"
+#      event:
+#        description: JSON representation of the triggering GitHub event
+#        required: true
 
 permissions:
   contents: read
@@ -40,7 +52,7 @@ jobs:
         uses: fjogeleit/http-request-action@bf78da14118941f7e940279dd58f67e863cbeff6 # v1.16.3
         with:
           url: ${{ secrets.RELEASE_JENKINS_INTEGRATION_URL  }}
-          data: ${{ inputs.event }}
+          data: ${{ inputs }}
 
       - name: Display Jenkins Payload
         env:

--- a/.github/workflows/node-zxf-deploy-integration.yaml
+++ b/.github/workflows/node-zxf-deploy-integration.yaml
@@ -30,9 +30,6 @@ on:
       headSha:
         required: true
         description: "The commit ID of the commit that triggered the workflow"
-#      event:
-#        description: JSON representation of the triggering GitHub event
-#        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/node-zxf-deploy-integration.yaml
+++ b/.github/workflows/node-zxf-deploy-integration.yaml
@@ -22,15 +22,15 @@ on:
         required: true
         description: "The github branch or tag that triggered the workflow"
       author:
-        required: false
+        required: true
         description: "The author of the commit"
         default: ""
       msg:
-        required: false
+        required: true
         description: "The message on the head commit"
         default: ""
       sha:
-        required: false
+        required: true
         description: "The commit ID of the commit that triggered the workflow"
         default: ""
 
@@ -49,7 +49,6 @@ jobs:
 
       - name: Notify Jenkins of Release (Integration)
         id: jenkins-integration
-        if: ${{ (inputs.author != '' && inputs.message != '' && inputs.headSha != '') && !cancelled() }}
         uses: fjogeleit/http-request-action@bf78da14118941f7e940279dd58f67e863cbeff6 # v1.16.3
         with:
           url: ${{ secrets.RELEASE_JENKINS_INTEGRATION_URL  }}


### PR DESCRIPTION
**Description**:
We need to re-enable the jenkins integration flow. To do this, we will pass a limited set of JSON fields from the github event through to the Jenkinsfile.

**Related Issue(s)**:

Fixes #16319

