### PR TITLE
refactor: adapt event hashing with new format

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/hashing/PbjStreamHasher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/hashing/PbjStreamHasher.java
@@ -54,7 +54,7 @@ public class PbjStreamHasher implements EventHasher, UnsignedEventHasher {
     public PlatformEvent hashEvent(@NonNull final PlatformEvent event) {
         Objects.requireNonNull(event);
         List<Bytes> transactions = event.getGossipEvent().transactions();
-        boolean isNewFormat = transactions.isEmpty();
+        boolean isNewFormat = !transactions.isEmpty();
         final Hash hash = hashEvent(event.getEventCore(), event.getTransactions(), isNewFormat);
         event.setHash(hash);
         return event;


### PR DESCRIPTION
**Description**:

Initially, we will support both: old and new transaction format hashing
1. Adding support for the new logic -> having transactions as bytes only

> [!NOTE]  
> New transaction Bytes will be temporarily wrapped in EventTransaction, we must make sure not to use this wrapper when hashing

**Related issue(s)**:

Fixes 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
