### PR TITLE
feat: Add cleanup `TssEncryptionKeyTransaction`'s from state

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/RosterService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/RosterService.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.node.app.roster.schemas.V0540RosterSchema;
 import com.hedera.node.app.roster.schemas.V057RosterSchema;
+import com.hedera.node.app.tss.stores.WritableTssStore;
 import com.swirlds.platform.state.service.ReadablePlatformStateStore;
 import com.swirlds.platform.state.service.WritableRosterStore;
 import com.swirlds.state.lifecycle.SchemaRegistry;
@@ -69,6 +70,7 @@ public class RosterService implements Service {
     public void registerSchemas(@NonNull final SchemaRegistry registry) {
         requireNonNull(registry);
         registry.register(new V0540RosterSchema());
-        registry.register(new V057RosterSchema(canAdopt, WritableRosterStore::new, ReadablePlatformStateStore::new));
+        registry.register(new V057RosterSchema(
+                canAdopt, WritableRosterStore::new, ReadablePlatformStateStore::new, WritableTssStore::new));
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/TssBaseServiceImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/TssBaseServiceImpl.java
@@ -124,6 +124,11 @@ public class TssBaseServiceImpl implements TssBaseService {
     }
 
     @Override
+    public int migrationOrder() {
+        return MIGRATION_ORDER;
+    }
+
+    @Override
     public void registerSchemas(@NonNull final SchemaRegistry registry) {
         requireNonNull(registry);
         registry.register(new V0560TssBaseSchema());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/stores/WritableTssStore.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/stores/WritableTssStore.java
@@ -23,6 +23,7 @@ import static com.hedera.node.app.tss.schemas.V0570TssBaseSchema.TSS_STATUS_KEY;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.state.common.EntityNumber;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.hapi.node.state.tss.TssMessageMapKey;
 import com.hedera.hapi.node.state.tss.TssStatus;
 import com.hedera.hapi.node.state.tss.TssVoteMapKey;
@@ -33,22 +34,35 @@ import com.swirlds.state.spi.WritableKVState;
 import com.swirlds.state.spi.WritableSingletonState;
 import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 
 /**
  * Extends the {@link ReadableTssStoreImpl} with write access to the TSS base store.
  */
 public class WritableTssStore extends ReadableTssStoreImpl {
     /**
-     * The underlying data storage class that holds the Pending Airdrops data.
+     * The underlying data storage class that holds the TssMessageTransaction data.
      */
     private final WritableKVState<TssMessageMapKey, TssMessageTransactionBody> tssMessageState;
-
+    /**
+     * The underlying data storage class that holds the TssVoteTransaction data.
+     */
     private final WritableKVState<TssVoteMapKey, TssVoteTransactionBody> tssVoteState;
-
+    /**
+     * The underlying data storage class that holds the Node ID to TssEncryptionKeyTransaction data.
+     */
     private final WritableKVState<EntityNumber, TssEncryptionKeyTransactionBody> tssEncryptionKeyState;
 
+    /**
+     * The singleton data storage that holds the current Tss state as a single status.
+     */
     private final WritableSingletonState<TssStatus> tssStatusState;
 
+    /**
+     * Constructs a new {@link WritableTssStore} instance.
+     *
+     * @param states the writable states
+     */
     public WritableTssStore(@NonNull final WritableStates states) {
         super(states);
         this.tssMessageState = states.get(TSS_MESSAGE_MAP_KEY);
@@ -57,44 +71,100 @@ public class WritableTssStore extends ReadableTssStoreImpl {
         this.tssStatusState = states.getSingleton(TSS_STATUS_KEY);
     }
 
+    /**
+     * Persists a new {@link TssMessageMapKey} with given {@link TssMessageTransactionBody} into the state.
+     *
+     * @param tssMessageMapKey  the {@link TssMessageMapKey} containing a target roster to be persisted
+     * @param txBody            the body of {@link TssMessageTransactionBody} for the given roster to be persisted
+     */
     public void put(@NonNull final TssMessageMapKey tssMessageMapKey, @NonNull final TssMessageTransactionBody txBody) {
         requireNonNull(tssMessageMapKey);
         requireNonNull(txBody);
         tssMessageState.put(tssMessageMapKey, txBody);
     }
 
+    /**
+     * Persists a new {@link TssVoteMapKey} with given {@link TssVoteTransactionBody} into the state.
+     *
+     * @param tssVoteMapKey     the {@link TssVoteMapKey} containing a target roster to be persisted
+     * @param txBody            the {@link TssVoteTransactionBody} for the given roster to be persisted
+     */
     public void put(@NonNull final TssVoteMapKey tssVoteMapKey, @NonNull final TssVoteTransactionBody txBody) {
         requireNonNull(tssVoteMapKey);
         requireNonNull(txBody);
         tssVoteState.put(tssVoteMapKey, txBody);
     }
 
+    /**
+     * Persists a new {@link EntityNumber} with given {@link TssEncryptionKeyTransactionBody} into the state.
+     *
+     * @param entityNumber      the corresponding Node ID to the {@link TssEncryptionKeyTransactionBody} to be persisted
+     * @param txBody            the {@link TssEncryptionKeyTransactionBody} for the given node to be persisted
+     */
     public void put(@NonNull final EntityNumber entityNumber, @NonNull final TssEncryptionKeyTransactionBody txBody) {
         requireNonNull(entityNumber);
         requireNonNull(txBody);
         tssEncryptionKeyState.put(entityNumber, txBody);
     }
 
+    /**
+     * Persists a new {@link TssStatus} for the current Tss state.
+     *
+     * @param tssStatus the {@link TssStatus} to be persisted
+     */
     public void put(@NonNull final TssStatus tssStatus) {
         requireNonNull(tssStatus);
         tssStatusState.put(tssStatus);
     }
 
+    /**
+     * Removes a {@link TssMessageTransactionBody} from the state.
+     *
+     * @param tssMessageMapKey for which the {@link TssMessageTransactionBody} to be removed.
+     */
     public void remove(@NonNull final TssMessageMapKey tssMessageMapKey) {
         requireNonNull(tssMessageMapKey);
         tssMessageState.remove(tssMessageMapKey);
     }
 
+    /**
+     * Removes a {@link TssVoteTransactionBody} from the state.
+     *
+     * @param tssVoteMapKey for which the {@link TssVoteTransactionBody} to be removed.
+     */
     public void remove(@NonNull final TssVoteMapKey tssVoteMapKey) {
         requireNonNull(tssVoteMapKey);
         tssVoteState.remove(tssVoteMapKey);
     }
 
+    /**
+     * Removes a {@link TssEncryptionKeyTransactionBody} from the state.
+     *
+     * @param entityNumber the Node for which the {@link TssEncryptionKeyTransactionBody} to be removed.
+     */
     public void remove(@NonNull final EntityNumber entityNumber) {
         requireNonNull(entityNumber);
         tssEncryptionKeyState.remove(entityNumber);
     }
 
+    /**
+     * Removes EntityNumber (Node ID) from the {@link TssEncryptionKeyTransactionBody} map, but only if
+     * the Node ID is present in neither the active roster's and the candidate roster's entries. {@link RosterEntry}
+     *
+     * @param rostersEntriesNodeIds contains the non-duplicate Node IDs of current active and candidate rosters entries
+     */
+    public void removeIfNotPresent(@NonNull final List<EntityNumber> rostersEntriesNodeIds) {
+        requireNonNull(rostersEntriesNodeIds);
+        tssEncryptionKeyState.keys().forEachRemaining(entityNumber -> {
+            if (!rostersEntriesNodeIds.contains(entityNumber)) {
+                remove(entityNumber);
+            }
+        });
+    }
+
+    /**
+     * Remove all TSS transaction bodies from the state.
+     */
     public void clear() {
         tssVoteState.keys().forEachRemaining(tssVoteState::remove);
         tssMessageState.keys().forEachRemaining(tssMessageState::remove);


### PR DESCRIPTION
**Description**:
This PR aims to clear any `TssEncryptionKeyTransactionBody` from state if the node id mapped to the transaction body is not present in any of the active rosters or a candidate roster. This cleanup is added on `restart()` of RostersSchema,  so that the state changes are present in the block stream.

**Related issue(s)**:

Fixes #16570 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
