### PR TITLE
chore: remove `AddressBookUtils.createRoster()`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -38,12 +38,12 @@ import static com.hedera.node.app.util.HederaAsciiArt.HEDERA;
 import static com.hedera.node.app.workflows.handle.metric.UnavailableMetrics.UNAVAILABLE_METRICS;
 import static com.hedera.node.config.types.StreamMode.BLOCKS;
 import static com.hedera.node.config.types.StreamMode.RECORDS;
+import static com.swirlds.platform.roster.RosterRetriever.buildRoster;
 import static com.swirlds.platform.state.service.PlatformStateService.PLATFORM_STATE_SERVICE;
 import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
 import static com.swirlds.platform.system.InitTrigger.EVENT_STREAM_RECOVERY;
 import static com.swirlds.platform.system.InitTrigger.GENESIS;
 import static com.swirlds.platform.system.InitTrigger.RECONNECT;
-import static com.swirlds.platform.system.address.AddressBookUtils.createRoster;
 import static com.swirlds.platform.system.status.PlatformStatus.ACTIVE;
 import static com.swirlds.platform.system.status.PlatformStatus.STARTING_UP;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -607,7 +607,7 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
         if (trigger == GENESIS) {
             final var config = configProvider.getConfiguration();
             final var ledgerConfig = config.getConfigData(LedgerConfig.class);
-            final var genesisRoster = createRoster(requireNonNull(genesisAddressBook));
+            final var genesisRoster = buildRoster(requireNonNull(genesisAddressBook));
 
             genesisNetworkInfo = new GenesisNetworkInfo(genesisRoster, ledgerConfig.id());
         }
@@ -968,7 +968,7 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
                 serviceMigrator,
                 version,
                 configProvider.getConfiguration(),
-                createRoster(platform.getAddressBook()));
+                buildRoster(platform.getAddressBook()));
         final var networkInfo =
                 new StateNetworkInfo(state, activeRoster, platform.getSelfId().id(), configProvider);
         // Fully qualified so as to not confuse javadoc

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -26,11 +26,11 @@ import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getMet
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.setupGlobalMetrics;
 import static com.swirlds.platform.config.internal.PlatformConfigUtils.checkConfiguration;
 import static com.swirlds.platform.crypto.CryptoStatic.initNodeSecurity;
+import static com.swirlds.platform.roster.RosterRetriever.buildRoster;
 import static com.swirlds.platform.state.signed.StartupStateUtils.getInitialState;
 import static com.swirlds.platform.system.SystemExitCode.CONFIGURATION_ERROR;
 import static com.swirlds.platform.system.SystemExitCode.NODE_ADDRESS_MISMATCH;
 import static com.swirlds.platform.system.SystemExitUtils.exitSystem;
-import static com.swirlds.platform.system.address.AddressBookUtils.createRoster;
 import static com.swirlds.platform.system.address.AddressBookUtils.initializeAddressBook;
 import static com.swirlds.platform.util.BootstrapUtils.checkNodesToRun;
 import static com.swirlds.platform.util.BootstrapUtils.getNodesToRun;
