### PR TITLE
fix: cherry pick to 0.57 of #16903 - a fix for smart contracts P1 metrics

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -603,11 +603,10 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
                     trigger,
                     RosterUtils.buildAddressBook(platform.getRoster()),
                     platform.getContext().getConfiguration());
-
-            contractServiceImpl.registerMetrics();
         }
         // With the States API grounded in the working state, we can create the object graph from it
         initializeDagger(state, trigger);
+        contractServiceImpl.registerMetrics();
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/ContractMetricsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/ContractMetricsTest.java
@@ -71,28 +71,28 @@ public class ContractMetricsTest {
 
         assertThat(subject.getAllCounterNames())
                 .containsExactlyInAnyOrder(
-                        "SmartContractService:Rejected-ethereumTxDueToIntrinsicGas_total",
-                        "SmartContractService:Rejected-ethereumTx_total",
-                        "SmartContractService:Rejected-contractCallTxDueToIntrinsicGas_total",
-                        "SmartContractService:Rejected-contractCallTx_total",
-                        "SmartContractService:Rejected-contractCreateTxDueToIntrinsicGas_total",
-                        "SmartContractService:Rejected-contractCreateTx_total",
-                        "SmartContractService:Rejected-ethType3BlobTransaction_total");
+                        "SmartContractService:Rejected_ethereumTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_ethereumTx_total",
+                        "SmartContractService:Rejected_contractCallTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_contractCallTx_total",
+                        "SmartContractService:Rejected_contractCreateTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_contractCreateTx_total",
+                        "SmartContractService:Rejected_ethType3BlobTransaction_total");
         assertThat(subject.getAllCounters())
                 .containsExactlyInAnyOrderEntriesOf(Map.of(
-                        "SmartContractService:Rejected-ethereumTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_ethereumTxDueToIntrinsicGas_total",
                         14L,
-                        "SmartContractService:Rejected-ethereumTx_total",
+                        "SmartContractService:Rejected_ethereumTx_total",
                         4L,
-                        "SmartContractService:Rejected-contractCallTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_contractCallTxDueToIntrinsicGas_total",
                         10L,
-                        "SmartContractService:Rejected-contractCallTx_total",
+                        "SmartContractService:Rejected_contractCallTx_total",
                         1L,
-                        "SmartContractService:Rejected-contractCreateTxDueToIntrinsicGas_total",
+                        "SmartContractService:Rejected_contractCreateTxDueToIntrinsicGas_total",
                         12L,
-                        "SmartContractService:Rejected-contractCreateTx_total",
+                        "SmartContractService:Rejected_contractCreateTx_total",
                         2L,
-                        "SmartContractService:Rejected-ethType3BlobTransaction_total",
+                        "SmartContractService:Rejected_ethType3BlobTransaction_total",
                         20L));
 
         // And there is no counter for this functionality

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
@@ -364,7 +364,7 @@ public class CryptoDeleteAllowanceSuite {
                         .addNftDeleteAllowance(owner, nft, List.of(1L))
                         .signedBy(payer, owner)
                         .via("twoDeleteNft"),
-                validateChargedUsdWithin("twoDeleteNft", 0.08124, 0.02));
+                validateChargedUsdWithin("twoDeleteNft", 0.08124, 0.035));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:

Cherry pick of #16903
- reliable initialization of smart contract metrics
- correct new metrics names to meet constraints

**Related issue(s)**:

Fixes #16942 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
