### PR TITLE
chore: replace `Platform.getAddressBook()` with `Platform.getRoster()`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -130,6 +130,7 @@ import com.swirlds.platform.listeners.PlatformStatusChangeNotification;
 import com.swirlds.platform.listeners.ReconnectCompleteListener;
 import com.swirlds.platform.listeners.ReconnectCompleteNotification;
 import com.swirlds.platform.listeners.StateWriteToDiskCompleteListener;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.MerkleStateRoot;
 import com.swirlds.platform.state.service.PlatformStateService;
@@ -583,7 +584,7 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
                     state,
                     metrics,
                     trigger,
-                    platform.getAddressBook(),
+                    RosterUtils.buildAddressBook(platform.getRoster()),
                     platform.getContext().getConfiguration());
         }
         // With the States API grounded in the working state, we can create the object graph from it
@@ -969,12 +970,7 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
         final var initialStateHash = new InitialStateHash(initialStateHashFuture, roundNum);
 
         final var activeRoster = tssBaseService.chooseRosterForNetwork(
-                state,
-                trigger,
-                serviceMigrator,
-                version,
-                configProvider.getConfiguration(),
-                buildRoster(platform.getAddressBook()));
+                state, trigger, serviceMigrator, version, configProvider.getConfiguration(), platform.getRoster());
         final var networkInfo =
                 new StateNetworkInfo(state, activeRoster, platform.getSelfId().id(), configProvider);
         // Fully qualified so as to not confuse javadoc

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/PlatformModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/PlatformModule.java
@@ -58,7 +58,7 @@ public interface PlatformModule {
     @Provides
     @Singleton
     static IntSupplier provideFrontendThrottleSplit(@NonNull final Platform platform) {
-        return () -> platform.getAddressBook().getSize();
+        return () -> platform.getRoster().rosterEntries().size();
     }
 
     @Binds

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakePlatform.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakePlatform.java
@@ -129,11 +129,6 @@ public final class FakePlatform implements Platform {
     }
 
     @Override
-    public AddressBook getAddressBook() {
-        return addressBook;
-    }
-
-    @Override
     public NodeId getSelfId() {
         return selfNodeId;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/AbstractFakePlatform.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/AbstractFakePlatform.java
@@ -100,12 +100,6 @@ public abstract class AbstractFakePlatform implements Platform {
 
     @NonNull
     @Override
-    public AddressBook getAddressBook() {
-        return addressBook;
-    }
-
-    @NonNull
-    @Override
     public Roster getRoster() {
         return roster;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -515,15 +515,6 @@ public class SwirldsPlatform implements Platform {
     /**
      * {@inheritDoc}
      */
-    @Override
-    @NonNull
-    public AddressBook getAddressBook() {
-        return currentAddressBook;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @SuppressWarnings("unchecked")
     @Override
     @NonNull

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/SwirldsGui.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/SwirldsGui.java
@@ -16,20 +16,18 @@
 
 package com.swirlds.platform.gui;
 
-import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.platform.gui.GuiUtils.winRect;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.Console;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.gui.internal.SwirldMenu;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.address.AddressBookNetworkUtils;
 import com.swirlds.platform.system.Platform;
-import com.swirlds.platform.system.address.Address;
-import com.swirlds.platform.system.address.AddressBook;
 import java.awt.Color;
 import java.awt.GraphicsEnvironment;
 import java.awt.Rectangle;
-import javax.swing.JFrame;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -54,37 +52,12 @@ public final class SwirldsGui {
             return null;
         }
         final NodeId selfId = platform.getSelfId();
-        final AddressBook addressBook = platform.getAddressBook();
-        final int winCount = AddressBookNetworkUtils.getLocalAddressCount(addressBook);
+        final Roster roster = platform.getRoster();
+        final int winCount = AddressBookNetworkUtils.getLocalAddressCount(roster);
         final Rectangle winRect = winRect(winCount, winNum);
         // if SwirldMain calls createConsole, this remembers the window created
-        final Console console =
-                GuiUtils.createBasicConsole(addressBook.getAddress(selfId).getSelfName(), winRect, visible);
+        final Console console = GuiUtils.createBasicConsole(RosterUtils.formatNodeName(selfId.id()), winRect, visible);
         SwirldMenu.addTo(platform, console.getWindow(), 40, Color.white, false);
         return console;
-    }
-
-    /**
-     * Create a new window of the recommended size and location, including the Swirlds menu.
-     *
-     * @param visible should the window be initially visible? If not, call setVisible(true) later.
-     * @return the new window
-     */
-    public static JFrame createWindow(
-            final Platform platform, final Address address, final int winCount, int winNum, final boolean visible) {
-        if (GraphicsEnvironment.isHeadless()) {
-            return null;
-        }
-        final Rectangle winRect = winRect(winCount, winNum);
-        JFrame frame = null;
-        try {
-            final String name = address.getSelfName();
-            frame = GuiUtils.createBasicWindow(name, winRect, visible);
-            SwirldMenu.addTo(platform, frame, 40, Color.BLUE, false);
-        } catch (final Exception e) {
-            logger.error(EXCEPTION.getMarker(), "", e);
-        }
-
-        return frame;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabAddresses.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabAddresses.java
@@ -19,10 +19,11 @@ package com.swirlds.platform.gui.internal;
 import static com.swirlds.platform.gui.GuiUtils.wrap;
 import static com.swirlds.platform.gui.internal.BrowserWindowManager.getPlatforms;
 
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.platform.gui.GuiUtils;
 import com.swirlds.platform.gui.components.PrePaintableJPanel;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.system.Platform;
-import com.swirlds.platform.system.address.Address;
 import javax.swing.JTextArea;
 
 /**
@@ -52,13 +53,15 @@ class WinTabAddresses extends PrePaintableJPanel {
         String s = "";
         synchronized (getPlatforms()) {
             for (final Platform p : getPlatforms()) {
-                final Address address = p.getAddressBook().getAddress(p.getSelfId());
-                s += "\n" + address.getNodeId().id() + "   " + address.getNickname()
-                        + "   " + address.getSelfName()
-                        + "   " + address.getHostnameInternal()
-                        + "   " + address.getPortInternal()
-                        + "   " + address.getHostnameExternal()
-                        + "   " + address.getPortExternal();
+                final RosterEntry entry =
+                        RosterUtils.getRosterEntry(p.getRoster(), p.getSelfId().id());
+                final String name = RosterUtils.formatNodeName(entry.nodeId());
+                s += "\n" + entry.nodeId() + "   " + name
+                        + "   " + name
+                        + "   " + RosterUtils.fetchHostname(entry, 1) // internal hostname
+                        + "   " + RosterUtils.fetchPort(entry, 1) // internal port
+                        + "   " + RosterUtils.fetchHostname(entry, 0) // external hostname
+                        + "   " + RosterUtils.fetchPort(entry, 0); // external port
             }
         }
         s += wrap(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveryPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveryPlatform.java
@@ -143,15 +143,6 @@ public class RecoveryPlatform implements Platform, AutoCloseableNonThrowing {
      */
     @Override
     @NonNull
-    public AddressBook getAddressBook() {
-        return addressBook;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @NonNull
     public NodeId getSelfId() {
         return selfId;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookNetworkUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookNetworkUtils.java
@@ -80,7 +80,8 @@ public final class AddressBookNetworkUtils {
     public static boolean isLocal(@NonNull final RosterEntry rosterEntry) {
         Objects.requireNonNull(rosterEntry, "The rosterEntry must not be null.");
         try {
-            final String internalHostname = RosterUtils.fetchHostname(rosterEntry, 1);
+            final int index = rosterEntry.gossipEndpoint().size() > 1 ? 1 : 0;
+            final String internalHostname = RosterUtils.fetchHostname(rosterEntry, index);
             assert internalHostname != null;
             return Network.isOwn(resolveName(internalHostname));
         } catch (final UnknownHostException e) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Platform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/Platform.java
@@ -22,7 +22,6 @@ import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.notification.NotificationEngine;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.utility.AutoCloseableWrapper;
-import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -53,14 +52,6 @@ public interface Platform {
      */
     @NonNull
     Roster getRoster();
-
-    /**
-     * Get the Address Book
-     *
-     * @return AddressBook
-     */
-    @NonNull
-    AddressBook getAddressBook();
 
     /**
      * Get the ID of current node

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -23,17 +23,18 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.SwirldsPlatform;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.Round;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.status.StatusActionSubmitter;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,16 +48,15 @@ class SwirldStateManagerTests {
     @BeforeEach
     void setup() {
         final SwirldsPlatform platform = mock(SwirldsPlatform.class);
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(Randotron.create()).build();
-        when(platform.getAddressBook()).thenReturn(addressBook);
+        final Roster roster = RandomRosterBuilder.create(Randotron.create()).build();
+        when(platform.getRoster()).thenReturn(roster);
         initialState = newState();
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
 
         swirldStateManager = new SwirldStateManager(
                 platformContext,
-                addressBook,
+                RosterUtils.buildAddressBook(roster),
                 NodeId.of(0L),
                 mock(StatusActionSubmitter.class),
                 new BasicSoftwareVersion(1));


### PR DESCRIPTION
**Description**:
As part of the platform refactor to replace usage of `AddressBook` with `Roster`, this PR replaces the use of `Platform.getAddressBook()` with `Platform.getRoster()`.   The impacted code is updated with equivalent usage for rosters.

**Related issue(s)**:

Fixes #16717

