### PR TITLE
fix: Use disk address book to construct network Info

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -955,7 +955,8 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
                 .consensusSnapshotOrThrow()
                 .round();
         final var initialStateHash = new InitialStateHash(initialStateHashFuture, roundNum);
-        final var networkInfo = new StateNetworkInfo(state, platform.getSelfId().id(), configProvider);
+        final var activeRoster = createRoster(platform.getAddressBook());
+        final var networkInfo = new StateNetworkInfo(state, platform.getSelfId().id(), configProvider, activeRoster);
         // Fully qualified so as to not confuse javadoc
         daggerApp = com.hedera.node.app.DaggerHederaInjectionComponent.builder()
                 .configProviderImpl(configProvider)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/NodeInfoImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/NodeInfoImpl.java
@@ -42,4 +42,15 @@ public record NodeInfoImpl(
                 rosterEntry.gossipEndpoint(),
                 rosterEntry.gossipCaCertificate());
     }
+
+    @NonNull
+    public static NodeInfo fromRosterEntry(
+            @NonNull final RosterEntry rosterEntry, @NonNull final AccountID nodeAccountID) {
+        return new NodeInfoImpl(
+                rosterEntry.nodeId(),
+                nodeAccountID,
+                rosterEntry.weight(),
+                rosterEntry.gossipEndpoint(),
+                rosterEntry.gossipCaCertificate());
+    }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/StateNetworkInfo.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/StateNetworkInfo.java
@@ -60,12 +60,12 @@ public class StateNetworkInfo implements NetworkInfo {
             @NonNull final ConfigProvider configProvider,
             @NonNull final Roster activeRoster) {
         this.selfId = selfId;
+        this.activeRoster = requireNonNull(activeRoster);
         this.nodeInfos = buildNodeInfoMap(state);
         // Load the ledger ID from configuration
         final var config = requireNonNull(configProvider.getConfiguration());
         final var ledgerConfig = config.getConfigData(LedgerConfig.class);
         ledgerId = ledgerConfig.id();
-        this.activeRoster = requireNonNull(activeRoster);
     }
 
     @NonNull

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/StateNetworkInfoTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/StateNetworkInfoTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.info;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.hedera.hapi.node.state.addressbook.Node;
+import com.hedera.hapi.node.state.common.EntityNumber;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import com.hedera.node.app.service.addressbook.AddressBookService;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.VersionedConfigImpl;
+import com.hedera.node.config.data.LedgerConfig;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.swirlds.state.State;
+import com.swirlds.state.spi.ReadableKVState;
+import com.swirlds.state.spi.ReadableStates;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class StateNetworkInfoTest {
+    @Mock
+    private State state;
+
+    @Mock
+    private ConfigProvider configProvider;
+
+    @Mock
+    private LedgerConfig ledgerConfig;
+
+    @Mock
+    private ReadableKVState<EntityNumber, Node> nodeState;
+
+    @Mock
+    private ReadableStates readableStates;
+
+    private static final long SELF_ID = 1L;
+    private final Roster activeRoster = new Roster(List.of(
+            RosterEntry.newBuilder().nodeId(SELF_ID).weight(10).build(),
+            RosterEntry.newBuilder().nodeId(3L).weight(20).build()));
+    private StateNetworkInfo networkInfo;
+
+    @BeforeEach
+    public void setUp() {
+        when(configProvider.getConfiguration())
+                .thenReturn(new VersionedConfigImpl(HederaTestConfigBuilder.createConfig(), 1));
+        when(state.getReadableStates(AddressBookService.NAME)).thenReturn(readableStates);
+        when(readableStates.<EntityNumber, Node>get("NODES")).thenReturn(nodeState);
+        networkInfo = new StateNetworkInfo(state, SELF_ID, configProvider, activeRoster);
+    }
+
+    @Test
+    public void testLedgerId() {
+        assertEquals("00", networkInfo.ledgerId().toHex());
+    }
+
+    @Test
+    public void testSelfNodeInfo() {
+        final var selfNode = networkInfo.selfNodeInfo();
+        assertNotNull(selfNode);
+        assertEquals(SELF_ID, selfNode.nodeId());
+    }
+
+    @Test
+    public void testAddressBook() {
+        final var addressBook = networkInfo.addressBook();
+        assertNotNull(addressBook);
+        assertEquals(2, addressBook.size());
+    }
+
+    @Test
+    public void testNodeInfo() {
+        final var nodeInfo = networkInfo.nodeInfo(SELF_ID);
+        assertNotNull(nodeInfo);
+        assertEquals(SELF_ID, nodeInfo.nodeId());
+        assertNull(networkInfo.nodeInfo(999L));
+    }
+
+    @Test
+    public void testContainsNode() {
+        assertTrue(networkInfo.containsNode(SELF_ID));
+        assertFalse(networkInfo.containsNode(999L));
+    }
+
+    @Test
+    public void testUpdateFrom() {
+        when(nodeState.get(any(EntityNumber.class))).thenReturn(mock(Node.class));
+
+        networkInfo.updateFrom(state);
+        assertEquals(2, networkInfo.addressBook().size());
+    }
+
+    @Test
+    public void testBuildNodeInfoMapNodeNotFound() {
+        when(nodeState.get(any(EntityNumber.class))).thenReturn(null);
+
+        StateNetworkInfo networkInfo = new StateNetworkInfo(state, SELF_ID, configProvider, activeRoster);
+        final var nodeInfo = networkInfo.nodeInfo(SELF_ID);
+
+        assertNotNull(nodeInfo);
+        assertEquals(SELF_ID + 3, nodeInfo.accountId().accountNum());
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/StateNetworkInfoTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/StateNetworkInfoTest.java
@@ -36,9 +36,7 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableKVState;
 import com.swirlds.state.spi.ReadableStates;
-
 import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/StateNetworkInfoTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/StateNetworkInfoTest.java
@@ -32,7 +32,6 @@ import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.node.app.service.addressbook.AddressBookService;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
-import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableKVState;
@@ -51,9 +50,6 @@ public class StateNetworkInfoTest {
 
     @Mock
     private ConfigProvider configProvider;
-
-    @Mock
-    private LedgerConfig ledgerConfig;
 
     @Mock
     private ReadableKVState<EntityNumber, Node> nodeState;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/StateNetworkInfoTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/StateNetworkInfoTest.java
@@ -36,7 +36,9 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableKVState;
 import com.swirlds.state.spi.ReadableStates;
+
 import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/16499

Use disk address book to construct StateNetworkInfo instead of using roster entries until Roster proposal and DAB are enabled