### PR TITLE
chore: (yahcli) Use hash of gRPC cert PEM instead of its X.509 DER encoding

### DIFF
--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/UpdateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/UpdateCommand.java
@@ -18,6 +18,7 @@ package com.hedera.services.yahcli.commands.nodes;
 
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asCsServiceEndpoints;
+import static com.hedera.services.yahcli.commands.nodes.CreateCommand.allBytesAt;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validateKeyAt;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validatedX509Cert;
 import static com.hedera.services.yahcli.config.ConfigUtils.keyFileFor;
@@ -31,6 +32,7 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -150,7 +152,9 @@ public class UpdateCommand implements Callable<Integer> {
             newGossipCaCertificate = null;
         }
         if (hapiCertificatePath != null) {
-            newHapiCertificateHash = noThrowSha384HashOf(validatedX509Cert(hapiCertificatePath, null, null, yahcli));
+            // Throws if the cert is not valid
+            validatedX509Cert(hapiCertificatePath, null, null, yahcli);
+            newHapiCertificateHash = noThrowSha384HashOf(allBytesAt(Paths.get(hapiCertificatePath)));
         } else {
             newHapiCertificateHash = null;
         }

--- a/hedera-node/test-clients/yahcli/run/build.sh
+++ b/hedera-node/test-clients/yahcli/run/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.4.9'}
+TAG=${1:-'0.5.0'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""

--- a/hedera-node/test-clients/yahcli/run/publish.sh
+++ b/hedera-node/test-clients/yahcli/run/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.4.9'}
+TAG=${1:-'0.5.0'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""
@@ -25,5 +25,5 @@ cd "${SCRIPT_PATH}/.."
 rm -f assets/yahcli.jar >/dev/null 2>&1 || true
 cp -f yahcli.jar assets/
 
-docker buildx create --use --name "multiarch$TAG"
+docker buildx create --use --name "multiarchASDF"
 docker buildx build --push --platform linux/amd64,linux/arm64 -t gcr.io/hedera-registry/yahcli:$TAG .


### PR DESCRIPTION
**Description**:
 - Closes #16723 