### PR TITLE
ci: Add env token for Check PR Title step to pull-request-formatting

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Check PR Title
         uses: step-security/conventional-pr-title-action@19fb561b33015fd2184055a05ce5a3bcf2ba3f54 # v3.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   milestone-check:
     name: Milestone Check


### PR DESCRIPTION
**Description**:

In commit 778d279 there was a merge for preventing forked repos running on our runners when PRs are created. In this, we removed one env token. This caused an authentication issue in the Check PR Title step. Adding the env token back to the workflow file will resolve the problem.

**Related Issue(s)**:

Fixes #16919
