### PR TITLE
fix: use floating point numbers for calculating percentage in #checkSignatures(SignedState)

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java
@@ -210,6 +210,10 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
 
         // don't log an error if this is a freeze state. they are expected to lack signatures
         if (reservedState.isFreezeState()) {
+            final double signingWeightPercent = ((double) reservedState.getSigningWeight())
+                    / reservedState.getAddressBook().getTotalWeight()
+                    * 100;
+
             logger.info(
                     STATE_TO_DISK.getMarker(),
                     """
@@ -219,10 +223,11 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
                     reservedState.getRound(),
                     reservedState.getSigningWeight(),
                     reservedState.getAddressBook().getTotalWeight(),
-                    reservedState.getSigningWeight()
-                            / reservedState.getAddressBook().getTotalWeight()
-                            * 100.0);
+                    signingWeightPercent);
         } else {
+            final double signingWeight1Percent = ((double) signingWeight1) / totalWeight1 * 100;
+            final double signingWeight2Percent = ((double) signingWeight2) / totalWeight2 * 100;
+
             logger.error(
                     EXCEPTION.getMarker(),
                     new InsufficientSignaturesPayload(
@@ -235,10 +240,10 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
                                             reservedState.getRound(),
                                             signingWeight1,
                                             totalWeight1,
-                                            signingWeight1 / totalWeight1 * 100.0,
+                                            signingWeight1Percent,
                                             signingWeight2,
                                             totalWeight2,
-                                            signingWeight2 / totalWeight2 * 100.0,
+                                            signingWeight2Percent,
                                             Threshold.SUPER_MAJORITY.isSatisfiedBy(signingWeight1, totalWeight1),
                                             Threshold.SUPER_MAJORITY.isSatisfiedBy(signingWeight2, totalWeight2)))));
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java
@@ -210,9 +210,9 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
 
         // don't log an error if this is a freeze state. they are expected to lack signatures
         if (reservedState.isFreezeState()) {
-            final double signingWeightPercent = ((double) reservedState.getSigningWeight())
-                    / reservedState.getAddressBook().getTotalWeight()
-                    * 100;
+            final double signingWeightPercent = (((double) reservedState.getSigningWeight())
+                    / ((double) reservedState.getAddressBook().getTotalWeight()))
+                    * 100.0;
 
             logger.info(
                     STATE_TO_DISK.getMarker(),
@@ -225,8 +225,8 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
                     reservedState.getAddressBook().getTotalWeight(),
                     signingWeightPercent);
         } else {
-            final double signingWeight1Percent = ((double) signingWeight1) / totalWeight1 * 100;
-            final double signingWeight2Percent = ((double) signingWeight2) / totalWeight2 * 100;
+            final double signingWeight1Percent = (((double) signingWeight1) / ((double) totalWeight1)) * 100.0;
+            final double signingWeight2Percent = (((double) signingWeight2) / ((double) totalWeight2)) * 100.0;
 
             logger.error(
                     EXCEPTION.getMarker(),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java
@@ -211,7 +211,7 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
         // don't log an error if this is a freeze state. they are expected to lack signatures
         if (reservedState.isFreezeState()) {
             final double signingWeightPercent = (((double) reservedState.getSigningWeight())
-                    / ((double) reservedState.getAddressBook().getTotalWeight()))
+                            / ((double) reservedState.getAddressBook().getTotalWeight()))
                     * 100.0;
 
             logger.info(


### PR DESCRIPTION
**Description**:
This fixes a bug where the output in an error message that calculated the weight as a percentage was using integers instead of floating point numbers. This caused the percent to always be 0%.

**Related issue(s)**:

Fixes #16879 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
