### PR TITLE
chore: consistently use findbugs annotation

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/pairings/FakeFieldElement.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/pairings/FakeFieldElement.java
@@ -18,7 +18,6 @@ package com.hedera.node.app.tss.pairings;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
-import org.jetbrains.annotations.NotNull;
 
 public class FakeFieldElement implements FieldElement {
 
@@ -28,7 +27,7 @@ public class FakeFieldElement implements FieldElement {
         this.value = value;
     }
 
-    @NotNull
+    @NonNull
     @Override
     public BigInteger toBigInteger() {
         return value;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/pairings/FakeGroupElement.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/pairings/FakeGroupElement.java
@@ -18,7 +18,6 @@ package com.hedera.node.app.tss.pairings;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
-import org.jetbrains.annotations.NotNull;
 
 public class FakeGroupElement implements GroupElement {
     public static final FakeGroupElement GENERATOR = new FakeGroupElement(BigInteger.valueOf(5L));
@@ -28,13 +27,13 @@ public class FakeGroupElement implements GroupElement {
         this.value = value;
     }
 
-    @NotNull
+    @NonNull
     @Override
-    public GroupElement add(@NotNull GroupElement other) {
+    public GroupElement add(@NonNull GroupElement other) {
         return new FakeGroupElement(value.add(new BigInteger(other.toBytes())));
     }
 
-    @NotNull
+    @NonNull
     @Override
     public byte[] toBytes() {
         return value.toByteArray();

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -55,9 +55,7 @@ module com.hedera.node.app {
     requires org.hyperledger.besu.datatypes;
     requires static com.github.spotbugs.annotations;
     requires static com.google.auto.service;
-    requires static java.compiler;
-    requires static org.jetbrains.annotations;
-    // javax.annotation.processing.Generated
+    requires static java.compiler; // javax.annotation.processing.Generated
 
     exports com.hedera.node.app;
     exports com.hedera.node.app.state to


### PR DESCRIPTION
**Description**:

Do not use 'org.jetbrains.annotations'.

See this for getting IntelliJ to be more helpful there:
https://github.com/hashgraph/hedera-services/blob/1fe6a2de8b797eec943a45420c48a0d59f9f3271/docs/intellij-quickstart.md#spotbugs-annotations 

This should not have been added: https://github.com/hashgraph/hedera-services/pull/15908/files#diff-b387a7cf1f02bb7e5aeb741f42e0f851f454dd6f5f48beab877b433b3cb46e6cR55

Please give some thought to `module-info` additions. In particular when it is about 3d party modules that have not been used before.

**Related issue(s)**:

Follow up to #15908

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
