### PR TITLE
feat: increase maximums to 100M each by default

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
@@ -40,7 +40,7 @@ public record AccountsConfig(
         @ConfigProperty(defaultValue = "2") @NetworkProperty long treasury,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean storeOnDisk,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean releaseAliasAfterDeletion,
-        @ConfigProperty(defaultValue = "20000000") @NetworkProperty long maxNumber,
+        @ConfigProperty(defaultValue = "100000000") @NetworkProperty long maxNumber,
         @ConfigProperty(value = "blocklist.enabled", defaultValue = "false") @NetworkProperty boolean blocklistEnabled,
         @ConfigProperty(value = "blocklist.path", defaultValue = "") @NetworkProperty String blocklistResource) {
 

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TokensConfig.java
@@ -39,7 +39,7 @@ public record TokensConfig(
         @ConfigProperty(value = "nfts.maxBatchSizeBurn", defaultValue = "10") @NetworkProperty int nftsMaxBatchSizeBurn,
         @ConfigProperty(value = "nfts.maxBatchSizeWipe", defaultValue = "10") @NetworkProperty int nftsMaxBatchSizeWipe,
         @ConfigProperty(value = "nfts.maxBatchSizeMint", defaultValue = "10") @NetworkProperty int nftsMaxBatchSizeMint,
-        @ConfigProperty(value = "nfts.maxAllowedMints", defaultValue = "20000000") @NetworkProperty
+        @ConfigProperty(value = "nfts.maxAllowedMints", defaultValue = "100000000") @NetworkProperty
                 long nftsMaxAllowedMints,
         @ConfigProperty(value = "nfts.maxQueryRange", defaultValue = "100") @NetworkProperty long nftsMaxQueryRange,
         @ConfigProperty(value = "nfts.useTreasuryWildcards", defaultValue = "true") @NetworkProperty


### PR DESCRIPTION
**Description**:
Increases the account and NFT maximums to 100M each.

**Related issue(s)**:

Addresses #16516 in release 57


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