@@ -287,7 +287,7 @@ public class ServicesMain implements SwirldMain {
         final var addressBook = initializeAddressBook(selfId, version, initialState, diskAddressBook, platformContext);
 
         // Follow the Inversion of Control pattern by injecting all needed dependencies into the PlatformBuilder.
-        final var roster = createRoster(addressBook);
+        final var roster = buildRoster(addressBook);
         final var platformBuilder = PlatformBuilder.create(
                         Hedera.APP_NAME,
                         Hedera.SWIRLD_NAME,

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/AppTestBase.java
@@ -16,7 +16,7 @@
 
 package com.hedera.node.app.fixtures;
 
-import static com.swirlds.platform.system.address.AddressBookUtils.createRoster;
+import static com.swirlds.platform.roster.RosterRetriever.buildRoster;
 import static com.swirlds.platform.system.address.AddressBookUtils.endpointFor;
 import static com.swirlds.platform.test.fixtures.state.TestSchema.CURRENT_VERSION;
 import static java.util.Objects.requireNonNull;
@@ -337,7 +337,7 @@ public class AppTestBase extends TestBase implements TransactionFactory, Scenari
             final var addressBook = new AddressBook(addresses);
             final var platform = new FakePlatform(realSelfNodeInfo.nodeId(), addressBook);
             final var initialState = new FakeState();
-            final var networkInfo = new GenesisNetworkInfo(createRoster(addressBook), Bytes.fromHex("03"));
+            final var networkInfo = new GenesisNetworkInfo(buildRoster(addressBook), Bytes.fromHex("03"));
             services.forEach(svc -> {
                 final var reg = new FakeSchemaRegistry();
                 svc.registerSchemas(reg);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -19,10 +19,10 @@ package com.hedera.services.bdd.junit.hedera.embedded;
 import static com.hedera.hapi.util.HapiUtils.parseAccount;
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.ADDRESS_BOOK;
+import static com.swirlds.platform.roster.RosterRetriever.buildRoster;
 import static com.swirlds.platform.state.service.PbjConverter.toPbjAddressBook;
 import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
 import static com.swirlds.platform.system.InitTrigger.GENESIS;
-import static com.swirlds.platform.system.address.AddressBookUtils.createRoster;
 import static com.swirlds.platform.system.status.PlatformStatus.ACTIVE;
 import static com.swirlds.platform.system.status.PlatformStatus.FREEZE_COMPLETE;
 import static java.util.Objects.requireNonNull;
@@ -56,7 +56,6 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader;
 import com.swirlds.platform.listeners.PlatformStatusChangeNotification;
-import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.WritableRosterStore;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -119,7 +118,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     protected AbstractEmbeddedHedera(@NonNull final EmbeddedNode node) {
         requireNonNull(node);
         addressBook = loadAddressBook(node.getExternalPath(ADDRESS_BOOK));
-        roster = RosterRetriever.buildRoster(addressBook);
+        roster = buildRoster(addressBook);
         nodeIds = stream(spliteratorUnknownSize(addressBook.iterator(), 0), false)
                 .collect(toMap(AbstractEmbeddedHedera::accountIdOf, Address::getNodeId));
         accountIds = stream(spliteratorUnknownSize(addressBook.iterator(), 0), false)
@@ -156,7 +155,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
                 .copyBuilder()
                 .addressBook(toPbjAddressBook(addressBook))
                 .build());
-        writableRosterStore.putActiveRoster(createRoster(addressBook), 0);
+        writableRosterStore.putActiveRoster(buildRoster(addressBook), 0);
         ((CommittableWritableStates) writableStates).commit();
         ((CommittableWritableStates) writableRosterStates).commit();
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -19,7 +19,6 @@ package com.swirlds.platform.system.address;
 import static com.swirlds.platform.util.BootstrapUtils.detectSoftwareUpgrade;
 
 import com.hedera.hapi.node.base.ServiceEndpoint;
-import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.context.PlatformContext;
@@ -33,10 +32,7 @@ import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.system.SoftwareVersion;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.security.cert.CertificateEncodingException;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -273,60 +269,6 @@ public class AddressBookUtils {
             builder.domainName(host);
         }
         return builder.build();
-    }
-
-    /**
-     * Creates a new roster from the bootstrap address book.
-     *
-     * @return a new roster
-     */
-    @NonNull
-    public static Roster createRoster(@NonNull final AddressBook bootstrapAddressBook) {
-        Objects.requireNonNull(bootstrapAddressBook, "The bootstrapAddressBook must not be null.");
-        final List<RosterEntry> rosterEntries = new ArrayList<>(bootstrapAddressBook.getSize());
-        for (int i = 0; i < bootstrapAddressBook.getSize(); i++) {
-            final NodeId nodeId = bootstrapAddressBook.getNodeId(i);
-            final Address address = bootstrapAddressBook.getAddress(nodeId);
-
-            final RosterEntry rosterEntry = AddressBookUtils.toRosterEntry(address, nodeId);
-            rosterEntries.add(rosterEntry);
-        }
-        return Roster.newBuilder().rosterEntries(rosterEntries).build();
-    }
-
-    /**
-     * Converts an address to a roster entry.
-     *
-     * @param address the address to convert
-     * @param nodeId  the node ID to use for the roster entry
-     * @return the roster entry
-     */
-    private static RosterEntry toRosterEntry(@NonNull final Address address, @NonNull final NodeId nodeId) {
-        Objects.requireNonNull(address);
-        Objects.requireNonNull(nodeId);
-        final var signingCertificate = address.getSigCert();
-        Bytes signingCertificateBytes;
-        try {
-            signingCertificateBytes =
-                    signingCertificate == null ? Bytes.EMPTY : Bytes.wrap(signingCertificate.getEncoded());
-        } catch (final CertificateEncodingException e) {
-            signingCertificateBytes = Bytes.EMPTY;
-        }
-
-        final List<ServiceEndpoint> serviceEndpoints = new ArrayList<>(2);
-        if (address.getHostnameInternal() != null) {
-            serviceEndpoints.add(endpointFor(address.getHostnameInternal(), address.getPortInternal()));
-        }
-        if (address.getHostnameExternal() != null) {
-            serviceEndpoints.add(endpointFor(address.getHostnameExternal(), address.getPortExternal()));
-        }
-
-        return RosterEntry.newBuilder()
-                .nodeId(nodeId.id())
-                .weight(address.getWeight())
-                .gossipCaCertificate(signingCertificateBytes)
-                .gossipEndpoint(serviceEndpoints)
-                .build();
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/AddressBookNetworkUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/util/AddressBookNetworkUtilsTests.java
@@ -16,9 +16,11 @@
 
 package com.swirlds.platform.util;
 
+import static com.swirlds.platform.roster.RosterRetriever.buildRoster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -30,6 +32,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.network.Network;
+import com.swirlds.platform.roster.InvalidAddressBookException;
 import com.swirlds.platform.state.address.AddressBookNetworkUtils;
 import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
@@ -96,7 +99,7 @@ class AddressBookNetworkUtilsTests {
         final AddressBook addressBook = new AddressBook();
         addressBook.add(address1);
         addressBook.add(address2);
-        final Roster roster = AddressBookUtils.createRoster(addressBook);
+        final Roster roster = buildRoster(addressBook);
 
         assertNotNull(roster);
         assertEquals(2, roster.rosterEntries().size());
@@ -106,16 +109,13 @@ class AddressBookNetworkUtilsTests {
 
     @Test
     void testCreateRosterFromNullAddressBook() {
-        assertThrows(
-                NullPointerException.class,
-                () -> AddressBookUtils.createRoster(null),
-                "Illegal attempt to create a Roster from a null AddressBook");
+        assertNull(buildRoster(null), "A null address book should produce a null roster.");
     }
 
     @Test
     void testCreateRosterFromEmptyAddressBook() {
         final AddressBook addressBook = new AddressBook();
-        final Roster roster = AddressBookUtils.createRoster(addressBook);
+        final Roster roster = buildRoster(addressBook);
 
         assertNotNull(roster);
         assertTrue(roster.rosterEntries().isEmpty());
@@ -128,16 +128,17 @@ class AddressBookNetworkUtilsTests {
         when(certificate.getEncoded()).thenThrow(new CertificateEncodingException());
 
         final AddressBook addressBook = new AddressBook(List.of(address));
-        final Roster roster = AddressBookUtils.createRoster(addressBook);
-
-        assertEquals(Bytes.EMPTY, roster.rosterEntries().getFirst().gossipCaCertificate());
+        assertThrows(
+                InvalidAddressBookException.class,
+                () -> buildRoster(addressBook),
+                "Invalid certificates are not allowed in Rosters.");
     }
 
     @Test
     void testToRosterEntryWithExternalHostname() {
         final Address address = new Address().copySetHostnameExternal("hostnameExternal");
         final AddressBook addressBook = new AddressBook(List.of(address));
-        final Roster roster = AddressBookUtils.createRoster(addressBook);
+        final Roster roster = buildRoster(addressBook);
 
         assertEquals(1, roster.rosterEntries().size());
         assertEquals(
@@ -149,7 +150,7 @@ class AddressBookNetworkUtilsTests {
     void testToRosterEntryWithInternalHostname() {
         final Address address = new Address().copySetHostnameInternal("hostnameInternal");
         final AddressBook addressBook = new AddressBook(List.of(address));
-        final Roster roster = AddressBookUtils.createRoster(addressBook);
+        final Roster roster = buildRoster(addressBook);
 
         assertEquals(1, roster.rosterEntries().size());
         assertEquals(


### PR DESCRIPTION
**Description**:

This PR removes the redundant `createRoster` from `AddressBookUtils` and replaces its usage with `buildRoster` from the `RosterRetriever`. 

Fixes #15573 

**Notes for reviewer**:
The behavior of `buildRoster` is the correct behavior and the unit tests in `AddressBookNetworkUtilsTest` have been updated to reflect this. 