### PR TITLE
feat: use RosterHistory in PlatformBuilder

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -33,7 +33,6 @@ import static com.swirlds.platform.gui.internal.BrowserWindowManager.setBrowserW
 import static com.swirlds.platform.gui.internal.BrowserWindowManager.setStateHierarchy;
 import static com.swirlds.platform.gui.internal.BrowserWindowManager.showBrowserWindow;
 import static com.swirlds.platform.state.signed.StartupStateUtils.getInitialState;
-import static com.swirlds.platform.system.address.AddressBookUtils.createRoster;
 import static com.swirlds.platform.system.address.AddressBookUtils.initializeAddressBook;
 import static com.swirlds.platform.util.BootstrapUtils.checkNodesToRun;
 import static com.swirlds.platform.util.BootstrapUtils.getNodesToRun;
@@ -67,11 +66,13 @@ import com.swirlds.platform.gui.internal.WinBrowser;
 import com.swirlds.platform.gui.model.InfoApp;
 import com.swirlds.platform.gui.model.InfoMember;
 import com.swirlds.platform.gui.model.InfoSwirld;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.signed.HashedReservedSignedState;
 import com.swirlds.platform.system.SwirldMain;
 import com.swirlds.platform.system.SystemExitCode;
 import com.swirlds.platform.system.SystemExitUtils;
 import com.swirlds.platform.system.address.AddressBook;
+import com.swirlds.platform.system.address.AddressBookUtils;
 import com.swirlds.platform.util.BootstrapUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.awt.GraphicsEnvironment;
