### PR TITLE
chore: Modify and mount default block streams output directory

### DIFF
--- a/hedera-node/configuration/compose/node.properties
+++ b/hedera-node/configuration/compose/node.properties
@@ -1,3 +1,4 @@
 hedera.recordStream.logDir=data/recordStreams
 hedera.recordStream.sidecarDir=
 netty.mode=TEST
+blockStream.blockFileDir=data/blockStreams

--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -14,3 +14,5 @@ bootstrap.throttleDefsJson.resource=genesis/throttles-dev.json
 ledger.id=0x03
 blockStream.streamMode=BOTH
 nodes.enableDAB=true
+hedera.recordStream.logDir=data/recordStreams
+blockStream.blockFileDir=data/blockStreams

--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -14,5 +14,4 @@ bootstrap.throttleDefsJson.resource=genesis/throttles-dev.json
 ledger.id=0x03
 blockStream.streamMode=BOTH
 nodes.enableDAB=true
-hedera.recordStream.logDir=data/recordStreams
 blockStream.blockFileDir=data/blockStreams

--- a/hedera-node/configuration/dev/node.properties
+++ b/hedera-node/configuration/dev/node.properties
@@ -2,3 +2,4 @@ hedera.profiles.active=DEV
 hedera.recordStream.logDir=data/recordStreams
 hedera.recordStream.sidecarDir=
 stats.executionTimesToTrack=1000
+blockStream.blockFileDir=data/blockStreams

--- a/hedera-node/data/config/node.properties
+++ b/hedera-node/data/config/node.properties
@@ -3,3 +3,4 @@ hedera.recordStream.logDir=data/recordstreams/
 hedera.recordStream.sidecarDir=
 hedera.recordStream.queueCapacity=5000
 netty.mode=TEST
+blockStream.blockFileDir=data/blockstreams/

--- a/hedera-node/data/config/node.properties
+++ b/hedera-node/data/config/node.properties
@@ -3,4 +3,4 @@ hedera.recordStream.logDir=data/recordstreams/
 hedera.recordStream.sidecarDir=
 hedera.recordStream.queueCapacity=5000
 netty.mode=TEST
-blockStream.blockFileDir=data/blockstreams/
+blockStream.blockFileDir=data/blockStreams/

--- a/hedera-node/docker/.dockerignore
+++ b/hedera-node/docker/.dockerignore
@@ -9,7 +9,7 @@ LICENSE*
 docs/
 hapi-proto/target/
 hedera-node/data/lib/
-hedera-node/data/recordStreams/
+hedera-node/data/recordstreams/
 hedera-node/data/blockStreams/
 hedera-node/data/accountBalances/
 hedera-node/data/saved/

--- a/hedera-node/docker/.dockerignore
+++ b/hedera-node/docker/.dockerignore
@@ -10,6 +10,7 @@ docs/
 hapi-proto/target/
 hedera-node/data/lib/
 hedera-node/data/recordstreams/
+hedera-node/data/blockstreams/
 hedera-node/data/accountBalances/
 hedera-node/data/saved/
 hedera-node/databases/

--- a/hedera-node/docker/.dockerignore
+++ b/hedera-node/docker/.dockerignore
@@ -9,8 +9,8 @@ LICENSE*
 docs/
 hapi-proto/target/
 hedera-node/data/lib/
