### PR TITLE
ci: add org to snyk action

### DIFF
--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -600,7 +600,7 @@ jobs:
             ) &&
             !cancelled()
           }}
-        run: ${CG_EXEC} snyk test --all-sub-projects --severity-threshold=high --policy-path=.snyk --json-file-output=snyk-test.json
+        run: ${CG_EXEC} snyk test --all-sub-projects --severity-threshold=high --policy-path=.snyk --json-file-output=snyk-test.json --org=hedera-services
 
       - name: Snyk Code
         id: snyk-code
@@ -617,7 +617,7 @@ jobs:
             ) &&
             !cancelled()
           }}
-        run: ${CG_EXEC} snyk code test --severity-threshold=high --json-file-output=snyk-code.json
+        run: ${CG_EXEC} snyk code test --severity-threshold=high --json-file-output=snyk-code.json --org=hedera-services
 
       - name: Publish Snyk Results
         if: >-


### PR DESCRIPTION
**Description**:
Snyk has an issue where it has not been successful on the mainline when running actions. It fails with a failure to authenticate. Adding the `--org=hedera-services` should resolve this issue.

**Related Issue(s)**:

Fixes #16878
