### PR TITLE
chore: Refactor hapi tests to use `hapiTest(...)` instead of `defaultHapiSpec(...)` (Part 1)

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/SubmitMessageSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/SubmitMessageSuite.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.suites.consensus;
 
 import static com.hedera.services.bdd.junit.TestTags.ADHOC;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
 import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
@@ -39,6 +39,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedBodyIds;
 import static com.hedera.services.bdd.suites.HapiSuite.asOpArray;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CHUNK_NUMBER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CHUNK_TRANSACTION_ID;
@@ -64,63 +65,52 @@ public class SubmitMessageSuite {
 
     @HapiTest
     final Stream<DynamicTest> pureCheckFails() {
-        return defaultHapiSpec("testTopic")
-                .given(cryptoCreate("nonTopicId"))
-                .when()
-                .then(
-                        submitMessageTo(spec -> asTopicId(spec.registry().getAccountID("nonTopicId")))
-                                .hasPrecheck(INVALID_TOPIC_ID),
-                        submitMessageTo((String) null).hasPrecheck(INVALID_TOPIC_ID));
+        return hapiTest(
+                cryptoCreate("nonTopicId"),
+                submitMessageTo(spec -> asTopicId(spec.registry().getAccountID("nonTopicId")))
+                        .hasPrecheck(INVALID_TOPIC_ID),
+                submitMessageTo((String) null).hasPrecheck(INVALID_TOPIC_ID));
     }
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(createTopic("testTopic"))
-                .when()
-                .then(submitModified(withSuccessivelyVariedBodyIds(), () -> submitMessageTo("testTopic")
-                        .message("HI")));
+        return hapiTest(createTopic("testTopic"), submitModified(withSuccessivelyVariedBodyIds(), () -> submitMessageTo(
+                        "testTopic")
+                .message("HI")));
     }
 
     @HapiTest
     final Stream<DynamicTest> topicIdIsValidated() {
-        return defaultHapiSpec("topicIdIsValidated")
-                .given(cryptoCreate("nonTopicId"))
-                .when()
-                .then(
-                        submitMessageTo((String) null)
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(INVALID_TOPIC_ID),
-                        submitMessageTo("1.2.3").hasRetryPrecheckFrom(BUSY).hasKnownStatus(INVALID_TOPIC_ID),
-                        submitMessageTo(spec -> asTopicId(spec.registry().getAccountID("nonTopicId")))
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(INVALID_TOPIC_ID));
+        return hapiTest(
+                cryptoCreate("nonTopicId"),
+                submitMessageTo((String) null).hasRetryPrecheckFrom(BUSY).hasKnownStatus(INVALID_TOPIC_ID),
+                submitMessageTo("1.2.3").hasRetryPrecheckFrom(BUSY).hasKnownStatus(INVALID_TOPIC_ID),
+                submitMessageTo(spec -> asTopicId(spec.registry().getAccountID("nonTopicId")))
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(INVALID_TOPIC_ID));
     }
 
     @HapiTest
     final Stream<DynamicTest> messageIsValidated() {
-        return defaultHapiSpec("messageIsValidated")
-                .given(createTopic("testTopic"))
-                .when()
-                .then(
-                        submitMessageTo("testTopic")
-                                .clearMessage()
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasPrecheck(INVALID_TOPIC_MESSAGE),
-                        submitMessageTo("testTopic")
-                                .message("")
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasPrecheck(INVALID_TOPIC_MESSAGE));
+        return hapiTest(
+                createTopic("testTopic"),
+                submitMessageTo("testTopic")
+                        .clearMessage()
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasPrecheck(INVALID_TOPIC_MESSAGE),
+                submitMessageTo("testTopic")
+                        .message("")
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasPrecheck(INVALID_TOPIC_MESSAGE));
     }
 
     @HapiTest
     final Stream<DynamicTest> messageSubmissionSimple() {
-        return defaultHapiSpec("messageSubmissionSimple")
-                .given(
-                        newKeyNamed("submitKey"),
-                        createTopic("testTopic").submitKeyName("submitKey").hasRetryPrecheckFrom(BUSY))
-                .when(cryptoCreate("civilian"))
-                .then(submitMessageTo("testTopic")
+        return hapiTest(
+                newKeyNamed("submitKey"),
+                createTopic("testTopic").submitKeyName("submitKey").hasRetryPrecheckFrom(BUSY),
+                cryptoCreate("civilian"),
+                submitMessageTo("testTopic")
                         .message("testmessage")
                         .payingWith("civilian")
                         .hasRetryPrecheckFrom(BUSY)
@@ -131,12 +121,11 @@ public class SubmitMessageSuite {
     final Stream<DynamicTest> messageSubmissionIncreasesSeqNo() {
         KeyShape submitKeyShape = threshOf(2, SIMPLE, SIMPLE, listOf(2));
 
-        return defaultHapiSpec("messageSubmissionIncreasesSeqNo")
-                .given(createTopic("testTopic").submitKeyShape(submitKeyShape))
-                .when(
-                        getTopicInfo("testTopic").hasSeqNo(0),
-                        submitMessageTo("testTopic").message("Hello world!").hasRetryPrecheckFrom(BUSY))
-                .then(getTopicInfo("testTopic").hasSeqNo(1));
+        return hapiTest(
+                createTopic("testTopic").submitKeyShape(submitKeyShape),
+                getTopicInfo("testTopic").hasSeqNo(0),
+                submitMessageTo("testTopic").message("Hello world!").hasRetryPrecheckFrom(BUSY),
+                getTopicInfo("testTopic").hasSeqNo(1));
     }
 
     @HapiTest
@@ -146,32 +135,30 @@ public class SubmitMessageSuite {
         SigControl validSig = submitKeyShape.signedWith(sigs(ON, OFF, sigs(ON, ON)));
         SigControl invalidSig = submitKeyShape.signedWith(sigs(ON, OFF, sigs(ON, OFF)));
 
-        return defaultHapiSpec("messageSubmissionWithSubmitKey")
-                .given(
-                        newKeyNamed("submitKey").shape(submitKeyShape),
-                        createTopic("testTopic").submitKeyName("submitKey"))
-                .when()
-                .then(
-                        submitMessageTo("testTopic")
-                                .sigControl(forKey("testTopicSubmit", invalidSig))
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        submitMessageTo("testTopic")
-                                .sigControl(forKey("testTopicSubmit", validSig))
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(SUCCESS));
+        return hapiTest(
+                newKeyNamed("submitKey").shape(submitKeyShape),
+                createTopic("testTopic").submitKeyName("submitKey"),
+                submitMessageTo("testTopic")
+                        .sigControl(forKey("testTopicSubmit", invalidSig))
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(INVALID_SIGNATURE),
+                submitMessageTo("testTopic")
+                        .sigControl(forKey("testTopicSubmit", validSig))
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(SUCCESS));
     }
 
     @HapiTest
     final Stream<DynamicTest> messageSubmissionMultiple() {
         final int numMessages = 10;
 
-        return defaultHapiSpec("messageSubmissionMultiple")
-                .given(createTopic("testTopic").hasRetryPrecheckFrom(BUSY))
-                .when(inParallel(asOpArray(
+        return hapiTest(
+                createTopic("testTopic").hasRetryPrecheckFrom(BUSY),
+                inParallel(asOpArray(
                         numMessages,
-                        i -> submitMessageTo("testTopic").message("message").hasRetryPrecheckFrom(BUSY))))
-                .then(sleepFor(1000), getTopicInfo("testTopic").hasSeqNo(numMessages));
+                        i -> submitMessageTo("testTopic").message("message").hasRetryPrecheckFrom(BUSY))),
+                sleepFor(1000),
+                getTopicInfo("testTopic").hasSeqNo(numMessages));
     }
 
     @HapiTest
@@ -179,12 +166,10 @@ public class SubmitMessageSuite {
         final byte[] messageBytes = new byte[4096]; // 4k
         Arrays.fill(messageBytes, (byte) 0b1);
 
-        return defaultHapiSpec("messageSubmissionOverSize")
-                .given(
-                        newKeyNamed("submitKey"),
-                        createTopic("testTopic").submitKeyName("submitKey").hasRetryPrecheckFrom(BUSY))
-                .when()
-                .then(submitMessageTo("testTopic")
+        return hapiTest(
+                newKeyNamed("submitKey"),
+                createTopic("testTopic").submitKeyName("submitKey").hasRetryPrecheckFrom(BUSY),
+                submitMessageTo("testTopic")
                         .message(new String(messageBytes))
                         // In hedera-app we don't enforce such prechecks
                         .hasPrecheckFrom(TRANSACTION_OVERSIZE, BUSY, OK)
@@ -195,17 +180,17 @@ public class SubmitMessageSuite {
     final Stream<DynamicTest> feeAsExpected() {
         final byte[] messageBytes = new byte[100]; // 4k
         Arrays.fill(messageBytes, (byte) 0b1);
-        return defaultHapiSpec("feeAsExpected")
-                .given(
-                        cryptoCreate("payer").hasRetryPrecheckFrom(BUSY),
-                        createTopic("testTopic").submitKeyName("payer").hasRetryPrecheckFrom(BUSY))
-                .when(submitMessageTo("testTopic")
+        return hapiTest(
+                cryptoCreate("payer").hasRetryPrecheckFrom(BUSY),
+                createTopic("testTopic").submitKeyName("payer").hasRetryPrecheckFrom(BUSY),
+                submitMessageTo("testTopic")
                         .blankMemo()
                         .payingWith("payer")
                         .message(new String(messageBytes))
                         .hasRetryPrecheckFrom(BUSY)
-                        .via("submitMessage"))
-                .then(sleepFor(1000), validateChargedUsd("submitMessage", 0.0001));
+                        .via("submitMessage"),
+                sleepFor(1000),
+                validateChargedUsd("submitMessage", 0.0001));
     }
 
     @HapiTest
@@ -216,110 +201,100 @@ public class SubmitMessageSuite {
         String nonsense = "Nonsense";
         String message3 = "Goodbye!";
 
-        return defaultHapiSpec("messageSubmissionCorrectlyUpdatesRunningHash")
-                .given(
-                        createTopic(topic),
-                        getTopicInfo(topic)
-                                .hasSeqNo(0)
-                                .hasRunningHash(new byte[48])
-                                .saveRunningHash())
-                .when(submitMessageTo(topic)
+        return hapiTest(
+                createTopic(topic),
+                getTopicInfo(topic).hasSeqNo(0).hasRunningHash(new byte[48]).saveRunningHash(),
+                submitMessageTo(topic)
                         .message(message1)
                         .hasRetryPrecheckFrom(BUSY)
-                        .via("submitMessage1"))
-                .then(
-                        getTxnRecord("submitMessage1").hasCorrectRunningHash(topic, message1),
-                        submitMessageTo(topic)
-                                .message(message2)
-                                .hasRetryPrecheckFrom(BUSY)
-                                .via("submitMessage2"),
-                        getTxnRecord("submitMessage2").hasCorrectRunningHash(topic, message2),
-                        submitMessageTo(topic)
-                                .message(nonsense)
-                                .via("nonsense")
-                                .chunkInfo(3, 4)
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(INVALID_CHUNK_NUMBER),
-                        getTxnRecord("nonsense")
-                                .hasCorrectRunningHash(topic, message2)
-                                .logged(),
-                        submitMessageTo(topic)
-                                .message(message3)
-                                .hasRetryPrecheckFrom(BUSY)
-                                .via("submitMessage3"),
-                        getTxnRecord("submitMessage3").hasCorrectRunningHash(topic, message3));
+                        .via("submitMessage1"),
+                getTxnRecord("submitMessage1").hasCorrectRunningHash(topic, message1),
+                submitMessageTo(topic)
+                        .message(message2)
+                        .hasRetryPrecheckFrom(BUSY)
+                        .via("submitMessage2"),
+                getTxnRecord("submitMessage2").hasCorrectRunningHash(topic, message2),
+                submitMessageTo(topic)
+                        .message(nonsense)
+                        .via("nonsense")
+                        .chunkInfo(3, 4)
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(INVALID_CHUNK_NUMBER),
+                getTxnRecord("nonsense").hasCorrectRunningHash(topic, message2).logged(),
+                submitMessageTo(topic)
+                        .message(message3)
+                        .hasRetryPrecheckFrom(BUSY)
+                        .via("submitMessage3"),
+                getTxnRecord("submitMessage3").hasCorrectRunningHash(topic, message3));
     }
 
     @HapiTest
     final Stream<DynamicTest> chunkNumberIsValidated() {
-        return defaultHapiSpec("chunkNumberIsValidated")
-                .given(createTopic("testTopic"))
-                .when()
-                .then(
-                        submitMessageTo("testTopic")
-                                .message("failsForChunkNumberGreaterThanTotalChunks")
-                                .chunkInfo(2, 3)
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(INVALID_CHUNK_NUMBER),
-                        submitMessageTo("testTopic")
-                                .message("acceptsChunkNumberLessThanTotalChunks")
-                                .chunkInfo(3, 2)
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(SUCCESS),
-                        submitMessageTo("testTopic")
-                                .message("acceptsChunkNumberEqualTotalChunks")
-                                .chunkInfo(5, 5)
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(SUCCESS));
+        return hapiTest(
+                createTopic("testTopic"),
+                submitMessageTo("testTopic")
+                        .message("failsForChunkNumberGreaterThanTotalChunks")
+                        .chunkInfo(2, 3)
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(INVALID_CHUNK_NUMBER),
+                submitMessageTo("testTopic")
+                        .message("acceptsChunkNumberLessThanTotalChunks")
+                        .chunkInfo(3, 2)
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(SUCCESS),
+                submitMessageTo("testTopic")
+                        .message("acceptsChunkNumberEqualTotalChunks")
+                        .chunkInfo(5, 5)
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(SUCCESS));
     }
 
     @HapiTest
     final Stream<DynamicTest> chunkTransactionIDIsValidated() {
-        return defaultHapiSpec("chunkTransactionIDIsValidated")
-                .given(cryptoCreate("initialTransactionPayer"), createTopic("testTopic"))
-                .when()
-                .then(
-                        submitMessageTo("testTopic")
-                                .message("failsForDifferentPayers")
-                                .chunkInfo(3, 2, "initialTransactionPayer")
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(INVALID_CHUNK_TRANSACTION_ID),
-                        // Add delay to make sure the valid start of the transaction will
-                        // not match
-                        // that of the initialTransactionID
-                        sleepFor(1000),
-                        /* AcceptsChunkNumberDifferentThan1HavingTheSamePayerEvenWhenNotMatchingValidStart */
-                        submitMessageTo("testTopic")
-                                .message("A")
-                                .chunkInfo(3, 3, "initialTransactionPayer")
-                                .payingWith("initialTransactionPayer")
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(SUCCESS),
-                        /* FailsForTransactionIDOfChunkNumber1NotMatchingTheEntireInitialTransactionID */
-                        sleepFor(1000),
-                        submitMessageTo("testTopic")
-                                .message("B")
-                                .chunkInfo(2, 1)
-                                // Also add delay here
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(INVALID_CHUNK_TRANSACTION_ID),
-                        /* AcceptsChunkNumber1WhenItsTransactionIDMatchesTheEntireInitialTransactionID */
-                        submitMessageTo("testTopic")
-                                .message("C")
-                                .chunkInfo(4, 1)
-                                .via("firstChunk")
-                                .payingWith("initialTransactionPayer")
-                                .usePresetTimestamp()
-                                .hasRetryPrecheckFrom(BUSY)
-                                .hasKnownStatus(SUCCESS));
+        return hapiTest(
+                cryptoCreate("initialTransactionPayer"),
+                createTopic("testTopic"),
+                submitMessageTo("testTopic")
+                        .message("failsForDifferentPayers")
+                        .chunkInfo(3, 2, "initialTransactionPayer")
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(INVALID_CHUNK_TRANSACTION_ID),
+                // Add delay to make sure the valid start of the transaction will
+                // not match
+                // that of the initialTransactionID
+                sleepFor(1000),
+                /* AcceptsChunkNumberDifferentThan1HavingTheSamePayerEvenWhenNotMatchingValidStart */
+                submitMessageTo("testTopic")
+                        .message("A")
+                        .chunkInfo(3, 3, "initialTransactionPayer")
+                        .payingWith("initialTransactionPayer")
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(SUCCESS),
+                /* FailsForTransactionIDOfChunkNumber1NotMatchingTheEntireInitialTransactionID */
+                sleepFor(1000),
+                submitMessageTo("testTopic")
+                        .message("B")
+                        .chunkInfo(2, 1)
+                        // Also add delay here
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(INVALID_CHUNK_TRANSACTION_ID),
+                /* AcceptsChunkNumber1WhenItsTransactionIDMatchesTheEntireInitialTransactionID */
+                submitMessageTo("testTopic")
+                        .message("C")
+                        .chunkInfo(4, 1)
+                        .via("firstChunk")
+                        .payingWith("initialTransactionPayer")
+                        .usePresetTimestamp()
+                        .hasRetryPrecheckFrom(BUSY)
+                        .hasKnownStatus(SUCCESS));
     }
 
     @HapiTest
     final Stream<DynamicTest> longMessageIsFragmentedIntoChunks() {
         String fileForLongMessage = "src/main/resources/RandomLargeBinary.bin";
-        return defaultHapiSpec("longMessageIsFragmentedIntoChunks")
-                .given(cryptoCreate("payer"), createTopic("testTopic"))
-                .when()
-                .then(chunkAFile(fileForLongMessage, CHUNK_SIZE, "payer", "testTopic"));
+        return hapiTest(flattened(
+                cryptoCreate("payer"),
+                createTopic("testTopic"),
+                chunkAFile(fileForLongMessage, CHUNK_SIZE, "payer", "testTopic")));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -16,7 +16,6 @@
 
 package com.hedera.services.bdd.suites.consensus;
 
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTopicInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
@@ -61,44 +60,35 @@ public class TopicCreateSuite {
 
     @HapiTest
     final Stream<DynamicTest> adminKeyIsValidated() {
-        return defaultHapiSpec("AdminKeyIsValidated")
-                .given()
-                .when()
-                .then(createTopic("testTopic")
-                        .adminKeyName(NONSENSE_KEY)
-                        .signedBy(GENESIS)
-                        .hasPrecheckFrom(OK, BAD_ENCODING)
-                        .hasKnownStatus(BAD_ENCODING));
+        return hapiTest(createTopic("testTopic")
+                .adminKeyName(NONSENSE_KEY)
+                .signedBy(GENESIS)
+                .hasPrecheckFrom(OK, BAD_ENCODING)
+                .hasKnownStatus(BAD_ENCODING));
     }
 
     @HapiTest
     final Stream<DynamicTest> submitKeyIsValidated() {
-        return defaultHapiSpec("SubmitKeyIsValidated")
-                .given()
-                .when()
-                .then(createTopic("testTopic")
-                        .submitKeyName(NONSENSE_KEY)
-                        .signedBy(GENESIS)
-                        .hasKnownStatus(BAD_ENCODING));
+        return hapiTest(createTopic("testTopic")
+                .submitKeyName(NONSENSE_KEY)
+                .signedBy(GENESIS)
+                .hasKnownStatus(BAD_ENCODING));
     }
 
     @HapiTest
     final Stream<DynamicTest> autoRenewAccountIsValidated() {
-        return defaultHapiSpec("AutoRenewAccountIsValidated")
-                .given()
-                .when()
-                .then(createTopic("testTopic")
-                        .autoRenewAccountId("1.2.3")
-                        .signedBy(GENESIS)
-                        .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT));
+        return hapiTest(createTopic("testTopic")
+                .autoRenewAccountId("1.2.3")
+                .signedBy(GENESIS)
+                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT));
     }
 
     @HapiTest
     final Stream<DynamicTest> autoRenewAccountIdNeedsAdminKeyToo() {
-        return defaultHapiSpec("autoRenewAccountIdNeedsAdminKeyToo")
-                .given(cryptoCreate("payer"), cryptoCreate("autoRenewAccount"))
-                .when()
-                .then(createTopic("noAdminKeyExplicitAutoRenewAccount")
+        return hapiTest(
+                cryptoCreate("payer"),
+                cryptoCreate("autoRenewAccount"),
+                createTopic("noAdminKeyExplicitAutoRenewAccount")
                         .payingWith("payer")
                         .autoRenewAccountId("autoRenewAccount")
                         .signedBy("payer", "autoRenewAccount")
@@ -109,10 +99,10 @@ public class TopicCreateSuite {
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
         final var autoRenewAccount = "autoRenewAccount";
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(cryptoCreate(autoRenewAccount), newKeyNamed("adminKey"))
-                .when()
-                .then(submitModified(
+        return hapiTest(
+                cryptoCreate(autoRenewAccount),
+                newKeyNamed("adminKey"),
+                submitModified(
                         withSuccessivelyVariedBodyIds(),
                         () -> createTopic("topic").adminKeyName("adminKey").autoRenewAccountId(autoRenewAccount)));
     }
@@ -121,27 +111,21 @@ public class TopicCreateSuite {
     final Stream<DynamicTest> autoRenewPeriodIsValidated() {
         final var tooShortAutoRenewPeriod = "tooShortAutoRenewPeriod";
         final var tooLongAutoRenewPeriod = "tooLongAutoRenewPeriod";
-        return defaultHapiSpec("autoRenewPeriodIsValidated")
-                .given()
-                .when()
-                .then(
-                        createTopic(tooShortAutoRenewPeriod)
-                                .autoRenewPeriod(0L)
-                                .hasKnownStatus(AUTORENEW_DURATION_NOT_IN_RANGE),
-                        createTopic(tooLongAutoRenewPeriod)
-                                .autoRenewPeriod(Long.MAX_VALUE)
-                                .hasKnownStatus(AUTORENEW_DURATION_NOT_IN_RANGE));
+        return hapiTest(
+                createTopic(tooShortAutoRenewPeriod)
+                        .autoRenewPeriod(0L)
+                        .hasKnownStatus(AUTORENEW_DURATION_NOT_IN_RANGE),
+                createTopic(tooLongAutoRenewPeriod)
+                        .autoRenewPeriod(Long.MAX_VALUE)
+                        .hasKnownStatus(AUTORENEW_DURATION_NOT_IN_RANGE));
     }
 
     @HapiTest
     final Stream<DynamicTest> noAutoRenewPeriod() {
-        return defaultHapiSpec("noAutoRenewPeriod")
-                .given()
-                .when()
-                .then(createTopic("testTopic")
-                        .clearAutoRenewPeriod()
-                        // No obvious reason to require INVALID_RENEWAL_PERIOD here
-                        .hasKnownStatusFrom(INVALID_RENEWAL_PERIOD, AUTORENEW_DURATION_NOT_IN_RANGE));
+        return hapiTest(createTopic("testTopic")
+                .clearAutoRenewPeriod()
+                // No obvious reason to require INVALID_RENEWAL_PERIOD here
+                .hasKnownStatusFrom(INVALID_RENEWAL_PERIOD, AUTORENEW_DURATION_NOT_IN_RANGE));
     }
 
     @HapiTest
@@ -149,78 +133,71 @@ public class TopicCreateSuite {
         long PAYER_BALANCE = 1_999_999_999L;
         final var contractWithAdminKey = "nonCryptoAccount";
 
-        return defaultHapiSpec("SigningRequirementsEnforced")
-                .given(
-                        newKeyNamed("adminKey"),
-                        newKeyNamed("contractAdminKey"),
-                        newKeyNamed("submitKey"),
-                        newKeyNamed("wrongKey"),
-                        cryptoCreate("payer").balance(PAYER_BALANCE),
-                        cryptoCreate("autoRenewAccount"),
-                        // This will have an admin key
-                        createDefaultContract(contractWithAdminKey).adminKey("contractAdminKey"),
-                        uploadInitCode(PAY_RECEIVABLE_CONTRACT),
-                        // And this won't
-                        contractCreate(PAY_RECEIVABLE_CONTRACT).omitAdminKey())
-                .when(
-                        createTopic("testTopic")
-                                .payingWith("payer")
-                                .signedBy("wrongKey")
-                                .hasPrecheck(INVALID_SIGNATURE),
-                        // But contracts without admin keys will get INVALID_SIGNATURE (can't sign!)
-                        createTopic("NotToBe")
-                                .autoRenewAccountId(PAY_RECEIVABLE_CONTRACT)
-                                .hasKnownStatusFrom(INVALID_SIGNATURE),
-                        createTopic("testTopic")
-                                .payingWith("payer")
-                                .autoRenewAccountId("autoRenewAccount")
-                                /* SigMap missing signature from auto-renew account's key. */
-                                .signedBy("payer")
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        createTopic("testTopic")
-                                .payingWith("payer")
-                                .adminKeyName("adminKey")
-                                /* SigMap missing signature from adminKey. */
-                                .signedBy("payer")
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        createTopic("testTopic")
-                                .payingWith("payer")
-                                .adminKeyName("adminKey")
-                                .autoRenewAccountId("autoRenewAccount")
-                                /* SigMap missing signature from auto-renew account's key. */
-                                .signedBy("payer", "adminKey")
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        createTopic("testTopic")
-                                .payingWith("payer")
-                                .adminKeyName("adminKey")
-                                .autoRenewAccountId("autoRenewAccount")
-                                /* SigMap missing signature from adminKey. */
-                                .signedBy("payer", "autoRenewAccount")
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        // In hedera-app, we'll allow contracts with admin keys to be auto-renew accounts
-                        createTopic("withContractAutoRenew")
-                                .adminKeyName("adminKey")
-                                .autoRenewAccountId(contractWithAdminKey))
-                .then(
-                        createTopic("noAdminKeyNoAutoRenewAccount"),
-                        getTopicInfo("noAdminKeyNoAutoRenewAccount")
-                                .hasNoAdminKey()
-                                .logged(),
-                        createTopic("explicitAdminKeyNoAutoRenewAccount").adminKeyName("adminKey"),
-                        getTopicInfo("explicitAdminKeyNoAutoRenewAccount")
-                                .hasAdminKey("adminKey")
-                                .logged(),
-                        createTopic("explicitAdminKeyExplicitAutoRenewAccount")
-                                .adminKeyName("adminKey")
-                                .autoRenewAccountId("autoRenewAccount"),
-                        getTopicInfo("explicitAdminKeyExplicitAutoRenewAccount")
-                                .hasAdminKey("adminKey")
-                                .hasAutoRenewAccount("autoRenewAccount")
-                                .logged(),
-                        getTopicInfo("withContractAutoRenew")
-                                .hasAdminKey("adminKey")
-                                .hasAutoRenewAccount(contractWithAdminKey)
-                                .logged());
+        return hapiTest(
+                newKeyNamed("adminKey"),
+                newKeyNamed("contractAdminKey"),
+                newKeyNamed("submitKey"),
+                newKeyNamed("wrongKey"),
+                cryptoCreate("payer").balance(PAYER_BALANCE),
+                cryptoCreate("autoRenewAccount"),
+                // This will have an admin key
+                createDefaultContract(contractWithAdminKey).adminKey("contractAdminKey"),
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                // And this won't
+                contractCreate(PAY_RECEIVABLE_CONTRACT).omitAdminKey(),
+                createTopic("testTopic")
+                        .payingWith("payer")
+                        .signedBy("wrongKey")
+                        .hasPrecheck(INVALID_SIGNATURE),
+                // But contracts without admin keys will get INVALID_SIGNATURE (can't sign!)
+                createTopic("NotToBe")
+                        .autoRenewAccountId(PAY_RECEIVABLE_CONTRACT)
+                        .hasKnownStatusFrom(INVALID_SIGNATURE),
+                createTopic("testTopic")
+                        .payingWith("payer")
+                        .autoRenewAccountId("autoRenewAccount")
+                        /* SigMap missing signature from auto-renew account's key. */
+                        .signedBy("payer")
+                        .hasKnownStatus(INVALID_SIGNATURE),
+                createTopic("testTopic")
+                        .payingWith("payer")
+                        .adminKeyName("adminKey")
+                        /* SigMap missing signature from adminKey. */
+                        .signedBy("payer")
+                        .hasKnownStatus(INVALID_SIGNATURE),
+                createTopic("testTopic")
+                        .payingWith("payer")
+                        .adminKeyName("adminKey")
+                        .autoRenewAccountId("autoRenewAccount")
+                        /* SigMap missing signature from auto-renew account's key. */
+                        .signedBy("payer", "adminKey")
+                        .hasKnownStatus(INVALID_SIGNATURE),
+                createTopic("testTopic")
+                        .payingWith("payer")
+                        .adminKeyName("adminKey")
+                        .autoRenewAccountId("autoRenewAccount")
+                        /* SigMap missing signature from adminKey. */
+                        .signedBy("payer", "autoRenewAccount")
+                        .hasKnownStatus(INVALID_SIGNATURE),
+                // In hedera-app, we'll allow contracts with admin keys to be auto-renew accounts
+                createTopic("withContractAutoRenew").adminKeyName("adminKey").autoRenewAccountId(contractWithAdminKey),
+                createTopic("noAdminKeyNoAutoRenewAccount"),
+                getTopicInfo("noAdminKeyNoAutoRenewAccount").hasNoAdminKey().logged(),
+                createTopic("explicitAdminKeyNoAutoRenewAccount").adminKeyName("adminKey"),
+                getTopicInfo("explicitAdminKeyNoAutoRenewAccount")
+                        .hasAdminKey("adminKey")
+                        .logged(),
+                createTopic("explicitAdminKeyExplicitAutoRenewAccount")
+                        .adminKeyName("adminKey")
+                        .autoRenewAccountId("autoRenewAccount"),
+                getTopicInfo("explicitAdminKeyExplicitAutoRenewAccount")
+                        .hasAdminKey("adminKey")
+                        .hasAutoRenewAccount("autoRenewAccount")
+                        .logged(),
+                getTopicInfo("withContractAutoRenew")
+                        .hasAdminKey("adminKey")
+                        .hasAutoRenewAccount(contractWithAdminKey)
+                        .logged());
     }
 
     @HapiTest
@@ -238,88 +215,78 @@ public class TopicCreateSuite {
 
     @HapiTest
     final Stream<DynamicTest> feeAsExpected() {
-        return defaultHapiSpec("feeAsExpected")
-                .given(
-                        newKeyNamed("adminKey"),
-                        newKeyNamed("submitKey"),
-                        cryptoCreate("autoRenewAccount"),
-                        cryptoCreate("payer").balance(ONE_HUNDRED_HBARS))
-                .when(createTopic("testTopic")
+        return hapiTest(
+                newKeyNamed("adminKey"),
+                newKeyNamed("submitKey"),
+                cryptoCreate("autoRenewAccount"),
+                cryptoCreate("payer").balance(ONE_HUNDRED_HBARS),
+                createTopic("testTopic")
                         .topicMemo("testmemo")
                         .adminKeyName("adminKey")
                         .submitKeyName("submitKey")
                         .autoRenewAccountId("autoRenewAccount")
                         .payingWith("payer")
-                        .via("topicCreate"))
-                .then(validateChargedUsd("topicCreate", 0.0226));
+                        .via("topicCreate"),
+                validateChargedUsd("topicCreate", 0.0226));
     }
 
     @HapiTest
     final Stream<DynamicTest> getInfoIdVariantsTreatedAsExpected() {
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(createTopic("topic"))
-                .when()
-                .then(sendModified(withSuccessivelyVariedQueryIds(), () -> getTopicInfo("topic")));
+        return hapiTest(
+                createTopic("topic"), sendModified(withSuccessivelyVariedQueryIds(), () -> getTopicInfo("topic")));
     }
 
     @HapiTest
     final Stream<DynamicTest> getInfoAllFieldsSetHappyCase() {
         // sequenceNumber should be 0 and runningHash should be 48 bytes all 0s.
         final AtomicReference<ByteString> targetLedgerId = new AtomicReference<>();
-        return defaultHapiSpec("AllFieldsSetHappyCase")
-                .given(
-                        newKeyNamed("adminKey"),
-                        newKeyNamed("submitKey"),
-                        cryptoCreate("autoRenewAccount"),
-                        cryptoCreate("payer"),
-                        createTopic(TEST_TOPIC)
-                                .topicMemo(TESTMEMO)
-                                .adminKeyName("adminKey")
-                                .submitKeyName("submitKey")
-                                .autoRenewAccountId("autoRenewAccount")
-                                .via("createTopic"))
-                .when()
-                .then(
-                        exposeTargetLedgerIdTo(targetLedgerId::set),
-                        sourcing(() -> getTopicInfo(TEST_TOPIC)
-                                .hasEncodedLedgerId(targetLedgerId.get())
-                                .hasMemo(TESTMEMO)
-                                .hasAdminKey("adminKey")
-                                .hasSubmitKey("submitKey")
-                                .hasAutoRenewAccount("autoRenewAccount")
-                                .hasSeqNo(0)
-                                .hasRunningHash(new byte[48])),
-                        getTxnRecord("createTopic").logged(),
-                        submitMessageTo(TEST_TOPIC)
-                                .blankMemo()
-                                .payingWith("payer")
-                                .message(new String("test".getBytes()))
-                                .via("submitMessage"),
-                        getTxnRecord("submitMessage").logged(),
-                        sourcing(() -> getTopicInfo(TEST_TOPIC)
-                                .hasEncodedLedgerId(targetLedgerId.get())
-                                .hasMemo(TESTMEMO)
-                                .hasAdminKey("adminKey")
-                                .hasSubmitKey("submitKey")
-                                .hasAutoRenewAccount("autoRenewAccount")
-                                .hasSeqNo(1)
-                                .logged()),
-                        updateTopic(TEST_TOPIC)
-                                .topicMemo("Don't worry about the vase")
-                                .via("updateTopic"),
-                        getTxnRecord("updateTopic").logged(),
-                        sourcing(() -> getTopicInfo(TEST_TOPIC)
-                                .hasEncodedLedgerId(targetLedgerId.get())
-                                .hasMemo("Don't worry about the vase")
-                                .hasAdminKey("adminKey")
-                                .hasSubmitKey("submitKey")
-                                .hasAutoRenewAccount("autoRenewAccount")
-                                .hasSeqNo(1)
-                                .logged()),
-                        deleteTopic(TEST_TOPIC).via("deleteTopic"),
-                        getTxnRecord("deleteTopic").logged(),
-                        getTopicInfo(TEST_TOPIC)
-                                .hasCostAnswerPrecheck(INVALID_TOPIC_ID)
-                                .logged());
+        return hapiTest(
+                newKeyNamed("adminKey"),
+                newKeyNamed("submitKey"),
+                cryptoCreate("autoRenewAccount"),
+                cryptoCreate("payer"),
+                createTopic(TEST_TOPIC)
+                        .topicMemo(TESTMEMO)
+                        .adminKeyName("adminKey")
+                        .submitKeyName("submitKey")
+                        .autoRenewAccountId("autoRenewAccount")
+                        .via("createTopic"),
+                exposeTargetLedgerIdTo(targetLedgerId::set),
+                sourcing(() -> getTopicInfo(TEST_TOPIC)
+                        .hasEncodedLedgerId(targetLedgerId.get())
+                        .hasMemo(TESTMEMO)
+                        .hasAdminKey("adminKey")
+                        .hasSubmitKey("submitKey")
+                        .hasAutoRenewAccount("autoRenewAccount")
+                        .hasSeqNo(0)
+                        .hasRunningHash(new byte[48])),
+                getTxnRecord("createTopic").logged(),
+                submitMessageTo(TEST_TOPIC)
+                        .blankMemo()
+                        .payingWith("payer")
+                        .message(new String("test".getBytes()))
+                        .via("submitMessage"),
+                getTxnRecord("submitMessage").logged(),
+                sourcing(() -> getTopicInfo(TEST_TOPIC)
+                        .hasEncodedLedgerId(targetLedgerId.get())
+                        .hasMemo(TESTMEMO)
+                        .hasAdminKey("adminKey")
+                        .hasSubmitKey("submitKey")
+                        .hasAutoRenewAccount("autoRenewAccount")
+                        .hasSeqNo(1)
+                        .logged()),
+                updateTopic(TEST_TOPIC).topicMemo("Don't worry about the vase").via("updateTopic"),
+                getTxnRecord("updateTopic").logged(),
+                sourcing(() -> getTopicInfo(TEST_TOPIC)
+                        .hasEncodedLedgerId(targetLedgerId.get())
+                        .hasMemo("Don't worry about the vase")
+                        .hasAdminKey("adminKey")
+                        .hasSubmitKey("submitKey")
+                        .hasAutoRenewAccount("autoRenewAccount")
+                        .hasSeqNo(1)
+                        .logged()),
+                deleteTopic(TEST_TOPIC).via("deleteTopic"),
+                getTxnRecord("deleteTopic").logged(),
+                getTopicInfo(TEST_TOPIC).hasCostAnswerPrecheck(INVALID_TOPIC_ID).logged());
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
@@ -53,6 +53,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
@@ -129,18 +130,17 @@ public class Evm46ValidationSuite {
     final Stream<DynamicTest> directCallToDeletedContractResultsInSuccessfulNoop() {
         AtomicReference<AccountID> receiverId = new AtomicReference<>();
 
-        return defaultHapiSpec("directCallToDeletedContractResultsInSuccessfulNoop")
-                .given(
-                        cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT)
-                                // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
-                                // tokenAssociate,
-                                // since we have CONTRACT_ID key
-                                .refusingEthConversion()
-                                .balance(ONE_HBAR),
-                        contractDelete(INTERNAL_CALLER_CONTRACT))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT)
+                        // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
+                        // tokenAssociate,
+                        // since we have CONTRACT_ID key
+                        .refusingEthConversion()
+                        .balance(ONE_HBAR),
+                contractDelete(INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("initialBalance", asAccountString(receiverId.get())),
                         contractCall(
@@ -148,21 +148,19 @@ public class Evm46ValidationSuite {
                                         CALL_WITH_VALUE_TO_FUNCTION,
                                         mirrorAddrWith(receiverId.get().getAccountNum()))
                                 .gas(GAS_LIMIT_FOR_CALL * 4)
-                                .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
-                        getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
+                getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
     final Stream<DynamicTest> selfdestructToExistingMirrorAddressResultsInSuccess() {
         AtomicReference<AccountID> receiverId = new AtomicReference<>();
-        return defaultHapiSpec("selfdestructToExistingMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> {
+        return hapiTest(
+                cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> {
                     allRunFor(
                             spec,
                             balanceSnapshot("selfdestructTargetAccount", asAccountString(receiverId.get())),
@@ -172,21 +170,19 @@ public class Evm46ValidationSuite {
                                             mirrorAddrWith(receiverId.get().getAccountNum()))
                                     .gas(GAS_LIMIT_FOR_CALL * 4)
                                     .via(INNER_TXN));
-                }))
-                .then(getAccountBalance(RECEIVER)
-                        .hasTinyBars(changeFromSnapshot("selfdestructTargetAccount", 100000000)));
+                }),
+                getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("selfdestructTargetAccount", 100000000)));
     }
 
     @HapiTest
     final Stream<DynamicTest> selfdestructToExistingNonMirrorAddressResultsInSuccess() {
-        return defaultHapiSpec("selfdestructToExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
-                        withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> {
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> {
                     final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
                     final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
                     final var addressBytes = recoverAddressFromPubKey(tmp);
@@ -197,27 +193,25 @@ public class Evm46ValidationSuite {
                             contractCall(INTERNAL_CALLER_CONTRACT, SELFDESTRUCT, asHeadlongAddress(addressBytes))
                                     .gas(GAS_LIMIT_FOR_CALL * 4)
                                     .via(INNER_TXN));
-                }))
-                .then(getAccountBalance(ECDSA_KEY)
-                        .hasTinyBars(changeFromSnapshot("selfdestructTargetAccount", 100000000)));
+                }),
+                getAccountBalance(ECDSA_KEY).hasTinyBars(changeFromSnapshot("selfdestructTargetAccount", 100000000)));
     }
 
     @HapiTest
     final Stream<DynamicTest> selfdestructToNonExistingNonMirrorAddressResultsInInvalidSolidityAddress() {
         AtomicReference<Bytes> nonExistingNonMirrorAddress = new AtomicReference<>();
 
-        return defaultHapiSpec("selfdestructToNonExistingNonMirrorAddressResultsInInvalidSolidityAddress")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        withOpContext((spec, op) -> {
-                            final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
-                            final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
-                            final var addressBytes = recoverAddressFromPubKey(tmp);
-                            nonExistingNonMirrorAddress.set(Bytes.of(addressBytes));
-                        }),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                withOpContext((spec, op) -> {
+                    final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
+                    final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
+                    final var addressBytes = recoverAddressFromPubKey(tmp);
+                    nonExistingNonMirrorAddress.set(Bytes.of(addressBytes));
+                }),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         contractCall(
                                         INTERNAL_CALLER_CONTRACT,
@@ -227,8 +221,8 @@ public class Evm46ValidationSuite {
                                                 .toArray()))
                                 .gas(ENOUGH_GAS_LIMIT_FOR_CREATION)
                                 .via(INNER_TXN)
-                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS))))
-                .then(getTxnRecord(INNER_TXN)
+                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS))),
+                getTxnRecord(INNER_TXN)
                         .hasPriority(recordWith()
                                 .status(INVALID_SOLIDITY_ADDRESS)
                                 .contractCallResult(resultWith().gasUsed(900000))));
@@ -236,11 +230,10 @@ public class Evm46ValidationSuite {
 
     @HapiTest
     final Stream<DynamicTest> selfdestructToNonExistingMirrorAddressResultsInInvalidSolidityAddress() {
-        return defaultHapiSpec("selfdestructToNonExistingMirrorAddressResultsInInvalidSolidityAddress")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         contractCall(
                                         INTERNAL_CALLER_CONTRACT,
@@ -248,8 +241,8 @@ public class Evm46ValidationSuite {
                                         mirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM))
                                 .gas(ENOUGH_GAS_LIMIT_FOR_CREATION)
                                 .via(INNER_TXN)
-                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS))))
-                .then(getTxnRecord(INNER_TXN)
+                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS))),
+                getTxnRecord(INNER_TXN)
                         .hasPriority(recordWith()
                                 .status(INVALID_SOLIDITY_ADDRESS)
                                 .contractCallResult(resultWith().gasUsed(900000))));
