### PR TITLE
fix: Export only active nodes in `NodeStakeUpdates`

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
@@ -209,7 +209,7 @@ public class EndOfStakingPeriodUpdater {
             // We rescale the weight range [0, sumOfConsensusWeights] back to [minStake, maxStake] before
             // externalizing the node stake metadata to stream consumers like mirror nodes
             final var rescaledWeight = rescaleWeight(newWeight, nodeInfo.minStake(), maxStake, totalStake, totalWeight);
-            if(!nodeInfo.deleted()){
+            if (!nodeInfo.deleted()) {
                 nodeStakes.add(EndOfStakingPeriodUtils.fromStakingInfo(
                         nodeRewardRates.get(nodeId),
                         nodeInfo.copyBuilder().stake(rescaledWeight).build()));

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
@@ -138,10 +138,6 @@ public class EndOfStakingPeriodUpdater {
             // The node's staking info at the end of the period, non-final because
             // we iteratively update its reward sum history,
             var nodeInfo = requireNonNull(stakingInfoStore.getForModify(nodeId));
-            if (nodeInfo.deleted()) {
-                log.info("Node {} is deleted, skipping", nodeId);
-                continue;
-            }
 
             // The return value here includes both the new reward sum history, and the reward rate
             // (tinybars-per-hbar) that will be paid to all accounts who had staked to reward for
@@ -213,9 +209,11 @@ public class EndOfStakingPeriodUpdater {
             // We rescale the weight range [0, sumOfConsensusWeights] back to [minStake, maxStake] before
             // externalizing the node stake metadata to stream consumers like mirror nodes
             final var rescaledWeight = rescaleWeight(newWeight, nodeInfo.minStake(), maxStake, totalStake, totalWeight);
-            nodeStakes.add(EndOfStakingPeriodUtils.fromStakingInfo(
-                    nodeRewardRates.get(nodeId),
-                    nodeInfo.copyBuilder().stake(rescaledWeight).build()));
+            if(!nodeInfo.deleted()){
+                nodeStakes.add(EndOfStakingPeriodUtils.fromStakingInfo(
+                        nodeRewardRates.get(nodeId),
+                        nodeInfo.copyBuilder().stake(rescaledWeight).build()));
+            }
             // Persist the updated staking info
             stakingInfoStore.put(nodeId, newNodeInfo);
         });

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/EndOfStakingPeriodUpdater.java
@@ -90,7 +90,7 @@ public class EndOfStakingPeriodUpdater {
      * Updates all (relevant) staking-related values for all nodes, as well as any network reward information,
      * at the end of a staking period. This method must be invoked during handling of a transaction
      *
-     * @param context the context of the transaction used to end the staking period
+     * @param context       the context of the transaction used to end the staking period
      * @param exchangeRates the active exchange rate set
      * @param weightUpdates the callback to use to propagate weight changes
      */
@@ -138,6 +138,10 @@ public class EndOfStakingPeriodUpdater {
             // The node's staking info at the end of the period, non-final because
             // we iteratively update its reward sum history,
             var nodeInfo = requireNonNull(stakingInfoStore.getForModify(nodeId));
+            if (nodeInfo.deleted()) {
+                log.info("Node {} is deleted, skipping", nodeId);
+                continue;
+            }
 
             // The return value here includes both the new reward sum history, and the reward rate
             // (tinybars-per-hbar) that will be paid to all accounts who had staked to reward for
@@ -253,10 +257,10 @@ public class EndOfStakingPeriodUpdater {
      * Scales up the weight of the node to the range [minStake, maxStakeOfAllNodes]
      * from the consensus weight range [0, sumOfConsensusWeights].
      *
-     * @param weight weight of the node
-     * @param newMinStake min stake of the node
-     * @param newMaxStake real max stake of all nodes computed by taking max(stakeOfNode1, stakeOfNode2, ...)
-     * @param totalStakeOfAllNodes total stake of all nodes at the start of new period
+     * @param weight                weight of the node
+     * @param newMinStake           min stake of the node
+     * @param newMaxStake           real max stake of all nodes computed by taking max(stakeOfNode1, stakeOfNode2, ...)
+     * @param totalStakeOfAllNodes  total stake of all nodes at the start of new period
      * @param sumOfConsensusWeights sum of consensus weights of all nodes
      * @return scaled weight of the node
      */
@@ -308,8 +312,9 @@ public class EndOfStakingPeriodUpdater {
      * The result are normalized weights whose sum will be approximately the given total weight. That is, any node
      * with a non-zero amount of stake will have a weight of at least {@code 1}; any node with a stake of at least one
      * out of every 250 whole hbars staked will have weight at least {@code 2}; and so on.
-     * @param nodeStake the stake of a single node, both rewarded and non-rewarded
-     * @param totalStake the total stake of all nodes
+     *
+     * @param nodeStake   the stake of a single node, both rewarded and non-rewarded
+     * @param totalStake  the total stake of all nodes
      * @param totalWeight the desired approximate total weight of all nodes
      * @return the scaled consensus weight for the node
      */
@@ -356,7 +361,7 @@ public class EndOfStakingPeriodUpdater {
      * threshold, from 0 for empty, up to 1 at the threshold.
      *
      * @param unreservedBalance the balance in {@code 0.0.800} minus the pending rewards
-     * @param thresholdBalance the threshold balance setting
+     * @param thresholdBalance  the threshold balance setting
      * @return the ratio of the balance to the threshold, from 0 for empty, up to 1 at the threshold
      */
     private BigDecimal ratioOf(final long unreservedBalance, final long thresholdBalance) {
@@ -371,9 +376,9 @@ public class EndOfStakingPeriodUpdater {
      * start of the period that is now ending, and the maximum amount of tinybars to pay as staking rewards in the
      * period, returns the effective per-hbar reward rate for the period.
      *
-     * @param balanceRatio the ratio of the {@code 0.0.800} balance to the threshold
-     * @param stakedToReward the amount of hbars staked to reward at the start of the ending period
-     * @param maxRewardRate the maximum amount of tinybars to pay per hbar reward
+     * @param balanceRatio     the ratio of the {@code 0.0.800} balance to the threshold
+     * @param stakedToReward   the amount of hbars staked to reward at the start of the ending period
+     * @param maxRewardRate    the maximum amount of tinybars to pay per hbar reward
      * @param maxStakeRewarded the maximum amount of stake that can be rewarded
      * @return the effective per-hbar reward rate for the period
      */

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
@@ -233,7 +233,7 @@ public class StakeInfoHelper {
             final var stakingInfo = requireNonNull(infoStore.getForModify(nodeId));
             if (!stakingInfo.deleted()) {
                 final var history = stakingInfo.rewardSumHistory();
-                final var rewardRate = stakingInfo.deleted() ? 0 : history.getFirst() - history.get(1);
+                final var rewardRate = history.getFirst() - history.get(1);
                 nodeStakes.add(fromStakingInfo(rewardRate, stakingInfo));
             }
         });

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeInfoHelper.java
@@ -231,9 +231,11 @@ public class StakeInfoHelper {
         final var nodeStakes = new ArrayList<NodeStake>();
         postUpgradeNodeIds.stream().sorted().forEach(nodeId -> {
             final var stakingInfo = requireNonNull(infoStore.getForModify(nodeId));
-            final var history = stakingInfo.rewardSumHistory();
-            final var rewardRate = stakingInfo.deleted() ? 0 : history.getFirst() - history.get(1);
-            nodeStakes.add(fromStakingInfo(rewardRate, stakingInfo));
+            if (!stakingInfo.deleted()) {
+                final var history = stakingInfo.rewardSumHistory();
+                final var rewardRate = stakingInfo.deleted() ? 0 : history.getFirst() - history.get(1);
+                nodeStakes.add(fromStakingInfo(rewardRate, stakingInfo));
+            }
         });
         final var stakingConfig = config.getConfigData(StakingConfig.class);
         final var syntheticNodeStakeUpdateTxn = newNodeStakeUpdateBuilder(

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/EndOfStakingPeriodUpdaterTest.java
@@ -27,14 +27,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.NetworkStakingRewards;
 import com.hedera.hapi.node.state.token.StakingNodeInfo;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNetworkStakingRewardsStore;
 import com.hedera.node.app.service.token.impl.WritableStakingInfoStore;
@@ -51,6 +55,7 @@ import com.hedera.node.app.spi.fixtures.util.LoggingTarget;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.StakingConfig;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.hedera.pbj.runtime.ParseException;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.state.spi.WritableSingletonState;
 import com.swirlds.state.spi.WritableSingletonStateBase;
@@ -67,6 +72,7 @@ import java.util.function.BiConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -201,7 +207,8 @@ public class EndOfStakingPeriodUpdaterTest {
     }
 
     @Test
-    void deletedNodesGetsZeroPendingRewards() {
+    void deletedNodesGetsZeroPendingRewards() throws ParseException {
+        final var captor = ArgumentCaptor.forClass(Transaction.class);
         commonSetup(
                 1_000_000_000L,
                 STAKING_INFO_1.copyBuilder().deleted(true).build(),
@@ -218,6 +225,7 @@ public class EndOfStakingPeriodUpdaterTest {
         given(nodeStakeUpdateRecordBuilder.memo(any())).willReturn(nodeStakeUpdateRecordBuilder);
         given(nodeStakeUpdateRecordBuilder.exchangeRate(ExchangeRateSet.DEFAULT))
                 .willReturn(nodeStakeUpdateRecordBuilder);
+        given(nodeStakeUpdateRecordBuilder.transaction(captor.capture())).willReturn(nodeStakeUpdateRecordBuilder);
 
         subject.updateNodes(context, ExchangeRateSet.DEFAULT, weightUpdates);
 
@@ -248,6 +256,18 @@ public class EndOfStakingPeriodUpdaterTest {
         assertThat(logCaptor.infoLogs()).contains("Non-zero reward sum history for node number 1 is now [6, 6, 5]");
         assertThat(logCaptor.infoLogs()).contains("Non-zero reward sum history for node number 2 is now [101, 1, 1]");
         assertThat(logCaptor.infoLogs()).contains("Non-zero reward sum history for node number 3 is now [3, 3, 1]");
+
+        // Doesn't export deleted nodes nodeStakeUpdates
+        verify(context).addPrecedingChildRecordBuilder(NodeStakeUpdateStreamBuilder.class, NODE_STAKE_UPDATE);
+        final var transaction = captor.getValue();
+        final var nodeStakeUpdate = TransactionBody.PROTOBUF
+                .parse(SignedTransaction.PROTOBUF
+                        .parse(transaction.signedTransactionBytes())
+                        .bodyBytes())
+                .nodeStakeUpdate();
+        final var nodeStakes = nodeStakeUpdate.nodeStake();
+        assertThat(nodeStakes).hasSize(1);
+        assertThat(nodeStakes.get(0).nodeId()).isEqualTo(NODE_NUM_2.number());
     }
 
     @Test


### PR DESCRIPTION
Fixes #17063 

Currently the deleted nodes are also exported in `NodeStakeUpdate` synthetic transaction every day. Fixed it to export only active nodes.