### PR TITLE
fix: correct a missing conversion between AddressBook cert hash hex-string-as-bytes and actual SHA2-384 hash bytes for Node entries.

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/schemas/V053AddressBookSchema.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/schemas/V053AddressBookSchema.java
@@ -127,9 +127,9 @@ public class V053AddressBookSchema extends Schema {
             if (nodeDetailMap != null) {
                 nodeDetail = nodeDetailMap.get(nodeInfo.nodeId());
                 if (nodeDetail != null) {
-                    nodeBuilder
-                            .serviceEndpoint(nodeDetail.serviceEndpoint())
-                            .grpcCertificateHash(nodeDetail.nodeCertHash());
+                    final Bytes hashBytes =
+                            Bytes.fromHex(nodeDetail.nodeCertHash().asUtf8String());
+                    nodeBuilder.serviceEndpoint(nodeDetail.serviceEndpoint()).grpcCertificateHash(hashBytes);
                 }
             }
             writableNodes.put(

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/schemas/V053AddressBookSchemaTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/schemas/V053AddressBookSchemaTest.java
@@ -201,7 +201,7 @@ class V053AddressBookSchemaTest extends AddressBookTestBase {
                         .gossipCaCertificate(Bytes.wrap(grpcCertificateHash))
                         .weight(1)
                         .adminKey(anotherKey)
-                        .grpcCertificateHash(Bytes.wrap("grpcCertificateHash1"))
+                        .grpcCertificateHash(Bytes.fromHex("ebdaba19283dadbabedab1"))
                         .serviceEndpoint(List.of(endpointFor("127.1.0.1", 1234), endpointFor("127.1.0.2", 1234)))
                         .build(),
                 writableNodes.get(EntityNumber.newBuilder().number(2).build()));
@@ -214,7 +214,7 @@ class V053AddressBookSchemaTest extends AddressBookTestBase {
                         .gossipCaCertificate(Bytes.wrap(grpcCertificateHash))
                         .weight(10)
                         .adminKey(anotherKey)
-                        .grpcCertificateHash(Bytes.wrap("grpcCertificateHash2"))
+                        .grpcCertificateHash(Bytes.fromHex("ebdaba19283dadbabedab2"))
                         .serviceEndpoint(
                                 List.of(endpointFor("domain.test1.com", 1234), endpointFor("domain.test2.com", 5678)))
                         .build(),
@@ -344,12 +344,12 @@ class V053AddressBookSchemaTest extends AddressBookTestBase {
         nodeDetails.addAll(List.of(
                 NodeAddress.newBuilder()
                         .nodeId(2)
-                        .nodeCertHash(Bytes.wrap("grpcCertificateHash1"))
+                        .nodeCertHash(Bytes.wrap("ebdaba19283dadbabedab1"))
                         .serviceEndpoint(List.of(endpointFor("127.1.0.1", 1234), endpointFor("127.1.0.2", 1234)))
                         .build(),
                 NodeAddress.newBuilder()
                         .nodeId(3)
-                        .nodeCertHash(Bytes.wrap("grpcCertificateHash2"))
+                        .nodeCertHash(Bytes.wrap("ebdaba19283dadbabedab2"))
                         .serviceEndpoint(
                                 List.of(endpointFor("domain.test1.com", 1234), endpointFor("domain.test2.com", 5678)))
                         .build()));

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/NodeMetadataHelper.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/NodeMetadataHelper.java
@@ -36,6 +36,7 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableStakingInfoStore;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.FilesConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.spi.info.NetworkInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -122,7 +123,7 @@ public class NodeMetadataHelper {
                     .weight(stakingInfo.weight())
                     .adminKey(addressBookAdminKey)
                     .serviceEndpoint(details.serviceEndpoint())
-                    .grpcCertificateHash(details.nodeCertHash());
+                    .grpcCertificateHash(Bytes.fromHex(details.nodeCertHash().asUtf8String()));
             nodeStore.put(builder.build());
         });
     }

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/V0490FileSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/V0490FileSchema.java
@@ -75,8 +75,10 @@ import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -266,7 +268,7 @@ public class V0490FileSchema extends Schema {
                 .forEach(node -> nodeDetails.add(NodeAddress.newBuilder()
                         .nodeId(node.nodeId())
                         .nodeAccountId(node.accountId())
-                        .nodeCertHash(node.grpcCertificateHash())
+                        .nodeCertHash(getHexStringBytesFromBytes(node.grpcCertificateHash()))
                         .description(node.description())
                         .stake(node.weight())
                         .rsaPubKey(readableKey(getPublicKeyFromCertBytes(
@@ -277,6 +279,11 @@ public class V0490FileSchema extends Schema {
                 NodeAddressBook.newBuilder().nodeAddress(nodeDetails).build());
     }
 
+    private Bytes getHexStringBytesFromBytes(final Bytes rawBytes) {
+        final String hexString = HexFormat.of().formatHex(rawBytes.toByteArray());
+        return Bytes.wrap(Normalizer.normalize(hexString, Normalizer.Form.NFD).getBytes(UTF_8));
+    }
+
     private Bytes nodeStoreAddressBook(@NonNull final ReadableNodeStore nodeStore) {
         final var nodeAddresses = new ArrayList<NodeAddress>();
         StreamSupport.stream(Spliterators.spliterator(nodeStore.keys(), nodeStore.sizeOfState(), DISTINCT), false)
@@ -285,7 +292,7 @@ public class V0490FileSchema extends Schema {
                 .filter(node -> node != null && !node.deleted())
                 .forEach(node -> nodeAddresses.add(NodeAddress.newBuilder()
                         .nodeId(node.nodeId())
-                        .nodeCertHash(node.grpcCertificateHash())
+                        .nodeCertHash(getHexStringBytesFromBytes(node.grpcCertificateHash()))
                         .nodeAccountId(node.accountId())
                         .serviceEndpoint(node.serviceEndpoint())
                         .build()));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip993/SystemFileExportsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip993/SystemFileExportsTest.java
@@ -70,6 +70,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 import static com.swirlds.common.utility.CommonUtils.unhex;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -103,6 +104,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.text.Normalizer;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -540,7 +543,7 @@ public class SystemFileExportsTest {
 
                     final var actualCertHash = address.nodeCertHash().toByteArray();
                     assertArrayEquals(
-                            grpcCertHashes[(int) address.nodeId()],
+                            getHexStringBytesFromBytes(grpcCertHashes[(int) address.nodeId()]),
                             actualCertHash,
                             "node" + address.nodeId() + " has wrong cert hash");
 
@@ -554,6 +557,11 @@ public class SystemFileExportsTest {
                 Assertions.fail("Update contents was not protobuf " + e.getMessage());
             }
         };
+    }
+
+    private static byte[] getHexStringBytesFromBytes(final byte[] rawBytes) {
+        final String hexString = HexFormat.of().formatHex(rawBytes);
+        return Normalizer.normalize(hexString, Normalizer.Form.NFD).getBytes(UTF_8);
     }
 
     private static VisibleItemsValidator addressBookExportValidator(
@@ -580,7 +588,7 @@ public class SystemFileExportsTest {
                 for (final var address : updatedAddressBook.nodeAddress()) {
                     final var actualCertHash = address.nodeCertHash().toByteArray();
                     assertArrayEquals(
-                            grpcCertHashes[(int) address.nodeId()],
+                            getHexStringBytesFromBytes(grpcCertHashes[(int) address.nodeId()]),
                             actualCertHash,
                             "node" + address.nodeId() + " has wrong cert hash");
 


### PR DESCRIPTION
* When migrating from an `AddressBook` to the `Node`s, convert from hex string to hash bits
* When generating an `AddressBook` from the `Node`s, convert from hash bits to hex string
* Fix the one unit test that assumed both were arbitrary bytes.
* Fix the one HAPI test that interacts with the `101`/`102` file generation.