### PR TITLE
fix: Eliminate node operator port conflict

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
@@ -220,7 +220,7 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
                 ((SubProcessNode) node)
                         .reassignPorts(
                                 nextGrpcPort + nodeId * 2,
-                                nextNodeOperatorPort + nodeId * 2,
+                                nextNodeOperatorPort + nodeId,
                                 nextGossipPort + nodeId * 2,
                                 nextGossipTlsPort + nodeId * 2,
                                 nextPrometheusPort + nodeId);
@@ -427,7 +427,7 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
         //   - prometheusPort = nextPrometheusPort + nodeId = 10018
         nextGrpcPort = firstGrpcPort;
         nextNodeOperatorPort = nextGrpcPort + 2 * size;
-        nextGossipPort = nextNodeOperatorPort + 1;
+        nextGossipPort = nextNodeOperatorPort + size;
         nextGossipTlsPort = nextGossipPort + 1;
         nextPrometheusPort = nextGossipPort + 2 * size;
         nextPortsInitialized = true;


### PR DESCRIPTION
**Description**:
 - The gRPC node operator port for `node0` in a `SubProcessNetwork` was conflicting with the external gossip port assigned to `node1`.