### PR TITLE
chore: Add useRosterLifecycle to platform AddressBookConfig

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/AddressBookConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/config/AddressBookConfig.java
@@ -37,10 +37,14 @@ import com.swirlds.config.api.ConfigProperty;
  *      AddressBookInitializer will create two new files in the `/data/saved/address_book` directory. The
  *      AddressBookInitializer will delete files by age, oldest first, if the number of files in the directory
  *      exceeds the maximum indicated by this setting.
+ * @param useRosterLifecycle
+ *      If true, then the platform will use the roster lifecycle. If false, then the
+ *      platform will not use the roster lifecycle.
  */
 @ConfigData("addressBook")
 public record AddressBookConfig(
         @ConfigProperty(defaultValue = "true") boolean updateAddressBookOnlyAtUpgrade,
         @ConfigProperty(defaultValue = "false") boolean forceUseOfConfigAddressBook,
         @ConfigProperty(defaultValue = "data/saved/address_book") String addressBookDirectory,
-        @ConfigProperty(defaultValue = "50") int maxRecordedAddressBookFiles) {}
+        @ConfigProperty(defaultValue = "50") int maxRecordedAddressBookFiles,
+        @ConfigProperty(defaultValue = "false") boolean useRosterLifecycle) {}

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/config/AddressBookConfigTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/config/AddressBookConfigTest.java
@@ -30,4 +30,15 @@ class AddressBookConfigTest {
         // then
         Assertions.assertDoesNotThrow(() -> configurationBuilder.build(), "All default values should be valid");
     }
+
+    @Test
+    public void testUseRosterLifecycleDefaultValue() {
+        // given
+        final ConfigurationBuilder configurationBuilder =
+                ConfigurationBuilder.create().withConfigDataTypes(AddressBookConfig.class);
+        // when
+        AddressBookConfig config = configurationBuilder.build().getConfigData(AddressBookConfig.class);
+        // then
+        Assertions.assertFalse(config.useRosterLifecycle(), "The default value of useRosterLifecycle should be false");
+    }
 }


### PR DESCRIPTION
**Description**:
This pull request introduces a new configuration option to the `AddressBookConfig` class and adds corresponding unit tests to ensure its default value is correctly set. The key changes include:

### Configuration Enhancements:

* Added a new configuration parameter `useRosterLifecycle` to the `AddressBookConfig` class, which determines whether the platform will use the roster lifecycle.

### Testing:

* Added a new test `testUseRosterLifecycleDefaultValue` in `AddressBookConfigTest` to verify that the default value of `useRosterLifecycle` is set to `false`.

**Related issue(s)**:

Fixes #16351 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
