### PR TITLE
fix: 16657: State validation fails for round 191161423 on LSE

### DIFF
--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/BreakableDataSource.java
@@ -66,7 +66,12 @@ public final class BreakableDataSource implements VirtualDataSource {
         }
 
         delegate.saveRecords(
-                firstLeafPath, lastLeafPath, pathHashRecordsToUpdate, leaves.stream(), leafRecordsToDelete);
+                firstLeafPath,
+                lastLeafPath,
+                pathHashRecordsToUpdate,
+                leaves.stream(),
+                leafRecordsToDelete,
+                isReconnectContext);
     }
 
     @Override

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/AbstractHashListener.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/merkle/AbstractHashListener.java
@@ -182,11 +182,11 @@ public abstract class AbstractHashListener<K extends VirtualKey, V extends Virtu
             finalLeavesToFlush = leaves;
             leaves = null;
         }
-        if (!finalNodesToFlush.isEmpty() || !finalLeavesToFlush.isEmpty()) {
-            assert !flushInProgress.get() : "Flush must not be in progress when hashing is complete";
-            flushInProgress.set(true);
-            flush(finalNodesToFlush, finalLeavesToFlush);
-        }
+        assert !flushInProgress.get() : "Flush must not be in progress when hashing is complete";
+        flushInProgress.set(true);
+        // Nodes / leaves lists may be empty, but a flush is still needed to make sure
+        // all stale leaves are removed from the data source
+        flush(finalNodesToFlush, finalLeavesToFlush);
     }
 
     // Since flushes may take quite some time, this method is called outside synchronized blocks,

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectNodeRemover.java
@@ -21,6 +21,7 @@ import static com.swirlds.logging.legacy.LogMarker.RECONNECT;
 import com.swirlds.virtualmap.VirtualKey;
 import com.swirlds.virtualmap.VirtualValue;
 import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
+import com.swirlds.virtualmap.internal.Path;
 import com.swirlds.virtualmap.internal.RecordAccessor;
 import java.util.HashSet;
 import java.util.Set;
