### PR TITLE
fix: load crypto into address book in `Browser` call to `GuiEventStorage`

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -210,6 +210,12 @@ public class Browser {
             BootstrapUtils.setupConfigBuilder(guiConfigBuilder, getAbsolutePath(DEFAULT_SETTINGS_FILE_NAME));
             final Configuration guiConfig = guiConfigBuilder.build();
 
+            final ConfigurationBuilder configBuilder = ConfigurationBuilder.create();
+            rethrowIO(() ->
+                    BootstrapUtils.setupConfigBuilder(configBuilder, getAbsolutePath(DEFAULT_SETTINGS_FILE_NAME)));
+            final Configuration configuration = configBuilder.build();
+
+            initNodeSecurity(appDefinition.getConfigAddressBook(), configuration);
             guiEventStorage = new GuiEventStorage(guiConfig, appDefinition.getConfigAddressBook());
 
             guiSource = new StandardGuiSource(appDefinition.getConfigAddressBook(), guiEventStorage);


### PR DESCRIPTION
**Description**:

This PR loads the cryptography in the address book given the to the `GuiEventStorage` constructor.   Without the crypto, the translate of the address book to a Roster throws an exception. 

This problem was missed because the Browser is not production code and not tested in the CI/CD pipeline.  It can only be used by starting platform applications locally and in nightly platform JRS tests. 

**Related issue(s)**:

Fixes #16452 

**Notes for reviewer**:

Verified local startup of Browser.
