### PR TITLE
fix: 16934 Reduce log level for a log statement in `StateUtils.hashString`

### DIFF
--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateUtils.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateUtils.java
@@ -195,7 +195,7 @@ public final class StateUtils {
         // default internal representation for strings, and we need to normalize that)
         final var data = getNormalisedStringBytes(s);
         long l = hashBytes(data);
-        logger.info(LogMarker.STARTUP.getMarker(), "Hashed string {} to {}", s, l);
+        logger.debug(LogMarker.STARTUP.getMarker(), "Hashed string {} to {}", s, l);
         return l;
     }
 


### PR DESCRIPTION
**Description**:

This simple PR reduces log level for a log statement in `StateUtils#hashString` to debug to reduce log pollution. 

**Related issue(s)**:

Fixes #16934

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
