### PR TITLE
fix: 16954 Shifted child indexes in `AddressBookTestingToolState` by two

### DIFF
--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -98,9 +98,9 @@ public class AddressBookTestingToolState extends PlatformMerkleStateRoot {
     }
 
     private static final long CLASS_ID = 0xf052378c7364ef47L;
-
-    private static final int RUNNING_SUM_INDEX = 1;
-    private static final int ROUND_HANDLED_INDEX = 2;
+    // 0 is PLATFORM_STATE, 1 is ROSTERS, 2 is ROSTER_STATE
+    private static final int RUNNING_SUM_INDEX = 3;
+    private static final int ROUND_HANDLED_INDEX = 4;
 
     private NodeId selfId;
 


### PR DESCRIPTION
**Description**:

This PR fixes `AddressBookTestingToolState`. After introduction of `ROSTERS` and `ROSTER_STATE` in this PR https://github.com/hashgraph/hedera-services/pull/16656, all the other states have to be shifted

**Related issue(s)**:

Fixes #16954 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
