### PR TITLE
ci: add spaces to JSON message cleanup

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -104,7 +104,7 @@ jobs:
           COMMIT_SHA: ${{ github.sha }}
         run: |
           # massage the message to remove invalid control characters
-          MASSAGED_MESSAGE="${MESSAGE//[$'\t\r\n ']}"
+          MASSAGED_MESSAGE="${MESSAGE//[$'\t\r\n']/' '}"
 
           # Assign github step outputs
           echo "input-ref=${REFERENCE}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Description**:
In the previous effort of escaping and cleaning the commit message, we removed all tabs, returns, newlines, and spaces to squash all the text together. To make the output more readable, we'd like to replace all tabs, returns, and newlines with spaces.

**Related Issue(s)**:

Fixes #16387