@@ -258,12 +251,12 @@ public class Evm46ValidationSuite {
     @HapiTest
     final Stream<DynamicTest> directCallToNonExistingMirrorAddressResultsInSuccessfulNoOp() {
 
-        return defaultHapiSpec("directCallToNonExistingMirrorAddressResultsInSuccessfulNoOp")
-                .given(withOpContext((spec, ctxLog) -> spec.registry()
+        return hapiTest(
+                withOpContext((spec, ctxLog) -> spec.registry()
                         .saveContractId(
                                 "nonExistingMirrorAddress",
-                                asContractIdWithEvmAddress(ByteString.copyFrom(unhex(NON_EXISTING_MIRROR_ADDRESS))))))
-                .when(withOpContext((spec, ctxLog) -> allRunFor(
+                                asContractIdWithEvmAddress(ByteString.copyFrom(unhex(NON_EXISTING_MIRROR_ADDRESS))))),
+                withOpContext((spec, ctxLog) -> allRunFor(
                         spec,
                         contractCallWithFunctionAbi("nonExistingMirrorAddress", getABIFor(FUNCTION, NAME, ERC_721_ABI))
                                 .gas(GAS_LIMIT_FOR_CALL)
@@ -271,31 +264,30 @@ public class Evm46ValidationSuite {
                         // attempt call again, make sure the result is the same
                         contractCallWithFunctionAbi("nonExistingMirrorAddress", getABIFor(FUNCTION, NAME, ERC_721_ABI))
                                 .gas(GAS_LIMIT_FOR_CALL)
-                                .via("directCallToNonExistingMirrorAddress2"))))
-                .then(
-                        getTxnRecord("directCallToNonExistingMirrorAddress")
-                                .hasPriority(recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
-                        getTxnRecord("directCallToNonExistingMirrorAddress2")
-                                .hasPriority(recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
-                        getContractInfo("nonExistingMirrorAddress").hasCostAnswerPrecheck(INVALID_CONTRACT_ID));
+                                .via("directCallToNonExistingMirrorAddress2"))),
+                getTxnRecord("directCallToNonExistingMirrorAddress")
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(
+                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
+                getTxnRecord("directCallToNonExistingMirrorAddress2")
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(
+                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
+                getContractInfo("nonExistingMirrorAddress").hasCostAnswerPrecheck(INVALID_CONTRACT_ID));
     }
 
     @HapiTest
     final Stream<DynamicTest> directCallToNonExistingNonMirrorAddressResultsInSuccessfulNoOp() {
 
-        return defaultHapiSpec("directCallToNonExistingNonMirrorAddressResultsInSuccessfulNoOp")
-                .given(withOpContext((spec, ctxLog) -> spec.registry()
+        return hapiTest(
+                withOpContext((spec, ctxLog) -> spec.registry()
                         .saveContractId(
                                 "nonExistingNonMirrorAddress",
                                 asContractIdWithEvmAddress(
-                                        ByteString.copyFrom(unhex(NON_EXISTING_NON_MIRROR_ADDRESS))))))
-                .when(withOpContext((spec, ctxLog) -> allRunFor(
+                                        ByteString.copyFrom(unhex(NON_EXISTING_NON_MIRROR_ADDRESS))))),
+                withOpContext((spec, ctxLog) -> allRunFor(
                         spec,
                         contractCallWithFunctionAbi(
                                         "nonExistingNonMirrorAddress", getABIFor(FUNCTION, NAME, ERC_721_ABI))
@@ -305,33 +297,33 @@ public class Evm46ValidationSuite {
                         contractCallWithFunctionAbi(
                                         "nonExistingNonMirrorAddress", getABIFor(FUNCTION, NAME, ERC_721_ABI))
                                 .gas(GAS_LIMIT_FOR_CALL)
-                                .via("directCallToNonExistingNonMirrorAddress2"))))
-                .then(
-                        getTxnRecord("directCallToNonExistingNonMirrorAddress")
-                                .hasPriority(recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
-                        getTxnRecord("directCallToNonExistingNonMirrorAddress2")
-                                .hasPriority(recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
-                        getContractInfo("nonExistingNonMirrorAddress").hasCostAnswerPrecheck(INVALID_CONTRACT_ID));
+                                .via("directCallToNonExistingNonMirrorAddress2"))),
+                getTxnRecord("directCallToNonExistingNonMirrorAddress")
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(
+                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
+                getTxnRecord("directCallToNonExistingNonMirrorAddress2")
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(
+                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
+                getContractInfo("nonExistingNonMirrorAddress").hasCostAnswerPrecheck(INVALID_CONTRACT_ID));
     }
 
     @HapiTest
     final Stream<DynamicTest> directCallToRevertingContractRevertsWithCorrectRevertReason() {
 
-        return defaultHapiSpec("directCallToRevertingContractRevertsWithCorrectRevertReason")
-                .given(uploadInitCode(INTERNAL_CALLEE_CONTRACT), contractCreate(INTERNAL_CALLEE_CONTRACT))
-                .when(withOpContext((spec, ctxLog) -> allRunFor(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLEE_CONTRACT),
+                contractCreate(INTERNAL_CALLEE_CONTRACT),
+                withOpContext((spec, ctxLog) -> allRunFor(
                         spec,
                         contractCall(INTERNAL_CALLEE_CONTRACT, REVERT_WITH_REVERT_REASON_FUNCTION)
                                 .gas(GAS_LIMIT_FOR_CALL)
                                 .via(INNER_TXN)
-                                .hasKnownStatusFrom(CONTRACT_REVERT_EXECUTED))))
-                .then(getTxnRecord(INNER_TXN)
+                                .hasKnownStatusFrom(CONTRACT_REVERT_EXECUTED))),
+                getTxnRecord(INNER_TXN)
                         .hasPriority(recordWith()
                                 .status(CONTRACT_REVERT_EXECUTED)
                                 .contractCallResult(resultWith()
@@ -346,47 +338,42 @@ public class Evm46ValidationSuite {
 
         AtomicReference<AccountID> mirrorAccountID = new AtomicReference<>();
 
-        return defaultHapiSpec("directCallToExistingCryptoAccountResultsInSuccess")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoCreate("MirrorAccount")
-                                .balance(ONE_HUNDRED_HBARS)
-                                .exposingCreatedIdTo(mirrorAccountID::set),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
-                        withOpContext((spec, opLog) -> {
-                            spec.registry()
-                                    .saveContractId(
-                                            "mirrorAddress",
-                                            asContract("0.0."
-                                                    + mirrorAccountID.get().getAccountNum()));
-                            updateSpecFor(spec, ECDSA_KEY);
-                            spec.registry()
-                                    .saveContractId(
-                                            "nonMirrorAddress",
-                                            asContract("0.0."
-                                                    + spec.registry()
-                                                            .getAccountID(ECDSA_KEY)
-                                                            .getAccountNum()));
-                        }))
-                .when(withOpContext((spec, ctxLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate("MirrorAccount").balance(ONE_HUNDRED_HBARS).exposingCreatedIdTo(mirrorAccountID::set),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> {
+                    spec.registry()
+                            .saveContractId(
+                                    "mirrorAddress",
+                                    asContract("0.0." + mirrorAccountID.get().getAccountNum()));
+                    updateSpecFor(spec, ECDSA_KEY);
+                    spec.registry()
+                            .saveContractId(
+                                    "nonMirrorAddress",
+                                    asContract("0.0."
+                                            + spec.registry()
+                                                    .getAccountID(ECDSA_KEY)
+                                                    .getAccountNum()));
+                }),
+                withOpContext((spec, ctxLog) -> allRunFor(
                         spec,
                         contractCallWithFunctionAbi("mirrorAddress", getABIFor(FUNCTION, NAME, ERC_721_ABI))
                                 .gas(GAS_LIMIT_FOR_CALL)
                                 .via("callToMirrorAddress"),
                         contractCallWithFunctionAbi("nonMirrorAddress", getABIFor(FUNCTION, NAME, ERC_721_ABI))
                                 .gas(GAS_LIMIT_FOR_CALL)
-                                .via("callToNonMirrorAddress"))))
-                .then(
-                        getTxnRecord("callToMirrorAddress")
-                                .hasPriority(recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
-                        getTxnRecord("callToNonMirrorAddress")
-                                .hasPriority(recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))));
+                                .via("callToNonMirrorAddress"))),
+                getTxnRecord("callToMirrorAddress")
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(
+                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
+                getTxnRecord("callToNonMirrorAddress")
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(
+                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))));
     }
 
     @HapiTest
@@ -394,41 +381,37 @@ public class Evm46ValidationSuite {
 
         AtomicReference<AccountID> mirrorAccountID = new AtomicReference<>();
 
-        return defaultHapiSpec("directCallWithValueToExistingCryptoAccountResultsInSuccess")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoCreate("MirrorAccount")
-                                .balance(ONE_HUNDRED_HBARS)
-                                .exposingCreatedIdTo(mirrorAccountID::set),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
-                        withOpContext((spec, opLog) -> {
-                            spec.registry()
-                                    .saveContractId(
-                                            "mirrorAddress",
-                                            asContract("0.0."
-                                                    + mirrorAccountID.get().getAccountNum()));
-                            updateSpecFor(spec, ECDSA_KEY);
-                            final var ecdsaKey = spec.registry()
-                                    .getKey(ECDSA_KEY)
-                                    .getECDSASecp256K1()
-                                    .toByteArray();
-                            final var senderAddress = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKey));
-                            spec.registry()
-                                    .saveContractId(
-                                            "nonMirrorAddress",
-                                            ContractID.newBuilder()
-                                                    .setEvmAddress(senderAddress)
-                                                    .build());
-                            spec.registry()
-                                    .saveAccountId(
-                                            "NonMirrorAccount",
-                                            AccountID.newBuilder()
-                                                    .setAccountNum(spec.registry()
-                                                            .getAccountID(ECDSA_KEY)
-                                                            .getAccountNum())
-                                                    .build());
-                        }))
-                .when(withOpContext((spec, ctxLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate("MirrorAccount").balance(ONE_HUNDRED_HBARS).exposingCreatedIdTo(mirrorAccountID::set),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> {
+                    spec.registry()
+                            .saveContractId(
+                                    "mirrorAddress",
+                                    asContract("0.0." + mirrorAccountID.get().getAccountNum()));
+                    updateSpecFor(spec, ECDSA_KEY);
+                    final var ecdsaKey = spec.registry()
+                            .getKey(ECDSA_KEY)
+                            .getECDSASecp256K1()
+                            .toByteArray();
+                    final var senderAddress = ByteString.copyFrom(recoverAddressFromPubKey(ecdsaKey));
+                    spec.registry()
+                            .saveContractId(
+                                    "nonMirrorAddress",
+                                    ContractID.newBuilder()
+                                            .setEvmAddress(senderAddress)
+                                            .build());
+                    spec.registry()
+                            .saveAccountId(
+                                    "NonMirrorAccount",
+                                    AccountID.newBuilder()
+                                            .setAccountNum(spec.registry()
+                                                    .getAccountID(ECDSA_KEY)
+                                                    .getAccountNum())
+                                            .build());
+                }),
+                withOpContext((spec, ctxLog) -> allRunFor(
                         spec,
                         balanceSnapshot("mirrorSnapshot", "MirrorAccount"),
                         balanceSnapshot("nonMirrorSnapshot", "NonMirrorAccount"),
@@ -439,37 +422,34 @@ public class Evm46ValidationSuite {
                         contractCallWithFunctionAbi("nonMirrorAddress", getABIFor(FUNCTION, NAME, ERC_721_ABI))
                                 .sending(ONE_HBAR)
                                 .gas(GAS_LIMIT_FOR_CALL)
-                                .via("callToNonMirrorAddress"))))
-                .then(
-                        getTxnRecord("callToMirrorAddress")
-                                .hasPriority(recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
-                        getTxnRecord("callToNonMirrorAddress")
-                                .hasPriority(recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
-                        getAccountBalance("MirrorAccount").hasTinyBars(changeFromSnapshot("mirrorSnapshot", ONE_HBAR)),
-                        getAccountBalance("NonMirrorAccount")
-                                .hasTinyBars(changeFromSnapshot("nonMirrorSnapshot", ONE_HBAR)));
+                                .via("callToNonMirrorAddress"))),
+                getTxnRecord("callToMirrorAddress")
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(
+                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
+                getTxnRecord("callToNonMirrorAddress")
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(
+                                        resultWith().gasUsed(INTRINSIC_GAS_COST + EXTRA_GAS_FOR_FUNCTION_SELECTOR))),
+                getAccountBalance("MirrorAccount").hasTinyBars(changeFromSnapshot("mirrorSnapshot", ONE_HBAR)),
+                getAccountBalance("NonMirrorAccount").hasTinyBars(changeFromSnapshot("nonMirrorSnapshot", ONE_HBAR)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalCallToNonExistingMirrorAddressResultsInNoopSuccess() {
 
-        return defaultHapiSpec("internalCallToNonExistingMirrorAddressResultsInNoopSuccess")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCall(
                                 INTERNAL_CALLER_CONTRACT,
                                 CALL_NON_EXISTING_FUNCTION,
                                 mirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 1))
                         .gas(GAS_LIMIT_FOR_CALL)
-                        .via(INNER_TXN))
-                .then(getTxnRecord(INNER_TXN)
+                        .via(INNER_TXN),
+                getTxnRecord(INNER_TXN)
                         .hasPriority(recordWith()
                                 .status(SUCCESS)
                                 .contractCallResult(
@@ -481,23 +461,22 @@ public class Evm46ValidationSuite {
 
         final AtomicLong calleeNum = new AtomicLong();
 
-        return defaultHapiSpec("internalCallToExistingMirrorAddressResultsInSuccessfulCall")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT, INTERNAL_CALLEE_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT)
-                                .balance(ONE_HBAR)
-                                // Adding refusingEthConversion() due to fee differences and not supported address type
-                                .refusingEthConversion(),
-                        contractCreate(INTERNAL_CALLEE_CONTRACT)
-                                .exposingNumTo(calleeNum::set)
-                                // Adding refusingEthConversion() due to fee differences and not supported address type
-                                .refusingEthConversion())
-                .when(withOpContext((spec, ignored) -> allRunFor(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT, INTERNAL_CALLEE_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT)
+                        .balance(ONE_HBAR)
+                        // Adding refusingEthConversion() due to fee differences and not supported address type
+                        .refusingEthConversion(),
+                contractCreate(INTERNAL_CALLEE_CONTRACT)
+                        .exposingNumTo(calleeNum::set)
+                        // Adding refusingEthConversion() due to fee differences and not supported address type
+                        .refusingEthConversion(),
+                withOpContext((spec, ignored) -> allRunFor(
                         spec,
                         contractCall(INTERNAL_CALLER_CONTRACT, CALL_EXTERNAL_FUNCTION, mirrorAddrWith(calleeNum.get()))
                                 .gas(GAS_LIMIT_FOR_CALL * 2)
-                                .via(INNER_TXN))))
-                .then(getTxnRecord(INNER_TXN)
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN)
                         .hasPriority(recordWith()
                                 .status(SUCCESS)
                                 .contractCallResult(resultWith()
@@ -509,17 +488,16 @@ public class Evm46ValidationSuite {
     @HapiTest
     final Stream<DynamicTest> internalCallToNonExistingNonMirrorAddressResultsInNoopSuccess() {
 
-        return defaultHapiSpec("internalCallToNonExistingNonMirrorAddressResultsInNoopSuccess")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCall(
                                 INTERNAL_CALLER_CONTRACT,
                                 CALL_NON_EXISTING_FUNCTION,
                                 nonMirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 2))
                         .gas(GAS_LIMIT_FOR_CALL)
-                        .via(INNER_TXN))
-                .then(getTxnRecord(INNER_TXN)
+                        .via(INNER_TXN),
+                getTxnRecord(INNER_TXN)
                         .hasPriority(recordWith()
                                 .status(SUCCESS)
                                 .contractCallResult(
@@ -531,12 +509,11 @@ public class Evm46ValidationSuite {
 
         final AtomicLong calleeNum = new AtomicLong();
 
-        return defaultHapiSpec("internalCallToExistingRevertingWithoutMessageResultsInSuccessfulTopLevelTxn")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT, INTERNAL_CALLEE_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
-                        contractCreate(INTERNAL_CALLEE_CONTRACT).exposingNumTo(calleeNum::set))
-                .when(withOpContext((spec, ignored) -> allRunFor(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT, INTERNAL_CALLEE_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCreate(INTERNAL_CALLEE_CONTRACT).exposingNumTo(calleeNum::set),
+                withOpContext((spec, ignored) -> allRunFor(
                         spec,
                         contractCall(
                                         INTERNAL_CALLER_CONTRACT,
@@ -544,23 +521,22 @@ public class Evm46ValidationSuite {
                                         mirrorAddrWith(calleeNum.get()))
                                 .gas(GAS_LIMIT_FOR_CALL * 8)
                                 .hasKnownStatus(SUCCESS)
-                                .via(INNER_TXN))))
-                .then(getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalTransferToNonExistingMirrorAddressResultsInInvalidAliasKey() {
-        return defaultHapiSpec("internalTransferToNonExistingMirrorAddressResultsInInvalidAliasKey")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCall(
                                 INTERNAL_CALLER_CONTRACT,
                                 TRANSFER_TO_FUNCTION,
                                 mirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 3))
                         .gas(GAS_LIMIT_FOR_CALL * 4)
-                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED))
-                .then(getAccountBalance("0.0." + (FIRST_NONEXISTENT_CONTRACT_NUM + 3))
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                getAccountBalance("0.0." + (FIRST_NONEXISTENT_CONTRACT_NUM + 3))
                         .nodePayment(ONE_HBAR)
                         .hasAnswerOnlyPrecheck(INVALID_ACCOUNT_ID));
     }
@@ -570,12 +546,11 @@ public class Evm46ValidationSuite {
 
         AtomicReference<AccountID> receiverId = new AtomicReference<>();
 
-        return defaultHapiSpec("internalTransferToExistingMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("initialBalance", asAccountString(receiverId.get())),
                         contractCall(
@@ -583,43 +558,40 @@ public class Evm46ValidationSuite {
                                         TRANSFER_TO_FUNCTION,
                                         mirrorAddrWith(receiverId.get().getAccountNum()))
                                 .gas(GAS_LIMIT_FOR_CALL * 4)
-                                .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, RECEIVER, 1)))),
-                        getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 1)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(recordWith()
+                                .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, RECEIVER, 1)))),
+                getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 1)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalTransferToNonExistingNonMirrorAddressResultsInRevert() {
-        return defaultHapiSpec("internalTransferToNonExistingNonMirrorAddressResultsInRevert")
-                .given(
-                        cryptoCreate(CUSTOM_PAYER).balance(ONE_HUNDRED_HBARS),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(contractCall(
+        return hapiTest(
+                cryptoCreate(CUSTOM_PAYER).balance(ONE_HUNDRED_HBARS),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCall(
                                 INTERNAL_CALLER_CONTRACT,
                                 TRANSFER_TO_FUNCTION,
                                 nonMirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 4))
                         .gas(GAS_LIMIT_FOR_CALL * 4)
                         .payingWith(CUSTOM_PAYER)
                         .via(INNER_TXN)
-                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED))
-                .then(getTxnRecord(INNER_TXN).hasPriority(recordWith().status(CONTRACT_REVERT_EXECUTED)));
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                getTxnRecord(INNER_TXN).hasPriority(recordWith().status(CONTRACT_REVERT_EXECUTED)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalTransferToExistingNonMirrorAddressResultsInSuccess() {
 
-        return defaultHapiSpec("internalTransferToExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
-                        withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> {
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> {
                     final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
                     final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
                     final var addressBytes = recoverAddressFromPubKey(tmp);
@@ -632,28 +604,25 @@ public class Evm46ValidationSuite {
                                             asHeadlongAddress(addressBytes))
                                     .gas(GAS_LIMIT_FOR_CALL * 4)
                                     .via(INNER_TXN));
-                }))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, ECDSA_KEY, 1)))),
-                        getAutoCreatedAccountBalance(ECDSA_KEY)
-                                .hasTinyBars(changeFromSnapshot("autoCreatedSnapshot", 1)));
+                }),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(recordWith()
+                                .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, ECDSA_KEY, 1)))),
+                getAutoCreatedAccountBalance(ECDSA_KEY).hasTinyBars(changeFromSnapshot("autoCreatedSnapshot", 1)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalSendToNonExistingMirrorAddressDoesNotLazyCreateIt() {
-        return defaultHapiSpec("internalSendToNonExistingMirrorAddressDoesNotLazyCreateIt")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCall(
                                 INTERNAL_CALLER_CONTRACT,
                                 SEND_TO_FUNCTION,
                                 mirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 5))
                         .gas(GAS_LIMIT_FOR_CALL * 4)
-                        .via(INNER_TXN))
-                .then(getAccountBalance("0.0." + (FIRST_NONEXISTENT_CONTRACT_NUM + 5))
+                        .via(INNER_TXN),
+                getAccountBalance("0.0." + (FIRST_NONEXISTENT_CONTRACT_NUM + 5))
                         .nodePayment(ONE_HBAR)
                         .hasAnswerOnlyPrecheck(INVALID_ACCOUNT_ID));
     }
@@ -663,12 +632,11 @@ public class Evm46ValidationSuite {
 
         AtomicReference<AccountID> receiverId = new AtomicReference<>();
 
-        return defaultHapiSpec("internalSendToExistingMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("initialBalance", asAccountString(receiverId.get())),
                         contractCall(
@@ -676,12 +644,11 @@ public class Evm46ValidationSuite {
                                         SEND_TO_FUNCTION,
                                         mirrorAddrWith(receiverId.get().getAccountNum()))
                                 .gas(GAS_LIMIT_FOR_CALL * 4)
-                                .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, RECEIVER, 1)))),
-                        getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 1)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(recordWith()
+                                .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, RECEIVER, 1)))),
+                getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 1)));
     }
 
     @HapiTest
