### PR TITLE
fix: init PlatformService and RosterService states in AddressBookTest…

### DIFF
--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/com/swirlds/demo/addressbook/AddressBookTestingToolState.java
@@ -51,6 +51,7 @@ import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MerkleStateLifecycles;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.PlatformStateModifier;
+import com.swirlds.platform.state.snapshot.SignedStateFileReader;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
@@ -204,6 +205,14 @@ public class AddressBookTestingToolState extends PlatformMerkleStateRoot {
             this.roundsHandled = Long.parseLong(roundsHandledLeaf.getLabel());
             logger.info(STARTUP.getMarker(), "State initialized with {} rounds handled.", roundsHandled);
         }
+
+        // Since this demo State doesn't call Hedera.onStateInitialized() to init States API for all services
+        // (because it doesn't call super.init(), and the FakeMerkleStateLifecycles doesn't do that anyway),
+        // we need to register PlatformService and RosterService states for the rest of the code to operate
+        // when an instance of this state is received via reconnect. In any other cases, this call
+        // should be idempotent.
+        SignedStateFileReader.registerServiceStates(this);
+        logger.info(STARTUP.getMarker(), "Registered PlatformService and RosterService states.");
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
@@ -179,9 +179,17 @@ public final class SignedStateFileReader {
      * @param signedState a signed state to register schemas in
      */
     public static void registerServiceStates(@NonNull final SignedState signedState) {
-        registerServiceState(
-                (MerkleStateRoot) signedState.getState(), new V0540PlatformStateSchema(), PlatformStateService.NAME);
-        registerServiceState((MerkleStateRoot) signedState.getState(), new V0540RosterSchema(), RosterStateId.NAME);
+        registerServiceStates((MerkleStateRoot) signedState.getState());
+    }
+
+    /**
+     * Register stub states for PlatformStateService and RosterService so that the State knows about them per the metadata and services registry.
+     * See the doc for registerServiceStates(SignedState) above for more details.
+     * @param state a State to register schemas in
+     */
+    public static void registerServiceStates(@NonNull final State state) {
+        registerServiceState(state, new V0540PlatformStateSchema(), PlatformStateService.NAME);
+        registerServiceState(state, new V0540RosterSchema(), RosterStateId.NAME);
     }
 
     private static void registerServiceState(
@@ -209,7 +217,8 @@ public final class SignedStateFileReader {
     /**
      * Unregister the PlatformStateService and RosterService so that the app
      * can initialize States API eventually. Currently, it wouldn't initialize it
-     * if it sees the PlatformStateService already present.
+     * if it sees the PlatformStateService already present. This check occurs at
+     * Hedera.onStateInitialized().
      *
      * See the doc for registerServiceStates above for more details on why
      * we initialize these stub states in the first place.


### PR DESCRIPTION
…ingToolState

**Description**:
After reconnecting a state, its init() method is invoked. The production state would then call `MerkleStateLifecycles.onStateInitialized()`, and the production code would then call `Hedera.onStateInitialized()` which would initialize states for all the services.

`AddressBookTestingToolState` is not a production state and it doesn't do the above. So after a reconnect, it ends up with no service states initialized, and hence it's unusable by the platform (because the platform needs to read from the Platform and Roster service states.)

In this fix, I'm registering the stub states so that they are usable.

**Related issue(s)**:

Fixes #17034

**Notes for reviewer**:
Tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
