### PR TITLE
#17040 access list support for signature calculation

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.hapi.utils.ethereum;
 import com.esaulpaugh.headlong.rlp.RLPDecoder;
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
 import com.esaulpaugh.headlong.rlp.RLPItem;
+import com.esaulpaugh.headlong.rlp.RLPList;
 import com.esaulpaugh.headlong.util.Integers;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -45,6 +46,7 @@ public record EthTxData(
         BigInteger value, // weibar, always positive - note that high-bit might be ON in RLP encoding: still positive
         byte[] callData,
         byte[] accessList,
+        RLPList accessListAsRLP,
         int recId, // "recovery id" part of a v,r,s ECDSA signature - range 0..1
         byte[] v, // actual `v` value, incoming, recovery id (`recId` above) (possibly) encoded with chain id
         byte[] r,
@@ -106,6 +108,7 @@ public record EthTxData(
                 value,
                 newCallData,
                 accessList,
+                null,
                 recId,
                 v,
                 r,
@@ -127,6 +130,7 @@ public record EthTxData(
                 value,
                 callData,
                 accessList,
+                null,
                 recId,
                 v,
                 r,
@@ -148,6 +152,7 @@ public record EthTxData(
                 replacementValue,
                 callData,
                 accessList,
+                null,
                 recId,
                 v,
                 r,
@@ -360,6 +365,7 @@ public record EthTxData(
                 value,
                 callData,
                 accessList,
+                null,
                 recId,
                 v,
                 r,
@@ -404,11 +410,12 @@ public record EthTxData(
                 rlpList.get(4).asBigInt(), // value
                 rlpList.get(5).data(), // callData
                 null, // accessList
+                null,
                 recId,
                 val,
                 rlpList.get(7).data(), // r
                 rlpList.get(8).data() // s
-                );
+        );
     }
 
     /**
@@ -425,7 +432,6 @@ public record EthTxData(
         if (rlpList.size() != 12) {
             return null;
         }
-
         return new EthTxData(
                 rawTx,
                 EthTransactionType.EIP1559,
@@ -439,11 +445,12 @@ public record EthTxData(
                 rlpList.get(6).asBigInt(), // value
                 rlpList.get(7).data(), // callData
                 rlpList.get(8).data(), // accessList
+                rlpList.get(8) != null && rlpList.get(8).isList() ? rlpList.get(8).asRLPList() : null, // accessList as RLPList
                 rlpList.get(9).asByte(), // recId
                 null, // v
                 rlpList.get(10).data(), // r
                 rlpList.get(11).data() // s
-                );
+        );
     }
 
     /**
@@ -474,11 +481,12 @@ public record EthTxData(
                 rlpList.get(5).asBigInt(), // value
                 rlpList.get(6).data(), // callData
                 rlpList.get(7).data(), // accessList
+                rlpList.get(7).isList() ? rlpList.get(7).asRLPList() : null, // accessList as RLPList
                 rlpList.get(8).asByte(), // recId
                 null, // v
                 rlpList.get(9).data(), // r
                 rlpList.get(10).data() // s
-                );
+        );
     }
 
     // before EIP155 the value of v in

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigs.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigs.java
@@ -23,10 +23,12 @@ import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.secp256k1_ec
 import static org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1.secp256k1_ecdsa_recoverable_signature_parse_compact;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
+import com.esaulpaugh.headlong.rlp.RLPList;
 import com.esaulpaugh.headlong.util.Integers;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.sun.jna.ptr.LongByReference;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.commons.codec.binary.Hex;
@@ -46,45 +48,92 @@ public record EthTxSigs(byte[] publicKey, byte[] address) {
     public static byte[] calculateSignableMessage(EthTxData ethTx) {
         return switch (ethTx.type()) {
             case LEGACY_ETHEREUM -> (ethTx.chainId() != null && ethTx.chainId().length > 0)
-                    ? RLPEncoder.encodeAsList(
-                            Integers.toBytes(ethTx.nonce()),
-                            ethTx.gasPrice(),
-                            Integers.toBytes(ethTx.gasLimit()),
-                            ethTx.to(),
-                            Integers.toBytesUnsigned(ethTx.value()),
-                            ethTx.callData(),
-                            ethTx.chainId(),
-                            Integers.toBytes(0),
-                            Integers.toBytes(0))
+                    ? RLPEncoder.encodeAsList(Integers.toBytes(ethTx.nonce()),
+                    ethTx.gasPrice(),
+                    Integers.toBytes(ethTx.gasLimit()),
+                    ethTx.to(),
+                    Integers.toBytesUnsigned(ethTx.value()),
+                    ethTx.callData(),
+                    ethTx.chainId(),
+                    Integers.toBytes(0),
+                    Integers.toBytes(0))
                     : RLPEncoder.encodeAsList(
-                            Integers.toBytes(ethTx.nonce()),
-                            ethTx.gasPrice(),
-                            Integers.toBytes(ethTx.gasLimit()),
-                            ethTx.to(),
-                            Integers.toBytesUnsigned(ethTx.value()),
-                            ethTx.callData());
-            case EIP1559 -> RLPEncoder.encodeSequentially(Integers.toBytes(2), new Object[] {
-                ethTx.chainId(),
-                Integers.toBytes(ethTx.nonce()),
-                ethTx.maxPriorityGas(),
-                ethTx.maxGas(),
-                Integers.toBytes(ethTx.gasLimit()),
-                ethTx.to(),
-                Integers.toBytesUnsigned(ethTx.value()),
-                ethTx.callData(),
-                new Object[0]
-            });
-            case EIP2930 -> RLPEncoder.encodeSequentially(Integers.toBytes(1), new Object[] {
-                ethTx.chainId(),
-                Integers.toBytes(ethTx.nonce()),
-                ethTx.gasPrice(),
-                Integers.toBytes(ethTx.gasLimit()),
-                ethTx.to(),
-                Integers.toBytesUnsigned(ethTx.value()),
-                ethTx.callData(),
-                new Object[0]
-            });
+                    Integers.toBytes(ethTx.nonce()),
+                    ethTx.gasPrice(),
+                    Integers.toBytes(ethTx.gasLimit()),
+                    ethTx.to(),
+                    Integers.toBytesUnsigned(ethTx.value()),
+                    ethTx.callData());
+            case EIP1559 -> resolveEIP1559(ethTx);
+            case EIP2930 -> resolveEIP2930(ethTx);
         };
+    }
+
+    static byte[] resolveEIP1559(EthTxData ethTx) {
+        if (ethTx.accessListAsRLP() != null) {
+            return RLPEncoder.encodeSequentially(Integers.toBytes(2), new Object[] {
+                    ethTx.chainId(),
+                    Integers.toBytes(ethTx.nonce()),
+                    ethTx.maxPriorityGas(),
+                    ethTx.maxGas(),
+                    Integers.toBytes(ethTx.gasLimit()),
+                    ethTx.to(),
+                    Integers.toBytesUnsigned(ethTx.value()),
+                    ethTx.callData(),
+                    encodeRLPList(ethTx.accessListAsRLP())
+            });
+        }
+        else {
+            return RLPEncoder.encodeSequentially(Integers.toBytes(2), new Object[] {
+                    ethTx.chainId(),
+                    Integers.toBytes(ethTx.nonce()),
+                    ethTx.maxPriorityGas(),
+                    ethTx.maxGas(),
+                    Integers.toBytes(ethTx.gasLimit()),
+                    ethTx.to(),
+                    Integers.toBytesUnsigned(ethTx.value()),
+                    ethTx.callData(),
+                    new Object[0]
+            });
+        }
+    }
+
+    static byte[] resolveEIP2930(EthTxData ethTx) {
+        if (ethTx.accessListAsRLP() != null) {
+            return RLPEncoder.encodeSequentially(Integers.toBytes(1), new Object[] {
+                    ethTx.chainId(),
+                    Integers.toBytes(ethTx.nonce()),
+                    ethTx.gasPrice(),
+                    Integers.toBytes(ethTx.gasLimit()),
+                    ethTx.to(),
+                    Integers.toBytesUnsigned(ethTx.value()),
+                    ethTx.callData(),
+                    encodeRLPList(ethTx.accessListAsRLP())
+            });
+        }
+        else {
+            return RLPEncoder.encodeSequentially(Integers.toBytes(1), new Object[] {
+                    ethTx.chainId(),
+                    Integers.toBytes(ethTx.nonce()),
+                    ethTx.gasPrice(),
+                    Integers.toBytes(ethTx.gasLimit()),
+                    ethTx.to(),
+                    Integers.toBytesUnsigned(ethTx.value()),
+                    ethTx.callData(),
+                    new Object[0]
+            });
+        }
+    }
+
+    static Object[] encodeRLPList(RLPList rlpList) {
+        return rlpList.elements().stream().map(rlpItem -> {
+            if (rlpItem.isList()) {
+                return encodeRLPList(rlpItem.asRLPList());
+            }
+            else {
+                return rlpItem.data();
+            }
+        }).toArray();
     }
 
     static byte[] recoverCompressedPubKey(LibSecp256k1.secp256k1_pubkey pubKey) {

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -268,8 +268,8 @@ class EthTxDataTest {
     }
 
     @Test
-    // EIP-155 adds chainId in order to prevent replay attacks. This test checks if the encoding works without the
-    // chainId
+        // EIP-155 adds chainId in order to prevent replay attacks. This test checks if the encoding works without the
+        // chainId
     void roundTrip155UnprotectedTx() {
         final var expected = Hex.decode(EIP155_UNPROTECTED);
         final var tx155 = EthTxData.populateEthTxData(expected);
@@ -395,6 +395,7 @@ class EthTxDataTest {
                 BigInteger.ONE,
                 oneByte,
                 oneByte,
+                null,
                 1,
                 oneByte,
                 oneByte,
@@ -415,6 +416,7 @@ class EthTxDataTest {
                 BigInteger.ONE,
                 oneByte,
                 oneByte,
+                null,
                 1,
                 oneByte,
                 oneByte,
@@ -478,6 +480,7 @@ class EthTxDataTest {
                 oneByte,
                 WEIBARS_IN_A_TINYBAR,
                 oneByte,
+                null,
                 null,
                 1,
                 oneByte,
@@ -545,6 +548,7 @@ class EthTxDataTest {
                         BigInteger.ONE,
                         oneByte,
                         oneByte,
+                        null,
                         1,
                         oneByte,
                         oneByte,
@@ -574,6 +578,7 @@ class EthTxDataTest {
                 BigInteger.ONE,
                 oneByte,
                 oneByte,
+                null,
                 1,
                 oneByte,
                 oneByte,
@@ -593,7 +598,7 @@ class EthTxDataTest {
 
         final var oneByte = new byte[] {1};
         final EthTxData ethTxData = new EthTxData(
-                oneByte, type, oneByte, 1, oneByte, oneByte, oneByte, 1, oneByte, bigValue, oneByte, null, 1, oneByte,
+                oneByte, type, oneByte, 1, oneByte, oneByte, oneByte, 1, oneByte, bigValue, oneByte, null, null,1, oneByte,
                 oneByte, oneByte);
         final var encoded = ethTxData.encodeTx();
 

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigsTest.java
@@ -109,6 +109,7 @@ class EthTxSigsTest {
                 BigInteger.ZERO,
                 ZERO_BYTES,
                 ZERO_BYTES,
+                null,
                 3,
                 new byte[0],
                 allFs,
@@ -132,6 +133,7 @@ class EthTxSigsTest {
                 BigInteger.ZERO,
                 ZERO_BYTES,
                 ZERO_BYTES,
+                null,
                 1,
                 new byte[0],
                 new byte[32],
@@ -147,5 +149,28 @@ class EthTxSigsTest {
 
         // failed recovery
         assertArrayEquals(new byte[0], recoverAddressFromPubKey(TRUFFLE0_PRIVATE_ECDSA_KEY));
+    }
+
+    @Test
+    void isAddressEqualForTransactionWithAccessList() {
+        // based on transaction from Sepolia https://sepolia.etherscan.io/tx/0xcadccd1934c0fda481414a756cd227cf87a215444d11f3f38c1186cce7a98235
+        final var expectedFromAddress = CommonUtils.unhex("eA1B261FB7Ec1C4F2BEeA2476f17017537b4B507");
+        final var ethTxData = EthTxData.populateEthTxData(
+                CommonUtils.unhex(
+                        "02f8cb83aa36a781d6843b9aca00843b9aca0e82653394bdf6a09235fa130c5e5ddb60a3c06852e794347580a42e64cec10000000000000000000000000000000000000000000000000000000000000000f838f794bdf6a09235fa130c5e5ddb60a3c06852e7943475e1a0000000000000000000000000000000000000000000000000000000000000000001a0db915ded35296ff17f81c4e4075ba39a7cc6a0a1bf622eb969a578dad169d04aa03471b14e0f6ada15f1e5ab0eac0ed3c71dd3447ba98dc4669c82d2e406bb16be" // INPROPER
+                ));
+        final var ethTxSigs = EthTxSigs.extractSignatures(ethTxData);
+        assertArrayEquals(expectedFromAddress, ethTxSigs.address());
+    }
+    @Test
+    void isAddressEqualForTransactionWithoutAccessList() {
+        // based on transaction from Sepolia https://sepolia.etherscan.io/tx/0xd26abe8a34f53a7a2062bf7f8dd0c7218d9cf760fa6cca289eb06a5905894a98
+        final var expectedFromAddress = CommonUtils.unhex("eA1B261FB7Ec1C4F2BEeA2476f17017537b4B507");
+        final var ethTxData = EthTxData.populateEthTxData(
+                CommonUtils.unhex(
+                        "02f89283aa36a781d5843b9aca00843b9aca0e825c3794bdf6a09235fa130c5e5ddb60a3c06852e794347580a42e64cec10000000000000000000000000000000000000000000000000000000000000000c080a09a3e200427a4d4eff9df54400d8a161b9439a0faae8d9d2a0b2275586011b3eba042defab332de10085042867558826d9bf16f8ff6e4a3c4f46640c9de16f927b0" // INPROPER
+                ));
+        final var ethTxSigs = EthTxSigs.extractSignatures(ethTxData);
+        assertArrayEquals(expectedFromAddress, ethTxSigs.address());
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumContractCreate.java
@@ -294,6 +294,7 @@ public class HapiEthereumContractCreate extends HapiBaseContractCreate<HapiEther
                 weibarsToTinybars(balance).orElse(BigInteger.ZERO),
                 callData,
                 new byte[] {},
+                null,
                 0,
                 null,
                 null,


### PR DESCRIPTION
**Description**:
When sending transaction with access list the public key and the address of the transaction sender is not properly calculated and it results in error for example of INVALID_ACCOUNT_ID. We added changes in EthTxData.java and EthTxSigs.java to fix this behaviour by firstly read `accessList` as object of RLPList instance and put it different variable `accessListAsRLP`. If this variable is present we transform it to array of Object containing byte array and then we add this to RLPEncoder.
We also put unit tests to check if now transactions on which we found this error are now calculating proper signature.


**Related issue(s)**:
https://github.com/hashgraph/hedera-services/issues/17040

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
