### PR TITLE
fix: 16858 Corrected class ids for PlatformMerkleStateRoot and MerkleStateRoot

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformMerkleStateRoot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/PlatformMerkleStateRoot.java
@@ -70,7 +70,7 @@ import java.util.function.Function;
 public class PlatformMerkleStateRoot extends MerkleStateRoot<PlatformMerkleStateRoot>
         implements SwirldState, MerkleRoot {
 
-    private static final long CLASS_ID = 0x8e300b0dfdafbb1bL;
+    private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
     /**
      * The callbacks for Hedera lifecycle events.
      */

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/MerkleStateRoot.java
@@ -106,7 +106,7 @@ public abstract class MerkleStateRoot<T extends MerkleStateRoot<T>> extends Part
      */
     private static final ReadableStates EMPTY_READABLE_STATES = new EmptyReadableStates();
 
-    private static final long CLASS_ID = 0x8e300b0dfdafbb1aL;
+    private static final long CLASS_ID = 0x8e300b0dfdafbb1bL;
     // Migrates from `PlatformState` to State API singleton
     public static final int CURRENT_VERSION = 31;
 


### PR DESCRIPTION
**Description**:

This PR swaps `classId`-s for `PlatformMerkleStateRoot` and `MerkleStateRoot`. This will resolve an issue with loading of saved state created with `release/0.56`


**Related issue(s)**:

Fixes #16858 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
