### PR TITLE
build: do not change license header to SPDX format

### DIFF
--- a/gradle/license-header.txt
+++ b/gradle/license-header.txt
@@ -1,0 +1,13 @@
+Copyright (C) $YEAR Hedera Hashgraph, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,20 @@
-// SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.1.1" }
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins { id("org.hiero.gradle.build") version "0.1.2" }
 
 javaModules {
     // This "intermediate parent project" should be removed


### PR DESCRIPTION
**Description**:

Reverts moving to a new license header already, which was part of #15282

**Related issue(s)**:
#15282
https://github.com/hiero-ledger/hiero-gradle-conventions/issues/48

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Tested (unit, integration, etc.)
