### PR TITLE
chore: Modified block stream handling for record file data

### DIFF
--- a/hapi/hedera-protobufs/block/stream/output/block_header.proto
+++ b/hapi/hedera-protobufs/block/stream/output/block_header.proto
@@ -152,14 +152,4 @@ message BlockHeader {
      * This SHOULD always be `SHA2_384`, currently.
      */
     proto.BlockHashAlgorithm hash_algorithm = 6;
-
-    /**
-     * A version for the network address book.<br/>
-     * The address book version is needed to determine the correct public
-     * key(s) to use to validate block signatures and state proofs.
-     * <p>
-     * This MUST be the version of the address book that signed this
-     * block.
-     */
-    proto.SemanticVersion address_book_version = 7;
 }

--- a/hapi/hedera-protobufs/block/stream/output/smart_contract_service.proto
+++ b/hapi/hedera-protobufs/block/stream/output/smart_contract_service.proto
@@ -1,7 +1,7 @@
 /**
  * #  Service
  * Block stream messages that report the results of transactions handled
- * by the `` service.
+ * by the `smart contract` service.
  *
  * > REVIEW NOTE
  * >> The use of sidecar records is a bit odd here. We may find it more

--- a/hapi/hedera-protobufs/block/stream/record_file_item.proto
+++ b/hapi/hedera-protobufs/block/stream/record_file_item.proto
@@ -48,57 +48,45 @@ import "timestamp.proto";
  * historical and current data; eliminating the need to search two sources for
  * block and block chain data.<br/>
  * Any block containing this item requires special handling.
- * - The block SHALL NOT have a `BlockHeader`.
+ * - The block SHALL have a `BlockHeader`.
+ *    - Some fields in the `BlockHeader` may be interpreted differently, and
+ *      may depend on when the original record file was created.
  * - The block SHALL NOT have a `BlockProof`.
+ * - The block SHALL end with an `AddressBookProof`, which is only used for
+ *   `RecordFileItem` blocks.
  * - The block SHALL contain _exactly one_ `RecordFileItem`.
- * - The block SHALL NOT contain any item other than a `RecordFileItem`.
+ * - The block SHALL NOT contain any content item other than a `RecordFileItem`.
  * - The content of the `RecordFileItem` MUST be validated using the
  *   signature data and content provided herein according to the
  *   process used for Record Files prior to the creation of Block Stream.
  *    - This block item only replaces the requirement to read several
  *      individual files from cloud storage services.
+ * - The address book relevant to a particular record file SHALL be available
+ *   separately as an `AddressBookProof` item.
  */
 message RecordFileItem {
-    /**
-     * The block number of this block.
-     * <p>
-     * This value MUST be exactly `1` more than the previous block.<br/>
-     * Client systems SHOULD optimistically reject any block with a gap or
-     * reverse in `number` sequence, and MAY assume the block stream has
-     * encountered data loss, data corruption, or unauthorized modification.
-     */
-    uint64 number = 1;
-
     /**
      * The consensus time the record file was produced for.<br/>
      * This comes from the record file name.
      */
-    proto.Timestamp creation_time = 2;
+    proto.Timestamp creation_time = 1;
 
     /**
      * The contents of a record file.<br/>
      * The first 4 bytes are a 32bit int little endian version number.
      * The versions that existed are 2,3,5 and 6.
      */
-    bytes record_file_contents = 3;
+    bytes record_file_contents = 2;
 
     /**
      * The contents of sidecar files for this block.<br/>
      * Each block can have zero or more sidecar files.
      */
-    repeated bytes sidecar_file_contents = 4;
-
-    /**
-     * A hash algorithm.<br/>
-     * This is the algorithm used to hash the block.
-     * <p>
-     * This SHOULD always be `SHA2_384`.
-     */
-    proto.BlockHashAlgorithm hash_algorithm = 5;
+    repeated bytes sidecar_file_contents = 3;
 
     /**
      * A collection of RSA signatures from consensus nodes.<br/>
      * These signatures validate the hash of the record_file_contents field.
      */
-    repeated bytes record_file_hash_signatures = 6;
+    repeated bytes record_file_hash_signatures = 4;
 }


### PR DESCRIPTION
 * Adjusted record file item to latest expectation
 * Removed address book version from block header
 * Added a missing service name in `block/stream/output/smart_contract_service.proto` documentation

### Details
During work to migrate record file data into block stream format, Jasper found some issues with the current proto files, and requested some modest changes.
The `address_book_version` field in `BlockHeader` is not needed with TSS.
The `number` and `hash_algorithm` in `RecordFileItem` are duplicative of `BlockHeader`.
A decision was made to add a `BlockHeader` to record file blocks.
A (to be designed) `AddressBookProof` item will also be added to record file blocks in a later PR.

### Implementation Note
The `address_book_version` field was not used anywhere, so removal does not require code changes.
The `RecordFileItem` is not used in consensus code, so changes do not impact code in this repository.