### PR TITLE
fix: ensure only one creation lambda executes per `SpecEntity`

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/AddressBookTestBase.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/AddressBookTestBase.java
@@ -38,6 +38,7 @@ import com.hedera.node.app.service.addressbook.impl.schemas.V053AddressBookSchem
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
 import com.swirlds.state.spi.ReadableStates;
@@ -92,6 +93,7 @@ public class AddressBookTestBase {
                                     KEY_BUILDER.apply(B_NAME).build(),
                                     A_COMPLEX_KEY)))
             .build();
+    public static final Configuration DEFAULT_CONFIG = HederaTestConfigBuilder.createConfig();
     protected final Key key = A_COMPLEX_KEY;
     protected final Key anotherKey = B_COMPLEX_KEY;
 
@@ -173,8 +175,7 @@ public class AddressBookTestBase {
         given(readableStates.<EntityNumber, Node>get(NODES_KEY)).willReturn(readableNodeState);
         given(writableStates.<EntityNumber, Node>get(NODES_KEY)).willReturn(writableNodeState);
         readableStore = new ReadableNodeStoreImpl(readableStates);
-        final var configuration = HederaTestConfigBuilder.createConfig();
-        writableStore = new WritableNodeStore(writableStates, configuration, storeMetricsService);
+        writableStore = new WritableNodeStore(writableStates, DEFAULT_CONFIG, storeMetricsService);
     }
 
     protected void refreshStoresWithCurrentNodeInBothReadableAndWritable() {

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeUpdateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeUpdateHandlerTest.java
@@ -64,6 +64,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,17 +89,21 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
 
     private TransactionBody txn;
     private NodeUpdateHandler subject;
-    private List<X509Certificate> certList;
+    private static List<X509Certificate> certList;
+
+    @BeforeAll
+    static void beforeAll() {
+        certList = generateX509Certificates(3);
+    }
 
     @BeforeEach
     void setUp() {
         final var addressBookValidator = new AddressBookValidator();
         subject = new NodeUpdateHandler(addressBookValidator);
-        certList = generateX509Certificates(3);
     }
 
     @Test
-    @DisplayName("pureChecks fail when nodeId is negagive")
+    @DisplayName("pureChecks fail when nodeId is negative")
     void nodeIdCannotNegative() {
         txn = new NodeUpdateBuilder().build();
         final var msg = assertThrows(PreCheckException.class, () -> subject.pureChecks(txn));
@@ -142,7 +147,7 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
     }
 
     @Test
-    void nodetIdMustInState() {
+    void nodeIdMustInState() {
         txn = new NodeUpdateBuilder().withNodeId(2L).build();
         given(handleContext.body()).willReturn(txn);
         refreshStoresWithCurrentNodeInWritable();
@@ -399,14 +404,13 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
     }
 
     @Test
-    void preHandleWorksWhenAdminKeyValid() throws PreCheckException {
+    void preHandleRequiresAdminKeySigForNonAddressBookAdmin() throws PreCheckException {
         txn = new NodeUpdateBuilder()
                 .withNodeId(nodeId.number())
                 .withAccountId(asAccount(53))
                 .withAdminKey(key)
                 .build();
         final var context = setupPreHandle(true, txn);
-
         subject.preHandle(context);
         assertThat(txn).isEqualTo(context.body());
         assertThat(context.payerKey()).isEqualTo(anotherKey);
@@ -515,19 +519,24 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
 
     private PreHandleContext setupPreHandle(boolean updateAccountIdAllowed, TransactionBody txn)
             throws PreCheckException {
+        return setupPreHandle(updateAccountIdAllowed, txn, payerId);
+    }
+
+    private PreHandleContext setupPreHandle(
+            boolean updateAccountIdAllowed, TransactionBody txn, AccountID contextPayerId) throws PreCheckException {
         final var config = HederaTestConfigBuilder.create()
                 .withValue("nodes.updateAccountIdAllowed", updateAccountIdAllowed)
                 .getOrCreateConfig();
-        mockPayerLookup(anotherKey);
+        mockPayerLookup(anotherKey, contextPayerId);
         final var context = new FakePreHandleContext(accountStore, txn, config);
         context.registerStore(ReadableNodeStore.class, readableStore);
         return context;
     }
 
-    private Key mockPayerLookup(Key key) {
+    private Key mockPayerLookup(Key key, AccountID contextPayerId) {
         final var account = mock(Account.class);
         given(account.key()).willReturn(key);
-        given(accountStore.getAccountById(payerId)).willReturn(account);
+        given(accountStore.getAccountById(contextPayerId)).willReturn(account);
         return key;
     }
 
@@ -543,38 +552,40 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
 
         private Bytes grpcCertificateHash = null;
         private Key adminKey = null;
+        private AccountID contextPayerId = payerId;
 
         private NodeUpdateBuilder() {}
 
         public TransactionBody build() {
-            final var txnId = TransactionID.newBuilder().accountID(payerId).transactionValidStart(consensusTimestamp);
-            final var txnBody = NodeUpdateTransactionBody.newBuilder();
-            txnBody.nodeId(nodeId);
+            final var txnId =
+                    TransactionID.newBuilder().accountID(contextPayerId).transactionValidStart(consensusTimestamp);
+            final var op = NodeUpdateTransactionBody.newBuilder();
+            op.nodeId(nodeId);
             if (accountId != null) {
-                txnBody.accountId(accountId);
+                op.accountId(accountId);
             }
             if (description != null) {
-                txnBody.description(description);
+                op.description(description);
             }
             if (gossipEndpoint != null) {
-                txnBody.gossipEndpoint(gossipEndpoint);
+                op.gossipEndpoint(gossipEndpoint);
             }
             if (serviceEndpoint != null) {
-                txnBody.serviceEndpoint(serviceEndpoint);
+                op.serviceEndpoint(serviceEndpoint);
             }
             if (gossipCaCertificate != null) {
-                txnBody.gossipCaCertificate(gossipCaCertificate);
+                op.gossipCaCertificate(gossipCaCertificate);
             }
             if (grpcCertificateHash != null) {
-                txnBody.grpcCertificateHash(grpcCertificateHash);
+                op.grpcCertificateHash(grpcCertificateHash);
             }
             if (adminKey != null) {
-                txnBody.adminKey(adminKey);
+                op.adminKey(adminKey);
             }
 
             return TransactionBody.newBuilder()
                     .transactionID(txnId)
-                    .nodeUpdate(txnBody.build())
+                    .nodeUpdate(op.build())
                     .build();
         }
 
@@ -585,6 +596,11 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
 
         public NodeUpdateBuilder withAccountId(final AccountID accountId) {
             this.accountId = accountId;
+            return this;
+        }
+
+        public NodeUpdateBuilder withPayerId(final AccountID overridePayerId) {
+            this.contextPayerId = overridePayerId;
             return this;
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/SpecEntity.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/SpecEntity.java
@@ -81,8 +81,6 @@ public interface SpecEntity {
      *
      * <p>Always use with <code>&#64;LeakyHapiTest(requirement = NO_CONCURRENT_CREATIONS)</code>.
      *
-     * <p>(See, e.g., {@link com.hedera.services.bdd.suites.contract.opcodes.SelfDestructSuite#selfDestructedContractIsDeletedInSameTx(String,SpecAccount,SpecContract,SpecContract)}.)
-     *
      * @param spec the spec to use to create an entity if it is not already created
      * @param entities - the entities to create, in order
      */

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/entities/AbstractSpecEntity.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/entities/AbstractSpecEntity.java
@@ -75,8 +75,8 @@ public abstract class AbstractSpecEntity<O extends SpecOperation, M extends Reco
 
     /**
      * Wraps a supplier of a future result, allowing us to defer scheduling that supplier until we know
-     * it is the privileged supplier of out of potentially several suppliers concurrent test executor
-     * threads created for this entity.
+     * it is the privileged supplier out of potentially several suppliers concurrent test executor threads
+     * created for this entity.
      * @param <M> the type of the model returned by the supplier
      */
     private static class DeferredResult<M extends Record> {


### PR DESCRIPTION
**Description**:
 - Closes #16434 
 - Speeds up `NodeUpdateHandlerTest` by only generating X509 certs once, in a `@BeforeAll` method.