### PR TITLE
fix: 16748 Fixed serialization for AddressBookTestingToolState

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
@@ -95,7 +95,7 @@ public final class SignedStateFileReader {
                     (final MerkleDataInputStream in) -> {
                         readAndCheckSigSetFileVersion(in);
                         final SigSet sigSet = in.readSerializable();
-                        return new MerkleTreeSnapshotReader.StateFileData(data.state(), data.hash(), sigSet);
+                        return new MerkleTreeSnapshotReader.StateFileData(data.stateRoot(), data.hash(), sigSet);
                     });
         } else {
             normalizedData = data;
@@ -104,7 +104,7 @@ public final class SignedStateFileReader {
         final SignedState newSignedState = new SignedState(
                 configuration,
                 CryptoStatic::verifySignature,
-                (MerkleRoot) normalizedData.state(),
+                (MerkleRoot) normalizedData.stateRoot(),
                 "SignedStateFileReader.readStateFile()",
                 false,
                 false,

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/MerkleStateRoot.java
@@ -908,6 +908,7 @@ public abstract class MerkleStateRoot<T extends MerkleStateRoot<T>> extends Part
      */
     @Override
     public MerkleStateRoot<?> loadSnapshot(@NonNull Path targetPath) throws IOException {
-        return MerkleTreeSnapshotReader.readStateFileData(targetPath).state();
+        return (MerkleStateRoot<?>)
+                MerkleTreeSnapshotReader.readStateFileData(targetPath).stateRoot();
     }
 }

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/MerkleTreeSnapshotReader.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/MerkleTreeSnapshotReader.java
@@ -20,6 +20,7 @@ import static com.swirlds.common.io.streams.StreamDebugUtils.deserializeAndDebug
 
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.io.streams.MerkleDataInputStream;
+import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.BufferedInputStream;
@@ -61,11 +62,12 @@ public class MerkleTreeSnapshotReader {
 
     /**
      * This is a helper class to hold the data read from a state file.
-     * @param state the Merkle tree state
+     * @param stateRoot the root of Merkle tree state
      * @param hash the hash of the state
      * @param sigSet the signature set
      */
-    public record StateFileData(@NonNull MerkleStateRoot<?> state, @NonNull Hash hash, @Nullable SigSet sigSet) {}
+    public record StateFileData(
+            @NonNull PartialNaryMerkleInternal stateRoot, @NonNull Hash hash, @Nullable SigSet sigSet) {}
 
     /**
      * Reads a state file from disk
@@ -100,7 +102,7 @@ public class MerkleTreeSnapshotReader {
             @NonNull final Path stateFile, @NonNull final MerkleDataInputStream in, @NonNull final Path directory)
             throws IOException {
         try {
-            final MerkleStateRoot<?> state = in.readMerkleTree(directory, MAX_MERKLE_NODES_IN_STATE);
+            final PartialNaryMerkleInternal state = in.readMerkleTree(directory, MAX_MERKLE_NODES_IN_STATE);
             final Hash hash = in.readSerializable();
             final SigSet sigSet = in.readSerializable();
             return new StateFileData(state, hash, sigSet);


### PR DESCRIPTION
**Description**:

This fix addresses `AddressBook`-related JTR failures. It should fix the following tests:

```
AddressBook-restart-force-use-config-addressbook-1k-4m 
AddressBook-restart-saved-state-same-version-1k-4m 
AddressBook-restart-upgrade-force-use-config-addressbook-1k-4m
AddressBook-restart-upgrade-weight-behavior2-1k-4m
```
**Related issue(s)**:

Fixes #16748 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)

```