@@ -689,19 +656,18 @@ public class Evm46ValidationSuite {
 
         AtomicReference<Bytes> nonExistingNonMirrorAddress = new AtomicReference<>();
 
-        return defaultHapiSpec("internalSendToNonExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(CUSTOM_PAYER).balance(ONE_HUNDRED_HBARS),
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        withOpContext((spec, op) -> {
-                            final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
-                            final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
-                            final var addressBytes = recoverAddressFromPubKey(tmp);
-                            nonExistingNonMirrorAddress.set(Bytes.of(addressBytes));
-                        }),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(CUSTOM_PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                withOpContext((spec, op) -> {
+                    final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
+                    final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
+                    final var addressBytes = recoverAddressFromPubKey(tmp);
+                    nonExistingNonMirrorAddress.set(Bytes.of(addressBytes));
+                }),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("contractBalance", INTERNAL_CALLER_CONTRACT),
                         contractCall(
@@ -711,26 +677,23 @@ public class Evm46ValidationSuite {
                                                 .get()
                                                 .toArray()))
                                 .gas(GAS_LIMIT_FOR_CALL * 4)
-                                .payingWith(CUSTOM_PAYER))))
-                .then(
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("contractBalance", 0)),
-                        sourcing(() -> getAliasedAccountInfo(ByteString.copyFrom(
-                                        nonExistingNonMirrorAddress.get().toArray()))
-                                .hasCostAnswerPrecheck(INVALID_ACCOUNT_ID)));
+                                .payingWith(CUSTOM_PAYER))),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("contractBalance", 0)),
+                sourcing(() -> getAliasedAccountInfo(ByteString.copyFrom(
+                                nonExistingNonMirrorAddress.get().toArray()))
+                        .hasCostAnswerPrecheck(INVALID_ACCOUNT_ID)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalSendToExistingNonMirrorAddressResultsInSuccess() {
 
-        return defaultHapiSpec("internalSendToExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
-                        withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> {
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> {
                     final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
                     final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
                     final var addressBytes = recoverAddressFromPubKey(tmp);
@@ -740,27 +703,24 @@ public class Evm46ValidationSuite {
                             contractCall(INTERNAL_CALLER_CONTRACT, SEND_TO_FUNCTION, asHeadlongAddress(addressBytes))
                                     .gas(GAS_LIMIT_FOR_CALL * 4)
                                     .via(INNER_TXN));
-                }))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, ECDSA_KEY, 1)))),
-                        getAutoCreatedAccountBalance(ECDSA_KEY)
-                                .hasTinyBars(changeFromSnapshot("autoCreatedSnapshot", 1)));
+                }),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(recordWith()
+                                .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, ECDSA_KEY, 1)))),
+                getAutoCreatedAccountBalance(ECDSA_KEY).hasTinyBars(changeFromSnapshot("autoCreatedSnapshot", 1)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalCallWithValueToNonExistingMirrorAddressResultsInInvalidAliasKey() {
-        return defaultHapiSpec("internalCallWithValueToNonExistingMirrorAddressResultsInInvalidAliasKey")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCall(
                                 INTERNAL_CALLER_CONTRACT,
                                 CALL_WITH_VALUE_TO_FUNCTION,
                                 mirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 6))
-                        .gas(ENOUGH_GAS_LIMIT_FOR_CREATION))
-                .then(getAccountBalance("0.0." + (FIRST_NONEXISTENT_CONTRACT_NUM + 6))
+                        .gas(ENOUGH_GAS_LIMIT_FOR_CREATION),
+                getAccountBalance("0.0." + (FIRST_NONEXISTENT_CONTRACT_NUM + 6))
                         .nodePayment(ONE_HBAR)
                         .hasAnswerOnlyPrecheck(INVALID_ACCOUNT_ID));
     }
@@ -770,12 +730,11 @@ public class Evm46ValidationSuite {
 
         AtomicReference<AccountID> receiverId = new AtomicReference<>();
 
-        return defaultHapiSpec("internalCallWithValueToExistingMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("initialBalance", asAccountString(receiverId.get())),
                         contractCall(
@@ -783,12 +742,11 @@ public class Evm46ValidationSuite {
                                         CALL_WITH_VALUE_TO_FUNCTION,
                                         mirrorAddrWith(receiverId.get().getAccountNum()))
                                 .gas(GAS_LIMIT_FOR_CALL * 4)
-                                .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, RECEIVER, 1)))),
-                        getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 1)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(recordWith()
+                                .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, RECEIVER, 1)))),
+                getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 1)));
     }
 
     @HapiTest
@@ -844,14 +802,13 @@ public class Evm46ValidationSuite {
     @HapiTest
     final Stream<DynamicTest> internalCallWithValueToExistingNonMirrorAddressResultsInSuccess() {
 
-        return defaultHapiSpec("internalCallWithValueToExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
-                        withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> {
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> {
                     final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
                     final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
                     final var addressBytes = recoverAddressFromPubKey(tmp);
@@ -864,40 +821,37 @@ public class Evm46ValidationSuite {
                                             asHeadlongAddress(addressBytes))
                                     .gas(GAS_LIMIT_FOR_CALL * 4)
                                     .via(INNER_TXN));
-                }))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, ECDSA_KEY, 1)))),
-                        getAutoCreatedAccountBalance(ECDSA_KEY)
-                                .hasTinyBars(changeFromSnapshot("autoCreatedSnapshot", 1)));
+                }),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(recordWith()
+                                .transfers(including(tinyBarsFromTo(INTERNAL_CALLER_CONTRACT, ECDSA_KEY, 1)))),
+                getAutoCreatedAccountBalance(ECDSA_KEY).hasTinyBars(changeFromSnapshot("autoCreatedSnapshot", 1)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalCallToDeletedContractReturnsSuccessfulNoop() {
         final AtomicLong calleeNum = new AtomicLong();
-        return defaultHapiSpec("internalCallToDeletedContractReturnsSuccessfulNoop")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT, INTERNAL_CALLEE_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT)
-                                // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
-                                // tokenAssociate,
-                                // since we have CONTRACT_ID key
-                                .refusingEthConversion()
-                                .balance(ONE_HBAR),
-                        contractCreate(INTERNAL_CALLEE_CONTRACT)
-                                // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
-                                // tokenAssociate,
-                                // since we have CONTRACT_ID key
-                                .refusingEthConversion()
-                                .exposingNumTo(calleeNum::set),
-                        contractDelete(INTERNAL_CALLEE_CONTRACT))
-                .when(withOpContext((spec, ignored) -> allRunFor(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT, INTERNAL_CALLEE_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT)
+                        // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
+                        // tokenAssociate,
+                        // since we have CONTRACT_ID key
+                        .refusingEthConversion()
+                        .balance(ONE_HBAR),
+                contractCreate(INTERNAL_CALLEE_CONTRACT)
+                        // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
+                        // tokenAssociate,
+                        // since we have CONTRACT_ID key
+                        .refusingEthConversion()
+                        .exposingNumTo(calleeNum::set),
+                contractDelete(INTERNAL_CALLEE_CONTRACT),
+                withOpContext((spec, ignored) -> allRunFor(
                         spec,
                         contractCall(INTERNAL_CALLER_CONTRACT, CALL_EXTERNAL_FUNCTION, mirrorAddrWith(calleeNum.get()))
                                 .gas(50_000L)
-                                .via(INNER_TXN))))
-                .then(withOpContext((spec, opLog) -> {
+                                .via(INNER_TXN))),
+                withOpContext((spec, opLog) -> {
                     final var lookup = getTxnRecord(INNER_TXN);
                     allRunFor(spec, lookup);
                     final var result =
@@ -909,38 +863,35 @@ public class Evm46ValidationSuite {
     @HapiTest
     final Stream<DynamicTest> callingDestructedContractReturnsStatusSuccess() {
         final AtomicReference<AccountID> accountIDAtomicReference = new AtomicReference<>();
-        return defaultHapiSpec("callingDestructedContractReturnsStatusSuccess")
-                .given(
-                        cryptoCreate(BENEFICIARY).exposingCreatedIdTo(accountIDAtomicReference::set),
-                        uploadInitCode(SIMPLE_UPDATE_CONTRACT))
-                .when(
-                        contractCreate(SIMPLE_UPDATE_CONTRACT).gas(300_000L),
-                        contractCall(SIMPLE_UPDATE_CONTRACT, "set", BigInteger.valueOf(5), BigInteger.valueOf(42))
-                                .gas(300_000L),
-                        sourcing(() -> contractCall(
-                                        SIMPLE_UPDATE_CONTRACT,
-                                        "del",
-                                        asHeadlongAddress(asAddress(accountIDAtomicReference.get())))
-                                .gas(1_000_000L)))
-                .then(contractCall(SIMPLE_UPDATE_CONTRACT, "set", BigInteger.valueOf(15), BigInteger.valueOf(434))
+        return hapiTest(
+                cryptoCreate(BENEFICIARY).exposingCreatedIdTo(accountIDAtomicReference::set),
+                uploadInitCode(SIMPLE_UPDATE_CONTRACT),
+                contractCreate(SIMPLE_UPDATE_CONTRACT).gas(300_000L),
+                contractCall(SIMPLE_UPDATE_CONTRACT, "set", BigInteger.valueOf(5), BigInteger.valueOf(42))
+                        .gas(300_000L),
+                sourcing(() -> contractCall(
+                                SIMPLE_UPDATE_CONTRACT,
+                                "del",
+                                asHeadlongAddress(asAddress(accountIDAtomicReference.get())))
+                        .gas(1_000_000L)),
+                contractCall(SIMPLE_UPDATE_CONTRACT, "set", BigInteger.valueOf(15), BigInteger.valueOf(434))
                         .gas(350_000L)
                         .hasKnownStatus(SUCCESS));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalStaticCallNonExistingMirrorAddressResultsInSuccess() {
-        return defaultHapiSpec("internalStaticCallNonExistingMirrorAddressResultsInSuccess")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCall(
                                 INTERNAL_CALLER_CONTRACT,
                                 STATIC_CALL_EXTERNAL_FUNCTION,
                                 mirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 9))
                         .gas(GAS_LIMIT_FOR_CALL)
                         .via(INNER_TXN)
-                        .hasKnownStatus(SUCCESS))
-                .then(getTxnRecord(INNER_TXN)
+                        .hasKnownStatus(SUCCESS),
+                getTxnRecord(INNER_TXN)
                         .logged()
                         .hasPriority(
                                 recordWith().contractCallResult(resultWith().contractCallResult(bigIntResult(0)))));
@@ -949,12 +900,11 @@ public class Evm46ValidationSuite {
     @HapiTest
     final Stream<DynamicTest> internalStaticCallExistingMirrorAddressResultsInSuccess() {
         AtomicReference<AccountID> receiverId = new AtomicReference<>();
-        return defaultHapiSpec("internalStaticCallExistingMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("initialBalance", asAccountString(receiverId.get())),
                         contractCall(
@@ -962,30 +912,28 @@ public class Evm46ValidationSuite {
                                         STATIC_CALL_EXTERNAL_FUNCTION,
                                         mirrorAddrWith(receiverId.get().getAccountNum()))
                                 .gas(GAS_LIMIT_FOR_CALL)
-                                .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
-                        getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(
+                                recordWith().contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
+                getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalStaticCallNonExistingNonMirrorAddressResultsInSuccess() {
         AtomicReference<Bytes> nonExistingNonMirrorAddress = new AtomicReference<>();
-        return defaultHapiSpec("internalStaticCallNonExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(CUSTOM_PAYER).balance(ONE_HUNDRED_HBARS),
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        withOpContext((spec, op) -> {
-                            final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
-                            final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
-                            final var addressBytes = recoverAddressFromPubKey(tmp);
-                            nonExistingNonMirrorAddress.set(Bytes.of(addressBytes));
-                        }),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(CUSTOM_PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                withOpContext((spec, op) -> {
+                    final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
+                    final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
+                    final var addressBytes = recoverAddressFromPubKey(tmp);
+                    nonExistingNonMirrorAddress.set(Bytes.of(addressBytes));
+                }),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("contractBalance", INTERNAL_CALLER_CONTRACT),
                         contractCall(
@@ -996,25 +944,22 @@ public class Evm46ValidationSuite {
                                                 .toArray()))
                                 .gas(GAS_LIMIT_FOR_CALL)
                                 .payingWith(CUSTOM_PAYER)
-                                .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("contractBalance", 0)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(
+                                recordWith().contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("contractBalance", 0)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalStaticCallExistingNonMirrorAddressResultsInSuccess() {
-        return defaultHapiSpec("internalStaticCallExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
-                        withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> {
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> {
                     final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
                     final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
                     final var addressBytes = recoverAddressFromPubKey(tmp);
@@ -1027,28 +972,26 @@ public class Evm46ValidationSuite {
                                             asHeadlongAddress(addressBytes))
                                     .gas(GAS_LIMIT_FOR_CALL)
                                     .via(INNER_TXN));
-                }))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
-                        getAutoCreatedAccountBalance(ECDSA_KEY).hasTinyBars(changeFromSnapshot("targetSnapshot", 0)));
+                }),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(
+                                recordWith().contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
+                getAutoCreatedAccountBalance(ECDSA_KEY).hasTinyBars(changeFromSnapshot("targetSnapshot", 0)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalDelegateCallNonExistingMirrorAddressResultsInSuccess() {
-        return defaultHapiSpec("internalDelegateCallNonExistingMirrorAddressResultsInSuccess")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                contractCall(
                                 INTERNAL_CALLER_CONTRACT,
                                 DELEGATE_CALL_EXTERNAL_FUNCTION,
                                 mirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 10))
                         .gas(GAS_LIMIT_FOR_CALL)
                         .via(INNER_TXN)
-                        .hasKnownStatus(SUCCESS))
-                .then(getTxnRecord(INNER_TXN)
+                        .hasKnownStatus(SUCCESS),
+                getTxnRecord(INNER_TXN)
                         .logged()
                         .hasPriority(
                                 recordWith().contractCallResult(resultWith().contractCallResult(bigIntResult(0)))));
@@ -1057,12 +1000,11 @@ public class Evm46ValidationSuite {
     @HapiTest
     final Stream<DynamicTest> internalDelegateCallExistingMirrorAddressResultsInSuccess() {
         AtomicReference<AccountID> receiverId = new AtomicReference<>();
-        return defaultHapiSpec("internalDelegateCallExistingMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(RECEIVER).exposingCreatedIdTo(receiverId::set),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("initialBalance", asAccountString(receiverId.get())),
                         contractCall(
@@ -1070,30 +1012,28 @@ public class Evm46ValidationSuite {
                                         DELEGATE_CALL_EXTERNAL_FUNCTION,
                                         mirrorAddrWith(receiverId.get().getAccountNum()))
                                 .gas(GAS_LIMIT_FOR_CALL)
-                                .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
-                        getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(
+                                recordWith().contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
+                getAccountBalance(RECEIVER).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalDelegateCallNonExistingNonMirrorAddressResultsInSuccess() {
         AtomicReference<Bytes> nonExistingNonMirrorAddress = new AtomicReference<>();
-        return defaultHapiSpec("internalDelegateCallNonExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        cryptoCreate(CUSTOM_PAYER).balance(ONE_HUNDRED_HBARS),
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        withOpContext((spec, op) -> {
-                            final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
-                            final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
-                            final var addressBytes = recoverAddressFromPubKey(tmp);
-                            nonExistingNonMirrorAddress.set(Bytes.of(addressBytes));
-                        }),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(CUSTOM_PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                withOpContext((spec, op) -> {
+                    final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
+                    final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
+                    final var addressBytes = recoverAddressFromPubKey(tmp);
+                    nonExistingNonMirrorAddress.set(Bytes.of(addressBytes));
+                }),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("contractBalance", INTERNAL_CALLER_CONTRACT),
                         contractCall(
@@ -1104,25 +1044,22 @@ public class Evm46ValidationSuite {
                                                 .toArray()))
                                 .gas(GAS_LIMIT_FOR_CALL)
                                 .payingWith(CUSTOM_PAYER)
-                                .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("contractBalance", 0)));
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(
+                                recordWith().contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("contractBalance", 0)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalDelegateCallExistingNonMirrorAddressResultsInSuccess() {
-        return defaultHapiSpec("internalDelegateCallExistingNonMirrorAddressResultsInSuccess")
-                .given(
-                        newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
-                        withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> {
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, ECDSA_KEY)),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> {
                     final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
                     final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
                     final var addressBytes = recoverAddressFromPubKey(tmp);
@@ -1135,24 +1072,22 @@ public class Evm46ValidationSuite {
                                             asHeadlongAddress(addressBytes))
                                     .gas(GAS_LIMIT_FOR_CALL)
                                     .via(INNER_TXN));
-                }))
-                .then(
-                        getTxnRecord(INNER_TXN)
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
-                        getAutoCreatedAccountBalance(ECDSA_KEY).hasTinyBars(changeFromSnapshot("targetSnapshot", 0)));
+                }),
+                getTxnRecord(INNER_TXN)
+                        .hasPriority(
+                                recordWith().contractCallResult(resultWith().contractCallResult(bigIntResult(0)))),
+                getAutoCreatedAccountBalance(ECDSA_KEY).hasTinyBars(changeFromSnapshot("targetSnapshot", 0)));
     }
 
     @HapiTest
     final Stream<DynamicTest> internalCallWithValueToAccountWithReceiverSigRequiredTrue() {
         AtomicReference<AccountID> receiverId = new AtomicReference<>();
 
-        return defaultHapiSpec("internalCallWithValueToAccountWithReceiverSigRequiredTrue")
-                .given(
-                        cryptoCreate(RECEIVER).receiverSigRequired(true).exposingCreatedIdTo(receiverId::set),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(withOpContext((spec, op) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(RECEIVER).receiverSigRequired(true).exposingCreatedIdTo(receiverId::set),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                withOpContext((spec, op) -> allRunFor(
                         spec,
                         balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
                         contractCall(
@@ -1161,11 +1096,9 @@ public class Evm46ValidationSuite {
                                         mirrorAddrWith(receiverId.get().getAccountNum()))
                                 .gas(GAS_LIMIT_FOR_CALL * 4)
                                 .via(INNER_TXN)
-                                .hasKnownStatus(INVALID_SIGNATURE))))
-                .then(
-                        getTxnRecord(INNER_TXN).hasPriority(recordWith().status(INVALID_SIGNATURE)),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+                                .hasKnownStatus(INVALID_SIGNATURE))),
+                getTxnRecord(INNER_TXN).hasPriority(recordWith().status(INVALID_SIGNATURE)),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
@@ -1173,24 +1106,20 @@ public class Evm46ValidationSuite {
         AtomicReference<AccountID> targetId = new AtomicReference<>();
         targetId.set(AccountID.newBuilder().setAccountNum(564L).build());
 
-        return defaultHapiSpec("internalCallToSystemAccount564ResultsInSuccessNoop")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
-                        withOpContext((spec, op) -> allRunFor(
-                                spec,
-                                contractCall(
-                                                INTERNAL_CALLER_CONTRACT,
-                                                CALL_EXTERNAL_FUNCTION,
-                                                mirrorAddrWith(targetId.get().getAccountNum()))
-                                        .gas(GAS_LIMIT_FOR_CALL * 4)
-                                        .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        INTERNAL_CALLER_CONTRACT,
+                                        CALL_EXTERNAL_FUNCTION,
+                                        mirrorAddrWith(targetId.get().getAccountNum()))
+                                .gas(GAS_LIMIT_FOR_CALL * 4)
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
@@ -1239,31 +1168,26 @@ public class Evm46ValidationSuite {
         AtomicReference<AccountID> targetId = new AtomicReference<>();
         targetId.set(AccountID.newBuilder().setAccountNum(2L).build());
 
-        return defaultHapiSpec("internalCallToEthereumPrecompile0x2ResultsInSuccess")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
-                        withOpContext((spec, op) -> allRunFor(
-                                spec,
-                                contractCall(
-                                                INTERNAL_CALLER_CONTRACT,
-                                                CALL_EXTERNAL_FUNCTION,
-                                                mirrorAddrWith(targetId.get().getAccountNum()))
-                                        .gas(GAS_LIMIT_FOR_CALL * 4)
-                                        .via(INNER_TXN))))
-                .then(
-                        withOpContext((spec, opLog) -> {
-                            final var lookup = getTxnRecord(INNER_TXN);
-                            allRunFor(spec, lookup);
-                            final var result = lookup.getResponseRecord()
-                                    .getContractCallResult()
-                                    .getContractCallResult();
-                            assertNotEquals(ByteString.copyFrom(new byte[32]), result);
-                        }),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        INTERNAL_CALLER_CONTRACT,
+                                        CALL_EXTERNAL_FUNCTION,
+                                        mirrorAddrWith(targetId.get().getAccountNum()))
+                                .gas(GAS_LIMIT_FOR_CALL * 4)
+                                .via(INNER_TXN))),
+                withOpContext((spec, opLog) -> {
+                    final var lookup = getTxnRecord(INNER_TXN);
+                    allRunFor(spec, lookup);
+                    final var result =
+                            lookup.getResponseRecord().getContractCallResult().getContractCallResult();
+                    assertNotEquals(ByteString.copyFrom(new byte[32]), result);
+                }),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
@@ -1271,22 +1195,20 @@ public class Evm46ValidationSuite {
         AtomicReference<AccountID> targetId = new AtomicReference<>();
         targetId.set(AccountID.newBuilder().setAccountNum(2L).build());
 
-        return defaultHapiSpec("internalCallWithValueToEthereumPrecompile0x2ResultsInRevert")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
-                        withOpContext((spec, op) -> allRunFor(
-                                spec,
-                                contractCall(
-                                                INTERNAL_CALLER_CONTRACT,
-                                                CALL_WITH_VALUE_TO_FUNCTION,
-                                                mirrorAddrWith(targetId.get().getAccountNum()))
-                                        .gas(GAS_LIMIT_FOR_CALL * 4)
-                                        .via(INNER_TXN)
-                                        .hasKnownStatus(INVALID_CONTRACT_ID))))
-                .then(getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        INTERNAL_CALLER_CONTRACT,
+                                        CALL_WITH_VALUE_TO_FUNCTION,
+                                        mirrorAddrWith(targetId.get().getAccountNum()))
+                                .gas(GAS_LIMIT_FOR_CALL * 4)
+                                .via(INNER_TXN)
+                                .hasKnownStatus(INVALID_CONTRACT_ID))),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
@@ -1294,24 +1216,20 @@ public class Evm46ValidationSuite {
         AtomicReference<AccountID> targetId = new AtomicReference<>();
         targetId.set(AccountID.newBuilder().setAccountNum(852L).build());
 
-        return defaultHapiSpec("internalCallToNonExistingSystemAccount852ResultsInSuccessNoop")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
-                        withOpContext((spec, op) -> allRunFor(
-                                spec,
-                                contractCall(
-                                                INTERNAL_CALLER_CONTRACT,
-                                                CALL_EXTERNAL_FUNCTION,
-                                                mirrorAddrWith(targetId.get().getAccountNum()))
-                                        .gas(GAS_LIMIT_FOR_CALL * 4)
-                                        .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        INTERNAL_CALLER_CONTRACT,
+                                        CALL_EXTERNAL_FUNCTION,
+                                        mirrorAddrWith(targetId.get().getAccountNum()))
+                                .gas(GAS_LIMIT_FOR_CALL * 4)
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
@@ -1320,23 +1238,19 @@ public class Evm46ValidationSuite {
         final var systemAccountNum = 852L;
         targetId.set(AccountID.newBuilder().setAccountNum(systemAccountNum).build());
 
-        return defaultHapiSpec("internalCallWithValueToNonExistingSystemAccount852ResultsInInvalidAliasKey")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
-                        withOpContext((spec, op) -> allRunFor(
-                                spec,
-                                contractCall(
-                                                INTERNAL_CALLER_CONTRACT,
-                                                CALL_WITH_VALUE_TO_FUNCTION,
-                                                mirrorAddrWith(targetId.get().getAccountNum()))
-                                        .gas(GAS_LIMIT_FOR_CALL * 4))))
-                .then(
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("initialBalance", 0)),
-                        getAccountBalance("0.0." + systemAccountNum).hasAnswerOnlyPrecheck(INVALID_ACCOUNT_ID));
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        INTERNAL_CALLER_CONTRACT,
+                                        CALL_WITH_VALUE_TO_FUNCTION,
+                                        mirrorAddrWith(targetId.get().getAccountNum()))
+                                .gas(GAS_LIMIT_FOR_CALL * 4))),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)),
+                getAccountBalance("0.0." + systemAccountNum).hasAnswerOnlyPrecheck(INVALID_ACCOUNT_ID));
     }
 
     @HapiTest
@@ -1344,22 +1258,20 @@ public class Evm46ValidationSuite {
         AtomicReference<AccountID> targetId = new AtomicReference<>();
         targetId.set(AccountID.newBuilder().setAccountNum(564L).build());
 
-        return defaultHapiSpec("internalCallWithValueToSystemAccount564ResultsInSuccessNoopNoTransfer")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
-                        withOpContext((spec, op) -> allRunFor(
-                                spec,
-                                contractCall(
-                                                INTERNAL_CALLER_CONTRACT,
-                                                CALL_WITH_VALUE_TO_FUNCTION,
-                                                mirrorAddrWith(targetId.get().getAccountNum()))
-                                        .gas(GAS_LIMIT_FOR_CALL * 4)
-                                        .via(INNER_TXN)
-                                        .hasKnownStatus(INVALID_CONTRACT_ID))))
-                .then(getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        INTERNAL_CALLER_CONTRACT,
+                                        CALL_WITH_VALUE_TO_FUNCTION,
+                                        mirrorAddrWith(targetId.get().getAccountNum()))
+                                .gas(GAS_LIMIT_FOR_CALL * 4)
+                                .via(INNER_TXN)
+                                .hasKnownStatus(INVALID_CONTRACT_ID))),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
@@ -1367,24 +1279,20 @@ public class Evm46ValidationSuite {
         AtomicReference<AccountID> targetId = new AtomicReference<>();
         targetId.set(AccountID.newBuilder().setAccountNum(800L).build());
 
-        return defaultHapiSpec("internalCallWithValueToExistingSystemAccount800ResultsInSuccessfulTransfer")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
-                        withOpContext((spec, op) -> allRunFor(
-                                spec,
-                                contractCall(
-                                                INTERNAL_CALLER_CONTRACT,
-                                                CALL_WITH_VALUE_TO_FUNCTION,
-                                                mirrorAddrWith(targetId.get().getAccountNum()))
-                                        .gas(GAS_LIMIT_FOR_CALL * 4)
-                                        .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("initialBalance", -1)));
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        INTERNAL_CALLER_CONTRACT,
+                                        CALL_WITH_VALUE_TO_FUNCTION,
+                                        mirrorAddrWith(targetId.get().getAccountNum()))
+                                .gas(GAS_LIMIT_FOR_CALL * 4)
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", -1)));
     }
 
     @HapiTest
@@ -1392,24 +1300,20 @@ public class Evm46ValidationSuite {
         AtomicReference<AccountID> targetId = new AtomicReference<>();
         targetId.set(AccountID.newBuilder().setAccountNum(800L).build());
 
-        return defaultHapiSpec("internalCallToExistingSystemAccount800ResultsInSuccessNoop")
-                .given(
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
-                        withOpContext((spec, op) -> allRunFor(
-                                spec,
-                                contractCall(
-                                                INTERNAL_CALLER_CONTRACT,
-                                                CALL_EXTERNAL_FUNCTION,
-                                                mirrorAddrWith(targetId.get().getAccountNum()))
-                                        .gas(GAS_LIMIT_FOR_CALL * 4)
-                                        .via(INNER_TXN))))
-                .then(
-                        getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("initialBalance", 0)));
+        return hapiTest(
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("initialBalance", INTERNAL_CALLER_CONTRACT),
+                withOpContext((spec, op) -> allRunFor(
+                        spec,
+                        contractCall(
+                                        INTERNAL_CALLER_CONTRACT,
+                                        CALL_EXTERNAL_FUNCTION,
+                                        mirrorAddrWith(targetId.get().getAccountNum()))
+                                .gas(GAS_LIMIT_FOR_CALL * 4)
+                                .via(INNER_TXN))),
+                getTxnRecord(INNER_TXN).hasPriority(recordWith().status(SUCCESS)),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("initialBalance", 0)));
     }
 
     @HapiTest
@@ -1433,10 +1337,11 @@ public class Evm46ValidationSuite {
                                     ContractFnResultAsserts.isEqualOrGreaterThan(
                                             BigInteger.valueOf(systemAccountBalance))));
         }
-        return defaultHapiSpec("verifiesSystemAccountBalanceOf")
-                .given(cryptoCreate("testAccount").balance(balance), uploadInitCode(contract), contractCreate(contract))
-                .when()
-                .then(opsArray);
+        return hapiTest(flattened(
+                cryptoCreate("testAccount").balance(balance),
+                uploadInitCode(contract),
+                contractCreate(contract),
+                opsArray));
     }
 
     @HapiTest
@@ -1460,29 +1365,29 @@ public class Evm46ValidationSuite {
                                     ContractFnResultAsserts.isLiteralResult(
                                             new Object[] {BigInteger.valueOf(systemAccountBalance)})));
         }
