### PR TITLE
test: fixed 16947 leaking file descriptors in swirlds-platform-core tests

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -454,13 +454,13 @@ class StateFileManagerTests {
             }
 
             // Verify that old states are properly deleted
-            int files_count = 0;
-            try (final Stream<Path> list = Files.list(statesDirectory)) {
-                files_count = (int) list.count();
+            int filesCount;
+            try (Stream<Path> list = Files.list(statesDirectory)) {
+                filesCount = (int) list.count();
             }
             assertEquals(
                     Math.min(statesOnDisk, round),
-                    files_count,
+                    filesCount,
                     "unexpected number of states on disk after saving round " + round);
 
             // ISS/fatal state should still be in place

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -84,6 +84,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
 class StateFileManagerTests {
 
     private static final NodeId SELF_ID = NodeId.of(1234);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -76,6 +76,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,7 +84,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-
 class StateFileManagerTests {
 
     private static final NodeId SELF_ID = NodeId.of(1234);
@@ -453,9 +453,13 @@ class StateFileManagerTests {
             }
 
             // Verify that old states are properly deleted
+            int files_count = 0;
+            try (final Stream<Path> list = Files.list(statesDirectory)) {
+                files_count = (int) list.count();
+            }
             assertEquals(
                     Math.min(statesOnDisk, round),
-                    (int) Files.list(statesDirectory).count(),
+                    files_count,
                     "unexpected number of states on disk after saving round " + round);
 
             // ISS/fatal state should still be in place

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -296,11 +296,11 @@ public class StartupStateUtilsTests {
         final Path savedStateDirectory = signedStateFilePath
                 .getSignedStateDirectory(mainClassName, selfId, swirldName, latestRound)
                 .getParent();
-        int files_count = 0;
-        try (final Stream<Path> list = Files.list(savedStateDirectory)) {
-            files_count = (int) list.count();
+        int filesCount;
+        try (Stream<Path> list = Files.list(savedStateDirectory)) {
+            filesCount = (int) list.count();
         }
-        assertEquals(5 - invalidStateCount, files_count);
+        assertEquals(5 - invalidStateCount, filesCount, "Unexpected number of files " + filesCount);
         assertEquals(invalidStateCount, recycleCount.get());
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -60,6 +60,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -295,8 +296,11 @@ public class StartupStateUtilsTests {
         final Path savedStateDirectory = signedStateFilePath
                 .getSignedStateDirectory(mainClassName, selfId, swirldName, latestRound)
                 .getParent();
-
-        assertEquals(5 - invalidStateCount, Files.list(savedStateDirectory).count());
+        int files_count = 0;
+        try (final Stream<Path> list = Files.list(savedStateDirectory)) {
+            files_count = (int) list.count();
+        }
+        assertEquals(5 - invalidStateCount, files_count);
         assertEquals(invalidStateCount, recycleCount.get());
     }
 


### PR DESCRIPTION

**Description**:
Fixed know leaking call Files.list()

**Related issue(s)**:

Fixes #16947

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
