### PR TITLE
fix: Remove tss encryption key from node-related protos

### DIFF
--- a/hapi/hedera-protobufs/services/node_create.proto
+++ b/hapi/hedera-protobufs/services/node_create.proto
@@ -137,27 +137,4 @@ message NodeCreateTransactionBody {
      * This field is REQUIRED and MUST NOT be set to an empty `KeyList`.
      */
     proto.Key admin_key = 7;
-
-    /**
-     * An ALT_BN128 elliptic curve public encryption key.<br/>
-     * This is controlled by the node operator and specific to this
-     * node's TSS operations.
-     * <p>
-     * The elliptic curve type MAY change in the future. For example,
-     * if the Ethereum ecosystem creates precompiles for BLS12_381,
-     * we may switch to that curve.<br/>
-     * This value SHALL be specified according to EIP-196 and EIP-197 standards.
-     * See [EIP-196](https://eips.ethereum.org/EIPS/eip-196#encoding) and
-     * (EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding)<br/>
-     * This field is OPTIONAL (that is, it can initially be null),
-     * but once set, it MUST NOT be null.<br/>
-     * If this field is set:
-     * <ul>
-     *   <li>This field MUST contain the bytes of a standard ALT_BN128 key value.</li>
-     *   <li>This key MUST only be used for node TSS operations.</li>
-     *   <li>This key MUST be unique in all future rosters.</li>
-     *   <li>This key MUST be used to encrypt all of this node's future TSS messages.</li>
-     * </ul>
-     */
-    bytes tss_encryption_key = 8;
 }

--- a/hapi/hedera-protobufs/services/node_update.proto
+++ b/hapi/hedera-protobufs/services/node_update.proto
@@ -161,27 +161,4 @@ message NodeUpdateTransactionBody {
      * If set, this field MUST NOT be set to an empty `KeyList`.
      */
     proto.Key admin_key = 8;
-
-    /**
-     * An ALT_BN128 elliptic curve public encryption key.<br/>
-     * This is controlled by the node operator and specific to this
-     * node's TSS operations.
-     * <p>
-     * The elliptic curve type MAY change in the future. For example,
-     * if the Ethereum ecosystem creates precompiles for BLS12_381,
-     * we may switch to that curve.<br/>
-     * This value SHALL be specified according to EIP-196 and EIP-197 standards.
-     * See [EIP-196](https://eips.ethereum.org/EIPS/eip-196#encoding) and
-     * (EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding)<br/>
-     * This field is OPTIONAL (that is, it can initially be null),
-     * but once set, it MUST NOT be null.<br/>
-     * If this field is set:
-     * <ul>
-     *   <li>This field MUST contain the bytes of a standard ALT_BN128 key value.</li>
-     *   <li>This key MUST only be used for node TSS operations.</li>
-     *   <li>This key MUST be unique in all future rosters.</li>
-     *   <li>This key MUST be used to encrypt all of this node's future TSS messages.</li>
-     * </ul>
-     */
-    bytes tss_encryption_key = 9;
 }

--- a/hapi/hedera-protobufs/services/state/addressbook/node.proto
+++ b/hapi/hedera-protobufs/services/state/addressbook/node.proto
@@ -146,27 +146,4 @@ message Node {
      * This field is REQUIRED and MUST NOT be set to an empty `KeyList`.
      */
     proto.Key admin_key = 10;
-
-    /**
-     * An ALT_BN128 elliptic curve public encryption key.<br/>
-     * This is controlled by the node operator and specific to this
-     * node's TSS operations.
-     * <p>
-     * The elliptic curve type MAY change in the future. For example,
-     * if the Ethereum ecosystem creates precompiles for BLS12_381,
-     * we may switch to that curve.<br/>
-     * This value SHALL be specified according to EIP-196 and EIP-197 standards.
-     * See [EIP-196](https://eips.ethereum.org/EIPS/eip-196#encoding) and
-     * (EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding)<br/>
-     * This field is OPTIONAL (that is, it can initially be null),
-     * but once set, it MUST NOT be null.<br/>
-     * If this field is set:
-     * <ul>
-     *   <li>This field MUST contain the bytes of a standard ALT_BN128 key value.</li>
-     *   <li>This key MUST only be used for node TSS operations.</li>
-     *   <li>This key MUST be unique in all future rosters.</li>
-     *   <li>This key MUST be used to encrypt all of this node's future TSS messages.</li>
-     * </ul>
-     */
-    bytes tss_encryption_key = 11;
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/ReadableNodeStoreImpl.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/ReadableNodeStoreImpl.java
@@ -98,7 +98,8 @@ public class ReadableNodeStoreImpl implements ReadableNodeStore {
                         .weight(node.weight())
                         .gossipCaCertificate(node.gossipCaCertificate())
                         .gossipEndpoint(node.gossipEndpoint())
-                        .tssEncryptionKey(node.tssEncryptionKey())
+                        // (TSS-FUTURE) Enable node's TSS encryption key
+                        // .tssEncryptionKey(node.tssEncryptionKey())
                         .build();
                 rosterEntries.add(entry);
             }

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/AddressBookTestBase.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/AddressBookTestBase.java
@@ -144,8 +144,6 @@ public class AddressBookTestBase {
     private final byte[] invalidIPBytes = {49, 46, 48, 46, 48, 46, 48};
     protected final ServiceEndpoint endpoint10 = new ServiceEndpoint(Bytes.wrap(invalidIPBytes), 1234, null);
 
-    private static final Bytes TSS_KEY = Bytes.wrap(new byte[] {1, 2, 3});
-
     protected Node node;
 
     @Mock
@@ -249,8 +247,7 @@ public class AddressBookTestBase {
                 Bytes.wrap(grpcCertificateHash),
                 0,
                 deleted,
-                key,
-                TSS_KEY);
+                key);
     }
 
     protected void givenValidNodeWithAdminKey(Key adminKey) {
@@ -264,8 +261,7 @@ public class AddressBookTestBase {
                 Bytes.wrap(grpcCertificateHash),
                 0,
                 false,
-                adminKey,
-                TSS_KEY);
+                adminKey);
     }
 
     protected Node createNode() {
@@ -279,7 +275,6 @@ public class AddressBookTestBase {
                 .grpcCertificateHash(Bytes.wrap(grpcCertificateHash))
                 .weight(0)
                 .adminKey(key)
-                .tssEncryptionKey(TSS_KEY)
                 .build();
     }
 

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/ReadableFreezeUpgradeActionsTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/ReadableFreezeUpgradeActionsTest.java
@@ -116,7 +116,6 @@ class ReadableFreezeUpgradeActionsTest {
                                     KEY_BUILDER.apply(B_NAME).build(),
                                     A_THRESHOLD_KEY)))
             .build();
