### PR TITLE
Test externalized contract admin key

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.contract.impl.exec.scope;
 import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CREATE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.FEE_SCHEDULE_UNITS_PER_TINYCENT;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.selfManagedCustomizedCreation;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.tuweniToPbjBytes;
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.THREE_MONTHS_IN_SECONDS;
 import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.synthAccountCreationFromHapi;
@@ -299,7 +300,9 @@ public class HandleHederaOperations implements HederaOperations {
                 number,
                 synthAccountCreationFromHapi(
                         ContractID.newBuilder().contractNum(number).build(), evmAddress, body),
-                functionality == HederaFunctionality.ETHEREUM_TRANSACTION ? body : null,
+                functionality == HederaFunctionality.ETHEREUM_TRANSACTION
+                        ? selfManagedCustomizedCreation(body, number)
+                        : null,
                 body.autoRenewAccountId(),
                 evmAddress,
                 body.hasInitcode() ? ExternalizeInitcodeOnSuccess.NO : ExternalizeInitcodeOnSuccess.YES);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -812,6 +812,25 @@ public class ConversionUtils {
     }
 
     /**
+     * Given a {@link ContractCreateTransactionBody} and a new account number, returns a creation body
+     * that contains a self-managed admin key (contract key with the new account number).
+     *
+     * @param op the creation body
+     * @param accountNum the new account number for the about to be newly created contract
+     * @return the fully customized creation body
+     */
+    public static @NonNull ContractCreateTransactionBody selfManagedCustomizedCreation(
+            @NonNull final ContractCreateTransactionBody op, final long accountNum) {
+        requireNonNull(op);
+        final var builder = op.copyBuilder();
+        return builder.adminKey(Key.newBuilder()
+                        .contractID(
+                                ContractID.newBuilder().contractNum(accountNum).build())
+                        .build())
+                .build();
+    }
+
+    /**
      * Returns a tuple of the {@code KeyValue} struct
      * <br><a href="https://github.com/hashgraph/hedera-smart-contracts/blob/main/contracts/hts-precompile/IHederaTokenService.sol#L92">Link</a>
      * @param key the key to get the tuple for

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
@@ -45,10 +45,12 @@ import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.pb
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.tuweniToPbjBytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.hapi.node.contract.ContractCreateTransactionBody;
 import com.hedera.hapi.node.contract.ContractLoginfo;
 import com.hedera.hapi.streams.ContractStateChange;
 import com.hedera.hapi.streams.ContractStateChanges;
@@ -242,6 +244,17 @@ class ConversionUtilsTest {
 
         final var actual2 = ConversionUtils.contractIDToBesuAddress(VALID_CONTRACT_ADDRESS);
         assertEquals(actual2, pbjToBesuAddress(VALID_CONTRACT_ADDRESS.evmAddress()));
+    }
+
+    @Test
+    void selfManagedCustomizedCreationTest() {
+        final var op = ContractCreateTransactionBody.DEFAULT;
+        final long newContractNum = 1005L;
+        final var actual = ConversionUtils.selfManagedCustomizedCreation(op, newContractNum);
+        assertTrue(actual.adminKey().hasContractID());
+        assertEquals(
+                newContractNum,
+                actual.adminKey().contractIDOrElse(ContractID.DEFAULT).contractNum());
     }
 
     private byte[] bloomFor(@NonNull final Log log) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/ContractSelfAdminKeyValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/ContractSelfAdminKeyValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.junit.support.validators;
+
+import static com.hedera.node.app.hapi.utils.CommonUtils.extractTransactionBody;
+import static java.util.Objects.requireNonNull;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.services.bdd.junit.support.RecordStreamValidator;
+import com.hedera.services.bdd.junit.support.RecordWithSidecars;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * This validator checks that transactions that contain ContractCreateTransactionBody
+ * have an admin key set to self manage the contract.
+ */
+public class ContractSelfAdminKeyValidator implements RecordStreamValidator {
+    private static final Logger log = LogManager.getLogger(ContractSelfAdminKeyValidator.class);
+    private final long newContractNum;
+
+    public ContractSelfAdminKeyValidator(final long newContractNum) {
+        this.newContractNum = newContractNum;
+    }
+
+    @Override
+    public void validateRecordsAndSidecars(@NonNull final List<RecordWithSidecars> recordsWithSidecars) {
+        requireNonNull(recordsWithSidecars);
+        for (final var recordWithSidecars : recordsWithSidecars) {
+            final var items = recordWithSidecars.recordFile().getRecordStreamItemsList();
+            for (final var item : items) {
+                try {
+                    final var txnBody = extractTransactionBody(item.getTransaction());
+                    if (txnBody.hasContractCreateInstance()) {
+                        final var adminKey = txnBody.getContractCreateInstance().getAdminKey();
+                        if (adminKey.hasContractID() && adminKey.getContractID().getContractNum() != newContractNum) {
+                            Assertions.fail("Contract create transaction does not have admin key set to self manage");
+                        }
+                    }
+                } catch (InvalidProtocolBufferException e) {
+                    log.error("Unable to parse and classify item {}", item, e);
+                    throw new IllegalStateException(e);
+                }
+            }
+        }
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -154,6 +154,7 @@ import com.hedera.services.bdd.spec.utilops.mod.SubmitModificationsOp;
 import com.hedera.services.bdd.spec.utilops.mod.TxnModification;
 import com.hedera.services.bdd.spec.utilops.pauses.HapiSpecSleep;
 import com.hedera.services.bdd.spec.utilops.pauses.HapiSpecWaitUntil;
+import com.hedera.services.bdd.spec.utilops.streams.ContractSelfAdminKeyValidationOp;
 import com.hedera.services.bdd.spec.utilops.streams.LogContainmentOp;
 import com.hedera.services.bdd.spec.utilops.streams.LogValidationOp;
 import com.hedera.services.bdd.spec.utilops.streams.StreamValidationOp;
@@ -2349,5 +2350,13 @@ public class UtilVerbs {
                 / rcd.getReceipt().getExchangeRate().getCurrentRate().getHbarEquiv()
                 * rcd.getReceipt().getExchangeRate().getCurrentRate().getCentEquiv()
                 / 100;
+    }
+
+    /**
+     * Validates that the contract created have admin key set to self-manage.
+     */
+    public static void validateSelfAdminContractKey(@NonNull final HapiSpec spec, final long newContractNum) {
+        final var op = new ContractSelfAdminKeyValidationOp(newContractNum);
+        allRunFor(spec, op);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/ContractSelfAdminKeyValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/ContractSelfAdminKeyValidationOp.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.spec.utilops.streams;
+
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeOnly;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hedera.services.bdd.spec.utilops.streams.StreamValidationOp.readMaybeRecordStreamDataFor;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+
+import com.hedera.services.bdd.junit.support.validators.ContractSelfAdminKeyValidator;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.utilops.UtilOp;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * A {@link UtilOp} that validates that the selected nodes' application or platform log contains or
+ * does not contain a given pattern.
+ */
+public class ContractSelfAdminKeyValidationOp extends UtilOp {
+    private static final long BUFFER_MS = 500L;
+    private final long newContractNum;
+
+    public ContractSelfAdminKeyValidationOp(final long newContractNum) {
+        this.newContractNum = newContractNum;
+    }
+
+    @Override
+    protected boolean submitOp(@NonNull final HapiSpec spec) throws Throwable {
+        // Freeze the network
+        allRunFor(
+                spec,
+                freezeOnly().payingWith(GENESIS).startingIn(2).seconds(),
+                // Wait for the final stream files to be created
+                sleepFor(10 * BUFFER_MS));
+        readMaybeRecordStreamDataFor(spec)
+                .ifPresentOrElse(
+                        data -> new ContractSelfAdminKeyValidator(newContractNum)
+                                .validationErrorsIn(data)
+                                .map(Throwable::getMessage)
+                                .forEach(Assertions::fail),
+                        () -> Assertions.fail("No record stream data found"));
+        return false;
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
@@ -160,8 +160,7 @@ public class StreamValidationOp extends UtilOp {
         return Optional.ofNullable(blocks);
     }
 
-    private static Optional<StreamFileAccess.RecordStreamData> readMaybeRecordStreamDataFor(
-            @NonNull final HapiSpec spec) {
+    static Optional<StreamFileAccess.RecordStreamData> readMaybeRecordStreamDataFor(@NonNull final HapiSpec spec) {
         StreamFileAccess.RecordStreamData data = null;
         final var streamLocs = spec.getNetworkNodes().stream()
                 .map(node -> node.getExternalPath(RECORD_STREAMS_DIR))


### PR DESCRIPTION
**Description**:
- make the admin key for contracts created via `EthereumTransaction` to be self managed.
- write validator class that implements `RecordStreamValidator` and use in new `ContractSelfAdminKeyValidationOp` to be called from BDD test.
 
**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
