### PR TITLE
fix: don't initStates() in ConstructableRegistry

### DIFF
--- a/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/com/swirlds/demo/crypto/CryptocurrencyDemoMain.java
+++ b/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/com/swirlds/demo/crypto/CryptocurrencyDemoMain.java
@@ -63,7 +63,6 @@ public class CryptocurrencyDemoMain implements SwirldMain {
             constructableRegistry.registerConstructable(new ClassConstructorPair(CryptocurrencyDemoState.class, () -> {
                 CryptocurrencyDemoState cryptocurrencyDemoState = new CryptocurrencyDemoState(
                         FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
-                FAKE_MERKLE_STATE_LIFECYCLES.initStates(cryptocurrencyDemoState);
                 return cryptocurrencyDemoState;
             }));
             registerMerkleStateRootClassIds();

--- a/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/com/swirlds/demo/hello/HelloSwirldDemoMain.java
+++ b/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/com/swirlds/demo/hello/HelloSwirldDemoMain.java
@@ -62,7 +62,6 @@ public class HelloSwirldDemoMain implements SwirldMain {
             constructableRegistry.registerConstructable(new ClassConstructorPair(HelloSwirldDemoState.class, () -> {
                 HelloSwirldDemoState helloSwirldDemoState = new HelloSwirldDemoState(
                         FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
-                FAKE_MERKLE_STATE_LIFECYCLES.initStates(helloSwirldDemoState);
                 return helloSwirldDemoState;
             }));
             registerMerkleStateRootClassIds();

--- a/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/com/swirlds/demo/stats/StatsDemoMain.java
+++ b/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/com/swirlds/demo/stats/StatsDemoMain.java
@@ -96,7 +96,6 @@ public class StatsDemoMain implements SwirldMain {
             constructableRegistry.registerConstructable(new ClassConstructorPair(StatsDemoState.class, () -> {
                 StatsDemoState statsDemoState = new StatsDemoState(
                         FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
-                FAKE_MERKLE_STATE_LIFECYCLES.initStates(statsDemoState);
                 return statsDemoState;
             }));
             registerMerkleStateRootClassIds();

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolMain.java
@@ -69,7 +69,6 @@ public class AddressBookTestingToolMain implements SwirldMain {
                     new ClassConstructorPair(AddressBookTestingToolState.class, () -> {
                         AddressBookTestingToolState addressBookTestingToolState = new AddressBookTestingToolState(
                                 FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
-                        FAKE_MERKLE_STATE_LIFECYCLES.initStates(addressBookTestingToolState);
                         return addressBookTestingToolState;
                     }));
             registerMerkleStateRootClassIds();

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolMain.java
@@ -58,7 +58,6 @@ public class ISSTestingToolMain implements SwirldMain {
             constructableRegistry.registerConstructable(new ClassConstructorPair(ISSTestingToolState.class, () -> {
                 ISSTestingToolState issTestingToolState = new ISSTestingToolState(
                         FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
-                FAKE_MERKLE_STATE_LIFECYCLES.initStates(issTestingToolState);
                 return issTestingToolState;
             }));
             registerMerkleStateRootClassIds();

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolMain.java
@@ -57,7 +57,6 @@ public class MigrationTestingToolMain implements SwirldMain {
                     new ClassConstructorPair(MigrationTestingToolState.class, () -> {
                         MigrationTestingToolState migrationTestingToolState = new MigrationTestingToolState(
                                 FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
-                        FAKE_MERKLE_STATE_LIFECYCLES.initStates(migrationTestingToolState);
                         return migrationTestingToolState;
                     }));
             constructableRegistry.registerConstructable(

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolMain.java
@@ -150,7 +150,6 @@ public class PlatformTestingToolMain implements SwirldMain {
             ConstructableRegistry.getInstance()
                     .registerConstructable(new ClassConstructorPair(PlatformTestingToolState.class, () -> {
                         PlatformTestingToolState ptt = new PlatformTestingToolState();
-                        FAKE_MERKLE_STATE_LIFECYCLES.initStates(ptt);
                         return ptt;
                     }));
             logger.info(

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/StatsSigningTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/com/swirlds/demo/stats/signing/StatsSigningTestingToolMain.java
@@ -75,7 +75,6 @@ public class StatsSigningTestingToolMain implements SwirldMain {
                                 FAKE_MERKLE_STATE_LIFECYCLES,
                                 version -> new BasicSoftwareVersion(version.major()),
                                 () -> null);
-                        FAKE_MERKLE_STATE_LIFECYCLES.initStates(statsSigningTestingToolState);
                         return statsSigningTestingToolState;
                     }));
             registerMerkleStateRootClassIds();

--- a/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/com/swirlds/demo/stress/StressTestingToolMain.java
@@ -68,7 +68,6 @@ public class StressTestingToolMain implements SwirldMain {
             constructableRegistry.registerConstructable(new ClassConstructorPair(StressTestingToolState.class, () -> {
                 StressTestingToolState stressTestingToolState = new StressTestingToolState(
                         FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
-                FAKE_MERKLE_STATE_LIFECYCLES.initStates(stressTestingToolState);
                 return stressTestingToolState;
             }));
             registerMerkleStateRootClassIds();


### PR DESCRIPTION
**Description**:
`ConstructableRegistry` constructors are used for deserialization. When deserializing a state object, the code that loads the state from disk already performs the initialization of service states if/when it's necessary to use the state and call the services. If the service states, such as the ROSTERS map of the RosterService, is also initialized in the `ConstructableRegistry` constructor, then this double initialization may cause problems in the VirtualMap implementation code that leads to thread pools being terminated and VirtualMap-related task runnables being rejected.

We've already fixed this problem for `ConsistencyTestingToolState` previously. This fix replicates the fix to all other demo states implementations.

**Related issue(s)**:

Fixes #17000

**Notes for reviewer**:
Tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