-    private static final Bytes TSS_KEY = Bytes.wrap(new byte[] {1, 2, 3});
 
     private Path noiseFileLoc;
     private Path noiseSubFileLoc;
@@ -429,8 +428,7 @@ class ReadableFreezeUpgradeActionsTest {
                 Bytes.wrap("grpc1CertificateHash"),
                 2,
                 false,
-                A_COMPLEX_KEY,
-                TSS_KEY);
+                A_COMPLEX_KEY);
         final var node2 = new Node(
                 2,
                 asAccount(4),
@@ -443,8 +441,7 @@ class ReadableFreezeUpgradeActionsTest {
                 Bytes.wrap("grpc2CertificateHash"),
                 4,
                 false,
-                A_COMPLEX_KEY,
-                TSS_KEY);
+                A_COMPLEX_KEY);
         final var node3 = new Node(
                 3,
                 asAccount(6),
@@ -457,8 +454,7 @@ class ReadableFreezeUpgradeActionsTest {
                 Bytes.wrap("grpc3CertificateHash"),
                 1,
                 true,
-                A_COMPLEX_KEY,
-                TSS_KEY);
+                A_COMPLEX_KEY);
         final var node4 = new Node(
                 4,
                 asAccount(8),
@@ -472,8 +468,7 @@ class ReadableFreezeUpgradeActionsTest {
                 Bytes.wrap("grpc5CertificateHash"),
                 8,
                 false,
-                A_COMPLEX_KEY,
-                TSS_KEY);
+                A_COMPLEX_KEY);
         final var readableNodeState = MapReadableKVState.<EntityNumber, Node>builder(NODES_KEY)
                 .value(new EntityNumber(4), node4)
                 .value(new EntityNumber(2), node2)
@@ -557,8 +552,7 @@ class ReadableFreezeUpgradeActionsTest {
                 Bytes.wrap("grpc1CertificateHash"),
                 2,
                 false,
-                A_COMPLEX_KEY,
-                TSS_KEY);
+                A_COMPLEX_KEY);
         final var node2 = new Node(
                 1,
                 asAccount(4),
@@ -571,8 +565,7 @@ class ReadableFreezeUpgradeActionsTest {
                 Bytes.wrap("grpc2CertificateHash"),
                 4,
                 false,
-                A_COMPLEX_KEY,
-                TSS_KEY);
+                A_COMPLEX_KEY);
         final var node3 = new Node(
                 2,
                 asAccount(6),
@@ -585,8 +578,7 @@ class ReadableFreezeUpgradeActionsTest {
                 Bytes.wrap("grpc3CertificateHash"),
                 1,
                 false,
-                A_COMPLEX_KEY,
-                TSS_KEY);
+                A_COMPLEX_KEY);
         final var node4 = new Node(
                 3,
                 asAccount(8),
@@ -600,8 +592,7 @@ class ReadableFreezeUpgradeActionsTest {
                 Bytes.wrap("grpc5CertificateHash"),
                 8,
                 true,
-                A_COMPLEX_KEY,
-                TSS_KEY);
+                A_COMPLEX_KEY);
         final var readableNodeState = MapReadableKVState.<EntityNumber, Node>builder(NODES_KEY)
                 .value(new EntityNumber(3), node4)
                 .value(new EntityNumber(1), node2)


### PR DESCRIPTION
We're not ready to specify requirements for a node's TSS key yet. We'll remove it for now to make syncing with the protobufs repo easier, and re-enable when we actually need it.