@@ -146,15 +147,12 @@ public class ReconnectNodeRemover<K extends VirtualKey, V extends VirtualValue> 
     }
 
     public synchronized void allNodesReceived() {
-        if (newLastLeafPath < 0) {
-            // Empty teacher
-            return;
-        }
-        // no-op if newLastLeafPath is greater or equal to oldLastLeafPath
         logger.info(
                 RECONNECT.getMarker(),
                 "allNodesReceived(): newLastLeafPath = " + newLastLeafPath + ", oldLastLeafPath = " + oldLastLeafPath);
-        for (long p = newLastLeafPath + 1; p <= oldLastLeafPath; p++) {
+        final long firstOldStalePath = (newLastLeafPath == Path.INVALID_PATH) ? 1 : newLastLeafPath + 1;
+        // No-op if newLastLeafPath is greater or equal to oldLastLeafPath
+        for (long p = firstOldStalePath; p <= oldLastLeafPath; p++) {
             final VirtualLeafRecord<K, ?> oldExtraLeafRecord = oldRecords.findLeafRecord(p, false);
             assert oldExtraLeafRecord != null || p < oldFirstLeafPath;
             if (oldExtraLeafRecord != null) {

--- a/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTest.java
@@ -91,24 +91,48 @@ class VirtualHasherTest extends VirtualHasherTestBase {
      */
     @Test
     @Tag(TestComponentTags.VMAP)
-    @DisplayName("Invalid leaf paths returns null for hash")
-    void invalidFirstOrLastLeafPathProducesNull() {
+    @DisplayName("Invalid leaf paths")
+    void invalidLeafPaths() {
         final TestDataSource ds = new TestDataSource(Path.INVALID_PATH, Path.INVALID_PATH);
         final VirtualHasher<TestKey, TestValue> hasher = new VirtualHasher<>();
-        final List<VirtualLeafRecord<TestKey, TestValue>> leaves = new ArrayList<>();
-        leaves.add(appleLeaf(VirtualTestBase.A_PATH));
+        final List<VirtualLeafRecord<TestKey, TestValue>> emptyLeaves = new ArrayList<>();
+        // Empty dirty leaves stream -> null hash
         assertNull(
-                hasher.hash(ds::loadHash, leaves.iterator(), Path.INVALID_PATH, 2, VIRTUAL_MAP_CONFIG),
+                hasher.hash(
+                        ds::loadHash, emptyLeaves.iterator(), Path.INVALID_PATH, Path.INVALID_PATH, VIRTUAL_MAP_CONFIG),
                 "Call should have produced null");
         assertNull(
-                hasher.hash(ds::loadHash, leaves.iterator(), 1, Path.INVALID_PATH, VIRTUAL_MAP_CONFIG),
+                hasher.hash(ds::loadHash, emptyLeaves.iterator(), Path.INVALID_PATH, 2, VIRTUAL_MAP_CONFIG),
                 "Call should have produced null");
         assertNull(
-                hasher.hash(ds::loadHash, leaves.iterator(), 0, 2, VIRTUAL_MAP_CONFIG),
+                hasher.hash(ds::loadHash, emptyLeaves.iterator(), 1, Path.INVALID_PATH, VIRTUAL_MAP_CONFIG),
                 "Call should have produced null");
         assertNull(
-                hasher.hash(ds::loadHash, leaves.iterator(), 1, 0, VIRTUAL_MAP_CONFIG),
+                hasher.hash(ds::loadHash, emptyLeaves.iterator(), 0, 2, VIRTUAL_MAP_CONFIG),
                 "Call should have produced null");
+        assertNull(
+                hasher.hash(ds::loadHash, emptyLeaves.iterator(), 1, 0, VIRTUAL_MAP_CONFIG),
+                "Call should have produced null");
+        // Non-empty dirty leaves stream + empty leaf path range -> IllegalStateException
+        final List<VirtualLeafRecord<TestKey, TestValue>> nonEmptyLeaves = new ArrayList<>();
+        nonEmptyLeaves.add(appleLeaf(VirtualTestBase.A_PATH));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> hasher.hash(
+                        ds::loadHash,
+                        nonEmptyLeaves.iterator(),
+                        Path.INVALID_PATH,
+                        Path.INVALID_PATH,
+                        VIRTUAL_MAP_CONFIG),
+                "Non-null leaves iterator + invalid paths should throw an exception");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> hasher.hash(ds::loadHash, nonEmptyLeaves.iterator(), 0, 2, VIRTUAL_MAP_CONFIG),
+                "Non-null leaves iterator + invalid paths should throw an exception");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> hasher.hash(ds::loadHash, nonEmptyLeaves.iterator(), 1, 0, VIRTUAL_MAP_CONFIG),
+                "Non-null leaves iterator + invalid paths should throw an exception");
     }
 
     /**


### PR DESCRIPTION
Fix summary:

1. `ReconnectNodeRemover`: changed `allNodesReceived()` to work correctly, if the new leaf path range from the teacher is empty (-1, -1)
2. `VirtualHasher`: hash listener is now notified about hashing started/finished even if the leaf path range is empty
3. `AbstractHashListener`: changed `onHashingCompleted()` to run the final flush even if the list of collected dirty leaves and the list of dirty hashes are empty. This is needed to delete stale leaves from the data source. This method is now called by `VirtualHasher` even if the virtual map is empty on the teacher

Testing:

1. Manual testing
2. Existing reconnect unit tests are improved to run deeper virtual key checks. It made some existing tests (with empty learner maps) fail without this fix and pass with it, as expected. However, it also made some other tests fail, this is why these test changes are not included to this PR, but a separate ticket is filed: https://github.com/hashgraph/hedera-services/issues/16754

Fixes: https://github.com/hashgraph/hedera-services/issues/16657
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
