### PR TITLE
fix: correct a missing conversion between `AddressBook` cert hash hex-string-as-bytes and actual SHA2-384 hash bytes for `Node` entries.

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/schemas/V053AddressBookSchema.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/schemas/V053AddressBookSchema.java
@@ -108,9 +108,9 @@ public class V053AddressBookSchema extends Schema {
             if (nodeDetailMap != null) {
                 nodeDetail = nodeDetailMap.get(nodeInfo.nodeId());
                 if (nodeDetail != null) {
-                    nodeBuilder
-                            .serviceEndpoint(nodeDetail.serviceEndpoint())
-                            .grpcCertificateHash(nodeDetail.nodeCertHash());
+                    final Bytes hashBytes =
+                            Bytes.fromHex(nodeDetail.nodeCertHash().asUtf8String());
+                    nodeBuilder.serviceEndpoint(nodeDetail.serviceEndpoint()).grpcCertificateHash(hashBytes);
                 }
             }
             writableNodes.put(

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/schemas/V056AddressBookSchema.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/schemas/V056AddressBookSchema.java
@@ -149,11 +149,15 @@ public class V056AddressBookSchema extends Schema {
                     .weight(nodeInfo.stake())
                     .adminKey(adminKey)
                     .serviceEndpoint(nodeDetail != null ? nodeDetail.serviceEndpoint() : emptyList())
-                    .grpcCertificateHash(nodeDetail != null ? nodeDetail.nodeCertHash() : Bytes.EMPTY);
+                    .grpcCertificateHash(getHashFromNodeDetail(nodeDetail));
 
             writableNodes.put(
                     EntityNumber.newBuilder().number(nodeInfo.nodeId()).build(), nodeBuilder.build());
         }
         log.info("Migrated {} nodes from address book", addressBook.size());
+    }
+
+    private Bytes getHashFromNodeDetail(@Nullable final NodeAddress nodeDetail) {
+        return nodeDetail != null ? Bytes.fromHex(nodeDetail.nodeCertHash().asUtf8String()) : Bytes.EMPTY;
     }
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/schemas/V053AddressBookSchemaTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/schemas/V053AddressBookSchemaTest.java
@@ -178,7 +178,7 @@ class V053AddressBookSchemaTest extends AddressBookTestBase {
                         .gossipCaCertificate(Bytes.wrap(grpcCertificateHash))
                         .weight(1)
                         .adminKey(anotherKey)
-                        .grpcCertificateHash(Bytes.wrap("grpcCertificateHash1"))
+                        .grpcCertificateHash(Bytes.fromHex("ebdaba19283dadbabedab1"))
                         .serviceEndpoint(List.of(endpointFor("127.1.0.1", 1234), endpointFor("127.1.0.2", 1234)))
                         .build(),
                 writableNodes.get(EntityNumber.newBuilder().number(2).build()));
@@ -191,7 +191,7 @@ class V053AddressBookSchemaTest extends AddressBookTestBase {
                         .gossipCaCertificate(Bytes.wrap(grpcCertificateHash))
                         .weight(10)
                         .adminKey(anotherKey)
-                        .grpcCertificateHash(Bytes.wrap("grpcCertificateHash2"))
+                        .grpcCertificateHash(Bytes.fromHex("ebdaba19283dadbabedab2"))
                         .serviceEndpoint(
                                 List.of(endpointFor("domain.test1.com", 1234), endpointFor("domain.test2.com", 5678)))
                         .build(),
@@ -305,12 +305,12 @@ class V053AddressBookSchemaTest extends AddressBookTestBase {
         nodeDetails.addAll(List.of(
                 NodeAddress.newBuilder()
                         .nodeId(2)
-                        .nodeCertHash(Bytes.wrap("grpcCertificateHash1"))
+                        .nodeCertHash(Bytes.wrap("ebdaba19283dadbabedab1"))
                         .serviceEndpoint(List.of(endpointFor("127.1.0.1", 1234), endpointFor("127.1.0.2", 1234)))
                         .build(),
                 NodeAddress.newBuilder()
                         .nodeId(3)
-                        .nodeCertHash(Bytes.wrap("grpcCertificateHash2"))
+                        .nodeCertHash(Bytes.wrap("ebdaba19283dadbabedab2"))
                         .serviceEndpoint(
                                 List.of(endpointFor("domain.test1.com", 1234), endpointFor("domain.test2.com", 5678)))
                         .build()));

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/schemas/V056AddressBookSchemaTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/schemas/V056AddressBookSchemaTest.java
@@ -159,7 +159,7 @@ class V056AddressBookSchemaTest extends AddressBookTestBase {
                         .gossipCaCertificate(Bytes.wrap(grpcCertificateHash))
                         .weight(1)
                         .adminKey(anotherKey)
-                        .grpcCertificateHash(Bytes.wrap("grpcCertificateHash1"))
+                        .grpcCertificateHash(Bytes.fromHex("ebdaba19283dadbabedab1"))
                         .serviceEndpoint(List.of(endpointFor("127.1.0.1", 1234), endpointFor("127.1.0.2", 1234)))
                         .build(),
                 writableNodes.get(EntityNumber.newBuilder().number(2).build()));
@@ -172,7 +172,7 @@ class V056AddressBookSchemaTest extends AddressBookTestBase {
                         .gossipCaCertificate(Bytes.wrap(grpcCertificateHash))
                         .weight(10)
                         .adminKey(anotherKey)
-                        .grpcCertificateHash(Bytes.wrap("grpcCertificateHash2"))
+                        .grpcCertificateHash(Bytes.fromHex("ebdaba19283dadbabedab2"))
                         .serviceEndpoint(
                                 List.of(endpointFor("domain.test1.com", 1234), endpointFor("domain.test2.com", 5678)))
                         .build(),
@@ -262,12 +262,12 @@ class V056AddressBookSchemaTest extends AddressBookTestBase {
         nodeDetails.addAll(List.of(
                 NodeAddress.newBuilder()
                         .nodeId(2)
-                        .nodeCertHash(Bytes.wrap("grpcCertificateHash1"))
+                        .nodeCertHash(Bytes.wrap("ebdaba19283dadbabedab1"))
                         .serviceEndpoint(List.of(endpointFor("127.1.0.1", 1234), endpointFor("127.1.0.2", 1234)))
                         .build(),
                 NodeAddress.newBuilder()
                         .nodeId(3)
-                        .nodeCertHash(Bytes.wrap("grpcCertificateHash2"))
+                        .nodeCertHash(Bytes.wrap("ebdaba19283dadbabedab2"))
                         .serviceEndpoint(
                                 List.of(endpointFor("domain.test1.com", 1234), endpointFor("domain.test2.com", 5678)))
                         .build()));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip993/SystemFileExportsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip993/SystemFileExportsTest.java
@@ -65,6 +65,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 import static com.swirlds.common.utility.CommonUtils.unhex;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -92,6 +93,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.text.Normalizer;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -447,7 +450,7 @@ public class SystemFileExportsTest {
 
                     final var actualCertHash = address.nodeCertHash().toByteArray();
                     assertArrayEquals(
-                            grpcCertHashes[(int) address.nodeId()],
+                            getHexStringBytesFromBytes(grpcCertHashes[(int) address.nodeId()]),
                             actualCertHash,
                             "node" + address.nodeId() + " has wrong cert hash");
 
@@ -461,6 +464,11 @@ public class SystemFileExportsTest {
                 Assertions.fail("Update contents was not protobuf " + e.getMessage());
             }
         };
+    }
+
+    private static byte[] getHexStringBytesFromBytes(final byte[] rawBytes) {
+        final String hexString = HexFormat.of().formatHex(rawBytes);
+        return Normalizer.normalize(hexString, Normalizer.Form.NFD).getBytes(UTF_8);
     }
 
     private static VisibleItemsValidator addressBookExportValidator(
@@ -487,7 +495,7 @@ public class SystemFileExportsTest {
                 for (final var address : updatedAddressBook.nodeAddress()) {
                     final var actualCertHash = address.nodeCertHash().toByteArray();
                     assertArrayEquals(
-                            grpcCertHashes[(int) address.nodeId()],
+                            getHexStringBytesFromBytes(grpcCertHashes[(int) address.nodeId()]),
                             actualCertHash,
                             "node" + address.nodeId() + " has wrong cert hash");
 


### PR DESCRIPTION
* When migrating from an `AddressBook` to the `Node`s, convert from hex string to hash bits
* When generating an `AddressBook` from the `Node`s, convert from hash bits to hex string
* Fix the two unit tests that assumed both were arbitrary bytes.
* Fix the one HAPI test that interacts with the `101`/`102` file generation.
