### PR TITLE
feat: bind interface for gossip server endpoint

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/SocketConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/SocketConfig.java
@@ -35,6 +35,9 @@ import com.swirlds.config.api.ConfigProperty;
  * @param tcpNoDelay                 if true, then Nagel's algorithm is disabled, which helps latency, hurts bandwidth
  *                                   usage
  * @param gzipCompression            whether to use gzip compression over the network
+ * @param bindInterfaceHostname      the hostname of the interface to bind to.  The default is all ipv4 interfaces.
+ * @param bindInterfacePort          the port of the interface to bind to.  If less than 0, the roster indicated port
+ *                                   for this node is used.
  */
 @ConfigData("socket")
 public record SocketConfig(
@@ -45,4 +48,8 @@ public record SocketConfig(
         @ConfigProperty(defaultValue = "5000") int timeoutServerAcceptConnect,
         @ConfigProperty(defaultValue = "false") boolean useLoopbackIp,
         @ConfigProperty(defaultValue = "true") boolean tcpNoDelay,
-        @ConfigProperty(defaultValue = "false") boolean gzipCompression) {}
+        @ConfigProperty(defaultValue = "false") boolean gzipCompression,
+        @ConfigProperty(defaultValue = ALL_IPV4_INTERFACES) String bindInterfaceHostname,
+        @ConfigProperty(defaultValue = "-1") int bindInterfacePort) {
+    public static final String ALL_IPV4_INTERFACES = "0.0.0.0";
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/SocketFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/SocketFactory.java
@@ -62,7 +62,15 @@ public interface SocketFactory {
             // set the IP_TOS option
             serverSocket.setOption(java.net.StandardSocketOptions.IP_TOS, socketConfig.ipTos());
         }
-        final InetSocketAddress endpoint = new InetSocketAddress(InetAddress.getByAddress(ALL_INTERFACES), port);
+
+        // Determine interface to bind to.
+        final InetAddress bindInterface = socketConfig.bindInterfaceHostname().equals(SocketConfig.ALL_IPV4_INTERFACES)
+                ? InetAddress.getByAddress(ALL_INTERFACES)
+                : InetAddress.getByName(socketConfig.bindInterfaceHostname());
+        // Determine port to bind to.
+        final int bindPort = socketConfig.bindInterfacePort() < 0 ? port : socketConfig.bindInterfacePort();
+
+        final InetSocketAddress endpoint = new InetSocketAddress(bindInterface, bindPort);
         serverSocket.setReuseAddress(true);
         serverSocket.bind(endpoint); // try to grab a port on this computer
         // do NOT do clientSocket.setSendBufferSize or clientSocket.setReceiveBufferSize

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/connectivity/SocketFactoryTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/connectivity/SocketFactoryTest.java
@@ -16,15 +16,21 @@
 
 package com.swirlds.platform.network.connectivity;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.Utilities;
 import com.swirlds.platform.crypto.KeysAndCerts;
 import com.swirlds.platform.network.NetworkUtils;
 import com.swirlds.platform.network.PeerInfo;
+import com.swirlds.platform.network.SocketConfig;
+import com.swirlds.platform.network.SocketConfig_;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.List;
@@ -120,5 +126,90 @@ class SocketFactoryTest extends ConnectivityTestBase {
         testSocketsBoth(
                 NetworkUtils.createSocketFactory(node1, node1Peers, keysAndCerts1, TLS_IP_TOS_CONFIG),
                 NetworkUtils.createSocketFactory(node2, node2Peers, keysAndCerts2, TLS_IP_TOS_CONFIG));
+    }
+
+    /**
+     * Tests the binding of the server socket to the specified interface and port
+     *
+     * @param roster       the roster of the network
+     * @param keysAndCerts keys and certificates to use for testing
+     * @throws IOException if the server socket cannot be created
+     */
+    @ParameterizedTest
+    @MethodSource({"com.swirlds.platform.crypto.CryptoArgsProvider#basicTestArgs"})
+    void bindInterfaceTest(@NonNull final Roster roster, @NonNull final Map<NodeId, KeysAndCerts> keysAndCerts)
+            throws IOException {
+        assertTrue(roster.rosterEntries().size() > 1, "Address book must contain at least 2 nodes");
+        final NodeId node0 = NodeId.of(roster.rosterEntries().getFirst().nodeId());
+
+        final Configuration defaultConfig = new TestConfigBuilder()
+                .withValue(SocketConfig_.BIND_INTERFACE_PORT, "12344")
+                .getOrCreateConfig();
+        testInterfaceBinding(node0, roster, keysAndCerts, defaultConfig);
+        final Configuration ipv4Config = new TestConfigBuilder()
+                .withValue(SocketConfig_.BIND_INTERFACE_HOSTNAME, "127.0.0.1")
+                .withValue(SocketConfig_.BIND_INTERFACE_PORT, "12345")
+                .getOrCreateConfig();
+        testInterfaceBinding(node0, roster, keysAndCerts, ipv4Config);
+        final Configuration ipv6Config = new TestConfigBuilder()
+                .withValue(SocketConfig_.BIND_INTERFACE_HOSTNAME, "0:0:0:0:0:0:0:1")
+                .withValue(SocketConfig_.BIND_INTERFACE_PORT, "12346")
+                .getOrCreateConfig();
+        testInterfaceBinding(node0, roster, keysAndCerts, ipv6Config);
+        final Configuration localhostConfig = new TestConfigBuilder()
+                .withValue(SocketConfig_.BIND_INTERFACE_HOSTNAME, "localhost")
+                .withValue(SocketConfig_.BIND_INTERFACE_PORT, "12347")
+                .getOrCreateConfig();
+        testInterfaceBinding(node0, roster, keysAndCerts, localhostConfig);
+    }
+
+    /**
+     * Tests the binding of the server socket to the configured interface and port
+     *
+     * @param selfId        the ID of the node
+     * @param roster        the roster of the network
+     * @param keysAndCerts  keys and certificates to use for testing
+     * @param configuration the configuration of the network
+     * @throws IOException  if the server socket cannot be created
+     */
+    private void testInterfaceBinding(
+            @NonNull final NodeId selfId,
+            @NonNull final Roster roster,
+            @NonNull final Map<NodeId, KeysAndCerts> keysAndCerts,
+            @NonNull final Configuration configuration)
+            throws IOException {
+
+        final List<PeerInfo> peers = Utilities.createPeerInfoList(roster, selfId);
+        final SocketFactory socketFactory =
+                NetworkUtils.createSocketFactory(selfId, peers, keysAndCerts.get(selfId), configuration);
+
+        try (final ServerSocket serverSocket = socketFactory.createServerSocket(PORT)) {
+            final SocketConfig socketConfig = configuration.getConfigData(SocketConfig.class);
+
+            if (socketConfig.bindInterfaceHostname().equals(SocketConfig.ALL_IPV4_INTERFACES)) {
+                assertTrue(
+                        serverSocket.getInetAddress().isAnyLocalAddress(),
+                        "ServerSocket should be bound to all interfaces");
+            } else if (socketConfig.bindInterfaceHostname().equals("127.0.0.1")
+                    || socketConfig.bindInterfaceHostname().equals("localhost")) {
+                assertTrue(
+                        serverSocket.getInetAddress().isLoopbackAddress(),
+                        "ServerSocket should be bound to the loopback interface");
+            } else {
+                assertEquals(
+                        serverSocket.getInetAddress().getHostAddress(),
+                        socketConfig.bindInterfaceHostname(),
+                        "ServerSocket should be bound to the specified interface");
+            }
+
+            if (socketConfig.bindInterfacePort() < 0) {
+                assertEquals(PORT, serverSocket.getLocalPort(), "ServerSocket should be bound to the specified port");
+            } else {
+                assertEquals(
+                        socketConfig.bindInterfacePort(),
+                        serverSocket.getLocalPort(),
+                        "ServerSocket should be bound to the specified port");
+            }
+        }
     }
 }


### PR DESCRIPTION
**Description**:

This PR adds configuration in `SocketConfig` for binding a specific network interface for the gossip server endpoint.

**Related issue(s)**:

Fixes #16986 

**Notes for reviewer**:

* Unit tests created. 
* I was not able to manually test in a local network due to local execution of the platform failing.  
* No integration tests ccreated.  An integration test would require modifying test infrastructure to provide multiple interfaces and validate binding a specific one. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
