### PR TITLE
feat: smart contract service metrics, P2 priority

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/RpcService.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/RpcService.java
@@ -41,6 +41,9 @@ public interface RpcService extends Service {
      *
      * Called on each Service when `Hedera.onStateInitialized() is called for `InitTrigger.GENESIS`.
      * Services module is still single-threaded when this happens.
+     *
+     * N.B.: Each service must take care about what's done at this point: It must lead to a
+     * deterministic state and deterministic block stream.
      */
     default void onStateInitializedForGenesis() {}
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/RpcService.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/RpcService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,4 +33,14 @@ public interface RpcService extends Service {
      */
     @NonNull
     Set<RpcServiceDefinition> rpcDefinitions();
+
+    /**
+     * Services may have initialization to be done which can't be done in the constructor (too soon)
+     * but should/must be done before the system starts processing transactions. This is the hook
+     * for that.
+     *
+     * Called on each Service when `Hedera.onStateInitialized() is called for `InitTrigger.GENESIS`.
+     * Services module is still single-threaded when this happens.
+     */
+    default void onStateInitializedForGenesis() {}
 }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/RpcService.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/RpcService.java
@@ -33,17 +33,4 @@ public interface RpcService extends Service {
      */
     @NonNull
     Set<RpcServiceDefinition> rpcDefinitions();
-
-    /**
-     * Services may have initialization to be done which can't be done in the constructor (too soon)
-     * but should/must be done before the system starts processing transactions. This is the hook
-     * for that.
-     *
-     * Called on each Service when `Hedera.onStateInitialized() is called for `InitTrigger.GENESIS`.
-     * Services module is still single-threaded when this happens.
-     *
-     * N.B.: Each service must take care about what's done at this point: It must lead to a
-     * deterministic state and deterministic block stream.
-     */
-    default void onStateInitializedForGenesis() {}
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/BootstrapConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/BootstrapConfigProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import com.hedera.node.config.converter.SemanticVersionConverter;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.BootstrapConfig;
+import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
@@ -68,6 +69,7 @@ public class BootstrapConfigProviderImpl extends ConfigProviderBase {
                 .withConfigDataType(LedgerConfig.class)
                 .withConfigDataType(AccountsConfig.class)
                 .withConfigDataType(TssConfig.class)
+                .withConfigDataType(ContractsConfig.class)
                 .withConverter(Bytes.class, new BytesConverter())
                 .withConverter(SemanticVersion.class, new SemanticVersionConverter())
                 .withConverter(LongPair.class, new LongPairConverter());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutors.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutors.java
@@ -250,8 +250,8 @@ public enum TransactionExecutors {
                         () -> state,
                         () -> componentRef.get().throttleServiceManager().activeThrottleDefinitionsOrThrow(),
                         ThrottleAccumulator::new));
-        final var contractService =
-                new ContractServiceImpl(appContext, NOOP_VERIFICATION_STRATEGIES, tracerBinding, customOps);
+        final var contractService = new ContractServiceImpl(
+                appContext, NO_OP_METRICS, NOOP_VERIFICATION_STRATEGIES, tracerBinding, customOps);
         final var fileService = new FileServiceImpl();
         final var scheduleService = new ScheduleServiceImpl();
         final var component = DaggerExecutorComponent.builder()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -126,7 +126,7 @@ class IngestComponentTest {
                 .configProviderImpl(configProvider)
                 .bootstrapConfigProviderImpl(new BootstrapConfigProviderImpl())
                 .fileServiceImpl(new FileServiceImpl())
-                .contractServiceImpl(new ContractServiceImpl(appContext))
+                .contractServiceImpl(new ContractServiceImpl(appContext, NO_OP_METRICS))
                 .scheduleService(new ScheduleServiceImpl())
                 .initTrigger(InitTrigger.GENESIS)
                 .platform(platform)

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
@@ -431,7 +431,7 @@ public class TransactionExecutorsTest {
         Set.of(
                         new EntityIdService(),
                         new ConsensusServiceImpl(),
-                        new ContractServiceImpl(appContext),
+                        new ContractServiceImpl(appContext, NO_OP_METRICS),
                         new FileServiceImpl(),
                         new FreezeServiceImpl(),
                         new ScheduleServiceImpl(),

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceComponent.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceComponent.java
@@ -19,6 +19,11 @@ package com.hedera.node.app.service.contract.impl;
 import com.hedera.node.app.service.contract.impl.annotations.CustomOps;
 import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.handlers.ContractHandlers;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import dagger.BindsInstance;
@@ -28,6 +33,8 @@ import java.time.InstantSource;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
+import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
@@ -57,6 +64,7 @@ public interface ContractServiceComponent {
                 @BindsInstance VerificationStrategies verificationStrategies,
                 @BindsInstance @Nullable Supplier<List<OperationTracer>> addOnTracers,
                 @BindsInstance ContractMetrics contractMetrics,
+                @BindsInstance SystemContractMethodRegistry systemContractMethodRegistry,
                 @BindsInstance @CustomOps Set<Operation> customOps);
     }
 
@@ -69,4 +77,18 @@ public interface ContractServiceComponent {
      * @return contract metrics collection, instance
      */
     ContractMetrics contractMetrics();
+
+    /**
+     * @return method registry for system contracts
+     */
+    SystemContractMethodRegistry systemContractMethodRegistry();
+
+    @Named("HasTranslators")
+    Provider<List<CallTranslator<HasCallAttempt>>> hasCallTranslators();
+
+    @Named("HssTranslators")
+    Provider<List<CallTranslator<HssCallAttempt>>> hssCallTranslators();
+
+    @Named("HtsTranslators")
+    Provider<List<CallTranslator<HtsCallAttempt>>> htsCallTranslators();
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceComponent.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceComponent.java
@@ -55,6 +55,8 @@ public interface ContractServiceComponent {
          * @param signatureVerifier the verifier used for signature verification
          * @param verificationStrategies the current verification strategy to use
          * @param addOnTracers all operation tracer callbacks
+         * @param contractMetrics holds all metrics for the smart contract service
+         * @param systemContractMethodRegistry registry of all system contract methods
          * @param customOps any additional custom operations to use when constructing the EVM
          * @return the contract service component
          */

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.service.contract.impl;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hedera.node.app.service.contract.ContractService;
 import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.DefaultVerificationStrategies;
@@ -30,13 +31,16 @@ import com.hedera.node.app.service.contract.impl.schemas.V0490ContractSchema;
 import com.hedera.node.app.service.contract.impl.schemas.V0500ContractSchema;
 import com.hedera.node.app.spi.AppContext;
 import com.hedera.node.config.data.ContractsConfig;
+import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.lifecycle.SchemaRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Supplier;
 import org.hyperledger.besu.evm.operation.Operation;
 import org.hyperledger.besu.evm.tracing.OperationTracer;
@@ -56,8 +60,8 @@ public class ContractServiceImpl implements ContractService {
     /**
      * @param appContext the current application context
      */
-    public ContractServiceImpl(@NonNull final AppContext appContext) {
-        this(appContext, null, null, Set.of());
+    public ContractServiceImpl(@NonNull final AppContext appContext, @NonNull final Metrics metrics) {
+        this(appContext, metrics, null, null, Set.of());
     }
 
     /**
@@ -68,17 +72,17 @@ public class ContractServiceImpl implements ContractService {
      */
     public ContractServiceImpl(
             @NonNull final AppContext appContext,
+            @NonNull final Metrics metrics,
             @Nullable final VerificationStrategies verificationStrategies,
             @Nullable final Supplier<List<OperationTracer>> addOnTracers,
             @NonNull final Set<Operation> customOps) {
         requireNonNull(appContext);
         requireNonNull(customOps);
-        final var metricsSupplier = requireNonNull(appContext.metricsSupplier());
+        requireNonNull(metrics);
         final Supplier<ContractsConfig> contractsConfigSupplier =
                 () -> appContext.configSupplier().get().getConfigData(ContractsConfig.class);
         final var systemContractMethodRegistry = new SystemContractMethodRegistry();
-        final var contractMetrics =
-                new ContractMetrics(metricsSupplier, contractsConfigSupplier, systemContractMethodRegistry);
+        final var contractMetrics = new ContractMetrics(metrics, contractsConfigSupplier, systemContractMethodRegistry);
 
         this.component = DaggerContractServiceComponent.factory()
                 .create(
@@ -99,15 +103,16 @@ public class ContractServiceImpl implements ContractService {
         registry.register(new V0500ContractSchema());
     }
 
-    @Override
-    public void onStateInitializedForGenesis() {
+    public void createMetrics() {
+        final var contractMetrics = requireNonNull(component.contractMetrics());
+
         // Force call translators to be instantiated now, so that all the system contract methods
         // will be registered, so the secondary metrics can be created.  (Left to its own devices
         // Dagger would delay instantiating them until transactions started flowing.)
         final var allTranslators = allCallTranslators();
 
-        component.contractMetrics().createContractPrimaryMetrics();
-        component.contractMetrics().createContractSecondaryMetrics();
+        contractMetrics.createContractPrimaryMetrics();
+        contractMetrics.createContractSecondaryMetrics();
     }
 
     /**
@@ -123,5 +128,13 @@ public class ContractServiceImpl implements ContractService {
         allCallTranslators.addAll(component.hssCallTranslators().get());
         allCallTranslators.addAll(component.htsCallTranslators().get());
         return allCallTranslators;
+    }
+
+    @VisibleForTesting
+    private Map<String, String> metricsInventory() {
+        final var inventory = new TreeMap<String, String>();
+        inventory.put("methods", component.systemContractMethodRegistry().allMethodsAsTable());
+        inventory.put("metrics", component.contractMetrics().allCountersAsTable());
+        return inventory;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceImpl.java
@@ -22,6 +22,9 @@ import com.hedera.node.app.service.contract.ContractService;
 import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.DefaultVerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.handlers.ContractHandlers;
 import com.hedera.node.app.service.contract.impl.schemas.V0490ContractSchema;
 import com.hedera.node.app.service.contract.impl.schemas.V0500ContractSchema;
@@ -30,6 +33,7 @@ import com.hedera.node.config.data.ContractsConfig;
 import com.swirlds.state.lifecycle.SchemaRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -41,6 +45,7 @@ import org.hyperledger.besu.evm.tracing.OperationTracer;
  * Implementation of the {@link ContractService}.
  */
 public class ContractServiceImpl implements ContractService {
+
     /**
      * Minimum gas required for contract operations.
      */
@@ -71,7 +76,10 @@ public class ContractServiceImpl implements ContractService {
         final var metricsSupplier = requireNonNull(appContext.metricsSupplier());
         final Supplier<ContractsConfig> contractsConfigSupplier =
                 () -> appContext.configSupplier().get().getConfigData(ContractsConfig.class);
-        final var contractMetrics = new ContractMetrics(metricsSupplier, contractsConfigSupplier);
+        final var systemContractMethodRegistry = new SystemContractMethodRegistry();
+        final var contractMetrics =
+                new ContractMetrics(metricsSupplier, contractsConfigSupplier, systemContractMethodRegistry);
+
         this.component = DaggerContractServiceComponent.factory()
                 .create(
                         appContext.instantSource(),
@@ -81,6 +89,7 @@ public class ContractServiceImpl implements ContractService {
                         Optional.ofNullable(verificationStrategies).orElseGet(DefaultVerificationStrategies::new),
                         addOnTracers,
                         contractMetrics,
+                        systemContractMethodRegistry,
                         customOps);
     }
 
@@ -90,12 +99,15 @@ public class ContractServiceImpl implements ContractService {
         registry.register(new V0500ContractSchema());
     }
 
-    /**
-     * Create the metrics for the smart contracts service. This needs to be delayed until _after_
-     * the metrics are available - which happens after `Hedera.initializeStatesApi`.
-     */
-    public void registerMetrics() {
-        component.contractMetrics().createContractMetrics();
+    @Override
+    public void onStateInitializedForGenesis() {
+        // Force call translators to be instantiated now, so that all the system contract methods
+        // will be registered, so the secondary metrics can be created.  (Left to its own devices
+        // Dagger would delay instantiating them until transactions started flowing.)
+        final var allTranslators = allCallTranslators();
+
+        component.contractMetrics().createContractPrimaryMetrics();
+        component.contractMetrics().createContractSecondaryMetrics();
     }
 
     /**
@@ -103,5 +115,13 @@ public class ContractServiceImpl implements ContractService {
      */
     public ContractHandlers handlers() {
         return component.handlers();
+    }
+
+    private @NonNull List<CallTranslator<? extends AbstractCallAttempt<?>>> allCallTranslators() {
+        final var allCallTranslators = new ArrayList<CallTranslator<? extends AbstractCallAttempt<?>>>();
+        allCallTranslators.addAll(component.hasCallTranslators().get());
+        allCallTranslators.addAll(component.hssCallTranslators().get());
+        allCallTranslators.addAll(component.htsCallTranslators().get());
+        return allCallTranslators;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,20 +24,30 @@ import static java.util.stream.Collectors.toMap;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
+import com.swirlds.common.metrics.platform.prometheus.NameConverter;
 import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.Metric;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.inject.Inject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hyperledger.besu.evm.frame.MessageFrame;
+import org.hyperledger.besu.evm.frame.MessageFrame.State;
 
 /**
  * Metrics collection management for Smart Contracts service
@@ -52,13 +62,55 @@ public class ContractMetrics {
     private final Supplier<Metrics> metricsSupplier;
     private final Supplier<ContractsConfig> contractsConfigSupplier;
     private boolean p1MetricsEnabled;
+    private boolean p2MetricsEnabled;
+    private final SystemContractMethodRegistry systemContractMethodRegistry;
+
+    // Counters that are the P1 metrics
 
     private final HashMap<HederaFunctionality, Counter> rejectedTxsCounters = new HashMap<>();
     private final HashMap<HederaFunctionality, Counter> rejectedTxsLackingIntrinsicGas = new HashMap<>();
     private Counter rejectedEthType3Counter;
 
+    private enum MethodMetricType {
+        TOTAL(0, "total"),
+        FAILED(1, "failed");
+        public final int index;
+        public final String name;
+
+        private MethodMetricType(final int index, @NonNull final String name) {
+            this.index = index;
+            this.name = name;
+        }
+
+        public @NonNull String toString() {
+            return this.name;
+        }
+    };
+
+    // Counters that are the P2 metrics, and maps that take `SystemContractMethods` into the specific counters
+
+    // Counters for SystemContract usage (i.e., calls to HAS, HSS, HTS)
+    private final Map<SystemContractMethod.SystemContract, Counter[]> systemContractMethodCounters = new HashMap<>();
+
+    // Counters for DIRECT vs PROXY usage
+    private final Map<SystemContractMethod.CallVia, Counter[]> systemContractMethodCountersVia = new HashMap<>();
+
+    // Counters for ERC-20 and ERC-721 usage (there's overlap as some methods are defined in _both_), plus the map
+    // that takes a `SystemContract` to the ERC types (if any)
+    private final Map<SystemContractMethod, EnumSet<SystemContractMethod.Category>> systemContractMethodErcMembers =
+            new HashMap<>();
+    private final Map<SystemContractMethod.Category, Counter[]> systemContractERCTypeCounters = new HashMap<>();
+
+    // Counters for the "method groups" (e.g., transfers vs creates vs burns etc), plus the map that takes a
+    // `SystemContract` to the method group(s) it is part of
+    private final Map<SystemContractMethod, EnumSet<SystemContractMethod.Category>> systemContractMethodGroupMembers =
+            new HashMap<>();
+    private final Map<SystemContractMethod.Category, Counter[]> systemContractMethodGroupCounters = new HashMap<>();
+
     private static final Map<HederaFunctionality, String> POSSIBLE_FAILING_TX_TYPES = Map.of(
             CONTRACT_CALL, "contractCallTx", CONTRACT_CREATE, "contractCreateTx", ETHEREUM_TRANSACTION, "ethereumTx");
+
+    // String templates and other stringish things used to create metrics' names and descriptions
 
     private static final String METRIC_CATEGORY = "app";
     private static final String METRIC_SERVICE = "SmartContractService";
@@ -74,76 +126,163 @@ public class ContractMetrics {
     private static final String REJECTED_TXN_SHORT_DESCR = "txns";
     private static final String REJECTED_TYPE3_SHORT_DESCR = "Ethereum Type 3 txns";
     private static final String REJECTED_FOR_GAS_SHORT_DESCR = "txns with not even intrinsic gas";
-
     private static final String REJECTED_TYPE3_FUNCTIONALITY = "ethType3BlobTransaction";
+
+    // The `SystemContractMethod.Category` enum has "categories" for both ERC-20/ERC-721, and method groups:
+    // These maps distinguish them
+
+    private static final EnumSet<SystemContractMethod.Category> ERC_TYPES = EnumSet.of(Category.ERC20, Category.ERC721);
+    private static final EnumSet<SystemContractMethod.Category> METHOD_GROUPS = EnumSet.complementOf(ERC_TYPES);
+
+    //             %1$s - metric name (system contract name or method category (group))
+    //             %2$s = METRIC_SERVICE
+    //             %3$s - METHOD_METRIC_TYPE
+    //             %4%s - clarification
+    private static final String METHOD_METRIC_NAME_TEMPLATE = "%2$s:Method_%1$s_%3$s";
+    private static final String METHOD_METRIC_DESCR_TEMPLATE = "system contract method %1$s %3$s %4$s";
 
     @Inject
     public ContractMetrics(
             @NonNull final Supplier<Metrics> metricsSupplier,
-            @NonNull final Supplier<ContractsConfig> contractsConfigSupplier) {
+            @NonNull final Supplier<ContractsConfig> contractsConfigSupplier,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry) {
         this.metricsSupplier = requireNonNull(
                 metricsSupplier, "metrics supplier (from platform via ServicesMain/Hedera must not be null");
         this.contractsConfigSupplier =
                 requireNonNull(contractsConfigSupplier, "contracts configuration supplier must not be null");
+        this.systemContractMethodRegistry =
+                requireNonNull(systemContractMethodRegistry, "systemContractMethodRegistry must not be null");
     }
 
-    private final Object metricsCreationLock = new Object();
-    private volatile boolean primaryMetricsAreCreated = false;
+    // --------------------
+    // Creating the metrics
 
-    public void createContractMetrics() {
+    /**
+     * Primary metrics are a fixed set and can be created when `Hedera` initializes the system.  But
+     * it actually must wait until the platform calls `Hedera.onStateInitialized`, and then for
+     * GENESIS only.
+     */
+    public void createContractPrimaryMetrics() {
+        final var contractsConfig = requireNonNull(contractsConfigSupplier.get());
+        this.p1MetricsEnabled = contractsConfig.metricsSmartContractPrimaryEnabled();
 
-        // Primary metrics are a fixed set and can be created when `Hedera` initializes the system.
-        // But it actually must wait until the platform calls `Hedera.onStateInitialized` and,
-        // remarkably, that can happen more than once.  We must only create the metrics the
-        // _first_ time.  Hence, the simple gate here.
+        if (p1MetricsEnabled) {
+            final var metrics = requireNonNull(metricsSupplier.get());
 
-        synchronized (metricsCreationLock) {
-            if (!primaryMetricsAreCreated) {
+            // Rejected transactions counters
+            for (final var txKind : POSSIBLE_FAILING_TX_TYPES.keySet()) {
+                final var name = toRejectedName(txKind, REJECTED_TXN_SHORT_DESCR);
+                final var descr = toRejectedDescr(txKind, REJECTED_TXN_SHORT_DESCR);
+                final var config = new Counter.Config(METRIC_CATEGORY, name)
+                        .withDescription(descr)
+                        .withUnit(METRIC_TXN_UNIT);
+                final var metric = newCounter(metrics, config);
+                rejectedTxsCounters.put(txKind, metric);
+            }
 
-                final var contractsConfig = requireNonNull(contractsConfigSupplier.get());
-                this.p1MetricsEnabled = contractsConfig.metricsSmartContractPrimaryEnabled();
+            // Rejected transactions because they don't even have intrinsic gas
+            for (final var txKind : POSSIBLE_FAILING_TX_TYPES.keySet()) {
+                final var functionalityName = POSSIBLE_FAILING_TX_TYPES.get(txKind) + "DueToIntrinsicGas";
+                final var name = toRejectedName(functionalityName, REJECTED_FOR_GAS_SHORT_DESCR);
+                final var descr = toRejectedDescr(functionalityName, REJECTED_FOR_GAS_SHORT_DESCR);
+                final var config = new Counter.Config(METRIC_CATEGORY, name)
+                        .withDescription(descr)
+                        .withUnit(METRIC_TXN_UNIT);
+                final var metric = newCounter(metrics, config);
+                rejectedTxsLackingIntrinsicGas.put(txKind, metric);
+            }
 
-                final var metrics = requireNonNull(metricsSupplier.get());
-
-                if (p1MetricsEnabled) {
-                    // Rejected transactions counters
-                    for (final var txKind : POSSIBLE_FAILING_TX_TYPES.keySet()) {
-                        final var name = toRejectedName(txKind, REJECTED_TXN_SHORT_DESCR);
-                        final var descr = toRejectedDescr(txKind, REJECTED_TXN_SHORT_DESCR);
-                        final var config = new Counter.Config(METRIC_CATEGORY, name)
-                                .withDescription(descr)
-                                .withUnit(METRIC_TXN_UNIT);
-                        final var metric = newCounter(metrics, config);
-                        rejectedTxsCounters.put(txKind, metric);
-                    }
-
-                    // Rejected transactions because they don't even have intrinsic gas
-                    for (final var txKind : POSSIBLE_FAILING_TX_TYPES.keySet()) {
-                        final var functionalityName = POSSIBLE_FAILING_TX_TYPES.get(txKind) + "DueToIntrinsicGas";
-                        final var name = toRejectedName(functionalityName, REJECTED_FOR_GAS_SHORT_DESCR);
-                        final var descr = toRejectedDescr(functionalityName, REJECTED_FOR_GAS_SHORT_DESCR);
-                        final var config = new Counter.Config(METRIC_CATEGORY, name)
-                                .withDescription(descr)
-                                .withUnit(METRIC_TXN_UNIT);
-                        final var metric = newCounter(metrics, config);
-                        rejectedTxsLackingIntrinsicGas.put(txKind, metric);
-                    }
-
-                    // Rejected transactions for ethereum calls that are in type 3 blob transaction format
-                    {
-                        final var name = toRejectedName(REJECTED_TYPE3_FUNCTIONALITY, REJECTED_TYPE3_SHORT_DESCR);
-                        final var descr = toRejectedDescr(REJECTED_TYPE3_FUNCTIONALITY, REJECTED_TYPE3_SHORT_DESCR);
-                        final var config = new Counter.Config(METRIC_CATEGORY, name)
-                                .withDescription(descr)
-                                .withUnit(METRIC_TXN_UNIT);
-                        final var metric = newCounter(metrics, config);
-                        rejectedEthType3Counter = metric;
-                    }
-                }
-                primaryMetricsAreCreated = true;
+            // Rejected transactions for ethereum calls that are in type 3 blob transaction format
+            {
+                final var name = toRejectedName(REJECTED_TYPE3_FUNCTIONALITY, REJECTED_TYPE3_SHORT_DESCR);
+                final var descr = toRejectedDescr(REJECTED_TYPE3_FUNCTIONALITY, REJECTED_TYPE3_SHORT_DESCR);
+                final var config = new Counter.Config(METRIC_CATEGORY, name)
+                        .withDescription(descr)
+                        .withUnit(METRIC_TXN_UNIT);
+                final var metric = newCounter(metrics, config);
+                rejectedEthType3Counter = metric;
             }
         }
     }
+
+    private @NonNull Counter makeCounter(
+            @NonNull final MethodMetricType metricType,
+            @NonNull final String nam,
+            @NonNull final String clarification) {
+        final var name = toMethodMetricName(nam, metricType);
+        final var descr = toMethodMetricDescr(nam, metricType, clarification);
+        final var config =
+                new Counter.Config(METRIC_CATEGORY, name).withDescription(descr).withUnit(METRIC_TXN_UNIT);
+        return newCounter(metricsSupplier.get(), config);
+    }
+
+    private @NonNull Counter[] makeCounterPair(@NonNull final String nam, @NonNull final String clarification) {
+        final var metricPair = new Counter[2];
+        metricPair[MethodMetricType.TOTAL.index] = makeCounter(MethodMetricType.TOTAL, nam, clarification);
+        metricPair[MethodMetricType.FAILED.index] = makeCounter(MethodMetricType.FAILED, nam, clarification);
+        return metricPair;
+    }
+
+    /**
+     * Secondary metrics are based on the system contract methods themselves, split into various categories that
+     * are based on their attributes.
+     */
+    public void createContractSecondaryMetrics() {
+
+        if (systemContractMethodRegistry.size() == 0) {
+            // Something went wrong with the order in which components were initialized
+            log.warn("no system contract methods registered when trying to create secondary metrics");
+        }
+
+        final var contractsConfig = requireNonNull(contractsConfigSupplier.get());
+        this.p2MetricsEnabled = contractsConfig.metricsSmartContractSecondaryEnabled();
+
+        if (p2MetricsEnabled) {
+            final var metrics = requireNonNull(metricsSupplier.get());
+
+            // P2 metrics come in pairs:  a total count of something, and the error count for that same thing
+
+            // By system contract
+            // Collect all system contracts in use and create counters
+            final var allSystemContracts = systemContractMethodRegistry.allMethods().stream()
+                    .map(m -> m.systemContract().orElseThrow())
+                    .collect(Collectors.toSet());
+            for (final var systemContract : allSystemContracts) {
+                systemContractMethodCounters.put(systemContract, makeCounterPair(systemContract.name(), ""));
+            }
+
+            // By via: DIRECT vs PROXY
+            for (final var callVia : SystemContractMethod.CallVia.values()) {
+                systemContractMethodCountersVia.put(callVia, makeCounterPair(callVia.name(), ""));
+            }
+
+            // By ERC type
+
+            for (final var method : systemContractMethodRegistry.allMethods()) {
+                final var ercMembership = intersect(method.categories(), ERC_TYPES);
+                systemContractMethodErcMembers.put(method, ercMembership);
+            }
+
+            for (final var ercType : ERC_TYPES) {
+                systemContractERCTypeCounters.put(ercType, makeCounterPair(ercType.name(), ercType.clarification()));
+            }
+
+            // By Method Group
+
+            for (final var method : systemContractMethodRegistry.allMethods()) {
+                final var groupMembership = intersect(method.categories(), METHOD_GROUPS);
+                systemContractMethodGroupMembers.put(method, groupMembership);
+            }
+
+            for (final var methodGroup : METHOD_GROUPS) {
+                systemContractMethodGroupCounters.put(
+                        methodGroup, makeCounterPair(methodGroup.name(), methodGroup.clarification()));
+            }
+        }
+    }
+
+    // ---------------------------------
+    // P1 metrics:  `pureCheck` failures
 
     public void incrementRejectedTx(@NonNull final HederaFunctionality txKind) {
         bumpRejectedTx(txKind, 1);
@@ -174,47 +313,142 @@ public class ContractMetrics {
         }
     }
 
+    // ---------------------------------------------
+    // P2 metrics: System contract per-method counts
+
+    enum MethodResult {
+        SUCCESS,
+        FAILURE;
+
+        public static @NonNull MethodResult from(@NonNull final MessageFrame.State state) {
+            return switch (state) {
+                case State.CODE_SUCCESS, State.COMPLETED_SUCCESS -> SUCCESS;
+                default -> FAILURE;
+            };
+        }
+    }
+
+    public void incrementSystemMethodCall(
+            @NonNull SystemContractMethod systemContractMethod, @NonNull final MessageFrame.State state) {
+        systemContractMethod =
+                systemContractMethodRegistry.fromMissingContractGetWithContract(requireNonNull(systemContractMethod));
+        requireNonNull(state);
+
+        final var result = MethodResult.from(state);
+        if (p2MetricsEnabled) {
+            // Handle each of the P2 metrics kinds
+
+            try {
+                final Consumer<Counter[]> bumpMetricsPair = metricsPair -> {
+                    metricsPair[MethodMetricType.TOTAL.index].increment();
+                    if (MethodResult.FAILURE == result) {
+                        metricsPair[MethodMetricType.FAILED.index].increment();
+                    }
+                };
+
+                bumpMetricsPair.accept(systemContractMethodCounters.get(
+                        systemContractMethod.systemContract().orElse(null)));
+                bumpMetricsPair.accept(systemContractMethodCountersVia.get(systemContractMethod.via()));
+                systemContractMethodErcMembers
+                        .get(systemContractMethod)
+                        .forEach(ercType -> bumpMetricsPair.accept(systemContractERCTypeCounters.get(ercType)));
+                systemContractMethodGroupMembers
+                        .get(systemContractMethod)
+                        .forEach(group -> bumpMetricsPair.accept(systemContractMethodGroupCounters.get(group)));
+            } catch (final NullPointerException e) {
+                // ignore: should never happen, but ... just in case ... don't fail tx because of bad
+                // metrics code
+            }
+        }
+    }
+
+    private final ConcurrentHashMap<SystemContractMethod, SystemContractMethod> methodsThatHaveCallsWithNullMethod =
+            new ConcurrentHashMap<>(50);
+
+    public void logWarnMissingSystemContractMethodOnCall(@NonNull final SystemContractMethod systemContractMethod) {
+        // Log, but only first time you see it for a specific method (to avoid spew)
+        requireNonNull(systemContractMethod);
+        if (methodsThatHaveCallsWithNullMethod.containsKey(systemContractMethod)) {
+            log.warn("Found `Call` without `SystemContractMethod`,  %s"
+                    .formatted(systemContractMethod.fullyDecoratedMethodName()));
+        } else {
+            methodsThatHaveCallsWithNullMethod.put(systemContractMethod, systemContractMethod);
+        }
+    }
+
+    // -----------------
+    // Unit test helpers
+
     @VisibleForTesting
-    public @NonNull Map<String, Long> getAllCounters() {
-        return Stream.concat(
-                        Stream.concat(
-                                rejectedTxsCounters.values().stream(),
-                                rejectedTxsLackingIntrinsicGas.values().stream()),
-                        Stream.ofNullable(rejectedEthType3Counter))
-                .collect(toMap(Counter::getName, Counter::get));
+    public @NonNull Set<Counter> getAllP1Counters() {
+        final var allCounters = new HashSet<Counter>(200);
+        allCounters.addAll(rejectedTxsCounters.values());
+        allCounters.addAll(rejectedTxsLackingIntrinsicGas.values());
+        if (rejectedEthType3Counter != null) allCounters.add(rejectedEthType3Counter);
+        return allCounters;
+    }
+
+    @VisibleForTesting
+    public @NonNull Set<Counter> getAllP2Counters() {
+        final var allCounters = new HashSet<Counter>(200);
+
+        final Consumer<Map<?, Counter[]>> adder = map -> {
+            map.values().forEach(counterPair -> {
+                allCounters.add(counterPair[MethodMetricType.TOTAL.index]);
+                allCounters.add(counterPair[MethodMetricType.FAILED.index]);
+            });
+        };
+        adder.accept(systemContractMethodCounters);
+        adder.accept(systemContractMethodCountersVia);
+        adder.accept(systemContractERCTypeCounters);
+        adder.accept(systemContractMethodGroupCounters);
+
+        return allCounters;
+    }
+
+    @VisibleForTesting
+    public @NonNull Set<Counter> getAllCounters() {
+        final var allCounters = getAllP1Counters();
+        allCounters.addAll(getAllP2Counters());
+        return allCounters;
+    }
+
+    @VisibleForTesting
+    public @NonNull Map<String, Long> getAllP1CounterValues() {
+        return getAllP1Counters().stream().collect(toMap(Counter::getName, Counter::get));
+    }
+
+    @VisibleForTesting
+    public @NonNull Map<String, Long> getAllCounterValues() {
+        return getAllCounters().stream().collect(toMap(Counter::getName, Counter::get));
+    }
+
+    @VisibleForTesting
+    public @NonNull List<String> getAllP1CounterNames() {
+        return getAllP1Counters().stream().map(Metric::getName).sorted().toList();
     }
 
     @VisibleForTesting
     public @NonNull List<String> getAllCounterNames() {
-        return Stream.concat(
-                        Stream.concat(
-                                rejectedTxsCounters.values().stream(),
-                                rejectedTxsLackingIntrinsicGas.values().stream()),
-                        Stream.ofNullable(rejectedEthType3Counter))
-                .map(Metric::getName)
-                .sorted()
-                .toList();
+        final var n = getAllCounters().stream().map(Metric::getDescription).count();
+        return getAllCounters().stream().map(Metric::getName).sorted().toList();
     }
 
     @VisibleForTesting
     public @NonNull List<String> getAllCounterDescriptions() {
-        return Stream.concat(
-                        Stream.concat(
-                                rejectedTxsCounters.values().stream(),
-                                rejectedTxsLackingIntrinsicGas.values().stream()),
-                        Stream.ofNullable(rejectedEthType3Counter))
-                .map(Metric::getDescription)
-                .sorted()
-                .toList();
+        return getAllCounters().stream().map(Metric::getDescription).sorted().toList();
     }
 
     @VisibleForTesting
     public @NonNull String allCountersToString() {
-        return getAllCounters().entrySet().stream()
+        return getAllCounterValues().entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
                 .map(e -> e.getKey() + ": " + e.getValue())
                 .collect(Collectors.joining(", ", "{", "}"));
     }
+
+    // ---------------------------------
+    // Helpers for making metrics' names
 
     private @NonNull Counter newCounter(@NonNull final Metrics metrics, @NonNull final Counter.Config config) {
         return metrics.getOrCreate(config);
@@ -240,10 +474,39 @@ public class ContractMetrics {
         return toString(REJECTED_DESCR_TEMPLATE, functionality, shortDescription);
     }
 
+    private static @NonNull String toMethodMetricName(
+            @NonNull final String name, @NonNull final MethodMetricType type) {
+        return toString(METHOD_METRIC_NAME_TEMPLATE, name, type, "");
+    }
+
+    private static @NonNull String toMethodMetricDescr(
+            @NonNull final String name, @NonNull final MethodMetricType type, @NonNull final String clarification) {
+        return toString(METHOD_METRIC_DESCR_TEMPLATE, name, type, clarification);
+    }
+
     private static @NonNull String toString(
             @NonNull final String template,
             @NonNull final String functionality,
             @NonNull final String shortDescription) {
-        return template.formatted(functionality, METRIC_SERVICE, shortDescription);
+        final var possiblyUnacceptableName = template.formatted(functionality, METRIC_SERVICE, shortDescription);
+        final var definitelyAcceptableName = NameConverter.fix(possiblyUnacceptableName);
+        return definitelyAcceptableName;
+    }
+
+    private static @NonNull String toString(
+            @NonNull final String template,
+            @NonNull final String name,
+            @NonNull final MethodMetricType type,
+            @NonNull final String clarification) {
+        final var possiblyUnacceptableName = template.formatted(name, METRIC_SERVICE, type, clarification);
+        final var definitelyAcceptableName = NameConverter.fix(possiblyUnacceptableName);
+        return definitelyAcceptableName;
+    }
+
+    private <E extends Enum<E>> @NonNull EnumSet<E> intersect(
+            @NonNull final EnumSet<E> set1, @NonNull final EnumSet<E> set2) {
+        final var r = set1.clone();
+        r.retainAll(set2);
+        return r;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
@@ -207,19 +207,20 @@ public class ContractMetrics {
 
     private @NonNull Counter makeCounter(
             @NonNull final MethodMetricType metricType,
-            @NonNull final String nam,
+            @NonNull final String name,
             @NonNull final String clarification) {
-        final var name = toMethodMetricName(nam, metricType);
-        final var descr = toMethodMetricDescr(nam, metricType, clarification);
-        final var config =
-                new Counter.Config(METRIC_CATEGORY, name).withDescription(descr).withUnit(METRIC_TXN_UNIT);
+        final var metricName = toMethodMetricName(name, metricType);
+        final var descr = toMethodMetricDescr(name, metricType, clarification);
+        final var config = new Counter.Config(METRIC_CATEGORY, metricName)
+                .withDescription(descr)
+                .withUnit(METRIC_TXN_UNIT);
         return newCounter(metricsSupplier.get(), config);
     }
 
-    private @NonNull Counter[] makeCounterPair(@NonNull final String nam, @NonNull final String clarification) {
+    private @NonNull Counter[] makeCounterPair(@NonNull final String name, @NonNull final String clarification) {
         final var metricPair = new Counter[2];
-        metricPair[MethodMetricType.TOTAL.index] = makeCounter(MethodMetricType.TOTAL, nam, clarification);
-        metricPair[MethodMetricType.FAILED.index] = makeCounter(MethodMetricType.FAILED, nam, clarification);
+        metricPair[MethodMetricType.TOTAL.index] = makeCounter(MethodMetricType.TOTAL, name, clarification);
+        metricPair[MethodMetricType.FAILED.index] = makeCounter(MethodMetricType.FAILED, name, clarification);
         return metricPair;
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
@@ -357,6 +357,8 @@ public class ContractMetrics {
             } catch (final NullPointerException e) {
                 // ignore: should never happen, but ... just in case ... don't fail tx because of bad
                 // metrics code
+                // FUTURE: Log a warning (since should never happen) but take care to log only _once_
+                // per missing member and system contract method.  (So logs don't get spammed over and over.)
             }
         }
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import static com.hedera.hapi.streams.ContractActionType.SYSTEM;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INSUFFICIENT_CHILD_RECORDS;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_SIGNATURE;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateTranslator.createSelectorsMap;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateTranslator.createMethodsMap;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.acquiredSenderAuthorizationViaDelegateCall;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.alreadyHalted;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.isTopLevelTransaction;
@@ -195,7 +195,7 @@ public class CustomMessageCallProcessor extends MessageCallProcessor {
             return false;
         }
         var selector = frame.getInputData().slice(0, 4).toArray();
-        return createSelectorsMap.keySet().stream().anyMatch(s -> Arrays.equals(s.selector(), selector));
+        return createMethodsMap.keySet().stream().anyMatch(s -> Arrays.equals(s.selector(), selector));
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HasSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HasSystemContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.as
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractNativeSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
@@ -42,8 +43,11 @@ public class HasSystemContract extends AbstractNativeSystemContract implements H
     public static final ContractID HAS_CONTRACT_ID = asNumberedContractId(Address.fromHexString(HAS_EVM_ADDRESS));
 
     @Inject
-    public HasSystemContract(@NonNull final GasCalculator gasCalculator, @NonNull final HasCallFactory callFactory) {
-        super(HAS_SYSTEM_CONTRACT_NAME, callFactory, HAS_CONTRACT_ID, gasCalculator);
+    public HasSystemContract(
+            @NonNull final GasCalculator gasCalculator,
+            @NonNull final HasCallFactory callFactory,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(HAS_SYSTEM_CONTRACT_NAME, callFactory, HAS_CONTRACT_ID, gasCalculator, contractMetrics);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HssSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HssSystemContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.as
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractNativeSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
@@ -45,8 +46,11 @@ public class HssSystemContract extends AbstractNativeSystemContract implements H
     public static final ContractID HSS_CONTRACT_ID = asNumberedContractId(Address.fromHexString(HSS_EVM_ADDRESS));
 
     @Inject
-    public HssSystemContract(@NonNull final GasCalculator gasCalculator, @NonNull final HssCallFactory callFactory) {
-        super(HSS_SYSTEM_CONTRACT_NAME, callFactory, HSS_CONTRACT_ID, gasCalculator);
+    public HssSystemContract(
+            @NonNull final GasCalculator gasCalculator,
+            @NonNull final HssCallFactory callFactory,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(HSS_SYSTEM_CONTRACT_NAME, callFactory, HSS_CONTRACT_ID, gasCalculator, contractMetrics);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/HtsSystemContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asNumberedContractId;
 
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractNativeSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
@@ -37,8 +38,11 @@ public class HtsSystemContract extends AbstractNativeSystemContract implements H
     public static final ContractID HTS_CONTRACT_ID = asNumberedContractId(Address.fromHexString(HTS_EVM_ADDRESS));
 
     @Inject
-    public HtsSystemContract(@NonNull final GasCalculator gasCalculator, @NonNull final HtsCallFactory callFactory) {
-        super(HTS_SYSTEM_CONTRACT_NAME, callFactory, HTS_CONTRACT_ID, gasCalculator);
+    public HtsSystemContract(
+            @NonNull final GasCalculator gasCalculator,
+            @NonNull final HtsCallFactory callFactory,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(HTS_SYSTEM_CONTRACT_NAME, callFactory, HTS_CONTRACT_ID, gasCalculator, contractMetrics);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalcu
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.SystemContractOperations;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -43,6 +44,7 @@ public abstract class AbstractCall implements Call {
     protected final SystemContractGasCalculator gasCalculator;
     protected final HederaWorldUpdater.Enhancement enhancement;
     private final boolean isViewCall;
+    private SystemContractMethod systemContractMethod;
 
     protected AbstractCall(
             @NonNull final SystemContractGasCalculator gasCalculator,
@@ -51,6 +53,14 @@ public abstract class AbstractCall implements Call {
         this.gasCalculator = requireNonNull(gasCalculator);
         this.enhancement = requireNonNull(enhancement);
         this.isViewCall = isViewCall;
+    }
+
+    public void setSystemContractMethod(@NonNull final SystemContractMethod systemContractMethod) {
+        this.systemContractMethod = systemContractMethod;
+    }
+
+    public SystemContractMethod getSystemContractMethod() {
+        return systemContractMethod;
     }
 
     protected HederaOperations operations() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCallAttempt.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCallAttempt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,9 @@ import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperatio
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.SystemContract;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -33,6 +36,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.BufferUnderflowException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 
@@ -54,6 +58,7 @@ public abstract class AbstractCallAttempt<T extends AbstractCallAttempt<T>> {
     private final VerificationStrategies verificationStrategies;
     private final SystemContractGasCalculator gasCalculator;
     private final List<CallTranslator<T>> callTranslators;
+    private final SystemContractMethodRegistry systemContractMethodRegistry;
     private final boolean isStaticCall;
 
     // If non-null, the address of a non-contract entity (e.g., account or token) whose
@@ -89,6 +94,7 @@ public abstract class AbstractCallAttempt<T extends AbstractCallAttempt<T>> {
             @NonNull final SystemContractGasCalculator gasCalculator,
             @NonNull final List<CallTranslator<T>> callTranslators,
             final boolean isStaticCall,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
             @NonNull final com.esaulpaugh.headlong.abi.Function redirectFunction) {
         requireNonNull(input);
         requireNonNull(redirectFunction);
@@ -101,6 +107,7 @@ public abstract class AbstractCallAttempt<T extends AbstractCallAttempt<T>> {
         this.enhancement = requireNonNull(enhancement);
         this.verificationStrategies = requireNonNull(verificationStrategies);
         this.onlyDelegatableContractKeysActive = onlyDelegatableContractKeysActive;
+        this.systemContractMethodRegistry = requireNonNull(systemContractMethodRegistry);
 
         if (isRedirectSelector(redirectFunction.selector(), input.toArrayUnsafe())) {
             Tuple abiCall = null;
@@ -126,6 +133,8 @@ public abstract class AbstractCallAttempt<T extends AbstractCallAttempt<T>> {
         this.senderId = addressIdConverter.convertSender(senderAddress);
         this.isStaticCall = isStaticCall;
     }
+
+    protected abstract SystemContract systemContractKind();
 
     protected abstract T self();
 
@@ -279,12 +288,41 @@ public abstract class AbstractCallAttempt<T extends AbstractCallAttempt<T>> {
 
     /**
      * Returns whether this call attempt is a selector for any of the given functions.
+     * @param methods selectors to match against
+     * @return boolean result
+     */
+    public boolean isSelector(@NonNull final SystemContractMethod... methods) {
+        return isMethod(methods).isPresent();
+    }
+
+    public @NonNull Optional<SystemContractMethod> isMethod(@NonNull final SystemContractMethod... methods) {
+        for (final var method : methods) {
+            if (Arrays.equals(method.selector(), this.selector())) {
+                return Optional.of(method);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Returns whether this call attempt is a selector for any of the given functions.
      * @param configEnabled whether the config is enabled
      * @param functions selectors to match against
      * @return boolean result
      */
     public boolean isSelectorIfConfigEnabled(final boolean configEnabled, @NonNull final Function... functions) {
         return configEnabled && isSelector(functions);
+    }
+
+    /**
+     * Returns whether this call attempt is a selector for any of the given functions.
+     * @param configEnabled whether the config is enabled
+     * @param methods selectors to match against
+     * @return boolean result
+     */
+    public boolean isSelectorIfConfigEnabled(
+            final boolean configEnabled, @NonNull final SystemContractMethod... methods) {
+        return configEnabled && isSelector(methods);
     }
 
     /**
@@ -304,5 +342,9 @@ public abstract class AbstractCallAttempt<T extends AbstractCallAttempt<T>> {
      */
     public boolean isOnlyDelegatableContractKeysActive() {
         return onlyDelegatableContractKeysActive;
+    }
+
+    public SystemContractMethodRegistry getSystemContractMethodRegistry() {
+        return systemContractMethodRegistry;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCallAttempt.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCallAttempt.java
@@ -307,16 +307,6 @@ public abstract class AbstractCallAttempt<T extends AbstractCallAttempt<T>> {
     /**
      * Returns whether this call attempt is a selector for any of the given functions.
      * @param configEnabled whether the config is enabled
-     * @param functions selectors to match against
-     * @return boolean result
-     */
-    public boolean isSelectorIfConfigEnabled(final boolean configEnabled, @NonNull final Function... functions) {
-        return configEnabled && isSelector(functions);
-    }
-
-    /**
-     * Returns whether this call attempt is a selector for any of the given functions.
-     * @param configEnabled whether the config is enabled
      * @param methods selectors to match against
      * @return boolean result
      */

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCallTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCallTranslator.java
@@ -25,8 +25,6 @@ import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod
 import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * Basic implementation support for a {@link CallTranslator} that returns a translated
@@ -34,8 +32,6 @@ import org.apache.logging.log4j.Logger;
  * @param <T> the type of the abstract call translator
  */
 public abstract class AbstractCallTranslator<T extends AbstractCallAttempt<T>> implements CallTranslator<T> {
-
-    private static final Logger log = LogManager.getLogger(AbstractCallTranslator.class);
 
     private final SystemContract systemContractKind;
     private final SystemContractMethodRegistry systemContractMethodRegistry;

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCallTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/AbstractCallTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,15 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.common;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.SystemContract;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Basic implementation support for a {@link CallTranslator} that returns a translated
@@ -27,15 +34,63 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * @param <T> the type of the abstract call translator
  */
 public abstract class AbstractCallTranslator<T extends AbstractCallAttempt<T>> implements CallTranslator<T> {
+
+    private static final Logger log = LogManager.getLogger(AbstractCallTranslator.class);
+
+    private final SystemContract systemContractKind;
+    private final SystemContractMethodRegistry systemContractMethodRegistry;
+    private final ContractMetrics contractMetrics;
+
+    public AbstractCallTranslator(
+            @NonNull final SystemContract systemContractKind,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        this.systemContractKind = requireNonNull(systemContractKind);
+        this.systemContractMethodRegistry = requireNonNull(systemContractMethodRegistry);
+        this.contractMetrics = requireNonNull(contractMetrics);
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public @Nullable Call translateCallAttempt(@NonNull final T attempt) {
         requireNonNull(attempt);
-        if (matches(attempt)) {
-            return callFrom(attempt);
+        final var call = identifyMethod(attempt)
+                .map(systemContractMethodRegistry::fromMissingContractGetWithContract)
+                .map(systemContractMethod -> callFrom(attempt, systemContractMethod))
+                .orElse(null);
+        if (call != null) {
+            if (call.getSystemContractMethod() == null) {
+                contractMetrics.logWarnMissingSystemContractMethodOnCall(
+                        identifyMethod(attempt).orElseThrow());
+            }
         }
-        return null;
+        return call;
+    }
+
+    public void registerMethods(@NonNull final SystemContractMethod... methods) {
+        requireNonNull(methods);
+        for (@NonNull final var method : methods) {
+            requireNonNull(method);
+            registerMethod(method, method.withContract(systemContractKind));
+        }
+    }
+
+    private void registerMethod(
+            @NonNull final SystemContractMethod methodWithoutContract,
+            @NonNull final SystemContractMethod methodWithContract) {
+        requireNonNull(methodWithoutContract);
+        requireNonNull(methodWithContract);
+        methodWithContract.verifyComplete();
+
+        if (systemContractMethodRegistry != null) {
+            systemContractMethodRegistry.register(methodWithoutContract, methodWithContract);
+        }
+    }
+
+    @VisibleForTesting
+    public @NonNull String kind() {
+        return systemContractKind != null ? systemContractKind.name() : "<UNKNOWN-CONTRACT>";
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/Call.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/Call.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.hapi.node.scheduled.SchedulableTransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
 import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -37,7 +38,7 @@ import org.hyperledger.besu.evm.precompile.PrecompiledContract.PrecompileContrac
  */
 public interface Call {
     /**
-     * Encapsulates the result of a call to the HTS system contract. There are two elements,
+     * Encapsulates the result of a call to the HAS/HSS/HTS system contract. There are two elements,
      * <ol>
      *     <li>The "full result" of the call, including both its EVM-standard {@link PrecompileContractResult}
      *     and gas requirement (which is often difficult to compute without executing the call); as well as
@@ -161,4 +162,8 @@ public interface Call {
     default SchedulableTransactionBody asSchedulableDispatchIn() {
         throw new UnsupportedOperationException("Needs scheduleNative() support");
     }
+
+    void setSystemContractMethod(@NonNull final SystemContractMethod systemContractMethod);
+
+    SystemContractMethod getSystemContractMethod();
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/CallTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/CallTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.common;
 
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Optional;
 
 /**
  * Strategy interface for translating {@link HtsCallAttempt}s into {@link Call}s.
@@ -36,12 +38,11 @@ public interface CallTranslator<T> {
     Call translateCallAttempt(@NonNull T attempt);
 
     /**
-     * Returns true if the attempt matches the selector of the call this translator is responsible for.
-     *
-     * @param attempt the selector to match
-     * @return true if the selector matches the selector of the call this translator is responsible for
+     * Returns the SystemContractMethod for this attempt's selector, if the selector is known.
+     * @param attempt the selector to match (in the Attempt)
+     * @return the SystemContractMethod for the attempt (or it can be empty if unknown)
      */
-    boolean matches(@NonNull T attempt);
+    abstract @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final T attempt);
 
     /**
      * Returns a call from the given attempt.
@@ -50,4 +51,16 @@ public interface CallTranslator<T> {
      * @return a call from the given attempt
      */
     Call callFrom(@NonNull T attempt);
+
+    /** Returns a call from the given attempt
+     *
+     * @param attempt the attempt to get the call from
+     * @param systemContractMethod system contract method the attempt is calling
+     * @return a call from the given attempt        hascall
+     */
+    default Call callFrom(@NonNull final T attempt, @NonNull final SystemContractMethod systemContractMethod) {
+        final var call = callFrom(attempt);
+        call.setSystemContractMethod(systemContractMethod);
+        return call;
+    }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/CallTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/CallTranslator.java
@@ -56,7 +56,7 @@ public interface CallTranslator<T> {
      *
      * @param attempt the attempt to get the call from
      * @param systemContractMethod system contract method the attempt is calling
-     * @return a call from the given attempt        hascall
+     * @return a call from the given attempt
      */
     default Call callFrom(@NonNull final T attempt, @NonNull final SystemContractMethod systemContractMethod) {
         final var call = callFrom(attempt);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/HasCallAttempt.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/HasCallAttempt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,9 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Abs
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.SystemContract;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.swirlds.config.api.Configuration;
@@ -68,6 +71,7 @@ public class HasCallAttempt extends AbstractCallAttempt<HasCallAttempt> {
             @NonNull final SignatureVerifier signatureVerifier,
             @NonNull final SystemContractGasCalculator gasCalculator,
             @NonNull final List<CallTranslator<HasCallAttempt>> callTranslators,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
             final boolean isStaticCall) {
         super(
                 input,
@@ -81,6 +85,7 @@ public class HasCallAttempt extends AbstractCallAttempt<HasCallAttempt> {
                 gasCalculator,
                 callTranslators,
                 isStaticCall,
+                systemContractMethodRegistry,
                 REDIRECT_FOR_ACCOUNT);
         if (isRedirect()) {
             this.redirectAccount = linkedAccount(requireNonNull(redirectAddress));
@@ -88,6 +93,11 @@ public class HasCallAttempt extends AbstractCallAttempt<HasCallAttempt> {
             this.redirectAccount = null;
         }
         this.signatureVerifier = requireNonNull(signatureVerifier);
+    }
+
+    @Override
+    protected SystemContract systemContractKind() {
+        return SystemContractMethod.SystemContract.HAS;
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/HasCallFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/HasCallFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Cal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.SyntheticIds;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
@@ -46,6 +47,7 @@ public class HasCallFactory implements CallFactory<HasCallAttempt> {
     private final VerificationStrategies verificationStrategies;
     private final SignatureVerifier signatureVerifier;
     private final List<CallTranslator<HasCallAttempt>> callTranslators;
+    private final SystemContractMethodRegistry systemContractMethodRegistry;
 
     @Inject
     public HasCallFactory(
@@ -53,12 +55,14 @@ public class HasCallFactory implements CallFactory<HasCallAttempt> {
             @NonNull final CallAddressChecks addressChecks,
             @NonNull final VerificationStrategies verificationStrategies,
             @NonNull final SignatureVerifier signatureVerifier,
-            @NonNull @Named("HasTranslators") final List<CallTranslator<HasCallAttempt>> callTranslators) {
+            @NonNull @Named("HasTranslators") final List<CallTranslator<HasCallAttempt>> callTranslators,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry) {
         this.syntheticIds = requireNonNull(syntheticIds);
         this.addressChecks = requireNonNull(addressChecks);
         this.verificationStrategies = requireNonNull(verificationStrategies);
         this.signatureVerifier = requireNonNull(signatureVerifier);
         this.callTranslators = requireNonNull(callTranslators);
+        this.systemContractMethodRegistry = requireNonNull(systemContractMethodRegistry);
     }
 
     /**
@@ -88,6 +92,7 @@ public class HasCallFactory implements CallFactory<HasCallAttempt> {
                 signatureVerifier,
                 systemContractGasCalculatorOf(frame),
                 callTranslators,
+                systemContractMethodRegistry,
                 frame.isStatic());
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/hederaaccountnumalias/HederaAccountNumAliasTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/hederaaccountnumalias/HederaAccountNumAliasTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,25 +19,39 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.heder
 import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class HederaAccountNumAliasTranslator extends AbstractCallTranslator<HasCallAttempt> {
 
     /** Selector for getHederaAccountNumAlias(address) method. */
-    public static final Function HEDERA_ACCOUNT_NUM_ALIAS =
-            new Function("getHederaAccountNumAlias(address)", ReturnTypes.RESPONSE_CODE_ADDRESS);
+    public static final SystemContractMethod HEDERA_ACCOUNT_NUM_ALIAS = SystemContractMethod.declare(
+                    "getHederaAccountNumAlias(address)", ReturnTypes.RESPONSE_CODE_ADDRESS)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.ALIASES);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public HederaAccountNumAliasTranslator() {
+    public HederaAccountNumAliasTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger
+        super(SystemContractMethod.SystemContract.HAS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(HEDERA_ACCOUNT_NUM_ALIAS);
     }
 
     /**
@@ -52,8 +66,9 @@ public class HederaAccountNumAliasTranslator extends AbstractCallTranslator<HasC
     }
 
     @Override
-    public boolean matches(@NonNull HasCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HasCallAttempt attempt) {
         requireNonNull(attempt, "attempt");
-        return attempt.isSelector(HEDERA_ACCOUNT_NUM_ALIAS);
+
+        return attempt.isMethod(HEDERA_ACCOUNT_NUM_ALIAS);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorized/IsAuthorizedTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorized/IsAuthorizedTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,24 +19,29 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isaut
 import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.node.app.service.contract.impl.annotations.ServicesV051;
 import com.hedera.node.app.service.contract.impl.exec.FeatureFlags;
 import com.hedera.node.app.service.contract.impl.exec.gas.CustomGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
 public class IsAuthorizedTranslator extends AbstractCallTranslator<HasCallAttempt> {
 
-    public static final Function IS_AUTHORIZED =
-            new Function("isAuthorized(address,bytes,bytes)", ReturnTypes.RESPONSE_CODE64_BOOL);
+    public static final SystemContractMethod IS_AUTHORIZED = SystemContractMethod.declare(
+                    "isAuthorized(address,bytes,bytes)", ReturnTypes.RESPONSE_CODE64_BOOL)
+            .withCategories(Category.IS_AUTHORIZED);
     private static final int ADDRESS_ARG = 0;
     private static final int MESSAGE_ARG = 1;
     private static final int SIGNATURE_BLOB_ARG = 2;
@@ -46,19 +51,26 @@ public class IsAuthorizedTranslator extends AbstractCallTranslator<HasCallAttemp
     @Inject
     public IsAuthorizedTranslator(
             @ServicesV051 @NonNull final FeatureFlags featureFlags,
-            @NonNull final CustomGasCalculator customGasCalculator) {
+            @NonNull final CustomGasCalculator customGasCalculator,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HAS, systemContractMethodRegistry, contractMetrics);
         requireNonNull(featureFlags, "featureFlags");
         this.customGasCalculator = requireNonNull(customGasCalculator);
+
+        registerMethods(IS_AUTHORIZED);
     }
 
     @Override
-    public boolean matches(@NonNull HasCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull HasCallAttempt attempt) {
         requireNonNull(attempt, "attempt");
 
-        final boolean callEnabled = attempt.configuration()
+        final var callEnabled = attempt.configuration()
                 .getConfigData(ContractsConfig.class)
                 .systemContractAccountServiceIsAuthorizedEnabled();
-        return callEnabled && attempt.isSelector(IS_AUTHORIZED);
+
+        if (attempt.isSelectorIfConfigEnabled(callEnabled, IS_AUTHORIZED)) return Optional.of(IS_AUTHORIZED);
+        return Optional.empty();
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isvalidalias/IsValidAliasTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isvalidalias/IsValidAliasTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,25 +19,40 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isval
 import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class IsValidAliasTranslator extends AbstractCallTranslator<HasCallAttempt> {
 
     /** Selector for isValidAlias(address) method. */
-    public static final Function IS_VALID_ALIAS = new Function("isValidAlias(address)", ReturnTypes.BOOL);
+    public static final SystemContractMethod IS_VALID_ALIAS = SystemContractMethod.declare(
+                    "isValidAlias(address)", ReturnTypes.BOOL)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.ALIASES);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public IsValidAliasTranslator() {
+    public IsValidAliasTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger
+        super(SystemContractMethod.SystemContract.HAS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(IS_VALID_ALIAS);
     }
 
     @Override
@@ -48,8 +63,9 @@ public class IsValidAliasTranslator extends AbstractCallTranslator<HasCallAttemp
     }
 
     @Override
-    public boolean matches(@NonNull HasCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HasCallAttempt attempt) {
         requireNonNull(attempt, "attempt");
-        return attempt.isSelector(IS_VALID_ALIAS);
+
+        return attempt.isMethod(IS_VALID_ALIAS);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/setunlimitedautoassociations/SetUnlimitedAutoAssociationsTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/setunlimitedautoassociations/SetUnlimitedAutoAssociationsTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,38 +18,51 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.setun
 
 import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.token.CryptoUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
 public class SetUnlimitedAutoAssociationsTranslator extends AbstractCallTranslator<HasCallAttempt> {
 
-    public static final Function SET_UNLIMITED_AUTO_ASSOC =
-            new Function("setUnlimitedAutomaticAssociations(bool)", ReturnTypes.INT_64);
+    public static final SystemContractMethod SET_UNLIMITED_AUTO_ASSOC = SystemContractMethod.declare(
+                    "setUnlimitedAutomaticAssociations(bool)", ReturnTypes.INT_64)
+            .withCategories(Category.ASSOCIATION);
 
     private static final int UNLIMITED_AUTO_ASSOCIATIONS = -1;
     private static final int NO_AUTO_ASSOCIATIONS = 0;
 
     @Inject
-    public SetUnlimitedAutoAssociationsTranslator() {
+    public SetUnlimitedAutoAssociationsTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HAS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(SET_UNLIMITED_AUTO_ASSOC);
     }
 
     @Override
-    public boolean matches(@NonNull final HasCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HasCallAttempt attempt) {
         final var setUnlimitedAutoAssocEnabled = attempt.configuration()
                 .getConfigData(ContractsConfig.class)
                 .systemContractSetUnlimitedAutoAssociationsEnabled();
-        return attempt.isSelectorIfConfigEnabled(setUnlimitedAutoAssocEnabled, SET_UNLIMITED_AUTO_ASSOC);
+
+        if (attempt.isSelectorIfConfigEnabled(setUnlimitedAutoAssocEnabled, SET_UNLIMITED_AUTO_ASSOC))
+            return Optional.of(SET_UNLIMITED_AUTO_ASSOC);
+        return Optional.empty();
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/HssCallAttempt.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/HssCallAttempt.java
@@ -34,6 +34,9 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Abs
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.SystemContract;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.swirlds.config.api.Configuration;
@@ -72,6 +75,7 @@ public class HssCallAttempt extends AbstractCallAttempt<HssCallAttempt> {
             @NonNull final SignatureVerifier signatureVerifier,
             @NonNull final SystemContractGasCalculator gasCalculator,
             @NonNull final List<CallTranslator<HssCallAttempt>> callTranslators,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
             final boolean isStaticCall) {
         super(
                 input,
@@ -85,6 +89,7 @@ public class HssCallAttempt extends AbstractCallAttempt<HssCallAttempt> {
                 gasCalculator,
                 callTranslators,
                 isStaticCall,
+                systemContractMethodRegistry,
                 REDIRECT_FOR_SCHEDULE_TXN);
         if (isRedirect()) {
             this.redirectScheduleTxn = linkedSchedule(requireNonNull(redirectAddress));
@@ -92,6 +97,11 @@ public class HssCallAttempt extends AbstractCallAttempt<HssCallAttempt> {
             this.redirectScheduleTxn = null;
         }
         this.signatureVerifier = signatureVerifier;
+    }
+
+    @Override
+    protected SystemContract systemContractKind() {
+        return SystemContractMethod.SystemContract.HSS;
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/HssCallFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/HssCallFactory.java
@@ -27,6 +27,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Cal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.SyntheticIds;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
@@ -44,8 +45,9 @@ public class HssCallFactory implements CallFactory<HssCallAttempt> {
     private final SyntheticIds syntheticIds;
     private final CallAddressChecks addressChecks;
     private final VerificationStrategies verificationStrategies;
-    private final List<CallTranslator<HssCallAttempt>> callTranslators;
     private final SignatureVerifier signatureVerifier;
+    private final List<CallTranslator<HssCallAttempt>> callTranslators;
+    private final SystemContractMethodRegistry systemContractMethodRegistry;
 
     @Inject
     public HssCallFactory(
@@ -53,12 +55,14 @@ public class HssCallFactory implements CallFactory<HssCallAttempt> {
             @NonNull final CallAddressChecks addressChecks,
             @NonNull final VerificationStrategies verificationStrategies,
             @NonNull final SignatureVerifier signatureVerifier,
-            @NonNull @Named("HssTranslators") final List<CallTranslator<HssCallAttempt>> callTranslators) {
+            @NonNull @Named("HssTranslators") final List<CallTranslator<HssCallAttempt>> callTranslators,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry) {
         this.syntheticIds = requireNonNull(syntheticIds);
         this.addressChecks = requireNonNull(addressChecks);
         this.verificationStrategies = requireNonNull(verificationStrategies);
         this.signatureVerifier = requireNonNull(signatureVerifier);
         this.callTranslators = requireNonNull(callTranslators);
+        this.systemContractMethodRegistry = requireNonNull(systemContractMethodRegistry);
     }
 
     /**
@@ -88,6 +92,7 @@ public class HssCallFactory implements CallFactory<HssCallAttempt> {
                 signatureVerifier,
                 systemContractGasCalculatorOf(frame),
                 callTranslators,
+                systemContractMethodRegistry,
                 frame.isStatic());
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/getscheduledinfo/GetScheduledInfoTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/getscheduledinfo/GetScheduledInfoTranslator.java
@@ -17,36 +17,56 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.getscheduledinfo;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.addressToScheduleID;
+import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.SystemContract;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 @Singleton
 public class GetScheduledInfoTranslator extends AbstractCallTranslator<HssCallAttempt> {
-    public static final Function GET_SCHEDULED_CREATE_FUNGIBLE_TOKEN_INFO =
-            new Function("getScheduledCreateFungibleTokenInfo(address)", ReturnTypes.RESPONSE_CODE_FUNGIBLE_TOKEN_INFO);
-    public static final Function GET_SCHEDULED_CREATE_NON_FUNGIBLE_TOKEN_INFO = new Function(
-            "getScheduledCreateNonFungibleTokenInfo(address)", ReturnTypes.RESPONSE_CODE_NON_FUNGIBLE_TOKEN_INFO);
+
+    public static final SystemContractMethod GET_SCHEDULED_CREATE_FUNGIBLE_TOKEN_INFO = SystemContractMethod.declare(
+                    "getScheduledCreateFungibleTokenInfo(address)", ReturnTypes.RESPONSE_CODE_FUNGIBLE_TOKEN_INFO)
+            .withCategories(Category.SCHEDULE)
+            .withVariant(Variant.FT);
+    public static final SystemContractMethod GET_SCHEDULED_CREATE_NON_FUNGIBLE_TOKEN_INFO =
+            SystemContractMethod.declare(
+                            "getScheduledCreateNonFungibleTokenInfo(address)",
+                            ReturnTypes.RESPONSE_CODE_NON_FUNGIBLE_TOKEN_INFO)
+                    .withCategories(Category.SCHEDULE)
+                    .withVariant(Variant.NFT);
 
     // Tuple index for the schedule address
     private static final int SCHEDULE_ADDRESS = 0;
 
     @Inject
-    public GetScheduledInfoTranslator() {
+    public GetScheduledInfoTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger
+        super(SystemContract.HSS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(GET_SCHEDULED_CREATE_FUNGIBLE_TOKEN_INFO, GET_SCHEDULED_CREATE_NON_FUNGIBLE_TOKEN_INFO);
     }
 
     @Override
-    public boolean matches(@NonNull final HssCallAttempt attempt) {
-        return attempt.isSelector(
-                GET_SCHEDULED_CREATE_FUNGIBLE_TOKEN_INFO, GET_SCHEDULED_CREATE_NON_FUNGIBLE_TOKEN_INFO);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HssCallAttempt attempt) {
+        requireNonNull(attempt);
+
+        return attempt.isMethod(GET_SCHEDULED_CREATE_FUNGIBLE_TOKEN_INFO, GET_SCHEDULED_CREATE_NON_FUNGIBLE_TOKEN_INFO);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/schedulenative/ScheduleNativeTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/schedulenative/ScheduleNativeTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,28 +17,31 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.schedulenative;
 
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsSystemContract.HTS_EVM_ADDRESS;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateTranslator.createSelectorsMap;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateTranslator.updateSelectorsMap;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateTranslator.createMethodsMap;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateTranslator.updateMethodsMap;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 import static org.hyperledger.besu.datatypes.Address.fromHexString;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.tuweni.bytes.Bytes;
@@ -46,8 +49,8 @@ import org.apache.tuweni.bytes.Bytes;
 @Singleton
 public class ScheduleNativeTranslator extends AbstractCallTranslator<HssCallAttempt> {
 
-    public static final Function SCHEDULED_NATIVE_CALL =
-            new Function("scheduleNative(address,bytes,address)", ReturnTypes.RESPONSE_CODE_ADDRESS);
+    public static final SystemContractMethod SCHEDULED_NATIVE_CALL =
+            SystemContractMethod.declare("scheduleNative(address,bytes,address)", ReturnTypes.RESPONSE_CODE_ADDRESS);
     private static final int SCHEDULE_CONTRACT_ADDRESS = 0;
     private static final int SCHEDULE_CALL_DATA = 1;
     private static final int SCHEDULE_PAYER = 2;
@@ -55,17 +58,27 @@ public class ScheduleNativeTranslator extends AbstractCallTranslator<HssCallAtte
     private final HtsCallFactory htsCallFactory;
 
     @Inject
-    public ScheduleNativeTranslator(@NonNull final HtsCallFactory htsCallFactory) {
+    public ScheduleNativeTranslator(
+            @NonNull final HtsCallFactory htsCallFactory,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        // Dagger
+        super(SystemContractMethod.SystemContract.HAS, systemContractMethodRegistry, contractMetrics);
+        registerMethods(SCHEDULED_NATIVE_CALL);
+
         requireNonNull(htsCallFactory);
         this.htsCallFactory = htsCallFactory;
     }
 
     @Override
-    public boolean matches(@NonNull final HssCallAttempt attempt) {
+    @NonNull
+    public Optional<SystemContractMethod> identifyMethod(@NonNull final HssCallAttempt attempt) {
         final var scheduleNativeEnabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractScheduleNativeEnabled();
-        return attempt.isSelectorIfConfigEnabled(scheduleNativeEnabled, SCHEDULED_NATIVE_CALL)
-                && innerCallValidation(attempt);
+
+        if (!attempt.isSelectorIfConfigEnabled(scheduleNativeEnabled, SCHEDULED_NATIVE_CALL)) return Optional.empty();
+        if (!innerCallValidation(attempt)) return Optional.empty();
+        return Optional.of(SCHEDULED_NATIVE_CALL);
     }
 
     @Override
@@ -116,9 +129,9 @@ public class ScheduleNativeTranslator extends AbstractCallTranslator<HssCallAtte
         final var innerCallSelector =
                 Bytes.wrap((byte[]) call.get(SCHEDULE_CALL_DATA)).slice(0, 4).toArray();
         final var canBeCreateToken =
-                createSelectorsMap.keySet().stream().anyMatch(s -> Arrays.equals(s.selector(), innerCallSelector));
+                createMethodsMap.keySet().stream().anyMatch(s -> Arrays.equals(s.selector(), innerCallSelector));
         final var canBeUpdateToken =
-                updateSelectorsMap.keySet().stream().anyMatch(s -> Arrays.equals(s.selector(), innerCallSelector));
+                updateMethodsMap.keySet().stream().anyMatch(s -> Arrays.equals(s.selector(), innerCallSelector));
 
         return canBeCreateToken || canBeUpdateToken;
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/schedulenative/ScheduleNativeTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/schedulenative/ScheduleNativeTranslator.java
@@ -36,6 +36,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
 import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
 import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
@@ -49,8 +50,9 @@ import org.apache.tuweni.bytes.Bytes;
 @Singleton
 public class ScheduleNativeTranslator extends AbstractCallTranslator<HssCallAttempt> {
 
-    public static final SystemContractMethod SCHEDULED_NATIVE_CALL =
-            SystemContractMethod.declare("scheduleNative(address,bytes,address)", ReturnTypes.RESPONSE_CODE_ADDRESS);
+    public static final SystemContractMethod SCHEDULED_NATIVE_CALL = SystemContractMethod.declare(
+                    "scheduleNative(address,bytes,address)", ReturnTypes.RESPONSE_CODE_ADDRESS)
+            .withCategories(Category.SCHEDULE);
     private static final int SCHEDULE_CONTRACT_ADDRESS = 0;
     private static final int SCHEDULE_CALL_DATA = 1;
     private static final int SCHEDULE_PAYER = 2;

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/signschedule/SignScheduleTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/signschedule/SignScheduleTranslator.java
@@ -27,7 +27,6 @@ import static com.hedera.pbj.runtime.io.buffer.Bytes.wrap;
 import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.node.base.AccountID;
@@ -38,11 +37,16 @@ import com.hedera.hapi.node.scheduled.ScheduleSignTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.DispatchForResponseCodeHssCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier.MessageType;
 import com.hedera.node.app.spi.signatures.SignatureVerifier.SimpleKeyStatus;
@@ -53,6 +57,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -62,19 +67,34 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class SignScheduleTranslator extends AbstractCallTranslator<HssCallAttempt> {
-    public static final Function SIGN_SCHEDULE = new Function("signSchedule(address,bytes)", ReturnTypes.INT_64);
-    public static final Function SIGN_SCHEDULE_PROXY = new Function("signSchedule()", ReturnTypes.INT_64);
-    public static final Function AUTHORIZE_SCHEDULE = new Function("authorizeSchedule(address)", ReturnTypes.INT_64);
+
+    public static final SystemContractMethod SIGN_SCHEDULE = SystemContractMethod.declare(
+                    "signSchedule(address,bytes)", ReturnTypes.INT_64)
+            .withCategories(Category.SCHEDULE);
     private static final int SCHEDULE_ID_INDEX = 0;
     private static final int SIGNATURE_MAP_INDEX = 1;
 
+    public static final SystemContractMethod SIGN_SCHEDULE_PROXY = SystemContractMethod.declare(
+                    "signSchedule()", ReturnTypes.INT_64)
+            .withVia(CallVia.PROXY)
+            .withCategories(Category.SCHEDULE);
+
+    public static final SystemContractMethod AUTHORIZE_SCHEDULE = SystemContractMethod.declare(
+                    "authorizeSchedule(address)", ReturnTypes.INT_64)
+            .withCategories(Category.SCHEDULE);
+
     @Inject
-    public SignScheduleTranslator() {
+    public SignScheduleTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HSS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(SIGN_SCHEDULE, AUTHORIZE_SCHEDULE, SIGN_SCHEDULE_PROXY);
     }
 
     @Override
-    public boolean matches(@NonNull final HssCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HssCallAttempt attempt) {
         requireNonNull(attempt);
         final var signScheduleEnabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractSignScheduleEnabled();
@@ -83,9 +103,14 @@ public class SignScheduleTranslator extends AbstractCallTranslator<HssCallAttemp
                 .systemContractSignScheduleFromContractEnabled();
         final var authorizeScheduleEnabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractAuthorizeScheduleEnabled();
-        return attempt.isSelectorIfConfigEnabled(signScheduleEnabled, SIGN_SCHEDULE_PROXY)
-                || attempt.isSelectorIfConfigEnabled(signScheduleFromContractEnabled, SIGN_SCHEDULE)
-                || attempt.isSelectorIfConfigEnabled(authorizeScheduleEnabled, AUTHORIZE_SCHEDULE);
+
+        if (attempt.isSelectorIfConfigEnabled(signScheduleEnabled, SIGN_SCHEDULE_PROXY))
+            return Optional.of(SIGN_SCHEDULE_PROXY);
+        if (attempt.isSelectorIfConfigEnabled(authorizeScheduleEnabled, AUTHORIZE_SCHEDULE))
+            return Optional.of(AUTHORIZE_SCHEDULE);
+        if (attempt.isSelectorIfConfigEnabled(signScheduleFromContractEnabled, SIGN_SCHEDULE))
+            return Optional.of(SIGN_SCHEDULE);
+        return Optional.empty();
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallAttempt.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallAttempt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,9 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsSystemC
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.SystemContract;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -73,6 +76,7 @@ public class HtsCallAttempt extends AbstractCallAttempt<HtsCallAttempt> {
             @NonNull final VerificationStrategies verificationStrategies,
             @NonNull final SystemContractGasCalculator gasCalculator,
             @NonNull final List<CallTranslator<HtsCallAttempt>> callTranslators,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
             final boolean isStaticCall) {
         super(
                 input,
@@ -86,6 +90,7 @@ public class HtsCallAttempt extends AbstractCallAttempt<HtsCallAttempt> {
                 gasCalculator,
                 callTranslators,
                 isStaticCall,
+                systemContractMethodRegistry,
                 REDIRECT_FOR_TOKEN);
         if (isRedirect()) {
             this.redirectToken = linkedToken(redirectAddress);
@@ -94,6 +99,11 @@ public class HtsCallAttempt extends AbstractCallAttempt<HtsCallAttempt> {
         }
         this.authorizingId =
                 (authorizingAddress != senderAddress) ? addressIdConverter.convertSender(authorizingAddress) : senderId;
+    }
+
+    @Override
+    protected SystemContract systemContractKind() {
+        return SystemContractMethod.SystemContract.HTS;
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/HtsCallFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Cal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallFactory;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.CallType;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import javax.inject.Inject;
@@ -44,17 +45,20 @@ public class HtsCallFactory implements CallFactory<HtsCallAttempt> {
     private final CallAddressChecks addressChecks;
     private final VerificationStrategies verificationStrategies;
     private final List<CallTranslator<HtsCallAttempt>> callTranslators;
+    private final SystemContractMethodRegistry systemContractMethodRegistry;
 
     @Inject
     public HtsCallFactory(
             @NonNull final SyntheticIds syntheticIds,
             @NonNull final CallAddressChecks addressChecks,
             @NonNull final VerificationStrategies verificationStrategies,
-            @NonNull @Named("HtsTranslators") final List<CallTranslator<HtsCallAttempt>> callTranslators) {
+            @NonNull @Named("HtsTranslators") final List<CallTranslator<HtsCallAttempt>> callTranslators,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry) {
         this.syntheticIds = requireNonNull(syntheticIds);
         this.addressChecks = requireNonNull(addressChecks);
         this.verificationStrategies = requireNonNull(verificationStrategies);
         this.callTranslators = requireNonNull(callTranslators);
+        this.systemContractMethodRegistry = requireNonNull(systemContractMethodRegistry);
     }
 
     /**
@@ -93,6 +97,7 @@ public class HtsCallFactory implements CallFactory<HtsCallAttempt> {
                 verificationStrategies,
                 systemContractGasCalculatorOf(frame),
                 callTranslators,
+                systemContractMethodRegistry,
                 frame.isStatic());
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/airdrops/TokenAirdropTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/airdrops/TokenAirdropTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,38 +18,53 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.airdr
 
 import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class TokenAirdropTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
-    public static final Function TOKEN_AIRDROP =
-            new Function("airdropTokens((address,(address,int64,bool)[],(address,address,int64,bool)[])[])", "(int32)");
+    public static final SystemContractMethod TOKEN_AIRDROP = SystemContractMethod.declare(
+                    "airdropTokens((address,(address,int64,bool)[],(address,address,int64,bool)[])[])", "(int32)")
+            .withCategories(Category.AIRDROP);
 
     private final TokenAirdropDecoder decoder;
 
     @Inject
-    public TokenAirdropTranslator(@NonNull final TokenAirdropDecoder decoder) {
+    public TokenAirdropTranslator(
+            @NonNull final TokenAirdropDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         requireNonNull(decoder);
         this.decoder = decoder;
+
+        registerMethods(TOKEN_AIRDROP);
     }
 
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
         final var airdropEnabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractAirdropTokensEnabled();
-        return attempt.isSelectorIfConfigEnabled(airdropEnabled, TOKEN_AIRDROP);
+        if (!airdropEnabled) return Optional.empty();
+        return attempt.isMethod(TOKEN_AIRDROP);
     }
 
     public static long gasRequirement(

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/allowance/GetAllowanceTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/allowance/GetAllowanceTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,23 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.allowance;
 
+import static java.util.Objects.requireNonNull;
+
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -37,27 +45,36 @@ public class GetAllowanceTranslator extends AbstractCallTranslator<HtsCallAttemp
     /**
      * Selector for allowance(address,address,address) method.
      */
-    public static final Function GET_ALLOWANCE =
-            new Function("allowance(address,address,address)", ReturnTypes.RESPONSE_CODE_UINT256);
+    public static final SystemContractMethod GET_ALLOWANCE = SystemContractMethod.declare(
+                    "allowance(address,address,address)", ReturnTypes.RESPONSE_CODE_UINT256)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.ALLOWANCE);
     /**
      * Selector for allowance(address,address) method.
      */
-    public static final Function ERC_GET_ALLOWANCE = new Function("allowance(address,address)", ReturnTypes.UINT256);
+    public static final SystemContractMethod ERC_GET_ALLOWANCE = SystemContractMethod.declare(
+                    "allowance(address,address)", ReturnTypes.UINT256)
+            .withVia(CallVia.PROXY)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.ALLOWANCE);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public GetAllowanceTranslator() {
+    public GetAllowanceTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(GET_ALLOWANCE, ERC_GET_ALLOWANCE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(GET_ALLOWANCE, ERC_GET_ALLOWANCE);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(GET_ALLOWANCE, ERC_GET_ALLOWANCE);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/associations/AssociationsTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/associations/AssociationsTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,25 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.associations;
 
-import com.esaulpaugh.headlong.abi.Function;
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -40,29 +47,41 @@ public class AssociationsTranslator extends AbstractCallTranslator<HtsCallAttemp
     /**
      * Selector for associate() method.
      */
-    public static final Function HRC_ASSOCIATE = new Function("associate()", ReturnTypes.INT);
+    public static final SystemContractMethod HRC_ASSOCIATE = SystemContractMethod.declare(
+                    "associate()", ReturnTypes.INT)
+            .withVia(CallVia.PROXY)
+            .withCategories(Category.ASSOCIATION);
     /**
      * Selector for associateToken(address,address) method.
      */
-    public static final Function ASSOCIATE_ONE = new Function("associateToken(address,address)", ReturnTypes.INT_64);
+    public static final SystemContractMethod ASSOCIATE_ONE = SystemContractMethod.declare(
+                    "associateToken(address,address)", ReturnTypes.INT_64)
+            .withCategories(Category.ASSOCIATION);
     /**
      * Selector for dissociateToken(address,address) method.
      */
-    public static final Function DISSOCIATE_ONE = new Function("dissociateToken(address,address)", ReturnTypes.INT_64);
+    public static final SystemContractMethod DISSOCIATE_ONE = SystemContractMethod.declare(
+                    "dissociateToken(address,address)", ReturnTypes.INT_64)
+            .withCategories(Category.ASSOCIATION);
     /**
      * Selector for dissociate() method.
      */
-    public static final Function HRC_DISSOCIATE = new Function("dissociate()", ReturnTypes.INT);
+    public static final SystemContractMethod HRC_DISSOCIATE = SystemContractMethod.declare(
+                    "dissociate()", ReturnTypes.INT)
+            .withVia(CallVia.PROXY)
+            .withCategories(Category.ASSOCIATION);
     /**
      * Selector for associateTokens(address,address[]) method.
      */
-    public static final Function ASSOCIATE_MANY =
-            new Function("associateTokens(address,address[])", ReturnTypes.INT_64);
+    public static final SystemContractMethod ASSOCIATE_MANY = SystemContractMethod.declare(
+                    "associateTokens(address,address[])", ReturnTypes.INT_64)
+            .withCategories(Category.ASSOCIATION);
     /**
      * Selector for dissociateTokens(address,address[]) method.
      */
-    public static final Function DISSOCIATE_MANY =
-            new Function("dissociateTokens(address,address[])", ReturnTypes.INT_64);
+    public static final SystemContractMethod DISSOCIATE_MANY = SystemContractMethod.declare(
+                    "dissociateTokens(address,address[])", ReturnTypes.INT_64)
+            .withCategories(Category.ASSOCIATION);
 
     private final AssociationsDecoder decoder;
 
@@ -71,18 +90,22 @@ public class AssociationsTranslator extends AbstractCallTranslator<HtsCallAttemp
      * @param decoder
      */
     @Inject
-    public AssociationsTranslator(@NonNull final AssociationsDecoder decoder) {
+    public AssociationsTranslator(
+            @NonNull final AssociationsDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(ASSOCIATE_ONE, ASSOCIATE_MANY, DISSOCIATE_ONE, DISSOCIATE_MANY, HRC_ASSOCIATE, HRC_DISSOCIATE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
         return attempt.isTokenRedirect()
-                ? attempt.isSelector(HRC_ASSOCIATE, HRC_DISSOCIATE)
-                : attempt.isSelector(ASSOCIATE_ONE, ASSOCIATE_MANY, DISSOCIATE_ONE, DISSOCIATE_MANY);
+                ? attempt.isMethod(HRC_ASSOCIATE, HRC_DISSOCIATE)
+                : attempt.isMethod(ASSOCIATE_ONE, ASSOCIATE_MANY, DISSOCIATE_ONE, DISSOCIATE_MANY);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/balanceof/BalanceOfTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/balanceof/BalanceOfTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,19 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.balanceof;
 
+import static java.util.Objects.requireNonNull;
+
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -33,14 +40,22 @@ public class BalanceOfTranslator extends AbstractCallTranslator<HtsCallAttempt> 
     /**
      * Selector for balanceOf(address) method.
      */
-    public static final Function BALANCE_OF = new Function("balanceOf(address)", ReturnTypes.INT);
+    public static final SystemContractMethod BALANCE_OF = SystemContractMethod.declare(
+                    "balanceOf(address)", ReturnTypes.INT)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public BalanceOfTranslator() {
+    public BalanceOfTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(BALANCE_OF);
     }
 
     /**
@@ -55,11 +70,9 @@ public class BalanceOfTranslator extends AbstractCallTranslator<HtsCallAttempt> 
                 attempt.enhancement(), attempt.systemContractGasCalculator(), attempt.redirectToken(), owner);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(BALANCE_OF);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(BALANCE_OF);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/cancelairdrops/TokenCancelAirdropDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/cancelairdrops/TokenCancelAirdropDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class TokenCancelAirdropDecoder {
     }
 
     public TransactionBody decodeCancelAirdrop(@NonNull final HtsCallAttempt attempt) {
-        final var call = TokenCancelAirdropTranslator.CANCEL_AIRDROP.decodeCall(attempt.inputBytes());
+        final var call = TokenCancelAirdropTranslator.CANCEL_AIRDROPS.decodeCall(attempt.inputBytes());
         final var maxPendingAirdropsToCancel =
                 attempt.configuration().getConfigData(TokensConfig.class).maxAllowedPendingAirdropsToCancel();
         final var transferList = (Tuple[]) call.get(TRANSFER_LIST);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/cancelairdrops/TokenCancelAirdropTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/cancelairdrops/TokenCancelAirdropTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,46 +18,71 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.cance
 
 import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class TokenCancelAirdropTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
     // Actual signature definition with struct name before flattening
     // cancelAirdrops(PendingAirdrop[])
-    public static final Function CANCEL_AIRDROP =
-            new Function("cancelAirdrops((address,address,address,int64)[])", ReturnTypes.INT_64);
-    public static final Function HRC_CANCEL_AIRDROP_FT = new Function("cancelAirdropFT(address)", ReturnTypes.INT_64);
-    public static final Function HRC_CANCEL_AIRDROP_NFT =
-            new Function("cancelAirdropNFT(address,int64)", ReturnTypes.INT_64);
+    public static final SystemContractMethod CANCEL_AIRDROPS = SystemContractMethod.declare(
+                    "cancelAirdrops((address,address,address,int64)[])", ReturnTypes.INT_64)
+            .withCategories(Category.AIRDROP);
+    public static final SystemContractMethod HRC_CANCEL_AIRDROP_FT = SystemContractMethod.declare(
+                    "cancelAirdropFT(address)", ReturnTypes.INT_64)
+            .withVia(CallVia.PROXY)
+            .withVariant(Variant.FT)
+            .withCategories(Category.AIRDROP);
+    public static final SystemContractMethod HRC_CANCEL_AIRDROP_NFT = SystemContractMethod.declare(
+                    "cancelAirdropNFT(address,int64)", ReturnTypes.INT_64)
+            .withVia(CallVia.PROXY)
+            .withVariant(Variant.NFT)
+            .withCategories(Category.AIRDROP);
 
     private final TokenCancelAirdropDecoder decoder;
 
     @Inject
-    public TokenCancelAirdropTranslator(@NonNull final TokenCancelAirdropDecoder decoder) {
+    public TokenCancelAirdropTranslator(
+            @NonNull final TokenCancelAirdropDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         requireNonNull(decoder);
         this.decoder = decoder;
+
+        registerMethods(CANCEL_AIRDROPS, HRC_CANCEL_AIRDROP_FT, HRC_CANCEL_AIRDROP_NFT);
     }
 
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
         final var cancelAirdropEnabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractCancelAirdropsEnabled();
+
+        if (!cancelAirdropEnabled) return Optional.empty();
         return attempt.isTokenRedirect()
-                ? attempt.isSelectorIfConfigEnabled(cancelAirdropEnabled, HRC_CANCEL_AIRDROP_FT, HRC_CANCEL_AIRDROP_NFT)
-                : attempt.isSelectorIfConfigEnabled(cancelAirdropEnabled, CANCEL_AIRDROP);
+                ? attempt.isMethod(HRC_CANCEL_AIRDROP_FT, HRC_CANCEL_AIRDROP_NFT)
+                : attempt.isMethod(CANCEL_AIRDROPS);
     }
 
     @Override
@@ -67,7 +92,7 @@ public class TokenCancelAirdropTranslator extends AbstractCallTranslator<HtsCall
     }
 
     private TransactionBody bodyFor(@NonNull final HtsCallAttempt attempt) {
-        if (attempt.isSelector(CANCEL_AIRDROP)) {
+        if (attempt.isSelector(CANCEL_AIRDROPS)) {
             return decoder.decodeCancelAirdrop(attempt);
         } else if (attempt.isSelector(HRC_CANCEL_AIRDROP_FT)) {
             return decoder.decodeCancelAirdropFT(attempt);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/claimairdrops/TokenClaimAirdropDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/claimairdrops/TokenClaimAirdropDecoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class TokenClaimAirdropDecoder {
     }
 
     public TransactionBody decodeTokenClaimAirdrop(@NonNull final HtsCallAttempt attempt) {
-        final var call = TokenClaimAirdropTranslator.CLAIM_AIRDROP.decodeCall(attempt.inputBytes());
+        final var call = TokenClaimAirdropTranslator.CLAIM_AIRDROPS.decodeCall(attempt.inputBytes());
         final var maxPendingAirdropsToClaim =
                 attempt.configuration().getConfigData(TokensConfig.class).maxAllowedPendingAirdropsToClaim();
         final var transferList = (Tuple[]) call.get(TRANSFER_LIST);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/claimairdrops/TokenClaimAirdropTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/claimairdrops/TokenClaimAirdropTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,49 +16,76 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.claimairdrops;
 
-import com.esaulpaugh.headlong.abi.Function;
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class TokenClaimAirdropTranslator extends AbstractCallTranslator<HtsCallAttempt> {
-    public static final Function CLAIM_AIRDROP =
-            new Function("claimAirdrops((address,address,address,int64)[])", ReturnTypes.INT_64);
-    public static final Function HRC_CLAIM_AIRDROP_FT = new Function("claimAirdropFT(address)", ReturnTypes.INT_64);
-    public static final Function HRC_CLAIM_AIRDROP_NFT =
-            new Function("claimAirdropNFT(address,int64)", ReturnTypes.INT_64);
+    public static final SystemContractMethod CLAIM_AIRDROPS = SystemContractMethod.declare(
+                    "claimAirdrops((address,address,address,int64)[])", ReturnTypes.INT_64)
+            .withCategories(Category.AIRDROP);
+    public static final SystemContractMethod HRC_CLAIM_AIRDROP_FT = SystemContractMethod.declare(
+                    "claimAirdropFT(address)", ReturnTypes.INT_64)
+            .withVia(CallVia.PROXY)
+            .withVariant(Variant.FT)
+            .withCategories(Category.AIRDROP);
+    public static final SystemContractMethod HRC_CLAIM_AIRDROP_NFT = SystemContractMethod.declare(
+                    "claimAirdropNFT(address,int64)", ReturnTypes.INT_64)
+            .withVia(CallVia.PROXY)
+            .withVariant(Variant.NFT)
+            .withCategories(Category.AIRDROP);
 
     private final TokenClaimAirdropDecoder decoder;
 
     @Inject
-    public TokenClaimAirdropTranslator(@NonNull final TokenClaimAirdropDecoder decoder) {
+    public TokenClaimAirdropTranslator(
+            @NonNull final TokenClaimAirdropDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(CLAIM_AIRDROPS, HRC_CLAIM_AIRDROP_FT, HRC_CLAIM_AIRDROP_NFT);
     }
 
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
         final var claimAirdropEnabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractClaimAirdropsEnabled();
+
+        if (!claimAirdropEnabled) return Optional.empty();
         return attempt.isTokenRedirect()
-                ? attempt.isSelectorIfConfigEnabled(claimAirdropEnabled, HRC_CLAIM_AIRDROP_FT, HRC_CLAIM_AIRDROP_NFT)
-                : attempt.isSelectorIfConfigEnabled(claimAirdropEnabled, CLAIM_AIRDROP);
+                ? attempt.isMethod(HRC_CLAIM_AIRDROP_FT, HRC_CLAIM_AIRDROP_NFT)
+                : attempt.isMethod(CLAIM_AIRDROPS);
     }
 
     @Override
     public Call callFrom(@NonNull final HtsCallAttempt attempt) {
         return new DispatchForResponseCodeHtsCall(
                 attempt,
-                attempt.isSelector(CLAIM_AIRDROP) ? bodyForClassic(attempt) : bodyForHRC(attempt),
+                attempt.isSelector(CLAIM_AIRDROPS) ? bodyForClassic(attempt) : bodyForHRC(attempt),
                 TokenClaimAirdropTranslator::gasRequirement);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,147 +27,191 @@ import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.HEDERA_T
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.HEDERA_TOKEN_WITH_METADATA;
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.ROYALTY_FEE;
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.ROYALTY_FEE_V2;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates {@code createFungibleToken}, {@code createNonFungibleToken},
  * {@code createFungibleTokenWithCustomFees} and {@code createNonFungibleTokenWithCustomFees} calls to the HTS system contract.
  */
+@Singleton
 public class CreateTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
     /** Selector for createFungibleToken(HEDERA_TOKEN_V1,uint,uint) method. */
-    public static final Function CREATE_FUNGIBLE_TOKEN_V1 =
-            new Function("createFungibleToken(" + HEDERA_TOKEN_V1 + ",uint,uint)", "(int64,address)");
+    public static final SystemContractMethod CREATE_FUNGIBLE_TOKEN_V1 = SystemContractMethod.declare(
+                    "createFungibleToken(" + HEDERA_TOKEN_V1 + ",uint,uint)", "(int64,address)")
+            .withVariants(Variant.V1, Variant.FT)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createFungibleToken(HEDERA_TOKEN_V2,uint64,uint32) method. */
-    public static final Function CREATE_FUNGIBLE_TOKEN_V2 =
-            new Function("createFungibleToken(" + HEDERA_TOKEN_V2 + ",uint64,uint32)", "(int64,address)");
+    public static final SystemContractMethod CREATE_FUNGIBLE_TOKEN_V2 = SystemContractMethod.declare(
+                    "createFungibleToken(" + HEDERA_TOKEN_V2 + ",uint64,uint32)", "(int64,address)")
+            .withVariants(Variant.V2, Variant.FT)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createFungibleToken(HEDERA_TOKEN_V3,int64,int32) method. */
-    public static final Function CREATE_FUNGIBLE_TOKEN_V3 =
-            new Function("createFungibleToken(" + HEDERA_TOKEN_V3 + ",int64,int32)", "(int64,address)");
+    public static final SystemContractMethod CREATE_FUNGIBLE_TOKEN_V3 = SystemContractMethod.declare(
+                    "createFungibleToken(" + HEDERA_TOKEN_V3 + ",int64,int32)", "(int64,address)")
+            .withVariants(Variant.V3, Variant.FT)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createFungibleTokenWithCustomFees(HEDERA_TOKEN_V1,uint,uint,FIXED_FEE[],FRACTIONAL_FEE[]) method. */
-    public static final Function CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V1 = new Function(
-            "createFungibleTokenWithCustomFees("
-                    + HEDERA_TOKEN_V1
-                    + ",uint,uint,"
-                    + FIXED_FEE
-                    + ARRAY_BRACKETS
-                    + ","
-                    + FRACTIONAL_FEE
-                    + ARRAY_BRACKETS
-                    + ")",
-            "(int64,address)");
+    public static final SystemContractMethod CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V1 = SystemContractMethod.declare(
+                    "createFungibleTokenWithCustomFees("
+                            + HEDERA_TOKEN_V1
+                            + ",uint,uint,"
+                            + FIXED_FEE
+                            + ARRAY_BRACKETS
+                            + ","
+                            + FRACTIONAL_FEE
+                            + ARRAY_BRACKETS
+                            + ")",
+                    "(int64,address)")
+            .withVariants(Variant.V1, Variant.FT, Variant.WITH_CUSTOM_FEES)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createFungibleTokenWithCustomFees(HEDERA_TOKEN_V2,uint64,uint32,FIXED_FEE[],FRACTIONAL_FEE[]) method. */
-    public static final Function CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V2 = new Function(
-            "createFungibleTokenWithCustomFees("
-                    + HEDERA_TOKEN_V2
-                    + ",uint64,uint32,"
-                    + FIXED_FEE
-                    + ARRAY_BRACKETS
-                    + ","
-                    + FRACTIONAL_FEE
-                    + ARRAY_BRACKETS
-                    + ")",
-            "(int64,address)");
+    public static final SystemContractMethod CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V2 = SystemContractMethod.declare(
+                    "createFungibleTokenWithCustomFees("
+                            + HEDERA_TOKEN_V2
+                            + ",uint64,uint32,"
+                            + FIXED_FEE
+                            + ARRAY_BRACKETS
+                            + ","
+                            + FRACTIONAL_FEE
+                            + ARRAY_BRACKETS
+                            + ")",
+                    "(int64,address)")
+            .withVariants(Variant.V2, Variant.FT, Variant.WITH_CUSTOM_FEES)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createFungibleTokenWithCustomFees(HEDERA_TOKEN_V3,int64,int32,FIXED_FEE_V2[],FRACTIONAL_FEE_V2[]) method. */
-    public static final Function CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V3 = new Function(
-            "createFungibleTokenWithCustomFees("
-                    + HEDERA_TOKEN_V3
-                    + ",int64,int32,"
-                    + FIXED_FEE_V2
-                    + ARRAY_BRACKETS
-                    + ","
-                    + FRACTIONAL_FEE_V2
-                    + ARRAY_BRACKETS
-                    + ")",
-            "(int64,address)");
+    public static final SystemContractMethod CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V3 = SystemContractMethod.declare(
+                    "createFungibleTokenWithCustomFees("
+                            + HEDERA_TOKEN_V3
+                            + ",int64,int32,"
+                            + FIXED_FEE_V2
+                            + ARRAY_BRACKETS
+                            + ","
+                            + FRACTIONAL_FEE_V2
+                            + ARRAY_BRACKETS
+                            + ")",
+                    "(int64,address)")
+            .withVariants(Variant.V3, Variant.FT, Variant.WITH_CUSTOM_FEES)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
 
     /** Selector for createNonFungibleToken(HEDERA_TOKEN_V1) method. */
-    public static final Function CREATE_NON_FUNGIBLE_TOKEN_V1 =
-            new Function("createNonFungibleToken(" + HEDERA_TOKEN_V1 + ")", "(int64,address)");
+    public static final SystemContractMethod CREATE_NON_FUNGIBLE_TOKEN_V1 = SystemContractMethod.declare(
+                    "createNonFungibleToken(" + HEDERA_TOKEN_V1 + ")", "(int64,address)")
+            .withVariants(Variant.V1, Variant.NFT)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createNonFungibleToken(HEDERA_TOKEN_V2) method. */
-    public static final Function CREATE_NON_FUNGIBLE_TOKEN_V2 =
-            new Function("createNonFungibleToken(" + HEDERA_TOKEN_V2 + ")", "(int64,address)");
+    public static final SystemContractMethod CREATE_NON_FUNGIBLE_TOKEN_V2 = SystemContractMethod.declare(
+                    "createNonFungibleToken(" + HEDERA_TOKEN_V2 + ")", "(int64,address)")
+            .withVariants(Variant.V2, Variant.NFT)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createNonFungibleToken(HEDERA_TOKEN_V3) method. */
-    public static final Function CREATE_NON_FUNGIBLE_TOKEN_V3 =
-            new Function("createNonFungibleToken(" + HEDERA_TOKEN_V3 + ")", "(int64,address)");
+    public static final SystemContractMethod CREATE_NON_FUNGIBLE_TOKEN_V3 = SystemContractMethod.declare(
+                    "createNonFungibleToken(" + HEDERA_TOKEN_V3 + ")", "(int64,address)")
+            .withVariants(Variant.V3, Variant.NFT)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
 
     /** Selector for createNonFungibleTokenWithCustomFees(HEDERA_TOKEN_V1,int64,int32,FIXED_FEE[],FRACTIONAL_FEE[]) method. */
-    public static final Function CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V1 = new Function(
-            "createNonFungibleTokenWithCustomFees("
-                    + HEDERA_TOKEN_V1
-                    + ","
-                    + FIXED_FEE
-                    + ARRAY_BRACKETS
-                    + ","
-                    + ROYALTY_FEE
-                    + ARRAY_BRACKETS
-                    + ")",
-            "(int64,address)");
+    public static final SystemContractMethod CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V1 =
+            SystemContractMethod.declare(
+                            "createNonFungibleTokenWithCustomFees("
+                                    + HEDERA_TOKEN_V1
+                                    + ","
+                                    + FIXED_FEE
+                                    + ARRAY_BRACKETS
+                                    + ","
+                                    + ROYALTY_FEE
+                                    + ARRAY_BRACKETS
+                                    + ")",
+                            "(int64,address)")
+                    .withVariants(Variant.V1, Variant.NFT, Variant.WITH_CUSTOM_FEES)
+                    .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createNonFungibleTokenWithCustomFees(HEDERA_TOKEN_V2,int64,int32,FIXED_FEE[],FRACTIONAL_FEE[]) method. */
-    public static final Function CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V2 = new Function(
-            "createNonFungibleTokenWithCustomFees("
-                    + HEDERA_TOKEN_V2
-                    + ","
-                    + FIXED_FEE
-                    + ARRAY_BRACKETS
-                    + ","
-                    + ROYALTY_FEE
-                    + ARRAY_BRACKETS
-                    + ")",
-            "(int64,address)");
+    public static final SystemContractMethod CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V2 =
+            SystemContractMethod.declare(
+                            "createNonFungibleTokenWithCustomFees("
+                                    + HEDERA_TOKEN_V2
+                                    + ","
+                                    + FIXED_FEE
+                                    + ARRAY_BRACKETS
+                                    + ","
+                                    + ROYALTY_FEE
+                                    + ARRAY_BRACKETS
+                                    + ")",
+                            "(int64,address)")
+                    .withVariants(Variant.V2, Variant.NFT, Variant.WITH_CUSTOM_FEES)
+                    .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createNonFungibleTokenWithCustomFees(HEDERA_TOKEN_V3,int64,int32,FIXED_FEE_2[],FRACTIONAL_FEE_2[]) method. */
-    public static final Function CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V3 = new Function(
-            "createNonFungibleTokenWithCustomFees("
-                    + HEDERA_TOKEN_V3
-                    + ","
-                    + FIXED_FEE_V2
-                    + ARRAY_BRACKETS
-                    + ","
-                    + ROYALTY_FEE_V2
-                    + ARRAY_BRACKETS
-                    + ")",
-            "(int64,address)");
+    public static final SystemContractMethod CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V3 =
+            SystemContractMethod.declare(
+                            "createNonFungibleTokenWithCustomFees("
+                                    + HEDERA_TOKEN_V3
+                                    + ","
+                                    + FIXED_FEE_V2
+                                    + ARRAY_BRACKETS
+                                    + ","
+                                    + ROYALTY_FEE_V2
+                                    + ARRAY_BRACKETS
+                                    + ")",
+                            "(int64,address)")
+                    .withVariants(Variant.V3, Variant.NFT, Variant.WITH_CUSTOM_FEES)
+                    .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createFungibleTokenWithCustomFees(HEDERA_TOKEN_WITH_METADATA,int64,int32) method. */
-    public static final Function CREATE_FUNGIBLE_TOKEN_WITH_METADATA =
-            new Function("createFungibleToken(" + HEDERA_TOKEN_WITH_METADATA + ",int64,int32)", "(int64,address)");
+    public static final SystemContractMethod CREATE_FUNGIBLE_TOKEN_WITH_METADATA = SystemContractMethod.declare(
+                    "createFungibleToken(" + HEDERA_TOKEN_WITH_METADATA + ",int64,int32)", "(int64,address)")
+            .withVariants(Variant.FT, Variant.WITH_METADATA)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createFungibleTokenWithCustomFees(HEDERA_TOKEN_WITH_METADATA,int64,int32,FIXED_FEE_2[],FRACTIONAL_FEE_2[]) method. */
-    public static final Function CREATE_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES = new Function(
-            "createFungibleTokenWithCustomFees("
-                    + HEDERA_TOKEN_WITH_METADATA
-                    + ",int64,int32,"
-                    + FIXED_FEE_V2
-                    + ARRAY_BRACKETS
-                    + ","
-                    + FRACTIONAL_FEE_V2
-                    + ARRAY_BRACKETS
-                    + ")",
-            "(int64,address)");
+    public static final SystemContractMethod CREATE_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES =
+            SystemContractMethod.declare(
+                            "createFungibleTokenWithCustomFees("
+                                    + HEDERA_TOKEN_WITH_METADATA
+                                    + ",int64,int32,"
+                                    + FIXED_FEE_V2
+                                    + ARRAY_BRACKETS
+                                    + ","
+                                    + FRACTIONAL_FEE_V2
+                                    + ARRAY_BRACKETS
+                                    + ")",
+                            "(int64,address)")
+                    .withVariants(Variant.FT, Variant.WITH_METADATA, Variant.WITH_CUSTOM_FEES)
+                    .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createNonFungibleToken(HEDERA_TOKEN_WITH_METADATA) method. */
-    public static final Function CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA =
-            new Function("createNonFungibleToken(" + HEDERA_TOKEN_WITH_METADATA + ")", "(int64,address)");
+    public static final SystemContractMethod CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA = SystemContractMethod.declare(
+                    "createNonFungibleToken(" + HEDERA_TOKEN_WITH_METADATA + ")", "(int64,address)")
+            .withVariants(Variant.NFT, Variant.WITH_METADATA)
+            .withCategory(Category.CREATE_DELETE_TOKEN);
     /** Selector for createNonFungibleTokenWithCustomFees(HEDERA_TOKEN_WITH_METADATA,FIXED_FEE_2[],FRACTIONAL_FEE_2[]) method. */
-    public static final Function CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES = new Function(
-            "createNonFungibleTokenWithCustomFees("
-                    + HEDERA_TOKEN_WITH_METADATA
-                    + ","
-                    + FIXED_FEE_V2
-                    + ARRAY_BRACKETS
-                    + ","
-                    + ROYALTY_FEE_V2
-                    + ARRAY_BRACKETS
-                    + ")",
-            "(int64,address)");
+    public static final SystemContractMethod CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES =
+            SystemContractMethod.declare(
+                            "createNonFungibleTokenWithCustomFees("
+                                    + HEDERA_TOKEN_WITH_METADATA
+                                    + ","
+                                    + FIXED_FEE_V2
+                                    + ARRAY_BRACKETS
+                                    + ","
+                                    + ROYALTY_FEE_V2
+                                    + ARRAY_BRACKETS
+                                    + ")",
+                            "(int64,address)")
+                    .withVariants(Variant.NFT, Variant.WITH_METADATA, Variant.WITH_CUSTOM_FEES)
+                    .withCategory(Category.CREATE_DELETE_TOKEN);
 
     /**
      * A set of `Function` objects representing various create functions for fungible and non-fungible tokens.
@@ -175,52 +219,76 @@ public class CreateTranslator extends AbstractCallTranslator<HtsCallAttempt> {
      * to determine if a given call attempt is a creation call, because we do not allow sending value to Hedera system contracts
      * except in the case of token creation
      */
-    public static final Map<Function, CreateDecoderFunction> createSelectorsMap = new HashMap<>();
+    public static final Map<SystemContractMethod, CreateDecoderFunction> createMethodsMap = new HashMap<>();
 
     /**
      * Constructor for injection.
      * @param decoder the decoder used to decode create calls
      */
     @Inject
-    public CreateTranslator(final CreateDecoder decoder) {
-        createSelectorsMap.put(CREATE_FUNGIBLE_TOKEN_V1, decoder::decodeCreateFungibleTokenV1);
-        createSelectorsMap.put(CREATE_FUNGIBLE_TOKEN_V2, decoder::decodeCreateFungibleTokenV2);
-        createSelectorsMap.put(CREATE_FUNGIBLE_TOKEN_V3, decoder::decodeCreateFungibleTokenV3);
-        createSelectorsMap.put(CREATE_FUNGIBLE_TOKEN_WITH_METADATA, decoder::decodeCreateFungibleTokenWithMetadata);
-        createSelectorsMap.put(CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V1, decoder::decodeCreateFungibleTokenWithCustomFeesV1);
-        createSelectorsMap.put(CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V2, decoder::decodeCreateFungibleTokenWithCustomFeesV2);
-        createSelectorsMap.put(CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V3, decoder::decodeCreateFungibleTokenWithCustomFeesV3);
-        createSelectorsMap.put(
+    public CreateTranslator(
+            final CreateDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(
+                CREATE_FUNGIBLE_TOKEN_V1,
+                CREATE_FUNGIBLE_TOKEN_V2,
+                CREATE_FUNGIBLE_TOKEN_V3,
+                CREATE_FUNGIBLE_TOKEN_WITH_METADATA,
+                CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V1,
+                CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V2,
+                CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V3,
+                CREATE_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES,
+                CREATE_NON_FUNGIBLE_TOKEN_V1,
+                CREATE_NON_FUNGIBLE_TOKEN_V2,
+                CREATE_NON_FUNGIBLE_TOKEN_V3,
+                CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA,
+                CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V1,
+                CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V2,
+                CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V3,
+                CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES);
+
+        createMethodsMap.put(CREATE_FUNGIBLE_TOKEN_V1, decoder::decodeCreateFungibleTokenV1);
+        createMethodsMap.put(CREATE_FUNGIBLE_TOKEN_V2, decoder::decodeCreateFungibleTokenV2);
+        createMethodsMap.put(CREATE_FUNGIBLE_TOKEN_V3, decoder::decodeCreateFungibleTokenV3);
+        createMethodsMap.put(CREATE_FUNGIBLE_TOKEN_WITH_METADATA, decoder::decodeCreateFungibleTokenWithMetadata);
+        createMethodsMap.put(CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V1, decoder::decodeCreateFungibleTokenWithCustomFeesV1);
+        createMethodsMap.put(CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V2, decoder::decodeCreateFungibleTokenWithCustomFeesV2);
+        createMethodsMap.put(CREATE_FUNGIBLE_WITH_CUSTOM_FEES_V3, decoder::decodeCreateFungibleTokenWithCustomFeesV3);
+        createMethodsMap.put(
                 CREATE_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES,
                 decoder::decodeCreateFungibleTokenWithMetadataAndCustomFees);
-        createSelectorsMap.put(CREATE_NON_FUNGIBLE_TOKEN_V1, decoder::decodeCreateNonFungibleV1);
-        createSelectorsMap.put(CREATE_NON_FUNGIBLE_TOKEN_V2, decoder::decodeCreateNonFungibleV2);
-        createSelectorsMap.put(CREATE_NON_FUNGIBLE_TOKEN_V3, decoder::decodeCreateNonFungibleV3);
-        createSelectorsMap.put(CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA, decoder::decodeCreateNonFungibleWithMetadata);
-        createSelectorsMap.put(
+        createMethodsMap.put(CREATE_NON_FUNGIBLE_TOKEN_V1, decoder::decodeCreateNonFungibleV1);
+        createMethodsMap.put(CREATE_NON_FUNGIBLE_TOKEN_V2, decoder::decodeCreateNonFungibleV2);
+        createMethodsMap.put(CREATE_NON_FUNGIBLE_TOKEN_V3, decoder::decodeCreateNonFungibleV3);
+        createMethodsMap.put(CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA, decoder::decodeCreateNonFungibleWithMetadata);
+        createMethodsMap.put(
                 CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V1, decoder::decodeCreateNonFungibleWithCustomFeesV1);
-        createSelectorsMap.put(
+        createMethodsMap.put(
                 CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V2, decoder::decodeCreateNonFungibleWithCustomFeesV2);
-        createSelectorsMap.put(
+        createMethodsMap.put(
                 CREATE_NON_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_V3, decoder::decodeCreateNonFungibleWithCustomFeesV3);
-        createSelectorsMap.put(
+        createMethodsMap.put(
                 CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES,
                 decoder::decodeCreateNonFungibleWithMetadataAndCustomFees);
     }
 
     @Override
-    public boolean matches(@NonNull HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull HtsCallAttempt attempt) {
+        requireNonNull(attempt);
         final var metaConfigEnabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).metadataKeyAndFieldEnabled();
-        final var metaSelectors = Set.of(
-                CREATE_FUNGIBLE_TOKEN_WITH_METADATA,
-                CREATE_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES,
-                CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA,
-                CREATE_NON_FUNGIBLE_TOKEN_WITH_METADATA_AND_CUSTOM_FEES);
-        return createSelectorsMap.keySet().stream()
-                .anyMatch(selector -> metaSelectors.contains(selector)
-                        ? attempt.isSelectorIfConfigEnabled(metaConfigEnabled, selector)
-                        : attempt.isSelector(selector));
+
+        for (final var method : createMethodsMap.keySet()) {
+            final var isMetadataMethod = method.hasVariant(Variant.WITH_METADATA);
+            Optional<SystemContractMethod> m = isMetadataMethod
+                    ? metaConfigEnabled ? attempt.isMethod(method) : Optional.empty()
+                    : attempt.isMethod(method);
+            if (m.isPresent()) return m;
+        }
+        return Optional.empty();
     }
 
     @Override
@@ -239,7 +307,7 @@ public class CreateTranslator extends AbstractCallTranslator<HtsCallAttempt> {
         final var nativeOperations = attempt.nativeOperations();
         final var addressIdConverter = attempt.addressIdConverter();
 
-        return createSelectorsMap.entrySet().stream()
+        return createMethodsMap.entrySet().stream()
                 .filter(entry -> attempt.isSelector(entry.getKey()))
                 .map(entry -> entry.getValue().decode(inputBytes, senderId, nativeOperations, addressIdConverter))
                 .findFirst()

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateTranslator.java
@@ -283,9 +283,13 @@ public class CreateTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
         for (final var method : createMethodsMap.keySet()) {
             final var isMetadataMethod = method.hasVariant(Variant.WITH_METADATA);
-            Optional<SystemContractMethod> m = isMetadataMethod
-                    ? metaConfigEnabled ? attempt.isMethod(method) : Optional.empty()
-                    : attempt.isMethod(method);
+
+            Optional<SystemContractMethod> m = Optional.empty();
+            if (isMetadataMethod) {
+                if (metaConfigEnabled) m = attempt.isMethod(method);
+            } else {
+                m = attempt.isMethod(method);
+            }
             if (m.isPresent()) return m;
         }
         return Optional.empty();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/customfees/TokenCustomFeesTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/customfees/TokenCustomFeesTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,31 +17,46 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.customfees;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class TokenCustomFeesTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
-    public static final Function TOKEN_CUSTOM_FEES =
-            new Function("getTokenCustomFees(address)", ReturnTypes.RESPONSE_CODE_CUSTOM_FEES);
+    public static final SystemContractMethod TOKEN_CUSTOM_FEES = SystemContractMethod.declare(
+                    "getTokenCustomFees(address)", ReturnTypes.RESPONSE_CODE_CUSTOM_FEES)
+            .withModifier(Modifier.VIEW)
+            .withVariant(Variant.WITH_CUSTOM_FEES)
+            .withCategory(Category.TOKEN_QUERY);
 
     @Inject
-    public TokenCustomFeesTranslator() {
+    public TokenCustomFeesTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(TOKEN_CUSTOM_FEES);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(TOKEN_CUSTOM_FEES);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(TOKEN_CUSTOM_FEES);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/decimals/DecimalsTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/decimals/DecimalsTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,19 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.decimals;
 
-import com.esaulpaugh.headlong.abi.Function;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -31,22 +38,27 @@ import javax.inject.Singleton;
 @Singleton
 public class DecimalsTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for updateTokenKeys(address, TOKEN_KEY[]) method. */
-    public static final Function DECIMALS = new Function("decimals()", ReturnTypes.BYTE);
+    public static final SystemContractMethod DECIMALS = SystemContractMethod.declare("decimals()", ReturnTypes.BYTE)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public DecimalsTranslator() {
+    public DecimalsTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(DECIMALS);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(DECIMALS);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(DECIMALS);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,37 +17,50 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.defaultfreezestatus;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates {@code getTokenDefaultFreezeStatus()} calls to the HTS system contract.
  */
+@Singleton
 public class DefaultFreezeStatusTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for getTokenDefaultFreezeStatus(address) method. */
-    public static final Function DEFAULT_FREEZE_STATUS =
-            new Function("getTokenDefaultFreezeStatus(address)", ReturnTypes.RESPONSE_CODE_BOOL);
+    public static final SystemContractMethod DEFAULT_FREEZE_STATUS = SystemContractMethod.declare(
+                    "getTokenDefaultFreezeStatus(address)", ReturnTypes.RESPONSE_CODE_BOOL)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public DefaultFreezeStatusTranslator() {
+    public DefaultFreezeStatusTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(DEFAULT_FREEZE_STATUS);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(DEFAULT_FREEZE_STATUS);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(DEFAULT_FREEZE_STATUS);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,37 +17,50 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.defaultkycstatus;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates {@code getTokenDefaultKycStatus()} calls to the HTS system contract.
  */
+@Singleton
 public class DefaultKycStatusTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for getTokenDefaultKycStatus(address) method. */
-    public static final Function DEFAULT_KYC_STATUS =
-            new Function("getTokenDefaultKycStatus(address)", ReturnTypes.RESPONSE_CODE_BOOL);
+    public static final SystemContractMethod DEFAULT_KYC_STATUS = SystemContractMethod.declare(
+                    "getTokenDefaultKycStatus(address)", ReturnTypes.RESPONSE_CODE_BOOL)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public DefaultKycStatusTranslator() {
+    public DefaultKycStatusTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(DEFAULT_KYC_STATUS);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(DEFAULT_KYC_STATUS);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(DEFAULT_KYC_STATUS);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/delete/DeleteTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/delete/DeleteTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,40 +16,56 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.delete;
 
-import com.esaulpaugh.headlong.abi.Function;
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.token.TokenDeleteTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates {@code delete} calls to the HTS system contract.
  */
+@Singleton
 public class DeleteTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for deleteToken(address) method. */
-    public static final Function DELETE_TOKEN = new Function("deleteToken(address)", ReturnTypes.INT);
+    public static final SystemContractMethod DELETE_TOKEN = SystemContractMethod.declare(
+                    "deleteToken(address)", ReturnTypes.INT)
+            .withCategories(Category.CREATE_DELETE_TOKEN);
 
     /**
      * Default constructor to delete.
      */
     @Inject
-    public DeleteTranslator() {
+    public DeleteTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(DELETE_TOKEN);
     }
 
     @Override
-    public boolean matches(@NonNull HtsCallAttempt attempt) {
-        return attempt.isSelector(DELETE_TOKEN);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(DELETE_TOKEN);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/freeze/FreezeUnfreezeTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/freeze/FreezeUnfreezeTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,25 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.freeze;
 
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall.FailureCustomizer.NOOP_CUSTOMIZER;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -40,9 +45,13 @@ import javax.inject.Singleton;
 @Singleton
 public class FreezeUnfreezeTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for freezeToken(address,address) method. */
-    public static final Function FREEZE = new Function("freezeToken(address,address)", ReturnTypes.INT_64);
+    public static final SystemContractMethod FREEZE = SystemContractMethod.declare(
+                    "freezeToken(address,address)", ReturnTypes.INT_64)
+            .withCategories(Category.FREEZE_UNFREEZE);
     /** Selector for unfreezeToken(address,address) method. */
-    public static final Function UNFREEZE = new Function("unfreezeToken(address,address)", ReturnTypes.INT_64);
+    public static final SystemContractMethod UNFREEZE = SystemContractMethod.declare(
+                    "unfreezeToken(address,address)", ReturnTypes.INT_64)
+            .withCategories(Category.FREEZE_UNFREEZE);
 
     private final FreezeUnfreezeDecoder decoder;
 
@@ -50,16 +59,20 @@ public class FreezeUnfreezeTranslator extends AbstractCallTranslator<HtsCallAtte
      * @param decoder the decoder used for freeze/unfreeze calls
      */
     @Inject
-    public FreezeUnfreezeTranslator(@NonNull final FreezeUnfreezeDecoder decoder) {
+    public FreezeUnfreezeTranslator(
+            @NonNull final FreezeUnfreezeDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(FREEZE, UNFREEZE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(FREEZE, UNFREEZE);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(FREEZE, UNFREEZE);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class FungibleTokenInfoCall extends AbstractNonRevertibleTokenViewCall {
             return revertResult(status, gasRequirement);
         }
 
-        return function.getName().equals(FUNGIBLE_TOKEN_INFO.getName())
+        return function.getName().equals(FUNGIBLE_TOKEN_INFO.methodName())
                 ? successResult(
                         FUNGIBLE_TOKEN_INFO
                                 .getOutputs()

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,43 +19,60 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.fungi
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
 import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class FungibleTokenInfoTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
     /** Selector for getFungibleTokenInfo(address) method. */
-    public static final Function FUNGIBLE_TOKEN_INFO =
-            new Function("getFungibleTokenInfo(address)", ReturnTypes.RESPONSE_CODE_FUNGIBLE_TOKEN_INFO);
+    public static final SystemContractMethod FUNGIBLE_TOKEN_INFO = SystemContractMethod.declare(
+                    "getFungibleTokenInfo(address)", ReturnTypes.RESPONSE_CODE_FUNGIBLE_TOKEN_INFO)
+            .withVariants(Variant.V1, Variant.FT)
+            .withCategory(Category.TOKEN_QUERY);
 
     /** Selector for getFungibleTokenInfoV2(address) method. */
-    public static final Function FUNGIBLE_TOKEN_INFO_V2 =
-            new Function("getFungibleTokenInfoV2(address)", ReturnTypes.RESPONSE_CODE_FUNGIBLE_TOKEN_INFO_V2);
+    public static final SystemContractMethod FUNGIBLE_TOKEN_INFO_V2 = SystemContractMethod.declare(
+                    "getFungibleTokenInfoV2(address)", ReturnTypes.RESPONSE_CODE_FUNGIBLE_TOKEN_INFO_V2)
+            .withVariants(Variant.V2, Variant.FT)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public FungibleTokenInfoTranslator() {
+    public FungibleTokenInfoTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(FUNGIBLE_TOKEN_INFO, FUNGIBLE_TOKEN_INFO_V2);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
         requireNonNull(attempt);
+
         final var v2Enabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractTokenInfoV2Enabled();
-        return attempt.isSelector(FUNGIBLE_TOKEN_INFO)
-                || attempt.isSelectorIfConfigEnabled(v2Enabled, FUNGIBLE_TOKEN_INFO_V2);
+
+        if (attempt.isMethod(FUNGIBLE_TOKEN_INFO).isPresent()) return Optional.of(FUNGIBLE_TOKEN_INFO);
+        if (attempt.isSelectorIfConfigEnabled(v2Enabled, FUNGIBLE_TOKEN_INFO_V2))
+            return Optional.of(FUNGIBLE_TOKEN_INFO_V2);
+        return Optional.empty();
     }
 
     /**
@@ -64,8 +81,8 @@ public class FungibleTokenInfoTranslator extends AbstractCallTranslator<HtsCallA
     @Override
     public Call callFrom(@NonNull final HtsCallAttempt attempt) {
         requireNonNull(attempt);
-        final var function = attempt.isSelector(FUNGIBLE_TOKEN_INFO) ? FUNGIBLE_TOKEN_INFO : FUNGIBLE_TOKEN_INFO_V2;
-        final var args = function.decodeCall(attempt.input().toArrayUnsafe());
+        final var method = attempt.isSelector(FUNGIBLE_TOKEN_INFO) ? FUNGIBLE_TOKEN_INFO : FUNGIBLE_TOKEN_INFO_V2;
+        final var args = method.decodeCall(attempt.input().toArrayUnsafe());
         final var token = attempt.linkedToken(fromHeadlongAddress(args.get(0)));
         return new FungibleTokenInfoCall(
                 attempt.systemContractGasCalculator(),
@@ -73,6 +90,6 @@ public class FungibleTokenInfoTranslator extends AbstractCallTranslator<HtsCallA
                 attempt.isStaticCall(),
                 token,
                 attempt.configuration(),
-                function);
+                method.function());
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/getapproved/GetApprovedTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/getapproved/GetApprovedTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,19 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.getap
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asExactLongValueOrZero;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -34,24 +41,35 @@ import javax.inject.Singleton;
 public class GetApprovedTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
     /** Selector for getApproved(address,uint256) method. */
-    public static final Function HAPI_GET_APPROVED = new Function("getApproved(address,uint256)", "(int32,address)");
+    public static final SystemContractMethod HAPI_GET_APPROVED = SystemContractMethod.declare(
+                    "getApproved(address,uint256)", "(int32,address)")
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.TOKEN_QUERY, Category.APPROVAL);
     /** Selector for getApproved(uint256) method. */
-    public static final Function ERC_GET_APPROVED = new Function("getApproved(uint256)", ReturnTypes.ADDRESS);
+    public static final SystemContractMethod ERC_GET_APPROVED = SystemContractMethod.declare(
+                    "getApproved(uint256)", ReturnTypes.ADDRESS)
+            .withVia(CallVia.PROXY)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.ERC721, Category.TOKEN_QUERY, Category.APPROVAL);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public GetApprovedTranslator() {
+    public GetApprovedTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(HAPI_GET_APPROVED, ERC_GET_APPROVED);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isTokenRedirect() ? attempt.isSelector(ERC_GET_APPROVED) : attempt.isSelector(HAPI_GET_APPROVED);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+
+        return attempt.isTokenRedirect() ? attempt.isMethod(ERC_GET_APPROVED) : attempt.isMethod(HAPI_GET_APPROVED);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isapprovedforall/IsApprovedForAllTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isapprovedforall/IsApprovedForAllTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,17 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.isapprovedforall;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -31,25 +37,32 @@ import javax.inject.Singleton;
 @Singleton
 public class IsApprovedForAllTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for isApprovedForAll(address,address,address) method. */
-    public static final Function CLASSIC_IS_APPROVED_FOR_ALL =
-            new Function("isApprovedForAll(address,address,address)", "(int64,bool)");
+    public static final SystemContractMethod CLASSIC_IS_APPROVED_FOR_ALL = SystemContractMethod.declare(
+                    "isApprovedForAll(address,address,address)", "(int64,bool)")
+            .withCategories(Category.TOKEN_QUERY, Category.APPROVAL);
     /** Selector for isApprovedForAll(address,address) method. */
-    public static final Function ERC_IS_APPROVED_FOR_ALL = new Function("isApprovedForAll(address,address)", "(bool)");
+    public static final SystemContractMethod ERC_IS_APPROVED_FOR_ALL = SystemContractMethod.declare(
+                    "isApprovedForAll(address,address)", "(bool)")
+            .withVia(CallVia.PROXY)
+            .withCategories(Category.TOKEN_QUERY, Category.APPROVAL);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public IsApprovedForAllTranslator() {
+    public IsApprovedForAllTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(CLASSIC_IS_APPROVED_FOR_ALL, ERC_IS_APPROVED_FOR_ALL);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(CLASSIC_IS_APPROVED_FOR_ALL, ERC_IS_APPROVED_FOR_ALL);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(CLASSIC_IS_APPROVED_FOR_ALL, ERC_IS_APPROVED_FOR_ALL);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isfrozen/IsFrozenTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/isfrozen/IsFrozenTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,33 +17,47 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.isfrozen;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class IsFrozenTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for isFrozen(address,address) method. */
-    public static final Function IS_FROZEN = new Function("isFrozen(address,address)", ReturnTypes.RESPONSE_CODE_BOOL);
+    public static final SystemContractMethod IS_FROZEN = SystemContractMethod.declare(
+                    "isFrozen(address,address)", ReturnTypes.RESPONSE_CODE_BOOL)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.TOKEN_QUERY, Category.FREEZE_UNFREEZE);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public IsFrozenTranslator() {
+    public IsFrozenTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(IS_FROZEN);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(IS_FROZEN);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(IS_FROZEN);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/iskyc/IsKycTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/iskyc/IsKycTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,33 +17,47 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.iskyc;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class IsKycTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for isKyc(address,address) method. */
-    public static final Function IS_KYC = new Function("isKyc(address,address)", ReturnTypes.RESPONSE_CODE_BOOL);
+    public static final SystemContractMethod IS_KYC = SystemContractMethod.declare(
+                    "isKyc(address,address)", ReturnTypes.RESPONSE_CODE_BOOL)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.TOKEN_QUERY, Category.KYC);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public IsKycTranslator() {
+    public IsKycTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(IS_KYC);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(IS_KYC);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(IS_KYC);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/istoken/IsTokenTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,33 +17,47 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.istoken;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class IsTokenTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for isToken(address) method. */
-    public static final Function IS_TOKEN = new Function("isToken(address)", ReturnTypes.RESPONSE_CODE_BOOL);
+    public static final SystemContractMethod IS_TOKEN = SystemContractMethod.declare(
+                    "isToken(address)", ReturnTypes.RESPONSE_CODE_BOOL)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public IsTokenTranslator() {
+    public IsTokenTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(IS_TOKEN);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(IS_TOKEN);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(IS_TOKEN);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/mint/MintTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/mint/MintTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,24 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.mint;
 
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.mint.MintDecoder.MINT_OUTPUT_FN;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -38,9 +44,15 @@ import javax.inject.Singleton;
 @Singleton
 public class MintTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for mintToken(address,uint64,bytes[]) method. */
-    public static final Function MINT = new Function("mintToken(address,uint64,bytes[])", "(int64,int64,int64[])");
+    public static final SystemContractMethod MINT = SystemContractMethod.declare(
+                    "mintToken(address,uint64,bytes[])", "(int64,int64,int64[])")
+            .withVariant(Variant.V1)
+            .withCategories(Category.MINT_BURN);
     /** Selector for mintToken(address,int64,bytes[]) method. */
-    public static final Function MINT_V2 = new Function("mintToken(address,int64,bytes[])", "(int64,int64,int64[])");
+    public static final SystemContractMethod MINT_V2 = SystemContractMethod.declare(
+                    "mintToken(address,int64,bytes[])", "(int64,int64,int64[])")
+            .withVariant(Variant.V2)
+            .withCategories(Category.MINT_BURN);
 
     private final MintDecoder decoder;
 
@@ -48,16 +60,20 @@ public class MintTranslator extends AbstractCallTranslator<HtsCallAttempt> {
      * @param decoder the decoder to use for mint calls
      */
     @Inject
-    public MintTranslator(@NonNull final MintDecoder decoder) {
+    public MintTranslator(
+            @NonNull final MintDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(MINT, MINT_V2);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(MINT, MINT_V2);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(MINT, MINT_V2);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/name/NameTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/name/NameTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,18 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.name;
 
-import com.esaulpaugh.headlong.abi.Function;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -30,22 +37,27 @@ import javax.inject.Singleton;
 @Singleton
 public class NameTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for name() method. */
-    public static final Function NAME = new Function("name()", ReturnTypes.STRING);
+    public static final SystemContractMethod NAME = SystemContractMethod.declare("name()", ReturnTypes.STRING)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public NameTranslator() {
+    public NameTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(NAME);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(NAME);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(NAME);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ public class NftTokenInfoCall extends AbstractNonRevertibleTokenViewCall {
         final var ledgerConfig = configuration.getConfigData(LedgerConfig.class);
         final var ledgerId = Bytes.wrap(ledgerConfig.id().toByteArray()).toString();
 
-        return function.getName().equals(NON_FUNGIBLE_TOKEN_INFO.getName())
+        return function.getName().equals(NON_FUNGIBLE_TOKEN_INFO.methodName())
                 ? successResult(
                         NON_FUNGIBLE_TOKEN_INFO
                                 .getOutputs()

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,43 +19,58 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.nftto
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
 import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class NftTokenInfoTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
     /** Selector for getNonFungibleTokenInfo(address,int64) method. */
-    public static final Function NON_FUNGIBLE_TOKEN_INFO =
-            new Function("getNonFungibleTokenInfo(address,int64)", ReturnTypes.RESPONSE_CODE_NON_FUNGIBLE_TOKEN_INFO);
+    public static final SystemContractMethod NON_FUNGIBLE_TOKEN_INFO = SystemContractMethod.declare(
+                    "getNonFungibleTokenInfo(address,int64)", ReturnTypes.RESPONSE_CODE_NON_FUNGIBLE_TOKEN_INFO)
+            .withVariants(Variant.V1, Variant.NFT)
+            .withCategory(Category.TOKEN_QUERY);
 
     /** Selector for getNonFungibleTokenInfoV2(address,int64) method. */
-    public static final Function NON_FUNGIBLE_TOKEN_INFO_V2 = new Function(
-            "getNonFungibleTokenInfoV2(address,int64)", ReturnTypes.RESPONSE_CODE_NON_FUNGIBLE_TOKEN_INFO_V2);
+    public static final SystemContractMethod NON_FUNGIBLE_TOKEN_INFO_V2 = SystemContractMethod.declare(
+                    "getNonFungibleTokenInfoV2(address,int64)", ReturnTypes.RESPONSE_CODE_NON_FUNGIBLE_TOKEN_INFO_V2)
+            .withVariants(Variant.V2, Variant.NFT)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public NftTokenInfoTranslator() {
+    public NftTokenInfoTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(NON_FUNGIBLE_TOKEN_INFO, NON_FUNGIBLE_TOKEN_INFO_V2);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
         requireNonNull(attempt);
         final var v2Enabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractTokenInfoV2Enabled();
-        return attempt.isSelector(NON_FUNGIBLE_TOKEN_INFO)
-                || attempt.isSelectorIfConfigEnabled(v2Enabled, NON_FUNGIBLE_TOKEN_INFO_V2);
+        if (attempt.isMethod(NON_FUNGIBLE_TOKEN_INFO).isPresent()) return Optional.of(NON_FUNGIBLE_TOKEN_INFO);
+        if (attempt.isSelectorIfConfigEnabled(v2Enabled, NON_FUNGIBLE_TOKEN_INFO_V2))
+            return Optional.of(NON_FUNGIBLE_TOKEN_INFO_V2);
+        return Optional.empty();
     }
 
     /**
@@ -64,9 +79,9 @@ public class NftTokenInfoTranslator extends AbstractCallTranslator<HtsCallAttemp
     @Override
     public Call callFrom(@NonNull final HtsCallAttempt attempt) {
         requireNonNull(attempt);
-        final var function =
+        final var method =
                 attempt.isSelector(NON_FUNGIBLE_TOKEN_INFO) ? NON_FUNGIBLE_TOKEN_INFO : NON_FUNGIBLE_TOKEN_INFO_V2;
-        final var args = function.decodeCall(attempt.input().toArrayUnsafe());
+        final var args = method.decodeCall(attempt.input().toArrayUnsafe());
         final var token = attempt.linkedToken(fromHeadlongAddress(args.get(0)));
         return new NftTokenInfoCall(
                 attempt.systemContractGasCalculator(),
@@ -75,6 +90,6 @@ public class NftTokenInfoTranslator extends AbstractCallTranslator<HtsCallAttemp
                 token,
                 args.get(1),
                 attempt.configuration(),
-                function);
+                method.function());
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/pauses/PausesTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/pauses/PausesTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,24 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.pauses;
 
-import com.esaulpaugh.headlong.abi.Function;
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -38,9 +44,13 @@ import javax.inject.Singleton;
 @Singleton
 public class PausesTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for pauseToken(address) method. */
-    public static final Function PAUSE = new Function("pauseToken(address)", ReturnTypes.INT_64);
+    public static final SystemContractMethod PAUSE = SystemContractMethod.declare(
+                    "pauseToken(address)", ReturnTypes.INT_64)
+            .withCategories(Category.PAUSE_UNPAUSE);
     /** Selector for unpauseToken(address) method. */
-    public static final Function UNPAUSE = new Function("unpauseToken(address)", ReturnTypes.INT_64);
+    public static final SystemContractMethod UNPAUSE = SystemContractMethod.declare(
+                    "unpauseToken(address)", ReturnTypes.INT_64)
+            .withCategories(Category.PAUSE_UNPAUSE);
 
     private final PausesDecoder decoder;
 
@@ -48,16 +58,20 @@ public class PausesTranslator extends AbstractCallTranslator<HtsCallAttempt> {
      * @param decoder the decoder to use for pause calls
      */
     @Inject
-    public PausesTranslator(@NonNull final PausesDecoder decoder) {
+    public PausesTranslator(
+            @NonNull final PausesDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(PAUSE, UNPAUSE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(PAUSE, UNPAUSE);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(PAUSE, UNPAUSE);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/setapproval/SetApprovalForAllTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,32 +16,42 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.setapproval;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates setApprovalForAll (including ERC) call to the HTS system contract. There are no special cases for these
  * calls, so the returned {@link Call} is simply an instance of {@link DispatchForResponseCodeHtsCall}.
  */
+@Singleton
 public class SetApprovalForAllTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
     /** Selector for setApprovalForAll(address,address,bool) method. */
-    public static final Function SET_APPROVAL_FOR_ALL =
-            new Function("setApprovalForAll(address,address,bool)", ReturnTypes.INT);
+    public static final SystemContractMethod SET_APPROVAL_FOR_ALL = SystemContractMethod.declare(
+                    "setApprovalForAll(address,address,bool)", ReturnTypes.INT)
+            .withCategory(Category.APPROVAL);
     /** Selector for setApprovalForAll(address,bool) method. */
-    public static final Function ERC721_SET_APPROVAL_FOR_ALL =
-            new Function("setApprovalForAll(address,bool)", ReturnTypes.INT);
+    public static final SystemContractMethod ERC721_SET_APPROVAL_FOR_ALL = SystemContractMethod.declare(
+                    "setApprovalForAll(address,bool)", ReturnTypes.INT)
+            .withVia(CallVia.PROXY)
+            .withCategories(Category.ERC721, Category.APPROVAL);
 
     private final SetApprovalForAllDecoder decoder;
 
@@ -49,18 +59,21 @@ public class SetApprovalForAllTranslator extends AbstractCallTranslator<HtsCallA
      * @param decoder the decoder to use for approve calls
      */
     @Inject
-    public SetApprovalForAllTranslator(final SetApprovalForAllDecoder decoder) {
+    public SetApprovalForAllTranslator(
+            final SetApprovalForAllDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(SET_APPROVAL_FOR_ALL, ERC721_SET_APPROVAL_FOR_ALL);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
         return attempt.isTokenRedirect()
-                ? attempt.isSelector(ERC721_SET_APPROVAL_FOR_ALL)
-                : attempt.isSelector(SET_APPROVAL_FOR_ALL);
+                ? attempt.isMethod(ERC721_SET_APPROVAL_FOR_ALL)
+                : attempt.isMethod(SET_APPROVAL_FOR_ALL);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/symbol/SymbolTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/symbol/SymbolTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,18 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.symbol;
 
-import com.esaulpaugh.headlong.abi.Function;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -30,22 +37,27 @@ import javax.inject.Singleton;
 @Singleton
 public class SymbolTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for symbol() method. */
-    public static final Function SYMBOL = new Function("symbol()", ReturnTypes.STRING);
+    public static final SystemContractMethod SYMBOL = SystemContractMethod.declare("symbol()", ReturnTypes.STRING)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.ERC20, Category.ERC721, Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public SymbolTranslator() {
+    public SymbolTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(SYMBOL);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(SYMBOL);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(SYMBOL);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenexpiry/TokenExpiryTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenexpiry/TokenExpiryTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,37 +17,50 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokenexpiry;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates {@code getTokenExpiry()} calls to the HTS system contract.
  */
+@Singleton
 public class TokenExpiryTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for getTokenExpiryInfo(address) method. */
-    public static final Function TOKEN_EXPIRY =
-            new Function("getTokenExpiryInfo(address)", ReturnTypes.RESPONSE_CODE_EXPIRY);
+    public static final SystemContractMethod TOKEN_EXPIRY = SystemContractMethod.declare(
+                    "getTokenExpiryInfo(address)", ReturnTypes.RESPONSE_CODE_EXPIRY)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public TokenExpiryTranslator() {
+    public TokenExpiryTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(TOKEN_EXPIRY);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(TOKEN_EXPIRY);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(TOKEN_EXPIRY);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokeninfo/TokenInfoCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokeninfo/TokenInfoCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class TokenInfoCall extends AbstractNonRevertibleTokenViewCall {
             return revertResult(status, gasRequirement);
         }
 
-        return function.getName().equals(TOKEN_INFO.getName())
+        return function.getName().equals(TOKEN_INFO.methodName())
                 ? successResult(
                         TOKEN_INFO
                                 .getOutputs()

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokeninfo/TokenInfoTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokeninfo/TokenInfoTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,43 +19,62 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.token
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
 import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates {@code getTokenInfo()} calls to the HTS system contract.
  */
+@Singleton
 public class TokenInfoTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for getTokenInfo(address) method. */
-    public static final Function TOKEN_INFO =
-            new Function("getTokenInfo(address)", ReturnTypes.RESPONSE_CODE_TOKEN_INFO);
+    public static final SystemContractMethod TOKEN_INFO = SystemContractMethod.declare(
+                    "getTokenInfo(address)", ReturnTypes.RESPONSE_CODE_TOKEN_INFO)
+            .withModifier(Modifier.VIEW)
+            .withVariant(Variant.V1)
+            .withCategory(Category.TOKEN_QUERY);
     /** Selector for getTokenInfoV2(address) method. */
-    public static final Function TOKEN_INFO_V2 =
-            new Function("getTokenInfoV2(address)", ReturnTypes.RESPONSE_CODE_TOKEN_INFO_V2);
+    public static final SystemContractMethod TOKEN_INFO_V2 = SystemContractMethod.declare(
+                    "getTokenInfoV2(address)", ReturnTypes.RESPONSE_CODE_TOKEN_INFO_V2)
+            .withModifier(Modifier.VIEW)
+            .withVariant(Variant.V2)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public TokenInfoTranslator() {
+    public TokenInfoTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(TOKEN_INFO, TOKEN_INFO_V2);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
         requireNonNull(attempt);
+
         final var v2Enabled =
                 attempt.configuration().getConfigData(ContractsConfig.class).systemContractTokenInfoV2Enabled();
-        return attempt.isSelector(TOKEN_INFO) || attempt.isSelectorIfConfigEnabled(v2Enabled, TOKEN_INFO_V2);
+        if (attempt.isSelector(TOKEN_INFO)) return Optional.of(TOKEN_INFO);
+        if (attempt.isSelectorIfConfigEnabled(v2Enabled, TOKEN_INFO_V2)) return Optional.of(TOKEN_INFO_V2);
+        return Optional.empty();
     }
 
     /**
@@ -64,8 +83,8 @@ public class TokenInfoTranslator extends AbstractCallTranslator<HtsCallAttempt> 
     @Override
     public Call callFrom(@NonNull final HtsCallAttempt attempt) {
         requireNonNull(attempt);
-        final var function = attempt.isSelector(TOKEN_INFO) ? TOKEN_INFO : TOKEN_INFO_V2;
-        final var args = function.decodeCall(attempt.input().toArrayUnsafe());
+        final var method = attempt.isSelector(TOKEN_INFO) ? TOKEN_INFO : TOKEN_INFO_V2;
+        final var args = method.decodeCall(attempt.input().toArrayUnsafe());
         final var token = attempt.linkedToken(fromHeadlongAddress(args.get(0)));
         return new TokenInfoCall(
                 attempt.systemContractGasCalculator(),
@@ -73,6 +92,6 @@ public class TokenInfoTranslator extends AbstractCallTranslator<HtsCallAttempt> 
                 attempt.isStaticCall(),
                 token,
                 attempt.configuration(),
-                function);
+                method.function());
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenkey/TokenKeyTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokenkey/TokenKeyTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,42 +17,55 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokenkey;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.hapi.utils.InvalidTransactionException;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates {@code getTokenKey()} calls to the HTS system contract.
  */
+@Singleton
 public class TokenKeyTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for getTokenKey(address,uint) method. */
-    public static final Function TOKEN_KEY =
-            new Function("getTokenKey(address,uint)", ReturnTypes.RESPONSE_CODE_TOKEN_KEY);
+    public static final SystemContractMethod TOKEN_KEY = SystemContractMethod.declare(
+                    "getTokenKey(address,uint)", ReturnTypes.RESPONSE_CODE_TOKEN_KEY)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public TokenKeyTranslator() {
+    public TokenKeyTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(TOKEN_KEY);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(TOKEN_KEY);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(TOKEN_KEY);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/tokentype/TokenTypeTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,36 +17,50 @@
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokentype;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
+import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates {@code getTokenType()} calls to the HTS system contract.
  */
+@Singleton
 public class TokenTypeTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for getTokenType(address) method. */
-    public static final Function TOKEN_TYPE = new Function("getTokenType(address)", ReturnTypes.RESPONSE_CODE_INT32);
+    public static final SystemContractMethod TOKEN_TYPE = SystemContractMethod.declare(
+                    "getTokenType(address)", ReturnTypes.RESPONSE_CODE_INT32)
+            .withModifier(Modifier.VIEW)
+            .withCategory(Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public TokenTypeTranslator() {
+    public TokenTypeTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(TOKEN_TYPE);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(TOKEN_TYPE);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        requireNonNull(attempt);
+        return attempt.isMethod(TOKEN_TYPE);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/totalsupply/TotalSupplyTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/totalsupply/TotalSupplyTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.totalsupply;
 
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Modifier;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -30,22 +35,27 @@ import javax.inject.Singleton;
 @Singleton
 public class TotalSupplyTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for totalSupply() method. */
-    public static final Function TOTAL_SUPPLY = new Function("totalSupply()", ReturnTypes.INT);
+    public static final SystemContractMethod TOTAL_SUPPLY = SystemContractMethod.declare(
+                    "totalSupply()", ReturnTypes.INT)
+            .withModifier(Modifier.VIEW)
+            .withCategories(Category.ERC20, Category.ERC721, Category.TOKEN_QUERY);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public TotalSupplyTranslator() {
+    public TotalSupplyTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(TOTAL_SUPPLY);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(TOTAL_SUPPLY);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        return attempt.isMethod(TOTAL_SUPPLY);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,14 +21,19 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.math.BigInteger;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -40,27 +45,39 @@ public class Erc20TransfersTranslator extends AbstractCallTranslator<HtsCallAtte
     /**
      * Selector for transfer(address,uint256) method.
      */
-    public static final Function ERC_20_TRANSFER = new Function("transfer(address,uint256)", ReturnTypes.BOOL);
+    public static final SystemContractMethod ERC_20_TRANSFER = SystemContractMethod.declare(
+                    "transfer(address,uint256)", ReturnTypes.BOOL)
+            .withVia(CallVia.PROXY)
+            .withCategories(Category.ERC20, Category.TRANSFER);
     /**
      * Selector for transferFrom(address,address,uint256) method.
      */
-    public static final Function ERC_20_TRANSFER_FROM =
-            new Function("transferFrom(address,address,uint256)", ReturnTypes.BOOL);
+    public static final SystemContractMethod ERC_20_TRANSFER_FROM = SystemContractMethod.declare(
+                    "transferFrom(address,address,uint256)", ReturnTypes.BOOL)
+            .withVia(CallVia.PROXY)
+            .withCategories(Category.ERC20, Category.TRANSFER);
 
     /**
      * Default constructor for injection.
      */
     @Inject
-    public Erc20TransfersTranslator() {
+    public Erc20TransfersTranslator(
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
         // Dagger2
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(ERC_20_TRANSFER, ERC_20_TRANSFER_FROM);
     }
 
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        // We will match the transferFrom() selector shared by ERC-20 and ERC-721 if the token is missing
-        return attempt.isTokenRedirect()
-                && attempt.isSelector(ERC_20_TRANSFER, ERC_20_TRANSFER_FROM)
-                && attempt.redirectTokenType() != NON_FUNGIBLE_UNIQUE;
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        // Here, for ERC-20 == fungible tokens, we allow `transferFrom` (signature shared by ERC-20
+        // and ERC-721) even if the token type doesn't exist.  (This is the case when `redirectTokenType()`
+        // returns `null`.)
+        if (!attempt.isTokenRedirect()) return Optional.empty();
+        if (attempt.redirectTokenType() == NON_FUNGIBLE_UNIQUE) return Optional.empty();
+        return attempt.isMethod(ERC_20_TRANSFER, ERC_20_TRANSFER_FROM);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateExpiryTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateExpiryTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,35 +20,46 @@ import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.EXPIRY;
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.EXPIRY_V2;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateDecoder.FAILURE_CUSTOMIZER;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * Translates ERC-721 {@code updateTokenExpiryInfo()} calls to the HTS system contract.
  */
+@Singleton
 public class UpdateExpiryTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /**
      * Selector for updateTokenExpiryInfo(address, EXPIRY) method.
      */
-    public static final Function UPDATE_TOKEN_EXPIRY_INFO_V1 =
-            new Function("updateTokenExpiryInfo(address," + EXPIRY + ")", ReturnTypes.INT);
+    public static final SystemContractMethod UPDATE_TOKEN_EXPIRY_INFO_V1 = SystemContractMethod.declare(
+                    "updateTokenExpiryInfo(address," + EXPIRY + ")", ReturnTypes.INT)
+            .withVariant(Variant.V1)
+            .withCategories(Category.UPDATE);
     /**
      * Selector for updateTokenExpiryInfo(address, EXPIRY_V2) method.
      */
-    public static final Function UPDATE_TOKEN_EXPIRY_INFO_V2 =
-            new Function("updateTokenExpiryInfo(address," + EXPIRY_V2 + ")", ReturnTypes.INT);
+    public static final SystemContractMethod UPDATE_TOKEN_EXPIRY_INFO_V2 = SystemContractMethod.declare(
+                    "updateTokenExpiryInfo(address," + EXPIRY_V2 + ")", ReturnTypes.INT)
+            .withVariant(Variant.V2)
+            .withCategories(Category.UPDATE);
 
     private final UpdateDecoder decoder;
 
@@ -56,13 +67,19 @@ public class UpdateExpiryTranslator extends AbstractCallTranslator<HtsCallAttemp
      * @param decoder the decoder used for token update calls
      */
     @Inject
-    public UpdateExpiryTranslator(UpdateDecoder decoder) {
+    public UpdateExpiryTranslator(
+            UpdateDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(UPDATE_TOKEN_EXPIRY_INFO_V1, UPDATE_TOKEN_EXPIRY_INFO_V2);
     }
 
     @Override
-    public boolean matches(@NonNull HtsCallAttempt attempt) {
-        return attempt.isSelector(UPDATE_TOKEN_EXPIRY_INFO_V1, UPDATE_TOKEN_EXPIRY_INFO_V2);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        return attempt.isMethod(UPDATE_TOKEN_EXPIRY_INFO_V1, UPDATE_TOKEN_EXPIRY_INFO_V2);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateNFTsMetadataTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateNFTsMetadataTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,34 @@
 
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class UpdateNFTsMetadataTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     /** Selector for updateNFTsMetadata(address,int64[],bytes) method. */
-    public static final Function UPDATE_NFTs_METADATA =
-            new Function("updateNFTsMetadata(address,int64[],bytes)", ReturnTypes.INT);
+    public static final SystemContractMethod UPDATE_NFTs_METADATA = SystemContractMethod.declare(
+                    "updateNFTsMetadata(address,int64[],bytes)", ReturnTypes.INT)
+            .withVariants(Variant.NFT, Variant.WITH_METADATA)
+            .withCategories(Category.UPDATE);
 
     private final UpdateDecoder decoder;
 
@@ -42,14 +51,21 @@ public class UpdateNFTsMetadataTranslator extends AbstractCallTranslator<HtsCall
      * @param decoder the decoder to use for NFTs update  metadata
      */
     @Inject
-    public UpdateNFTsMetadataTranslator(@NonNull final UpdateDecoder decoder) {
+    public UpdateNFTsMetadataTranslator(
+            @NonNull final UpdateDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(UPDATE_NFTs_METADATA);
     }
 
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.configuration().getConfigData(ContractsConfig.class).systemContractUpdateNFTsMetadataEnabled()
-                && attempt.isSelector(UPDATE_NFTs_METADATA);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        if (!attempt.configuration().getConfigData(ContractsConfig.class).systemContractUpdateNFTsMetadataEnabled())
+            return Optional.empty();
+        return attempt.isMethod(UPDATE_NFTs_METADATA);
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/update/UpdateTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,23 +22,30 @@ import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.EXPIRY_V
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.HEDERA_TOKEN_WITH_METADATA;
 import static com.hedera.node.app.hapi.utils.contracts.ParsingConstants.TOKEN_KEY;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class UpdateTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     private static final String UPDATE_TOKEN_INFO_STRING = "updateTokenInfo(address,";
     private static final String HEDERA_TOKEN_STRUCT =
@@ -48,40 +55,58 @@ public class UpdateTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     private static final String HEDERA_TOKEN_STRUCT_V3 =
             "(string,string,address,string,bool,int64,bool," + TOKEN_KEY + ARRAY_BRACKETS + "," + EXPIRY_V2 + ")";
     /** Selector for updateTokenInfo(address, HEDERA_TOKEN_STRUCT) method. */
-    public static final Function TOKEN_UPDATE_INFO_FUNCTION_V1 =
-            new Function(UPDATE_TOKEN_INFO_STRING + HEDERA_TOKEN_STRUCT + ")", ReturnTypes.INT);
+    public static final SystemContractMethod TOKEN_UPDATE_INFO_FUNCTION_V1 = SystemContractMethod.declare(
+                    UPDATE_TOKEN_INFO_STRING + HEDERA_TOKEN_STRUCT + ")", ReturnTypes.INT)
+            .withVariant(Variant.V1)
+            .withCategories(Category.UPDATE);
     /** Selector for updateTokenInfo(address, HEDERA_TOKEN_STRUCT_V2) method. */
-    public static final Function TOKEN_UPDATE_INFO_FUNCTION_V2 =
-            new Function(UPDATE_TOKEN_INFO_STRING + HEDERA_TOKEN_STRUCT_V2 + ")", ReturnTypes.INT);
+    public static final SystemContractMethod TOKEN_UPDATE_INFO_FUNCTION_V2 = SystemContractMethod.declare(
+                    UPDATE_TOKEN_INFO_STRING + HEDERA_TOKEN_STRUCT_V2 + ")", ReturnTypes.INT)
+            .withVariant(Variant.V2)
+            .withCategories(Category.UPDATE);
     /** Selector for updateTokenInfo(address, HEDERA_TOKEN_STRUCT_V3) method. */
-    public static final Function TOKEN_UPDATE_INFO_FUNCTION_V3 =
-            new Function(UPDATE_TOKEN_INFO_STRING + HEDERA_TOKEN_STRUCT_V3 + ")", ReturnTypes.INT);
+    public static final SystemContractMethod TOKEN_UPDATE_INFO_FUNCTION_V3 = SystemContractMethod.declare(
+                    UPDATE_TOKEN_INFO_STRING + HEDERA_TOKEN_STRUCT_V3 + ")", ReturnTypes.INT)
+            .withVariant(Variant.V3)
+            .withCategories(Category.UPDATE);
     /** Selector for updateTokenInfo(address, HEDERA_TOKEN_WITH_METADATA) method. */
-    public static final Function TOKEN_UPDATE_INFO_FUNCTION_WITH_METADATA =
-            new Function(UPDATE_TOKEN_INFO_STRING + HEDERA_TOKEN_WITH_METADATA + ")", ReturnTypes.INT);
+    public static final SystemContractMethod TOKEN_UPDATE_INFO_FUNCTION_WITH_METADATA = SystemContractMethod.declare(
+                    UPDATE_TOKEN_INFO_STRING + HEDERA_TOKEN_WITH_METADATA + ")", ReturnTypes.INT)
+            .withVariant(Variant.WITH_METADATA)
+            .withCategories(Category.UPDATE);
 
-    public static final Map<Function, UpdateDecoderFunction> updateSelectorsMap = new HashMap<>();
+    public static final Map<SystemContractMethod, UpdateDecoderFunction> updateMethodsMap = new HashMap<>();
 
     /**
      * @param decoder the decoder to use for token update info calls
      */
     @Inject
-    public UpdateTranslator(final UpdateDecoder decoder) {
-        updateSelectorsMap.put(TOKEN_UPDATE_INFO_FUNCTION_V1, decoder::decodeTokenUpdateV1);
-        updateSelectorsMap.put(TOKEN_UPDATE_INFO_FUNCTION_V2, decoder::decodeTokenUpdateV2);
-        updateSelectorsMap.put(TOKEN_UPDATE_INFO_FUNCTION_V3, decoder::decodeTokenUpdateV3);
-        updateSelectorsMap.put(TOKEN_UPDATE_INFO_FUNCTION_WITH_METADATA, decoder::decodeTokenUpdateWithMetadata);
+    public UpdateTranslator(
+            final UpdateDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
+        registerMethods(
+                TOKEN_UPDATE_INFO_FUNCTION_V1,
+                TOKEN_UPDATE_INFO_FUNCTION_V2,
+                TOKEN_UPDATE_INFO_FUNCTION_V3,
+                TOKEN_UPDATE_INFO_FUNCTION_WITH_METADATA);
+
+        updateMethodsMap.put(TOKEN_UPDATE_INFO_FUNCTION_V1, decoder::decodeTokenUpdateV1);
+        updateMethodsMap.put(TOKEN_UPDATE_INFO_FUNCTION_V2, decoder::decodeTokenUpdateV2);
+        updateMethodsMap.put(TOKEN_UPDATE_INFO_FUNCTION_V3, decoder::decodeTokenUpdateV3);
+        updateMethodsMap.put(TOKEN_UPDATE_INFO_FUNCTION_WITH_METADATA, decoder::decodeTokenUpdateWithMetadata);
     }
 
     @Override
-    public boolean matches(@NonNull HtsCallAttempt attempt) {
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
         final boolean metadataSupport =
                 attempt.configuration().getConfigData(ContractsConfig.class).metadataKeyAndFieldEnabled();
 
-        return updateSelectorsMap.keySet().stream()
-                .anyMatch(selector -> selector.equals(TOKEN_UPDATE_INFO_FUNCTION_WITH_METADATA)
-                        ? attempt.isSelectorIfConfigEnabled(metadataSupport, selector)
-                        : attempt.isSelector(selector));
+        if (attempt.isSelectorIfConfigEnabled(metadataSupport, TOKEN_UPDATE_INFO_FUNCTION_WITH_METADATA))
+            return Optional.of(TOKEN_UPDATE_INFO_FUNCTION_WITH_METADATA);
+        return updateMethodsMap.keySet().stream().filter(attempt::isSelector).findFirst();
     }
 
     @Override
@@ -106,7 +131,7 @@ public class UpdateTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     }
 
     private TransactionBody nominalBodyFor(@NonNull final HtsCallAttempt attempt) {
-        return updateSelectorsMap.entrySet().stream()
+        return updateMethodsMap.entrySet().stream()
                 .filter(entry -> attempt.isSelector(entry.getKey()))
                 .map(entry -> entry.getValue().decode(attempt))
                 .findFirst()

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/updatetokencustomfees/UpdateTokenCustomFeesTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/updatetokencustomfees/UpdateTokenCustomFeesTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,44 +20,63 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.updatetokencustomfees.UpdateTokenCustomFeesDecoder.UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_STRING;
 import static java.util.Objects.requireNonNull;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
+@Singleton
 public class UpdateTokenCustomFeesTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
     /** Selector for updateFungibleTokenCustomFees(address,(int64,address,bool,bool,address)[],(int64,int64,int64,int64,bool,address)[]) method. */
-    public static final Function UPDATE_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION =
-            new Function(UPDATE_FUNGIBLE_TOKEN_CUSTOM_FEES_STRING, ReturnTypes.INT);
+    public static final SystemContractMethod UPDATE_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION = SystemContractMethod.declare(
+                    UPDATE_FUNGIBLE_TOKEN_CUSTOM_FEES_STRING, ReturnTypes.INT)
+            .withVariants(Variant.FT, Variant.WITH_CUSTOM_FEES)
+            .withCategories(Category.UPDATE);
     /** Selector for updateNonFungibleTokenCustomFees(address,(int64,address,bool,bool,address)[],(int64,int64,int64,address,bool,address)[]) method. */
-    public static final Function UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION =
-            new Function(UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_STRING, ReturnTypes.INT);
+    public static final SystemContractMethod UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION =
+            SystemContractMethod.declare(UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_STRING, ReturnTypes.INT)
+                    .withVariants(Variant.NFT, Variant.WITH_CUSTOM_FEES)
+                    .withCategories(Category.UPDATE);
 
     private final UpdateTokenCustomFeesDecoder decoder;
 
     @Inject
-    public UpdateTokenCustomFeesTranslator(@NonNull final UpdateTokenCustomFeesDecoder decoder) {
+    public UpdateTokenCustomFeesTranslator(
+            @NonNull final UpdateTokenCustomFeesDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
+
         requireNonNull(decoder);
         this.decoder = decoder;
+
+        registerMethods(UPDATE_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION, UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION);
     }
 
     @Override
-    public boolean matches(@NonNull HtsCallAttempt attempt) {
-        return attempt.configuration().getConfigData(ContractsConfig.class).systemContractUpdateCustomFeesEnabled()
-                && attempt.isSelector(
-                        UPDATE_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION, UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        if (!attempt.configuration().getConfigData(ContractsConfig.class).systemContractUpdateCustomFeesEnabled())
+            return Optional.empty();
+        return attempt.isMethod(
+                UPDATE_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION, UPDATE_NON_FUNGIBLE_TOKEN_CUSTOM_FEES_FUNCTION);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/wipe/WipeTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/wipe/WipeTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,23 @@ package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.wipe;
 
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall.FailureCustomizer.NOOP_CUSTOMIZER;
 
-import com.esaulpaugh.headlong.abi.Function;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Category;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -37,28 +42,37 @@ import javax.inject.Singleton;
 public class WipeTranslator extends AbstractCallTranslator<HtsCallAttempt> {
 
     /** Selector for wipeTokenAccount(address,address,uint32) method. */
-    public static final Function WIPE_FUNGIBLE_V1 =
-            new Function("wipeTokenAccount(address,address,uint32)", ReturnTypes.INT);
+    public static final SystemContractMethod WIPE_FUNGIBLE_V1 = SystemContractMethod.declare(
+                    "wipeTokenAccount(address,address,uint32)", ReturnTypes.INT)
+            .withVariants(Variant.V1, Variant.FT)
+            .withCategories(Category.WIPE);
     /** Selector for wipeTokenAccount(address,address,int64) method. */
-    public static final Function WIPE_FUNGIBLE_V2 =
-            new Function("wipeTokenAccount(address,address,int64)", ReturnTypes.INT);
+    public static final SystemContractMethod WIPE_FUNGIBLE_V2 = SystemContractMethod.declare(
+                    "wipeTokenAccount(address,address,int64)", ReturnTypes.INT)
+            .withVariants(Variant.V2, Variant.FT)
+            .withCategories(Category.WIPE);
     /** Selector for wipeTokenAccountNFT(address,address,int64[]) method. */
-    public static final Function WIPE_NFT =
-            new Function("wipeTokenAccountNFT(address,address,int64[])", ReturnTypes.INT);
+    public static final SystemContractMethod WIPE_NFT = SystemContractMethod.declare(
+                    "wipeTokenAccountNFT(address,address,int64[])", ReturnTypes.INT)
+            .withVariant(Variant.NFT)
+            .withCategories(Category.WIPE);
 
     private final WipeDecoder decoder;
 
     @Inject
-    public WipeTranslator(@NonNull final WipeDecoder decoder) {
+    public WipeTranslator(
+            @NonNull final WipeDecoder decoder,
+            @NonNull final SystemContractMethodRegistry systemContractMethodRegistry,
+            @NonNull final ContractMetrics contractMetrics) {
+        super(SystemContractMethod.SystemContract.HTS, systemContractMethodRegistry, contractMetrics);
         this.decoder = decoder;
+
+        registerMethods(WIPE_FUNGIBLE_V1, WIPE_FUNGIBLE_V2, WIPE_NFT);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public boolean matches(@NonNull final HtsCallAttempt attempt) {
-        return attempt.isSelector(WIPE_FUNGIBLE_V1, WIPE_FUNGIBLE_V2, WIPE_NFT);
+    public @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final HtsCallAttempt attempt) {
+        return attempt.isMethod(WIPE_FUNGIBLE_V1, WIPE_FUNGIBLE_V2, WIPE_NFT);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/SystemContractMethod.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/SystemContractMethod.java
@@ -348,17 +348,17 @@ public record SystemContractMethod(
         return methodName;
     }
 
-    private @NonNull String variantsSuffix() {
+    public @NonNull String variantsSuffix() {
         if (variants.isEmpty()) return "";
         return variants.stream().map(Variant::asSuffix).sorted().collect(Collectors.joining("_", "_", ""));
     }
 
-    private @NonNull String categoriesSuffix() {
+    public @NonNull String categoriesSuffix() {
         if (categories.isEmpty()) return "";
         return categories.stream().map(Category::asSuffix).sorted().collect(Collectors.joining(",", "_[", "]"));
     }
 
-    private @NonNull String modifiersSuffix() {
+    public @NonNull String modifiersSuffix() {
         if (modifier.isEmpty()) return "";
         return "_[" + modifier.get().asSuffix() + "]";
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/SystemContractMethod.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/SystemContractMethod.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.contract.impl.exec.utils;
+
+import static java.util.Objects.requireNonNull;
+
+import com.esaulpaugh.headlong.abi.Function;
+import com.esaulpaugh.headlong.abi.Tuple;
+import com.esaulpaugh.headlong.abi.TupleType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.tuweni.bytes.Bytes;
+
+/**
+ * Represents a system contract method: It's signature + outputs, and other information about how it is declared
+ * @param function A headlong description of this method: signature + outputs, selector
+ * @param systemContract Which system contract this method is part of (HAS, HSS, HTS, PRNG, EXCHANGE)
+ * @param via Whether called directly or via redirect (aka proxy)
+ * @param categories Set of category flags possibly empty
+ * @param modifier An optional Solidity function modifier (e.g., pure or view)
+ * @param variants Set of method variants (e.g., version number, or FT vs NFT), possibly empty
+ */
+public record SystemContractMethod(
+        @NonNull Function function,
+        @NonNull Optional<SystemContract> systemContract,
+        @NonNull CallVia via,
+        @NonNull EnumSet<Category> categories,
+        @NonNull Optional<Modifier> modifier,
+        @NonNull EnumSet<Variant> variants) {
+
+    public SystemContractMethod {
+        requireNonNull(function);
+        requireNonNull(systemContract);
+        requireNonNull(via);
+        requireNonNull(categories);
+        requireNonNull(modifier);
+        requireNonNull(variants);
+    }
+
+    /**
+     * Factory to create a SystemContractMethod given its signature and outputs
+     *
+     * This SystemContractMethod is incomplete in that it doesn't have the SystemContract field,
+     * which must be added later (with `withContract`)
+     */
+    public static SystemContractMethod declare(@NonNull final String signature, @NonNull final String outputs) {
+        final var function = new com.esaulpaugh.headlong.abi.Function(signature, outputs);
+        return new SystemContractMethod(
+                function,
+                Optional.empty(),
+                CallVia.DIRECT,
+                EnumSet.noneOf(Category.class),
+                Optional.empty(),
+                EnumSet.noneOf(Variant.class));
+    }
+
+    /**
+     * Factory to create a SystemContractMethod given its signature when it returns nothing
+     *
+     * This SystemContractMethod is incomplete in that it doesn't have the SystemContract field,
+     * which must be added later (with `withContract`)
+     */
+    public static SystemContractMethod declare(@NonNull final String signature) {
+        final var function = new com.esaulpaugh.headlong.abi.Function(signature);
+        return new SystemContractMethod(
+                function,
+                Optional.empty(),
+                CallVia.DIRECT,
+                EnumSet.noneOf(Category.class),
+                Optional.empty(),
+                EnumSet.noneOf(Variant.class));
+    }
+
+    /**
+     * Verify that the SystemContractMethod was created correctly
+     *
+     * Specifically, check that a SystemContract was provided for it eventually
+     */
+    public void verifyComplete() {
+        if (systemContract.isEmpty()) {
+            throw new IllegalStateException("System contract %s is empty".formatted(function.getName()));
+        }
+    }
+
+    /** The system contract "kind" for this SystemContractMethod */
+    public enum SystemContract {
+        HTS,
+        HAS,
+        HSS,
+        PNRG,
+        EXCHANGE
+    }
+
+    public interface AsSuffix {
+        @NonNull
+        String asSuffix();
+    }
+
+    /** Says that this SystemContractMethod is called directly or via redirect/proxy */
+    public enum CallVia implements AsSuffix {
+        DIRECT(""),
+        PROXY("[PROXY]");
+
+        private final String asSuffix;
+
+        CallVia(@NonNull final String viaSuffix) {
+            asSuffix = viaSuffix;
+        }
+
+        public @NonNull String asSuffix() {
+            return asSuffix;
+        }
+    }
+
+    /**
+     * Says that this SystemContractMethod is a view function or a pure function (as in Solidity).
+     *
+     * If neither is specified then it is a normal (state-changing) function.
+     */
+    public enum Modifier implements AsSuffix {
+        VIEW("VIEW"),
+        PURE("PURE");
+
+        private final String asSuffix;
+
+        Modifier(String modifierSuffix) {
+            this.asSuffix = modifierSuffix;
+        }
+
+        public @NonNull String asSuffix() {
+            return asSuffix;
+        }
+    }
+
+    /**
+     * Categorizes the SystemContractMethod.  None, one, or more of these categories can be specified.
+     *
+     * Useful for grouping methods together.
+     */
+    public enum Category implements AsSuffix {
+        ERC20("ERC20", "(can overlap with ERC721)"),
+        ERC721("ERC721", "(can overlap with ERC20)"),
+
+        SCHEDULE("SCHEDULE"),
+        TOKEN_QUERY("TOKEN_QUERY", "(any token field query)"),
+
+        ALIASES("ALIASES"),
+        IS_AUTHORIZED("IS_AUTHORIZED", "(IsAuthorized, IsAuthorizedRaw)"),
+
+        AIRDROP("AIRDROP"),
+        ALLOWANCE("ALLOWANCE", "(Allowance related)"),
+        APPROVAL("APPROVAL", "(Approval related)"),
+        ASSOCIATION("ASSOCIATION"),
+        CREATE_DELETE_TOKEN("CREATE_OR_DELETE_TOKEN", "(Create or Delete Token)"),
+        FREEZE_UNFREEZE("FREEZE_UNFREEZE", "(Freeze or Unfreeze Token)"),
+        KYC("KYC"),
+        MINT_BURN("MINT_OR_BURN", "(Mint or Burn Token)"),
+        PAUSE_UNPAUSE("PAUSE_UNPAUSE", "(Pause or Unpause Token)"),
+        REJECT("REJECT_TOKEN"),
+        TRANSFER("TRANSFER_TOKEN", "(any token transfer transaction"),
+        UPDATE("UPDATE_TOKEN", "(any token field update)"),
+        WIPE("WIPE_TOKEN");
+
+        private final String asSuffix;
+        private final String clarification;
+
+        Category(@NonNull final String categorySuffix) {
+            this.asSuffix = requireNonNull(categorySuffix);
+            this.clarification = "(%s)".formatted(this.asSuffix);
+        }
+
+        Category(@NonNull final String categorySuffix, @NonNull final String clarification) {
+            this.asSuffix = requireNonNull(categorySuffix);
+            this.clarification = requireNonNull(clarification);
+        }
+
+        public @NonNull String asSuffix() {
+            return asSuffix;
+        }
+
+        public @NonNull String clarification() {
+            return clarification;
+        }
+    }
+
+    /**
+     * Distinguishes overloads of SystemContractMethods that have the same simple name.
+     */
+    public enum Variant implements AsSuffix {
+        FT,
+        NFT,
+        V1,
+        V2,
+        V3,
+        WITH_METADATA,
+        WITH_CUSTOM_FEES;
+
+        public @NonNull String asSuffix() {
+            return name();
+        }
+    }
+
+    // Fluent builders
+
+    public @NonNull SystemContractMethod withContract(@NonNull final SystemContract systemContract) {
+        return new SystemContractMethod(function, Optional.of(systemContract), via, categories, modifier, variants);
+    }
+
+    public @NonNull SystemContractMethod withVia(@NonNull final CallVia via) {
+        return new SystemContractMethod(function, systemContract, via, categories, modifier, variants);
+    }
+
+    public @NonNull SystemContractMethod withCategories(@NonNull final Category... categories) {
+        final var c = EnumSet.copyOf(this.categories);
+        c.addAll(Arrays.asList(categories));
+        return new SystemContractMethod(function, systemContract, via, c, modifier, variants);
+    }
+
+    public @NonNull SystemContractMethod withCategory(@NonNull final Category category) {
+        final var c = EnumSet.copyOf(categories);
+        c.add(category);
+        return new SystemContractMethod(function, systemContract, via, c, modifier, variants);
+    }
+
+    public @NonNull SystemContractMethod withModifier(@NonNull final Modifier modifier) {
+        return new SystemContractMethod(function, systemContract, via, categories, Optional.of(modifier), variants);
+    }
+
+    public @NonNull SystemContractMethod withVariants(@NonNull final Variant... variants) {
+        final var v = EnumSet.copyOf(this.variants);
+        v.addAll(Arrays.asList(variants));
+        return new SystemContractMethod(function, systemContract, via, categories, modifier, v);
+    }
+
+    public @NonNull SystemContractMethod withVariant(@NonNull final Variant variant) {
+        final var v = EnumSet.copyOf(variants);
+        v.add(variant);
+        return new SystemContractMethod(function, systemContract, via, categories, modifier, v);
+    }
+
+    // Forwarding to com.esaulpaugh.headlong.abi.Function
+
+    public Tuple decodeCall(byte[] call) {
+        return function.decodeCall(call);
+    }
+
+    public ByteBuffer encodeCall(Tuple tuple) {
+        return function.encodeCall(tuple);
+    }
+
+    public ByteBuffer encodeCallWithArgs(Object... args) {
+        return function.encodeCallWithArgs(args);
+    }
+
+    public TupleType getOutputs() {
+        return function.getOutputs();
+    }
+
+    public @NonNull String signature() {
+        return function.getCanonicalSignature();
+    }
+
+    public @NonNull String signatureWithReturn() {
+        return signature() + ':' + function.getOutputs();
+    }
+
+    public @NonNull byte[] selector() {
+        return function.selector();
+    }
+
+    public long selectorLong() {
+        return Bytes.wrap(function.selector()).toLong(ByteOrder.BIG_ENDIAN);
+    }
+
+    public @NonNull String selectorHex() {
+        return function.selectorHex();
+    }
+
+    public boolean hasVariant(@NonNull final Variant variant) {
+        return variants.contains(variant);
+    }
+
+    public boolean hasCategory(@NonNull final Category category) {
+        return categories.contains(category);
+    }
+
+    public boolean hasCategory(@NonNull final Set<Category> categories) {
+        var intersection = this.categories.clone();
+        intersection.retainAll(categories);
+        return !intersection.isEmpty();
+    }
+
+    /**
+     * Return the method's name (simple, undecorated)
+     * @return the method's name
+     */
+    public @NonNull String methodName() {
+        return function.getName();
+    }
+
+    /**
+     * Return the method's name with variant decorations
+     *
+     * The variant decorations (e.g., `_V1` and `_V2`) distinguish overloads of the method
+     * @return the method names with the variants as suffix
+     */
+    public @NonNull String variatedMethodName() {
+        return methodName() + variantsSuffix();
+    }
+
+    public @NonNull String fullyDecoratedMethodName() {
+        var name = qualifiedMethodName();
+        name += modifiersSuffix();
+        name += categoriesSuffix();
+        return name;
+    }
+
+    /**
+     * "Qualified" method name has the contract name in front of it, and the variants appended to it.
+     */
+    public @NonNull String qualifiedMethodName() {
+        final var systemContractName = systemContract.map(Enum::name).orElse("???");
+        final var methodName =
+                switch (via) {
+                    case DIRECT -> systemContractName + "." + variatedMethodName();
+                    case PROXY -> systemContractName + "(PROXY)." + variatedMethodName();
+                };
+        return methodName;
+    }
+
+    private @NonNull String variantsSuffix() {
+        if (variants.isEmpty()) return "";
+        return variants.stream().map(Variant::asSuffix).sorted().collect(Collectors.joining("_", "_", ""));
+    }
+
+    private @NonNull String categoriesSuffix() {
+        if (categories.isEmpty()) return "";
+        return categories.stream().map(Category::asSuffix).sorted().collect(Collectors.joining(",", "_[", "]"));
+    }
+
+    private @NonNull String modifiersSuffix() {
+        if (modifier.isEmpty()) return "";
+        return "_[" + modifier.get().asSuffix() + "]";
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/SystemContractMethodRegistry.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/SystemContractMethodRegistry.java
@@ -122,8 +122,15 @@ public class SystemContractMethodRegistry {
                 .toList();
         final var sb = new StringBuilder();
         for (final var method : allMethods) {
-            sb.append("%s: 0x%s - %s\n"
-                    .formatted(method.qualifiedMethodName(), method.selectorHex(), method.signatureWithReturn()));
+            var categoriesSuffix = method.categoriesSuffix();
+            if (categoriesSuffix.isEmpty()) categoriesSuffix = "No Category";
+            else categoriesSuffix = categoriesSuffix.substring(1);
+            sb.append("%s: 0x%s - %s - %s\n"
+                    .formatted(
+                            method.qualifiedMethodName(),
+                            method.selectorHex(),
+                            method.signatureWithReturn(),
+                            categoriesSuffix));
         }
         return sb.toString();
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/SystemContractMethodRegistry.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/SystemContractMethodRegistry.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.contract.impl.exec.utils;
+
+import static java.util.Comparator.comparing;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
+import java.util.SequencedCollection;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * A registry for all the system contract methods - their names, selectors, and signatures.
+ *
+ * Methods are added to this registry when they're defined in the various `FooTranslator` classes,
+ * which, since they're all (or should be) Dagger singletons, is done as the smart contract service
+ * is coming up.  Thus, the completed registry is available once processing starts, and so is ready
+ * for use to enumerate all system contract methods.
+ *
+ * The principal use case for this registry is to be able to generate various per-system-contract-method
+ * metrics.
+ */
+@Singleton
+public class SystemContractMethodRegistry {
+
+    private static final int EXPECTED_SYSTEM_CONTRACT_METHODS_UPPER_BOUND = 250;
+    private final ConcurrentHashMap<String, SystemContractMethod> byName =
+            new ConcurrentHashMap<>(EXPECTED_SYSTEM_CONTRACT_METHODS_UPPER_BOUND);
+
+    // The static constant `SystemContractMethod`s in each of the translator classes do _not_ have
+    // the `SystemContract` field set.  That's set later after all the static fields are created.
+    // So there needs to be a way to get from the version _without_ the system contract to the version
+    // _with_ the system contract.  That's this map.
+    //
+    // Thus, in the running system there are two instances of `SystemContractMethod` for each system
+    // contract method:  One without the `SystemContract`, one with.  This is an acceptable fixed
+    // overhead.  Alternative would have been to bite the bullet and explicitly set the system contract
+    // field in the constructor of each of the static constants in each of the translator classes.
+    // Perhaps that's a refactor that would be worth it sometime.
+    private final ConcurrentHashMap<SystemContractMethod, SystemContractMethod> withoutToWithSystemContract =
+            new ConcurrentHashMap<>(EXPECTED_SYSTEM_CONTRACT_METHODS_UPPER_BOUND);
+
+    @Inject
+    public SystemContractMethodRegistry() {
+        requireNonNull(SystemContractMethod.SystemContract.HTS); // DEBUGGING
+    }
+
+    /**
+     * Add a system contract method into the registry of system contract methods
+     */
+    public void register(
+            @NonNull final SystemContractMethod systemContractMethodWithoutContract,
+            @NonNull final SystemContractMethod systemContractMethodWithContract) {
+        requireNonNull(systemContractMethodWithoutContract);
+        requireNonNull(systemContractMethodWithContract);
+
+        var keyName = systemContractMethodWithContract.variatedMethodName();
+        if (systemContractMethodWithContract.via() == CallVia.PROXY)
+            keyName += systemContractMethodWithContract.via().asSuffix();
+
+        byName.putIfAbsent(keyName, systemContractMethodWithContract);
+        withoutToWithSystemContract.putIfAbsent(systemContractMethodWithoutContract, systemContractMethodWithContract);
+    }
+
+    // Queries:
+
+    public long size() {
+        return byName.size();
+    }
+
+    public @NonNull SystemContractMethod fromMissingContractGetWithContract(
+            @NonNull final SystemContractMethod systemContractMethodWithoutContract) {
+        if (systemContractMethodWithoutContract.systemContract().isPresent())
+            return systemContractMethodWithoutContract;
+        else return withoutToWithSystemContract.get(systemContractMethodWithoutContract);
+    }
+
+    public @NonNull SequencedCollection<String> allQualifiedMethods() {
+        return allMethodsGivenMapper(SystemContractMethod::qualifiedMethodName);
+    }
+
+    public @NonNull SequencedCollection<String> allSignatures() {
+        return allMethodsGivenMapper(SystemContractMethod::signature);
+    }
+
+    public @NonNull SequencedCollection<String> allSignaturesWithReturns() {
+        return allMethodsGivenMapper(SystemContractMethod::signatureWithReturn);
+    }
+
+    public @NonNull SequencedCollection<String> allMethodsGivenMapper(
+            @NonNull final java.util.function.Function<SystemContractMethod, String> methodMapper) {
+        return byName.values().stream().map(methodMapper).sorted().toList();
+    }
+
+    public @NonNull Collection<SystemContractMethod> allMethods() {
+        return byName.values();
+    }
+
+    @VisibleForTesting
+    public @NonNull String allMethodsAsTable() {
+        final var allMethods = allMethods().stream()
+                .sorted(comparing(SystemContractMethod::qualifiedMethodName))
+                .toList();
+        final var sb = new StringBuilder();
+        for (final var method : allMethods) {
+            sb.append("%s: 0x%s - %s\n"
+                    .formatted(method.qualifiedMethodName(), method.selectorHex(), method.signatureWithReturn()));
+        }
+        return sb.toString();
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/AbstractContractTransactionHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/AbstractContractTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,5 +103,10 @@ public abstract class AbstractContractTransactionHandler implements TransactionH
             @NonNull final com.hederahashgraph.api.proto.java.TransactionBody txBody,
             @NonNull final SigValueObj sigValObj) {
         throw new IllegalStateException("must be overridden if `calculateFees` _not_ overridden");
+    }
+
+    protected @NonNull TransactionComponent getTransactionComponent(
+            @NonNull final HandleContext context, @NonNull final HederaFunctionality functionality) {
+        return provider.get().create(context, functionality);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ public class ContractCallHandler extends AbstractContractTransactionHandler {
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
         // Create the transaction-scoped component
-        final var component = provider.get().create(context, CONTRACT_CALL);
+        final var component = getTransactionComponent(context, CONTRACT_CALL);
 
         // Run its in-scope transaction and get the outcome
         final var outcome = component.contextTransactionProcessor().call();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
@@ -39,7 +39,6 @@ import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
-import com.hedera.node.app.service.contract.impl.ContractServiceComponent;
 import com.hedera.node.app.service.contract.impl.exec.QueryComponent;
 import com.hedera.node.app.service.contract.impl.exec.QueryComponent.Factory;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -66,7 +65,6 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
     private final Provider<QueryComponent.Factory> provider;
     private final GasCalculator gasCalculator;
     private final InstantSource instantSource;
-    private final ContractServiceComponent contractServiceComponent;
 
     /**
      *  Constructs a {@link ContractCreateHandler} with the given {@link Provider}, {@link GasCalculator} and {@link InstantSource}.
@@ -79,12 +77,10 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
     public ContractCallLocalHandler(
             @NonNull final Provider<Factory> provider,
             @NonNull final GasCalculator gasCalculator,
-            @NonNull final InstantSource instantSource,
-            @NonNull final ContractServiceComponent contractServiceComponent) {
+            @NonNull final InstantSource instantSource) {
         this.provider = requireNonNull(provider);
         this.gasCalculator = requireNonNull(gasCalculator);
         this.instantSource = requireNonNull(instantSource);
-        this.contractServiceComponent = requireNonNull(contractServiceComponent);
     }
 
     @Override
@@ -145,7 +141,7 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
         requireNonNull(context);
         requireNonNull(header);
 
-        final var component = provider.get().create(context, instantSource.instant(), CONTRACT_CALL_LOCAL);
+        final var component = getQueryComponent(context);
 
         final var outcome = component.contextQueryProcessor().call();
 
@@ -183,5 +179,10 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
                     .setNodedata(feeData.getNodedata().toBuilder().setGas(op.gas()))
                     .build();
         });
+    }
+
+    @NonNull
+    private QueryComponent getQueryComponent(@NonNull final QueryContext context) {
+        return requireNonNull(provider.get().create(context, instantSource.instant(), CONTRACT_CALL_LOCAL));
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCallLocalHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SmartContractFeeBuilder;
+import com.hedera.node.app.service.contract.impl.ContractServiceComponent;
 import com.hedera.node.app.service.contract.impl.exec.QueryComponent;
 import com.hedera.node.app.service.contract.impl.exec.QueryComponent.Factory;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -65,6 +66,7 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
     private final Provider<QueryComponent.Factory> provider;
     private final GasCalculator gasCalculator;
     private final InstantSource instantSource;
+    private final ContractServiceComponent contractServiceComponent;
 
     /**
      *  Constructs a {@link ContractCreateHandler} with the given {@link Provider}, {@link GasCalculator} and {@link InstantSource}.
@@ -77,10 +79,12 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
     public ContractCallLocalHandler(
             @NonNull final Provider<Factory> provider,
             @NonNull final GasCalculator gasCalculator,
-            @NonNull final InstantSource instantSource) {
+            @NonNull final InstantSource instantSource,
+            @NonNull final ContractServiceComponent contractServiceComponent) {
         this.provider = requireNonNull(provider);
         this.gasCalculator = requireNonNull(gasCalculator);
         this.instantSource = requireNonNull(instantSource);
+        this.contractServiceComponent = requireNonNull(contractServiceComponent);
     }
 
     @Override
@@ -142,6 +146,7 @@ public class ContractCallLocalHandler extends PaidQueryHandler {
         requireNonNull(header);
 
         final var component = provider.get().create(context, instantSource.instant(), CONTRACT_CALL_LOCAL);
+
         final var outcome = component.contextQueryProcessor().call();
 
         final var responseHeader = outcome.isSuccess()

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractCreateHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class ContractCreateHandler extends AbstractContractTransactionHandler {
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
         // Create the transaction-scoped component
-        final var component = provider.get().create(context, CONTRACT_CREATE);
+        final var component = getTransactionComponent(context, CONTRACT_CREATE);
 
         // Run its in-scope transaction and get the outcome
         final var outcome = component.contextTransactionProcessor().call();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,7 +155,7 @@ public class EthereumTransactionHandler extends AbstractContractTransactionHandl
     @Override
     public void handle(@NonNull final HandleContext context) throws HandleException {
         // Create the transaction-scoped component
-        final var component = provider.get().create(context, ETHEREUM_TRANSACTION);
+        final var component = getTransactionComponent(context, ETHEREUM_TRANSACTION);
 
         // Run its in-scope transaction and get the outcome
         final var outcome = component.contextTransactionProcessor().call();
@@ -180,7 +180,7 @@ public class EthereumTransactionHandler extends AbstractContractTransactionHandl
      * @param context the handle context
      */
     public void handleThrottled(@NonNull final HandleContext context) {
-        final var component = provider.get().create(context, ETHEREUM_TRANSACTION);
+        final var component = getTransactionComponent(context, ETHEREUM_TRANSACTION);
         final var ethTxData =
                 requireNonNull(requireNonNull(component.hydratedEthTxData()).ethTxData());
         context.savepointStack()

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/ContractServiceImplTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/ContractServiceImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,9 @@ import com.hedera.node.app.service.contract.impl.schemas.V0490ContractSchema;
 import com.hedera.node.app.service.contract.impl.schemas.V0500ContractSchema;
 import com.hedera.node.app.spi.AppContext;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
+import com.hedera.node.config.data.ContractsConfig;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.lifecycle.Schema;
 import com.swirlds.state.lifecycle.SchemaRegistry;
 import java.time.InstantSource;
@@ -48,6 +51,15 @@ class ContractServiceImplTest {
     @Mock
     private SignatureVerifier signatureVerifier;
 
+    @Mock
+    private Configuration configuration;
+
+    @Mock
+    private Metrics metrics;
+
+    @Mock
+    private ContractsConfig contractsConfig;
+
     private ContractServiceImpl subject;
 
     @BeforeEach
@@ -55,9 +67,8 @@ class ContractServiceImplTest {
         // given
         when(appContext.instantSource()).thenReturn(instantSource);
         when(appContext.signatureVerifier()).thenReturn(signatureVerifier);
-        when(appContext.metricsSupplier()).thenReturn(() -> null);
 
-        subject = new ContractServiceImpl(appContext);
+        subject = new ContractServiceImpl(appContext, metrics);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/ContractMetricsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/ContractMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import static org.mockito.BDDMockito.given;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.wipe.WipeTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.common.metrics.config.MetricsConfig;
@@ -34,6 +36,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.function.Supplier;
+import org.hyperledger.besu.evm.frame.MessageFrame.State;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -47,9 +50,13 @@ public class ContractMetricsTest {
     @Mock
     private ContractsConfig contractsConfig;
 
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     public @NonNull ContractMetrics getSubject() {
-        final var contractMetrics = new ContractMetrics(metricsSupplier, () -> contractsConfig);
-        contractMetrics.createContractMetrics();
+        final var contractMetrics =
+                new ContractMetrics(metricsSupplier, () -> contractsConfig, systemContractMethodRegistry);
+        contractMetrics.createContractPrimaryMetrics();
+        contractMetrics.createContractSecondaryMetrics();
         return contractMetrics;
     }
 
@@ -69,7 +76,7 @@ public class ContractMetricsTest {
 
         subject.bumpRejectedType3EthTx(20);
 
-        assertThat(subject.getAllCounterNames())
+        assertThat(subject.getAllP1CounterNames())
                 .containsExactlyInAnyOrder(
                         "SmartContractService:Rejected_ethereumTxDueToIntrinsicGas_total",
                         "SmartContractService:Rejected_ethereumTx_total",
@@ -78,7 +85,7 @@ public class ContractMetricsTest {
                         "SmartContractService:Rejected_contractCreateTxDueToIntrinsicGas_total",
                         "SmartContractService:Rejected_contractCreateTx_total",
                         "SmartContractService:Rejected_ethType3BlobTransaction_total");
-        assertThat(subject.getAllCounters())
+        assertThat(subject.getAllP1CounterValues())
                 .containsExactlyInAnyOrderEntriesOf(Map.of(
                         "SmartContractService:Rejected_ethereumTxDueToIntrinsicGas_total",
                         14L,
@@ -102,8 +109,9 @@ public class ContractMetricsTest {
     }
 
     @Test
-    public void rejectedTxCountersGetIgnoredWhenDisabled() {
+    public void countersGetIgnoredWhenDisabled() {
         given(contractsConfig.metricsSmartContractPrimaryEnabled()).willReturn(false);
+        given(contractsConfig.metricsSmartContractSecondaryEnabled()).willReturn(false);
 
         final var subject = getSubject();
 
@@ -117,8 +125,10 @@ public class ContractMetricsTest {
 
         subject.bumpRejectedType3EthTx(20);
 
+        subject.incrementSystemMethodCall(WipeTranslator.WIPE_FUNGIBLE_V1, State.EXCEPTIONAL_HALT);
+
         assertThat(subject.getAllCounterNames()).isEmpty();
-        assertThat(subject.getAllCounters()).isEmpty();
+        assertThat(subject.getAllCounterValues()).isEmpty();
     }
 
     private static final long DEFAULT_NODE_ID = 3;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/ContractMetricsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/ContractMetricsTest.java
@@ -35,7 +35,6 @@ import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.concurrent.Executors;
-import java.util.function.Supplier;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +44,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ContractMetricsTest {
 
-    private final Supplier<Metrics> metricsSupplier = () -> fakeMetrics();
+    private final Metrics metrics = fakeMetrics();
 
     @Mock
     private ContractsConfig contractsConfig;
@@ -53,8 +52,7 @@ public class ContractMetricsTest {
     private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
 
     public @NonNull ContractMetrics getSubject() {
-        final var contractMetrics =
-                new ContractMetrics(metricsSupplier, () -> contractsConfig, systemContractMethodRegistry);
+        final var contractMetrics = new ContractMetrics(metrics, () -> contractsConfig, systemContractMethodRegistry);
         contractMetrics.createContractPrimaryMetrics();
         contractMetrics.createContractSecondaryMetrics();
         return contractMetrics;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/CallAttemptHelpers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/CallAttemptHelpers.java
@@ -28,6 +28,8 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
@@ -55,7 +57,8 @@ public final class CallAttemptHelpers {
             final HederaWorldUpdater.Enhancement enhancement,
             final AddressIdConverter addressIdConverter,
             final VerificationStrategies verificationStrategies,
-            final SystemContractGasCalculator gasCalculator) {
+            final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry) {
         final var input = Bytes.wrap(function.selector());
 
         return new HtsCallAttempt(
@@ -69,6 +72,32 @@ public final class CallAttemptHelpers {
                 verificationStrategies,
                 gasCalculator,
                 List.of(translator),
+                systemContractMethodRegistry,
+                false);
+    }
+
+    public static HtsCallAttempt prepareHtsAttemptWithSelector(
+            final SystemContractMethod systemContractMethod,
+            final CallTranslator<HtsCallAttempt> translator,
+            final HederaWorldUpdater.Enhancement enhancement,
+            final AddressIdConverter addressIdConverter,
+            final VerificationStrategies verificationStrategies,
+            final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry) {
+        final var input = Bytes.wrap(systemContractMethod.selector());
+
+        return new HtsCallAttempt(
+                input,
+                OWNER_BESU_ADDRESS,
+                OWNER_BESU_ADDRESS,
+                false,
+                enhancement,
+                DEFAULT_CONFIG,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                List.of(translator),
+                systemContractMethodRegistry,
                 false);
     }
 
@@ -87,7 +116,8 @@ public final class CallAttemptHelpers {
             final HederaWorldUpdater.Enhancement enhancement,
             final AddressIdConverter addressIdConverter,
             final VerificationStrategies verificationStrategies,
-            final SystemContractGasCalculator gasCalculator) {
+            final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry) {
         final var input = TestHelpers.bytesForRedirect(function.selector(), NON_SYSTEM_LONG_ZERO_ADDRESS);
 
         return new HtsCallAttempt(
@@ -101,6 +131,32 @@ public final class CallAttemptHelpers {
                 verificationStrategies,
                 gasCalculator,
                 List.of(translator),
+                systemContractMethodRegistry,
+                false);
+    }
+
+    public static HtsCallAttempt prepareHtsAttemptWithSelectorForRedirect(
+            final SystemContractMethod systemContractMethod,
+            final CallTranslator<HtsCallAttempt> translator,
+            final HederaWorldUpdater.Enhancement enhancement,
+            final AddressIdConverter addressIdConverter,
+            final VerificationStrategies verificationStrategies,
+            final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry) {
+        final var input = TestHelpers.bytesForRedirect(systemContractMethod.selector(), NON_SYSTEM_LONG_ZERO_ADDRESS);
+
+        return new HtsCallAttempt(
+                input,
+                OWNER_BESU_ADDRESS,
+                OWNER_BESU_ADDRESS,
+                false,
+                enhancement,
+                DEFAULT_CONFIG,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                List.of(translator),
+                systemContractMethodRegistry,
                 false);
     }
 
@@ -121,6 +177,7 @@ public final class CallAttemptHelpers {
             final AddressIdConverter addressIdConverter,
             final VerificationStrategies verificationStrategies,
             final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
             final Configuration config) {
         final var input = TestHelpers.bytesForRedirect(function.selector(), NON_SYSTEM_LONG_ZERO_ADDRESS);
 
@@ -135,6 +192,33 @@ public final class CallAttemptHelpers {
                 verificationStrategies,
                 gasCalculator,
                 List.of(translator),
+                systemContractMethodRegistry,
+                false);
+    }
+
+    public static HtsCallAttempt prepareHtsAttemptWithSelectorForRedirectWithConfig(
+            final SystemContractMethod systemContractMethod,
+            final CallTranslator<HtsCallAttempt> translator,
+            final HederaWorldUpdater.Enhancement enhancement,
+            final AddressIdConverter addressIdConverter,
+            final VerificationStrategies verificationStrategies,
+            final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
+            final Configuration config) {
+        final var input = TestHelpers.bytesForRedirect(systemContractMethod.selector(), NON_SYSTEM_LONG_ZERO_ADDRESS);
+
+        return new HtsCallAttempt(
+                input,
+                OWNER_BESU_ADDRESS,
+                OWNER_BESU_ADDRESS,
+                false,
+                enhancement,
+                config,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                List.of(translator),
+                systemContractMethodRegistry,
                 false);
     }
 
@@ -155,6 +239,7 @@ public final class CallAttemptHelpers {
             final AddressIdConverter addressIdConverter,
             final VerificationStrategies verificationStrategies,
             final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
             final Configuration config) {
         final var input = Bytes.wrap(function.selector());
 
@@ -169,11 +254,38 @@ public final class CallAttemptHelpers {
                 verificationStrategies,
                 gasCalculator,
                 List.of(translator),
+                systemContractMethodRegistry,
+                false);
+    }
+
+    public static HtsCallAttempt prepareHtsAttemptWithSelectorAndCustomConfig(
+            final SystemContractMethod systemContractMethod,
+            final CallTranslator<HtsCallAttempt> translator,
+            final HederaWorldUpdater.Enhancement enhancement,
+            final AddressIdConverter addressIdConverter,
+            final VerificationStrategies verificationStrategies,
+            final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
+            final Configuration config) {
+        final var input = Bytes.wrap(systemContractMethod.selector());
+
+        return new HtsCallAttempt(
+                input,
+                OWNER_BESU_ADDRESS,
+                OWNER_BESU_ADDRESS,
+                false,
+                enhancement,
+                config,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                List.of(translator),
+                systemContractMethodRegistry,
                 false);
     }
 
     /**
-     * @param function the selector to match against
+     * @param systemContractMethod the selector to match against (as a `SystemContractMethod`)
      * @param translator the translator for this specific call attempt
      * @param enhancement the enhancement that is used
      * @param addressIdConverter the address ID converter for this call
@@ -183,26 +295,28 @@ public final class CallAttemptHelpers {
      * @return the call attempt
      */
     public static HasCallAttempt prepareHasAttemptWithSelector(
-            final Function function,
+            final SystemContractMethod systemContractMethod,
             final CallTranslator<HasCallAttempt> translator,
             final HederaWorldUpdater.Enhancement enhancement,
             final AddressIdConverter addressIdConverter,
             final VerificationStrategies verificationStrategies,
             final SignatureVerifier signatureVerifier,
-            final SystemContractGasCalculator gasCalculator) {
+            final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry) {
         return prepareHasAttemptWithSelectorAndCustomConfig(
-                function,
+                systemContractMethod,
                 translator,
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 DEFAULT_CONFIG);
     }
 
     /**
-     * @param function the selector to match against
+     * @param systemContractMethod the selector to match against (as a `SystemContractMethod`)
      * @param translator the translator for this specific call attempt
      * @param enhancement the enhancement that is used
      * @param addressIdConverter the address ID converter for this call
@@ -213,28 +327,29 @@ public final class CallAttemptHelpers {
      * @return the call attempt
      */
     public static HasCallAttempt prepareHasAttemptWithSelectorAndCustomConfig(
-            final Function function,
+            final SystemContractMethod systemContractMethod,
             final CallTranslator<HasCallAttempt> translator,
             final HederaWorldUpdater.Enhancement enhancement,
             final AddressIdConverter addressIdConverter,
             final VerificationStrategies verificationStrategies,
             final SignatureVerifier signatureVerifier,
             final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
             final Configuration config) {
         return prepareHasAttemptWithSelectorAndInputAndCustomConfig(
-                function,
-                TestHelpers.bytesForRedirectAccount(function.selector(), NON_SYSTEM_LONG_ZERO_ADDRESS),
+                systemContractMethod,
+                TestHelpers.bytesForRedirectAccount(systemContractMethod.selector(), NON_SYSTEM_LONG_ZERO_ADDRESS),
                 translator,
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 config);
     }
 
     /**
-     * @param function the selector to match against
      * @param input the input in bytes
      * @param translator the translator for this specific call attempt
      * @param enhancement the enhancement that is used
@@ -246,7 +361,6 @@ public final class CallAttemptHelpers {
      * @return the call attempt
      */
     public static HasCallAttempt prepareHasAttemptWithSelectorAndInputAndCustomConfig(
-            final Function function,
             final Bytes input,
             final CallTranslator<HasCallAttempt> translator,
             final HederaWorldUpdater.Enhancement enhancement,
@@ -254,6 +368,7 @@ public final class CallAttemptHelpers {
             final VerificationStrategies verificationStrategies,
             final SignatureVerifier signatureVerifier,
             final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
             final Configuration config) {
         return new HasCallAttempt(
                 input,
@@ -266,11 +381,38 @@ public final class CallAttemptHelpers {
                 signatureVerifier,
                 gasCalculator,
                 List.of(translator),
+                systemContractMethodRegistry,
+                false);
+    }
+
+    public static HasCallAttempt prepareHasAttemptWithSelectorAndInputAndCustomConfig(
+            final SystemContractMethod systemContractMethod,
+            final Bytes input,
+            final CallTranslator<HasCallAttempt> translator,
+            final HederaWorldUpdater.Enhancement enhancement,
+            final AddressIdConverter addressIdConverter,
+            final VerificationStrategies verificationStrategies,
+            final SignatureVerifier signatureVerifier,
+            final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
+            final Configuration config) {
+        return new HasCallAttempt(
+                input,
+                OWNER_BESU_ADDRESS,
+                false,
+                enhancement,
+                config,
+                addressIdConverter,
+                verificationStrategies,
+                signatureVerifier,
+                gasCalculator,
+                List.of(translator),
+                systemContractMethodRegistry,
                 false);
     }
 
     /**
-     * @param function the selector to match against
+     * @param systemContractMethod the selector to match against (as a `SystemContractMethod`)
      * @param translator the translator for this specific call attempt
      * @param enhancement the enhancement that is used
      * @param addressIdConverter the address ID converter for this call
@@ -280,15 +422,16 @@ public final class CallAttemptHelpers {
      * @return the call attempt
      */
     public static HssCallAttempt prepareHssAttemptWithSelectorAndCustomConfig(
-            final Function function,
+            final SystemContractMethod systemContractMethod,
             final CallTranslator<HssCallAttempt> translator,
             final HederaWorldUpdater.Enhancement enhancement,
             final AddressIdConverter addressIdConverter,
             final VerificationStrategies verificationStrategies,
             final SignatureVerifier signatureVerifier,
             final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
             final Configuration config) {
-        final var input = Bytes.wrap(function.selector());
+        final var input = Bytes.wrap(systemContractMethod.selector());
 
         return new HssCallAttempt(
                 input,
@@ -301,6 +444,34 @@ public final class CallAttemptHelpers {
                 signatureVerifier,
                 gasCalculator,
                 List.of(translator),
+                systemContractMethodRegistry,
+                false);
+    }
+
+    public static HssCallAttempt prepareHssAttemptWithSelectorAndCustomConfig(
+            final SystemContractMethod systemContractMethod,
+            final CallTranslator<HssCallAttempt> translator,
+            final HederaWorldUpdater.Enhancement enhancement,
+            final AddressIdConverter addressIdConverter,
+            final VerificationStrategies verificationStrategies,
+            final SystemContractGasCalculator gasCalculator,
+            final SignatureVerifier signatureVerifier,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
+            final Configuration config) {
+        final var input = Bytes.wrap(systemContractMethod.selector());
+
+        return new HssCallAttempt(
+                input,
+                OWNER_BESU_ADDRESS,
+                false,
+                enhancement,
+                config,
+                addressIdConverter,
+                verificationStrategies,
+                signatureVerifier,
+                gasCalculator,
+                List.of(translator),
+                systemContractMethodRegistry,
                 false);
     }
 
@@ -312,6 +483,7 @@ public final class CallAttemptHelpers {
             final VerificationStrategies verificationStrategies,
             final SignatureVerifier signatureVerifier,
             final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
             final Configuration config) {
 
         return new HssCallAttempt(
@@ -325,6 +497,7 @@ public final class CallAttemptHelpers {
                 signatureVerifier,
                 gasCalculator,
                 List.of(translator),
+                systemContractMethodRegistry,
                 false);
     }
 
@@ -336,6 +509,7 @@ public final class CallAttemptHelpers {
             final VerificationStrategies verificationStrategies,
             final SignatureVerifier signatureVerifier,
             final SystemContractGasCalculator gasCalculator,
+            final SystemContractMethodRegistry systemContractMethodRegistry,
             final Configuration config) {
 
         return new HssCallAttempt(
@@ -349,6 +523,7 @@ public final class CallAttemptHelpers {
                 signatureVerifier,
                 gasCalculator,
                 List.of(translator),
+                systemContractMethodRegistry,
                 false);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HasSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HasSystemContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.co
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.assertSamePrecompileResult;
 import static org.mockito.Mockito.when;
 
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HasSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
@@ -52,6 +53,9 @@ class HasSystemContractTest {
     @Mock
     private GasCalculator gasCalculator;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private MockedStatic<FrameUtils> frameUtils;
 
     private HasSystemContract subject;
@@ -60,7 +64,7 @@ class HasSystemContractTest {
     @BeforeEach
     void setUp() {
         frameUtils = Mockito.mockStatic(FrameUtils.class);
-        subject = new HasSystemContract(gasCalculator, attemptFactory);
+        subject = new HasSystemContract(gasCalculator, attemptFactory, contractMetrics);
     }
 
     @AfterEach

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HssSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HssSystemContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.co
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.assertSamePrecompileResult;
 import static org.mockito.Mockito.when;
 
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HssSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
@@ -52,6 +53,9 @@ class HssSystemContractTest {
     @Mock
     private GasCalculator gasCalculator;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private MockedStatic<FrameUtils> frameUtils;
 
     private HssSystemContract subject;
@@ -60,7 +64,7 @@ class HssSystemContractTest {
     @BeforeEach
     void setUp() {
         frameUtils = Mockito.mockStatic(FrameUtils.class);
-        subject = new HssSystemContract(gasCalculator, attemptFactory);
+        subject = new HssSystemContract(gasCalculator, attemptFactory, contractMetrics);
     }
 
     @AfterEach

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HtsSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/HtsSystemContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.SystemContractOperations;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsSystemContract;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call;
@@ -78,6 +79,9 @@ class HtsSystemContractTest {
     @Mock
     private GasCalculator gasCalculator;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private MockedStatic<FrameUtils> frameUtils;
 
     private HtsSystemContract subject;
@@ -86,7 +90,7 @@ class HtsSystemContractTest {
     @BeforeEach
     void setUp() {
         frameUtils = Mockito.mockStatic(FrameUtils.class);
-        subject = new HtsSystemContract(gasCalculator, attemptFactory);
+        subject = new HtsSystemContract(gasCalculator, attemptFactory, contractMetrics);
     }
 
     @AfterEach

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/HasCallAttemptTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/HasCallAttemptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.BDDMockito.given;
 
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
@@ -36,6 +37,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbaral
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarapprove.HbarApproveCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarapprove.HbarApproveTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
@@ -56,11 +58,18 @@ class HasCallAttemptTest extends CallTestBase {
     @Mock
     private AddressIdConverter addressIdConverter;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private List<CallTranslator<HasCallAttempt>> callTranslators;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
 
     @BeforeEach
     void setUp() {
-        callTranslators = List.of(new HbarAllowanceTranslator(), new HbarApproveTranslator());
+        callTranslators = List.of(
+                new HbarAllowanceTranslator(systemContractMethodRegistry, contractMetrics),
+                new HbarApproveTranslator(systemContractMethodRegistry, contractMetrics));
     }
 
     @Test
@@ -80,6 +89,7 @@ class HasCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertNull(subject.redirectAccount());
     }
@@ -98,6 +108,7 @@ class HasCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertNull(subject.asExecutableCall());
     }
@@ -122,6 +133,7 @@ class HasCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(HbarAllowanceCall.class, subject.asExecutableCall());
     }
@@ -148,6 +160,7 @@ class HasCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(HbarAllowanceCall.class, subject.asExecutableCall());
     }
@@ -174,6 +187,7 @@ class HasCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(HbarApproveCall.class, subject.asExecutableCall());
     }
@@ -201,6 +215,7 @@ class HasCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(HbarApproveCall.class, subject.asExecutableCall());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/HasCallFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/HasCallFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallAddressChecks;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallFactory;
@@ -38,6 +39,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbaral
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.SyntheticIds;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
@@ -77,10 +79,15 @@ class HasCallFactoryTest extends CallTestBase {
     @Mock
     private MessageFrame initialFrame;
 
-    private Deque<MessageFrame> stack = new ArrayDeque<>();
+    private final Deque<MessageFrame> stack = new ArrayDeque<>();
 
     @Mock
     private ProxyWorldUpdater updater;
+
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
 
     private HasCallFactory subject;
 
@@ -91,7 +98,8 @@ class HasCallFactoryTest extends CallTestBase {
                 addressChecks,
                 verificationStrategies,
                 signatureVerifier,
-                List.of(new HbarAllowanceTranslator()));
+                List.of(new HbarAllowanceTranslator(systemContractMethodRegistry, contractMetrics)),
+                systemContractMethodRegistry);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/evmaddressalias/EvmAddressAliasTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/evmaddressalias/EvmAddressAliasTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,18 +22,18 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.APPROVE
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHasAttemptWithSelector;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.getevmaddressalias.EvmAddressAliasCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.getevmaddressalias.EvmAddressAliasTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import org.apache.tuweni.bytes.Bytes;
@@ -66,11 +66,16 @@ class EvmAddressAliasTranslatorTest {
     @Mock
     private HederaNativeOperations nativeOperations;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private EvmAddressAliasTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new EvmAddressAliasTranslator();
+        subject = new EvmAddressAliasTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -83,8 +88,9 @@ class EvmAddressAliasTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
         assertEquals("0xdea3d081" /*copied from HIP-632*/, "0x" + EVM_ADDRESS_ALIAS.selectorHex());
     }
 
@@ -98,8 +104,9 @@ class EvmAddressAliasTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertFalse(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hbarAllowance/HbarAllowanceTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hbarAllowance/HbarAllowanceTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,18 +25,18 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.B_NEW_A
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHORIZED_SPENDER_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHasAttemptWithSelector;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarallowance.HbarAllowanceCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarallowance.HbarAllowanceTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import org.apache.tuweni.bytes.Bytes;
@@ -69,11 +69,16 @@ public class HbarAllowanceTranslatorTest {
     @Mock
     private HederaNativeOperations nativeOperations;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private HbarAllowanceTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new HbarAllowanceTranslator();
+        subject = new HbarAllowanceTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -86,8 +91,9 @@ public class HbarAllowanceTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
 
         attempt = prepareHasAttemptWithSelector(
                 HBAR_ALLOWANCE_PROXY,
@@ -96,8 +102,9 @@ public class HbarAllowanceTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -110,8 +117,9 @@ public class HbarAllowanceTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertFalse(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hederaaccountnumalias/HederaAccountNumAliasTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hederaaccountnumalias/HederaAccountNumAliasTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,18 +22,18 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_A
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHasAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hederaaccountnumalias.HederaAccountNumAliasCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hederaaccountnumalias.HederaAccountNumAliasTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import org.apache.tuweni.bytes.Bytes;
@@ -67,11 +67,16 @@ public class HederaAccountNumAliasTranslatorTest {
     @Mock
     private HederaNativeOperations nativeOperations;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private HederaAccountNumAliasTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new HederaAccountNumAliasTranslator();
+        subject = new HederaAccountNumAliasTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -84,8 +89,9 @@ public class HederaAccountNumAliasTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
         assertEquals("0xbbf12d2e" /*copied from HIP-632*/, "0x" + HEDERA_ACCOUNT_NUM_ALIAS.selectorHex());
     }
 
@@ -99,8 +105,9 @@ public class HederaAccountNumAliasTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertFalse(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isvalidalias/IsValidAliasTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isvalidalias/IsValidAliasTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,18 +22,18 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_A
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHasAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isvalidalias.IsValidAliasCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isvalidalias.IsValidAliasTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import org.apache.tuweni.bytes.Bytes;
@@ -67,11 +67,16 @@ public class IsValidAliasTranslatorTest {
     @Mock
     private HederaNativeOperations nativeOperations;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private IsValidAliasTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new IsValidAliasTranslator();
+        subject = new IsValidAliasTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -84,8 +89,9 @@ public class IsValidAliasTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
         assertEquals("0x308ef301" /*copied from HIP-632*/, "0x" + IS_VALID_ALIAS.selectorHex());
     }
 
@@ -99,8 +105,9 @@ public class IsValidAliasTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 signatureVerifier,
-                gasCalculator);
-        assertFalse(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/setunlimitedautoassociations/SetUnlimitedAutoAssociationsTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/setunlimitedautoassociations/SetUnlimitedAutoAssociationsTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,17 @@ package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.has.
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.setunlimitedautoassociations.SetUnlimitedAutoAssociationsTranslator.SET_UNLIMITED_AUTO_ASSOC;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHasAttemptWithSelectorAndCustomConfig;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.setunlimitedautoassociations.SetUnlimitedAutoAssociationsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.setunlimitedautoassociations.SetUnlimitedAutoAssociationsTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.hedera.node.config.data.ContractsConfig;
@@ -70,11 +70,16 @@ class SetUnlimitedAutoAssociationsTranslatorTest {
     @Mock
     private ContractsConfig contractsConfig;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private SetUnlimitedAutoAssociationsTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new SetUnlimitedAutoAssociationsTranslator();
+        subject = new SetUnlimitedAutoAssociationsTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -91,8 +96,9 @@ class SetUnlimitedAutoAssociationsTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -109,8 +115,9 @@ class SetUnlimitedAutoAssociationsTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertFalse(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/HssCallAttemptTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/HssCallAttemptTest.java
@@ -24,11 +24,13 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.signschedule.SignScheduleTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
@@ -49,9 +51,14 @@ class HssCallAttemptTest extends CallTestBase {
 
     private List<CallTranslator<HssCallAttempt>> callTranslators;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     @BeforeEach
     void setUp() {
-        callTranslators = List.of(new SignScheduleTranslator());
+        callTranslators = List.of(new SignScheduleTranslator(systemContractMethodRegistry, contractMetrics));
     }
 
     @Test
@@ -70,6 +77,7 @@ class HssCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertNull(subject.redirectScheduleTxn());
     }
@@ -88,6 +96,7 @@ class HssCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertNull(subject.asExecutableCall());
     }
@@ -106,6 +115,7 @@ class HssCallAttemptTest extends CallTestBase {
                 signatureVerifier,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertTrue(subject.isOnlyDelegatableContractKeysActive());
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/HssCallFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/HssCallFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import static org.mockito.BDDMockito.given;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallAddressChecks;
@@ -40,6 +41,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.signsc
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.SyntheticIds;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
@@ -80,7 +82,7 @@ class HssCallFactoryTest extends CallTestBase {
     @Mock
     private MessageFrame initialFrame;
 
-    private Deque<MessageFrame> stack = new ArrayDeque<>();
+    private final Deque<MessageFrame> stack = new ArrayDeque<>();
 
     @Mock
     private ProxyWorldUpdater updater;
@@ -91,6 +93,11 @@ class HssCallFactoryTest extends CallTestBase {
     @Mock
     private Key maybeEthSenderKey;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private HssCallFactory subject;
 
     @BeforeEach
@@ -100,7 +107,8 @@ class HssCallFactoryTest extends CallTestBase {
                 addressChecks,
                 verificationStrategies,
                 signatureVerifier,
-                List.of(new SignScheduleTranslator()));
+                List.of(new SignScheduleTranslator(systemContractMethodRegistry, contractMetrics)),
+                systemContractMethodRegistry);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/schedulenative/ScheduleNativeTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/schedulenative/ScheduleNativeTranslatorTest.java
@@ -37,6 +37,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallAttempt;
@@ -46,6 +47,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.Addres
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallFactory;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.hedera.node.config.data.ContractsConfig;
@@ -100,12 +102,17 @@ class ScheduleNativeTranslatorTest extends CallTestBase {
 
     private CreateTranslator createTranslator;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private ScheduleNativeTranslator subject;
 
     @BeforeEach
     void setUp() {
-        createTranslator = new CreateTranslator(decoder);
-        subject = new ScheduleNativeTranslator(htsCallFactory);
+        createTranslator = new CreateTranslator(decoder, systemContractMethodRegistry, contractMetrics);
+        subject = new ScheduleNativeTranslator(htsCallFactory, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -126,11 +133,10 @@ class ScheduleNativeTranslatorTest extends CallTestBase {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
         // when/then
-        // we need to fill in the create translator map for this test to work.
-        new CreateTranslator(new CreateDecoder());
-        assertTrue(subject.matches(attempt));
+        assertTrue(subject.identifyMethod(attempt).isPresent());
     }
 
     @Test
@@ -144,10 +150,11 @@ class ScheduleNativeTranslatorTest extends CallTestBase {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 DEFAULT_CONFIG);
 
         // when/then
-        assertFalse(subject.matches(attempt));
+        assertFalse(subject.identifyMethod(attempt).isPresent());
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/signschedule/SignScheduleTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/signschedule/SignScheduleTranslatorTest.java
@@ -27,9 +27,7 @@ import static com.hedera.node.app.service.contract.impl.test.exec.systemcontract
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHssAttemptWithSelectorAndCustomConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -45,6 +43,7 @@ import com.hedera.hapi.node.state.schedule.Schedule;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.SystemContractOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
@@ -54,6 +53,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.signschedule.SignScheduleTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.mint.MintTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -114,6 +114,11 @@ class SignScheduleTranslatorTest {
     private ScheduleID scheduleID;
 
     @Mock
+    ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
+    @Mock
     private Key key;
 
     @Mock
@@ -132,12 +137,11 @@ class SignScheduleTranslatorTest {
 
     @BeforeEach
     void setUp() {
-        subject = new SignScheduleTranslator();
+        subject = new SignScheduleTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void testMatchesWhenSignScheduleEnabled() {
-        // given:
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractSignScheduleEnabled()).willReturn(true);
         attempt = prepareHssAttemptWithSelectorAndCustomConfig(
@@ -148,18 +152,13 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-
-        // when:
-        boolean matches = subject.matches(attempt);
-
-        // then:
-        assertTrue(matches);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void testFailsMatchesWhenSignScheduleEnabled() {
-        // given:
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractSignScheduleEnabled()).willReturn(false);
         attempt = prepareHssAttemptWithSelectorAndCustomConfig(
@@ -170,18 +169,13 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-
-        // when:
-        boolean matches = subject.matches(attempt);
-
-        // then:
-        assertFalse(matches);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test
     void testMatchesWhenAuthorizeScheduleEnabled() {
-        // given:
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractAuthorizeScheduleEnabled()).willReturn(true);
         attempt = prepareHssAttemptWithSelectorAndCustomConfig(
@@ -192,18 +186,13 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-
-        // when:
-        boolean matches = subject.matches(attempt);
-
-        // then:
-        assertTrue(matches);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void testFailsMatchesWhenAuthorizeScheduleEnabled() {
-        // given:
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractAuthorizeScheduleEnabled()).willReturn(false);
         attempt = prepareHssAttemptWithSelectorAndCustomConfig(
@@ -214,18 +203,13 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-
-        // when:
-        boolean matches = subject.matches(attempt);
-
-        // then:
-        assertFalse(matches);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test
     void testMatchesFailsOnRandomSelector() {
-        // given:
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractSignScheduleEnabled()).willReturn(true);
         attempt = prepareHssAttemptWithSelectorAndCustomConfig(
@@ -236,13 +220,9 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-
-        // when:
-        boolean matches = subject.matches(attempt);
-
-        // then:
-        assertFalse(matches);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test
@@ -266,6 +246,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         // then:
@@ -296,6 +277,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         // then:
@@ -319,6 +301,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         // then:
@@ -346,6 +329,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         // then:
@@ -375,6 +359,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         // then:
@@ -418,6 +403,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         final var returnedScheduleId = subject.scheduleIdFor(attempt);
@@ -439,6 +425,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         final var returnedScheduleId = subject.scheduleIdFor(attempt);
@@ -460,6 +447,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         final var returnedScheduleId = subject.scheduleIdFor(attempt);
@@ -486,6 +474,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         final var keySet = SignScheduleTranslator.getKeyForSignSchedule(attempt);
@@ -513,6 +502,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         final var keySet = SignScheduleTranslator.getKeyForSignSchedule(attempt);
@@ -538,6 +528,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         assertThrows(HandleException.class, () -> SignScheduleTranslator.getKeyForSignSchedule(attempt));
@@ -561,6 +552,7 @@ class SignScheduleTranslatorTest {
                 verificationStrategies,
                 signatureVerifier,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
 
         final var keySet = SignScheduleTranslator.getKeyForSignSchedule(attempt);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallAttemptTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallAttemptTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.hapi.node.token.TokenMintTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
@@ -71,6 +72,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transf
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc20TransfersTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc721TransferFromCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc721TransferFromTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.swirlds.common.utility.CommonUtils;
@@ -103,24 +105,29 @@ class HtsCallAttemptTest extends CallTestBase {
     @Mock
     private MintDecoder mintDecoder;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private List<CallTranslator<HtsCallAttempt>> callTranslators;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
 
     @BeforeEach
     void setUp() {
         callTranslators = List.of(
-                new AssociationsTranslator(associationsDecoder),
-                new Erc20TransfersTranslator(),
-                new Erc721TransferFromTranslator(),
-                new MintTranslator(mintDecoder),
-                new ClassicTransfersTranslator(classicTransfersDecoder),
-                new BalanceOfTranslator(),
-                new IsApprovedForAllTranslator(),
-                new NameTranslator(),
-                new TotalSupplyTranslator(),
-                new SymbolTranslator(),
-                new TokenUriTranslator(),
-                new OwnerOfTranslator(),
-                new DecimalsTranslator());
+                new AssociationsTranslator(associationsDecoder, systemContractMethodRegistry, contractMetrics),
+                new Erc20TransfersTranslator(systemContractMethodRegistry, contractMetrics),
+                new Erc721TransferFromTranslator(systemContractMethodRegistry, contractMetrics),
+                new MintTranslator(mintDecoder, systemContractMethodRegistry, contractMetrics),
+                new ClassicTransfersTranslator(classicTransfersDecoder, systemContractMethodRegistry, contractMetrics),
+                new BalanceOfTranslator(systemContractMethodRegistry, contractMetrics),
+                new IsApprovedForAllTranslator(systemContractMethodRegistry, contractMetrics),
+                new NameTranslator(systemContractMethodRegistry, contractMetrics),
+                new TotalSupplyTranslator(systemContractMethodRegistry, contractMetrics),
+                new SymbolTranslator(systemContractMethodRegistry, contractMetrics),
+                new TokenUriTranslator(systemContractMethodRegistry, contractMetrics),
+                new OwnerOfTranslator(systemContractMethodRegistry, contractMetrics),
+                new DecimalsTranslator(systemContractMethodRegistry, contractMetrics));
     }
 
     @Test
@@ -138,6 +145,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertNull(subject.redirectToken());
         verifyNoInteractions(nativeOperations);
@@ -159,6 +167,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertNull(subject.asExecutableCall());
     }
@@ -178,6 +187,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(DecimalsCall.class, subject.asExecutableCall());
     }
@@ -197,6 +207,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(TokenUriCall.class, subject.asExecutableCall());
     }
@@ -216,6 +227,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(OwnerOfCall.class, subject.asExecutableCall());
     }
@@ -238,6 +250,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(BalanceOfCall.class, subject.asExecutableCall());
     }
@@ -261,6 +274,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(IsApprovedForAllCall.class, subject.asExecutableCall());
     }
@@ -282,6 +296,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(IsApprovedForAllCall.class, subject.asExecutableCall());
     }
@@ -301,6 +316,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(TotalSupplyCall.class, subject.asExecutableCall());
     }
@@ -320,6 +336,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(NameCall.class, subject.asExecutableCall());
     }
@@ -339,6 +356,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(SymbolCall.class, subject.asExecutableCall());
     }
@@ -369,6 +387,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(Erc721TransferFromCall.class, subject.asExecutableCall());
     }
@@ -399,6 +418,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(Erc20TransfersCall.class, subject.asExecutableCall());
     }
@@ -426,6 +446,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
         assertInstanceOf(Erc20TransfersCall.class, subject.asExecutableCall());
     }
@@ -479,6 +500,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
 
         assertInstanceOf(DispatchForResponseCodeHtsCall.class, subject.asExecutableCall());
@@ -542,6 +564,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
 
         assertInstanceOf(ClassicTransfersCall.class, subject.asExecutableCall());
@@ -613,6 +636,7 @@ class HtsCallAttemptTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
 
         assertInstanceOf(DispatchForResponseCodeHtsCall.class, subject.asExecutableCall());

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallFactoryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/HtsCallFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallAddressChecks;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
@@ -37,6 +38,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.Synthe
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.balanceof.BalanceOfCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.balanceof.BalanceOfTranslator;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import java.util.ArrayDeque;
@@ -76,12 +78,21 @@ class HtsCallFactoryTest extends CallTestBase {
     @Mock
     private ProxyWorldUpdater updater;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private HtsCallFactory subject;
+
+    private SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
 
     @BeforeEach
     void setUp() {
         subject = new HtsCallFactory(
-                syntheticIds, addressChecks, verificationStrategies, List.of(new BalanceOfTranslator()));
+                syntheticIds,
+                addressChecks,
+                verificationStrategies,
+                List.of(new BalanceOfTranslator(systemContractMethodRegistry, contractMetrics)),
+                systemContractMethodRegistry);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/allowance/GetAllowanceTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/allowance/GetAllowanceTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,17 +24,17 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBL
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.allowance.GetAllowanceCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.allowance.GetAllowanceTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,25 +63,43 @@ public class GetAllowanceTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private GetAllowanceTranslator subject;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
 
     @BeforeEach
     void setUp() {
-        subject = new GetAllowanceTranslator();
+        subject = new GetAllowanceTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesGetAllowance() {
         attempt = prepareHtsAttemptWithSelector(
-                GET_ALLOWANCE, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                GET_ALLOWANCE,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesERCGetAllowance() {
         attempt = prepareHtsAttemptWithSelector(
-                ERC_GET_ALLOWANCE, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                ERC_GET_ALLOWANCE,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
+        ;
     }
 
     @Test
@@ -92,8 +110,9 @@ public class GetAllowanceTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertFalse(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/cancelairdrops/TokenCancelAirdropDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/cancelairdrops/TokenCancelAirdropDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PENDING_AIRDROP_ID_LIST_TOO_LONG;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.cancelairdrops.TokenCancelAirdropTranslator.CANCEL_AIRDROP;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.cancelairdrops.TokenCancelAirdropTranslator.CANCEL_AIRDROPS;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.cancelairdrops.TokenCancelAirdropTranslator.HRC_CANCEL_AIRDROP_FT;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.cancelairdrops.TokenCancelAirdropTranslator.HRC_CANCEL_AIRDROP_NFT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN;
@@ -99,7 +99,7 @@ class TokenCancelAirdropDecoderTest {
                 .willReturn(SENDER_ID);
         given(addressIdConverter.convert(OWNER_ACCOUNT_AS_ADDRESS)).willReturn(OWNER_ID);
 
-        final var encoded = Bytes.wrapByteBuffer(CANCEL_AIRDROP.encodeCall(Tuple.singleton(new Tuple[] {
+        final var encoded = Bytes.wrapByteBuffer(CANCEL_AIRDROPS.encodeCall(Tuple.singleton(new Tuple[] {
             Tuple.of(
                     asHeadlongAddress(SENDER_ID.accountNum()),
                     OWNER_ACCOUNT_AS_ADDRESS,
@@ -133,7 +133,7 @@ class TokenCancelAirdropDecoderTest {
                 FUNGIBLE_TOKEN_HEADLONG_ADDRESS,
                 0L);
         final var encoded =
-                Bytes.wrapByteBuffer(CANCEL_AIRDROP.encodeCall(Tuple.singleton(new Tuple[] {tuple, tuple, tuple})));
+                Bytes.wrapByteBuffer(CANCEL_AIRDROPS.encodeCall(Tuple.singleton(new Tuple[] {tuple, tuple, tuple})));
         given(attempt.inputBytes()).willReturn(encoded.toArrayUnsafe());
 
         assertThatExceptionOfType(HandleException.class)
@@ -150,7 +150,7 @@ class TokenCancelAirdropDecoderTest {
                 .willReturn(SENDER_ID);
         given(addressIdConverter.convert(OWNER_ACCOUNT_AS_ADDRESS)).willReturn(OWNER_ID);
 
-        final var encoded = Bytes.wrapByteBuffer(CANCEL_AIRDROP.encodeCall(Tuple.singleton(new Tuple[] {
+        final var encoded = Bytes.wrapByteBuffer(CANCEL_AIRDROPS.encodeCall(Tuple.singleton(new Tuple[] {
             Tuple.of(
                     asHeadlongAddress(SENDER_ID.accountNum()),
                     OWNER_ACCOUNT_AS_ADDRESS,
@@ -173,7 +173,7 @@ class TokenCancelAirdropDecoderTest {
                 .willReturn(SENDER_ID);
         given(addressIdConverter.convert(OWNER_ACCOUNT_AS_ADDRESS)).willReturn(OWNER_ID);
 
-        final var encoded = Bytes.wrapByteBuffer(CANCEL_AIRDROP.encodeCall(Tuple.singleton(new Tuple[] {
+        final var encoded = Bytes.wrapByteBuffer(CANCEL_AIRDROPS.encodeCall(Tuple.singleton(new Tuple[] {
             Tuple.of(
                     asHeadlongAddress(SENDER_ID.accountNum()),
                     OWNER_ACCOUNT_AS_ADDRESS,

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/claimairdrops/TokenClaimAirdropDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/claimairdrops/TokenClaimAirdropDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.claimairdrops;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
-import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.claimairdrops.TokenClaimAirdropTranslator.CLAIM_AIRDROP;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.claimairdrops.TokenClaimAirdropTranslator.CLAIM_AIRDROPS;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.claimairdrops.TokenClaimAirdropTranslator.HRC_CLAIM_AIRDROP_FT;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.claimairdrops.TokenClaimAirdropTranslator.HRC_CLAIM_AIRDROP_NFT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN;
@@ -99,7 +99,7 @@ public class TokenClaimAirdropDecoderTest {
         given(addressIdConverter.convert(asHeadlongAddress(SENDER_ID.accountNum())))
                 .willReturn(SENDER_ID);
 
-        final var encoded = Bytes.wrapByteBuffer(CLAIM_AIRDROP.encodeCall(Tuple.singleton(new Tuple[] {
+        final var encoded = Bytes.wrapByteBuffer(CLAIM_AIRDROPS.encodeCall(Tuple.singleton(new Tuple[] {
             Tuple.of(
                     asHeadlongAddress(SENDER_ID.accountNum()),
                     OWNER_ACCOUNT_AS_ADDRESS,
@@ -129,7 +129,7 @@ public class TokenClaimAirdropDecoderTest {
         given(configuration.getConfigData(TokensConfig.class)).willReturn(tokensConfig);
         given(tokensConfig.maxAllowedPendingAirdropsToClaim()).willReturn(10);
 
-        final var encoded = Bytes.wrapByteBuffer(CLAIM_AIRDROP.encodeCall(Tuple.singleton(new Tuple[] {
+        final var encoded = Bytes.wrapByteBuffer(CLAIM_AIRDROPS.encodeCall(Tuple.singleton(new Tuple[] {
             Tuple.of(
                     asHeadlongAddress(SENDER_ID.accountNum()),
                     OWNER_ACCOUNT_AS_ADDRESS,
@@ -204,7 +204,7 @@ public class TokenClaimAirdropDecoderTest {
                 .willReturn(SENDER_ID);
         given(addressIdConverter.convert(OWNER_ACCOUNT_AS_ADDRESS)).willReturn(OWNER_ID);
 
-        final var encoded = Bytes.wrapByteBuffer(CLAIM_AIRDROP.encodeCall(Tuple.singleton(new Tuple[] {
+        final var encoded = Bytes.wrapByteBuffer(CLAIM_AIRDROPS.encodeCall(Tuple.singleton(new Tuple[] {
             Tuple.of(
                     asHeadlongAddress(SENDER_ID.accountNum()),
                     OWNER_ACCOUNT_AS_ADDRESS,
@@ -252,7 +252,7 @@ public class TokenClaimAirdropDecoderTest {
                 .willReturn(SENDER_ID);
         given(addressIdConverter.convert(OWNER_ACCOUNT_AS_ADDRESS)).willReturn(OWNER_ID);
 
-        final var encoded = Bytes.wrapByteBuffer(CLAIM_AIRDROP.encodeCall(Tuple.singleton(new Tuple[] {
+        final var encoded = Bytes.wrapByteBuffer(CLAIM_AIRDROPS.encodeCall(Tuple.singleton(new Tuple[] {
             Tuple.of(
                     asHeadlongAddress(SENDER_ID.accountNum()),
                     OWNER_ACCOUNT_AS_ADDRESS,

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/CreateTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/create/CreateTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,11 +53,10 @@ import static com.hedera.node.app.service.contract.impl.test.exec.systemcontract
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.create.CreateTestHelper.CREATE_NON_FUNGIBLE_WITH_META_AND_FEES_TUPLE;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.create.CreateTestHelper.CREATE_NON_FUNGIBLE_WITH_META_TUPLE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
@@ -65,6 +64,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.ClassicCreatesCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.create.CreateTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.config.data.ContractsConfig;
@@ -106,13 +106,18 @@ public class CreateTranslatorTest extends CallTestBase {
     @Mock
     Configuration configuration;
 
-    private CreateDecoder decoder = new CreateDecoder();
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
+    private final CreateDecoder decoder = new CreateDecoder();
 
     private CreateTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new CreateTranslator(decoder);
+        subject = new CreateTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -123,8 +128,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -135,8 +141,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -147,8 +154,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -161,8 +169,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -173,8 +182,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -185,8 +195,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -197,8 +208,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -211,8 +223,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -223,8 +236,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -235,8 +249,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -247,8 +262,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -261,8 +277,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -273,8 +290,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -285,8 +303,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -297,8 +316,9 @@ public class CreateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -311,15 +331,22 @@ public class CreateTranslatorTest extends CallTestBase {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void falseOnInvalidSelector() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/customfees/TokenCustomFeesTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/customfees/TokenCustomFeesTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,17 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.customfees.TokenCustomFeesCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.customfees.TokenCustomFeesTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,25 +57,42 @@ class TokenCustomFeesTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private TokenCustomFeesTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new TokenCustomFeesTranslator();
+        subject = new TokenCustomFeesTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesTokenCustomFeesTranslatorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                TOKEN_CUSTOM_FEES, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                TOKEN_CUSTOM_FEES,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultfreezestatus/DefaultFreezeStatusTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,17 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.defaultfreezestatus.DefaultFreezeStatusCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.defaultfreezestatus.DefaultFreezeStatusTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,25 +57,42 @@ class DefaultFreezeStatusTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private DefaultFreezeStatusTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new DefaultFreezeStatusTranslator();
+        subject = new DefaultFreezeStatusTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesDefaultFreezeTranslatorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                DEFAULT_FREEZE_STATUS, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                DEFAULT_FREEZE_STATUS,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/defaultkycstatus/DefaultKycStatusTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,17 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.defaultkycstatus.DefaultKycStatusCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.defaultkycstatus.DefaultKycStatusTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,25 +57,42 @@ class DefaultKycStatusTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private DefaultKycStatusTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new DefaultKycStatusTranslator();
+        subject = new DefaultKycStatusTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesDefaultKycTranslatorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                DEFAULT_KYC_STATUS, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                DEFAULT_KYC_STATUS,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/delete/DeleteTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/delete/DeleteTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,19 +22,19 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_FUN
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_SYSTEM_ACCOUNT_ID;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.delete.DeleteTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,25 +63,42 @@ class DeleteTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private DeleteTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new DeleteTranslator();
+        subject = new DeleteTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesDelete() {
         attempt = prepareHtsAttemptWithSelector(
-                DELETE_TOKEN, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                DELETE_TOKEN,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/freeze/FreezeUnfreezeTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/freeze/FreezeUnfreezeTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,16 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.freeze.FreezeUnfreezeTranslator.FREEZE;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.freeze.FreezeUnfreezeTranslator.UNFREEZE;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.freeze.FreezeUnfreezeDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.freeze.FreezeUnfreezeTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,32 +55,55 @@ class FreezeUnfreezeTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private final FreezeUnfreezeDecoder decoder = new FreezeUnfreezeDecoder();
     private FreezeUnfreezeTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new FreezeUnfreezeTranslator(decoder);
+        subject = new FreezeUnfreezeTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void freezeMatches() {
         attempt = prepareHtsAttemptWithSelector(
-                FREEZE, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                FREEZE,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void unfreezeMatches() {
         attempt = prepareHtsAttemptWithSelector(
-                UNFREEZE, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                UNFREEZE,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void falseOnInvalidSelector() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,12 @@ class FungibleTokenInfoCallTest extends CallTestBase {
         when(ledgerConfig.id()).thenReturn(expectedLedgerId);
 
         final var subject = new FungibleTokenInfoCall(
-                gasCalculator, mockEnhancement(), false, FUNGIBLE_EVERYTHING_TOKEN, config, FUNGIBLE_TOKEN_INFO);
+                gasCalculator,
+                mockEnhancement(),
+                false,
+                FUNGIBLE_EVERYTHING_TOKEN,
+                config,
+                FUNGIBLE_TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -106,7 +111,12 @@ class FungibleTokenInfoCallTest extends CallTestBase {
         when(ledgerConfig.id()).thenReturn(expectedLedgerId);
 
         final var subject = new FungibleTokenInfoCall(
-                gasCalculator, mockEnhancement(), false, FUNGIBLE_EVERYTHING_TOKEN_V2, config, FUNGIBLE_TOKEN_INFO_V2);
+                gasCalculator,
+                mockEnhancement(),
+                false,
+                FUNGIBLE_EVERYTHING_TOKEN_V2,
+                config,
+                FUNGIBLE_TOKEN_INFO_V2.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -150,8 +160,8 @@ class FungibleTokenInfoCallTest extends CallTestBase {
         final var expectedLedgerId = com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01");
         when(ledgerConfig.id()).thenReturn(expectedLedgerId);
 
-        final var subject =
-                new FungibleTokenInfoCall(gasCalculator, mockEnhancement(), false, null, config, FUNGIBLE_TOKEN_INFO);
+        final var subject = new FungibleTokenInfoCall(
+                gasCalculator, mockEnhancement(), false, null, config, FUNGIBLE_TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -192,8 +202,8 @@ class FungibleTokenInfoCallTest extends CallTestBase {
         when(config.getConfigData(LedgerConfig.class)).thenReturn(ledgerConfig);
         when(ledgerConfig.id()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01"));
 
-        final var subject =
-                new FungibleTokenInfoCall(gasCalculator, mockEnhancement(), true, null, config, FUNGIBLE_TOKEN_INFO);
+        final var subject = new FungibleTokenInfoCall(
+                gasCalculator, mockEnhancement(), true, null, config, FUNGIBLE_TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -206,8 +216,8 @@ class FungibleTokenInfoCallTest extends CallTestBase {
         when(config.getConfigData(LedgerConfig.class)).thenReturn(ledgerConfig);
         when(ledgerConfig.id()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01"));
 
-        final var subject =
-                new FungibleTokenInfoCall(gasCalculator, mockEnhancement(), true, null, config, FUNGIBLE_TOKEN_INFO_V2);
+        final var subject = new FungibleTokenInfoCall(
+                gasCalculator, mockEnhancement(), true, null, config, FUNGIBLE_TOKEN_INFO_V2.function());
 
         final var result = subject.execute().fullResult().result();
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/fungibletokeninfo/FungibleTokenInfoTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,17 +23,17 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBL
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelectorAndCustomConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.fungibletokeninfo.FungibleTokenInfoCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.fungibletokeninfo.FungibleTokenInfoTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import com.hedera.node.config.data.ContractsConfig;
 import com.swirlds.config.api.Configuration;
@@ -67,18 +67,29 @@ class FungibleTokenInfoTranslatorTest {
     @Mock
     private ContractsConfig contractsConfig;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private FungibleTokenInfoTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new FungibleTokenInfoTranslator();
+        subject = new FungibleTokenInfoTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesFungibleTokenInfoTranslatorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                FUNGIBLE_TOKEN_INFO, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                FUNGIBLE_TOKEN_INFO,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -92,15 +103,22 @@ class FungibleTokenInfoTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/getapproved/GetApprovedTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/getapproved/GetApprovedTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,20 +24,20 @@ import static com.hedera.node.app.service.contract.impl.test.exec.systemcontract
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelectorForRedirect;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.getapproved.GetApprovedCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.getapproved.GetApprovedTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
@@ -73,11 +73,16 @@ public class GetApprovedTranslatorTest {
     @Mock
     private HederaNativeOperations nativeOperations;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private GetApprovedTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new GetApprovedTranslator();
+        subject = new GetApprovedTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -85,22 +90,40 @@ public class GetApprovedTranslatorTest {
         given(enhancement.nativeOperations()).willReturn(nativeOperations);
         given(nativeOperations.getToken(anyLong())).willReturn(FUNGIBLE_TOKEN);
         attempt = prepareHtsAttemptWithSelectorForRedirect(
-                ERC_GET_APPROVED, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                ERC_GET_APPROVED,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesHapiGetApprovedTest() {
         attempt = prepareHtsAttemptWithSelector(
-                HAPI_GET_APPROVED, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                HAPI_GET_APPROVED,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsOnIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/GrantApprovalTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/GrantApprovalTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,8 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHO
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHORIZED_SPENDER_ID;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelectorForRedirect;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -40,6 +39,7 @@ import static org.mockito.BDDMockito.given;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
@@ -49,6 +49,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.granta
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.ERCGrantApprovalCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
@@ -82,19 +83,30 @@ class GrantApprovalTranslatorTest {
     @Mock
     private HederaNativeOperations nativeOperations;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private final GrantApprovalDecoder decoder = new GrantApprovalDecoder();
     private GrantApprovalTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new GrantApprovalTranslator(decoder);
+        subject = new GrantApprovalTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void grantApprovalMatches() {
         attempt = prepareHtsAttemptWithSelector(
-                GRANT_APPROVAL, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                GRANT_APPROVAL,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -102,8 +114,14 @@ class GrantApprovalTranslatorTest {
         given(enhancement.nativeOperations()).willReturn(nativeOperations);
         given(nativeOperations.getToken(anyLong())).willReturn(FUNGIBLE_TOKEN);
         attempt = prepareHtsAttemptWithSelectorForRedirect(
-                ERC_GRANT_APPROVAL, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                ERC_GRANT_APPROVAL,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -116,22 +134,35 @@ class GrantApprovalTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void grantApprovalNFTMatches() {
         attempt = prepareHtsAttemptWithSelector(
-                GRANT_APPROVAL_NFT, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                GRANT_APPROVAL_NFT,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void falseOnInvalidSelector() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantrevokekyc/GrantRevokeKycTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,16 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantrevokekyc.GrantRevokeKycTranslator.GRANT_KYC;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantrevokekyc.GrantRevokeKycTranslator.REVOKE_KYC;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantrevokekyc.GrantRevokeKycDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantrevokekyc.GrantRevokeKycTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,32 +54,55 @@ class GrantRevokeKycTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private final GrantRevokeKycDecoder decoder = new GrantRevokeKycDecoder();
     private GrantRevokeKycTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new GrantRevokeKycTranslator(decoder);
+        subject = new GrantRevokeKycTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesGrantKycTest() {
         attempt = prepareHtsAttemptWithSelector(
-                GRANT_KYC, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                GRANT_KYC,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesRevokeKycTest() {
         attempt = prepareHtsAttemptWithSelector(
-                REVOKE_KYC, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                REVOKE_KYC,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsWithIncorrectSelector() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/isfrozen/IsFrozenTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/isfrozen/IsFrozenTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,18 +23,18 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_H
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.isfrozen.IsFrozenCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.isfrozen.IsFrozenTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,25 +63,42 @@ class IsFrozenTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private IsFrozenTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new IsFrozenTranslator();
+        subject = new IsFrozenTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesIsFrozenTest() {
         attempt = prepareHtsAttemptWithSelector(
-                IS_FROZEN, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                IS_FROZEN,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/iskyc/IsKycTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/iskyc/IsKycTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,18 +23,18 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_H
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.fromHeadlongAddress;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.iskyc.IsKycCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.iskyc.IsKycTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,25 +63,42 @@ class IsKycTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private IsKycTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new IsKycTranslator();
+        subject = new IsKycTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesIsKycTest() {
         attempt = prepareHtsAttemptWithSelector(
-                IS_KYC, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                IS_KYC,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/istoken/IsTokenTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,17 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.istoken.IsTokenCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.istoken.IsTokenTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,25 +57,42 @@ class IsTokenTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private IsTokenTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new IsTokenTranslator();
+        subject = new IsTokenTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesIsTokenTest() {
         attempt = prepareHtsAttemptWithSelector(
-                IS_TOKEN, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                IS_TOKEN,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ class NftTokenInfoCallTest extends CallTestBase {
                 FUNGIBLE_EVERYTHING_TOKEN,
                 2L,
                 config,
-                NON_FUNGIBLE_TOKEN_INFO);
+                NON_FUNGIBLE_TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -139,7 +139,7 @@ class NftTokenInfoCallTest extends CallTestBase {
                 FUNGIBLE_EVERYTHING_TOKEN_V2,
                 2L,
                 config,
-                NON_FUNGIBLE_TOKEN_INFO_V2);
+                NON_FUNGIBLE_TOKEN_INFO_V2.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -189,7 +189,7 @@ class NftTokenInfoCallTest extends CallTestBase {
         when(ledgerConfig.id()).thenReturn(expectedLedgerId);
 
         final var subject = new NftTokenInfoCall(
-                gasCalculator, mockEnhancement(), false, null, 0L, config, NON_FUNGIBLE_TOKEN_INFO);
+                gasCalculator, mockEnhancement(), false, null, 0L, config, NON_FUNGIBLE_TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -231,8 +231,8 @@ class NftTokenInfoCallTest extends CallTestBase {
 
     @Test
     void returnsNftTokenInfoStatusForMissingTokenStaticCall() {
-        final var subject =
-                new NftTokenInfoCall(gasCalculator, mockEnhancement(), true, null, 0L, config, NON_FUNGIBLE_TOKEN_INFO);
+        final var subject = new NftTokenInfoCall(
+                gasCalculator, mockEnhancement(), true, null, 0L, config, NON_FUNGIBLE_TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -243,7 +243,7 @@ class NftTokenInfoCallTest extends CallTestBase {
     @Test
     void returnsNftTokenInfoStatusForMissingTokenStaticCallV2() {
         final var subject = new NftTokenInfoCall(
-                gasCalculator, mockEnhancement(), true, null, 0L, config, NON_FUNGIBLE_TOKEN_INFO_V2);
+                gasCalculator, mockEnhancement(), true, null, 0L, config, NON_FUNGIBLE_TOKEN_INFO_V2.function());
 
         final var result = subject.execute().fullResult().result();
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/nfttokeninfo/NftTokenInfoTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,17 +23,17 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBL
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelectorAndCustomConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.nfttokeninfo.NftTokenInfoCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.nfttokeninfo.NftTokenInfoTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import com.hedera.node.config.data.ContractsConfig;
 import com.swirlds.config.api.Configuration;
@@ -67,11 +67,16 @@ class NftTokenInfoTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private NftTokenInfoTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new NftTokenInfoTranslator();
+        subject = new NftTokenInfoTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -82,8 +87,9 @@ class NftTokenInfoTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -97,15 +103,22 @@ class NftTokenInfoTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/pauses/PausesTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/pauses/PausesTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,16 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.pauses.PausesTranslator.PAUSE;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.pauses.PausesTranslator.UNPAUSE;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.pauses.PausesDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.pauses.PausesTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,33 +54,56 @@ public class PausesTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
-    private PausesDecoder decoder = new PausesDecoder();
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
+    private final PausesDecoder decoder = new PausesDecoder();
 
     private PausesTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new PausesTranslator(decoder);
+        subject = new PausesTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesPauseTest() {
         attempt = prepareHtsAttemptWithSelector(
-                PAUSE, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                PAUSE,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesUnpauseTest() {
         attempt = prepareHtsAttemptWithSelector(
-                UNPAUSE, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                UNPAUSE,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsOnIncorrectSelector() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/setapproval/SetApprovalForAllTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,18 +22,19 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelectorForRedirect;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.setapproval.SetApprovalForAllDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.setapproval.SetApprovalForAllTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,20 +63,31 @@ public class SetApprovalForAllTranslatorTest {
     @Mock
     private HederaNativeOperations nativeOperations;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private final SetApprovalForAllDecoder decoder = new SetApprovalForAllDecoder();
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
 
     private SetApprovalForAllTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new SetApprovalForAllTranslator(decoder);
+        subject = new SetApprovalForAllTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesClassicalSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                SET_APPROVAL_FOR_ALL, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                SET_APPROVAL_FOR_ALL,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -88,14 +100,21 @@ public class SetApprovalForAllTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void falseOnInvalidSelector() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenexpiry/TokenExpiryTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenexpiry/TokenExpiryTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,17 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokenexpiry.TokenExpiryCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokenexpiry.TokenExpiryTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,25 +57,42 @@ class TokenExpiryTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private TokenExpiryTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new TokenExpiryTranslator();
+        subject = new TokenExpiryTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesTokenExpiryTranslatorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                TOKEN_EXPIRY, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                TOKEN_EXPIRY,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokeninfo/TokenInfoCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokeninfo/TokenInfoCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ class TokenInfoCallTest extends CallTestBase {
         when(ledgerConfig.id()).thenReturn(expectedLedgerId);
 
         final var subject = new TokenInfoCall(
-                gasCalculator, mockEnhancement(), false, FUNGIBLE_EVERYTHING_TOKEN, config, TOKEN_INFO);
+                gasCalculator, mockEnhancement(), false, FUNGIBLE_EVERYTHING_TOKEN, config, TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -105,7 +105,12 @@ class TokenInfoCallTest extends CallTestBase {
         when(ledgerConfig.id()).thenReturn(expectedLedgerId);
 
         final var subject = new TokenInfoCall(
-                gasCalculator, mockEnhancement(), false, FUNGIBLE_EVERYTHING_TOKEN_V2, config, TOKEN_INFO_V2);
+                gasCalculator,
+                mockEnhancement(),
+                false,
+                FUNGIBLE_EVERYTHING_TOKEN_V2,
+                config,
+                TOKEN_INFO_V2.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -147,7 +152,8 @@ class TokenInfoCallTest extends CallTestBase {
         final var expectedLedgerId = com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01");
         when(ledgerConfig.id()).thenReturn(expectedLedgerId);
 
-        final var subject = new TokenInfoCall(gasCalculator, mockEnhancement(), false, null, config, TOKEN_INFO);
+        final var subject =
+                new TokenInfoCall(gasCalculator, mockEnhancement(), false, null, config, TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -186,7 +192,8 @@ class TokenInfoCallTest extends CallTestBase {
         when(config.getConfigData(LedgerConfig.class)).thenReturn(ledgerConfig);
         when(ledgerConfig.id()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01"));
 
-        final var subject = new TokenInfoCall(gasCalculator, mockEnhancement(), true, null, config, TOKEN_INFO);
+        final var subject =
+                new TokenInfoCall(gasCalculator, mockEnhancement(), true, null, config, TOKEN_INFO.function());
 
         final var result = subject.execute().fullResult().result();
 
@@ -199,7 +206,8 @@ class TokenInfoCallTest extends CallTestBase {
         when(config.getConfigData(LedgerConfig.class)).thenReturn(ledgerConfig);
         when(ledgerConfig.id()).thenReturn(com.hedera.pbj.runtime.io.buffer.Bytes.fromHex("01"));
 
-        final var subject = new TokenInfoCall(gasCalculator, mockEnhancement(), true, null, config, TOKEN_INFO_V2);
+        final var subject =
+                new TokenInfoCall(gasCalculator, mockEnhancement(), true, null, config, TOKEN_INFO_V2.function());
 
         final var result = subject.execute().fullResult().result();
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokeninfo/TokenInfoTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokeninfo/TokenInfoTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,17 +23,17 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBL
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelectorAndCustomConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokeninfo.TokenInfoCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokeninfo.TokenInfoTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import com.hedera.node.config.data.ContractsConfig;
 import com.swirlds.config.api.Configuration;
@@ -67,18 +67,29 @@ class TokenInfoTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private TokenInfoTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new TokenInfoTranslator();
+        subject = new TokenInfoTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesTokenInfoTranslatorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                TOKEN_INFO, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                TOKEN_INFO,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -92,15 +103,23 @@ class TokenInfoTranslatorTest {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
+        ;
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/TokenKeyTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/TokenKeyTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,19 +21,19 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokenkey.TokenKeyCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokenkey.TokenKeyTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -63,25 +63,42 @@ class TokenKeyTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private TokenKeyTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new TokenKeyTranslator();
+        subject = new TokenKeyTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesTokenKeyTranslatorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                TOKEN_KEY, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                TOKEN_KEY,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokentype/TokenTypeTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokentype/TokenTypeTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,17 @@ import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokentype.TokenTypeCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.tokentype.TokenTypeTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,25 +57,42 @@ class TokenTypeTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private TokenTypeTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new TokenTypeTranslator();
+        subject = new TokenTypeTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesTokenTypeTest() {
         attempt = prepareHtsAttemptWithSelector(
-                TOKEN_TYPE, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                TOKEN_TYPE,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesFailsIfIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.CallTranslator;
@@ -34,6 +35,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.swirlds.common.utility.CommonUtils;
 import java.lang.reflect.Field;
@@ -63,13 +65,19 @@ class ClassicTransfersTranslatorTest extends CallTestBase {
     @Mock
     private VerificationStrategy strategy;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private ClassicTransfersTranslator subject;
 
     private List<CallTranslator<HtsCallAttempt>> callTranslators;
 
     @BeforeEach
     void setUp() {
-        callTranslators = List.of(new ClassicTransfersTranslator(classicTransfersDecoder));
+        callTranslators = List.of(
+                new ClassicTransfersTranslator(classicTransfersDecoder, systemContractMethodRegistry, contractMetrics));
     }
 
     @Test
@@ -81,7 +89,8 @@ class ClassicTransfersTranslatorTest extends CallTestBase {
                         NON_SYSTEM_LONG_ZERO_ADDRESS, true, nativeOperations))
                 .willReturn(strategy);
 
-        subject = new ClassicTransfersTranslator(classicTransfersDecoder);
+        subject =
+                new ClassicTransfersTranslator(classicTransfersDecoder, systemContractMethodRegistry, contractMetrics);
         final var call = subject.callFrom(givenV2SubjectWithV2Enabled(ABI_ID_TRANSFER_TOKEN));
         Field senderIdField = ClassicTransfersCall.class.getDeclaredField("senderId");
         senderIdField.setAccessible(true);
@@ -97,7 +106,8 @@ class ClassicTransfersTranslatorTest extends CallTestBase {
                         NON_SYSTEM_LONG_ZERO_ADDRESS, true, nativeOperations))
                 .willReturn(strategy);
 
-        subject = new ClassicTransfersTranslator(classicTransfersDecoder);
+        subject =
+                new ClassicTransfersTranslator(classicTransfersDecoder, systemContractMethodRegistry, contractMetrics);
         final var call = subject.callFrom(givenV2SubjectWithV2Enabled(ABI_ID_CRYPTO_TRANSFER_V2));
         Field senderIdField = ClassicTransfersCall.class.getDeclaredField("senderId");
         senderIdField.setAccessible(true);
@@ -119,6 +129,7 @@ class ClassicTransfersTranslatorTest extends CallTestBase {
                 verificationStrategies,
                 gasCalculator,
                 callTranslators,
+                systemContractMethodRegistry,
                 false);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateExpiryTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateExpiryTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,13 +24,12 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_SYS
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
@@ -38,6 +37,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.Dispat
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateExpiryTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import java.time.Instant;
 import org.apache.tuweni.bytes.Bytes;
@@ -67,6 +67,11 @@ class UpdateExpiryTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private UpdateExpiryTranslator subject;
 
     private final UpdateDecoder decoder = new UpdateDecoder();
@@ -77,7 +82,7 @@ class UpdateExpiryTranslatorTest {
 
     @BeforeEach
     void setUp() {
-        subject = new UpdateExpiryTranslator(decoder);
+        subject = new UpdateExpiryTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -88,8 +93,9 @@ class UpdateExpiryTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -100,8 +106,9 @@ class UpdateExpiryTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -112,8 +119,9 @@ class UpdateExpiryTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertFalse(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateKeysTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateKeysTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,17 @@
 package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.update;
 
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.freeze.FreezeUnfreezeTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateKeysTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,13 +52,18 @@ class UpdateKeysTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private UpdateKeysTranslator subject;
 
     private final UpdateDecoder decoder = new UpdateDecoder();
 
     @BeforeEach
     void setUp() {
-        subject = new UpdateKeysTranslator(decoder);
+        subject = new UpdateKeysTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -68,8 +74,9 @@ class UpdateKeysTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -80,7 +87,8 @@ class UpdateKeysTranslatorTest {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertFalse(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateNFTsMetadataTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateNFTsMetadataTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,22 +19,24 @@ package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_FUNGIBLE_TOKEN_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_SYSTEM_ACCOUNT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.DispatchForResponseCodeHtsCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateNFTsMetadataTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,29 +62,30 @@ class UpdateNFTsMetadataTranslatorTest {
     @Mock
     private VerificationStrategy verificationStrategy;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private UpdateNFTsMetadataTranslator subject;
 
     private final UpdateDecoder decoder = new UpdateDecoder();
 
     @BeforeEach
     void setUp() {
-        subject = new UpdateNFTsMetadataTranslator(decoder);
+        subject = new UpdateNFTsMetadataTranslator(decoder, new SystemContractMethodRegistry(), contractMetrics);
     }
 
     @Test
     void matchesUpdateNFTsMetadataTest() {
         given(attempt.configuration()).willReturn(getTestConfiguration(true));
-        given(attempt.isSelector(UpdateNFTsMetadataTranslator.UPDATE_NFTs_METADATA))
-                .willReturn(true);
-        final var matches = subject.matches(attempt);
-        assertThat(matches).isTrue();
+        given(attempt.isMethod(UpdateNFTsMetadataTranslator.UPDATE_NFTs_METADATA))
+                .willReturn(Optional.of(UpdateNFTsMetadataTranslator.UPDATE_NFTs_METADATA));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void doesNotMatchUpdateNFTsMetadataWhenDisabled() {
         given(attempt.configuration()).willReturn(getTestConfiguration(false));
-        var matches = subject.matches(attempt);
-        assertFalse(matches);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/update/UpdateTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,6 @@ import static com.hedera.node.app.service.contract.impl.test.exec.systemcontract
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelectorAndCustomConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
@@ -46,6 +44,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.token.TokenUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
@@ -54,6 +53,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCal
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.freeze.FreezeUnfreezeTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.update.UpdateTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -96,6 +96,11 @@ class UpdateTranslatorTest extends CallTestBase {
     @Mock
     Configuration configuration;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private UpdateTranslator subject;
 
     private final UpdateDecoder decoder = new UpdateDecoder();
@@ -115,7 +120,7 @@ class UpdateTranslatorTest extends CallTestBase {
 
     @BeforeEach
     void setUp() {
-        subject = new UpdateTranslator(decoder);
+        subject = new UpdateTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -187,8 +192,9 @@ class UpdateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -199,8 +205,9 @@ class UpdateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -211,8 +218,9 @@ class UpdateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertTrue(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -226,8 +234,9 @@ class UpdateTranslatorTest extends CallTestBase {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -238,8 +247,9 @@ class UpdateTranslatorTest extends CallTestBase {
                 enhancement,
                 addressIdConverter,
                 verificationStrategies,
-                gasCalculator);
-        assertFalse(subject.matches(attempt));
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/updatetokencustomfees/UpdateTokenCustomFeesTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/updatetokencustomfees/UpdateTokenCustomFeesTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,14 +26,13 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_I
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.SENDER_ID;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelectorAndCustomConfig;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.esaulpaugh.headlong.abi.Tuple;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
@@ -41,6 +40,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.Dispat
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.updatetokencustomfees.UpdateTokenCustomFeesDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.updatetokencustomfees.UpdateTokenCustomFeesTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.config.data.ContractsConfig;
@@ -80,13 +80,18 @@ class UpdateTokenCustomFeesTranslatorTest extends CallTestBase {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    @Mock
+    private ContractMetrics contractMetrics;
+
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private final UpdateTokenCustomFeesDecoder decoder = new UpdateTokenCustomFeesDecoder();
 
     private UpdateTokenCustomFeesTranslator subject;
 
     @BeforeEach
     void setUp() {
-        subject = new UpdateTokenCustomFeesTranslator(decoder);
+        subject = new UpdateTokenCustomFeesTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
@@ -100,8 +105,9 @@ class UpdateTokenCustomFeesTranslatorTest extends CallTestBase {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -115,8 +121,9 @@ class UpdateTokenCustomFeesTranslatorTest extends CallTestBase {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertTrue(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
@@ -124,7 +131,7 @@ class UpdateTokenCustomFeesTranslatorTest extends CallTestBase {
         // given:
         setConfiguration(false);
         // expect:
-        assertFalse(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test
@@ -138,8 +145,9 @@ class UpdateTokenCustomFeesTranslatorTest extends CallTestBase {
                 addressIdConverter,
                 verificationStrategies,
                 gasCalculator,
+                systemContractMethodRegistry,
                 configuration);
-        assertFalse(subject.matches(attempt));
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/wipe/WipeTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/wipe/WipeTranslatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,16 @@ package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.burn.BurnTranslator.BURN_TOKEN_V2;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.wipe.WipeTranslator.WIPE_FUNGIBLE_V1;
 import static com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.CallAttemptHelpers.prepareHtsAttemptWithSelector;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategies;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.wipe.WipeDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.wipe.WipeTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater.Enhancement;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,40 +54,69 @@ public class WipeTranslatorTest {
     @Mock
     private VerificationStrategies verificationStrategies;
 
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
+    @Mock
+    private ContractMetrics contractMetrics;
+
     private final WipeDecoder decoder = new WipeDecoder();
 
     private WipeTranslator subject;
 
     @BeforeEach
     void setup() {
-        subject = new WipeTranslator(decoder);
+        subject = new WipeTranslator(decoder, systemContractMethodRegistry, contractMetrics);
     }
 
     @Test
     void matchesWipeFungibleV1Test() {
         attempt = prepareHtsAttemptWithSelector(
-                WIPE_FUNGIBLE_V1, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                WIPE_FUNGIBLE_V1,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesWipeFungibleV2Test() {
         attempt = prepareHtsAttemptWithSelector(
-                WIPE_FUNGIBLE_V1, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                WIPE_FUNGIBLE_V1,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchesWipeNftTest() {
         attempt = prepareHtsAttemptWithSelector(
-                WIPE_FUNGIBLE_V1, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertTrue(subject.matches(attempt));
+                WIPE_FUNGIBLE_V1,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isPresent();
     }
 
     @Test
     void matchFailsOnIncorrectSelectorTest() {
         attempt = prepareHtsAttemptWithSelector(
-                BURN_TOKEN_V2, subject, enhancement, addressIdConverter, verificationStrategies, gasCalculator);
-        assertFalse(subject.matches(attempt));
+                BURN_TOKEN_V2,
+                subject,
+                enhancement,
+                addressIdConverter,
+                verificationStrategies,
+                gasCalculator,
+                systemContractMethodRegistry);
+        assertThat(subject.identifyMethod(attempt)).isEmpty();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/SystemContractMethodRegistryTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/utils/SystemContractMethodRegistryTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.service.contract.impl.test.exec.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.esaulpaugh.headlong.abi.Function;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.getevmaddressalias.EvmAddressAliasTranslator;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarapprove.HbarApproveTranslator;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isvalidalias.IsValidAliasTranslator;
+import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.CallVia;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.SystemContract;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod.Variant;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SystemContractMethodRegistryTest {
+
+    @Mock
+    ContractMetrics contractMetrics;
+
+    @Test
+    void testMethodCreationHappyPath() {
+
+        final var signature = new Function("collectReward(string)", ReturnTypes.ADDRESS);
+        final var subject = SystemContractMethod.declare(
+                        signature.getCanonicalSignature(),
+                        signature.getOutputs().toString())
+                .withContract(SystemContract.EXCHANGE)
+                .withVia(CallVia.DIRECT);
+
+        assertThat(subject.methodName()).isEqualTo("collectReward");
+        assertThat(subject.qualifiedMethodName()).isEqualTo("EXCHANGE.collectReward");
+        assertThat(subject.signature()).isEqualTo("collectReward(string)");
+        assertThat(subject.signatureWithReturn()).isEqualTo("collectReward(string):(address)");
+        assertThat(subject.selectorLong()).isEqualTo(0x3cbf0049L);
+        assertThat(subject.selectorHex()).isEqualTo("3cbf0049");
+    }
+
+    @Test
+    void testMethodCreationVariations() {
+
+        final var signature = new Function("collectReward(string)", ReturnTypes.ADDRESS);
+
+        // Proxy
+        final var subjectProxy = SystemContractMethod.declare(
+                        signature.getCanonicalSignature(),
+                        signature.getOutputs().toString())
+                .withContract(SystemContract.EXCHANGE)
+                .withVia(CallVia.PROXY);
+        assertThat(subjectProxy.qualifiedMethodName()).isEqualTo("EXCHANGE(PROXY).collectReward");
+
+        // Variant method name
+        final var subjectOverrideName = SystemContractMethod.declare(
+                        signature.getCanonicalSignature(),
+                        signature.getOutputs().toString())
+                .withContract(SystemContract.EXCHANGE)
+                .withVariant(Variant.NFT);
+        assertThat(subjectOverrideName.qualifiedMethodName()).isEqualTo("EXCHANGE.collectReward_NFT");
+        assertThat(subjectOverrideName.signature()).isEqualTo("collectReward(string)");
+        assertThat(subjectOverrideName.selectorLong()).isEqualTo(0x3cbf0049L);
+    }
+
+    @Test
+    void testHappyMethodRegistrations() {
+
+        final var subject = new SystemContractMethodRegistry();
+
+        // Add some registrations by simply creating instances of classes known to register methods
+
+        final var t1 = new IsValidAliasTranslator(subject, contractMetrics);
+        final var t2 = new HbarApproveTranslator(subject, contractMetrics);
+        final var t3 = new EvmAddressAliasTranslator(subject, contractMetrics);
+
+        // Test expected methods are registered (test data is known from looking at the classes involved)
+
+        //        HAS(PROXY).hbarApprove: 0x86aff07c - hbarApprove(address,int256):(int64)
+        //        HAS.getEvmAddressAlias: 0xdea3d081 - getEvmAddressAlias(address):(int64,address)
+        //        HAS.hbarApprove:        0xa0918464 - hbarApprove(address,address,int256):(int64)
+        //        HAS.isValidAlias:       0x308ef301 - isValidAlias(address):(bool)
+
+        final var actualAllQualifiedMethods = subject.allQualifiedMethods();
+        assertThat(actualAllQualifiedMethods)
+                .hasSize(4)
+                .containsExactlyInAnyOrder(
+                        "HAS.isValidAlias", "HAS.getEvmAddressAlias", "HAS.hbarApprove", "HAS(PROXY).hbarApprove");
+
+        final var actualAllSignatures = subject.allSignatures();
+        assertThat(actualAllSignatures)
+                .hasSize(4)
+                .containsExactlyInAnyOrder(
+                        "getEvmAddressAlias(address)",
+                        "hbarApprove(address,address,int256)",
+                        "hbarApprove(address,int256)",
+                        "isValidAlias(address)");
+
+        final var actualAllSignaturesWithReturns = subject.allSignaturesWithReturns();
+        assertThat(actualAllSignaturesWithReturns)
+                .hasSize(4)
+                .containsExactlyInAnyOrder(
+                        "getEvmAddressAlias(address):(int64,address)",
+                        "hbarApprove(address,address,int256):(int64)",
+                        "hbarApprove(address,int256):(int64)",
+                        "isValidAlias(address):(bool)");
+    }
+
+    @Test
+    void testDuplicateMethodRegistrationRegistersOnlyOneCopy() {
+
+        final var subject = new SystemContractMethodRegistry();
+
+        // Add some registrations twice - this might happen if a `FooTranslator` isn't marked `@Singleton`
+        final var t1 = new IsValidAliasTranslator(subject, contractMetrics);
+        final var t2 = new IsValidAliasTranslator(subject, contractMetrics);
+
+        // Test only one method is registered
+
+        final var actualAllQualifiedMethods = subject.allQualifiedMethods();
+        assertThat(actualAllQualifiedMethods).hasSize(1).containsExactly("HAS.isValidAlias");
+
+        final var actualAllSignatures = subject.allSignatures();
+        assertThat(actualAllSignatures).hasSize(1).containsExactly("isValidAlias(address)");
+
+        final var actualAllSignaturesWithReturns = subject.allSignaturesWithReturns();
+        assertThat(actualAllSignaturesWithReturns).hasSize(1).containsExactly("isValidAlias(address):(bool)");
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
@@ -97,7 +97,7 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
 
     private final Metrics metrics = new NoOpMetrics();
     private final ContractMetrics contractMetrics =
-            new ContractMetrics(() -> metrics, () -> contractsConfig, systemContractMethodRegistry);
+            new ContractMetrics(metrics, () -> contractsConfig, systemContractMethodRegistry);
 
     private ContractCallHandler subject;
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextTransactionProcessor;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
 import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCallHandler;
 import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
@@ -92,14 +93,17 @@ class ContractCallHandlerTest extends ContractHandlerTestBase {
     @Mock
     private ContractsConfig contractsConfig;
 
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private final Metrics metrics = new NoOpMetrics();
-    private final ContractMetrics contractMetrics = new ContractMetrics(() -> metrics, () -> contractsConfig);
+    private final ContractMetrics contractMetrics =
+            new ContractMetrics(() -> metrics, () -> contractsConfig, systemContractMethodRegistry);
 
     private ContractCallHandler subject;
 
     @BeforeEach
     void setUp() {
-        contractMetrics.createContractMetrics();
+        contractMetrics.createContractPrimaryMetrics();
         given(contractServiceComponent.contractMetrics()).willReturn(contractMetrics);
         subject = new ContractCallHandler(() -> factory, gasCalculator, contractServiceComponent);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallLocalHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallLocalHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,11 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.node.app.hapi.utils.fee.FeeBuilder;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
+import com.hedera.node.app.service.contract.impl.ContractServiceComponent;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextQueryProcessor;
 import com.hedera.node.app.service.contract.impl.exec.QueryComponent;
+import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCallLocalHandler;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -61,6 +63,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -120,9 +123,16 @@ class ContractCallLocalHandlerTest {
 
     private ContractCallLocalHandler subject;
 
+    @Mock(strictness = Strictness.LENIENT)
+    private ContractServiceComponent contractServiceComponent;
+
+    @Mock
+    private ContractMetrics contractMetrics;
+
     @BeforeEach
     void setUp() {
-        subject = new ContractCallLocalHandler(() -> factory, gasCalculator, instantSource);
+        given(contractServiceComponent.contractMetrics()).willReturn(contractMetrics);
+        subject = new ContractCallLocalHandler(() -> factory, gasCalculator, instantSource, contractServiceComponent);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallLocalHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCallLocalHandlerTest.java
@@ -40,11 +40,9 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.node.app.hapi.utils.fee.FeeBuilder;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
-import com.hedera.node.app.service.contract.impl.ContractServiceComponent;
 import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextQueryProcessor;
 import com.hedera.node.app.service.contract.impl.exec.QueryComponent;
-import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCallLocalHandler;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -63,7 +61,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -123,16 +120,9 @@ class ContractCallLocalHandlerTest {
 
     private ContractCallLocalHandler subject;
 
-    @Mock(strictness = Strictness.LENIENT)
-    private ContractServiceComponent contractServiceComponent;
-
-    @Mock
-    private ContractMetrics contractMetrics;
-
     @BeforeEach
     void setUp() {
-        given(contractServiceComponent.contractMetrics()).willReturn(contractMetrics);
-        subject = new ContractCallLocalHandler(() -> factory, gasCalculator, instantSource, contractServiceComponent);
+        subject = new ContractCallLocalHandler(() -> factory, gasCalculator, instantSource);
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import com.hedera.node.app.service.contract.impl.exec.CallOutcome;
 import com.hedera.node.app.service.contract.impl.exec.ContextTransactionProcessor;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
 import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCreateHandler;
 import com.hedera.node.app.service.contract.impl.records.ContractCreateStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.RootProxyWorldUpdater;
@@ -98,14 +99,17 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
     @Mock
     private ContractsConfig contractsConfig;
 
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private final Metrics metrics = new NoOpMetrics();
-    private final ContractMetrics contractMetrics = new ContractMetrics(() -> metrics, () -> contractsConfig);
+    private final ContractMetrics contractMetrics =
+            new ContractMetrics(() -> metrics, () -> contractsConfig, systemContractMethodRegistry);
 
     private ContractCreateHandler subject;
 
     @BeforeEach
     void setUp() {
-        contractMetrics.createContractMetrics();
+        contractMetrics.createContractPrimaryMetrics();
         given(contractServiceComponent.contractMetrics()).willReturn(contractMetrics);
         subject = new ContractCreateHandler(() -> factory, gasCalculator, contractServiceComponent);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractCreateHandlerTest.java
@@ -103,7 +103,7 @@ class ContractCreateHandlerTest extends ContractHandlerTestBase {
 
     private final Metrics metrics = new NoOpMetrics();
     private final ContractMetrics contractMetrics =
-            new ContractMetrics(() -> metrics, () -> contractsConfig, systemContractMethodRegistry);
+            new ContractMetrics(metrics, () -> contractsConfig, systemContractMethodRegistry);
 
     private ContractCreateHandler subject;
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import com.hedera.node.app.service.contract.impl.exec.TransactionProcessor;
 import com.hedera.node.app.service.contract.impl.exec.gas.CustomGasCharging;
 import com.hedera.node.app.service.contract.impl.exec.metrics.ContractMetrics;
 import com.hedera.node.app.service.contract.impl.exec.tracers.EvmActionTracer;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.handlers.EthereumTransactionHandler;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmContext;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
@@ -165,12 +166,15 @@ class EthereumTransactionHandlerTest {
     @Mock
     private ContractsConfig contractsConfig;
 
+    private final SystemContractMethodRegistry systemContractMethodRegistry = new SystemContractMethodRegistry();
+
     private final Metrics metrics = new NoOpMetrics();
-    private final ContractMetrics contractMetrics = new ContractMetrics(() -> metrics, () -> contractsConfig);
+    private final ContractMetrics contractMetrics =
+            new ContractMetrics(() -> metrics, () -> contractsConfig, systemContractMethodRegistry);
 
     @BeforeEach
     void setUp() {
-        contractMetrics.createContractMetrics();
+        contractMetrics.createContractPrimaryMetrics();
         given(contractServiceComponent.contractMetrics()).willReturn(contractMetrics);
         subject = new EthereumTransactionHandler(
                 ethereumSignatures, callDataHydration, () -> factory, gasCalculator, contractServiceComponent);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/EthereumTransactionHandlerTest.java
@@ -170,7 +170,7 @@ class EthereumTransactionHandlerTest {
 
     private final Metrics metrics = new NoOpMetrics();
     private final ContractMetrics contractMetrics =
-            new ContractMetrics(() -> metrics, () -> contractsConfig, systemContractMethodRegistry);
+            new ContractMetrics(metrics, () -> contractsConfig, systemContractMethodRegistry);
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
**Description**:
Smart contract service metrics, P2 priority.

These are the metrics that are interesting now and we can collect in the consensus node, but later we'll 
collect in other ways. E.g., from block nodes. (All these metrics are for post-consensus transactions and will show up in the record/block stream.)

Metrics at this time are:
* ERC-20 & ERC-721 call counts
* HAS/HSS/HTS contract call counts, and fail counts
* Direct vs Proxy call counts, and fail counts
* "Category" call counts, and fail counts

FYI: There are currently 115 system methods declared in 57 `*Translator` classes.

**Related issue(s)**:

Fixes #16088 
Fixes #16868

**Notes for reviewer**:

Changes a boatload of files.  Each of the ~50 FooTranslator classes (about one for each system
contract method Foo) needs a small change, but that's a change to the constructor, and so it had
effects on all the unit tests for those classes as well.  You'll quickly see the pattern ...

There are methods marked `@VisibleForTesting` that don't show up in unit tests - this is because they're
meant for _manual_ testing, i.e., evaluating them in the debugger.  Useful now and in the future when ensuring,
manually, that all methods are properly _registered_ and also have the correct metadata fields.

Here are the metrics defined (by name):
```
SmartContractService:Method_AIRDROP_failed
SmartContractService:Method_AIRDROP_total
SmartContractService:Method_ALIASES_failed
SmartContractService:Method_ALIASES_total
SmartContractService:Method_ALLOWANCE_failed
SmartContractService:Method_ALLOWANCE_total
SmartContractService:Method_APPROVAL_failed
SmartContractService:Method_APPROVAL_total
SmartContractService:Method_ASSOCIATION_failed
SmartContractService:Method_ASSOCIATION_total
SmartContractService:Method_CREATE_DELETE_TOKEN_failed
SmartContractService:Method_CREATE_DELETE_TOKEN_total
SmartContractService:Method_DIRECT_failed
SmartContractService:Method_DIRECT_total
SmartContractService:Method_ERC20_failed
SmartContractService:Method_ERC20_total
SmartContractService:Method_ERC721_failed
SmartContractService:Method_ERC721_total
SmartContractService:Method_FREEZE_UNFREEZE_failed
SmartContractService:Method_FREEZE_UNFREEZE_total
SmartContractService:Method_HAS_failed
SmartContractService:Method_HAS_total
SmartContractService:Method_HSS_failed
SmartContractService:Method_HSS_total
SmartContractService:Method_HTS_failed
SmartContractService:Method_HTS_total
SmartContractService:Method_IS_AUTHORIZED_failed
SmartContractService:Method_IS_AUTHORIZED_total
SmartContractService:Method_KYC_failed
SmartContractService:Method_KYC_total
SmartContractService:Method_MINT_BURN_failed
SmartContractService:Method_MINT_BURN_total
SmartContractService:Method_PAUSE_UNPAUSE_failed
SmartContractService:Method_PAUSE_UNPAUSE_total
SmartContractService:Method_PROXY_failed
SmartContractService:Method_PROXY_total
SmartContractService:Method_REJECT_failed
SmartContractService:Method_REJECT_total
SmartContractService:Method_SCHEDULE_failed
SmartContractService:Method_SCHEDULE_total
SmartContractService:Method_TOKEN_QUERY_failed
SmartContractService:Method_TOKEN_QUERY_total
SmartContractService:Method_TRANSFER_failed
SmartContractService:Method_TRANSFER_total
SmartContractService:Method_UPDATE_failed
SmartContractService:Method_UPDATE_total
SmartContractService:Method_WIPE_failed
SmartContractService:Method_WIPE_total
SmartContractService:Rejected_contractCallTxDueToIntrinsicGas_total
SmartContractService:Rejected_contractCallTx_total
SmartContractService:Rejected_contractCreateTxDueToIntrinsicGas_total
SmartContractService:Rejected_contractCreateTx_total
SmartContractService:Rejected_ethType3BlobTransaction_total
SmartContractService:Rejected_ethereumTxDueToIntrinsicGas_total
SmartContractService:Rejected_ethereumTx_total
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
