### PR TITLE
chore: Update setup-gradle action from v3.4.2 to v4.2.1

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -184,23 +184,17 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
           gradle-version: ${{ inputs.gradle-version }}
 
       - name: Gradle Update Version (As Specified)
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
         if: ${{ inputs.version-policy == 'specified' && !cancelled() && !failure() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: versionAsSpecified -PnewVersion=${{ inputs.new-version }} --scan
+        run: ./gradlew versionAsSpecified -PnewVersion=${{ inputs.new-version }} --scan
 
       - name: Gradle Update Version (Branch Commit)
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
         if: ${{ inputs.version-policy != 'specified' && !cancelled() && !failure() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: versionAsPrefixedCommit -PcommitPrefix=${{ steps.parameters.outputs.commit-prefix }} --scan
+        run: ./gradlew versionAsPrefixedCommit -PcommitPrefix=${{ steps.parameters.outputs.commit-prefix }} --scan
 
       - name: Compute Final Effective Version
         id: effective-version
@@ -295,7 +289,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
           gradle-version: ${{ inputs.gradle-version }}
 
@@ -314,16 +308,10 @@ jobs:
 
       - name: Gradle Assemble
         id: gradle-build
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: assemble --scan
+        run: ./gradlew assemble --scan
 
       - name: Gradle Version Summary
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: githubVersionSummary --scan
+        run: ./gradlew githubVersionSummary --scan
 
       - name: Stage Artifact Build Folder
         id: artifact-staging
@@ -732,7 +720,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
           gradle-version: ${{ inputs.gradle-version }}
 
@@ -744,16 +732,10 @@ jobs:
           key: node-build-version-${{ needs.validate.outputs.version }}-${{ github.sha }}
 
       - name: Gradle Assemble
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: assemble --scan
+        run: ./gradlew assemble --scan
 
       - name: Gradle Version Summary
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: githubVersionSummary --scan
+        run: ./gradlew githubVersionSummary --scan
 
       - name: Stage SDK Release Archives
         working-directory: platform-sdk
@@ -828,24 +810,18 @@ jobs:
           echo "::endgroup::"
 
       - name: Gradle Publish Platform to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
         if: ${{ inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
         env:
           NEXUS_USERNAME: ${{ secrets.sdk-ossrh-username }}
           NEXUS_PASSWORD: ${{ secrets.sdk-ossrh-password }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.swirlds -Ps01SonatypeHost=true -PpublishSigningEnabled=true --scan --no-configuration-cache"
+        run: ./gradlew "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.swirlds -Ps01SonatypeHost=true -PpublishSigningEnabled=true --scan --no-configuration-cache"
 
       - name: Gradle Publish Services to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
-        uses: gradle/gradle-build-action@ac2d340dc04d9e1113182899e983b5400c17cda1 # v3.5.0
         if: ${{ inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
         env:
           NEXUS_USERNAME: ${{ secrets.svcs-ossrh-username }}
           NEXUS_PASSWORD: ${{ secrets.svcs-ossrh-password }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --scan --no-configuration-cache"
+        run: ./gradlew "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --scan --no-configuration-cache"
 
       - name: Upload SDK Release Archives
         if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -190,16 +190,16 @@ jobs:
 
       - name: Gradle Update Version (As Specified)
         if: ${{ inputs.version-policy == 'specified' && !cancelled() && !failure() }}
-        run: ./gradlew versionAsSpecified -PnewVersion=${{ inputs.new-version }} --scan
+        run: gradle versionAsSpecified -PnewVersion=${{ inputs.new-version }} --scan
 
       - name: Gradle Update Version (Branch Commit)
         if: ${{ inputs.version-policy != 'specified' && !cancelled() && !failure() }}
-        run: ./gradlew versionAsPrefixedCommit -PcommitPrefix=${{ steps.parameters.outputs.commit-prefix }} --scan
+        run: gradle versionAsPrefixedCommit -PcommitPrefix=${{ steps.parameters.outputs.commit-prefix }} --scan
 
       - name: Compute Final Effective Version
         id: effective-version
         run: |
-          EFF_VERSION="$(./gradlew showVersion --quiet | tr -d '[:space:]')"
+          EFF_VERSION="$(gradle showVersion --quiet | tr -d '[:space:]')"
           PRERELEASE_SUFFIX="$(semver get prerel "${EFF_VERSION}")"
           PRERELEASE="false"
           [[ -n "${PRERELEASE_SUFFIX}" ]] && PRERELEASE="true"
@@ -308,10 +308,10 @@ jobs:
 
       - name: Gradle Assemble
         id: gradle-build
-        run: ./gradlew assemble --scan
+        run: gradle assemble --scan
 
       - name: Gradle Version Summary
-        run: ./gradlew githubVersionSummary --scan
+        run: gradle githubVersionSummary --scan
 
       - name: Stage Artifact Build Folder
         id: artifact-staging
@@ -732,10 +732,10 @@ jobs:
           key: node-build-version-${{ needs.validate.outputs.version }}-${{ github.sha }}
 
       - name: Gradle Assemble
-        run: ./gradlew assemble --scan
+        run: gradle assemble --scan
 
       - name: Gradle Version Summary
-        run: ./gradlew githubVersionSummary --scan
+        run: gradle githubVersionSummary --scan
 
       - name: Stage SDK Release Archives
         working-directory: platform-sdk
@@ -814,14 +814,14 @@ jobs:
         env:
           NEXUS_USERNAME: ${{ secrets.sdk-ossrh-username }}
           NEXUS_PASSWORD: ${{ secrets.sdk-ossrh-password }}
-        run: ./gradlew "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.swirlds -Ps01SonatypeHost=true -PpublishSigningEnabled=true --scan --no-configuration-cache"
+        run: gradle "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.swirlds -Ps01SonatypeHost=true -PpublishSigningEnabled=true --scan --no-configuration-cache"
 
       - name: Gradle Publish Services to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
         if: ${{ inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
         env:
           NEXUS_USERNAME: ${{ secrets.svcs-ossrh-username }}
           NEXUS_PASSWORD: ${{ secrets.svcs-ossrh-password }}
-        run: ./gradlew "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --scan --no-configuration-cache"
+        run: gradle "release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --scan --no-configuration-cache"
 
       - name: Upload SDK Release Archives
         if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -182,7 +182,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
           cache-read-only: false
 

--- a/.github/workflows/node-zxf-snyk-monitor.yaml
+++ b/.github/workflows/node-zxf-snyk-monitor.yaml
@@ -46,16 +46,13 @@ jobs:
           java-version: 21
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
-          build-root-directory: hedera-node
           gradle-version: wrapper
 
       - name: Compile
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
-        with:
-          gradle-version: wrapper
-          arguments: assemble --scan
+        working-directory: hedera-node
+        run: ./gradlew assemble --scan
 
       - name: Disable Gradle Configuration Cache
         run: sed -i 's/^org.gradle.configuration-cache=.*$/org.gradle.configuration-cache=false/' gradle.properties

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -409,6 +409,9 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
 
+      - name: Verify Gradle Installation
+        run: gradle --version
+
       - name: Gradle Assemble
         id: gradle-build
         run: gradle assemble :test-clients:shadowJar --scan

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -340,11 +340,6 @@ jobs:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-
       - name: Install Python Virtual Environment
         run: |
           echo "::group::Aptitude Update"
@@ -409,14 +404,19 @@ jobs:
           echo "key-file=${GCP_KEY_FILE}" >> "${GITHUB_OUTPUT}"
           rclone config create gcs "google cloud storage" project_number "${{ secrets.gcp-project-number }}" service_account_file "${GCP_KEY_FILE}"
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
+        with:
+          gradle-version: ${{ inputs.gradle-version }}
+
       - name: Gradle Assemble
         id: gradle-build
-        run: gradle assemble :test-clients:shadowJar --scan
+        run: ./gradlew assemble :test-clients:shadowJar --scan
 
       - name: Regression Gradle Assemble
         id: regression-gradle-build
         working-directory: platform-sdk/regression
-        run: gradle assemble --scan
+        run: ../../gradlew assemble --scan
 
       - name: Compute Actual Branch Name
         id: branch

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -411,12 +411,12 @@ jobs:
 
       - name: Gradle Assemble
         id: gradle-build
-        run: ${HOME}/gradlew assemble :test-clients:shadowJar --scan
+        run: gradle assemble :test-clients:shadowJar --scan
 
       - name: Regression Gradle Assemble
         id: regression-gradle-build
         working-directory: platform-sdk/regression
-        run: ${HOME}/gradlew assemble --scan
+        run: gradle assemble --scan
 
       - name: Compute Actual Branch Name
         id: branch

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -407,20 +407,20 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
-          gradle-version: 8.11
+          gradle-version: wrapper
           #gradle-version: ${{ inputs.gradle-version }}
 
       - name: Verify Gradle Installation
-        run: gradle --version
+        run: ./gradlew --version
 
       - name: Gradle Assemble
         id: gradle-build
-        run: gradle assemble :test-clients:shadowJar --scan
+        run: ./gradlew assemble :test-clients:shadowJar --scan
 
       - name: Regression Gradle Assemble
         id: regression-gradle-build
         working-directory: platform-sdk/regression
-        run: gradle assemble --scan
+        run: ./gradlew assemble --scan
 
       - name: Compute Actual Branch Name
         id: branch

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -411,12 +411,12 @@ jobs:
 
       - name: Gradle Assemble
         id: gradle-build
-        run: ./gradlew assemble :test-clients:shadowJar --scan
+        run: gradle assemble :test-clients:shadowJar --scan
 
       - name: Regression Gradle Assemble
         id: regression-gradle-build
         working-directory: platform-sdk/regression
-        run: ../../gradlew assemble --scan
+        run: gradle assemble --scan
 
       - name: Compute Actual Branch Name
         id: branch

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -344,7 +344,6 @@ jobs:
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
           gradle-version: ${{ inputs.gradle-version }}
-          gradle-home-cache-strict-match: false
 
       - name: Install Python Virtual Environment
         run: |
@@ -412,12 +411,12 @@ jobs:
 
       - name: Gradle Assemble
         id: gradle-build
-        run: ./gradlew assemble :test-clients:shadowJar --scan
+        run: ${HOME}/gradlew assemble :test-clients:shadowJar --scan
 
       - name: Regression Gradle Assemble
         id: regression-gradle-build
         working-directory: platform-sdk/regression
-        run: ./gradlew assemble --scan
+        run: ${HOME}/gradlew assemble --scan
 
       - name: Compute Actual Branch Name
         id: branch

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -407,7 +407,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
-          gradle-version: ${{ inputs.gradle-version }}
+          gradle-version: 8.11
+          #gradle-version: ${{ inputs.gradle-version }}
 
       - name: Verify Gradle Installation
         run: gradle --version

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -341,7 +341,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
           gradle-version: ${{ inputs.gradle-version }}
           gradle-home-cache-strict-match: false
@@ -412,18 +412,12 @@ jobs:
 
       - name: Gradle Assemble
         id: gradle-build
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: assemble :test-clients:shadowJar --scan
+        run: ./gradlew assemble :test-clients:shadowJar --scan
 
       - name: Regression Gradle Assemble
         id: regression-gradle-build
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
-        with:
-          build-root-directory: platform-sdk/regression
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: assemble --scan
+        working-directory: platform-sdk/regression
+        run: ./gradlew assemble --scan
 
       - name: Compute Actual Branch Name
         id: branch

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -125,7 +125,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         with:
           cache-disabled: true

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -84,7 +84,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
           cache-disabled: true
 
@@ -181,7 +181,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+        uses: gradle/actions/setup-gradle@cc4fc85e6b35bafd578d5ffbc76a5518407e1af0 # v4.2.1
         with:
           cache-disabled: true
 


### PR DESCRIPTION
**Description**:

- Updates setup-gradle action from v3.4.2 to v4.2.1
- Replaces calls to setup-gradle with calls to ./gradlew per the [v4.2.1 breaking changes guide](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md)
- Removes last instance of gradle-build-action which was superseded by setup-gradle action after v3.5.0

**Related Issue(s)**:
Fixes #16777

**Checklist**

- [x] Tested (unit, integration, etc.)