-hedera-node/data/recordstreams/
-hedera-node/data/blockstreams/
+hedera-node/data/recordStreams/
+hedera-node/data/blockStreams/
 hedera-node/data/accountBalances/
 hedera-node/data/saved/
 hedera-node/databases/

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
@@ -38,7 +38,7 @@ import com.swirlds.config.api.validation.annotation.Min;
 public record BlockStreamConfig(
         @ConfigProperty(defaultValue = "BOTH") @NetworkProperty StreamMode streamMode,
         @ConfigProperty(defaultValue = "FILE") @NodeProperty BlockStreamWriterMode writerMode,
-        @ConfigProperty(defaultValue = "data/block-streams") @NodeProperty String blockFileDir,
+        @ConfigProperty(defaultValue = "/opt/hgcapp/blockStreams") @NodeProperty String blockFileDir,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean compressFilesOnCreation,
         @ConfigProperty(defaultValue = "32") @NetworkProperty int serializationBatchSize,
         @ConfigProperty(defaultValue = "32") @NetworkProperty int hashCombineBatchSize,

--- a/hedera-node/infrastructure/docker/containers/local-node/network-node-base/Dockerfile
+++ b/hedera-node/infrastructure/docker/containers/local-node/network-node-base/Dockerfile
@@ -101,6 +101,7 @@ RUN mkdir -p "/opt/hgcapp" && \
     mkdir -p "/opt/hgcapp/accountBalances" && \
     mkdir -p "/opt/hgcapp/eventsStreams" && \
     mkdir -p "/opt/hgcapp/recordStreams" && \
+    mkdir -p "/opt/hgcapp/blockStreams" && \
     mkdir -p "/opt/hgcapp/services-hedera" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data" && \
@@ -129,6 +130,7 @@ RUN echo >> /etc/sudoers && \
 VOLUME "/opt/hgcapp/accountBalances"
 VOLUME "/opt/hgcapp/eventsStreams"
 VOLUME "/opt/hgcapp/recordStreams"
+VOLUME "/opt/hgcapp/blockStreams"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/config"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/diskFs"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys"

--- a/hedera-node/infrastructure/docker/containers/production-next/consensus-node/Dockerfile
+++ b/hedera-node/infrastructure/docker/containers/production-next/consensus-node/Dockerfile
@@ -175,6 +175,7 @@ RUN mkdir -p "/opt/hgcapp" && \
     mkdir -p "/opt/hgcapp/accountBalances" && \
     mkdir -p "/opt/hgcapp/eventsStreams" && \
     mkdir -p "/opt/hgcapp/recordStreams" && \
+    mkdir -p "/opt/hgcapp/blockStreams" && \
     mkdir -p "/opt/hgcapp/services-hedera" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data" && \
@@ -287,6 +288,7 @@ ENV LOG_DIR_NAME ""
 VOLUME "/opt/hgcapp/accountBalances"
 VOLUME "/opt/hgcapp/eventsStreams"
 VOLUME "/opt/hgcapp/recordStreams"
+VOLUME "/opt/hgcapp/blockStreams"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/config"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/diskFs"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys"

--- a/hedera-node/infrastructure/docker/containers/production/network-node-base/Dockerfile
+++ b/hedera-node/infrastructure/docker/containers/production/network-node-base/Dockerfile
@@ -93,6 +93,7 @@ RUN mkdir -p "/opt/hgcapp" && \
     mkdir -p "/opt/hgcapp/accountBalances" && \
     mkdir -p "/opt/hgcapp/eventsStreams" && \
     mkdir -p "/opt/hgcapp/recordStreams" && \
+    mkdir -p "/opt/hgcapp/blockStreams" && \
     mkdir -p "/opt/hgcapp/services-hedera" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data" && \
@@ -122,6 +123,7 @@ RUN chmod +rx /usr/local/bin/wait-for
 VOLUME "/opt/hgcapp/accountBalances"
 VOLUME "/opt/hgcapp/eventsStreams"
 VOLUME "/opt/hgcapp/recordStreams"
+VOLUME "/opt/hgcapp/blockStreams"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/config"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/diskFs"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys"

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/ProcessUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/ProcessUtils.java
@@ -60,7 +60,7 @@ public class ProcessUtils {
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
     public static final String SAVED_STATES_DIR = "saved";
     public static final String RECORD_STREAMS_DIR = "recordStreams";
-    public static final String BLOCK_STREAMS_DIR = "block-streams";
+    public static final String BLOCK_STREAMS_DIR = "blockStreams";
     private static final long WAIT_SLEEP_MILLIS = 100L;
 
     public static final Executor EXECUTOR = Executors.newCachedThreadPool();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/TransactionRecordParityValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/TransactionRecordParityValidator.java
@@ -87,7 +87,7 @@ public class TransactionRecordParityValidator implements BlockStreamValidator {
                 .toAbsolutePath()
                 .normalize();
         final var blocksLoc =
-                node0Data.resolve("block-streams/block-0.0.3").toAbsolutePath().normalize();
+                node0Data.resolve("blockStreams/block-0.0.3").toAbsolutePath().normalize();
         final var blocks = BlockStreamAccess.BLOCK_STREAM_ACCESS.readBlocks(blocksLoc);
         final var recordsLoc =
                 node0Data.resolve("recordStreams/record0.0.3").toAbsolutePath().normalize();


### PR DESCRIPTION
This PR modifies the default block streams output directory to `/opt/hgcapp/blockStreams` in order to match the corresponding record streams directory. This directory is also added as a mount in the relevant docker compose files.

Closes #16713 