### PR TITLE
fix: name field missing in generated pom file

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.maven-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.maven-publish.gradle.kts
@@ -69,6 +69,7 @@ val maven =
                     .reader()
             )
 
+            name.set(project.name)
             url = "https://www.hashgraph.com/"
             inceptionYear = "2016"
 


### PR DESCRIPTION
**Description**:

The name field was removed from the pom generation scheme. Added the field back in.

**Related Issue(s)**:
Fixes #16582

**Checklist**

- [x] Tested (unit, integration, etc.)
