### PR TITLE
feat: introduce RosterHistory

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterHistory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterHistory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.roster;
+
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RoundRosterPair;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A Roster History object that encapsulates information about the current active roster
+ * and the previous active roster, and their corresponding starting round numbers.
+ */
+public class RosterHistory {
+    private final List<RoundRosterPair> history;
+    private final Map<Bytes, Roster> rosters;
+
+    /**
+     * Construct a RosterHistory out of the RosterState and RosterMap inputs.
+     * @param history a non-empty list of round number/roster hash pairs
+     * @param rosters a map from roster hash to roster objects which must contain all the roster hashes found in the history.
+     */
+    public RosterHistory(@NonNull final List<RoundRosterPair> history, @NonNull final Map<Bytes, Roster> rosters) {
+        this.history = history;
+        this.rosters = rosters;
+
+        if (history.isEmpty()) {
+            throw new IllegalArgumentException("Roster history is empty");
+        }
+
+        if (history.stream().map(RoundRosterPair::activeRosterHash).anyMatch(hash -> !rosters.containsKey(hash))) {
+            throw new IllegalArgumentException(
+                    "Roster history refers to roster hashes not found in the roster map: history: " + history
+                            + ", rosters: " + rosters);
+        }
+    }
+
+    /**
+     * Constructs a RosterHistory out of a current and previous Roster objects and their corresponding starting round numbers.
+     * This is a simplified version of the constructor to be used with the legacy, AddressBook/config.txt-driven startup lifecycle
+     * until the new, Roster-only-based lifecycle is fully implemented.
+     * @param currentRoster currentRoster
+     * @param currentRound {@code currentRound >= previousRound}
+     * @param previousRoster previousRoster
+     * @param previousRound {@code previousRound <= currentRound}
+     */
+    public RosterHistory(
+            @NonNull final Roster currentRoster,
+            final long currentRound,
+            @NonNull final Roster previousRoster,
+            final long previousRound) {
+        if (currentRound < previousRound) {
+            throw new IllegalArgumentException(
+                    "Current round must be greater than or equal to the previous round. currentRound: " + currentRound
+                            + ", previousRound: " + previousRound);
+        }
+
+        final Bytes currentHash = RosterUtils.hash(currentRoster).getBytes();
+        final Bytes previousHash = RosterUtils.hash(previousRoster).getBytes();
+
+        this.rosters = Map.of(
+                currentHash, currentRoster,
+                previousHash, previousRoster);
+
+        this.history = List.of(
+                RoundRosterPair.newBuilder()
+                        .activeRosterHash(currentHash)
+                        .roundNumber(currentRound)
+                        .build(),
+                RoundRosterPair.newBuilder()
+                        .activeRosterHash(previousHash)
+                        .roundNumber(previousRound)
+                        .build());
+    }
+
+    /**
+     * Returns the current active roster, which is the very first (index == 0) entry in the history list.
+     * @return the current active roster
+     */
+    @NonNull
+    public Roster getCurrentRoster() {
+        return rosters.get(history.get(0).activeRosterHash());
+    }
+
+    /**
+     * Returns the previous roster, which is the second (index == 1) entry in the history list,
+     * or the very first entry equal to the current active roster if the history has a single entry only.
+     * @return the previous roster
+     */
+    @NonNull
+    public Roster getPreviousRoster() {
+        return rosters.get(history.get(history.size() > 1 ? 1 : 0).activeRosterHash());
+    }
+
+    /**
+     * Returns a roster active in a given round, or null if the given round predates the available roster history.
+     * @param roundNumber a round number
+     * @return an active roster for that round
+     */
+    @Nullable
+    public Roster getRosterForRound(final long roundNumber) {
+        for (final RoundRosterPair roundRosterPair : history) {
+            if (roundRosterPair.roundNumber() <= roundNumber) {
+                return rosters.get(roundRosterPair.activeRosterHash());
+            }
+        }
+        return null;
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterHistoryTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterHistoryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.roster;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.hapi.node.base.ServiceEndpoint;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import com.hedera.hapi.node.state.roster.RoundRosterPair;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RosterHistoryTest {
+    private static final Roster ROSTER_1 = RosterValidatorTests.buildValidRoster();
+    private static final Roster ROSTER_2 = RosterValidatorTests.buildValidRoster()
+            .copyBuilder()
+            .rosterEntries(Stream.<RosterEntry>concat(
+                            ROSTER_1.rosterEntries().stream(),
+                            List.of(RosterEntry.newBuilder()
+                                            .nodeId(73846583745L)
+                                            .weight(87432653L)
+                                            .gossipCaCertificate(Bytes.wrap("test349573845"))
+                                            .gossipEndpoint(ServiceEndpoint.newBuilder()
+                                                    .domainName("test298543.com")
+                                                    .port(999)
+                                                    .build())
+                                            .build())
+                                    .stream())
+                    .toList())
+            .build();
+
+    private static final long ROUND_1 = 1097534987L;
+    private static final long ROUND_2 = 2983745987L;
+
+    /**
+     * Build identical RosterHistory objects using different constructors.
+     * @return stream of arguments
+     */
+    private static Stream<Arguments> provideArguments() {
+        final Bytes hash1 = RosterUtils.hash(ROSTER_1).getBytes();
+        final Bytes hash2 = RosterUtils.hash(ROSTER_2).getBytes();
+
+        return Stream.of(
+                Arguments.of(new RosterHistory(
+                        List.of(
+                                RoundRosterPair.newBuilder()
+                                        .roundNumber(ROUND_2)
+                                        .activeRosterHash(hash2)
+                                        .build(),
+                                RoundRosterPair.newBuilder()
+                                        .roundNumber(ROUND_1)
+                                        .activeRosterHash(hash1)
+                                        .build()),
+                        Map.of(
+                                hash1, ROSTER_1,
+                                hash2, ROSTER_2))),
+                Arguments.of(new RosterHistory(ROSTER_2, ROUND_2, ROSTER_1, ROUND_1)));
+    }
+
+    @ParameterizedTest
+    @MethodSource({"provideArguments"})
+    void testGetCurrentRoster(final RosterHistory rosterHistory) {
+        assertEquals(ROSTER_2, rosterHistory.getCurrentRoster());
+    }
+
+    @ParameterizedTest
+    @MethodSource({"provideArguments"})
+    void testGetPreviousRoster(final RosterHistory rosterHistory) {
+        assertEquals(ROSTER_1, rosterHistory.getPreviousRoster());
+    }
+
+    @ParameterizedTest
+    @MethodSource({"provideArguments"})
+    void testGetRosterForRound(final RosterHistory rosterHistory) {
+        assertEquals(ROSTER_2, rosterHistory.getRosterForRound(ROUND_2 + 1));
+        assertEquals(ROSTER_2, rosterHistory.getRosterForRound(ROUND_2));
+
+        assertEquals(ROSTER_1, rosterHistory.getRosterForRound(ROUND_2 - 1));
+
+        assertEquals(ROSTER_1, rosterHistory.getRosterForRound(ROUND_1 + 1));
+        assertEquals(ROSTER_1, rosterHistory.getRosterForRound(ROUND_1));
+
+        assertEquals(null, rosterHistory.getRosterForRound(ROUND_1 - 1));
+    }
+
+    @Test
+    void testConstructor() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new RosterHistory(List.of(), Map.of()),
+                "Roster history is empty");
+
+        final IllegalArgumentException iae1 = assertThrows(
+                IllegalArgumentException.class,
+                () -> new RosterHistory(
+                        List.of(RoundRosterPair.newBuilder()
+                                .roundNumber(ROUND_2)
+                                .activeRosterHash(RosterUtils.hash(ROSTER_2).getBytes())
+                                .build()),
+                        Map.of()));
+        assertTrue(iae1.getMessage().startsWith("Roster history refers to roster hashes not found in the roster map"));
+
+        final IllegalArgumentException iae2 = assertThrows(
+                IllegalArgumentException.class, () -> new RosterHistory(ROSTER_2, ROUND_1 - 1, ROSTER_1, ROUND_1));
+        assertTrue(iae2.getMessage().startsWith("Current round must be greater than or equal to the previous round"));
+    }
+}


### PR DESCRIPTION
**Description**:
Introducing a `RosterHistory` class to encapsulate the information about active/previous (and in the future, any historical) rosters necessary for the consensus node to function. Specifically, this object is going to be a `PlatformBuilder` input instead of the currently used `withAddressBook`/`withRoster` and friends. The refactoring of the PlatformBuilder, as well as the code in ServicesMain that instantiates it, will be performed in a separate PR in the future.

**Related issue(s)**:

Fixes #16353

**Notes for reviewer**:
Unit tests.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