-        return defaultHapiSpec("verifiesSystemAccountBalanceOf")
-                .given(cryptoCreate("testAccount").balance(balance), uploadInitCode(contract), contractCreate(contract))
-                .when()
-                .then(opsArray);
+        return hapiTest(flattened(
+                cryptoCreate("testAccount").balance(balance),
+                uploadInitCode(contract),
+                contractCreate(contract),
+                opsArray));
     }
 
     @HapiTest
     final Stream<DynamicTest> directCallToSystemAccountResultsInSuccessfulNoOp() {
-        return defaultHapiSpec("directCallToSystemAccountResultsInSuccessfulNoOp")
-                .given(
-                        cryptoCreate("account").balance(ONE_HUNDRED_HBARS),
-                        withOpContext((spec, opLog) -> spec.registry()
-                                .saveContractId(
-                                        "contract",
-                                        asContractIdWithEvmAddress(ByteString.copyFrom(
-                                                unhex("0000000000000000000000000000000000000275"))))))
-                .when(withOpContext((spec, ctxLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate("account").balance(ONE_HUNDRED_HBARS),
+                withOpContext((spec, opLog) -> spec.registry()
+                        .saveContractId(
+                                "contract",
+                                asContractIdWithEvmAddress(
+                                        ByteString.copyFrom(unhex("0000000000000000000000000000000000000275"))))),
+                withOpContext((spec, ctxLog) -> allRunFor(
                         spec,
                         contractCallWithFunctionAbi("contract", getABIFor(FUNCTION, NAME, ERC_721_ABI))
                                 .gas(GAS_LIMIT_FOR_CALL)
                                 .via("callToSystemAddress")
-                                .signingWith("account"))))
-                .then(getTxnRecord("callToSystemAddress")
+                                .signingWith("account"))),
+                getTxnRecord("callToSystemAddress")
                         .hasPriority(recordWith()
                                 .status(SUCCESS)
                                 .contractCallResult(resultWith().gasUsed(GAS_LIMIT_FOR_CALL))));
@@ -1493,10 +1398,7 @@ public class Evm46ValidationSuite {
         final var contract = "CallOperationsCheckerSuccess";
         final var functionName = "call";
         final HapiSpecOperation[] opsArray = getCallOperationsOnSystemAccounts(contract, functionName);
-        return defaultHapiSpec("testCallOperationsForSystemAccounts")
-                .given(uploadInitCode(contract), contractCreate(contract))
-                .when()
-                .then(opsArray);
+        return hapiTest(flattened(uploadInitCode(contract), contractCreate(contract), opsArray));
     }
 
     @HapiTest
@@ -1504,10 +1406,7 @@ public class Evm46ValidationSuite {
         final var contract = "CallOperationsCheckerSuccess";
         final var functionName = "callCode";
         final HapiSpecOperation[] opsArray = getCallOperationsOnSystemAccounts(contract, functionName);
-        return defaultHapiSpec("testCallCodeOperationsForSystemAccounts")
-                .given(uploadInitCode(contract), contractCreate(contract))
-                .when()
-                .then(opsArray);
+        return hapiTest(flattened(uploadInitCode(contract), contractCreate(contract), opsArray));
     }
 
     @HapiTest
@@ -1515,10 +1414,7 @@ public class Evm46ValidationSuite {
         final var contract = "CallOperationsCheckerSuccess";
         final var functionName = "delegateCall";
         final HapiSpecOperation[] opsArray = getCallOperationsOnSystemAccounts(contract, functionName);
-        return defaultHapiSpec("testDelegateCallOperationsForSystemAccounts")
-                .given(uploadInitCode(contract), contractCreate(contract))
-                .when()
-                .then(opsArray);
+        return hapiTest(flattened(uploadInitCode(contract), contractCreate(contract), opsArray));
     }
 
     @HapiTest
@@ -1526,10 +1422,7 @@ public class Evm46ValidationSuite {
         final var contract = "CallOperationsCheckerSuccess";
         final var functionName = "staticcall";
         final HapiSpecOperation[] opsArray = getCallOperationsOnSystemAccounts(contract, functionName);
-        return defaultHapiSpec("testStaticCallOperationsForSystemAccounts")
-                .given(uploadInitCode(contract), contractCreate(contract))
-                .when()
-                .then(opsArray);
+        return hapiTest(flattened(uploadInitCode(contract), contractCreate(contract), opsArray));
     }
 
     private HapiSpecOperation[] getCallOperationsOnSystemAccounts(final String contract, final String functionName) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallHapiOnlySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallHapiOnlySuite.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.suites.contract.hapi;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
 import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
@@ -53,15 +53,14 @@ public class ContractCallHapiOnlySuite {
     @HapiTest
     final Stream<DynamicTest> callFailsWhenAmountIsNegativeButStillChargedFee() {
         final var payer = "payer";
-        return defaultHapiSpec("callFailsWhenAmountIsNegativeButStillChargedFee")
-                .given(
-                        uploadInitCode(PAY_RECEIVABLE_CONTRACT),
-                        contractCreate(PAY_RECEIVABLE_CONTRACT)
-                                .adminKey(THRESHOLD)
-                                .gas(1_000_000)
-                                .refusingEthConversion(),
-                        cryptoCreate(payer).balance(ONE_MILLION_HBARS).payingWith(GENESIS))
-                .when(withOpContext((spec, ignore) -> {
+        return hapiTest(
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT)
+                        .adminKey(THRESHOLD)
+                        .gas(1_000_000)
+                        .refusingEthConversion(),
+                cryptoCreate(payer).balance(ONE_MILLION_HBARS).payingWith(GENESIS),
+                withOpContext((spec, ignore) -> {
                     final var subop1 = balanceSnapshot("balanceBefore0", payer);
                     final var subop2 = contractCall(PAY_RECEIVABLE_CONTRACT)
                             .via(PAY_TXN)
@@ -78,7 +77,6 @@ public class ContractCallHapiOnlySuite {
                     final var subop4 =
                             getAccountBalance(payer).hasTinyBars(changeFromSnapshot("balanceBefore0", -delta));
                     allRunFor(spec, subop4);
-                }))
-                .then();
+                }));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCallLocalSuite.java
@@ -19,7 +19,6 @@ package com.hedera.services.bdd.suites.contract.hapi;
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.isLiteralResult;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
@@ -162,10 +161,11 @@ public class ContractCallLocalSuite {
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).adminKey(THRESHOLD))
-                .when(contractCall(CONTRACT, "create").gas(785_000))
-                .then(sendModified(withSuccessivelyVariedQueryIds(), () -> contractCallLocal(CONTRACT, "getIndirect")));
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT).adminKey(THRESHOLD),
+                contractCall(CONTRACT, "create").gas(785_000),
+                sendModified(withSuccessivelyVariedQueryIds(), () -> contractCallLocal(CONTRACT, "getIndirect")));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractDeleteSuite.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.suites.contract.hapi;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
@@ -98,20 +97,17 @@ public class ContractDeleteSuite {
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(
-                        newKeyNamed("adminKey"),
-                        uploadInitCode(CONTRACT),
-                        contractCreate(CONTRACT),
-                        cryptoCreate("transferAccount"))
-                .when(
-                        contractCreate("a").bytecode(CONTRACT).adminKey("adminKey"),
-                        contractCreate("b").bytecode(CONTRACT).adminKey("adminKey"))
-                .then(
-                        submitModified(withSuccessivelyVariedBodyIds(), () -> contractDelete("a")
-                                .transferAccount("transferAccount")),
-                        submitModified(withSuccessivelyVariedBodyIds(), () -> contractDelete("b")
-                                .transferContract(CONTRACT)));
+        return hapiTest(
+                newKeyNamed("adminKey"),
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                cryptoCreate("transferAccount"),
+                contractCreate("a").bytecode(CONTRACT).adminKey("adminKey"),
+                contractCreate("b").bytecode(CONTRACT).adminKey("adminKey"),
+                submitModified(withSuccessivelyVariedBodyIds(), () -> contractDelete("a")
+                        .transferAccount("transferAccount")),
+                submitModified(withSuccessivelyVariedBodyIds(), () -> contractDelete("b")
+                        .transferContract(CONTRACT)));
     }
 
     @HapiTest
@@ -205,40 +201,38 @@ public class ContractDeleteSuite {
         final var multiKey = "multi";
         final var escapeRoute = "civilian";
         final var beneficiary = "beneficiary";
-        return defaultHapiSpec("CannotDeleteOrSelfDestructTokenTreasury")
-                .given(
-                        cryptoCreate(beneficiary).balance(ONE_HUNDRED_HBARS),
-                        newKeyNamed(multiKey),
-                        cryptoCreate(escapeRoute),
-                        uploadInitCode(selfDestructCallable),
-                        contractCustomCreate(selfDestructCallable, "1")
-                                .adminKey(multiKey)
-                                .balance(123)
-                                // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
-                                // tokenAssociate,
-                                // since we have CONTRACT_ID key
-                                .refusingEthConversion(),
-                        contractCustomCreate(selfDestructCallable, "2")
-                                .adminKey(multiKey)
-                                .balance(321)
-                                // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
-                                // tokenAssociate,
-                                // since we have CONTRACT_ID key
-                                .refusingEthConversion(),
-                        tokenCreate(someToken).adminKey(multiKey).treasury(selfDestructCallable + "1"))
-                .when(
-                        contractDelete(selfDestructCallable + "1").hasKnownStatus(ACCOUNT_IS_TREASURY),
-                        tokenAssociate(selfDestructCallable + "2", someToken),
-                        tokenUpdate(someToken)
-                                .treasury(selfDestructCallable + "2")
-                                .signedByPayerAnd(multiKey, selfDestructCallable + "2"),
-                        contractDelete(selfDestructCallable + "1"),
-                        contractCall(selfDestructCallable + "2", CONTRACT_DESTROY)
-                                .hasKnownStatus(CONTRACT_EXECUTION_EXCEPTION)
-                                .payingWith(beneficiary),
-                        tokenAssociate(escapeRoute, someToken),
-                        tokenUpdate(someToken).treasury(escapeRoute).signedByPayerAnd(multiKey, escapeRoute))
-                .then(contractCall(selfDestructCallable + "2", CONTRACT_DESTROY).payingWith(beneficiary));
+        return hapiTest(
+                cryptoCreate(beneficiary).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(multiKey),
+                cryptoCreate(escapeRoute),
+                uploadInitCode(selfDestructCallable),
+                contractCustomCreate(selfDestructCallable, "1")
+                        .adminKey(multiKey)
+                        .balance(123)
+                        // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
+                        // tokenAssociate,
+                        // since we have CONTRACT_ID key
+                        .refusingEthConversion(),
+                contractCustomCreate(selfDestructCallable, "2")
+                        .adminKey(multiKey)
+                        .balance(321)
+                        // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
+                        // tokenAssociate,
+                        // since we have CONTRACT_ID key
+                        .refusingEthConversion(),
+                tokenCreate(someToken).adminKey(multiKey).treasury(selfDestructCallable + "1"),
+                contractDelete(selfDestructCallable + "1").hasKnownStatus(ACCOUNT_IS_TREASURY),
+                tokenAssociate(selfDestructCallable + "2", someToken),
+                tokenUpdate(someToken)
+                        .treasury(selfDestructCallable + "2")
+                        .signedByPayerAnd(multiKey, selfDestructCallable + "2"),
+                contractDelete(selfDestructCallable + "1"),
+                contractCall(selfDestructCallable + "2", CONTRACT_DESTROY)
+                        .hasKnownStatus(CONTRACT_EXECUTION_EXCEPTION)
+                        .payingWith(beneficiary),
+                tokenAssociate(escapeRoute, someToken),
+                tokenUpdate(someToken).treasury(escapeRoute).signedByPayerAnd(multiKey, escapeRoute),
+                contractCall(selfDestructCallable + "2", CONTRACT_DESTROY).payingWith(beneficiary));
     }
 
     @HapiTest
