### PR TITLE
chore: replace use of `AddressBook` with `Roster` in `ReconnectMetrics and `AddressBookMetrics`

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -222,7 +222,7 @@ public class SwirldsPlatform implements Platform {
 
         platformWiring = new PlatformWiring(platformContext, blocks.model(), blocks.applicationCallbacks());
 
-        registerAddressBookMetrics(platformContext.getMetrics(), currentAddressBook, selfId);
+        registerAddressBookMetrics(platformContext.getMetrics(), currentRoster, selfId);
 
         RuntimeMetrics.setup(platformContext.getMetrics());
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -22,7 +22,7 @@ import static com.swirlds.logging.legacy.LogMarker.STATE_TO_DISK;
 import static com.swirlds.platform.StateInitializer.initializeState;
 import static com.swirlds.platform.event.preconsensus.PcesBirthRoundMigration.migratePcesToBirthRoundMode;
 import static com.swirlds.platform.state.BirthRoundStateMigration.modifyStateForBirthRoundMigration;
-import static com.swirlds.platform.state.address.AddressBookMetrics.registerAddressBookMetrics;
+import static com.swirlds.platform.state.address.RosterMetrics.registerRosterMetrics;
 import static com.swirlds.platform.state.snapshot.SignedStateFileReader.getSavedStateFiles;
 
 import com.hedera.hapi.node.state.roster.Roster;
@@ -222,7 +222,7 @@ public class SwirldsPlatform implements Platform {
 
         platformWiring = new PlatformWiring(platformContext, blocks.model(), blocks.applicationCallbacks());
 
-        registerAddressBookMetrics(platformContext.getMetrics(), currentRoster, selfId);
+        registerRosterMetrics(platformContext.getMetrics(), currentRoster, selfId);
 
         RuntimeMetrics.setup(platformContext.getMetrics());
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
@@ -78,7 +78,6 @@ import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.SoftwareVersion;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.status.PlatformStatus;
 import com.swirlds.platform.system.status.StatusActionSubmitter;
 import com.swirlds.platform.wiring.NoInput;
@@ -227,8 +226,7 @@ public class SyncGossip implements ConnectionTracker, Gossip {
         networkMetrics = new NetworkMetrics(platformContext.getMetrics(), selfId, roster);
         platformContext.getMetrics().addUpdater(networkMetrics::update);
 
-        final AddressBook addressBook = RosterUtils.buildAddressBook(roster);
-        reconnectMetrics = new ReconnectMetrics(platformContext.getMetrics(), addressBook);
+        reconnectMetrics = new ReconnectMetrics(platformContext.getMetrics(), roster);
 
         final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
 
@@ -255,7 +253,7 @@ public class SyncGossip implements ConnectionTracker, Gossip {
                 new ReconnectLearnerFactory(
                         platformContext,
                         threadManager,
-                        addressBook,
+                        RosterUtils.buildAddressBook(roster),
                         reconnectConfig.asyncStreamTimeout(),
                         reconnectMetrics),
                 stateConfig);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ReconnectMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ReconnectMetrics.java
@@ -146,10 +146,10 @@ public class ReconnectMetrics {
      *
      * @param nodeId the peer being rejected.
      */
-    public void recordReconnectRejection(@NonNull final Long nodeId) {
-        Objects.requireNonNull(nodeId);
-        if (rejectionFrequency.containsKey(nodeId)) {
-            rejectionFrequency.get(nodeId).count();
+    public void recordReconnectRejection(final long nodeId) {
+        final Long id = nodeId;
+        if (rejectionFrequency.containsKey(id)) {
+            rejectionFrequency.get(id).count();
         }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectProtocol.java
@@ -244,7 +244,7 @@ public class ReconnectProtocol implements Protocol {
             teacherState.close();
             teacherState = null;
         }
-        reconnectMetrics.recordReconnectRejection(peerId);
+        reconnectMetrics.recordReconnectRejection(peerId.id());
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookMetrics.java
@@ -16,10 +16,10 @@
 
 package com.swirlds.platform.state.address;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.metrics.FunctionGauge;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -33,19 +33,19 @@ public final class AddressBookMetrics {
      * Register the metrics for the address book.
      *
      * @param metrics     the metrics engine
-     * @param addressBook the address book to register metrics for
+     * @param roster      the roster reflecting the address book to register metrics for
      * @param selfId      the ID of the node
      */
     public static void registerAddressBookMetrics(
-            @NonNull final Metrics metrics, @NonNull final AddressBook addressBook, @NonNull final NodeId selfId) {
+            @NonNull final Metrics metrics, @NonNull final Roster roster, @NonNull final NodeId selfId) {
 
         metrics.getOrCreate(new FunctionGauge.Config<>(Metrics.INFO_CATEGORY, "memberID", Long.class, selfId::id)
                 .withUnit("nodeID")
                 .withDescription("The node ID number of this member"));
 
-        metrics.getOrCreate(
-                new FunctionGauge.Config<>(Metrics.INFO_CATEGORY, "members", Integer.class, addressBook::getSize)
-                        .withUnit("count")
-                        .withDescription("total number of nodes currently in the address book"));
+        metrics.getOrCreate(new FunctionGauge.Config<>(
+                        Metrics.INFO_CATEGORY, "members", Integer.class, roster.rosterEntries()::size)
+                .withUnit("count")
+                .withDescription("total number of nodes currently in the address book"));
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/RosterMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/RosterMetrics.java
@@ -25,18 +25,18 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 /**
  * A utility class to encapsulate the metrics for the address book.
  */
-public final class AddressBookMetrics {
+public final class RosterMetrics {
 
-    private AddressBookMetrics() {}
+    private RosterMetrics() {}
 
     /**
      * Register the metrics for the address book.
      *
      * @param metrics     the metrics engine
-     * @param roster      the roster reflecting the address book to register metrics for
+     * @param roster      the roster to register metrics for
      * @param selfId      the ID of the node
      */
-    public static void registerAddressBookMetrics(
+    public static void registerRosterMetrics(
             @NonNull final Metrics metrics, @NonNull final Roster roster, @NonNull final NodeId selfId) {
 
         metrics.getOrCreate(new FunctionGauge.Config<>(Metrics.INFO_CATEGORY, "memberID", Long.class, selfId::id)
@@ -46,6 +46,6 @@ public final class AddressBookMetrics {
         metrics.getOrCreate(new FunctionGauge.Config<>(
                         Metrics.INFO_CATEGORY, "members", Integer.class, roster.rosterEntries()::size)
                 .withUnit("count")
-                .withDescription("total number of nodes currently in the address book"));
+                .withDescription("total number of nodes currently in the roster"));
     }
 }


### PR DESCRIPTION
**Description**:

A small PR to replace the use of `AddressBook` with `Roster` in `ReconnectMetrics` and `AddressBookMetrics`. 

**Related issue(s)**:

Fixes #16718 
