### PR TITLE
fix: cryptography always generates agreement keys on startup

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -551,7 +551,7 @@ public final class CryptoStatic {
                     keysAndCerts = EnhancedKeyStoreLoader.using(addressBook, configuration)
                             .migrate()
                             .scan()
-                            .generateIfNecessary()
+                            .generate()
                             .verify()
                             .injectInAddressBook()
                             .keysAndCerts();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
@@ -298,16 +298,11 @@ public class EnhancedKeyStoreLoader {
                 localNodes.add(nodeId);
                 sigPrivateKeys.compute(
                         nodeId, (k, v) -> resolveNodePrivateKey(nodeId, nodeAlias, KeyCertPurpose.SIGNING));
-                agrPrivateKeys.compute(
-                        nodeId, (k, v) -> resolveNodePrivateKey(nodeId, nodeAlias, KeyCertPurpose.AGREEMENT));
             }
 
             sigCertificates.compute(
                     nodeId,
                     (k, v) -> resolveNodeCertificate(nodeId, nodeAlias, KeyCertPurpose.SIGNING, legacyPublicStore));
-            agrCertificates.compute(
-                    nodeId,
-                    (k, v) -> resolveNodeCertificate(nodeId, nodeAlias, KeyCertPurpose.AGREEMENT, legacyPublicStore));
         });
 
         logger.trace(STARTUP.getMarker(), "Completed key store enumeration");
@@ -315,16 +310,15 @@ public class EnhancedKeyStoreLoader {
     }
 
     /**
-     * Iterates over the local nodes and creates the agreement key and certificate for each if they do not exist.  This
-     * method should be called after {@link #scan()} and before {@link #verify()} in order to generate any missing
-     * agreement keys for local nodes to pass verification.
+     * Iterates over the local nodes and creates the agreement key and certificate for each.  This
+     * method should be called after {@link #scan()} and before {@link #verify()}.
      *
      * @return this {@link EnhancedKeyStoreLoader} instance.
      * @throws NoSuchAlgorithmException if the algorithm required to generate the key pair is not available.
      * @throws NoSuchProviderException  if the security provider required to generate the key pair is not available.
      * @throws KeyGeneratingException   if an error occurred while generating the agreement key pair.
      */
-    public EnhancedKeyStoreLoader generateIfNecessary()
+    public EnhancedKeyStoreLoader generate()
             throws NoSuchAlgorithmException, NoSuchProviderException, KeyGeneratingException {
 
         for (final NodeId node : localNodes) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
@@ -310,8 +310,8 @@ public class EnhancedKeyStoreLoader {
     }
 
     /**
-     * Iterates over the local nodes and creates the agreement key and certificate for each.  This
-     * method should be called after {@link #scan()} and before {@link #verify()}.
+     * Iterates over the local nodes and creates the agreement key and certificate for each.  This method should be
+     * called after {@link #scan()} and before {@link #verify()}.
      *
      * @return this {@link EnhancedKeyStoreLoader} instance.
      * @throws NoSuchAlgorithmException if the algorithm required to generate the key pair is not available.
@@ -1476,7 +1476,7 @@ public class EnhancedKeyStoreLoader {
         if (sPublicPfx.exists()
                 && sPublicPfx.isFile()
                 && !sPublicPfx.renameTo(
-                        pfxArchiveDirectory.resolve(sPublicPfx.getName()).toFile())) {
+                        pfxDateDirectory.resolve(sPublicPfx.getName()).toFile())) {
             cleanupErrorCount.incrementAndGet();
         }
         if (cleanupErrorCount.get() > 0) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
@@ -102,7 +102,7 @@ public class CryptoArgsProvider {
         final Map<NodeId, KeysAndCerts> loadedC = EnhancedKeyStoreLoader.using(
                         createdAB, configure(ResourceLoader.getFile("preGeneratedPEMKeysAndCerts/")))
                 .scan()
-                .generateIfNecessary()
+                .generate()
                 .verify()
                 .injectInAddressBook()
                 .keysAndCerts();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
@@ -117,7 +117,7 @@ class EnhancedKeyStoreLoaderTest {
         assertThat(loader).isNotNull();
         assertThatCode(loader::migrate).doesNotThrowAnyException();
         assertThatCode(loader::scan).doesNotThrowAnyException();
-        assertThatCode(loader::generateIfNecessary).doesNotThrowAnyException();
+        assertThatCode(loader::generate).doesNotThrowAnyException();
         assertThatCode(loader::verify).doesNotThrowAnyException();
         assertThatCode(loader::injectInAddressBook).doesNotThrowAnyException();
 
@@ -189,13 +189,9 @@ class EnhancedKeyStoreLoaderTest {
         assertThat(loader).isNotNull();
         assertThatCode(loader::migrate).doesNotThrowAnyException();
         assertThatCode(loader::scan).doesNotThrowAnyException();
-        assertThatCode(loader::generateIfNecessary).isInstanceOf(KeyGeneratingException.class);
+        assertThatCode(loader::generate).isInstanceOf(KeyGeneratingException.class);
         assertThatCode(loader::verify).isInstanceOf(KeyLoadingException.class);
-        if (directoryName.equals("hybrid-invalid-case-2") || directoryName.equals("enhanced-invalid-case-2")) {
-            assertThatCode(loader::injectInAddressBook).isInstanceOf(KeyLoadingException.class);
-        } else {
-            assertThatCode(loader::injectInAddressBook).doesNotThrowAnyException();
-        }
+        assertThatCode(loader::injectInAddressBook).isInstanceOf(KeyLoadingException.class);
         assertThatCode(loader::keysAndCerts).isInstanceOf(KeyLoadingException.class);
     }
 


### PR DESCRIPTION
**Description**:

There is an edge case if the migration of the cryptography is removed and a PFX file is placed in the cryptography directory that contains an old agreement key, the old agreement key will be loaded and prevent mTLS gossip connections from being formed with peers.  

This contains two cherry picked commits.  
1. Always generating agreement keys and not loading them
2. A fix for migrating the public.pfx file to the wrong sub-directory.  

**Related issue(s)**:

Fixes #16453
Fixes #16451 

**Notes for reviewer**:

The PRs for develop: 
1. https://github.com/hashgraph/hedera-services/pull/16315
1. https://github.com/hashgraph/hedera-services/pull/16444