@@ -283,107 +277,99 @@ public class ContractDeleteSuite {
 
     @HapiTest
     final Stream<DynamicTest> rejectsWithoutProperSig() {
-        return defaultHapiSpec("rejectsWithoutProperSig")
+        return hapiTest(
                 // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon tokenAssociate,
                 // since we have CONTRACT_ID key
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).refusingEthConversion())
-                .when()
-                .then(contractDelete(CONTRACT).signedBy(GENESIS).hasKnownStatus(INVALID_SIGNATURE));
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT).refusingEthConversion(),
+                contractDelete(CONTRACT).signedBy(GENESIS).hasKnownStatus(INVALID_SIGNATURE));
     }
 
     @HapiTest
     final Stream<DynamicTest> systemCannotDeleteOrUndeleteContracts() {
-        return defaultHapiSpec("SystemCannotDeleteOrUndeleteContracts")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when()
-                .then(
-                        systemContractDelete(CONTRACT)
-                                .payingWith(SYSTEM_DELETE_ADMIN)
-                                .hasPrecheck(NOT_SUPPORTED),
-                        systemContractUndelete(CONTRACT)
-                                .payingWith(SYSTEM_UNDELETE_ADMIN)
-                                .hasPrecheck(NOT_SUPPORTED),
-                        getContractInfo(CONTRACT).hasAnswerOnlyPrecheck(OK));
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                systemContractDelete(CONTRACT).payingWith(SYSTEM_DELETE_ADMIN).hasPrecheck(NOT_SUPPORTED),
+                systemContractUndelete(CONTRACT)
+                        .payingWith(SYSTEM_UNDELETE_ADMIN)
+                        .hasPrecheck(NOT_SUPPORTED),
+                getContractInfo(CONTRACT).hasAnswerOnlyPrecheck(OK));
     }
 
     @HapiTest
     final Stream<DynamicTest> deleteWorksWithMutableContract() {
         final var tbdFile = "FTBD";
         final var tbdContract = "CTBD";
-        return defaultHapiSpec("DeleteWorksWithMutableContract")
-                .given(
-                        fileCreate(tbdFile),
-                        fileDelete(tbdFile),
-                        // refuse eth conversion because we can't set invalid bytecode to callData in ethereum
-                        // transaction + trying to delete immutable contract
-                        createDefaultContract(tbdContract)
-                                .bytecode(tbdFile)
-                                .hasKnownStatus(FILE_DELETED)
-                                .refusingEthConversion())
-                .when(uploadInitCode(CONTRACT), contractCreate(CONTRACT).refusingEthConversion())
-                .then(
-                        contractDelete(CONTRACT)
-                                .claimingPermanentRemoval()
-                                .hasPrecheck(PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION),
-                        contractDelete(CONTRACT),
-                        getContractInfo(CONTRACT).has(contractWith().isDeleted()));
+        return hapiTest(
+                fileCreate(tbdFile),
+                fileDelete(tbdFile),
+                // refuse eth conversion because we can't set invalid bytecode to callData in ethereum
+                // transaction + trying to delete immutable contract
+                createDefaultContract(tbdContract)
+                        .bytecode(tbdFile)
+                        .hasKnownStatus(FILE_DELETED)
+                        .refusingEthConversion(),
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT).refusingEthConversion(),
+                contractDelete(CONTRACT)
+                        .claimingPermanentRemoval()
+                        .hasPrecheck(PERMANENT_REMOVAL_REQUIRES_SYSTEM_INITIATION),
+                contractDelete(CONTRACT),
+                getContractInfo(CONTRACT).has(contractWith().isDeleted()));
     }
 
     @HapiTest
     final Stream<DynamicTest> deleteFailsWithImmutableContract() {
-        return defaultHapiSpec("DeleteFailsWithImmutableContract")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT).omitAdminKey())
-                .when()
-                .then(contractDelete(CONTRACT).hasKnownStatus(MODIFYING_IMMUTABLE_CONTRACT));
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT).omitAdminKey(),
+                contractDelete(CONTRACT).hasKnownStatus(MODIFYING_IMMUTABLE_CONTRACT));
     }
 
     @HapiTest
     final Stream<DynamicTest> deleteTransfersToAccount() {
-        return defaultHapiSpec("DeleteTransfersToAccount")
-                .given(
-                        cryptoCreate(RECEIVER_CONTRACT_NAME).balance(0L),
-                        uploadInitCode(PAYABLE_CONSTRUCTOR),
-                        contractCreate(PAYABLE_CONSTRUCTOR)
-                                // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
-                                // tokenAssociate,
-                                // since we have CONTRACT_ID key
-                                .refusingEthConversion()
-                                .balance(1L))
-                .when(contractDelete(PAYABLE_CONSTRUCTOR).transferAccount(RECEIVER_CONTRACT_NAME))
-                .then(getAccountBalance(RECEIVER_CONTRACT_NAME).hasTinyBars(1L));
+        return hapiTest(
+                cryptoCreate(RECEIVER_CONTRACT_NAME).balance(0L),
+                uploadInitCode(PAYABLE_CONSTRUCTOR),
+                contractCreate(PAYABLE_CONSTRUCTOR)
+                        // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
+                        // tokenAssociate,
+                        // since we have CONTRACT_ID key
+                        .refusingEthConversion()
+                        .balance(1L),
+                contractDelete(PAYABLE_CONSTRUCTOR).transferAccount(RECEIVER_CONTRACT_NAME),
+                getAccountBalance(RECEIVER_CONTRACT_NAME).hasTinyBars(1L));
     }
 
     @HapiTest
     final Stream<DynamicTest> deleteTransfersToContract() {
         final var suffix = "Receiver";
 
-        return defaultHapiSpec("DeleteTransfersToContract")
-                .given(
-                        uploadInitCode(PAYABLE_CONSTRUCTOR),
-                        contractCreate(PAYABLE_CONSTRUCTOR)
-                                // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
-                                // tokenAssociate,
-                                // since we have CONTRACT_ID key
-                                .refusingEthConversion()
-                                .balance(0L),
-                        contractCustomCreate(PAYABLE_CONSTRUCTOR, suffix).balance(1L))
-                .when(contractDelete(PAYABLE_CONSTRUCTOR).transferContract(PAYABLE_CONSTRUCTOR + suffix))
-                .then(getAccountBalance(PAYABLE_CONSTRUCTOR + suffix).hasTinyBars(1L));
+        return hapiTest(
+                uploadInitCode(PAYABLE_CONSTRUCTOR),
+                contractCreate(PAYABLE_CONSTRUCTOR)
+                        // Refusing ethereum create conversion, because we get INVALID_SIGNATURE upon
+                        // tokenAssociate,
+                        // since we have CONTRACT_ID key
+                        .refusingEthConversion()
+                        .balance(0L),
+                contractCustomCreate(PAYABLE_CONSTRUCTOR, suffix).balance(1L),
+                contractDelete(PAYABLE_CONSTRUCTOR).transferContract(PAYABLE_CONSTRUCTOR + suffix),
+                getAccountBalance(PAYABLE_CONSTRUCTOR + suffix).hasTinyBars(1L));
     }
 
     @HapiTest
     final Stream<DynamicTest> localCallToDeletedContract() {
-        return defaultHapiSpec("LocalCallToDeletedContract")
+        return hapiTest(
                 // refuse eth conversion because MODIFYING_IMMUTABLE_CONTRACT
-                .given(
-                        uploadInitCode(SIMPLE_STORAGE_CONTRACT),
-                        contractCreate(SIMPLE_STORAGE_CONTRACT).refusingEthConversion())
-                .when(
-                        contractCallLocal(SIMPLE_STORAGE_CONTRACT, "get")
-                                .hasCostAnswerPrecheck(OK)
-                                .has(resultWith().contractCallResult(() -> Bytes32.fromHexString("0x0F"))),
-                        contractDelete(SIMPLE_STORAGE_CONTRACT))
-                .then(contractCallLocal(SIMPLE_STORAGE_CONTRACT, "get")
+                uploadInitCode(SIMPLE_STORAGE_CONTRACT),
+                contractCreate(SIMPLE_STORAGE_CONTRACT).refusingEthConversion(),
+                contractCallLocal(SIMPLE_STORAGE_CONTRACT, "get")
+                        .hasCostAnswerPrecheck(OK)
+                        .has(resultWith().contractCallResult(() -> Bytes32.fromHexString("0x0F"))),
+                contractDelete(SIMPLE_STORAGE_CONTRACT),
+                contractCallLocal(SIMPLE_STORAGE_CONTRACT, "get")
                         .hasCostAnswerPrecheck(OK)
                         .has(resultWith().contractCallResult(() -> Bytes.EMPTY)));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetInfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetInfoSuite.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.contract.hapi;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.approxChangeFromSnapshot;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
@@ -55,12 +54,10 @@ public class ContractGetInfoSuite {
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
         final var contract = "Multipurpose";
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(
-                        uploadInitCode(contract),
-                        contractCreate(contract).entityMemo(MEMO).autoRenewSecs(6999999L))
-                .when()
-                .then(sendModified(withSuccessivelyVariedQueryIds(), () -> getContractInfo(contract)));
+        return hapiTest(
+                uploadInitCode(contract),
+                contractCreate(contract).entityMemo(MEMO).autoRenewSecs(6999999L),
+                sendModified(withSuccessivelyVariedQueryIds(), () -> getContractInfo(contract)));
     }
 
     @HapiTest
@@ -101,20 +98,14 @@ public class ContractGetInfoSuite {
 
     @HapiTest
     final Stream<DynamicTest> invalidContractFromCostAnswer() {
-        return defaultHapiSpec("InvalidContractFromCostAnswer")
-                .given()
-                .when()
-                .then(getContractInfo(NON_EXISTING_CONTRACT)
-                        .hasCostAnswerPrecheck(ResponseCodeEnum.INVALID_CONTRACT_ID));
+        return hapiTest(
+                getContractInfo(NON_EXISTING_CONTRACT).hasCostAnswerPrecheck(ResponseCodeEnum.INVALID_CONTRACT_ID));
     }
 
     @HapiTest
     final Stream<DynamicTest> invalidContractFromAnswerOnly() {
-        return defaultHapiSpec("InvalidContractFromAnswerOnly")
-                .given()
-                .when()
-                .then(getContractInfo(NON_EXISTING_CONTRACT)
-                        .nodePayment(27_159_182L)
-                        .hasAnswerOnlyPrecheck(ResponseCodeEnum.INVALID_CONTRACT_ID));
+        return hapiTest(getContractInfo(NON_EXISTING_CONTRACT)
+                .nodePayment(27_159_182L)
+                .hasAnswerOnlyPrecheck(ResponseCodeEnum.INVALID_CONTRACT_ID));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractStateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractStateSuite.java
@@ -17,13 +17,13 @@
 package com.hedera.services.bdd.suites.contract.hapi;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateAnyLogAfter;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static java.lang.Integer.MAX_VALUE;
 
 import com.esaulpaugh.headlong.abi.Address;
@@ -80,9 +80,10 @@ public class ContractStateSuite {
                 Map.entry("Int128", BigInteger.valueOf(5)),
                 Map.entry("Int256", BigInteger.valueOf(6)));
 
-        return defaultHapiSpec("stateChangesSpec")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when(IntStream.range(0, iterations)
+        return hapiTest(flattened(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                IntStream.range(0, iterations)
                         .boxed()
                         .flatMap(i -> Stream.of(
                                         Stream.of(contractCall(CONTRACT, "setVarBool", RANDOM.nextBoolean())),
@@ -98,8 +99,7 @@ public class ContractStateSuite {
                                         randomSetAndDeleteString(),
                                         randomSetAndDeleteStruct())
                                 .flatMap(s -> s))
-                        .toArray(HapiSpecOperation[]::new))
-                .then();
+                        .toArray(HapiSpecOperation[]::new)));
     }
 
     private Stream<HapiSpecOperation> randomSetAndDeleteVarInt() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CreateOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/CreateOperationSuite.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.contract.opcodes;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
@@ -147,17 +146,15 @@ public class CreateOperationSuite {
 
     @HapiTest
     final Stream<DynamicTest> resetOnFactoryFailureWorks() {
-        return defaultHapiSpec("ResetOnFactoryFailureWorks")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when(
-                        contractCall(CONTRACT, "stackedDeploymentFailure")
-                                .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
-                                .gas(780_000)
-                                .via("deploymentFailureTxn"),
-                        contractCall(CONTRACT, DEPLOYMENT_SUCCESS_FUNCTION)
-                                .gas(780_000)
-                                .via(DEPLOYMENT_SUCCESS_TXN))
-                .then(withOpContext((spec, opLog) -> {
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                contractCall(CONTRACT, "stackedDeploymentFailure")
+                        .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
+                        .gas(780_000)
+                        .via("deploymentFailureTxn"),
+                contractCall(CONTRACT, DEPLOYMENT_SUCCESS_FUNCTION).gas(780_000).via(DEPLOYMENT_SUCCESS_TXN),
+                withOpContext((spec, opLog) -> {
                     final var revertTxn = getTxnRecord("deploymentFailureTxn");
                     final var deploymentSuccessTxn = getTxnRecord(DEPLOYMENT_SUCCESS_TXN);
                     final var parentContract = getContractInfo(CONTRACT).saveToRegistry(CONTRACT_INFO);
@@ -179,17 +176,15 @@ public class CreateOperationSuite {
 
     @HapiTest
     final Stream<DynamicTest> resetOnFactoryFailureAfterDeploymentWorks() {
-        return defaultHapiSpec("ResetOnFactoryFailureAfterDeploymentWorks")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when(
-                        contractCall(CONTRACT, "failureAfterDeploy")
-                                .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
-                                .gas(780_000)
-                                .via("failureAfterDeploymentTxn"),
-                        contractCall(CONTRACT, DEPLOYMENT_SUCCESS_FUNCTION)
-                                .gas(780_000)
-                                .via(DEPLOYMENT_SUCCESS_TXN))
-                .then(withOpContext((spec, opLog) -> {
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                contractCall(CONTRACT, "failureAfterDeploy")
+                        .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
+                        .gas(780_000)
+                        .via("failureAfterDeploymentTxn"),
+                contractCall(CONTRACT, DEPLOYMENT_SUCCESS_FUNCTION).gas(780_000).via(DEPLOYMENT_SUCCESS_TXN),
+                withOpContext((spec, opLog) -> {
                     final var revertTxn = getTxnRecord("failureAfterDeploymentTxn");
                     final var deploymentSuccessTxn = getTxnRecord(DEPLOYMENT_SUCCESS_TXN);
                     final var parentContract = getContractInfo(CONTRACT).saveToRegistry(CONTRACT_INFO);
@@ -211,17 +206,15 @@ public class CreateOperationSuite {
 
     @HapiTest
     final Stream<DynamicTest> resetOnStackedFactoryFailureWorks() {
-        return defaultHapiSpec("ResetOnStackedFactoryFailureWorks")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when(
-                        contractCall(CONTRACT, "stackedDeploymentFailure")
-                                .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
-                                .gas(780_000)
-                                .via("stackedDeploymentFailureTxn"),
-                        contractCall(CONTRACT, DEPLOYMENT_SUCCESS_FUNCTION)
-                                .gas(780_000)
-                                .via(DEPLOYMENT_SUCCESS_TXN))
-                .then(withOpContext((spec, opLog) -> {
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                contractCall(CONTRACT, "stackedDeploymentFailure")
+                        .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
+                        .gas(780_000)
+                        .via("stackedDeploymentFailureTxn"),
+                contractCall(CONTRACT, DEPLOYMENT_SUCCESS_FUNCTION).gas(780_000).via(DEPLOYMENT_SUCCESS_TXN),
+                withOpContext((spec, opLog) -> {
                     final var revertTxn = getTxnRecord("stackedDeploymentFailureTxn");
                     final var deploymentSuccessTxn = getTxnRecord(DEPLOYMENT_SUCCESS_TXN);
                     final var parentContract = getContractInfo(CONTRACT).saveToRegistry(CONTRACT_INFO);
@@ -264,10 +257,10 @@ public class CreateOperationSuite {
         final var contract = "CreateTrivial";
         final var CREATED_TRIVIAL_CONTRACT_RETURNS = 7;
 
-        return defaultHapiSpec("childContractStorageWorks")
-                .given(uploadInitCode(contract))
-                .when(contractCreate(contract).via("firstContractTxn"))
-                .then(assertionsHold((spec, ctxLog) -> {
+        return hapiTest(
+                uploadInitCode(contract),
+                contractCreate(contract).via("firstContractTxn"),
+                assertionsHold((spec, ctxLog) -> {
                     final var subop1 =
                             contractCall(contract, "create").gas(785_000).via("createContractTxn");
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/DelegateCallOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/DelegateCallOperationSuite.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.suites.contract.opcodes;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
@@ -39,21 +39,19 @@ public class DelegateCallOperationSuite {
     final Stream<DynamicTest> verifiesExistence() {
         final var contract = "CallOperationsChecker";
         final var INVALID_ADDRESS = "0x0000000000000000000000000000000000123456";
-        return defaultHapiSpec("VerifiesExistence")
-                .given(uploadInitCode(contract), contractCreate(contract))
-                .when()
-                .then(
-                        contractCall(contract, "delegateCall", asHeadlongAddress(INVALID_ADDRESS))
-                                .hasKnownStatus(SUCCESS),
-                        withOpContext((spec, opLog) -> {
-                            final var id = spec.registry().getAccountID(DEFAULT_PAYER);
-                            final var solidityAddress = HapiPropertySource.asHexedSolidityAddress(id);
+        return hapiTest(
+                uploadInitCode(contract),
+                contractCreate(contract),
+                contractCall(contract, "delegateCall", asHeadlongAddress(INVALID_ADDRESS))
+                        .hasKnownStatus(SUCCESS),
+                withOpContext((spec, opLog) -> {
+                    final var id = spec.registry().getAccountID(DEFAULT_PAYER);
+                    final var solidityAddress = HapiPropertySource.asHexedSolidityAddress(id);
 
-                            final var contractCall = contractCall(
-                                            contract, "delegateCall", asHeadlongAddress(solidityAddress))
-                                    .hasKnownStatus(SUCCESS);
+                    final var contractCall = contractCall(contract, "delegateCall", asHeadlongAddress(solidityAddress))
+                            .hasKnownStatus(SUCCESS);
 
-                            allRunFor(spec, contractCall);
-                        }));
+                    allRunFor(spec, contractCall);
+                }));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/GlobalPropertiesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/GlobalPropertiesSuite.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.suites.contract.opcodes;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.*;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
@@ -55,55 +55,55 @@ public class GlobalPropertiesSuite {
         final var defaultChainId = BigInteger.valueOf(295L);
         final var devChainId = BigInteger.valueOf(298L);
         final Set<Object> acceptableChainIds = Set.of(devChainId, defaultChainId);
-        return defaultHapiSpec("chainIdWorks")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when(contractCall(CONTRACT, GET_CHAIN_ID).via("chainId"))
-                .then(
-                        getTxnRecord("chainId")
-                                .logged()
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith()
-                                                .resultThruAbi(
-                                                        getABIFor(FUNCTION, GET_CHAIN_ID, CONTRACT),
-                                                        isOneOfLiteral(acceptableChainIds)))),
-                        contractCallLocal(CONTRACT, GET_CHAIN_ID)
-                                .nodePayment(1_234_567)
-                                .has(ContractFnResultAsserts.resultWith()
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                contractCall(CONTRACT, GET_CHAIN_ID).via("chainId"),
+                getTxnRecord("chainId")
+                        .logged()
+                        .hasPriority(recordWith()
+                                .contractCallResult(resultWith()
                                         .resultThruAbi(
                                                 getABIFor(FUNCTION, GET_CHAIN_ID, CONTRACT),
-                                                isOneOfLiteral(acceptableChainIds))));
+                                                isOneOfLiteral(acceptableChainIds)))),
+                contractCallLocal(CONTRACT, GET_CHAIN_ID)
+                        .nodePayment(1_234_567)
+                        .has(ContractFnResultAsserts.resultWith()
+                                .resultThruAbi(
+                                        getABIFor(FUNCTION, GET_CHAIN_ID, CONTRACT),
+                                        isOneOfLiteral(acceptableChainIds))));
     }
 
     @HapiTest
     final Stream<DynamicTest> baseFeeWorks() {
         final var expectedBaseFee = BigInteger.valueOf(0);
-        return defaultHapiSpec("baseFeeWorks")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when(contractCall(CONTRACT, GET_BASE_FEE).via("baseFee"))
-                .then(
-                        getTxnRecord("baseFee")
-                                .logged()
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith()
-                                                .resultThruAbi(
-                                                        getABIFor(FUNCTION, GET_BASE_FEE, CONTRACT),
-                                                        isLiteralResult(new Object[] {BigInteger.valueOf(0)})))),
-                        contractCallLocal(CONTRACT, GET_BASE_FEE)
-                                .nodePayment(1_234_567)
-                                .has(ContractFnResultAsserts.resultWith()
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                contractCall(CONTRACT, GET_BASE_FEE).via("baseFee"),
+                getTxnRecord("baseFee")
+                        .logged()
+                        .hasPriority(recordWith()
+                                .contractCallResult(resultWith()
                                         .resultThruAbi(
                                                 getABIFor(FUNCTION, GET_BASE_FEE, CONTRACT),
-                                                ContractFnResultAsserts.isLiteralResult(
-                                                        new Object[] {expectedBaseFee}))));
+                                                isLiteralResult(new Object[] {BigInteger.valueOf(0)})))),
+                contractCallLocal(CONTRACT, GET_BASE_FEE)
+                        .nodePayment(1_234_567)
+                        .has(ContractFnResultAsserts.resultWith()
+                                .resultThruAbi(
+                                        getABIFor(FUNCTION, GET_BASE_FEE, CONTRACT),
+                                        ContractFnResultAsserts.isLiteralResult(new Object[] {expectedBaseFee}))));
     }
 
     @SuppressWarnings("java:S5960")
     @HapiTest
     final Stream<DynamicTest> coinbaseWorks() {
-        return defaultHapiSpec("coinbaseWorks")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when(contractCall(CONTRACT, "getCoinbase").via("coinbase"))
-                .then(withOpContext((spec, opLog) -> {
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                contractCall(CONTRACT, "getCoinbase").via("coinbase"),
+                withOpContext((spec, opLog) -> {
                     final var expectedCoinbase =
                             parsedToByteString(DEFAULT_PROPS.fundingAccount().getAccountNum());
 
@@ -123,10 +123,10 @@ public class GlobalPropertiesSuite {
 
     @HapiTest
     final Stream<DynamicTest> gasLimitWorks() {
-        return defaultHapiSpec("gasLimitWorks")
-                .given(uploadInitCode(CONTRACT), contractCreate(CONTRACT))
-                .when()
-                .then(doSeveralWithStartupConfig("contracts.maxGasPerSec", value -> {
+        return hapiTest(
+                uploadInitCode(CONTRACT),
+                contractCreate(CONTRACT),
+                doSeveralWithStartupConfig("contracts.maxGasPerSec", value -> {
                     final var gasLimit = Long.parseLong(value);
                     return specOps(
                             contractCall(CONTRACT, GET_GAS_LIMIT)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ApproveAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ApproveAllowanceSuite.java
@@ -19,7 +19,6 @@ package com.hedera.services.bdd.suites.contract.precompile;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asSolidityAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
@@ -216,40 +215,37 @@ public class ApproveAllowanceSuite {
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(
-                        newKeyNamed("supplyKey"),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(OWNER).maxAutomaticTokenAssociations(2),
-                        cryptoCreate("delegatingOwner").maxAutomaticTokenAssociations(1),
-                        cryptoCreate(SPENDER))
-                .when(
-                        tokenCreate("fungibleToken").initialSupply(123).treasury(TOKEN_TREASURY),
-                        tokenCreate("nonFungibleToken")
-                                .treasury(TOKEN_TREASURY)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0L)
-                                .supplyKey("supplyKey"),
-                        mintToken(
-                                "nonFungibleToken",
-                                List.of(
-                                        ByteString.copyFromUtf8("A"),
-                                        ByteString.copyFromUtf8("B"),
-                                        ByteString.copyFromUtf8("C"))),
-                        cryptoTransfer(
-                                movingUnique("nonFungibleToken", 1L, 2L).between(TOKEN_TREASURY, OWNER),
-                                moving(10, "fungibleToken").between(TOKEN_TREASURY, OWNER)),
-                        cryptoTransfer(movingUnique("nonFungibleToken", 3L).between(TOKEN_TREASURY, "delegatingOwner")))
-                .then(
-                        submitModified(withSuccessivelyVariedBodyIds(), () -> cryptoApproveAllowance()
-                                .addNftAllowance("delegatingOwner", "nonFungibleToken", OWNER, true, List.of())
-                                .signedBy(DEFAULT_PAYER, "delegatingOwner")),
-                        submitModified(withSuccessivelyVariedBodyIds(), () -> cryptoApproveAllowance()
-                                .addNftAllowance(OWNER, "nonFungibleToken", SPENDER, false, List.of(1L))
-                                .addTokenAllowance(OWNER, "fungibleToken", SPENDER, 1L)
-                                .addDelegatedNftAllowance(
-                                        "delegatingOwner", "nonFungibleToken", SPENDER, OWNER, false, List.of(3L))
-                                .signedBy(DEFAULT_PAYER, OWNER)));
+        return hapiTest(
+                newKeyNamed("supplyKey"),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(OWNER).maxAutomaticTokenAssociations(2),
+                cryptoCreate("delegatingOwner").maxAutomaticTokenAssociations(1),
+                cryptoCreate(SPENDER),
+                tokenCreate("fungibleToken").initialSupply(123).treasury(TOKEN_TREASURY),
+                tokenCreate("nonFungibleToken")
+                        .treasury(TOKEN_TREASURY)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0L)
+                        .supplyKey("supplyKey"),
+                mintToken(
+                        "nonFungibleToken",
+                        List.of(
+                                ByteString.copyFromUtf8("A"),
+                                ByteString.copyFromUtf8("B"),
+                                ByteString.copyFromUtf8("C"))),
+                cryptoTransfer(
+                        movingUnique("nonFungibleToken", 1L, 2L).between(TOKEN_TREASURY, OWNER),
+                        moving(10, "fungibleToken").between(TOKEN_TREASURY, OWNER)),
+                cryptoTransfer(movingUnique("nonFungibleToken", 3L).between(TOKEN_TREASURY, "delegatingOwner")),
+                submitModified(withSuccessivelyVariedBodyIds(), () -> cryptoApproveAllowance()
+                        .addNftAllowance("delegatingOwner", "nonFungibleToken", OWNER, true, List.of())
+                        .signedBy(DEFAULT_PAYER, "delegatingOwner")),
+                submitModified(withSuccessivelyVariedBodyIds(), () -> cryptoApproveAllowance()
+                        .addNftAllowance(OWNER, "nonFungibleToken", SPENDER, false, List.of(1L))
+                        .addTokenAllowance(OWNER, "fungibleToken", SPENDER, 1L)
+                        .addDelegatedNftAllowance(
+                                "delegatingOwner", "nonFungibleToken", SPENDER, OWNER, false, List.of(3L))
+                        .signedBy(DEFAULT_PAYER, OWNER)));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileSuite.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiPropertySource.idAsHeadlongAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -93,25 +92,27 @@ public class AssociatePrecompileSuite {
     /* -- HSCS-PREC-27 from HTS Precompile Test Plan -- */
     @HapiTest
     final Stream<DynamicTest> functionCallWithLessThanFourBytesFailsWithinSingleContractCall() {
-        return defaultHapiSpec("functionCallWithLessThanFourBytesFailsWithinSingleContractCall")
-                .given(uploadInitCode(THE_GRACEFULLY_FAILING_CONTRACT), contractCreate(THE_GRACEFULLY_FAILING_CONTRACT))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(THE_GRACEFULLY_FAILING_CONTRACT),
+                contractCreate(THE_GRACEFULLY_FAILING_CONTRACT),
+                contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
                                 "performLessThanFourBytesFunctionCall",
                                 HapiParserUtil.asHeadlongAddress(ACCOUNT_ADDRESS),
                                 HapiParserUtil.asHeadlongAddress(TOKEN_ADDRESS))
                         .notTryingAsHexedliteral()
                         .via("Function call with less than 4 bytes txn")
-                        .gas(100_000))
-                .then(childRecordsCheck("Function call with less than 4 bytes txn", SUCCESS));
+                        .gas(100_000),
+                childRecordsCheck("Function call with less than 4 bytes txn", SUCCESS));
     }
 
     /* -- HSCS-PREC-27 from HTS Precompile Test Plan -- */
     @HapiTest
     final Stream<DynamicTest> invalidAbiCallGracefullyFailsWithinSingleContractCall() {
-        return defaultHapiSpec("invalidAbiCallGracefullyFailsWithinSingleContractCall")
-                .given(uploadInitCode(THE_GRACEFULLY_FAILING_CONTRACT), contractCreate(THE_GRACEFULLY_FAILING_CONTRACT))
-                .when(contractCall(
+        return hapiTest(
+                uploadInitCode(THE_GRACEFULLY_FAILING_CONTRACT),
+                contractCreate(THE_GRACEFULLY_FAILING_CONTRACT),
+                contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
                                 "performInvalidlyFormattedFunctionCall",
                                 HapiParserUtil.asHeadlongAddress(ACCOUNT_ADDRESS),
@@ -120,8 +121,8 @@ public class AssociatePrecompileSuite {
                                     HapiParserUtil.asHeadlongAddress(TOKEN_ADDRESS)
                                 })
                         .notTryingAsHexedliteral()
-                        .via("Invalid Abi Function call txn"))
-                .then(childRecordsCheck("Invalid Abi Function call txn", SUCCESS));
+                        .via("Invalid Abi Function call txn"),
+                childRecordsCheck("Invalid Abi Function call txn", SUCCESS));
     }
 
     /* -- HSCS-PREC-26 from HTS Precompile Test Plan -- */
@@ -301,27 +302,26 @@ public class AssociatePrecompileSuite {
         final var zeroAccountAddress = "zeroAccountAddress";
         final var nullTokenArray = "nullTokens";
         final var nonExistingTokensInArray = "nonExistingTokensInArray";
-        return defaultHapiSpec("associateTokensNegativeScenarios")
-                .given(
-                        uploadInitCode(NEGATIVE_ASSOCIATIONS_CONTRACT),
-                        contractCreate(NEGATIVE_ASSOCIATIONS_CONTRACT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(50L)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY)
-                                .exposingAddressTo(tokenAddress1::set),
-                        tokenCreate(TOKEN1)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(50L)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY)
-                                .exposingAddressTo(tokenAddress2::set),
-                        cryptoCreate(ACCOUNT).exposingCreatedIdTo(id -> accountAddress.set(idAsHeadlongAddress(id))))
-                .when(withOpContext((spec, custom) -> allRunFor(
+        return hapiTest(
+                uploadInitCode(NEGATIVE_ASSOCIATIONS_CONTRACT),
+                contractCreate(NEGATIVE_ASSOCIATIONS_CONTRACT),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(50L)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY)
+                        .exposingAddressTo(tokenAddress1::set),
+                tokenCreate(TOKEN1)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(50L)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY)
+                        .exposingAddressTo(tokenAddress2::set),
+                cryptoCreate(ACCOUNT).exposingCreatedIdTo(id -> accountAddress.set(idAsHeadlongAddress(id))),
+                withOpContext((spec, custom) -> allRunFor(
                         spec,
                         contractCall(
                                         NEGATIVE_ASSOCIATIONS_CONTRACT,
@@ -383,28 +383,24 @@ public class AssociatePrecompileSuite {
                                 .via(someNonExistingTokenArray)
                                 .logged(),
                         getAccountInfo(ACCOUNT).hasToken(relationshipWith(TOKEN)),
-                        getAccountInfo(ACCOUNT).hasToken(relationshipWith(TOKEN1)))))
-                .then(
-                        childRecordsCheck(
-                                nonExistingAccount,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ACCOUNT_ID)),
-                        childRecordsCheck(
-                                nonExistingTokenArray, SUCCESS, recordWith().status(SUCCESS)),
-                        childRecordsCheck(
-                                someNonExistingTokenArray, SUCCESS, recordWith().status(SUCCESS)),
-                        childRecordsCheck(
-                                zeroAccountAddress,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ACCOUNT_ID)),
-                        childRecordsCheck(
-                                nullTokenArray,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                nonExistingTokensInArray,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)));
+                        getAccountInfo(ACCOUNT).hasToken(relationshipWith(TOKEN1)))),
+                childRecordsCheck(
+                        nonExistingAccount,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_ACCOUNT_ID)),
+                childRecordsCheck(nonExistingTokenArray, SUCCESS, recordWith().status(SUCCESS)),
+                childRecordsCheck(
+                        someNonExistingTokenArray, SUCCESS, recordWith().status(SUCCESS)),
+                childRecordsCheck(
+                        zeroAccountAddress,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_ACCOUNT_ID)),
+                childRecordsCheck(
+                        nullTokenArray, CONTRACT_REVERT_EXECUTED, recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        nonExistingTokensInArray,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)));
     }
 
     @HapiTest
@@ -415,20 +411,19 @@ public class AssociatePrecompileSuite {
         final var nullAccount = "nullAccount";
         final var nonExistingToken = "nonExistingToken";
         final var nullToken = "nullToken";
-        return defaultHapiSpec("associateTokenNegativeScenarios")
-                .given(
-                        uploadInitCode(NEGATIVE_ASSOCIATIONS_CONTRACT),
-                        contractCreate(NEGATIVE_ASSOCIATIONS_CONTRACT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(50L)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY)
-                                .exposingAddressTo(tokenAddress::set),
-                        cryptoCreate(ACCOUNT).exposingCreatedIdTo(id -> accountAddress.set(idAsHeadlongAddress(id))))
-                .when(withOpContext((spec, custom) -> allRunFor(
+        return hapiTest(
+                uploadInitCode(NEGATIVE_ASSOCIATIONS_CONTRACT),
+                contractCreate(NEGATIVE_ASSOCIATIONS_CONTRACT),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(50L)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY)
+                        .exposingAddressTo(tokenAddress::set),
+                cryptoCreate(ACCOUNT).exposingCreatedIdTo(id -> accountAddress.set(idAsHeadlongAddress(id))),
+                withOpContext((spec, custom) -> allRunFor(
                         spec,
                         newKeyNamed(CONTRACT_KEY).shape(KEY_SHAPE.signedWith(sigs(ON, NEGATIVE_ASSOCIATIONS_CONTRACT))),
                         cryptoUpdate(ACCOUNT).key(CONTRACT_KEY),
@@ -467,23 +462,16 @@ public class AssociatePrecompileSuite {
                                 .gas(GAS_TO_OFFER)
                                 .via(nullToken)
                                 .logged(),
-                        getAccountInfo(ACCOUNT).hasNoTokenRelationship(TOKEN))))
-                .then(
-                        childRecordsCheck(
-                                nonExistingAccount,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ACCOUNT_ID)),
-                        childRecordsCheck(
-                                nullAccount,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ACCOUNT_ID)),
-                        childRecordsCheck(
-                                nonExistingToken,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                nullToken,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)));
+                        getAccountInfo(ACCOUNT).hasNoTokenRelationship(TOKEN))),
+                childRecordsCheck(
+                        nonExistingAccount,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_ACCOUNT_ID)),
+                childRecordsCheck(
+                        nullAccount, CONTRACT_REVERT_EXECUTED, recordWith().status(INVALID_ACCOUNT_ID)),
+                childRecordsCheck(
+                        nonExistingToken, CONTRACT_REVERT_EXECUTED, recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        nullToken, CONTRACT_REVERT_EXECUTED, recordWith().status(INVALID_TOKEN_ID)));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/AssociatePrecompileV2SecurityModelSuite.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.CONTRACT;
@@ -96,49 +96,48 @@ public class AssociatePrecompileV2SecurityModelSuite {
     @HapiTest
     final Stream<DynamicTest> v2Security031AssociateSingleTokenWithDelegateContractKey() {
 
-        return defaultHapiSpec("v2Security031AssociateSingleTokenWithDelegateContractKey")
-                .given(
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
-                        cryptoCreate(ACCOUNT).balance(10 * ONE_HUNDRED_HBARS),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        tokenCreate(FROZEN_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(TOTAL_SUPPLY)
-                                .freezeKey(FREEZE_KEY)
-                                .freezeDefault(true)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        tokenCreate(UNFROZEN_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .freezeKey(FREEZE_KEY)
-                                .freezeDefault(false)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        tokenCreate(KYC_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .kycKey(KYC_KEY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        uploadInitCode(ASSOCIATE_CONTRACT, MINT_TOKEN_CONTRACT),
-                        contractCreate(MINT_TOKEN_CONTRACT),
-                        contractCreate(ASSOCIATE_CONTRACT))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(KYC_KEY),
+                cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
+                cryptoCreate(ACCOUNT).balance(10 * ONE_HUNDRED_HBARS),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                tokenCreate(FROZEN_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(TOTAL_SUPPLY)
+                        .freezeKey(FREEZE_KEY)
+                        .freezeDefault(true)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                tokenCreate(UNFROZEN_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .freezeKey(FREEZE_KEY)
+                        .freezeDefault(false)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                tokenCreate(KYC_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .kycKey(KYC_KEY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                uploadInitCode(ASSOCIATE_CONTRACT, MINT_TOKEN_CONTRACT),
+                contractCreate(MINT_TOKEN_CONTRACT),
+                contractCreate(ASSOCIATE_CONTRACT),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         newKeyNamed(CONTRACT_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, ASSOCIATE_CONTRACT))),
                         cryptoUpdate(SIGNER).key(CONTRACT_KEY),
@@ -202,8 +201,8 @@ public class AssociatePrecompileV2SecurityModelSuite {
                                 .hasRetryPrecheckFrom(BUSY)
                                 .via("multipleTokensAssociate")
                                 .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(SUCCESS))))
-                .then(getAccountInfo(ACCOUNT)
+                                .hasKnownStatus(SUCCESS))),
+                getAccountInfo(ACCOUNT)
                         .hasToken(relationshipWith(FUNGIBLE_TOKEN)
                                 .kyc(KycNotApplicable)
                                 .freeze(FreezeNotApplicable))
@@ -221,50 +220,49 @@ public class AssociatePrecompileV2SecurityModelSuite {
 
     @HapiTest
     final Stream<DynamicTest> v2Security006TokenAssociateNegativeTests() {
-        return defaultHapiSpec("v2Security006TokenAssociateNegativeTests")
-                .given(
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(SIGNER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(ACCOUNT).balance(10 * ONE_HUNDRED_HBARS),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(ADMIN_KEY)
-                                .supplyKey(TOKEN_TREASURY),
-                        tokenCreate(FROZEN_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(TOTAL_SUPPLY)
-                                .freezeKey(FREEZE_KEY)
-                                .freezeDefault(true)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        tokenCreate(UNFROZEN_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .freezeKey(FREEZE_KEY)
-                                .freezeDefault(false)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        tokenCreate(KYC_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .kycKey(KYC_KEY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        uploadInitCode(ASSOCIATE_CONTRACT, NESTED_ASSOCIATE_CONTRACT, MINT_TOKEN_CONTRACT),
-                        contractCreate(ASSOCIATE_CONTRACT),
-                        contractCreate(MINT_TOKEN_CONTRACT))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(KYC_KEY),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(SIGNER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(ACCOUNT).balance(10 * ONE_HUNDRED_HBARS),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(ADMIN_KEY)
+                        .supplyKey(TOKEN_TREASURY),
+                tokenCreate(FROZEN_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(TOTAL_SUPPLY)
+                        .freezeKey(FREEZE_KEY)
+                        .freezeDefault(true)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                tokenCreate(UNFROZEN_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .freezeKey(FREEZE_KEY)
+                        .freezeDefault(false)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                tokenCreate(KYC_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .kycKey(KYC_KEY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                uploadInitCode(ASSOCIATE_CONTRACT, NESTED_ASSOCIATE_CONTRACT, MINT_TOKEN_CONTRACT),
+                contractCreate(ASSOCIATE_CONTRACT),
+                contractCreate(MINT_TOKEN_CONTRACT),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 NESTED_ASSOCIATE_CONTRACT,
@@ -372,71 +370,69 @@ public class AssociatePrecompileV2SecurityModelSuite {
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                         getTxnRecord("associateTokenToContractFails")
                                 .andAllChildRecords()
-                                .logged())))
-                .then(
-                        childRecordsCheck(
-                                "fungibleTokenAssociate",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
-                        childRecordsCheck(
-                                "nonFungibleTokenAssociate",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
-                        childRecordsCheck(
-                                "multipleTokensAssociate",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
-                        childRecordsCheck(
-                                "nestedAssociateFungibleTxn",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
-                        childRecordsCheck(
-                                "associateTokenToContractFails",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))));
+                                .logged())),
+                childRecordsCheck(
+                        "fungibleTokenAssociate",
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith()
+                                .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
+                childRecordsCheck(
+                        "nonFungibleTokenAssociate",
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith()
+                                .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
+                childRecordsCheck(
+                        "multipleTokensAssociate",
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith()
+                                .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
+                childRecordsCheck(
+                        "nestedAssociateFungibleTxn",
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith()
+                                .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
+                childRecordsCheck(
+                        "associateTokenToContractFails",
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith()
+                                .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))));
     }
 
     @HapiTest
     final Stream<DynamicTest> v2Security010NestedAssociateNftAndNonFungibleTokens() {
 
-        return defaultHapiSpec("v2Security010NestedAssociateNftAndNonFungibleTokens")
-                .given(
-                        cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(TOKEN_TREASURY)
-                                .initialSupply(0)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY),
-                        uploadInitCode(ASSOCIATE_CONTRACT, NESTED_ASSOCIATE_CONTRACT),
-                        contractCreate(ASSOCIATE_CONTRACT))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(TOKEN_TREASURY)
+                        .initialSupply(0)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY),
+                uploadInitCode(ASSOCIATE_CONTRACT, NESTED_ASSOCIATE_CONTRACT),
+                contractCreate(ASSOCIATE_CONTRACT),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 NESTED_ASSOCIATE_CONTRACT,
@@ -477,54 +473,52 @@ public class AssociatePrecompileV2SecurityModelSuite {
                                 .hasRetryPrecheckFrom(BUSY)
                                 .via("nestedAssociateNonFungibleTxn")
                                 .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(SUCCESS))))
-                .then(
-                        getAccountInfo(ACCOUNT)
-                                .hasToken(relationshipWith(FUNGIBLE_TOKEN)
-                                        .kyc(KycNotApplicable)
-                                        .freeze(FreezeNotApplicable))
-                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN)
-                                        .kyc(KycNotApplicable)
-                                        .freeze(FreezeNotApplicable)),
-                        childRecordsCheck(
-                                "nestedAssociateFungibleTxn",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(
-                                                        htsPrecompileResult().withStatus(SUCCESS)))),
-                        childRecordsCheck(
-                                "nestedAssociateNonFungibleTxn",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(
-                                                        htsPrecompileResult().withStatus(SUCCESS)))));
+                                .hasKnownStatus(SUCCESS))),
+                getAccountInfo(ACCOUNT)
+                        .hasToken(relationshipWith(FUNGIBLE_TOKEN)
+                                .kyc(KycNotApplicable)
+                                .freeze(FreezeNotApplicable))
+                        .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN)
+                                .kyc(KycNotApplicable)
+                                .freeze(FreezeNotApplicable)),
+                childRecordsCheck(
+                        "nestedAssociateFungibleTxn",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(
+                                                htsPrecompileResult().withStatus(SUCCESS)))),
+                childRecordsCheck(
+                        "nestedAssociateNonFungibleTxn",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(
+                                                htsPrecompileResult().withStatus(SUCCESS)))));
     }
 
     @HapiTest
     final Stream<DynamicTest> V2Security036TokenAssociateFromDelegateCallWithDelegateContractId() {
 
-        return defaultHapiSpec("v2Security010NestedAssociateNftAndNonFungibleTokens")
-                .given(
-                        cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(TOKEN_TREASURY)
-                                .initialSupply(0)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY),
-                        uploadInitCode(ASSOCIATE_CONTRACT, NESTED_ASSOCIATE_CONTRACT),
-                        contractCreate(ASSOCIATE_CONTRACT))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(TOKEN_TREASURY)
+                        .initialSupply(0)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY),
+                uploadInitCode(ASSOCIATE_CONTRACT, NESTED_ASSOCIATE_CONTRACT),
+                contractCreate(ASSOCIATE_CONTRACT),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 NESTED_ASSOCIATE_CONTRACT,
@@ -565,55 +559,53 @@ public class AssociatePrecompileV2SecurityModelSuite {
                                 .hasKnownStatus(SUCCESS),
                         getTxnRecord("nestedAssociateNonFungibleTxn")
                                 .andAllChildRecords()
-                                .logged())))
-                .then(
-                        getAccountInfo(ACCOUNT)
-                                .hasToken(relationshipWith(FUNGIBLE_TOKEN)
-                                        .kyc(KycNotApplicable)
-                                        .freeze(FreezeNotApplicable))
-                                .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN)
-                                        .kyc(KycNotApplicable)
-                                        .freeze(FreezeNotApplicable)),
-                        childRecordsCheck(
-                                "nestedAssociateFungibleTxn",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(
-                                                        htsPrecompileResult().withStatus(SUCCESS)))),
-                        childRecordsCheck(
-                                "nestedAssociateNonFungibleTxn",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(
-                                                        htsPrecompileResult().withStatus(SUCCESS)))));
+                                .logged())),
+                getAccountInfo(ACCOUNT)
+                        .hasToken(relationshipWith(FUNGIBLE_TOKEN)
+                                .kyc(KycNotApplicable)
+                                .freeze(FreezeNotApplicable))
+                        .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN)
+                                .kyc(KycNotApplicable)
+                                .freeze(FreezeNotApplicable)),
+                childRecordsCheck(
+                        "nestedAssociateFungibleTxn",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(
+                                                htsPrecompileResult().withStatus(SUCCESS)))),
+                childRecordsCheck(
+                        "nestedAssociateNonFungibleTxn",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(
+                                                htsPrecompileResult().withStatus(SUCCESS)))));
     }
 
     @HapiTest
     final Stream<DynamicTest> V2Security041TokenAssociateFromStaticcallAndCallcode() {
 
-        return defaultHapiSpec("V2Security041TokenAssociateFromStaticcallAndCallcode")
-                .given(
-                        cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY).balance(THOUSAND_HBAR),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(TOKEN_TREASURY)
-                                .initialSupply(0)
-                                .adminKey(TOKEN_TREASURY)
-                                .treasury(TOKEN_TREASURY),
-                        uploadInitCode(ASSOCIATE_CONTRACT, NESTED_ASSOCIATE_CONTRACT, CALLCODE_CONTRACT),
-                        contractCreate(ASSOCIATE_CONTRACT),
-                        contractCreate(CALLCODE_CONTRACT))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY).balance(THOUSAND_HBAR),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(TOKEN_TREASURY)
+                        .initialSupply(0)
+                        .adminKey(TOKEN_TREASURY)
+                        .treasury(TOKEN_TREASURY),
+                uploadInitCode(ASSOCIATE_CONTRACT, NESTED_ASSOCIATE_CONTRACT, CALLCODE_CONTRACT),
+                contractCreate(ASSOCIATE_CONTRACT),
+                contractCreate(CALLCODE_CONTRACT),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 NESTED_ASSOCIATE_CONTRACT,
@@ -651,12 +643,14 @@ public class AssociatePrecompileV2SecurityModelSuite {
                                         asHeadlongAddress(getNestedContractAddress(ASSOCIATE_CONTRACT, spec)),
                                         Bytes.wrap(AssociationsTranslator.ASSOCIATE_ONE
                                                         .encodeCallWithArgs(
-                                                                HapiParserUtil.asHeadlongAddress(asAddress(
-                                                                        spec.registry()
-                                                                                .getAccountID(ACCOUNT))),
-                                                                HapiParserUtil.asHeadlongAddress(asAddress(
-                                                                        spec.registry()
-                                                                                .getTokenID(FUNGIBLE_TOKEN))))
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getAccountID(ACCOUNT))),
+                                                                HapiParserUtil.asHeadlongAddress(
+                                                                        asAddress(
+                                                                                spec.registry()
+                                                                                        .getTokenID(FUNGIBLE_TOKEN))))
                                                         .array())
                                                 .toArray())
                                 .via("associateCallcodeFungibleTxn")
@@ -669,10 +663,9 @@ public class AssociatePrecompileV2SecurityModelSuite {
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                         getTxnRecord("associateCallcodeFungibleTxn")
                                 .andAllChildRecords()
-                                .logged())))
-                .then(
-                        emptyChildRecordsCheck("associateStaticcallFungibleTxn", CONTRACT_REVERT_EXECUTED),
-                        emptyChildRecordsCheck("associateCallcodeFungibleTxn", CONTRACT_REVERT_EXECUTED),
-                        getAccountInfo(ACCOUNT).hasNoTokenRelationship(FUNGIBLE_TOKEN));
+                                .logged())),
+                emptyChildRecordsCheck("associateStaticcallFungibleTxn", CONTRACT_REVERT_EXECUTED),
+                emptyChildRecordsCheck("associateCallcodeFungibleTxn", CONTRACT_REVERT_EXECUTED),
+                getAccountInfo(ACCOUNT).hasNoTokenRelationship(FUNGIBLE_TOKEN));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSSuite.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
@@ -160,52 +159,44 @@ public class ContractBurnHTSSuite {
         final var negativeBurnNFT = "negativeBurnNFT";
         final AtomicReference<Address> tokenAddress = new AtomicReference<>();
         final AtomicReference<Address> nftAddress = new AtomicReference<>();
-        return defaultHapiSpec("burnWithNegativeAmount")
-                .given(
-                        uploadInitCode(NEGATIVE_BURN_CONTRACT),
-                        contractCreate(NEGATIVE_BURN_CONTRACT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(1_000L)
-                                .exposingAddressTo(tokenAddress::set),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(0L)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .exposingAddressTo(nftAddress::set),
-                        mintToken(NFT, List.of(copyFromUtf8(FIRST), copyFromUtf8(SECOND))))
-                .when(
-                        sourcing(() -> contractCall(
-                                        NEGATIVE_BURN_CONTRACT, "burnFungibleNegativeLong", tokenAddress.get())
-                                .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                .via(negativeBurnFungible)
-                                .logged()),
-                        newKeyNamed(CONTRACT_KEY).shape(KeyShape.CONTRACT.signedWith(NEGATIVE_BURN_CONTRACT)),
-                        tokenUpdate(NFT).supplyKey(CONTRACT_KEY).signedByPayerAnd(TOKEN_TREASURY),
-                        sourcing(() -> contractCall(
-                                        NEGATIVE_BURN_CONTRACT, "burnNFTNegativeLong", nftAddress.get(), new long[] {
-                                            1L, 2L
-                                        })
-                                .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(SUCCESS)
-                                .payingWith(TOKEN_TREASURY)
-                                .signingWith(TOKEN_TREASURY)
-                                .via(negativeBurnNFT)
-                                .logged()))
-                .then(
-                        childRecordsCheck(
-                                negativeBurnFungible,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_BURN_AMOUNT)),
-                        childRecordsCheck(negativeBurnNFT, SUCCESS, recordWith().status(SUCCESS)),
-                        getAccountBalance(TOKEN_TREASURY)
-                                .hasTokenBalance(TOKEN, 1_000)
-                                .hasTokenBalance(NFT, 0));
+        return hapiTest(
+                uploadInitCode(NEGATIVE_BURN_CONTRACT),
+                contractCreate(NEGATIVE_BURN_CONTRACT),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(1_000L)
+                        .exposingAddressTo(tokenAddress::set),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(0L)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .exposingAddressTo(nftAddress::set),
+                mintToken(NFT, List.of(copyFromUtf8(FIRST), copyFromUtf8(SECOND))),
+                sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnFungibleNegativeLong", tokenAddress.get())
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                        .via(negativeBurnFungible)
+                        .logged()),
+                newKeyNamed(CONTRACT_KEY).shape(KeyShape.CONTRACT.signedWith(NEGATIVE_BURN_CONTRACT)),
+                tokenUpdate(NFT).supplyKey(CONTRACT_KEY).signedByPayerAnd(TOKEN_TREASURY),
+                sourcing(() -> contractCall(
+                                NEGATIVE_BURN_CONTRACT, "burnNFTNegativeLong", nftAddress.get(), new long[] {1L, 2L})
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(SUCCESS)
+                        .payingWith(TOKEN_TREASURY)
+                        .signingWith(TOKEN_TREASURY)
+                        .via(negativeBurnNFT)
+                        .logged()),
+                childRecordsCheck(
+                        negativeBurnFungible,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_BURN_AMOUNT)),
+                childRecordsCheck(negativeBurnNFT, SUCCESS, recordWith().status(SUCCESS)),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(TOKEN, 1_000).hasTokenBalance(NFT, 0));
     }
 
     @HapiTest
@@ -214,102 +205,89 @@ public class ContractBurnHTSSuite {
         final AtomicReference<Address> nftAddress = new AtomicReference<>();
         final var fungibleExtremeAmount = "fungibleExtremeAmounts";
         final var nftExtremeAmount = "NFTExtremeAmounts";
-        return defaultHapiSpec("burnAboveMaxLongAmount")
-                .given(
-                        uploadInitCode(NEGATIVE_BURN_CONTRACT),
-                        contractCreate(NEGATIVE_BURN_CONTRACT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(1_000)
-                                .exposingAddressTo(tokenAddress::set),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(0L)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .exposingAddressTo(nftAddress::set),
-                        mintToken(NFT, List.of(copyFromUtf8(FIRST), copyFromUtf8(SECOND))))
-                .when(
-                        sourcing(() -> contractCall(
-                                        NEGATIVE_BURN_CONTRACT, "burnFungibleWithExtremeAmounts", tokenAddress.get())
+        return hapiTest(
+                uploadInitCode(NEGATIVE_BURN_CONTRACT),
+                contractCreate(NEGATIVE_BURN_CONTRACT),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(1_000)
+                        .exposingAddressTo(tokenAddress::set),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(0L)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .exposingAddressTo(nftAddress::set),
+                mintToken(NFT, List.of(copyFromUtf8(FIRST), copyFromUtf8(SECOND))),
+                sourcing(
+                        () -> contractCall(NEGATIVE_BURN_CONTRACT, "burnFungibleWithExtremeAmounts", tokenAddress.get())
                                 .gas(GAS_TO_OFFER)
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
                                 .via(fungibleExtremeAmount)
                                 .logged()),
-                        newKeyNamed(CONTRACT_KEY).shape(KeyShape.CONTRACT.signedWith(NEGATIVE_BURN_CONTRACT)),
-                        tokenUpdate(NFT).supplyKey(CONTRACT_KEY).signedByPayerAnd(TOKEN_TREASURY),
-                        sourcing(() -> contractCall(
-                                        NEGATIVE_BURN_CONTRACT,
-                                        "burnNFTWithExtremeAmounts",
-                                        nftAddress.get(),
-                                        new long[] {1L, 2L})
-                                .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                .payingWith(TOKEN_TREASURY)
-                                .signingWith(TOKEN_TREASURY)
-                                .via(nftExtremeAmount)
-                                .logged()))
-                .then(
-                        emptyChildRecordsCheck(fungibleExtremeAmount, CONTRACT_REVERT_EXECUTED),
-                        emptyChildRecordsCheck(nftExtremeAmount, CONTRACT_REVERT_EXECUTED),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(TOKEN, 1_000),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2));
+                newKeyNamed(CONTRACT_KEY).shape(KeyShape.CONTRACT.signedWith(NEGATIVE_BURN_CONTRACT)),
+                tokenUpdate(NFT).supplyKey(CONTRACT_KEY).signedByPayerAnd(TOKEN_TREASURY),
+                sourcing(() -> contractCall(
+                                NEGATIVE_BURN_CONTRACT, "burnNFTWithExtremeAmounts", nftAddress.get(), new long[] {
+                                    1L, 2L
+                                })
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                        .payingWith(TOKEN_TREASURY)
+                        .signingWith(TOKEN_TREASURY)
+                        .via(nftExtremeAmount)
+                        .logged()),
+                emptyChildRecordsCheck(fungibleExtremeAmount, CONTRACT_REVERT_EXECUTED),
+                emptyChildRecordsCheck(nftExtremeAmount, CONTRACT_REVERT_EXECUTED),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(TOKEN, 1_000),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2));
     }
 
     @HapiTest
     final Stream<DynamicTest> burnWithZeroAddress() {
-        return defaultHapiSpec("burnWithZeroAddress")
-                .given(uploadInitCode(NEGATIVE_BURN_CONTRACT), contractCreate(NEGATIVE_BURN_CONTRACT))
-                .when(
-                        sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnFungibleZeroAddress")
-                                .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                .via("zeroAddress")
-                                .logged()),
-                        sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnNFTZeroAddress", new long[] {1L, 2L})
-                                .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                .via("zeroAddressNFT")
-                                .logged()))
-                .then(
-                        childRecordsCheck(
-                                "zeroAddress",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                "zeroAddressNFT",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)));
+        return hapiTest(
+                uploadInitCode(NEGATIVE_BURN_CONTRACT),
+                contractCreate(NEGATIVE_BURN_CONTRACT),
+                sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnFungibleZeroAddress")
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                        .via("zeroAddress")
+                        .logged()),
+                sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnNFTZeroAddress", new long[] {1L, 2L})
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                        .via("zeroAddressNFT")
+                        .logged()),
+                childRecordsCheck(
+                        "zeroAddress", CONTRACT_REVERT_EXECUTED, recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        "zeroAddressNFT", CONTRACT_REVERT_EXECUTED, recordWith().status(INVALID_TOKEN_ID)));
     }
 
     @HapiTest
     final Stream<DynamicTest> burnWithInvalidAddress() {
-        return defaultHapiSpec("burnWithInvalidAddress")
-                .given(uploadInitCode(NEGATIVE_BURN_CONTRACT), contractCreate(NEGATIVE_BURN_CONTRACT))
-                .when(
-                        sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnFungibleInvalidAddress")
-                                .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                .via("invalidAddress")
-                                .logged()),
-                        sourcing(
-                                () -> contractCall(NEGATIVE_BURN_CONTRACT, "burnNFTInvalidAddress", new long[] {1L, 2L})
-                                        .gas(GAS_TO_OFFER)
-                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                        .via("invalidAddressNFT")
-                                        .logged()))
-                .then(
-                        childRecordsCheck(
-                                "invalidAddress",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                "invalidAddressNFT",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)));
+        return hapiTest(
+                uploadInitCode(NEGATIVE_BURN_CONTRACT),
+                contractCreate(NEGATIVE_BURN_CONTRACT),
+                sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnFungibleInvalidAddress")
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                        .via("invalidAddress")
+                        .logged()),
+                sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnNFTInvalidAddress", new long[] {1L, 2L})
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                        .via("invalidAddressNFT")
+                        .logged()),
+                childRecordsCheck(
+                        "invalidAddress", CONTRACT_REVERT_EXECUTED, recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        "invalidAddressNFT",
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)));
     }
 
     @HapiTest
