### PR TITLE
build: run validatePomFiles as part of qualityGate and PR checks

### DIFF
--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Gradle Dependency Scopes Check
         if: ${{ inputs.enable-dependency-check && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        run: ${GRADLE_EXEC} checkAllModuleInfo --scan --continue
+        run: ${GRADLE_EXEC} checkAllModuleInfo validatePomFiles --scan --continue
 
       - name: Unit Testing
         id: gradle-test

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -32,13 +32,11 @@ dependencies {
     implementation(
         "gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.2.2"
     )
+    implementation("io.freefair.gradle:maven-plugin:8.11") // for POM validation
     implementation("io.github.gradle-nexus:publish-plugin:1.3.0")
     implementation("me.champeau.jmh:jmh-gradle-plugin:0.7.2")
     implementation("net.swiftzer.semver:semver:1.3.0")
     implementation("org.gradlex:extra-java-module-info:1.9")
     implementation("org.gradlex:jvm-dependency-conflict-resolution:2.1.2")
     implementation("org.gradlex:java-module-dependencies:1.7.1")
-    implementation(
-        "io.freefair.maven-central.validate-poms:io.freefair.maven-central.validate-poms.gradle.plugin:8.6"
-    )
 }

--- a/gradle/plugins/src/main/kotlin/com.hedera.gradle.maven-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/com.hedera.gradle.maven-publish.gradle.kts
@@ -131,3 +131,5 @@ if (publishSigningEnabled) {
         useGpgCmd()
     }
 }
+
+tasks.named("qualityGate") { dependsOn(tasks.validatePomFiles) }

--- a/hedera-node/hedera-app-spi/build.gradle.kts
+++ b/hedera-node/hedera-app-spi/build.gradle.kts
@@ -29,7 +29,5 @@ testModuleInfo {
     requires("org.assertj.core")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
-    requires("org.mockito")
-    requires("org.mockito.junit.jupiter")
     requiresStatic("com.github.spotbugs.annotations")
 }


### PR DESCRIPTION
**Description**:

Run `validatePomFiles` as part of qualityGate and PR checks. It is not expensive to run this check and this will hopefully reduce the amount of issues we only find very late in the publishing process right now.

**Related issue(s)**:

Resolves #16649
Builds on #16651

**Checklist**

- [x] Tested (unit, integration, etc.)
