### PR TITLE
fix: Eliminate node operator port conflict 

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/NodeMetadata.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/NodeMetadata.java
@@ -40,7 +40,7 @@ public record NodeMetadata(
      * Create a new instance with the same values as this instance, but different ports.
      *
      * @param grpcPort the new grpc port
-     *                 @param grpcNodeOperatorPort the new grpc node operator port
+     * @param grpcNodeOperatorPort the new grpc node operator port
      * @param gossipPort the new gossip port
      * @param tlsGossipPort the new tls gossip port
      * @param prometheusPort the new prometheus port

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
@@ -220,7 +220,7 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
                 ((SubProcessNode) node)
                         .reassignPorts(
                                 nextGrpcPort + nodeId * 2,
-                                nextNodeOperatorPort + nodeId * 2,
+                                nextNodeOperatorPort + nodeId,
                                 nextGossipPort + nodeId * 2,
                                 nextGossipTlsPort + nodeId * 2,
                                 nextPrometheusPort + nodeId);
@@ -427,7 +427,7 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
         //   - prometheusPort = nextPrometheusPort + nodeId = 10018
         nextGrpcPort = firstGrpcPort;
         nextNodeOperatorPort = nextGrpcPort + 2 * size;
-        nextGossipPort = nextNodeOperatorPort + 1;
+        nextGossipPort = nextNodeOperatorPort + size;
         nextGossipTlsPort = nextGossipPort + 1;
         nextPrometheusPort = nextGossipPort + 2 * size;
         nextPortsInitialized = true;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
@@ -413,18 +413,12 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
      * @param firstGrpcPort the first gRPC port
      */
     public static void initializeNextPortsForNetwork(final int size, final int firstGrpcPort) {
-        // Suppose firstGrpcPort is 10000 with 4 nodes in the network, then:
-        //   - nextGrpcPort = 10000
-        //   - nextNodeOperatorPort = 10008
-        //   - nextGossipPort = 10009
-        //   - nextGossipTlsPort = 10010
-        //   - nextPrometheusPort = 10016
-        // So for a nodeId of 2, the assigned ports are:
-        //   - grpcPort = nextGrpcPort + nodeId * 2 = 10004
-        //   - grpcNodeOperatorPort = nextNodeOperatorPort + nodeId * 2 = 10012
-        //   - gossipPort = nextGossipPort + nodeId * 2 = 10013
-        //   - gossipTlsPort = nextGossipTlsPort + nodeId * 2 = 10014
-        //   - prometheusPort = nextPrometheusPort + nodeId = 10018
+        // Suppose firstGrpcPort is 10000 with 4 nodes in the network, then the port assignments are,
+        //   - grpcPort = 10000, 10002, 10004, 10006
+        //   - nodeOperatorPort = 10008, 10009, 10010, 10011
+        //   - gossipPort = 10012, 10014, 10016, 10018
+        //   - gossipTlsPort = 10013, 10015, 10017, 10019
+        //   - prometheusPort = 10020, 10021, 10022, 10023
         nextGrpcPort = firstGrpcPort;
         nextNodeOperatorPort = nextGrpcPort + 2 * size;
         nextGossipPort = nextNodeOperatorPort + size;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/AddressBookUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/AddressBookUtils.java
@@ -123,7 +123,7 @@ public class AddressBookUtils {
                         .build(),
                 host,
                 nextGrpcPort + nodeId * 2,
-                nextNodeOperatorPort + nodeId * 2,
+                nextNodeOperatorPort + nodeId,
                 nextGossipPort + nodeId * 2,
                 nextGossipTlsPort + nodeId * 2,
                 nextPrometheusPort + nodeId,


### PR DESCRIPTION
Description:

The gRPC node operator port for node0 in a SubProcessNetwork was conflicting with the external gossip port assigned to node1.