@@ -318,43 +296,39 @@ public class ContractBurnHTSSuite {
         final AtomicReference<Address> nftAddress = new AtomicReference<>();
         final var negativeBurnFungible = "negativeBurnFungible";
         final var negativeBurnNft = "negativeBurnNft";
-        return defaultHapiSpec("burnWithInvalidSerials")
-                .given(
-                        uploadInitCode(NEGATIVE_BURN_CONTRACT),
-                        contractCreate(NEGATIVE_BURN_CONTRACT),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(TOKEN)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(1_000)
-                                .exposingAddressTo(tokenAddress::set),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(0L)
-                                .supplyKey(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .exposingAddressTo(nftAddress::set),
-                        mintToken(NFT, List.of(copyFromUtf8(FIRST), copyFromUtf8(SECOND))))
-                .when(
-                        sourcing(() -> contractCall(
-                                        NEGATIVE_BURN_CONTRACT, "burnFungibleWithInvalidSerials", tokenAddress.get())
+        return hapiTest(
+                uploadInitCode(NEGATIVE_BURN_CONTRACT),
+                contractCreate(NEGATIVE_BURN_CONTRACT),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(1_000)
+                        .exposingAddressTo(tokenAddress::set),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(0L)
+                        .supplyKey(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .exposingAddressTo(nftAddress::set),
+                mintToken(NFT, List.of(copyFromUtf8(FIRST), copyFromUtf8(SECOND))),
+                sourcing(
+                        () -> contractCall(NEGATIVE_BURN_CONTRACT, "burnFungibleWithInvalidSerials", tokenAddress.get())
                                 .gas(GAS_TO_OFFER)
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
                                 .via(negativeBurnFungible)
                                 .logged()),
-                        sourcing(() -> contractCall(
-                                        NEGATIVE_BURN_CONTRACT, "burnNFTWithInvalidSerials", nftAddress.get())
-                                .gas(GAS_TO_OFFER)
-                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
-                                .payingWith(TOKEN_TREASURY)
-                                .signingWith(TOKEN_TREASURY)
-                                .via(negativeBurnNft)
-                                .logged()))
-                .then(
-                        emptyChildRecordsCheck(negativeBurnFungible, CONTRACT_REVERT_EXECUTED),
-                        emptyChildRecordsCheck(negativeBurnNft, CONTRACT_REVERT_EXECUTED),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(TOKEN, 1_000),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2));
+                sourcing(() -> contractCall(NEGATIVE_BURN_CONTRACT, "burnNFTWithInvalidSerials", nftAddress.get())
+                        .gas(GAS_TO_OFFER)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                        .payingWith(TOKEN_TREASURY)
+                        .signingWith(TOKEN_TREASURY)
+                        .via(negativeBurnNft)
+                        .logged()),
+                emptyChildRecordsCheck(negativeBurnFungible, CONTRACT_REVERT_EXECUTED),
+                emptyChildRecordsCheck(negativeBurnNft, CONTRACT_REVERT_EXECUTED),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(TOKEN, 1_000),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractBurnHTSV2SecurityModelSuite.java
@@ -19,7 +19,7 @@ package com.hedera.services.bdd.suites.contract.precompile;
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asToken;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.ContractLogAsserts.logWith;
@@ -113,22 +113,21 @@ public class ContractBurnHTSV2SecurityModelSuite {
         final var amountToBurn = 5L;
         final AtomicReference<TokenID> fungible = new AtomicReference<>();
         // sync
-        return defaultHapiSpec("V2Security004FungibleTokenBurnPositive")
-                .given(
-                        //  overriding(CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
-                        // CONTRACTS_V2_SECURITY_MODEL_BLOCK_CUTOFF),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(SIGNER2),
-                        cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(initialAmount)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY)
-                                .exposingCreatedIdTo(idLit -> fungible.set(asToken(idLit))),
-                        uploadInitCode(MIXED_BURN_TOKEN))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                //  overriding(CONTRACTS_MAX_NUM_WITH_HAPI_SIGS_ACCESS,
+                // CONTRACTS_V2_SECURITY_MODEL_BLOCK_CUTOFF),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(SIGNER2),
+                cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(initialAmount)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY)
+                        .exposingCreatedIdTo(idLit -> fungible.set(asToken(idLit))),
+                uploadInitCode(MIXED_BURN_TOKEN),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 MIXED_BURN_TOKEN,
@@ -190,21 +189,20 @@ public class ContractBurnHTSV2SecurityModelSuite {
                                 .signedBy(SIGNER),
                         // Assert that the token is burned - total supply should be decreased with the amount that was
                         // burned
-                        getTokenInfo(FUNGIBLE_TOKEN).hasTotalSupply(initialAmount - 4 * amountToBurn))))
-                .then(
-                        // Verify that each test case has 1 successful child record
-                        getTxnRecord(SIGNER_BURNS_WITH_CONTRACT_ID)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(SUCCESS)),
-                        getTxnRecord(SIGNER_HAS_KEY_WITH_CORRECT_CONTRACT_ID)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(SUCCESS)),
-                        getTxnRecord(SIGNER_AND_PAYER_ARE_DIFFERENT)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(SUCCESS)),
-                        getTxnRecord(SIGNER_BURNS_WITH_TRESHOLD_KEY)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(SUCCESS)));
+                        getTokenInfo(FUNGIBLE_TOKEN).hasTotalSupply(initialAmount - 4 * amountToBurn))),
+                // Verify that each test case has 1 successful child record
+                getTxnRecord(SIGNER_BURNS_WITH_CONTRACT_ID)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(SUCCESS)),
+                getTxnRecord(SIGNER_HAS_KEY_WITH_CORRECT_CONTRACT_ID)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(SUCCESS)),
+                getTxnRecord(SIGNER_AND_PAYER_ARE_DIFFERENT)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(SUCCESS)),
+                getTxnRecord(SIGNER_BURNS_WITH_TRESHOLD_KEY)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(SUCCESS)));
     }
 
     @HapiTest
@@ -215,24 +213,23 @@ public class ContractBurnHTSV2SecurityModelSuite {
         final var serialNumber2 = new long[] {2L};
         final var serialNumber3 = new long[] {3L};
 
-        return defaultHapiSpec("V2Security005NonFungibleTokenBurnPositive")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(SIGNER2),
-                        cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY)
-                                .exposingCreatedIdTo(idLit -> nonFungible.set(asToken(idLit))),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(SECOND))),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(THIRD))),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FOURTH))),
-                        uploadInitCode(MIXED_BURN_TOKEN))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(SIGNER2),
+                cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY)
+                        .exposingCreatedIdTo(idLit -> nonFungible.set(asToken(idLit))),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(SECOND))),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(THIRD))),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FOURTH))),
+                uploadInitCode(MIXED_BURN_TOKEN),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 MIXED_BURN_TOKEN,
@@ -272,18 +269,17 @@ public class ContractBurnHTSV2SecurityModelSuite {
                                 .hasRetryPrecheckFrom(BUSY)
                                 .payingWith(SIGNER2)
                                 .signedBy(SIGNER2, TOKEN_TREASURY),
-                        getTokenInfo(NON_FUNGIBLE_TOKEN).hasTotalSupply(2 - amountToBurn))))
-                .then(
-                        // Verify that each test case has 1 successful child record
-                        getTxnRecord(SIGNER_BURNS_WITH_CONTRACT_ID)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(SUCCESS)),
-                        getTxnRecord(SIGNER_HAS_KEY_WITH_CORRECT_CONTRACT_ID)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(SUCCESS)),
-                        getTxnRecord(SIGNER_AND_PAYER_ARE_DIFFERENT)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(SUCCESS)));
+                        getTokenInfo(NON_FUNGIBLE_TOKEN).hasTotalSupply(2 - amountToBurn))),
+                // Verify that each test case has 1 successful child record
+                getTxnRecord(SIGNER_BURNS_WITH_CONTRACT_ID)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(SUCCESS)),
+                getTxnRecord(SIGNER_HAS_KEY_WITH_CORRECT_CONTRACT_ID)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(SUCCESS)),
+                getTxnRecord(SIGNER_AND_PAYER_ARE_DIFFERENT)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(SUCCESS)));
     }
 
     @HapiTest
@@ -292,22 +288,21 @@ public class ContractBurnHTSV2SecurityModelSuite {
         final var amountToBurn = 5L;
         final AtomicReference<TokenID> fungible = new AtomicReference<>();
 
-        return defaultHapiSpec("V2Security004FungibleTokenBurnNegative")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(initialAmount)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY)
-                                .exposingCreatedIdTo(idLit -> fungible.set(asToken(idLit))),
-                        uploadInitCode(MIXED_BURN_TOKEN),
-                        uploadInitCode(MINT_CONTRACT),
-                        sourcing(() -> contractCreate(
-                                MINT_CONTRACT, HapiParserUtil.asHeadlongAddress(asAddress(fungible.get())))))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(initialAmount)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY)
+                        .exposingCreatedIdTo(idLit -> fungible.set(asToken(idLit))),
+                uploadInitCode(MIXED_BURN_TOKEN),
+                uploadInitCode(MINT_CONTRACT),
+                sourcing(() ->
+                        contractCreate(MINT_CONTRACT, HapiParserUtil.asHeadlongAddress(asAddress(fungible.get())))),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(MIXED_BURN_TOKEN, HapiParserUtil.asHeadlongAddress(asAddress(fungible.get()))),
                         // Test Case 1: Signer paying and signing a token burn transaction,
@@ -373,18 +368,17 @@ public class ContractBurnHTSV2SecurityModelSuite {
                         getTokenInfo(FUNGIBLE_TOKEN).hasTotalSupply(initialAmount),
                         getTxnRecord(TOKEN_HAS_NO_UPDATED_KEY)
                                 .andAllChildRecords()
-                                .logged())))
-                .then(
-                        // Verify that the child records fail with the expected status
-                        getTxnRecord(SIGNER_AND_TOKEN_HAVE_NO_UPDATED_KEYS)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
-                        getTxnRecord(SIGNER_MINTS_WITH_SIGNER_PUBLIC_KEY_AND_WRONG_CONTRACT_ID)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
-                        getTxnRecord(TOKEN_HAS_NO_UPDATED_KEY)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)));
+                                .logged())),
+                // Verify that the child records fail with the expected status
+                getTxnRecord(SIGNER_AND_TOKEN_HAVE_NO_UPDATED_KEYS)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
+                getTxnRecord(SIGNER_MINTS_WITH_SIGNER_PUBLIC_KEY_AND_WRONG_CONTRACT_ID)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
+                getTxnRecord(TOKEN_HAS_NO_UPDATED_KEY)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)));
     }
 
     @HapiTest
@@ -392,25 +386,24 @@ public class ContractBurnHTSV2SecurityModelSuite {
         final AtomicReference<TokenID> nonFungible = new AtomicReference<>();
         final var serialNumber1 = new long[] {1L};
 
-        return defaultHapiSpec("V2Security004NonFungibleTokenBurnNegative")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY)
-                                .exposingCreatedIdTo(idLit -> nonFungible.set(asToken(idLit))),
-                        // Mint NFT, so that we can verify that the burn fails as expected
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
-                        uploadInitCode(MIXED_BURN_TOKEN),
-                        // contractCreate(MIXED_BURN_TOKEN),
-                        uploadInitCode(MINT_CONTRACT),
-                        sourcing(() -> contractCreate(
-                                MINT_CONTRACT, HapiParserUtil.asHeadlongAddress(asAddress(nonFungible.get())))))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY)
+                        .exposingCreatedIdTo(idLit -> nonFungible.set(asToken(idLit))),
+                // Mint NFT, so that we can verify that the burn fails as expected
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
+                uploadInitCode(MIXED_BURN_TOKEN),
+                // contractCreate(MIXED_BURN_TOKEN),
+                uploadInitCode(MINT_CONTRACT),
+                sourcing(() ->
+                        contractCreate(MINT_CONTRACT, HapiParserUtil.asHeadlongAddress(asAddress(nonFungible.get())))),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 MIXED_BURN_TOKEN, HapiParserUtil.asHeadlongAddress(asAddress(nonFungible.get()))),
@@ -479,36 +472,34 @@ public class ContractBurnHTSV2SecurityModelSuite {
                         getTokenInfo(NON_FUNGIBLE_TOKEN).hasTotalSupply(1L),
                         getTxnRecord(TOKEN_HAS_NO_UPDATED_KEY)
                                 .andAllChildRecords()
-                                .logged())))
-                .then(
-                        // Verify that the child records fail with the expected status
-                        getTxnRecord(SIGNER_AND_TOKEN_HAVE_NO_UPDATED_KEYS)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
-                        getTxnRecord(SIGNER_MINTS_WITH_SIGNER_PUBLIC_KEY_AND_WRONG_CONTRACT_ID)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
-                        getTxnRecord(TOKEN_HAS_NO_UPDATED_KEY)
-                                .andAllChildRecords()
-                                .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)));
+                                .logged())),
+                // Verify that the child records fail with the expected status
+                getTxnRecord(SIGNER_AND_TOKEN_HAVE_NO_UPDATED_KEYS)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
+                getTxnRecord(SIGNER_MINTS_WITH_SIGNER_PUBLIC_KEY_AND_WRONG_CONTRACT_ID)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)),
+                getTxnRecord(TOKEN_HAS_NO_UPDATED_KEY)
+                        .andAllChildRecords()
+                        .hasChildRecords(recordWith().status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)));
     }
 
     @HapiTest
     final Stream<DynamicTest> V2Security039NonFungibleTokenWithDelegateContractKeyCanNotBurnFromDelegatecall() {
         final var serialNumber1 = new long[] {1L};
-        return defaultHapiSpec("V2Security035NonFungibleTokenWithDelegateContractKeyCanNotBurnFromDelegatecall")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
-                        uploadInitCode(MIXED_BURN_TOKEN))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
+                uploadInitCode(MIXED_BURN_TOKEN),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 MIXED_BURN_TOKEN,
@@ -567,8 +558,8 @@ public class ContractBurnHTSV2SecurityModelSuite {
                         // Assert that the token is NOT burned
                         getTokenInfo(NON_FUNGIBLE_TOKEN).hasTotalSupply(1L),
                         // Assert the token is NOT burned from the token treasury account
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L))))
-                .then(withOpContext((spec, opLog) -> {
+                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L))),
+                withOpContext((spec, opLog) -> {
                     allRunFor(
                             spec,
                             // Verify that each test case has 1 top level call with the correct status
@@ -585,18 +576,17 @@ public class ContractBurnHTSV2SecurityModelSuite {
     @HapiTest
     final Stream<DynamicTest> V2Security039FungibleTokenWithDelegateContractKeyCanNotBurnFromDelegatecall() {
         final var initialAmount = 20L;
-        return defaultHapiSpec("V2Security035FungibleTokenWithDelegateContractKeyCanNotBurnFromDelegatecall")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(initialAmount)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(TOKEN_TREASURY)
-                                .supplyKey(TOKEN_TREASURY),
-                        uploadInitCode(MIXED_BURN_TOKEN))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(SIGNER).balance(ONE_MILLION_HBARS),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(initialAmount)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(TOKEN_TREASURY)
+                        .supplyKey(TOKEN_TREASURY),
+                uploadInitCode(MIXED_BURN_TOKEN),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCreate(
                                 MIXED_BURN_TOKEN,
@@ -645,8 +635,8 @@ public class ContractBurnHTSV2SecurityModelSuite {
                         // Assert that the token is NOT burned
                         getTokenInfo(FUNGIBLE_TOKEN).hasTotalSupply(initialAmount),
                         // Assert the token is NOT burned from the token treasury account
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, initialAmount))))
-                .then(withOpContext((spec, opLog) -> {
+                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, initialAmount))),
+                withOpContext((spec, opLog) -> {
                     allRunFor(
                             spec,
                             // Verify that each test case has 1 top level call with the correct status
@@ -667,30 +657,28 @@ public class ContractBurnHTSV2SecurityModelSuite {
         final var amount = 99L;
         final AtomicLong fungibleNum = new AtomicLong();
 
-        return defaultHapiSpec("burnTokenWithFullPrefixAndPartialPrefixKeys")
-                .given(
-                        newKeyNamed(SIGNER),
-                        uploadInitCode(ORDINARY_CALLS_CONTRACT),
-                        contractCreate(ORDINARY_CALLS_CONTRACT),
-                        newKeyNamed(THRESHOLD_KEY)
-                                .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, ORDINARY_CALLS_CONTRACT))),
-                        cryptoCreate(ACCOUNT_NAME).balance(10 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(100)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(SIGNER)
-                                .supplyKey(THRESHOLD_KEY)
-                                .exposingCreatedIdTo(idLit -> fungibleNum.set(asDotDelimitedLongArray(idLit)[2])),
-                        tokenCreate(FUNGIBLE_TOKEN_2)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(100)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(SIGNER)
-                                .supplyKey(SIGNER)
-                                .exposingCreatedIdTo(idLit -> fungibleNum.set(asDotDelimitedLongArray(idLit)[2])))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(SIGNER),
+                uploadInitCode(ORDINARY_CALLS_CONTRACT),
+                contractCreate(ORDINARY_CALLS_CONTRACT),
+                newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, ORDINARY_CALLS_CONTRACT))),
+                cryptoCreate(ACCOUNT_NAME).balance(10 * ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(100)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(SIGNER)
+                        .supplyKey(THRESHOLD_KEY)
+                        .exposingCreatedIdTo(idLit -> fungibleNum.set(asDotDelimitedLongArray(idLit)[2])),
+                tokenCreate(FUNGIBLE_TOKEN_2)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(100)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(SIGNER)
+                        .supplyKey(SIGNER)
+                        .exposingCreatedIdTo(idLit -> fungibleNum.set(asDotDelimitedLongArray(idLit)[2])),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCall(
                                         ORDINARY_CALLS_CONTRACT,
@@ -713,30 +701,29 @@ public class ContractBurnHTSV2SecurityModelSuite {
                                 .via(secondBurnTxn)
                                 .payingWith(ACCOUNT_NAME)
                                 .alsoSigningWithFullPrefix(SIGNER, THRESHOLD_KEY, ACCOUNT_NAME)
-                                .hasKnownStatus(SUCCESS))))
-                .then(
-                        childRecordsCheck(
-                                firstBurnTxn,
-                                SUCCESS,
-                                recordWith()
-                                        .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
-                                                        .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
-                        childRecordsCheck(
-                                secondBurnTxn,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
-                                                        .withStatus(SUCCESS)
-                                                        .withTotalSupply(99)))
-                                        .newTotalSupply(99)),
-                        getTokenInfo(FUNGIBLE_TOKEN).hasTotalSupply(amount),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, amount));
+                                .hasKnownStatus(SUCCESS))),
+                childRecordsCheck(
+                        firstBurnTxn,
+                        SUCCESS,
+                        recordWith()
+                                .status(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                .withStatus(INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE)))),
+                childRecordsCheck(
+                        secondBurnTxn,
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                .withStatus(SUCCESS)
+                                                .withTotalSupply(99)))
+                                .newTotalSupply(99)),
+                getTokenInfo(FUNGIBLE_TOKEN).hasTotalSupply(amount),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, amount));
     }
 
     @HapiTest
@@ -748,80 +735,77 @@ public class ContractBurnHTSV2SecurityModelSuite {
         final var SUPPLY_KEY = "SUPPLY_KEY";
         final var ADMIN_KEY = "ADMIN_KEY";
 
-        return defaultHapiSpec("hscsPreC020RollbackBurnThatFailsAfterAPrecompileTransfer")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(ADMIN_KEY).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(ALICE).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(bob).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(feeCollector).balance(0L),
-                        tokenCreate(tokenWithHbarFee)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .initialSupply(0L)
-                                .treasury(TOKEN_TREASURY)
-                                .withCustom(fixedHbarFee(300 * ONE_HBAR, feeCollector)),
-                        mintToken(tokenWithHbarFee, List.of(copyFromUtf8(FIRST))),
-                        mintToken(tokenWithHbarFee, List.of(copyFromUtf8(SECOND))),
-                        uploadInitCode(theContract),
-                        withOpContext((spec, opLog) -> allRunFor(
-                                spec,
-                                contractCreate(
-                                                theContract,
-                                                asHeadlongAddress(asHexedAddress(
-                                                        spec.registry().getTokenID(tokenWithHbarFee))))
-                                        .payingWith(bob)
-                                        .gas(GAS_TO_OFFER))),
-                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, theContract))),
-                        tokenUpdate(tokenWithHbarFee).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
-                        tokenAssociate(ALICE, tokenWithHbarFee),
-                        tokenAssociate(bob, tokenWithHbarFee),
-                        tokenAssociate(theContract, tokenWithHbarFee),
-                        cryptoTransfer(movingUnique(tokenWithHbarFee, 2L).between(TOKEN_TREASURY, ALICE))
-                                .payingWith(GENESIS),
-                        getAccountInfo(feeCollector)
-                                .has(AccountInfoAsserts.accountWith().balance(0L)))
-                .when(
-                        withOpContext((spec, opLog) -> {
-                            final var serialNumbers = new long[] {1L};
-                            allRunFor(
-                                    spec,
-                                    contractCall(
-                                                    theContract,
-                                                    "transferBurn",
-                                                    HapiParserUtil.asHeadlongAddress(asAddress(
-                                                            spec.registry().getAccountID(ALICE))),
-                                                    HapiParserUtil.asHeadlongAddress(asAddress(
-                                                            spec.registry().getAccountID(bob))),
-                                                    BigInteger.ZERO,
-                                                    2L,
-                                                    serialNumbers)
-                                            .alsoSigningWithFullPrefix(ALICE, THRESHOLD_KEY)
-                                            .gas(GAS_TO_OFFER)
-                                            .via("contractCallTxn")
-                                            .hasKnownStatus(CONTRACT_REVERT_EXECUTED));
-                        }),
-                        childRecordsCheck(
-                                "contractCallTxn",
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith()
-                                        .status(REVERTED_SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
-                                                        .withStatus(SUCCESS)
-                                                        .withTotalSupply(1))),
-                                recordWith()
-                                        .status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .withStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE)))))
-                .then(
-                        getAccountBalance(bob).hasTokenBalance(tokenWithHbarFee, 0),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(tokenWithHbarFee, 1),
-                        getAccountBalance(ALICE).hasTokenBalance(tokenWithHbarFee, 1));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(ADMIN_KEY).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(ALICE).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(bob).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(feeCollector).balance(0L),
+                tokenCreate(tokenWithHbarFee)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(SUPPLY_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .initialSupply(0L)
+                        .treasury(TOKEN_TREASURY)
+                        .withCustom(fixedHbarFee(300 * ONE_HBAR, feeCollector)),
+                mintToken(tokenWithHbarFee, List.of(copyFromUtf8(FIRST))),
+                mintToken(tokenWithHbarFee, List.of(copyFromUtf8(SECOND))),
+                uploadInitCode(theContract),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        contractCreate(
+                                        theContract,
+                                        asHeadlongAddress(
+                                                asHexedAddress(spec.registry().getTokenID(tokenWithHbarFee))))
+                                .payingWith(bob)
+                                .gas(GAS_TO_OFFER))),
+                newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, theContract))),
+                tokenUpdate(tokenWithHbarFee).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
+                tokenAssociate(ALICE, tokenWithHbarFee),
+                tokenAssociate(bob, tokenWithHbarFee),
+                tokenAssociate(theContract, tokenWithHbarFee),
+                cryptoTransfer(movingUnique(tokenWithHbarFee, 2L).between(TOKEN_TREASURY, ALICE))
+                        .payingWith(GENESIS),
+                getAccountInfo(feeCollector)
+                        .has(AccountInfoAsserts.accountWith().balance(0L)),
+                withOpContext((spec, opLog) -> {
+                    final var serialNumbers = new long[] {1L};
+                    allRunFor(
+                            spec,
+                            contractCall(
+                                            theContract,
+                                            "transferBurn",
+                                            HapiParserUtil.asHeadlongAddress(
+                                                    asAddress(spec.registry().getAccountID(ALICE))),
+                                            HapiParserUtil.asHeadlongAddress(
+                                                    asAddress(spec.registry().getAccountID(bob))),
+                                            BigInteger.ZERO,
+                                            2L,
+                                            serialNumbers)
+                                    .alsoSigningWithFullPrefix(ALICE, THRESHOLD_KEY)
+                                    .gas(GAS_TO_OFFER)
+                                    .via("contractCallTxn")
+                                    .hasKnownStatus(CONTRACT_REVERT_EXECUTED));
+                }),
+                childRecordsCheck(
+                        "contractCallTxn",
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith()
+                                .status(REVERTED_SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                .withStatus(SUCCESS)
+                                                .withTotalSupply(1))),
+                        recordWith()
+                                .status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(
+                                                htsPrecompileResult().withStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE)))),
+                getAccountBalance(bob).hasTokenBalance(tokenWithHbarFee, 0),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(tokenWithHbarFee, 1),
+                getAccountBalance(ALICE).hasTokenBalance(tokenWithHbarFee, 1));
     }
 
     @HapiTest
