### PR TITLE
fix: move initialization of P1 smart contract metrics

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -603,11 +603,10 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
                     trigger,
                     RosterUtils.buildAddressBook(platform.getRoster()),
                     platform.getContext().getConfiguration());
-
-            contractServiceImpl.registerMetrics();
         }
         // With the States API grounded in the working state, we can create the object graph from it
         initializeDagger(state, trigger);
+        contractServiceImpl.registerMetrics();
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
@@ -52,7 +52,6 @@ public class ContractMetrics {
     private final Supplier<Metrics> metricsSupplier;
     private final Supplier<ContractsConfig> contractsConfigSupplier;
     private boolean p1MetricsEnabled;
-    private boolean p2MetricsEnabled;
 
     private final HashMap<HederaFunctionality, Counter> rejectedTxsCounters = new HashMap<>();
     private final HashMap<HederaFunctionality, Counter> rejectedTxsLackingIntrinsicGas = new HashMap<>();
@@ -88,52 +87,61 @@ public class ContractMetrics {
                 requireNonNull(contractsConfigSupplier, "contracts configuration supplier must not be null");
     }
 
+    private final Object metricsCreationLock = new Object();
+    private volatile boolean primaryMetricsAreCreated = false;
+
     public void createContractMetrics() {
 
-        final var contractsConfig = requireNonNull(contractsConfigSupplier.get());
-        this.p1MetricsEnabled = contractsConfig.metricsSmartContractPrimaryEnabled();
-        this.p2MetricsEnabled = contractsConfig.metricsSmartContractSecondaryEnabled();
+        // Primary metrics are a fixed set and can be created when `Hedera` initializes the system.
+        // But it actually must wait until the platform calls `Hedera.onStateInitialized` and,
+        // remarkably, that can happen more than once.  We must only create the metrics the
+        // _first_ time.  Hence, the simple gate here.
 
-        final var metrics = requireNonNull(metricsSupplier.get());
+        synchronized (metricsCreationLock) {
+            if (!primaryMetricsAreCreated) {
 
-        if (p1MetricsEnabled) {
-            // Rejected transactions counters
-            for (final var txKind : POSSIBLE_FAILING_TX_TYPES.keySet()) {
-                final var name = toRejectedName(txKind, REJECTED_TXN_SHORT_DESCR);
-                final var descr = toRejectedDescr(txKind, REJECTED_TXN_SHORT_DESCR);
-                final var config = new Counter.Config(METRIC_CATEGORY, name)
-                        .withDescription(descr)
-                        .withUnit(METRIC_TXN_UNIT);
-                final var metric = newCounter(metrics, config);
-                rejectedTxsCounters.put(txKind, metric);
+                final var contractsConfig = requireNonNull(contractsConfigSupplier.get());
+                this.p1MetricsEnabled = contractsConfig.metricsSmartContractPrimaryEnabled();
+
+                final var metrics = requireNonNull(metricsSupplier.get());
+
+                if (p1MetricsEnabled) {
+                    // Rejected transactions counters
+                    for (final var txKind : POSSIBLE_FAILING_TX_TYPES.keySet()) {
+                        final var name = toRejectedName(txKind, REJECTED_TXN_SHORT_DESCR);
+                        final var descr = toRejectedDescr(txKind, REJECTED_TXN_SHORT_DESCR);
+                        final var config = new Counter.Config(METRIC_CATEGORY, name)
+                                .withDescription(descr)
+                                .withUnit(METRIC_TXN_UNIT);
+                        final var metric = newCounter(metrics, config);
+                        rejectedTxsCounters.put(txKind, metric);
+                    }
+
+                    // Rejected transactions because they don't even have intrinsic gas
+                    for (final var txKind : POSSIBLE_FAILING_TX_TYPES.keySet()) {
+                        final var functionalityName = POSSIBLE_FAILING_TX_TYPES.get(txKind) + "DueToIntrinsicGas";
+                        final var name = toRejectedName(functionalityName, REJECTED_FOR_GAS_SHORT_DESCR);
+                        final var descr = toRejectedDescr(functionalityName, REJECTED_FOR_GAS_SHORT_DESCR);
+                        final var config = new Counter.Config(METRIC_CATEGORY, name)
+                                .withDescription(descr)
+                                .withUnit(METRIC_TXN_UNIT);
+                        final var metric = newCounter(metrics, config);
+                        rejectedTxsLackingIntrinsicGas.put(txKind, metric);
+                    }
+
+                    // Rejected transactions for ethereum calls that are in type 3 blob transaction format
+                    {
+                        final var name = toRejectedName(REJECTED_TYPE3_FUNCTIONALITY, REJECTED_TYPE3_SHORT_DESCR);
+                        final var descr = toRejectedDescr(REJECTED_TYPE3_FUNCTIONALITY, REJECTED_TYPE3_SHORT_DESCR);
+                        final var config = new Counter.Config(METRIC_CATEGORY, name)
+                                .withDescription(descr)
+                                .withUnit(METRIC_TXN_UNIT);
+                        final var metric = newCounter(metrics, config);
+                        rejectedEthType3Counter = metric;
+                    }
+                }
+                primaryMetricsAreCreated = true;
             }
-
-            // Rejected transactions because they don't even have intrinsic gas
-            for (final var txKind : POSSIBLE_FAILING_TX_TYPES.keySet()) {
-                final var functionalityName = POSSIBLE_FAILING_TX_TYPES.get(txKind) + "DueToIntrinsicGas";
-                final var name = toRejectedName(functionalityName, REJECTED_FOR_GAS_SHORT_DESCR);
-                final var descr = toRejectedDescr(functionalityName, REJECTED_FOR_GAS_SHORT_DESCR);
-                final var config = new Counter.Config(METRIC_CATEGORY, name)
-                        .withDescription(descr)
-                        .withUnit(METRIC_TXN_UNIT);
-                final var metric = newCounter(metrics, config);
-                rejectedTxsLackingIntrinsicGas.put(txKind, metric);
-            }
-
-            // Rejected transactions for ethereum calls that are in type 3 blob transaction format
-            {
-                final var name = toRejectedName(REJECTED_TYPE3_FUNCTIONALITY, REJECTED_TYPE3_SHORT_DESCR);
-                final var descr = toRejectedDescr(REJECTED_TYPE3_FUNCTIONALITY, REJECTED_TYPE3_SHORT_DESCR);
-                final var config = new Counter.Config(METRIC_CATEGORY, name)
-                        .withDescription(descr)
-                        .withUnit(METRIC_TXN_UNIT);
-                final var metric = newCounter(metrics, config);
-                rejectedEthType3Counter = metric;
-            }
-        }
-
-        if (p2MetricsEnabled) {
-            // PLACEHOLDER
         }
     }
 
@@ -142,7 +150,9 @@ public class ContractMetrics {
     }
 
     public void bumpRejectedTx(@NonNull final HederaFunctionality txKind, final long bumpBy) {
-        if (p1MetricsEnabled) requireNonNull(rejectedTxsCounters.get(txKind)).add(bumpBy);
+        if (p1MetricsEnabled) {
+            requireNonNull(rejectedTxsCounters.get(txKind)).add(bumpBy);
+        }
     }
 
     public void incrementRejectedForGasTx(@NonNull final HederaFunctionality txKind) {
@@ -159,7 +169,9 @@ public class ContractMetrics {
     }
 
     public void bumpRejectedType3EthTx(final long bumpBy) {
-        if (p1MetricsEnabled) rejectedEthType3Counter.add(bumpBy);
+        if (p1MetricsEnabled) {
+            rejectedEthType3Counter.add(bumpBy);
+        }
     }
 
     @VisibleForTesting

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/metrics/ContractMetrics.java
@@ -68,7 +68,7 @@ public class ContractMetrics {
     //             %2$s - METRIC_SERVICE
     //             %3$s - short specific metric description
 
-    private static final String REJECTED_NAME_TEMPLATE = "%2$s:Rejected-%1$s_total";
+    private static final String REJECTED_NAME_TEMPLATE = "%2$s:Rejected_%1$s_total";
     private static final String REJECTED_DESCR_TEMPLATE = "submitted %1$s %3$s rejected by pureChecks";
 
     private static final String REJECTED_TXN_SHORT_DESCR = "txns";

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/ContractMetricsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/ContractMetricsTest.java
@@ -71,28 +71,28 @@ public class ContractMetricsTest {
 
         assertThat(subject.getAllCounterNames())
                 .containsExactlyInAnyOrder(
-                        "SmartContractService:Rejected-ethereumTxDueToIntrinsicGas_total",
-                        "SmartContractService:Rejected-ethereumTx_total",
-                        "SmartContractService:Rejected-contractCallTxDueToIntrinsicGas_total",
-                        "SmartContractService:Rejected-contractCallTx_total",
-                        "SmartContractService:Rejected-contractCreateTxDueToIntrinsicGas_total",
-                        "SmartContractService:Rejected-contractCreateTx_total",
-                        "SmartContractService:Rejected-ethType3BlobTransaction_total");
+                        "SmartContractService:Rejected_ethereumTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_ethereumTx_total",
+                        "SmartContractService:Rejected_contractCallTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_contractCallTx_total",
+                        "SmartContractService:Rejected_contractCreateTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_contractCreateTx_total",
+                        "SmartContractService:Rejected_ethType3BlobTransaction_total");
         assertThat(subject.getAllCounters())
                 .containsExactlyInAnyOrderEntriesOf(Map.of(
-                        "SmartContractService:Rejected-ethereumTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_ethereumTxDueToIntrinsicGas_total",
                         14L,
-                        "SmartContractService:Rejected-ethereumTx_total",
+                        "SmartContractService:Rejected_ethereumTx_total",
                         4L,
-                        "SmartContractService:Rejected-contractCallTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_contractCallTxDueToIntrinsicGas_total",
                         10L,
-                        "SmartContractService:Rejected-contractCallTx_total",
+                        "SmartContractService:Rejected_contractCallTx_total",
                         1L,
-                        "SmartContractService:Rejected-contractCreateTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_contractCreateTxDueToIntrinsicGas_total",
                         12L,
-                        "SmartContractService:Rejected-contractCreateTx_total",
+                        "SmartContractService:Rejected_contractCreateTx_total",
                         2L,
-                        "SmartContractService:Rejected-ethType3BlobTransaction_total",
+                        "SmartContractService:Rejected_ethType3BlobTransaction_total",
                         20L));
 
         // And there is no counter for this functionality

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
@@ -364,7 +364,7 @@ public class CryptoDeleteAllowanceSuite {
                         .addNftDeleteAllowance(owner, nft, List.of(1L))
                         .signedBy(payer, owner)
                         .via("twoDeleteNft"),
-                validateChargedUsdWithin("twoDeleteNft", 0.08124, 0.02));
+                validateChargedUsdWithin("twoDeleteNft", 0.08124, 0.035));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:

Move initialization call of P1 smart contract metrics.

The new place for it has the potential to be called multiple times but metrics must only be created once. So there is a gate too.

**Related issue(s)**:

Fixes #16902 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x[ Tested (unit, integration, etc.)
