### PR TITLE
chore: removing notnull annotations and replacing libraries

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakePlatformContext.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakePlatformContext.java
@@ -44,7 +44,6 @@ import com.swirlds.platform.config.TransactionConfig;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.ScheduledExecutorService;
-import org.jetbrains.annotations.NotNull;
 
 public class FakePlatformContext implements PlatformContext {
     private final Configuration platformConfig = ConfigurationBuilder.create()
@@ -115,7 +114,7 @@ public class FakePlatformContext implements PlatformContext {
         throw new UnsupportedOperationException("Not used by Hedera");
     }
 
-    @NotNull
+    @NonNull
     @Override
     public MerkleCryptography getMerkleCryptography() {
         return MerkleCryptographyFactory.create(platformConfig, getCryptography());


### PR DESCRIPTION
Description: This PR modifies standardization for code which means we are trying to use just one library for annotations [@nonnull](https://github.com/nonnull) and https://github.com/nullable - edu.umd.cs.findbugs.annotations For this standardization it was neccessary to remove https://github.com/NotNull annotations in the code.

Related issue(s): #15375 

Fixes #
Notes for reviewer:
@netopyr hopes that this would be good