@@ -830,82 +814,80 @@ public class ContractBurnHTSV2SecurityModelSuite {
         final var CREATION_TX = "CREATION_TX";
         final var MULTI_KEY = "MULTI_KEY";
 
-        return defaultHapiSpec("V2SecurityHscsPrec004TokenBurnOfFungibleTokenUnits")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(50L)
-                                .supplyKey(MULTI_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        uploadInitCode(MIXED_BURN_TOKEN),
-                        withOpContext((spec, opLog) -> allRunFor(
-                                spec,
-                                contractCreate(
-                                                MIXED_BURN_TOKEN,
-                                                asHeadlongAddress(asHexedAddress(
-                                                        spec.registry().getTokenID(FUNGIBLE_TOKEN))))
-                                        .payingWith(ALICE)
-                                        .via(CREATION_TX)
-                                        .gas(GAS_TO_OFFER))),
-                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
-                        tokenUpdate(FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
-                        getTxnRecord(CREATION_TX).logged())
-                .when(
-                        contractCall(MIXED_BURN_TOKEN, BURN_TOKEN_WITH_EVENT, BigInteger.ZERO, new long[0])
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(50L)
+                        .supplyKey(MULTI_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .treasury(TOKEN_TREASURY),
+                uploadInitCode(MIXED_BURN_TOKEN),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        contractCreate(
+                                        MIXED_BURN_TOKEN,
+                                        asHeadlongAddress(
+                                                asHexedAddress(spec.registry().getTokenID(FUNGIBLE_TOKEN))))
                                 .payingWith(ALICE)
-                                .alsoSigningWithFullPrefix(THRESHOLD_KEY)
-                                .gas(GAS_TO_OFFER)
-                                .via("burnZero"),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 50),
-                        contractCall(MIXED_BURN_TOKEN, BURN_TOKEN_WITH_EVENT, BigInteger.ONE, new long[0])
-                                .payingWith(ALICE)
-                                .alsoSigningWithFullPrefix(THRESHOLD_KEY)
-                                .gas(GAS_TO_OFFER)
-                                .via("burn"),
-                        getTxnRecord("burn")
-                                .hasPriority(recordWith()
-                                        .contractCallResult(resultWith()
-                                                .logs(inOrder(logWith()
-                                                        .noData()
-                                                        .withTopicsInOrder(List.of(parsedToByteString(49))))))),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 49),
-                        childRecordsCheck(
-                                "burn",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
-                                                        .withStatus(SUCCESS)
-                                                        .withTotalSupply(49))
-                                                .gasUsed(gasUsed))
-                                        .newTotalSupply(49)
-                                        .tokenTransfers(changingFungibleBalances()
-                                                .including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))
-                                        .newTotalSupply(49)),
-                        contractCall(MIXED_BURN_TOKEN, "burnToken", BigInteger.ONE, new long[0])
-                                .via("burn with contract key")
-                                .gas(GAS_TO_OFFER),
-                        childRecordsCheck(
-                                "burn with contract key",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
-                                                        .withStatus(SUCCESS)
-                                                        .withTotalSupply(48)))
-                                        .newTotalSupply(48)
-                                        .tokenTransfers(changingFungibleBalances()
-                                                .including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))))
-                .then(getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 48));
+                                .via(CREATION_TX)
+                                .gas(GAS_TO_OFFER))),
+                newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, MIXED_BURN_TOKEN))),
+                tokenUpdate(FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
+                getTxnRecord(CREATION_TX).logged(),
+                contractCall(MIXED_BURN_TOKEN, BURN_TOKEN_WITH_EVENT, BigInteger.ZERO, new long[0])
+                        .payingWith(ALICE)
+                        .alsoSigningWithFullPrefix(THRESHOLD_KEY)
+                        .gas(GAS_TO_OFFER)
+                        .via("burnZero"),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 50),
+                contractCall(MIXED_BURN_TOKEN, BURN_TOKEN_WITH_EVENT, BigInteger.ONE, new long[0])
+                        .payingWith(ALICE)
+                        .alsoSigningWithFullPrefix(THRESHOLD_KEY)
+                        .gas(GAS_TO_OFFER)
+                        .via("burn"),
+                getTxnRecord("burn")
+                        .hasPriority(recordWith()
+                                .contractCallResult(resultWith()
+                                        .logs(inOrder(logWith()
+                                                .noData()
+                                                .withTopicsInOrder(List.of(parsedToByteString(49))))))),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 49),
+                childRecordsCheck(
+                        "burn",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                .withStatus(SUCCESS)
+                                                .withTotalSupply(49))
+                                        .gasUsed(gasUsed))
+                                .newTotalSupply(49)
+                                .tokenTransfers(
+                                        changingFungibleBalances().including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))
+                                .newTotalSupply(49)),
+                contractCall(MIXED_BURN_TOKEN, "burnToken", BigInteger.ONE, new long[0])
+                        .via("burn with contract key")
+                        .gas(GAS_TO_OFFER),
+                childRecordsCheck(
+                        "burn with contract key",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                .withStatus(SUCCESS)
+                                                .withTotalSupply(48)))
+                                .newTotalSupply(48)
+                                .tokenTransfers(
+                                        changingFungibleBalances().including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 48));
     }
 
     @HapiTest
@@ -917,131 +899,121 @@ public class ContractBurnHTSV2SecurityModelSuite {
         final var CREATION_TX = "CREATION_TX";
         final var BURN_AFTER_NESTED_MINT_TX = "burnAfterNestedMint";
 
-        return defaultHapiSpec("V2SecurityHscsPrec011BurnAfterNestedMint")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(50L)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        uploadInitCode(innerContract, outerContract),
-                        contractCreate(innerContract).gas(GAS_TO_OFFER),
-                        withOpContext((spec, opLog) -> allRunFor(
-                                spec,
-                                contractCreate(
-                                                outerContract,
-                                                asHeadlongAddress(getNestedContractAddress(innerContract, spec)))
-                                        .payingWith(ALICE)
-                                        .via(CREATION_TX)
-                                        .gas(GAS_TO_OFFER))),
-                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, outerContract))),
-                        tokenUpdate(FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
-                        getTxnRecord(CREATION_TX).logged())
-                .when(
-                        withOpContext((spec, opLog) -> allRunFor(
-                                spec,
-                                newKeyNamed(CONTRACT_KEY)
-                                        .shape(revisedKey.signedWith(sigs(ON, innerContract, outerContract))),
-                                tokenUpdate(FUNGIBLE_TOKEN)
-                                        .supplyKey(CONTRACT_KEY)
-                                        .signedByPayerAnd(ADMIN_KEY),
-                                contractCall(
-                                                outerContract,
-                                                BURN_AFTER_NESTED_MINT_TX,
-                                                BigInteger.ONE,
-                                                HapiParserUtil.asHeadlongAddress(asAddress(
-                                                        spec.registry().getTokenID(FUNGIBLE_TOKEN))),
-                                                new long[0])
-                                        .payingWith(ALICE)
-                                        .alsoSigningWithFullPrefix(CONTRACT_KEY)
-                                        .hasKnownStatus(SUCCESS)
-                                        .via(BURN_AFTER_NESTED_MINT_TX))),
-                        childRecordsCheck(
-                                BURN_AFTER_NESTED_MINT_TX,
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .forFunction(ParsingConstants.FunctionType.HAPI_MINT)
-                                                        .withStatus(SUCCESS)
-                                                        .withTotalSupply(51)
-                                                        .withSerialNumbers()))
-                                        .tokenTransfers(
-                                                changingFungibleBalances().including(FUNGIBLE_TOKEN, TOKEN_TREASURY, 1))
-                                        .newTotalSupply(51),
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
-                                                        .withStatus(SUCCESS)
-                                                        .withTotalSupply(50)))
-                                        .tokenTransfers(changingFungibleBalances()
-                                                .including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))
-                                        .newTotalSupply(50)))
-                .then(getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 50));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(50L)
+                        .supplyKey(SUPPLY_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .treasury(TOKEN_TREASURY),
+                uploadInitCode(innerContract, outerContract),
+                contractCreate(innerContract).gas(GAS_TO_OFFER),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        contractCreate(outerContract, asHeadlongAddress(getNestedContractAddress(innerContract, spec)))
+                                .payingWith(ALICE)
+                                .via(CREATION_TX)
+                                .gas(GAS_TO_OFFER))),
+                newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, outerContract))),
+                tokenUpdate(FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
+                getTxnRecord(CREATION_TX).logged(),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        newKeyNamed(CONTRACT_KEY).shape(revisedKey.signedWith(sigs(ON, innerContract, outerContract))),
+                        tokenUpdate(FUNGIBLE_TOKEN).supplyKey(CONTRACT_KEY).signedByPayerAnd(ADMIN_KEY),
+                        contractCall(
+                                        outerContract,
+                                        BURN_AFTER_NESTED_MINT_TX,
+                                        BigInteger.ONE,
+                                        HapiParserUtil.asHeadlongAddress(
+                                                asAddress(spec.registry().getTokenID(FUNGIBLE_TOKEN))),
+                                        new long[0])
+                                .payingWith(ALICE)
+                                .alsoSigningWithFullPrefix(CONTRACT_KEY)
+                                .hasKnownStatus(SUCCESS)
+                                .via(BURN_AFTER_NESTED_MINT_TX))),
+                childRecordsCheck(
+                        BURN_AFTER_NESTED_MINT_TX,
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(ParsingConstants.FunctionType.HAPI_MINT)
+                                                .withStatus(SUCCESS)
+                                                .withTotalSupply(51)
+                                                .withSerialNumbers()))
+                                .tokenTransfers(changingFungibleBalances().including(FUNGIBLE_TOKEN, TOKEN_TREASURY, 1))
+                                .newTotalSupply(51),
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                .withStatus(SUCCESS)
+                                                .withTotalSupply(50)))
+                                .tokenTransfers(
+                                        changingFungibleBalances().including(FUNGIBLE_TOKEN, TOKEN_TREASURY, -1))
+                                .newTotalSupply(50)),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 50));
     }
 
     @HapiTest
     final Stream<DynamicTest> V2SecurityHscsPrec005TokenBurnOfNft() {
         final var gasUsed = 15284L;
         final var CREATION_TX = "CREATION_TX";
-        return defaultHapiSpec("V2SecurityHscsPrec005TokenBurnOfNft")
-                .given(
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0L)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(SECOND))),
-                        uploadInitCode(BURN_TOKEN),
-                        withOpContext((spec, opLog) -> allRunFor(
-                                spec,
-                                contractCreate(
-                                                BURN_TOKEN,
-                                                asHeadlongAddress(asHexedAddress(
-                                                        spec.registry().getTokenID(NON_FUNGIBLE_TOKEN))))
-                                        .payingWith(ALICE)
-                                        .via(CREATION_TX)
-                                        .gas(GAS_TO_OFFER))),
-                        newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, BURN_TOKEN))),
-                        tokenUpdate(NON_FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
-                        getTxnRecord(CREATION_TX).logged())
-                .when(
-                        withOpContext((spec, opLog) -> {
-                            final var serialNumbers = new long[] {1L};
-                            allRunFor(
-                                    spec,
-                                    contractCall(BURN_TOKEN, "burnToken", BigInteger.ZERO, serialNumbers)
-                                            .payingWith(ALICE)
-                                            .alsoSigningWithFullPrefix(THRESHOLD_KEY)
-                                            .gas(GAS_TO_OFFER)
-                                            .via("burn"));
-                        }),
-                        childRecordsCheck(
-                                "burn",
-                                SUCCESS,
-                                recordWith()
-                                        .status(SUCCESS)
-                                        .contractCallResult(resultWith()
-                                                .contractCallResult(htsPrecompileResult()
-                                                        .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
-                                                        .withStatus(SUCCESS)
-                                                        .withTotalSupply(1))
-                                                .gasUsed(gasUsed))
-                                        .newTotalSupply(1)))
-                .then(getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1));
+        return hapiTest(
+                newKeyNamed(ADMIN_KEY),
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(ALICE).balance(10 * ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0L)
+                        .supplyKey(SUPPLY_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(FIRST))),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8(SECOND))),
+                uploadInitCode(BURN_TOKEN),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        contractCreate(
+                                        BURN_TOKEN,
+                                        asHeadlongAddress(
+                                                asHexedAddress(spec.registry().getTokenID(NON_FUNGIBLE_TOKEN))))
+                                .payingWith(ALICE)
+                                .via(CREATION_TX)
+                                .gas(GAS_TO_OFFER))),
+                newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, BURN_TOKEN))),
+                tokenUpdate(NON_FUNGIBLE_TOKEN).supplyKey(THRESHOLD_KEY).signedByPayerAnd(ADMIN_KEY),
+                getTxnRecord(CREATION_TX).logged(),
+                withOpContext((spec, opLog) -> {
+                    final var serialNumbers = new long[] {1L};
+                    allRunFor(
+                            spec,
+                            contractCall(BURN_TOKEN, "burnToken", BigInteger.ZERO, serialNumbers)
+                                    .payingWith(ALICE)
+                                    .alsoSigningWithFullPrefix(THRESHOLD_KEY)
+                                    .gas(GAS_TO_OFFER)
+                                    .via("burn"));
+                }),
+                childRecordsCheck(
+                        "burn",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(ParsingConstants.FunctionType.HAPI_BURN)
+                                                .withStatus(SUCCESS)
+                                                .withTotalSupply(1))
+                                        .gasUsed(gasUsed))
+                                .newTotalSupply(1)),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractHTSSuite.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -357,30 +356,29 @@ public class ContractHTSSuite {
         final var TXN_WITH_INVALID_TOKEN_ADDRESS = "TXN_WITH_INVALID_TOKEN_ADDRESS";
         final var TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE = "TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE";
 
-        return defaultHapiSpec("shouldFailWhenTransferringTokensWithInvalidParametersAndConditions")
-                .given(
-                        newKeyNamed(UNIVERSAL_KEY),
-                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECEIVER),
-                        cryptoCreate(SECOND_RECEIVER),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(1_000L)
-                                .supplyKey(UNIVERSAL_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        uploadInitCode(TOKEN_TRANSFERS_CONTRACT),
-                        contractCreate(TOKEN_TRANSFERS_CONTRACT).gas(GAS_TO_OFFER),
-                        tokenAssociate(ACCOUNT, FUNGIBLE_TOKEN),
-                        tokenAssociate(RECEIVER, FUNGIBLE_TOKEN),
-                        tokenAssociate(SECOND_RECEIVER, FUNGIBLE_TOKEN),
-                        cryptoApproveAllowance()
-                                .payingWith(DEFAULT_PAYER)
-                                .addTokenAllowance(ACCOUNT, FUNGIBLE_TOKEN, TOKEN_TRANSFERS_CONTRACT, 200L)
-                                .signedBy(DEFAULT_PAYER, ACCOUNT)
-                                .fee(ONE_HBAR),
-                        cryptoTransfer(moving(200L, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, ACCOUNT)))
-                .when(withOpContext((spec, opLog) -> {
+        return hapiTest(
+                newKeyNamed(UNIVERSAL_KEY),
+                cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER),
+                cryptoCreate(SECOND_RECEIVER),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(1_000L)
+                        .supplyKey(UNIVERSAL_KEY)
+                        .treasury(TOKEN_TREASURY),
+                uploadInitCode(TOKEN_TRANSFERS_CONTRACT),
+                contractCreate(TOKEN_TRANSFERS_CONTRACT).gas(GAS_TO_OFFER),
+                tokenAssociate(ACCOUNT, FUNGIBLE_TOKEN),
+                tokenAssociate(RECEIVER, FUNGIBLE_TOKEN),
+                tokenAssociate(SECOND_RECEIVER, FUNGIBLE_TOKEN),
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addTokenAllowance(ACCOUNT, FUNGIBLE_TOKEN, TOKEN_TRANSFERS_CONTRACT, 200L)
+                        .signedBy(DEFAULT_PAYER, ACCOUNT)
+                        .fee(ONE_HBAR),
+                cryptoTransfer(moving(200L, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, ACCOUNT)),
+                withOpContext((spec, opLog) -> {
                     final var receiver1 = asAddress(spec.registry().getAccountID(RECEIVER));
                     final var receiver2 = asAddress(spec.registry().getAccountID(SECOND_RECEIVER));
                     final var sender = asAddress(spec.registry().getAccountID(ACCOUNT));
@@ -467,20 +465,19 @@ public class ContractHTSSuite {
                                     .gas(GAS_TO_OFFER)
                                     .via(TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE)
                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED));
-                }))
-                .then(
-                        childRecordsCheck(
-                                TXN_WITH_NEGATIVE_AMOUNTS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN)),
-                        childRecordsCheck(
-                                TXN_WITH_INVALID_TOKEN_ADDRESS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
+                }),
+                childRecordsCheck(
+                        TXN_WITH_NEGATIVE_AMOUNTS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN)),
+                childRecordsCheck(
+                        TXN_WITH_INVALID_TOKEN_ADDRESS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
     }
 
     @HapiTest
@@ -491,28 +488,27 @@ public class ContractHTSSuite {
         final var TXN_WITH_NEGATIVE_AMOUNT = "TXN_WITH_NEGATIVE_AMOUNT";
         final var TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE = "TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE";
 
-        return defaultHapiSpec("shouldFailOnInvalidTokenTransferParametersAndConditions")
-                .given(
-                        newKeyNamed(UNIVERSAL_KEY),
-                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECEIVER),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(1_000L)
-                                .supplyKey(UNIVERSAL_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        uploadInitCode(TOKEN_TRANSFERS_CONTRACT),
-                        contractCreate(TOKEN_TRANSFERS_CONTRACT).gas(GAS_TO_OFFER),
-                        tokenAssociate(ACCOUNT, FUNGIBLE_TOKEN),
-                        tokenAssociate(RECEIVER, FUNGIBLE_TOKEN),
-                        cryptoApproveAllowance()
-                                .payingWith(DEFAULT_PAYER)
-                                .addTokenAllowance(ACCOUNT, FUNGIBLE_TOKEN, TOKEN_TRANSFERS_CONTRACT, 200L)
-                                .signedBy(DEFAULT_PAYER, ACCOUNT)
-                                .fee(ONE_HBAR),
-                        cryptoTransfer(moving(200L, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, ACCOUNT)))
-                .when(withOpContext((spec, opLog) -> {
+        return hapiTest(
+                newKeyNamed(UNIVERSAL_KEY),
+                cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(1_000L)
+                        .supplyKey(UNIVERSAL_KEY)
+                        .treasury(TOKEN_TREASURY),
+                uploadInitCode(TOKEN_TRANSFERS_CONTRACT),
+                contractCreate(TOKEN_TRANSFERS_CONTRACT).gas(GAS_TO_OFFER),
+                tokenAssociate(ACCOUNT, FUNGIBLE_TOKEN),
+                tokenAssociate(RECEIVER, FUNGIBLE_TOKEN),
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addTokenAllowance(ACCOUNT, FUNGIBLE_TOKEN, TOKEN_TRANSFERS_CONTRACT, 200L)
+                        .signedBy(DEFAULT_PAYER, ACCOUNT)
+                        .fee(ONE_HBAR),
+                cryptoTransfer(moving(200L, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, ACCOUNT)),
+                withOpContext((spec, opLog) -> {
                     final var receiver1 =
                             asHeadlongAddress(asAddress(spec.registry().getAccountID(RECEIVER)));
                     final var sender =
@@ -589,16 +585,15 @@ public class ContractHTSSuite {
                                     .gas(GAS_TO_OFFER)
                                     .via(TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE)
                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED));
-                }))
-                .then(
-                        childRecordsCheck(
-                                TXN_WITH_INVALID_TOKEN_ADDRESS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
+                }),
+                childRecordsCheck(
+                        TXN_WITH_INVALID_TOKEN_ADDRESS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
     }
 
     @HapiTest
@@ -611,31 +606,29 @@ public class ContractHTSSuite {
         final var TXN_WITH_INVALID_SERIALS = "TXN_WITH_INVALID_SERIALS";
         final var TXN_WITH_NOT_OWNED_NFT = "TXN_WITH_NOT_OWNED_NFT";
 
-        return defaultHapiSpec("shouldFailWhenTransferringMultipleNFTsWithInvalidParametersAndConditions")
-                .given(
-                        newKeyNamed(UNIVERSAL_KEY),
-                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECEIVER),
-                        cryptoCreate(SECOND_RECEIVER),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(UNIVERSAL_KEY)
-                                .initialSupply(0),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("dark"), copyFromUtf8("matter"))),
-                        tokenAssociate(ACCOUNT, NON_FUNGIBLE_TOKEN),
-                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
-                        cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L).between(TOKEN_TREASURY, ACCOUNT)),
-                        uploadInitCode(TOKEN_TRANSFERS_CONTRACT),
-                        contractCreate(TOKEN_TRANSFERS_CONTRACT).gas(GAS_TO_OFFER),
-                        cryptoApproveAllowance()
-                                .payingWith(DEFAULT_PAYER)
-                                .addNftAllowance(
-                                        ACCOUNT, NON_FUNGIBLE_TOKEN, TOKEN_TRANSFERS_CONTRACT, false, List.of(1L, 2L))
-                                .signedBy(DEFAULT_PAYER, ACCOUNT)
-                                .fee(ONE_HBAR))
-                .when(withOpContext((spec, opLog) -> {
+        return hapiTest(
+                newKeyNamed(UNIVERSAL_KEY),
+                cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER),
+                cryptoCreate(SECOND_RECEIVER),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .treasury(TOKEN_TREASURY)
+                        .supplyKey(UNIVERSAL_KEY)
+                        .initialSupply(0),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("dark"), copyFromUtf8("matter"))),
+                tokenAssociate(ACCOUNT, NON_FUNGIBLE_TOKEN),
+                tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L).between(TOKEN_TREASURY, ACCOUNT)),
+                uploadInitCode(TOKEN_TRANSFERS_CONTRACT),
+                contractCreate(TOKEN_TRANSFERS_CONTRACT).gas(GAS_TO_OFFER),
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addNftAllowance(ACCOUNT, NON_FUNGIBLE_TOKEN, TOKEN_TRANSFERS_CONTRACT, false, List.of(1L, 2L))
+                        .signedBy(DEFAULT_PAYER, ACCOUNT)
+                        .fee(ONE_HBAR),
+                withOpContext((spec, opLog) -> {
                     final var receiver1 = asAddress(spec.registry().getAccountID(RECEIVER));
                     final var receiver2 = asAddress(spec.registry().getAccountID(SECOND_RECEIVER));
                     final var sender = asAddress(spec.registry().getAccountID(ACCOUNT));
@@ -743,20 +736,19 @@ public class ContractHTSSuite {
                                     .gas(GAS_TO_OFFER)
                                     .via(TXN_WITH_NOT_OWNED_NFT)
                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED));
-                }))
-                .then(
-                        childRecordsCheck(
-                                TXN_WITH_INVALID_TOKEN_ADDRESS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                TXN_WITH_INVALID_SERIALS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_NFT_SERIAL_NUMBER)),
-                        childRecordsCheck(
-                                TXN_WITH_NOT_OWNED_NFT,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)));
+                }),
+                childRecordsCheck(
+                        TXN_WITH_INVALID_TOKEN_ADDRESS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        TXN_WITH_INVALID_SERIALS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_NFT_SERIAL_NUMBER)),
+                childRecordsCheck(
+                        TXN_WITH_NOT_OWNED_NFT,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)));
     }
 
     @HapiTest
@@ -767,30 +759,28 @@ public class ContractHTSSuite {
         final var TXN_WITH_NEGATIVE_SERIAL = "TXN_WITH_NEGATIVE_SERIAL";
         final var TXN_ACCOUNT_DOES_NOT_OWN_NFT = "TXN_ACCOUNT_DOES_NOT_OWN_NFT";
 
-        return defaultHapiSpec("shouldFailOnInvalidNFTTransferParametersAndConditions")
-                .given(
-                        newKeyNamed(UNIVERSAL_KEY),
-                        cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECEIVER),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(UNIVERSAL_KEY)
-                                .initialSupply(0),
-                        mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("dark"), copyFromUtf8("matter"))),
-                        tokenAssociate(ACCOUNT, NON_FUNGIBLE_TOKEN),
-                        tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
-                        cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L).between(TOKEN_TREASURY, ACCOUNT)),
-                        uploadInitCode(TOKEN_TRANSFERS_CONTRACT),
-                        contractCreate(TOKEN_TRANSFERS_CONTRACT).gas(GAS_TO_OFFER),
-                        cryptoApproveAllowance()
-                                .payingWith(DEFAULT_PAYER)
-                                .addNftAllowance(
-                                        ACCOUNT, NON_FUNGIBLE_TOKEN, TOKEN_TRANSFERS_CONTRACT, false, List.of(1L, 2L))
-                                .signedBy(DEFAULT_PAYER, ACCOUNT)
-                                .fee(ONE_HBAR))
-                .when(withOpContext((spec, opLog) -> {
+        return hapiTest(
+                newKeyNamed(UNIVERSAL_KEY),
+                cryptoCreate(ACCOUNT).balance(100 * ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .treasury(TOKEN_TREASURY)
+                        .supplyKey(UNIVERSAL_KEY)
+                        .initialSupply(0),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(copyFromUtf8("dark"), copyFromUtf8("matter"))),
+                tokenAssociate(ACCOUNT, NON_FUNGIBLE_TOKEN),
+                tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L).between(TOKEN_TREASURY, ACCOUNT)),
+                uploadInitCode(TOKEN_TRANSFERS_CONTRACT),
+                contractCreate(TOKEN_TRANSFERS_CONTRACT).gas(GAS_TO_OFFER),
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addNftAllowance(ACCOUNT, NON_FUNGIBLE_TOKEN, TOKEN_TRANSFERS_CONTRACT, false, List.of(1L, 2L))
+                        .signedBy(DEFAULT_PAYER, ACCOUNT)
+                        .fee(ONE_HBAR),
+                withOpContext((spec, opLog) -> {
                     final var receiver1 =
                             asHeadlongAddress(asAddress(spec.registry().getAccountID(RECEIVER)));
                     final var sender =
@@ -864,27 +854,26 @@ public class ContractHTSSuite {
                                     .gas(GAS_TO_OFFER)
                                     .via(TXN_ACCOUNT_DOES_NOT_OWN_NFT)
                                     .hasKnownStatus(CONTRACT_REVERT_EXECUTED));
-                }))
-                .then(
-                        childRecordsCheck(
-                                TXN_WITH_INVALID_RECEIVER_ADDRESS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ALIAS_KEY)),
-                        childRecordsCheck(
-                                TXN_WITH_INVALID_SENDER_ADDRESS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ACCOUNT_ID)),
-                        childRecordsCheck(
-                                TXN_WITH_INVALID_TOKEN_ADDRESS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                TXN_WITH_NEGATIVE_SERIAL,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_NFT_SERIAL_NUMBER)),
-                        childRecordsCheck(
-                                TXN_ACCOUNT_DOES_NOT_OWN_NFT,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)));
+                }),
+                childRecordsCheck(
+                        TXN_WITH_INVALID_RECEIVER_ADDRESS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_ALIAS_KEY)),
+                childRecordsCheck(
+                        TXN_WITH_INVALID_SENDER_ADDRESS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_ACCOUNT_ID)),
+                childRecordsCheck(
+                        TXN_WITH_INVALID_TOKEN_ADDRESS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        TXN_WITH_NEGATIVE_SERIAL,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_NFT_SERIAL_NUMBER)),
+                childRecordsCheck(
+                        TXN_ACCOUNT_DOES_NOT_OWN_NFT,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(SPENDER_DOES_NOT_HAVE_ALLOWANCE)));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSSuite.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiPropertySource.idAsHeadlongAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -109,29 +108,28 @@ public class ContractMintHTSSuite {
 
         var invalidTokenNFTTest = "invalidTokenNFTTest";
         var invalidTokenTest = "invalidTokenTest";
-        return defaultHapiSpec("MintFungibleTokenWithInvalidAndExtremeValues")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECIPIENT).maxAutomaticTokenAssociations(1),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(1000)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        uploadInitCode(NEGATIVE_MINT_CONTRACT),
-                        contractCreate(NEGATIVE_MINT_CONTRACT).gas(GAS_TO_OFFER))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(RECIPIENT).maxAutomaticTokenAssociations(1),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(MULTI_KEY)
+                        .supplyKey(MULTI_KEY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(1000)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(MULTI_KEY)
+                        .supplyKey(MULTI_KEY),
+                uploadInitCode(NEGATIVE_MINT_CONTRACT),
+                contractCreate(NEGATIVE_MINT_CONTRACT).gas(GAS_TO_OFFER),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         // Fungible Mint calls with extreme values
                         contractCall(
@@ -202,14 +200,11 @@ public class ContractMintHTSSuite {
                                 .alsoSigningWithFullPrefix(MULTI_KEY)
                                 .gas(GAS_TO_OFFER),
                         getTxnRecord(invalidTokenTest).andAllChildRecords().logged(),
-                        getTxnRecord(invalidTokenNFTTest).andAllChildRecords().logged())))
-                .then(
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 1_000),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 0),
-                        childRecordsCheck(
-                                invalidTokenTest, SUCCESS, recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                invalidTokenNFTTest, SUCCESS, recordWith().status(INVALID_TOKEN_ID)));
+                        getTxnRecord(invalidTokenNFTTest).andAllChildRecords().logged())),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 1_000),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 0),
+                childRecordsCheck(invalidTokenTest, SUCCESS, recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(invalidTokenNFTTest, SUCCESS, recordWith().status(INVALID_TOKEN_ID)));
     }
 
     @HapiTest
