### PR TITLE
chore: add mirror node team to a dir in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 #########################
 
 /hapi/                                          @hashgraph/hedera-services @hashgraph/hedera-smart-contracts-core @hashgraph/platform-hashgraph @hashgraph/platform-data @hashgraph/platform-base @hashgraph/platform-architects
-/hapi/hedera-protobufs/services                 @hashgraph/hedera-services @hashgraph/hedera-smart-contracts-core @jsync-swirlds
+/hapi/hedera-protobufs/services                 @hashgraph/hedera-services @hashgraph/hedera-smart-contracts-core @jsync-swirlds @hashgraph/mirror-node
 
 
 #########################


### PR DESCRIPTION
**Description**:
Add the @hashgraph/mirror-node team to the CODEOWNERS file, line below:
`/hapi/hedera-protobufs/services`

**Related issue(s)**:

Fixes #17025 

**Notes for reviewer**:
N/A

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
