### PR TITLE
test: fixed 16948 leaking file descriptors

### DIFF
--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/FileUtilsTests.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/io/utility/FileUtilsTests.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -200,9 +201,14 @@ class FileUtilsTests {
         assertEquals(isDirectory(treeA), isDirectory(treeB), "files should be the same type");
 
         if (isDirectory(treeA)) {
-            final List<Path> childrenA = Files.list(treeA).toList();
-            final List<Path> childrenB = Files.list(treeB).toList();
-
+            final List<Path> childrenA;
+            final List<Path> childrenB;
+            try (Stream<Path> list = Files.list(treeA)) {
+                childrenA = list.toList();
+            }
+            try (Stream<Path> list = Files.list(treeB)) {
+                childrenB = list.toList();
+            }
             assertEquals(childrenA.size(), childrenB.size(), "directories have a different number of files¬");
 
             final Map<String, Path> mapA = new HashMap<>();

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesFileTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesFileTests.java
@@ -310,7 +310,6 @@ class PcesFileTests {
         }
 
         // After all files have been deleted, the test directory should be empty again.
-        int filesCount;
         try (Stream<Path> list = Files.list(testDirectory)) {
             filesCount = (int) list.count();
         }
@@ -392,7 +391,6 @@ class PcesFileTests {
         }
 
         // After all files have been deleted, the test directory should be empty again.
-        int filesCount;
         try (Stream<Path> list = Files.list(streamDirectory)) {
             filesCount = (int) list.count();
         }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesFileTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesFileTests.java
@@ -258,7 +258,11 @@ class PcesFileTests {
         final Instant now = Instant.now();
 
         // When we start out, the test directory should be empty.
-        assertEquals(0, Files.list(testDirectory).count());
+        int filesCount;
+        try (Stream<Path> list = Files.list(testDirectory)) {
+            filesCount = (int) list.count();
+        }
+        assertEquals(0, filesCount, "Unexpected number of files: " + filesCount);
 
         final List<Instant> times = new ArrayList<>();
         times.add(now);
@@ -306,7 +310,11 @@ class PcesFileTests {
         }
 
         // After all files have been deleted, the test directory should be empty again.
-        assertEquals(0, Files.list(testDirectory).count());
+        int filesCount;
+        try (Stream<Path> list = Files.list(testDirectory)) {
+            filesCount = (int) list.count();
+        }
+        assertEquals(0, filesCount, "Unexpected number of files: " + filesCount);
     }
 
     @SuppressWarnings("resource")
@@ -332,7 +340,11 @@ class PcesFileTests {
         Files.createDirectories(recycleDirectory);
 
         // When we start out, the test directory should be empty.
-        assertEquals(0, Files.list(streamDirectory).count());
+        int filesCount;
+        try (Stream<Path> list = Files.list(streamDirectory)) {
+            filesCount = (int) list.count();
+        }
+        assertEquals(0, filesCount, "Unexpected number of files: " + filesCount);
 
         final List<Instant> times = new ArrayList<>();
         times.add(now);
@@ -380,7 +392,11 @@ class PcesFileTests {
         }
 
         // After all files have been deleted, the test directory should be empty again.
-        assertEquals(0, Files.list(streamDirectory).count());
+        int filesCount;
+        try (Stream<Path> list = Files.list(streamDirectory)) {
+            filesCount = (int) list.count();
+        }
+        assertEquals(0, filesCount, "Unexpected number of files: " + filesCount);
 
         // All files should have been moved to the recycle directory
         for (final PcesFile file : files) {


### PR DESCRIPTION
**Description**:
Fixed #16948 using try-with-resources, similarly to fix #16947

**Related issue(s)**:

Fixes #16948

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