@@ -296,7 +297,9 @@ public class Browser {
                     appDefinition.getSwirldName(),
                     appMain.getSoftwareVersion(),
                     initialState,
-                    nodeId);
+                    nodeId,
+                    AddressBookUtils.formatConsensusEventStreamName(addressBook, nodeId),
+                    RosterUtils.buildRosterHistory(initialState.get().getState().getReadablePlatformState()));
             if (showUi && index == 0) {
                 builder.withPreconsensusEventCallback(guiEventStorage::handlePreconsensusEvent);
                 builder.withConsensusSnapshotOverrideCallback(guiEventStorage::handleSnapshotOverride);
@@ -306,8 +309,6 @@ public class Browser {
             final SwirldsPlatform platform = (SwirldsPlatform) builder.withConfiguration(configuration)
                     .withPlatformContext(platformContext)
                     .withConfiguration(configuration)
-                    .withAddressBook(addressBook)
-                    .withRoster(createRoster(appDefinition.getConfigAddressBook()))
                     .withKeysAndCerts(keysAndCerts)
                     .build();
             platforms.put(nodeId, platform);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -57,6 +57,7 @@ import com.swirlds.platform.metrics.RuntimeMetrics;
 import com.swirlds.platform.pool.TransactionPoolNexus;
 import com.swirlds.platform.publisher.DefaultPlatformPublisher;
 import com.swirlds.platform.publisher.PlatformPublisher;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformStateAccessor;
 import com.swirlds.platform.state.SwirldStateManager;
@@ -211,7 +212,7 @@ public class SwirldsPlatform implements Platform {
         initialPcesFiles = blocks.initialPcesFiles();
         notificationEngine = blocks.notificationEngine();
 
-        currentAddressBook = initialState.getAddressBook();
+        currentAddressBook = RosterUtils.buildAddressBook(blocks.rosterHistory().getCurrentRoster());
 
         platformWiring = new PlatformWiring(platformContext, blocks.model(), blocks.applicationCallbacks());
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -139,22 +139,18 @@ public final class PlatformBuilder {
     /**
      * Create a new platform builder.
      *
-     * <p>When this builder is used to create a platform, it tries to load an existing app state from
-     * a snapshot on disk, if exists, using the provided {@code snapshotStateReader} function. If there
-     * is no snapshot on disk, or the reader throws an exception trying to load the snapshot, a new
-     * genesis state is created using {@code genesisStateBuilder} supplier.
-     *
-     * <p>Note: if an existing snapshot can't be loaded, or a new genesist state can't be created, the
-     * corresponding functions must throw an exception rather than return a null value.
+     * <p>Before calling this method, the app would try and load a state snapshot from disk. If one exists,
+     * the app will pass the loaded state via the initialState argument to this method. If the snapshot doesn't exist,
+     * then the app will create a new genesis state and pass it via the same initialState argument.
      *
      * @param appName             the name of the application, currently used for deciding where to store states on
      *                            disk
      * @param swirldName          the name of the swirld, currently used for deciding where to store states on disk
      * @param selfId              the ID of this node
      * @param softwareVersion     the software version of the application
-     * @param initialState        the genesis state supplied by the application
-     * @param consensusEventStreamName the consensusEventStreamName
-     * @param rosterHistory       the RosterHistory
+     * @param initialState        the initial state supplied by the application
+     * @param consensusEventStreamName a part of the name of the directory where the consensus event stream is written
+     * @param rosterHistory       the roster history provided by the application to use at startup
      */
     @NonNull
     public static PlatformBuilder create(
@@ -178,8 +174,8 @@ public final class PlatformBuilder {
      * @param softwareVersion       the software version of the application
      * @param initialState          the genesis state supplied by application
      * @param selfId                the ID of this node
-     * @param consensusEventStreamName the consensusEventStreamName
-     * @param rosterHistory         the RosterHistory
+     * @param consensusEventStreamName a part of the name of the directory where the consensus event stream is written
+     * @param rosterHistory         the roster history provided by the application to use at startup
      */
     private PlatformBuilder(
             @NonNull final String appName,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
@@ -59,6 +59,7 @@ import java.util.function.Supplier;
  * @param swirldName                             the name of the swirld being run
  * @param appVersion                             the current version of the running application
  * @param initialState                           the initial state of the platform
+ * @param rosterHistory                          the roster history provided by the application to use at startup
  * @param applicationCallbacks                   the callbacks that the platform will call when certain events happen
  * @param preconsensusEventConsumer              the consumer for preconsensus events, null if publishing this data has
  *                                               not been enabled
@@ -76,7 +77,7 @@ import java.util.function.Supplier;
  *                                               underlying data source), this indirection can be removed once states
  *                                               are passed within the wiring framework
  * @param initialPcesFiles                       the initial set of PCES files present when the node starts
- * @param consensusEventStreamName               a string used to format a directory with consensusEventStream data
+ * @param consensusEventStreamName               a part of the name of the directory where the consensus event stream is written
  * @param issScratchpad                          scratchpad storage for ISS recovery
  * @param notificationEngine                     for sending notifications to the application (legacy pattern)
  * @param firstPlatform                          if this is the first platform being built (there is static setup that

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
@@ -28,13 +28,13 @@ import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.event.preconsensus.PcesFileTracker;
 import com.swirlds.platform.gossip.IntakeEventCounter;
 import com.swirlds.platform.pool.TransactionPoolNexus;
+import com.swirlds.platform.roster.RosterHistory;
 import com.swirlds.platform.scratchpad.Scratchpad;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.iss.IssScratchpad;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.SoftwareVersion;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.status.StatusActionSubmitter;
 import com.swirlds.platform.util.RandomBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -76,6 +76,7 @@ import java.util.function.Supplier;
  *                                               underlying data source), this indirection can be removed once states
  *                                               are passed within the wiring framework
  * @param initialPcesFiles                       the initial set of PCES files present when the node starts
+ * @param consensusEventStreamName               a string used to format a directory with consensusEventStream data
  * @param issScratchpad                          scratchpad storage for ISS recovery
  * @param notificationEngine                     for sending notifications to the application (legacy pattern)
  * @param firstPlatform                          if this is the first platform being built (there is static setup that
@@ -102,6 +103,7 @@ public record PlatformBuildingBlocks(
         @NonNull String swirldName,
         @NonNull SoftwareVersion appVersion,
         @NonNull ReservedSignedState initialState,
+        @NonNull RosterHistory rosterHistory,
         @NonNull ApplicationCallbacks applicationCallbacks,
         @Nullable Consumer<PlatformEvent> preconsensusEventConsumer,
         @Nullable Consumer<ConsensusSnapshot> snapshotOverrideConsumer,
@@ -111,6 +113,7 @@ public record PlatformBuildingBlocks(
         @NonNull AtomicReference<Predicate<Instant>> isInFreezePeriodReference,
         @NonNull AtomicReference<Function<String, ReservedSignedState>> latestImmutableStateProviderReference,
         @NonNull PcesFileTracker initialPcesFiles,
+        @NonNull String consensusEventStreamName,
         @NonNull Scratchpad<IssScratchpad> issScratchpad,
         @NonNull NotificationEngine notificationEngine,
         @NonNull AtomicReference<StatusActionSubmitter> statusActionSubmitterReference,
@@ -129,6 +132,7 @@ public record PlatformBuildingBlocks(
         requireNonNull(swirldName);
         requireNonNull(appVersion);
         requireNonNull(initialState);
+        requireNonNull(rosterHistory);
         requireNonNull(applicationCallbacks);
         requireNonNull(intakeEventCounter);
         requireNonNull(randomBuilder);
@@ -136,6 +140,7 @@ public record PlatformBuildingBlocks(
         requireNonNull(isInFreezePeriodReference);
         requireNonNull(latestImmutableStateProviderReference);
         requireNonNull(initialPcesFiles);
+        requireNonNull(consensusEventStreamName);
         requireNonNull(issScratchpad);
         requireNonNull(notificationEngine);
         requireNonNull(statusActionSubmitterReference);
@@ -143,15 +148,5 @@ public record PlatformBuildingBlocks(
         requireNonNull(getLatestCompleteStateReference);
         requireNonNull(loadReconnectStateReference);
         requireNonNull(clearAllPipelinesForReconnectReference);
-    }
-
-    /**
-     * Get the address book from the initial state.
-     *
-     * @return the initial address book
-     */
-    @NonNull
-    public AddressBook initialAddressBook() {
-        return initialState.get().getState().getReadablePlatformState().getAddressBook();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterHistory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterHistory.java
@@ -53,44 +53,6 @@ public class RosterHistory {
     }
 
     /**
-     * Constructs a RosterHistory out of a current and previous Roster objects and their corresponding starting round numbers.
-     * This is a simplified version of the constructor to be used with the legacy, AddressBook/config.txt-driven startup lifecycle
-     * until the new, Roster-only-based lifecycle is fully implemented.
-     * @param currentRoster currentRoster
-     * @param currentRound {@code currentRound >= previousRound}
-     * @param previousRoster previousRoster
-     * @param previousRound {@code previousRound <= currentRound}
-     */
-    public RosterHistory(
-            @NonNull final Roster currentRoster,
-            final long currentRound,
-            @NonNull final Roster previousRoster,
-            final long previousRound) {
-        if (currentRound < previousRound) {
-            throw new IllegalArgumentException(
-                    "Current round must be greater than or equal to the previous round. currentRound: " + currentRound
-                            + ", previousRound: " + previousRound);
-        }
-
-        final Bytes currentHash = RosterUtils.hash(currentRoster).getBytes();
-        final Bytes previousHash = RosterUtils.hash(previousRoster).getBytes();
-
-        this.rosters = Map.of(
-                currentHash, currentRoster,
-                previousHash, previousRoster);
-
-        this.history = List.of(
-                RoundRosterPair.newBuilder()
-                        .activeRosterHash(currentHash)
-                        .roundNumber(currentRound)
-                        .build(),
-                RoundRosterPair.newBuilder()
-                        .activeRosterHash(previousHash)
-                        .roundNumber(previousRound)
-                        .build());
-    }
-
-    /**
      * Returns the current active roster, which is the very first (index == 0) entry in the history list.
      * @return the current active roster
      */

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterRetriever.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterRetriever.java
@@ -30,6 +30,7 @@ import com.swirlds.base.utility.Pair;
 import com.swirlds.common.RosterStateId;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.ReadablePlatformStateStore;
+import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableKVState;
@@ -146,6 +147,55 @@ public final class RosterRetriever {
     }
 
     /**
+     * Builds a RosterEntry out of a given Address.
+     * @param address an Address from AddressBook
+     * @return a RosterEntry
+     */
+    @NonNull
+    public static RosterEntry buildRosterEntry(@NonNull final Address address) {
+        try {
+            return RosterEntry.newBuilder()
+                    .nodeId(address.getNodeId().id())
+                    .weight(address.getWeight())
+                    .gossipCaCertificate(Bytes.wrap(address.getSigCert().getEncoded()))
+                    .gossipEndpoint(List.of(
+                                    Pair.of(address.getHostnameExternal(), address.getPortExternal()),
+                                    Pair.of(address.getHostnameInternal(), address.getPortInternal()))
+                            .stream()
+                            .filter(pair -> pair.left() != null && !pair.left().isBlank() && pair.right() != 0)
+                            .distinct()
+                            .map(pair -> {
+                                final Matcher matcher = IP_ADDRESS_PATTERN.matcher(pair.left());
+
+                                if (!matcher.matches()) {
+                                    return ServiceEndpoint.newBuilder()
+                                            .domainName(pair.left())
+                                            .port(pair.right())
+                                            .build();
+                                }
+
+                                try {
+                                    return ServiceEndpoint.newBuilder()
+                                            .ipAddressV4(Bytes.wrap(new byte[] {
+                                                (byte) Integer.parseInt(matcher.group(1)),
+                                                (byte) Integer.parseInt(matcher.group(2)),
+                                                (byte) Integer.parseInt(matcher.group(3)),
+                                                (byte) Integer.parseInt(matcher.group(4)),
+                                            }))
+                                            .port(pair.right())
+                                            .build();
+                                } catch (NumberFormatException e) {
+                                    throw new InvalidAddressBookException(e);
+                                }
+                            })
+                            .toList())
+                    .build();
+        } catch (CertificateEncodingException e) {
+            throw new InvalidAddressBookException(e);
+        }
+    }
+
+    /**
      * Builds a Roster object out of a given AddressBook object.
      *
      * @param addressBook an AddressBook
@@ -159,55 +209,7 @@ public final class RosterRetriever {
         return Roster.newBuilder()
                 .rosterEntries(addressBook.getNodeIdSet().stream()
                         .map(addressBook::getAddress)
-                        .map(address -> {
-                            try {
-                                return RosterEntry.newBuilder()
-                                        .nodeId(address.getNodeId().id())
-                                        .weight(address.getWeight())
-                                        .gossipCaCertificate(
-                                                Bytes.wrap(address.getSigCert().getEncoded()))
-                                        .gossipEndpoint(List.of(
-                                                        Pair.of(
-                                                                address.getHostnameExternal(),
-                                                                address.getPortExternal()),
-                                                        Pair.of(
-                                                                address.getHostnameInternal(),
-                                                                address.getPortInternal()))
-                                                .stream()
-                                                .filter(pair -> pair.left() != null
-                                                        && !pair.left().isBlank()
-                                                        && pair.right() != 0)
-                                                .distinct()
-                                                .map(pair -> {
-                                                    final Matcher matcher = IP_ADDRESS_PATTERN.matcher(pair.left());
-
-                                                    if (!matcher.matches()) {
-                                                        return ServiceEndpoint.newBuilder()
-                                                                .domainName(pair.left())
-                                                                .port(pair.right())
-                                                                .build();
-                                                    }
-
-                                                    try {
-                                                        return ServiceEndpoint.newBuilder()
-                                                                .ipAddressV4(Bytes.wrap(new byte[] {
-                                                                    (byte) Integer.parseInt(matcher.group(1)),
-                                                                    (byte) Integer.parseInt(matcher.group(2)),
-                                                                    (byte) Integer.parseInt(matcher.group(3)),
-                                                                    (byte) Integer.parseInt(matcher.group(4)),
-                                                                }))
-                                                                .port(pair.right())
-                                                                .build();
-                                                    } catch (NumberFormatException e) {
-                                                        throw new InvalidAddressBookException(e);
-                                                    }
-                                                })
-                                                .toList())
-                                        .build();
-                            } catch (CertificateEncodingException e) {
-                                throw new InvalidAddressBookException(e);
-                            }
-                        })
+                        .map(RosterRetriever::buildRosterEntry)
                         .sorted(Comparator.comparing(RosterEntry::nodeId))
                         .toList())
                 .build();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -25,6 +25,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.formatting.TextTable;
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.address.AddressBookInitializer;
@@ -234,7 +235,17 @@ public class AddressBookUtils {
             }
             final Address address1 = addressBook1.getAddress(nodeId1);
             final Address address2 = addressBook2.getAddress(nodeId2);
-            if (!address1.equals(address2)) {
+
+            // With a switch from AddressBook to Roster, only a subset of fields in Address are truly comparable
+            // because the AddressBook instance that the PlatformBuilder passes to the reconnect classes is built
+            // from a Roster which is missing certain fields (custom names, memos, etc.)
+            // When the AB to Roster refactoring is complete, and specifically when the reconnect code migrates
+            // to using rosters, this method will be replaced with the one comparing the Rosters directly.
+            // For now, we're modifying the implementation here to only compare the fields in Address that are present
+            // in the Roster.
+            final RosterEntry rosterEntry1 = RosterRetriever.buildRosterEntry(address1);
+            final RosterEntry rosterEntry2 = RosterRetriever.buildRosterEntry(address2);
+            if (!rosterEntry1.equals(rosterEntry2)) {
                 throw new IllegalStateException("The address books do not have the same addresses.");
             }
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -364,4 +364,38 @@ public class AddressBookUtils {
         }
         return addressBook;
     }
+
+    /**
+     * Format a "consensusEventStreamName" using the "memo" field from the self-Address.
+     *
+     * !!! IMPORTANT !!!: It's imperative to retain the logic that is based on the current content of the "memo" field,
+     * even if the code is updated to source the content of "memo" from another place. The "consensusEventStreamName" is used
+     * as a directory name to save some files on disk, and the directory name should remain unchanged for now.
+     * <p>
+     * Per @lpetrovic05 : "As far as I know, CES isn't really used for anything.
+     * It is however, uploaded to google storage, so maybe the name change might affect the uploader."
+     * <p>
+     * This logic could and should eventually change to use the nodeId only (see the else{} branch below.)
+     * However, this change needs to be coordinated with DevOps and NodeOps to ensure the data continues to be uploaded.
+     * Replacing the directory and starting with an empty one may or may not affect the DefaultConsensusEventStream
+     * which will need to be tested when this change takes place.
+     *
+     * @param addressBook an AddressBook
+     * @param selfId a NodeId for self
+     * @return consensusEventStreamName
+     */
+    @NonNull
+    public static String formatConsensusEventStreamName(
+            @NonNull final AddressBook addressBook, @NonNull final NodeId selfId) {
+        // !!!!! IMPORTANT !!!!! Read the javadoc above and the comment below before modifying this code.
+        // Required for conformity with legacy behavior. This sort of funky logic is normally something
+        // we'd try to move away from, but since we will be removing the CES entirely, it's simpler
+        // to just wait until the entire component disappears.
+        final Address address = addressBook.getAddress(selfId);
+        if (!address.getMemo().isEmpty()) {
+            return address.getMemo();
+        } else {
+            return String.valueOf(selfId);
+        }
+    }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterHistoryTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterHistoryTest.java
@@ -54,28 +54,26 @@ class RosterHistoryTest {
     private static final long ROUND_2 = 2983745987L;
 
     /**
-     * Build identical RosterHistory objects using different constructors.
+     * Build RosterHistory object(s) for tests.
      * @return stream of arguments
      */
     private static Stream<Arguments> provideArguments() {
         final Bytes hash1 = RosterUtils.hash(ROSTER_1).getBytes();
         final Bytes hash2 = RosterUtils.hash(ROSTER_2).getBytes();
 
-        return Stream.of(
-                Arguments.of(new RosterHistory(
-                        List.of(
-                                RoundRosterPair.newBuilder()
-                                        .roundNumber(ROUND_2)
-                                        .activeRosterHash(hash2)
-                                        .build(),
-                                RoundRosterPair.newBuilder()
-                                        .roundNumber(ROUND_1)
-                                        .activeRosterHash(hash1)
-                                        .build()),
-                        Map.of(
-                                hash1, ROSTER_1,
-                                hash2, ROSTER_2))),
-                Arguments.of(new RosterHistory(ROSTER_2, ROUND_2, ROSTER_1, ROUND_1)));
+        return Stream.of(Arguments.of(new RosterHistory(
+                List.of(
+                        RoundRosterPair.newBuilder()
+                                .roundNumber(ROUND_2)
+                                .activeRosterHash(hash2)
+                                .build(),
+                        RoundRosterPair.newBuilder()
+                                .roundNumber(ROUND_1)
+                                .activeRosterHash(hash1)
+                                .build()),
+                Map.of(
+                        hash1, ROSTER_1,
+                        hash2, ROSTER_2))));
     }
 
     @ParameterizedTest
@@ -120,9 +118,5 @@ class RosterHistoryTest {
                                 .build()),
                         Map.of()));
         assertTrue(iae1.getMessage().startsWith("Roster history refers to roster hashes not found in the roster map"));
-
-        final IllegalArgumentException iae2 = assertThrows(
-                IllegalArgumentException.class, () -> new RosterHistory(ROSTER_2, ROUND_1 - 1, ROSTER_1, ROUND_1));
-        assertTrue(iae2.getMessage().startsWith("Current round must be greater than or equal to the previous round"));
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
@@ -19,7 +19,6 @@ package com.swirlds.platform.turtle.runner;
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getMetricsProvider;
 import static com.swirlds.platform.state.signed.StartupStateUtils.getInitialState;
-import static com.swirlds.platform.system.address.AddressBookUtils.createRoster;
 
 import com.swirlds.base.time.Time;
 import com.swirlds.common.context.PlatformContext;
@@ -36,10 +35,12 @@ import com.swirlds.platform.builder.PlatformBuilder;
 import com.swirlds.platform.builder.PlatformComponentBuilder;
 import com.swirlds.platform.config.BasicConfig_;
 import com.swirlds.platform.crypto.KeysAndCerts;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.address.AddressBook;
+import com.swirlds.platform.system.address.AddressBookUtils;
 import com.swirlds.platform.test.fixtures.turtle.gossip.SimulatedGossip;
 import com.swirlds.platform.test.fixtures.turtle.gossip.SimulatedNetwork;
 import com.swirlds.platform.util.RandomBuilder;
@@ -111,11 +112,16 @@ public class TurtleNode {
                 configuration, recycleBin, version, genesisStateSupplier, "foo", "bar", nodeId, addressBook);
         final var initialState = reservedState.state();
         final PlatformBuilder platformBuilder = PlatformBuilder.create(
-                        "foo", "bar", new BasicSoftwareVersion(1), initialState, nodeId)
+                        "foo",
+                        "bar",
+                        new BasicSoftwareVersion(1),
+                        initialState,
+                        nodeId,
+                        AddressBookUtils.formatConsensusEventStreamName(addressBook, nodeId),
+                        RosterUtils.buildRosterHistory(
+                                initialState.get().getState().getReadablePlatformState()))
                 .withModel(model)
                 .withRandomBuilder(new RandomBuilder(randotron.nextLong()))
-                .withAddressBook(addressBook)
-                .withRoster(createRoster(addressBook))
                 .withKeysAndCerts(privateKeys)
                 .withPlatformContext(platformContext)
                 .withConfiguration(configuration);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/AddressBookNetworkUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/AddressBookNetworkUtilsTests.java
@@ -29,11 +29,8 @@ import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.Randotron;
-import com.swirlds.platform.builder.PlatformBuilder;
 import com.swirlds.platform.network.Network;
 import com.swirlds.platform.state.address.AddressBookNetworkUtils;
-import com.swirlds.platform.state.signed.ReservedSignedState;
-import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.address.AddressBookUtils;
@@ -94,19 +91,11 @@ class AddressBookNetworkUtilsTests {
 
     @Test
     void testCreateRosterFromNonEmptyAddressBook() {
-        final PlatformBuilder platformBuilder = PlatformBuilder.create(
-                "name",
-                "swirldName",
-                new BasicSoftwareVersion(1),
-                ReservedSignedState.createNullReservation(),
-                NodeId.of(0));
-
         final Address address1 = new Address(NodeId.of(1), "", "", 10, null, 77, null, 88, null, null, "");
         final Address address2 = new Address(NodeId.of(2), "", "", 10, null, 77, null, 88, null, null, "");
         final AddressBook addressBook = new AddressBook();
         addressBook.add(address1);
         addressBook.add(address2);
-        platformBuilder.withAddressBook(addressBook);
         final Roster roster = AddressBookUtils.createRoster(addressBook);
 
         assertNotNull(roster);
@@ -125,14 +114,7 @@ class AddressBookNetworkUtilsTests {
 
     @Test
     void testCreateRosterFromEmptyAddressBook() {
-        final PlatformBuilder platformBuilder = PlatformBuilder.create(
-                "name",
-                "swirldName",
-                new BasicSoftwareVersion(1),
-                ReservedSignedState.createNullReservation(),
-                NodeId.of(0));
         final AddressBook addressBook = new AddressBook();
-        platformBuilder.withAddressBook(addressBook);
         final Roster roster = AddressBookUtils.createRoster(addressBook);
 
         assertNotNull(roster);


### PR DESCRIPTION
**Description**:
Refactor `PlatformBuilder` to accept a RosterHistory object as the medium of receiving rosters.

With this change, the PlatformBuilder `.withAddressBook()` and `.withRoster()` are gone and replaced with a `RosterHistory` argument to the PlatformBuilder constructor. Further, the RosterHistory is propagated to the `PlatformBuildingBlocks` and then used in the `PlatformComponentBuilder` to access the current and "previous" rosters.

This is a step towards removing the AddressBook object from the PlatformState.

Please note that the `SignedState.getAddressBook()` still exists and is used in a few places, notably in reconnect and recovery-related code, as well as some state-signing-related code. We'll be looking into these other usages separately in the future.

**One extra modification of note:** the `AddressBookUtils.formatConsensusEventStreamName()` is introduced to produce a string that is based on the `memo` field in the AddressBook. Apparently the platform code needs to store some files in a directory which name includes the `memo`. From the platform perspective, it's currently unclear how this logic will evolve in the future. For now, I've introduced this new method to unblock the current work. Please see the javadoc and comments in that method for further context.

**Related issue(s)**:

Fixes #16354

**Notes for reviewer**:
Unit tests pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
