### PR TITLE
build: remove duplicated dependency versions

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -15,15 +15,34 @@ dependencies {
     }
 }
 
+val autoService = "1.1.1"
+val besu = "24.3.3"
+val bouncycastle = "1.79"
+val dagger = "2.42"
+val eclipseCollections = "10.4.0"
+val grpc = "1.64.0"
+val hederaCryptography = "0.1.1-SNAPSHOT"
+val helidon = "4.1.1"
+val jackson = "2.16.0"
+val junit5 = "5.10.2"
+val log4j = "2.21.1"
+val mockito = "5.8.0"
+val protobuf = "4.28.2"
+val testContainers = "1.17.2"
+val tuweni = "2.4.2"
+val webcompare = "2.1.5"
+
 dependencies.constraints {
-    api("io.helidon.common:helidon-common:4.1.1") { because("io.helidon.common") }
-    api("io.helidon.webclient:helidon-webclient:4.1.1") { because("io.helidon.webclient") }
-    api("io.helidon.webclient:helidon-webclient-grpc:4.1.1") {
+    api("io.helidon.common:helidon-common:$helidon") { because("io.helidon.common") }
+    api("io.helidon.webclient:helidon-webclient:$helidon") { because("io.helidon.webclient") }
+    api("io.helidon.webclient:helidon-webclient-grpc:$helidon") {
         because("io.helidon.webclient.grpc")
     }
     api("org.awaitility:awaitility:4.2.0") { because("awaitility") }
-    api("com.fasterxml.jackson.core:jackson-core:2.16.0") { because("com.fasterxml.jackson.core") }
-    api("com.fasterxml.jackson.core:jackson-databind:2.16.0") {
+    api("com.fasterxml.jackson.core:jackson-core:$jackson") {
+        because("com.fasterxml.jackson.core")
+    }
+    api("com.fasterxml.jackson.core:jackson-databind:$jackson") {
         because("com.fasterxml.jackson.databind")
     }
     api("com.github.ben-manes.caffeine:caffeine:3.1.1") { because("com.github.benmanes.caffeine") }
@@ -31,25 +50,25 @@ dependencies.constraints {
     api("com.github.spotbugs:spotbugs-annotations:4.7.3") {
         because("com.github.spotbugs.annotations")
     }
-    api("com.google.auto.service:auto-service-annotations:1.1.1") {
+    api("com.google.auto.service:auto-service-annotations:$autoService") {
         because("com.google.auto.service")
     }
-    api("com.google.auto.service:auto-service:1.1.1") {
+    api("com.google.auto.service:auto-service:$autoService") {
         because("com.google.auto.service.processor")
     }
     api("com.google.guava:guava:33.3.1-jre") { because("com.google.common") }
     api("com.google.j2objc:j2objc-annotations:3.0.0") { because("com.google.j2objc.annotations") }
     api("com.google.jimfs:jimfs:1.2") { because("com.google.jimfs") }
-    api("com.google.protobuf:protobuf-java:4.28.2") { because("com.google.protobuf") }
-    api("com.google.protobuf:protobuf-java-util:4.28.2") { because("com.google.protobuf.util") }
+    api("com.google.protobuf:protobuf-java:$protobuf") { because("com.google.protobuf") }
+    api("com.google.protobuf:protobuf-java-util:$protobuf") { because("com.google.protobuf.util") }
     api("com.hedera.pbj:pbj-runtime:0.9.2") { because("com.hedera.pbj.runtime") }
     api("com.squareup:javapoet:1.13.0") { because("com.squareup.javapoet") }
     api("net.java.dev.jna:jna:5.12.1") { because("com.sun.jna") }
-    api("com.google.dagger:dagger:2.42") { because("dagger") }
-    api("com.google.dagger:dagger-compiler:2.42") { because("dagger.compiler") }
-    api("io.grpc:grpc-netty:1.64.0") { because("io.grpc.netty") }
-    api("io.grpc:grpc-protobuf:1.64.0") { because("io.grpc.protobuf") }
-    api("io.grpc:grpc-stub:1.64.0") { because("io.grpc.stub") }
+    api("com.google.dagger:dagger:$dagger") { because("dagger") }
+    api("com.google.dagger:dagger-compiler:$dagger") { because("dagger.compiler") }
+    api("io.grpc:grpc-netty:$grpc") { because("io.grpc.netty") }
+    api("io.grpc:grpc-protobuf:$grpc") { because("io.grpc.protobuf") }
+    api("io.grpc:grpc-stub:$grpc") { because("io.grpc.stub") }
     api("com.esaulpaugh:headlong:6.1.1") { because("com.esaulpaugh.headlong") }
     api("info.picocli:picocli:4.6.3") { because("info.picocli") }
     api("io.github.classgraph:classgraph:4.8.65") { because("io.github.classgraph") }
@@ -70,57 +89,59 @@ dependencies.constraints {
     api("commons-io:commons-io:2.15.1") { because("org.apache.commons.io") }
     api("org.apache.commons:commons-lang3:3.14.0") { because("org.apache.commons.lang3") }
     api("org.apache.commons:commons-compress:1.26.0") { because("org.apache.commons.compress") }
-    api("org.apache.logging.log4j:log4j-api:2.21.1") { because("org.apache.logging.log4j") }
-    api("org.apache.logging.log4j:log4j-core:2.21.1") { because("org.apache.logging.log4j.core") }
-    api("org.apache.logging.log4j:log4j-slf4j2-impl:2.21.1") {
+    api("org.apache.logging.log4j:log4j-api:$log4j") { because("org.apache.logging.log4j") }
+    api("org.apache.logging.log4j:log4j-core:$log4j") { because("org.apache.logging.log4j.core") }
+    api("org.apache.logging.log4j:log4j-slf4j2-impl:$log4j") {
         because("org.apache.logging.log4j.slf4j2.impl")
     }
     api("org.assertj:assertj-core:3.23.1") { because("org.assertj.core") }
-    api("org.bouncycastle:bcpkix-jdk18on:1.79") { because("org.bouncycastle.pkix") }
-    api("org.bouncycastle:bcprov-jdk18on:1.78") { because("org.bouncycastle.provider") }
-    api("org.eclipse.collections:eclipse-collections-api:10.4.0") {
+    api("org.bouncycastle:bcpkix-jdk18on:$bouncycastle") { because("org.bouncycastle.pkix") }
+    api("org.bouncycastle:bcprov-jdk18on:$bouncycastle") { because("org.bouncycastle.provider") }
+    api("org.eclipse.collections:eclipse-collections-api:$eclipseCollections") {
         because("org.eclipse.collections.api")
     }
-    api("org.eclipse.collections:eclipse-collections:10.4.0") {
+    api("org.eclipse.collections:eclipse-collections:$eclipseCollections") {
         because("org.eclipse.collections.impl")
     }
     api("org.hamcrest:hamcrest:2.2") { because("org.hamcrest") }
-    api("org.hyperledger.besu:besu-datatypes:24.3.3") { because("org.hyperledger.besu.datatypes") }
-    api("org.hyperledger.besu:evm:24.3.3") { because("org.hyperledger.besu.evm") }
+    api("org.hyperledger.besu:besu-datatypes:$besu") { because("org.hyperledger.besu.datatypes") }
+    api("org.hyperledger.besu:evm:$besu") { because("org.hyperledger.besu.evm") }
     api("org.hyperledger.besu:secp256k1:0.8.2") {
         because("org.hyperledger.besu.nativelib.secp256k1")
     }
     api("org.json:json:20231013") { because("org.json") }
-    api("org.junit.jupiter:junit-jupiter-api:5.10.2") { because("org.junit.jupiter.api") }
-    api("org.junit.jupiter:junit-jupiter-engine:5.10.2") { because("org.junit.jupiter.engine") }
+    api("org.junit.jupiter:junit-jupiter-api:$junit5") { because("org.junit.jupiter.api") }
+    api("org.junit.jupiter:junit-jupiter-engine:$junit5") { because("org.junit.jupiter.engine") }
     api("org.junit-pioneer:junit-pioneer:2.0.1") { because("org.junitpioneer") }
-    api("org.mockito:mockito-core:5.8.0") { because("org.mockito") }
-    api("org.mockito:mockito-junit-jupiter:5.8.0") { because("org.mockito.junit.jupiter") }
+    api("org.mockito:mockito-core:$mockito") { because("org.mockito") }
+    api("org.mockito:mockito-junit-jupiter:$mockito") { because("org.mockito.junit.jupiter") }
     api("org.opentest4j:opentest4j:1.2.0") { because("org.opentest4j") }
-    api("org.testcontainers:testcontainers:1.17.2") { because("org.testcontainers") }
-    api("org.testcontainers:junit-jupiter:1.17.2") { because("org.testcontainers.junit.jupiter") }
+    api("org.testcontainers:testcontainers:$testContainers") { because("org.testcontainers") }
+    api("org.testcontainers:junit-jupiter:$testContainers") {
+        because("org.testcontainers.junit.jupiter")
+    }
     api("org.yaml:snakeyaml:2.2") { because("org.yaml.snakeyaml") }
-    api("io.tmio:tuweni-bytes:2.4.2") { because("tuweni.bytes") }
-    api("io.tmio:tuweni-units:2.4.2") { because("tuweni.units") }
-    api("uk.org.webcompere:system-stubs-core:2.1.5") {
+    api("io.tmio:tuweni-bytes:$tuweni") { because("tuweni.bytes") }
+    api("io.tmio:tuweni-units:$tuweni") { because("tuweni.units") }
+    api("uk.org.webcompere:system-stubs-core:$webcompare") {
         because("uk.org.webcompere.systemstubs.core")
     }
-    api("uk.org.webcompere:system-stubs-jupiter:2.1.5") {
+    api("uk.org.webcompere:system-stubs-jupiter:$webcompare") {
         because("uk.org.webcompere.systemstubs.jupiter")
     }
     api("com.google.protobuf:protoc:3.25.4")
     api("io.grpc:protoc-gen-grpc-java:1.66.0")
 
-    api("com.hedera.cryptography:hedera-cryptography-pairings-api:0.1.1-SNAPSHOT") {
+    api("com.hedera.cryptography:hedera-cryptography-pairings-api:$hederaCryptography") {
         because("com.hedera.cryptography.pairings.api")
     }
-    api("com.hedera.cryptography:hedera-cryptography-altbn128:0.1.1-SNAPSHOT") {
+    api("com.hedera.cryptography:hedera-cryptography-altbn128:$hederaCryptography") {
         because("com.hedera.cryptography.altbn128")
     }
-    api("com.hedera.cryptography:hedera-cryptography-bls:0.1.1-SNAPSHOT") {
+    api("com.hedera.cryptography:hedera-cryptography-bls:$hederaCryptography") {
         because("com.hedera.cryptography.bls")
     }
-    api("com.hedera.cryptography:hedera-cryptography-tss:0.1.1-SNAPSHOT") {
+    api("com.hedera.cryptography:hedera-cryptography-tss:$hederaCryptography") {
         because("com.hedera.cryptography.tss")
     }
 }


### PR DESCRIPTION
**Description**:

Some versions for _dependency groups_ – such as all `io.grpc:*` dependencies – were defined multiple times. This let to multiple Dependabot PRs for the same versions, leading to inconsistencies between merging of the several PRs.

Each repeated version is now only defined once in a `val` in the `hiero-dependency-versions/build.gradle.kts` file. This notation is supported by Dependabot.

