### PR TITLE
fix: revert 8b7c003d0c2b99184d457e92e3d92af1ed8c49a2

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.eventhandling;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionPrehandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionPrehandler.java
@@ -18,7 +18,6 @@ package com.swirlds.platform.eventhandling;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.metrics.api.Metrics.INTERNAL_CATEGORY;
-import static com.swirlds.platform.components.transaction.system.SystemTransactionExtractionUtils.extractFromEvent;
 
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.swirlds.base.time.Time;
@@ -82,8 +81,7 @@ public class DefaultTransactionPrehandler implements TransactionPrehandler {
      * {@inheritDoc}
      */
     @Override
-    public List<ScopedSystemTransaction<StateSignatureTransaction>> prehandleApplicationTransactions(
-            @NonNull final PlatformEvent event) {
+    public void prehandleApplicationTransactions(@NonNull final PlatformEvent event) {
         final long startTime = time.nanoTime();
 
         ReservedSignedState latestImmutableState = null;
@@ -104,9 +102,5 @@ public class DefaultTransactionPrehandler implements TransactionPrehandler {
 
             preHandleTime.update(startTime, time.nanoTime());
         }
-
-        // TODO adapt this logic to read transactions directly from the callback passed in SwirldState.preHandle() when
-        // implemented
-        return extractFromEvent(event, StateSignatureTransaction.class);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionPrehandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionPrehandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.eventhandling;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/TransactionPrehandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/TransactionPrehandler.java
@@ -16,12 +16,9 @@
 
 package com.swirlds.platform.eventhandling;
 
-import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.swirlds.common.wiring.component.InputWireLabel;
-import com.swirlds.platform.components.transaction.system.ScopedSystemTransaction;
 import com.swirlds.platform.event.PlatformEvent;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
 
 /**
  * Performs the prehandling of transactions
@@ -33,6 +30,5 @@ public interface TransactionPrehandler {
      * @param event the event to prehandle
      */
     @InputWireLabel("PlatformEvent")
-    List<ScopedSystemTransaction<StateSignatureTransaction>> prehandleApplicationTransactions(
-            @NonNull PlatformEvent event);
+    void prehandleApplicationTransactions(@NonNull PlatformEvent event);
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/TransactionPrehandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/TransactionPrehandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.eventhandling;
 
 import com.swirlds.common.wiring.component.InputWireLabel;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.state;
 
 import static com.swirlds.platform.state.SwirldStateManagerUtils.fastCopy;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.state;
 
-import static com.swirlds.platform.components.transaction.system.SystemTransactionExtractionUtils.extractFromRound;
 import static com.swirlds.platform.state.SwirldStateManagerUtils.fastCopy;
 
 import com.hedera.hapi.node.state.roster.Roster;
@@ -127,15 +126,11 @@ public class SwirldStateManager implements FreezePeriodChecker {
      *
      * @param round the round to handle
      */
-    public List<ScopedSystemTransaction<StateSignatureTransaction>> handleConsensusRound(final ConsensusRound round) {
+    public void handleConsensusRound(final ConsensusRound round) {
         final MerkleRoot state = stateRef.get();
 
         uptimeTracker.handleRound(round);
         transactionHandler.handleRound(round, state);
-
-        // TODO update this logic to return the transactions from the callback consumer passed in
-        // state.getSwirldState().handleConsensusRound, when it is implemented
-        return extractFromRound(round, StateSignatureTransaction.class);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.state.iss;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
@@ -28,8 +28,10 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.utility.throttle.RateLimiter;
 import com.swirlds.logging.legacy.payload.IssPayload;
 import com.swirlds.platform.components.transaction.system.ScopedSystemTransaction;
+import com.swirlds.platform.components.transaction.system.SystemTransactionExtractionUtils;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.consensus.ConsensusConfig;
+import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.metrics.IssMetrics;
 import com.swirlds.platform.sequence.map.ConcurrentSequenceMap;
 import com.swirlds.platform.sequence.map.SequenceMap;
@@ -245,7 +247,7 @@ public class DefaultIssDetector implements IssDetector {
                 issNotifications.add(selfHashCheckResult);
             }
 
-            issNotifications.addAll(handlePostconsensusSignatures(stateAndRound.systemTransactions()));
+            issNotifications.addAll(handlePostconsensusSignatures(stateAndRound.round()));
 
             return issNotifications.isEmpty() ? null : issNotifications;
         }
@@ -290,12 +292,14 @@ public class DefaultIssDetector implements IssDetector {
     /**
      * Handle postconsensus state signatures.
      *
-     * @param stateSignatureTransactions the transactions containining state signatures
+     * @param round the round that may contain state signatures
      * @return a list of ISS notifications, which may be empty, but will not contain null
      */
     @NonNull
-    private List<IssNotification> handlePostconsensusSignatures(
-            final List<ScopedSystemTransaction<StateSignatureTransaction>> stateSignatureTransactions) {
+    private List<IssNotification> handlePostconsensusSignatures(@NonNull final ConsensusRound round) {
+        final List<ScopedSystemTransaction<StateSignatureTransaction>> stateSignatureTransactions =
+                SystemTransactionExtractionUtils.extractFromRound(round, StateSignatureTransaction.class);
+
         if (stateSignatureTransactions == null) {
             return List.of();
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -16,11 +16,9 @@
 
 package com.swirlds.platform.wiring;
 
-import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.swirlds.common.wiring.component.ComponentWiring;
 import com.swirlds.common.wiring.transformers.RoutableData;
 import com.swirlds.platform.components.consensus.ConsensusEngine;
-import com.swirlds.platform.components.transaction.system.ScopedSystemTransaction;
 import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.event.branching.BranchDetector;
 import com.swirlds.platform.event.branching.BranchReporter;
@@ -67,8 +65,7 @@ public class PlatformCoordinator {
     private final GossipWiring gossipWiring;
     private final ComponentWiring<ConsensusEngine, List<ConsensusRound>> consensusEngineWiring;
     private final ComponentWiring<EventCreationManager, UnsignedEvent> eventCreationManagerWiring;
-    private final ComponentWiring<TransactionPrehandler, List<ScopedSystemTransaction<StateSignatureTransaction>>>
-            applicationTransactionPrehandlerWiring;
+    private final ComponentWiring<TransactionPrehandler, Void> applicationTransactionPrehandlerWiring;
     private final ComponentWiring<StateSignatureCollector, List<ReservedSignedState>> stateSignatureCollectorWiring;
     private final ComponentWiring<TransactionHandler, StateAndRound> transactionHandlerWiring;
     private final ComponentWiring<RoundDurabilityBuffer, List<ConsensusRound>> roundDurabilityBufferWiring;
@@ -113,10 +110,7 @@ public class PlatformCoordinator {
             @NonNull final GossipWiring gossipWiring,
             @NonNull final ComponentWiring<ConsensusEngine, List<ConsensusRound>> consensusEngineWiring,
             @NonNull final ComponentWiring<EventCreationManager, UnsignedEvent> eventCreationManagerWiring,
-            @NonNull
-                    final ComponentWiring<
-                                    TransactionPrehandler, List<ScopedSystemTransaction<StateSignatureTransaction>>>
-                            applicationTransactionPrehandlerWiring,
+            @NonNull final ComponentWiring<TransactionPrehandler, Void> applicationTransactionPrehandlerWiring,
             @NonNull
                     final ComponentWiring<StateSignatureCollector, List<ReservedSignedState>>
                             stateSignatureCollectorWiring,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.wiring;
 
 import com.swirlds.common.wiring.component.ComponentWiring;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -45,6 +45,7 @@ import com.swirlds.platform.components.appcomm.CompleteStateNotificationWithClea
 import com.swirlds.platform.components.appcomm.LatestCompleteStateNotifier;
 import com.swirlds.platform.components.consensus.ConsensusEngine;
 import com.swirlds.platform.components.transaction.system.ScopedSystemTransaction;
+import com.swirlds.platform.components.transaction.system.SystemTransactionExtractionUtils;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.consensus.EventWindow;
 import com.swirlds.platform.event.AncientMode;
@@ -135,8 +136,7 @@ public class PlatformWiring {
     private final ComponentWiring<InlinePcesWriter, PlatformEvent> pcesInlineWriterWiring;
     private final ComponentWiring<RoundDurabilityBuffer, List<ConsensusRound>> roundDurabilityBufferWiring;
     private final ComponentWiring<PcesSequencer, PlatformEvent> pcesSequencerWiring;
-    private final ComponentWiring<TransactionPrehandler, List<ScopedSystemTransaction<StateSignatureTransaction>>>
-            applicationTransactionPrehandlerWiring;
+    private final ComponentWiring<TransactionPrehandler, Void> applicationTransactionPrehandlerWiring;
     private final ComponentWiring<StateSignatureCollector, List<ReservedSignedState>> stateSignatureCollectorWiring;
     private final GossipWiring gossipWiring;
     private final ComponentWiring<EventWindowManager, EventWindow> eventWindowManagerWiring;
@@ -493,7 +493,16 @@ public class PlatformWiring {
         splitOrphanBufferOutput.solderTo(applicationTransactionPrehandlerWiring.getInputWire(
                 TransactionPrehandler::prehandleApplicationTransactions));
 
-        applicationTransactionPrehandlerWiring
+        // From the orphan buffer, extract signatures from preconsensus events for input to the StateSignatureCollector.
+        final WireTransformer<PlatformEvent, List<ScopedSystemTransaction<StateSignatureTransaction>>>
+                preConsensusTransformer = new WireTransformer<>(
+                        model,
+                        "extractPreconsensusSignatureTransactions",
+                        "preconsensus signatures",
+                        event -> SystemTransactionExtractionUtils.extractFromEvent(
+                                event, StateSignatureTransaction.class));
+        splitOrphanBufferOutput.solderTo(preConsensusTransformer.getInputWire());
+        preConsensusTransformer
                 .getOutputWire()
                 .solderTo(stateSignatureCollectorWiring.getInputWire(
                         StateSignatureCollector::handlePreconsensusSignatures));
@@ -620,15 +629,6 @@ public class PlatformWiring {
                 .getOutputWire()
                 .buildTransformer("postHasher_getConsensusRound", "stateAndRound", StateAndRound::round);
 
-        transactionHandlerWiring
-                .getOutputWire()
-                .buildTransformer(
-                        "getSystemTransactions",
-                        "stateAndRound with system transactions",
-                        StateAndRound::systemTransactions)
-                .solderTo(stateSignatureCollectorWiring.getInputWire(
-                        StateSignatureCollector::handlePostconsensusSignatures));
-
         hashedStateOutputWire.solderTo(hashLoggerWiring.getInputWire(HashLogger::logHashes));
         hashedStateOutputWire.solderTo(stateSignerWiring.getInputWire(StateSigner::signState));
         hashedStateAndRoundOutputWire.solderTo(issDetectorWiring.getInputWire(IssDetector::handleStateAndRound));
@@ -643,6 +643,19 @@ public class PlatformWiring {
         // FUTURE WORK: combine the signedStateHasherWiring State and Round outputs into a single StateAndRound output.
         // FUTURE WORK: Split the single StateAndRound output into separate State and Round wires.
 
+        // Extract signatures from post-consensus events for input to the StateSignatureCollector.
+        final WireTransformer<ConsensusRound, List<ScopedSystemTransaction<StateSignatureTransaction>>>
+                postConsensusTransformer = new WireTransformer<>(
+                        model,
+                        "extractConsensusSignatureTransactions",
+                        "consensus events",
+                        round -> SystemTransactionExtractionUtils.extractFromRound(
+                                round, StateSignatureTransaction.class));
+        hashedConsensusRoundOutput.solderTo(postConsensusTransformer.getInputWire());
+        postConsensusTransformer
+                .getOutputWire()
+                .solderTo(stateSignatureCollectorWiring.getInputWire(
+                        StateSignatureCollector::handlePostconsensusSignatures));
         // Solder the state output as input to the state signature collector.
         hashedStateOutputWire.solderTo(
                 stateSignatureCollectorWiring.getInputWire(StateSignatureCollector::addReservedState));

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.wiring;
 
 import static com.swirlds.common.wiring.schedulers.builders.TaskSchedulerConfiguration.DIRECT_THREADSAFE_CONFIGURATION;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/StateAndRound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/StateAndRound.java
@@ -16,24 +16,17 @@
 
 package com.swirlds.platform.wiring.components;
 
-import com.hedera.hapi.platform.event.StateSignatureTransaction;
-import com.swirlds.platform.components.transaction.system.ScopedSystemTransaction;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
 
 /**
  * Contains a reserved signed state, and the consensus round which caused the state to be created
  *
  * @param reservedSignedState the state
  * @param round               the round that caused the state to be created
- * @param systemTransactions  the system transactions that were included in the round
  */
-public record StateAndRound(
-        @NonNull ReservedSignedState reservedSignedState,
-        @NonNull ConsensusRound round,
-        @NonNull List<ScopedSystemTransaction<StateSignatureTransaction>> systemTransactions) {
+public record StateAndRound(@NonNull ReservedSignedState reservedSignedState, @NonNull ConsensusRound round) {
     /**
      * Make an additional reservation on the reserved signed state
      *
@@ -42,6 +35,6 @@ public record StateAndRound(
      */
     @NonNull
     public StateAndRound makeAdditionalReservation(@NonNull final String reservationReason) {
-        return new StateAndRound(reservedSignedState.getAndReserve(reservationReason), round, systemTransactions);
+        return new StateAndRound(reservedSignedState.getAndReserve(reservationReason), round);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/StateAndRound.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/StateAndRound.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.wiring.components;
 
 import com.swirlds.platform.internal.ConsensusRound;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform;
 
 import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyEquals;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -322,8 +322,7 @@ class StateFileManagerTests {
                     .build();
             final ReservedSignedState reservedSignedState = signedState.reserve("initialTestReservation");
 
-            controller.markSavedState(
-                    new StateAndRound(reservedSignedState, mock(ConsensusRound.class), mock(ArrayList.class)));
+            controller.markSavedState(new StateAndRound(reservedSignedState, mock(ConsensusRound.class)));
             makeImmutable(reservedSignedState.get());
 
             if (signedState.isStateToSave()) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/DefaultStateHasherTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/DefaultStateHasherTests.java
@@ -26,7 +26,6 @@ import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.state.hasher.DefaultStateHasher;
 import com.swirlds.platform.state.hasher.StateHasher;
 import com.swirlds.platform.wiring.components.StateAndRound;
-import java.util.ArrayList;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -48,8 +47,7 @@ public class DefaultStateHasherTests {
         final ReservedSignedState reservedSignedState = mock(ReservedSignedState.class);
         when(reservedSignedState.get()).thenReturn(signedState);
 
-        final StateAndRound stateAndRound =
-                new StateAndRound(reservedSignedState, mock(ConsensusRound.class), mock(ArrayList.class));
+        final StateAndRound stateAndRound = new StateAndRound(reservedSignedState, mock(ConsensusRound.class));
 
         // do the test
         final StateAndRound result = hasher.hashState(stateAndRound);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/DefaultStateHasherTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/DefaultStateHasherTests.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.state.signed;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StateGarbageCollectorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StateGarbageCollectorTests.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.state.signed;
 
 import static com.swirlds.common.test.fixtures.RandomUtils.getRandomPrintSeed;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StateGarbageCollectorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StateGarbageCollectorTests.java
@@ -27,7 +27,6 @@ import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import com.swirlds.platform.wiring.components.StateAndRound;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -70,9 +69,7 @@ class StateGarbageCollectorTests {
                         .build();
                 unreleasedStates.add(signedState.reserve("hold local copy of state"));
                 garbageCollector.registerState(new StateAndRound(
-                        signedState.reserve("send state to garbage collector"),
-                        mock(ConsensusRound.class),
-                        mock(ArrayList.class)));
+                        signedState.reserve("send state to garbage collector"), mock(ConsensusRound.class)));
             }
 
             // Randomly release some of the states.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/state/notifications/StateHashedNotificationTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/state/notifications/StateHashedNotificationTest.java
@@ -19,15 +19,12 @@ package com.swirlds.platform.system.state.notifications;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 
-import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.swirlds.common.crypto.Hash;
-import com.swirlds.platform.components.transaction.system.ScopedSystemTransaction;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.wiring.components.StateAndRound;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -50,9 +47,6 @@ class StateHashedNotificationTest {
     @Mock
     private ReservedSignedState reservedSignedState;
 
-    @Mock
-    private List<ScopedSystemTransaction<StateSignatureTransaction>> systemTransactions;
-
     @Test
     void factoryWorksAsExpected() {
         given(round.getRoundNum()).willReturn(ROUND);
@@ -60,8 +54,7 @@ class StateHashedNotificationTest {
         given(signedState.getState()).willReturn(merkleRoot);
         given(merkleRoot.getHash()).willReturn(HASH);
 
-        final var notification =
-                StateHashedNotification.from(new StateAndRound(reservedSignedState, round, systemTransactions));
+        final var notification = StateHashedNotification.from(new StateAndRound(reservedSignedState, round));
 
         assertEquals(ROUND, notification.round());
         assertEquals(HASH, notification.hash());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/state/notifications/StateHashedNotificationTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/state/notifications/StateHashedNotificationTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.system.state.notifications;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssDetectorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssDetectorTests.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.test.state;
 
 import static com.hedera.hapi.platform.event.EventTransaction.TransactionOneOfType.STATE_SIGNATURE_TRANSACTION;


### PR DESCRIPTION
**Description**:
The PR at https://github.com/hashgraph/hedera-services/pull/16899 caused the `IssDetectorTests` to fail. This PR reverts that commit.

This is done via `git revert -n 8b7c003d0c2b99184d457e92e3d92af1ed8c49a2`

**Related issue(s)**:

Fixes #17122

**Notes for reviewer**:
Tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
