### PR TITLE
build(bug): description field in pom.xml was not populated

### DIFF
--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.maven-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.maven-publish.gradle.kts
@@ -73,13 +73,14 @@ val maven =
             url = "https://www.hashgraph.com/"
             inceptionYear = "2016"
 
+            // this field must be present. Default to empty string.
             description =
                 providers
                     .fileContents(layout.projectDirectory.file("../description.txt"))
                     .asText
-                    .orElse(provider { project.description })
+                    .orElse(provider(project::getDescription))
                     .map { it.replace("\n", " ").trim() }
-                    .orNull
+                    .orElse("")
 
             organization {
                 name = "Hedera Hashgraph, LLC"


### PR DESCRIPTION
**Description**:

The `<description></description>` field was not present in the pom.xml file generated for maven central. Needed to update two parts of the field setter:

- `.orElse(provider { project.description })` became `.orElse(provider(project::getDescription))` to actually populate with the project description
- `.orNull()` becomes `.orElse("")` to prevent a null entry on description if it is not present in the other ways

**Related Issue(s)**:

Fixes #16624

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.) - Tested with gradle pom generation task
