### PR TITLE
chore: #16913 - replace AddressBook with Roster in SignedStateValidator

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/DefaultSignedStateValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/DefaultSignedStateValidator.java
@@ -18,13 +18,13 @@ package com.swirlds.platform.reconnect;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateInvalidException;
 import com.swirlds.platform.state.signed.SignedStateValidationData;
 import com.swirlds.platform.state.signed.SignedStateValidator;
-import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -48,9 +48,9 @@ public class DefaultSignedStateValidator implements SignedStateValidator {
      * {@inheritDoc}
      */
     public void validate(
-            final SignedState signedState, final AddressBook addressBook, SignedStateValidationData previousStateData) {
+            final SignedState signedState, final Roster roster, SignedStateValidationData previousStateData) {
         throwIfOld(signedState, previousStateData);
-        signedState.pruneInvalidSignatures(addressBook);
+        signedState.pruneInvalidSignatures(roster);
         signedState.throwIfNotVerifiable();
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
@@ -30,7 +30,6 @@ import com.swirlds.logging.legacy.payload.ReconnectDataUsagePayload;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -106,8 +105,7 @@ public class ReconnectLearner {
         this.statistics = Objects.requireNonNull(statistics);
 
         // Save some of the current state data for validation
-        this.stateValidationData = new SignedStateValidationData(
-                currentState.getReadablePlatformState(), RosterUtils.buildAddressBook(roster));
+        this.stateValidationData = new SignedStateValidationData(currentState.getReadablePlatformState(), roster);
     }
 
     /**
@@ -159,7 +157,7 @@ public class ReconnectLearner {
         try {
             receiveSignatures();
             reservedSignedState = reconnect();
-            validator.validate(reservedSignedState.get(), RosterUtils.buildAddressBook(roster), stateValidationData);
+            validator.validate(reservedSignedState.get(), roster, stateValidationData);
             ReconnectUtils.endReconnectHandshake(connection);
             SignedStateFileReader.unregisterServiceStates(reservedSignedState.get());
             return reservedSignedState;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -24,6 +24,8 @@ import static com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAc
 import static com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAction.RELEASE;
 import static com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAction.RESERVE;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.platform.NodeId;
@@ -46,9 +48,11 @@ import com.swirlds.state.merkle.MerkleStateRoot;
 import com.swirlds.state.merkle.SigSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
@@ -624,6 +628,32 @@ public class SignedState implements SignedStateInfo {
     }
 
     /**
+     * Check if a signature is valid. If a node has no weight or is missing a certificate, we consider the signature to
+     * be invalid.
+     *
+     * @param rosterEntry the roster entry of the signer, or null if there was no signing address
+     * @param signature   the signature to check
+     * @return true if the signature is valid, else false
+     */
+    private boolean isSignatureValid(@Nullable final RosterEntry rosterEntry, @NonNull final Signature signature) {
+        if (rosterEntry == null) {
+            return false;
+        }
+
+        if (rosterEntry.weight() == 0) {
+            return false;
+        }
+
+        X509Certificate cert = RosterUtils.fetchGossipCaCertificate(rosterEntry);
+
+        if (cert == null) {
+            return false;
+        }
+
+        return signatureVerifier.verifySignature(state.getHash().getBytes(), signature.getBytes(), cert.getPublicKey());
+    }
+
+    /**
      * Add a signature to the sigset if the signature is valid.
      *
      * @param addressBook use this address book to determine if the signature is valid or not
@@ -700,6 +730,41 @@ public class SignedState implements SignedStateInfo {
                 signingWeight += trustedAddressBook.getAddress(nodeId).getWeight();
             }
         }
+    }
+
+    /**
+     * Remove all invalid signatures from a signed state.
+     *
+     * @param trustedRoster use this roster to determine signature validity instead of using the roster from the signed
+     *                      state. (Useful if validating signed states from untrusted sources.)
+     */
+    public void pruneInvalidSignatures(@NonNull final Roster trustedRoster) {
+        Objects.requireNonNull(trustedRoster);
+
+        final Map<Long, RosterEntry> entriesByNodeId = RosterUtils.toMap(trustedRoster);
+        final List<NodeId> signaturesToRemove = new ArrayList<>();
+
+        for (final NodeId nodeId : sigSet) {
+            final RosterEntry entry = entriesByNodeId.get(nodeId.id());
+            if (!isSignatureValid(entry, sigSet.getSignature(nodeId))) {
+                signaturesToRemove.add(nodeId);
+            }
+        }
+
+        for (final NodeId nodeId : signaturesToRemove) {
+            sigSet.removeSignature(nodeId);
+        }
+
+        long newWeight = 0;
+
+        for (final NodeId nodeId : sigSet) {
+            final RosterEntry entry = entriesByNodeId.get(nodeId.id());
+            if (entry != null) {
+                newWeight += entry.weight();
+            }
+        }
+
+        signingWeight = newWeight;
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidationData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidationData.java
@@ -16,9 +16,10 @@
 
 package com.swirlds.platform.state.signed;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.PlatformStateAccessor;
-import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
@@ -30,23 +31,22 @@ import java.time.Instant;
  * 		the minimum round to be considered a valid state
  * @param consensusTimestamp
  * 		The consensus timestamp from an earlier state
- * @param addressBookHash
- * 		The address book hash value for the current address book (mostly used for diagnostics).
+ * @param rosterHash
+ * 		The roster hash value for the current roster (mostly used for diagnostics).
  * @param consensusEventsRunningHash
  * 		The running hash of the consensus event hashes throughout history
  */
 public record SignedStateValidationData(
         long round,
         @NonNull Instant consensusTimestamp,
-        @Nullable Hash addressBookHash,
+        @Nullable Hash rosterHash,
         @NonNull Hash consensusEventsRunningHash) {
 
-    public SignedStateValidationData(
-            @NonNull final PlatformStateAccessor that, @Nullable final AddressBook addressBook) {
+    public SignedStateValidationData(@NonNull final PlatformStateAccessor that, @Nullable final Roster roster) {
         this(
                 that.getRound(),
                 that.getConsensusTimestamp(),
-                addressBook == null ? null : addressBook.getHash(),
+                roster == null ? null : RosterUtils.hash(roster),
                 that.getLegacyRunningEventHash());
     }
 
@@ -64,8 +64,8 @@ public record SignedStateValidationData(
                 .append(consensusTimestamp)
                 .append(", consensus Events running hash = ")
                 .append(consensusEventsRunningHash)
-                .append(", address book hash = ")
-                .append(addressBookHash != null ? addressBookHash : "not provided")
+                .append(", roster hash = ")
+                .append(rosterHash != null ? rosterHash : "not provided")
                 .toString();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidator.java
@@ -16,8 +16,8 @@
 
 package com.swirlds.platform.state.signed;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.platform.state.service.ReadablePlatformStateStore;
-import com.swirlds.platform.system.address.AddressBook;
 
 /**
  * Validates a signed state received via reconnect.
@@ -25,21 +25,18 @@ import com.swirlds.platform.system.address.AddressBook;
 public interface SignedStateValidator {
 
     /**
-     * Determines if a signed state is valid with the address book. Validation usually includes
-     * verifying that the signed state is signed with a sufficient number of valid signatures to meet a certain weighting
-     * threshold, but other requirements could be included as well.
+     * Determines if a signed state is valid with the roster. Validation usually includes verifying that the signed
+     * state is signed with a sufficient number of valid signatures to meet a certain weighting threshold, but other
+     * requirements could be included as well.
      *
      * @param signedState       the signed state to validate
-     * @param addressBook       the address book used for this signed state
+     * @param roster            the roster used for this signed state
      * @param previousStateData A {@link SignedStateValidationData} containing data from the
      *        {@link ReadablePlatformStateStore} in the state before the signed state to be validated.
      *        This may be used to ensure signed state is usable and valid, and also contains useful information for
      *        diagnostics produced when the signed state is not considered valid.
      * @throws SignedStateInvalidException if the signed state is not valid
      */
-    void validate(
-            final SignedState signedState,
-            final AddressBook addressBook,
-            final SignedStateValidationData previousStateData)
+    void validate(final SignedState signedState, final Roster roster, final SignedStateValidationData previousStateData)
             throws SignedStateInvalidException;
 }


### PR DESCRIPTION
**Description**:
This PR refactors `SignedStateValidator` to use Roster instead of AddressBook. It also adds some duplicate methods in `SignedState` to support rosters; address book usages here will be cleaned up in #16906.

**Related issue(s)**:

Fixes #16913 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