@@ -220,29 +215,28 @@ public class ContractMintHTSSuite {
         var mintWithZeroedAddressTest = "mintWithZeroedAddressTest";
         var mintWithZeroedAddressAndMetadataTest = "mintWithZeroedAddressAndMetadataTest";
 
-        return defaultHapiSpec("MintFungibleTokenWithInvalidAndExtremeValues")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(RECIPIENT).maxAutomaticTokenAssociations(1),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(1000)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        tokenCreate(NON_FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(MULTI_KEY)
-                                .supplyKey(MULTI_KEY),
-                        uploadInitCode(NEGATIVE_MINT_CONTRACT),
-                        contractCreate(NEGATIVE_MINT_CONTRACT).gas(GAS_TO_OFFER))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(ACCOUNT).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(RECIPIENT).maxAutomaticTokenAssociations(1),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(1000)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(MULTI_KEY)
+                        .supplyKey(MULTI_KEY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(MULTI_KEY)
+                        .supplyKey(MULTI_KEY),
+                uploadInitCode(NEGATIVE_MINT_CONTRACT),
+                contractCreate(NEGATIVE_MINT_CONTRACT).gas(GAS_TO_OFFER),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         newKeyNamed(CONTRACT_KEY).shape(CONTRACT.signedWith(NEGATIVE_MINT_CONTRACT)),
                         tokenUpdate(FUNGIBLE_TOKEN).supplyKey(CONTRACT_KEY).signedByPayerAnd(MULTI_KEY),
@@ -293,33 +287,31 @@ public class ContractMintHTSSuite {
                                 .logged(),
                         getTxnRecord(mintWithZeroedAddressAndMetadataTest)
                                 .andAllChildRecords()
-                                .logged())))
-                .then(
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 1_000),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 0),
-                        childRecordsCheck(
-                                fungibleMintWithMetadataTest,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TRANSACTION_BODY)),
-                        childRecordsCheck(
-                                mintWithZeroedAddressTest,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        childRecordsCheck(
-                                mintWithZeroedAddressAndMetadataTest,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)),
-                        withOpContext((spec, opLog) -> {
-                            final var baseTxnId = spec.registry().getTxnId(mintWithZeroedAddressAndMetadataTest);
-                            final var childTxnId =
-                                    baseTxnId.toBuilder().setNonce(1).build();
-                            allRunFor(spec, getReceipt(childTxnId).hasPriorityStatus(INVALID_TOKEN_ID));
-                            allRunFor(
-                                    spec,
-                                    getTxnRecord(childTxnId)
-                                            .assertingNothingAboutHashes()
-                                            .hasPriority(recordWith().status(INVALID_TOKEN_ID)));
-                        }));
+                                .logged())),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 1_000),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NON_FUNGIBLE_TOKEN, 0),
+                childRecordsCheck(
+                        fungibleMintWithMetadataTest,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TRANSACTION_BODY)),
+                childRecordsCheck(
+                        mintWithZeroedAddressTest,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)),
+                childRecordsCheck(
+                        mintWithZeroedAddressAndMetadataTest,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)),
+                withOpContext((spec, opLog) -> {
+                    final var baseTxnId = spec.registry().getTxnId(mintWithZeroedAddressAndMetadataTest);
+                    final var childTxnId = baseTxnId.toBuilder().setNonce(1).build();
+                    allRunFor(spec, getReceipt(childTxnId).hasPriorityStatus(INVALID_TOKEN_ID));
+                    allRunFor(
+                            spec,
+                            getTxnRecord(childTxnId)
+                                    .assertingNothingAboutHashes()
+                                    .hasPriority(recordWith().status(INVALID_TOKEN_ID)));
+                }));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CryptoTransferHTSSuite.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.contract.precompile;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
@@ -539,21 +538,20 @@ public class CryptoTransferHTSSuite {
         final var TXN_FROM_NON_EXISTING_ADDRESS = "TXN_FROM_NON_EXISTING_ADDRESS";
         final var TXN_WITH_NON_EXISTING_TOKEN = "TXN_WITH_NON_EXISTING_TOKEN";
 
-        return defaultHapiSpec("hapiTransferFromForFungibleTokenWithInvalidAddressesFails")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(5),
-                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(5),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(10L)
-                                .maxSupply(1000L)
-                                .supplyKey(MULTI_KEY)
-                                .treasury(OWNER),
-                        uploadInitCode(HTS_TRANSFER_FROM_CONTRACT),
-                        contractCreate(HTS_TRANSFER_FROM_CONTRACT))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(5),
+                cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(5),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .initialSupply(10L)
+                        .maxSupply(1000L)
+                        .supplyKey(MULTI_KEY)
+                        .treasury(OWNER),
+                uploadInitCode(HTS_TRANSFER_FROM_CONTRACT),
+                contractCreate(HTS_TRANSFER_FROM_CONTRACT),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         // transfer TO address that does not exist
                         contractCall(
@@ -596,20 +594,19 @@ public class CryptoTransferHTSSuite {
                                 .gas(100_000_00L)
                                 .via(TXN_WITH_NON_EXISTING_TOKEN)
                                 .payingWith(GENESIS)
-                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED))))
-                .then(
-                        childRecordsCheck(
-                                TXN_TO_NON_EXISTING_ADDRESS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ALIAS_KEY)),
-                        childRecordsCheck(
-                                TXN_FROM_NON_EXISTING_ADDRESS,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_ACCOUNT_ID)),
-                        childRecordsCheck(
-                                TXN_WITH_NON_EXISTING_TOKEN,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INVALID_TOKEN_ID)));
+                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED))),
+                childRecordsCheck(
+                        TXN_TO_NON_EXISTING_ADDRESS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_ALIAS_KEY)),
+                childRecordsCheck(
+                        TXN_FROM_NON_EXISTING_ADDRESS,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_ACCOUNT_ID)),
+                childRecordsCheck(
+                        TXN_WITH_NON_EXISTING_TOKEN,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INVALID_TOKEN_ID)));
     }
 
     @HapiTest
@@ -620,34 +617,32 @@ public class CryptoTransferHTSSuite {
         final var TXN_WITH_AMOUNT_OVERFLOW_UINT = "TXN_WITH_AMOUNT_OVERFLOW_UINT";
 
         final var allowance = 10L;
-        return defaultHapiSpec("hapiTransferFromForFungibleTokenWithInvalidAmountsFails")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(5),
-                        cryptoCreate(SPENDER).maxAutomaticTokenAssociations(5),
-                        cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(5),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(15L)
-                                .maxSupply(1000L)
-                                .supplyKey(MULTI_KEY)
-                                .treasury(OWNER),
-                        uploadInitCode(HTS_TRANSFER_FROM_CONTRACT),
-                        contractCreate(HTS_TRANSFER_FROM_CONTRACT),
-                        uploadInitCode(NEGATIVE_HTS_TRANSFER_FROM_CONTRACT),
-                        contractCreate(NEGATIVE_HTS_TRANSFER_FROM_CONTRACT),
-                        cryptoApproveAllowance()
-                                .payingWith(DEFAULT_PAYER)
-                                .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, HTS_TRANSFER_FROM_CONTRACT, allowance)
-                                .signedBy(DEFAULT_PAYER, OWNER)
-                                .fee(ONE_HBAR),
-                        getAccountDetails(OWNER)
-                                .payingWith(GENESIS)
-                                .has(accountDetailsWith()
-                                        .tokenAllowancesContaining(
-                                                FUNGIBLE_TOKEN, HTS_TRANSFER_FROM_CONTRACT, allowance)))
-                .when(withOpContext((spec, opLog) -> allRunFor(
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(OWNER).balance(100 * ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(5),
+                cryptoCreate(SPENDER).maxAutomaticTokenAssociations(5),
+                cryptoCreate(RECEIVER).maxAutomaticTokenAssociations(5),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .initialSupply(15L)
+                        .maxSupply(1000L)
+                        .supplyKey(MULTI_KEY)
+                        .treasury(OWNER),
+                uploadInitCode(HTS_TRANSFER_FROM_CONTRACT),
+                contractCreate(HTS_TRANSFER_FROM_CONTRACT),
+                uploadInitCode(NEGATIVE_HTS_TRANSFER_FROM_CONTRACT),
+                contractCreate(NEGATIVE_HTS_TRANSFER_FROM_CONTRACT),
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, HTS_TRANSFER_FROM_CONTRACT, allowance)
+                        .signedBy(DEFAULT_PAYER, OWNER)
+                        .fee(ONE_HBAR),
+                getAccountDetails(OWNER)
+                        .payingWith(GENESIS)
+                        .has(accountDetailsWith()
+                                .tokenAllowancesContaining(FUNGIBLE_TOKEN, HTS_TRANSFER_FROM_CONTRACT, allowance)),
+                withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         // transfer with amount > allowance for the caller
                         contractCall(
@@ -710,16 +705,15 @@ public class CryptoTransferHTSSuite {
                                 .via(TXN_WITH_AMOUNT_OVERFLOW_UINT)
                                 .payingWith(GENESIS)
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
-                        emptyChildRecordsCheck(TXN_WITH_AMOUNT_OVERFLOW_UINT, CONTRACT_REVERT_EXECUTED))))
-                .then(
-                        childRecordsCheck(
-                                TXN_WITH_AMOUNT_BIGGER_THAN_ALLOWANCE,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(AMOUNT_EXCEEDS_ALLOWANCE)),
-                        childRecordsCheck(
-                                TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE,
-                                CONTRACT_REVERT_EXECUTED,
-                                recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
+                        emptyChildRecordsCheck(TXN_WITH_AMOUNT_OVERFLOW_UINT, CONTRACT_REVERT_EXECUTED))),
+                childRecordsCheck(
+                        TXN_WITH_AMOUNT_BIGGER_THAN_ALLOWANCE,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(AMOUNT_EXCEEDS_ALLOWANCE)),
+                childRecordsCheck(
+                        TXN_WITH_AMOUNT_BIGGER_THAN_BALANCE,
+                        CONTRACT_REVERT_EXECUTED,
+                        recordWith().status(INSUFFICIENT_TOKEN_BALANCE)));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyTokensSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyTokensSuite.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenNftInfo;
@@ -86,196 +86,186 @@ public class Hip17UnhappyTokensSuite {
 
     @HapiTest
     final Stream<DynamicTest> canStillGetNftInfoWhenDeleted() {
-        return defaultHapiSpec("canStillGetNftInfoWhenDeleted")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NFTdeleted, List.of(metadata(FIRST_MEMO))))
-                .when(tokenDelete(NFTdeleted))
-                .then(getTokenNftInfo(NFTdeleted, 1L).hasTokenID(NFTdeleted).hasSerialNum(1L));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                tokenCreate(NFTdeleted)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFTdeleted, List.of(metadata(FIRST_MEMO))),
+                (tokenDelete(NFTdeleted)),
+                (getTokenNftInfo(NFTdeleted, 1L).hasTokenID(NFTdeleted).hasSerialNum(1L)));
     }
 
     @HapiTest
     final Stream<DynamicTest> cannotTransferNftWhenDeleted() {
-        return defaultHapiSpec("cannotTransferNftWhenDeleted")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(ANOTHER_USER),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(
-                        tokenAssociate(ANOTHER_USER, NFTdeleted),
-                        mintToken(NFTdeleted, List.of(metadata(FIRST_MEMO), metadata(SECOND_MEMO))),
-                        cryptoTransfer(
-                                TokenMovement.movingUnique(NFTdeleted, 1L).between(TOKEN_TREASURY, ANOTHER_USER)),
-                        tokenDelete(NFTdeleted))
-                .then(cryptoTransfer(TokenMovement.movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER))
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(ANOTHER_USER),
+                tokenCreate(NFTdeleted)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenAssociate(ANOTHER_USER, NFTdeleted),
+                mintToken(NFTdeleted, List.of(metadata(FIRST_MEMO), metadata(SECOND_MEMO))),
+                cryptoTransfer(TokenMovement.movingUnique(NFTdeleted, 1L).between(TOKEN_TREASURY, ANOTHER_USER)),
+                tokenDelete(NFTdeleted),
+                cryptoTransfer(TokenMovement.movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER))
                         .hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest
     final Stream<DynamicTest> cannotUnfreezeNftWhenDeleted() {
-        return defaultHapiSpec("cannotUnfreezeNftWhenDeleted")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L).key(ADMIN_KEY),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0L)
-                                .freezeKey(FREEZE_KEY)
-                                .freezeDefault(true)
-                                .adminKey(ADMIN_KEY)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(tokenDelete(NFTdeleted))
-                .then(tokenUnfreeze(NFTdeleted, TOKEN_TREASURY).hasKnownStatus(TOKEN_WAS_DELETED));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate(TOKEN_TREASURY).balance(0L).key(ADMIN_KEY),
+                tokenCreate(NFTdeleted)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0L)
+                        .freezeKey(FREEZE_KEY)
+                        .freezeDefault(true)
+                        .adminKey(ADMIN_KEY)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenDelete(NFTdeleted),
+                tokenUnfreeze(NFTdeleted, TOKEN_TREASURY).hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest
     final Stream<DynamicTest> cannotFreezeNftWhenDeleted() {
-        return defaultHapiSpec("cannotFreezeNftWhenDeleted")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L).key(ADMIN_KEY),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .freezeKey(FREEZE_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0L)
-                                .treasury(TOKEN_TREASURY))
-                .when(tokenDelete(NFTdeleted))
-                .then(tokenFreeze(NFTdeleted, TOKEN_TREASURY).hasPrecheck(OK).hasKnownStatus(TOKEN_WAS_DELETED));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate(TOKEN_TREASURY).balance(0L).key(ADMIN_KEY),
+                tokenCreate(NFTdeleted)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .freezeKey(FREEZE_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0L)
+                        .treasury(TOKEN_TREASURY),
+                tokenDelete(NFTdeleted),
+                tokenFreeze(NFTdeleted, TOKEN_TREASURY).hasPrecheck(OK).hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest
     final Stream<DynamicTest> cannotDissociateNftWhenDeleted() {
-        return defaultHapiSpec("cannotDissociateNftWhenDeleted")
-                .given(
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-                        cryptoCreate(ANOTHER_USER),
-                        tokenCreate(NFTdeleted)
-                                .initialSupply(0)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        tokenAssociate(ANOTHER_USER, NFTdeleted))
-                .when(tokenDelete(NFTdeleted))
-                .then(tokenDissociate(ANOTHER_USER, NFTdeleted).hasKnownStatus(SUCCESS));
+        return hapiTest(
+                newKeyNamed(ADMIN_KEY),
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                cryptoCreate(ANOTHER_USER),
+                tokenCreate(NFTdeleted)
+                        .initialSupply(0)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenAssociate(ANOTHER_USER, NFTdeleted),
+                tokenDelete(NFTdeleted),
+                tokenDissociate(ANOTHER_USER, NFTdeleted).hasKnownStatus(SUCCESS));
     }
 
     @HapiTest
     final Stream<DynamicTest> cannotAssociateNftWhenDeleted() {
-        return defaultHapiSpec("cannotAssociateNftWhenDeleted")
-                .given(
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-                        cryptoCreate(ANOTHER_USER),
-                        tokenCreate(NFTdeleted)
-                                .initialSupply(0)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey(ADMIN_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(tokenDelete(NFTdeleted))
-                .then(tokenAssociate(ANOTHER_USER, NFTdeleted).hasKnownStatus(TOKEN_WAS_DELETED));
+        return hapiTest(
+                newKeyNamed(ADMIN_KEY),
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                cryptoCreate(ANOTHER_USER),
+                tokenCreate(NFTdeleted)
+                        .initialSupply(0)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .adminKey(ADMIN_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenDelete(NFTdeleted),
+                tokenAssociate(ANOTHER_USER, NFTdeleted).hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest // transferList differ
     final Stream<DynamicTest> cannotUpdateNftWhenDeleted() {
-        return defaultHapiSpec("cannotUpdateNftWhenDeleted")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(NEW_TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(AUTO_RENEW_ACCT).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(NEW_AUTO_RENEW_ACCT).balance(ONE_HUNDRED_HBARS),
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(NEW_FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        newKeyNamed(NEW_KYC_KEY),
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(NEW_SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        newKeyNamed(NEW_WIPE_KEY),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .name(SALTED_NAME)
-                                .entityMemo(FIRST_MEMO)
-                                .treasury(TOKEN_TREASURY)
-                                .autoRenewAccount(AUTO_RENEW_ACCT)
-                                .initialSupply(0)
-                                .adminKey(ADMIN_KEY)
-                                .freezeKey(FREEZE_KEY)
-                                .kycKey(KYC_KEY)
-                                .supplyKey(SUPPLY_KEY)
-                                .wipeKey(WIPE_KEY),
-                        tokenAssociate(NEW_TOKEN_TREASURY, NFTdeleted),
-                        // can update before NFT is deleted
-                        tokenUpdate(NFTdeleted)
-                                .entityMemo(ZERO_BYTE_MEMO)
-                                .signedByPayerAnd(ADMIN_KEY)
-                                .hasPrecheck(INVALID_ZERO_BYTE_IN_STRING),
-                        tokenUpdate(NFTdeleted)
-                                .name(NEW_SALTED_NAME)
-                                .entityMemo(SECOND_MEMO)
-                                .treasury(NEW_TOKEN_TREASURY)
-                                .autoRenewAccount(NEW_AUTO_RENEW_ACCT)
-                                .freezeKey(NEW_FREEZE_KEY)
-                                .kycKey(NEW_KYC_KEY)
-                                .supplyKey(NEW_SUPPLY_KEY)
-                                .wipeKey(NEW_WIPE_KEY)
-                                .signedByPayerAnd(ADMIN_KEY, NEW_TOKEN_TREASURY, NEW_AUTO_RENEW_ACCT)
-                                .hasKnownStatus(SUCCESS))
-                .when(tokenDelete(NFTdeleted))
-                .then(
-                        // can't update after NFT is deleted.
-                        tokenUpdate(NFTdeleted)
-                                .name(NEW_SALTED_NAME)
-                                .entityMemo(SECOND_MEMO)
-                                .signedByPayerAnd(ADMIN_KEY)
-                                .hasKnownStatus(TOKEN_WAS_DELETED),
-                        tokenUpdate(NFTdeleted)
-                                .treasury(NEW_TOKEN_TREASURY)
-                                .signedByPayerAnd(ADMIN_KEY, NEW_TOKEN_TREASURY)
-                                .hasKnownStatus(TOKEN_WAS_DELETED),
-                        tokenUpdate(NFTdeleted)
-                                .autoRenewAccount(NEW_AUTO_RENEW_ACCT)
-                                .signedByPayerAnd(ADMIN_KEY, NEW_AUTO_RENEW_ACCT)
-                                .hasKnownStatus(TOKEN_WAS_DELETED),
-                        tokenUpdate(NFTdeleted)
-                                .freezeKey(NEW_FREEZE_KEY)
-                                .kycKey(NEW_KYC_KEY)
-                                .supplyKey(NEW_SUPPLY_KEY)
-                                .wipeKey(NEW_WIPE_KEY)
-                                .signedByPayerAnd(ADMIN_KEY)
-                                .hasKnownStatus(TOKEN_WAS_DELETED));
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(NEW_TOKEN_TREASURY).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(AUTO_RENEW_ACCT).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(NEW_AUTO_RENEW_ACCT).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(ADMIN_KEY),
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(NEW_FREEZE_KEY),
+                newKeyNamed(KYC_KEY),
+                newKeyNamed(NEW_KYC_KEY),
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(NEW_SUPPLY_KEY),
+                newKeyNamed(WIPE_KEY),
+                newKeyNamed(NEW_WIPE_KEY),
+                tokenCreate(NFTdeleted)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .name(SALTED_NAME)
+                        .entityMemo(FIRST_MEMO)
+                        .treasury(TOKEN_TREASURY)
+                        .autoRenewAccount(AUTO_RENEW_ACCT)
+                        .initialSupply(0)
+                        .adminKey(ADMIN_KEY)
+                        .freezeKey(FREEZE_KEY)
+                        .kycKey(KYC_KEY)
+                        .supplyKey(SUPPLY_KEY)
+                        .wipeKey(WIPE_KEY),
+                tokenAssociate(NEW_TOKEN_TREASURY, NFTdeleted),
+                // can update before NFT is deleted
+                tokenUpdate(NFTdeleted)
+                        .entityMemo(ZERO_BYTE_MEMO)
+                        .signedByPayerAnd(ADMIN_KEY)
+                        .hasPrecheck(INVALID_ZERO_BYTE_IN_STRING),
+                tokenUpdate(NFTdeleted)
+                        .name(NEW_SALTED_NAME)
+                        .entityMemo(SECOND_MEMO)
+                        .treasury(NEW_TOKEN_TREASURY)
+                        .autoRenewAccount(NEW_AUTO_RENEW_ACCT)
+                        .freezeKey(NEW_FREEZE_KEY)
+                        .kycKey(NEW_KYC_KEY)
+                        .supplyKey(NEW_SUPPLY_KEY)
+                        .wipeKey(NEW_WIPE_KEY)
+                        .signedByPayerAnd(ADMIN_KEY, NEW_TOKEN_TREASURY, NEW_AUTO_RENEW_ACCT)
+                        .hasKnownStatus(SUCCESS),
+                tokenDelete(NFTdeleted),
+                // can't update after NFT is deleted.
+                tokenUpdate(NFTdeleted)
+                        .name(NEW_SALTED_NAME)
+                        .entityMemo(SECOND_MEMO)
+                        .signedByPayerAnd(ADMIN_KEY)
+                        .hasKnownStatus(TOKEN_WAS_DELETED),
+                tokenUpdate(NFTdeleted)
+                        .treasury(NEW_TOKEN_TREASURY)
+                        .signedByPayerAnd(ADMIN_KEY, NEW_TOKEN_TREASURY)
+                        .hasKnownStatus(TOKEN_WAS_DELETED),
+                tokenUpdate(NFTdeleted)
+                        .autoRenewAccount(NEW_AUTO_RENEW_ACCT)
+                        .signedByPayerAnd(ADMIN_KEY, NEW_AUTO_RENEW_ACCT)
+                        .hasKnownStatus(TOKEN_WAS_DELETED),
+                tokenUpdate(NFTdeleted)
+                        .freezeKey(NEW_FREEZE_KEY)
+                        .kycKey(NEW_KYC_KEY)
+                        .supplyKey(NEW_SUPPLY_KEY)
+                        .wipeKey(NEW_WIPE_KEY)
+                        .signedByPayerAnd(ADMIN_KEY)
+                        .hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest
@@ -284,109 +274,103 @@ public class Hip17UnhappyTokensSuite {
         final var newHbarFee = 4_321L;
         final var hbarCollector = "hbarFee";
 
-        return defaultHapiSpec("cannotUpdateNftFeeScheduleWhenDeleted")
-                .given(
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(FEE_SCHEDULE_KEY),
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-                        cryptoCreate(hbarCollector),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0L)
-                                .adminKey(ADMIN_KEY)
-                                .treasury(TOKEN_TREASURY)
-                                .supplyKey(SUPPLY_KEY)
-                                .feeScheduleKey(FEE_SCHEDULE_KEY)
-                                .withCustom(fixedHbarFee(origHbarFee, hbarCollector)))
-                .when(tokenDelete(NFTdeleted))
-                .then(tokenFeeScheduleUpdate(NFTdeleted)
+        return hapiTest(
+                newKeyNamed(ADMIN_KEY),
+                newKeyNamed(FEE_SCHEDULE_KEY),
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                cryptoCreate(hbarCollector),
+                tokenCreate(NFTdeleted)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0L)
+                        .adminKey(ADMIN_KEY)
+                        .treasury(TOKEN_TREASURY)
+                        .supplyKey(SUPPLY_KEY)
+                        .feeScheduleKey(FEE_SCHEDULE_KEY)
+                        .withCustom(fixedHbarFee(origHbarFee, hbarCollector)),
+                tokenDelete(NFTdeleted),
+                tokenFeeScheduleUpdate(NFTdeleted)
                         .withCustom(fixedHbarFee(newHbarFee, hbarCollector))
                         .hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest
     final Stream<DynamicTest> cannotMintNftWhenDeleted() {
-        return defaultHapiSpec("cannotMintNftWhenDeleted")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-                        cryptoCreate(ANOTHER_USER),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(ADMIN_KEY))
-                .when(tokenDelete(NFTdeleted))
-                .then(mintToken(NFTdeleted, List.of(ByteString.copyFromUtf8(FIRST_MEMO)))
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(WIPE_KEY),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                cryptoCreate(ANOTHER_USER),
+                tokenCreate(NFTdeleted)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(ADMIN_KEY),
+                tokenDelete(NFTdeleted),
+                mintToken(NFTdeleted, List.of(ByteString.copyFromUtf8(FIRST_MEMO)))
                         .hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest
     final Stream<DynamicTest> cannotBurnNftWhenDeleted() {
-        return defaultHapiSpec("cannotBurnNftWhenDeleted")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(ANOTHER_KEY),
-                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-                        cryptoCreate(ANOTHER_USER).key(ANOTHER_KEY),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(ADMIN_KEY),
-                        tokenAssociate(ANOTHER_USER, NFTdeleted),
-                        mintToken(
-                                NFTdeleted,
-                                List.of(ByteString.copyFromUtf8(FIRST_MEMO), ByteString.copyFromUtf8(SECOND_MEMO))),
-                        cryptoTransfer(movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER)),
-                        getAccountInfo(ANOTHER_USER).hasOwnedNfts(1),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
-                        getTokenInfo(NFTdeleted).hasTotalSupply(2),
-                        getTokenNftInfo(NFTdeleted, 2).hasCostAnswerPrecheck(OK),
-                        getTokenNftInfo(NFTdeleted, 1).hasSerialNum(1))
-                .when(tokenDelete(NFTdeleted))
-                .then(burnToken(NFTdeleted, List.of(2L)).hasKnownStatus(TOKEN_WAS_DELETED));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(WIPE_KEY),
+                newKeyNamed(ADMIN_KEY),
+                newKeyNamed(ANOTHER_KEY),
+                cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                cryptoCreate(ANOTHER_USER).key(ANOTHER_KEY),
+                tokenCreate(NFTdeleted)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(ADMIN_KEY),
+                tokenAssociate(ANOTHER_USER, NFTdeleted),
+                mintToken(
+                        NFTdeleted, List.of(ByteString.copyFromUtf8(FIRST_MEMO), ByteString.copyFromUtf8(SECOND_MEMO))),
+                cryptoTransfer(movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER)),
+                getAccountInfo(ANOTHER_USER).hasOwnedNfts(1),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
+                getTokenInfo(NFTdeleted).hasTotalSupply(2),
+                getTokenNftInfo(NFTdeleted, 2).hasCostAnswerPrecheck(OK),
+                getTokenNftInfo(NFTdeleted, 1).hasSerialNum(1),
+                tokenDelete(NFTdeleted),
+                burnToken(NFTdeleted, List.of(2L)).hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest
     final Stream<DynamicTest> cannotWipeNftWhenDeleted() {
-        return defaultHapiSpec("cannotWipeNftWhenDeleted")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        newKeyNamed(ADMIN_KEY),
-                        newKeyNamed(ANOTHER_KEY),
-                        cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
-                        cryptoCreate(ANOTHER_USER).key(ANOTHER_KEY),
-                        tokenCreate(NFTdeleted)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .adminKey(ADMIN_KEY)
-                                .wipeKey(WIPE_KEY),
-                        tokenAssociate(ANOTHER_USER, NFTdeleted),
-                        mintToken(
-                                NFTdeleted,
-                                List.of(ByteString.copyFromUtf8(FIRST_MEMO), ByteString.copyFromUtf8(SECOND_MEMO))),
-                        cryptoTransfer(movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER)),
-                        getAccountInfo(ANOTHER_USER).hasOwnedNfts(1),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
-                        getTokenInfo(NFTdeleted).hasTotalSupply(2),
-                        getTokenNftInfo(NFTdeleted, 2).hasCostAnswerPrecheck(OK),
-                        getTokenNftInfo(NFTdeleted, 1).hasSerialNum(1))
-                .when(tokenDelete(NFTdeleted))
-                .then(wipeTokenAccount(NFTdeleted, ANOTHER_USER, List.of(1L)).hasKnownStatus(TOKEN_WAS_DELETED));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(WIPE_KEY),
+                newKeyNamed(ADMIN_KEY),
+                newKeyNamed(ANOTHER_KEY),
+                cryptoCreate(TOKEN_TREASURY).key(ADMIN_KEY),
+                cryptoCreate(ANOTHER_USER).key(ANOTHER_KEY),
+                tokenCreate(NFTdeleted)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(ADMIN_KEY)
+                        .wipeKey(WIPE_KEY),
+                tokenAssociate(ANOTHER_USER, NFTdeleted),
+                mintToken(
+                        NFTdeleted, List.of(ByteString.copyFromUtf8(FIRST_MEMO), ByteString.copyFromUtf8(SECOND_MEMO))),
+                cryptoTransfer(movingUnique(NFTdeleted, 2L).between(TOKEN_TREASURY, ANOTHER_USER)),
+                getAccountInfo(ANOTHER_USER).hasOwnedNfts(1),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
+                getTokenInfo(NFTdeleted).hasTotalSupply(2),
+                getTokenNftInfo(NFTdeleted, 2).hasCostAnswerPrecheck(OK),
+                getTokenNftInfo(NFTdeleted, 1).hasSerialNum(1),
+                tokenDelete(NFTdeleted),
+                wipeTokenAccount(NFTdeleted, ANOTHER_USER, List.of(1L)).hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     private ByteString metadata(String contents) {


### PR DESCRIPTION
This PR does not change any test conditions; instead, it merely wraps each set of spec operations with the new `hapiTest(...)` method wrapper instead of `defaultHapiSpec(...)`. 

Part of #16494 