### PR TITLE
chore: use RosterRetriever in RosterUtils.buildRosterHistory

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -27,7 +27,6 @@ import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getMet
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.setupGlobalMetrics;
 import static com.swirlds.platform.config.internal.PlatformConfigUtils.checkConfiguration;
 import static com.swirlds.platform.crypto.CryptoStatic.initNodeSecurity;
-import static com.swirlds.platform.roster.RosterRetriever.buildRoster;
 import static com.swirlds.platform.state.signed.StartupStateUtils.getInitialState;
 import static com.swirlds.platform.system.SystemExitCode.CONFIGURATION_ERROR;
 import static com.swirlds.platform.system.SystemExitCode.NODE_ADDRESS_MISMATCH;
@@ -82,6 +81,7 @@ import com.swirlds.platform.system.SwirldState;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.address.AddressBookUtils;
 import com.swirlds.platform.util.BootstrapUtils;
+import com.swirlds.state.State;
 import com.swirlds.state.merkle.MerkleStateRoot;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.InstantSource;
@@ -294,11 +294,10 @@ public class ServicesMain implements SwirldMain {
             rosterHistory = RosterUtils.createRosterHistory(rosterStore);
         } else {
             rosterHistory =
-                    RosterUtils.buildRosterHistory(initialState.get().getState().getReadablePlatformState());
+                    RosterUtils.buildRosterHistory((State) initialState.get().getState());
         }
 
         // Follow the Inversion of Control pattern by injecting all needed dependencies into the PlatformBuilder.
-        final var roster = buildRoster(addressBook);
         final var platformBuilder = PlatformBuilder.create(
                         Hedera.APP_NAME,
                         Hedera.SWIRLD_NAME,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -74,6 +74,7 @@ import com.swirlds.platform.system.SystemExitUtils;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.address.AddressBookUtils;
 import com.swirlds.platform.util.BootstrapUtils;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.awt.GraphicsEnvironment;
 import java.nio.file.Path;
@@ -302,7 +303,7 @@ public class Browser {
                     initialState,
                     nodeId,
                     AddressBookUtils.formatConsensusEventStreamName(addressBook, nodeId),
-                    RosterUtils.buildRosterHistory(initialState.get().getState().getReadablePlatformState()));
+                    RosterUtils.buildRosterHistory((State) initialState.get().getState()));
             if (showUi && index == 0) {
                 builder.withPreconsensusEventCallback(guiEventStorage::handlePreconsensusEvent);
                 builder.withConsensusSnapshotOverrideCallback(guiEventStorage::handleSnapshotOverride);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -25,11 +25,11 @@ import com.swirlds.common.crypto.CryptographyException;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.crypto.CryptoStatic;
-import com.swirlds.platform.state.PlatformStateAccessor;
 import com.swirlds.platform.state.service.ReadableRosterStore;
 import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.util.PbjRecordHasher;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.security.cert.X509Certificate;
@@ -218,28 +218,28 @@ public final class RosterUtils {
     }
 
     /**
-     * Build an instance of RosterHistory from the current/previous AddressBook found in the PlatformState.
+     * Build an instance of RosterHistory from the current/previous rosters as reported by the RosterRetriever.
+     *
+     * The RosterRetriever implementation fetches the rosters from the RosterState/RosterMap,
+     * and automatically falls back to fetching them from the PlatformState if the RosterState is empty.
+     *
      * @deprecated To be removed once AddressBook to Roster refactoring is complete.
-     * @param readablePlatformState
+     * @param state a State object to fetch data from
      * @return a RosterHistory
      */
     @Deprecated(forRemoval = true)
     @NonNull
-    public static RosterHistory buildRosterHistory(final PlatformStateAccessor readablePlatformState) {
-        if (readablePlatformState.getAddressBook() == null) {
-            throw new IllegalStateException("Address book is null");
-        }
-
+    public static RosterHistory buildRosterHistory(final State state) {
         final List<RoundRosterPair> roundRosterPairList = new ArrayList<>();
         final Map<Bytes, Roster> rosterMap = new HashMap<>();
 
-        final Roster currentRoster = RosterRetriever.buildRoster(readablePlatformState.getAddressBook());
+        final Roster currentRoster = RosterRetriever.retrieveActiveOrGenesisRoster(state);
         final Bytes currentHash = RosterUtils.hash(currentRoster).getBytes();
-        roundRosterPairList.add(new RoundRosterPair(readablePlatformState.getRound(), currentHash));
+        roundRosterPairList.add(new RoundRosterPair(RosterRetriever.getRound(state), currentHash));
         rosterMap.put(currentHash, currentRoster);
 
-        if (readablePlatformState.getPreviousAddressBook() != null) {
-            final Roster previousRoster = RosterRetriever.buildRoster(readablePlatformState.getPreviousAddressBook());
+        final Roster previousRoster = RosterRetriever.retrievePreviousRoster(state);
+        if (previousRoster != null) {
             final Bytes previousHash = RosterUtils.hash(previousRoster).getBytes();
             roundRosterPairList.add(new RoundRosterPair(0, previousHash));
             rosterMap.put(previousHash, previousRoster);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
@@ -46,6 +46,7 @@ import com.swirlds.platform.test.fixtures.turtle.gossip.SimulatedGossip;
 import com.swirlds.platform.test.fixtures.turtle.gossip.SimulatedNetwork;
 import com.swirlds.platform.util.RandomBuilder;
 import com.swirlds.platform.wiring.PlatformSchedulersConfig_;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.function.Supplier;
 
@@ -121,7 +122,7 @@ public class TurtleNode {
                         nodeId,
                         AddressBookUtils.formatConsensusEventStreamName(addressBook, nodeId),
                         RosterUtils.buildRosterHistory(
-                                initialState.get().getState().getReadablePlatformState()))
+                                (State) initialState.get().getState()))
                 .withModel(model)
                 .withRandomBuilder(new RandomBuilder(randotron.nextLong()))
                 .withKeysAndCerts(privateKeys)


### PR DESCRIPTION
**Description**:
This fix removes the last meaningful use of the `PlatformStateAccessor.getPreviousAddressBook()` by making the `RosterUtils.buildRosterHistory` use the RosterRetriever calls instead of fetching the current/previous AddressBooks directly from the PlatformState.

The RosterRetriever would automatically fetch the data from the RosterState/RosterMap once we start populating these states. Until then, the code will automatically fall back to reading the current/previous ABs from the PlatformState and converting them to rosters.

A few remaining usages of the `PlatformStateAccessor.getPreviousAddressBook()` are listed in the #16922 and cannot be removed immediately.

**Related issue(s)**:

Fixes #16922 

**Notes for reviewer**:
Tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
