### PR TITLE
fix: set admin key to self managed key for EthereumTransaction contract deployments

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -33,6 +33,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.Duration;
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.hapi.node.token.CryptoCreateTransactionBody;
@@ -457,9 +458,17 @@ public class HandleHederaOperations implements HederaOperations {
     private ContractCreateTransactionBody standardized(
             final long createdNumber, @NonNull final ContractCreateTransactionBody op) {
         if (needsStandardization(op)) {
+            Key newAdminKey = null;
+            if (!op.hasAdminKey()) {
+                newAdminKey = Key.newBuilder()
+                        .contractID(ContractID.newBuilder()
+                                .contractNum(createdNumber)
+                                .build())
+                        .build();
+            }
             return new ContractCreateTransactionBody(
                     com.hedera.hapi.node.contract.codec.ContractCreateTransactionBodyProtoCodec.INITCODE_SOURCE_UNSET,
-                    op.adminKey(),
+                    newAdminKey,
                     0L,
                     0L,
                     op.proxyAccountID(),

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -458,7 +458,9 @@ public class HandleHederaOperations implements HederaOperations {
     private ContractCreateTransactionBody standardized(
             final long createdNumber, @NonNull final ContractCreateTransactionBody op) {
         if (needsStandardization(op)) {
-            Key newAdminKey = null;
+            Key newAdminKey = op.adminKey();
+            // If the admin key is not set, we set it to the contract itself for externalization
+            // Typically, the op will not have an adminkey if the transaction's HederaFunctionality is ETHEREUM_TRANSACTION
             if (!op.hasAdminKey()) {
                 newAdminKey = Key.newBuilder()
                         .contractID(ContractID.newBuilder()

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -460,7 +460,8 @@ public class HandleHederaOperations implements HederaOperations {
         if (needsStandardization(op)) {
             Key newAdminKey = op.adminKey();
             // If the admin key is not set, we set it to the contract itself for externalization
-            // Typically, the op will not have an adminkey if the transaction's HederaFunctionality is ETHEREUM_TRANSACTION
+            // Typically, the op will not have an adminkey if the transaction's HederaFunctionality is
+            // ETHEREUM_TRANSACTION
             if (!op.hasAdminKey()) {
                 newAdminKey = Key.newBuilder()
                         .contractID(ContractID.newBuilder()


### PR DESCRIPTION

**Description**:
Contracts deployed via `EthereumTransaction` are setting the externalized record to the mirror node as null.  Update to externalize a self managing contract key

**Related issue(s)**:

Fixes #16508 

