### PR TITLE
chore: refactor RandomSignedStateGenerator to use Roster

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.crypto.SignatureVerifier;
-import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateInvalidException;
 import com.swirlds.platform.state.signed.SignedStateValidationData;
@@ -349,7 +348,7 @@ class DefaultSignedStateValidatorTests {
 
         return new RandomSignedStateGenerator()
                 .setRound(ROUND)
-                .setAddressBook(RosterUtils.buildAddressBook(roster))
+                .setRoster(roster)
                 .setStateHash(stateHash)
                 .setSignatures(nodeSigs(signingNodes))
                 .setSignatureVerifier(signatureVerifier)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,8 @@ import com.swirlds.platform.network.SocketConnection;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
 import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder.WeightDistributionStrategy;
 import com.swirlds.platform.test.fixtures.state.FakeMerkleStateLifecycles;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import java.io.IOException;
@@ -120,15 +119,15 @@ final class ReconnectTest {
                 IntStream.range(0, numNodes).mapToObj(NodeId::of).toList();
         final Random random = RandomUtils.getRandomPrintSeed();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(numNodes)
                 .withAverageWeight(weightPerNode)
-                .withWeightDistributionStrategy(RandomAddressBookBuilder.WeightDistributionStrategy.BALANCED)
+                .withWeightDistributionStrategy(WeightDistributionStrategy.BALANCED)
                 .build();
 
         try (final PairedStreams pairedStreams = new PairedStreams()) {
             final SignedState signedState = new RandomSignedStateGenerator()
-                    .setAddressBook(addressBook)
+                    .setRoster(roster)
                     .setSigningNodeIds(nodeIds)
                     .build();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ class StateSigningTests {
                 .withSize(nodeCount)
                 .build();
         final SignedState signedState = new RandomSignedStateGenerator(random)
-                .setAddressBook(RosterUtils.buildAddressBook(roster))
+                .setRoster(roster)
                 .setSignatures(new HashMap<>())
                 .build();
 
@@ -191,7 +191,7 @@ class StateSigningTests {
                 .withSize(nodeCount)
                 .build();
         final SignedState signedState = new RandomSignedStateGenerator(random)
-                .setAddressBook(RosterUtils.buildAddressBook(roster))
+                .setRoster(roster)
                 .setSignatures(new HashMap<>())
                 .build();
 
@@ -286,7 +286,7 @@ class StateSigningTests {
                 .build();
 
         final SignedState signedState = new RandomSignedStateGenerator(random)
-                .setAddressBook(RosterUtils.buildAddressBook(roster))
+                .setRoster(roster)
                 .setSignatures(new HashMap<>())
                 .build();
 
@@ -371,7 +371,7 @@ class StateSigningTests {
                 .build();
 
         final SignedState signedState = new RandomSignedStateGenerator(random)
-                .setAddressBook(RosterUtils.buildAddressBook(roster))
+                .setRoster(roster)
                 .setSignatures(new HashMap<>())
                 .build();
 
@@ -414,7 +414,7 @@ class StateSigningTests {
                 .build();
 
         final SignedState signedState = new RandomSignedStateGenerator(random)
-                .setAddressBook(RosterUtils.buildAddressBook(roster))
+                .setRoster(roster)
                 .setSignatures(new HashMap<>())
                 .build();
 
@@ -484,7 +484,7 @@ class StateSigningTests {
         final Roster roster = new Roster(rosterEntries);
 
         final SignedState signedState = new RandomSignedStateGenerator(random)
-                .setAddressBook(RosterUtils.buildAddressBook(roster))
+                .setRoster(roster)
                 .setSignatures(new HashMap<>())
                 .build();
 
@@ -534,7 +534,7 @@ class StateSigningTests {
                 .build();
 
         final SignedState signedState = new RandomSignedStateGenerator(random)
-                .setAddressBook(RosterUtils.buildAddressBook(roster))
+                .setRoster(roster)
                 .setSignatures(new HashMap<>())
                 .build();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/OldCompleteStateEventuallyReleasedTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/OldCompleteStateEventuallyReleasedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.Signature;
@@ -30,13 +32,13 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.platform.system.address.Address;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
+import java.security.PublicKey;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -52,8 +54,7 @@ class OldCompleteStateEventuallyReleasedTest extends AbstractStateSignatureColle
     // the class file with other tests.
     // DO NOT ADD ADDITIONAL UNIT TESTS TO THIS CLASS!
 
-    private final AddressBook addressBook =
-            RandomAddressBookBuilder.create(random).withSize(4).build();
+    private final Roster roster = RandomRosterBuilder.create(random).withSize(4).build();
 
     /**
      * Called on each state as it gets too old without collecting enough signatures.
@@ -101,13 +102,15 @@ class OldCompleteStateEventuallyReleasedTest extends AbstractStateSignatureColle
 
         final Hash stateHash = randomHash(random);
         final Map<NodeId, Signature> signatures = new HashMap<>();
-        for (final Address address : addressBook) {
-            signatures.put(address.getNodeId(), buildFakeSignature(address.getSigPublicKey(), stateHash));
+        for (final RosterEntry node : roster.rosterEntries()) {
+            final PublicKey publicKey =
+                    RosterUtils.fetchGossipCaCertificate(node).getPublicKey();
+            signatures.put(NodeId.of(node.nodeId()), buildFakeSignature(publicKey, stateHash));
         }
 
         // Add a complete signed state. Eventually this will get released.
         final SignedState stateFromDisk = new RandomSignedStateGenerator(random)
-                .setAddressBook(addressBook)
+                .setRoster(roster)
                 .setRound(0)
                 .setSignatures(signatures)
                 .build();
@@ -127,7 +130,7 @@ class OldCompleteStateEventuallyReleasedTest extends AbstractStateSignatureColle
         for (int round = 1; round < count; round++) {
             MerkleDb.resetDefaultInstancePath();
             final SignedState signedState = new RandomSignedStateGenerator(random)
-                    .setAddressBook(addressBook)
+                    .setRoster(roster)
                     .setRound(round)
                     .setSignatures(new HashMap<>())
                     .build();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/PostconsensusSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/PostconsensusSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,18 +21,22 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.DefaultStateSignatureCollector;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder.WeightDistributionStrategy;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -47,9 +51,9 @@ import org.junit.jupiter.api.Test;
  */
 class PostconsensusSignaturesTest extends AbstractStateSignatureCollectorTest {
 
-    private final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+    private final Roster roster = RandomRosterBuilder.create(random)
             .withSize(4)
-            .withWeightDistributionStrategy(RandomAddressBookBuilder.WeightDistributionStrategy.BALANCED)
+            .withWeightDistributionStrategy(WeightDistributionStrategy.BALANCED)
             .build();
 
     /**
@@ -100,7 +104,7 @@ class PostconsensusSignaturesTest extends AbstractStateSignatureCollectorTest {
         for (int round = 0; round < count; round++) {
             MerkleDb.resetDefaultInstancePath();
             final SignedState signedState = new RandomSignedStateGenerator(random)
-                    .setAddressBook(addressBook)
+                    .setRoster(roster)
                     .setRound(round)
                     .setSignatures(new HashMap<>())
                     .build();
@@ -115,15 +119,15 @@ class PostconsensusSignaturesTest extends AbstractStateSignatureCollectorTest {
 
             manager.addReservedState(signedState.reserve("test"));
 
-            for (int node = 0; node < addressBook.getSize(); node++) {
+            for (int node = 0; node < roster.rosterEntries().size(); node++) {
+                final RosterEntry rosterNode = roster.rosterEntries().get(node);
                 manager.handlePostconsensusSignatureTransaction(
-                        addressBook.getNodeId(node),
+                        NodeId.of(rosterNode.nodeId()),
                         StateSignatureTransaction.newBuilder()
                                 .round(round)
                                 .signature(buildFakeSignatureBytes(
-                                        addressBook
-                                                .getAddress(addressBook.getNodeId(node))
-                                                .getSigPublicKey(),
+                                        RosterUtils.fetchGossipCaCertificate(rosterNode)
+                                                .getPublicKey(),
                                         states.get(round).getState().getHash()))
                                 .hash(states.get(round).getState().getHash().getBytes())
                                 .build());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/RegisterStatesWithoutSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/RegisterStatesWithoutSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
@@ -29,8 +30,7 @@ import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import java.util.HashMap;
 import org.junit.jupiter.api.AfterEach;
@@ -46,8 +46,7 @@ public class RegisterStatesWithoutSignaturesTest extends AbstractStateSignatureC
     // the class file with other tests.
     // DO NOT ADD ADDITIONAL UNIT TESTS TO THIS CLASS!
 
-    private final AddressBook addressBook =
-            RandomAddressBookBuilder.create(random).withSize(4).build();
+    private final Roster roster = RandomRosterBuilder.create(random).withSize(4).build();
 
     /**
      * Called on each state as it gets too old without collecting enough signatures.
@@ -105,7 +104,7 @@ public class RegisterStatesWithoutSignaturesTest extends AbstractStateSignatureC
         for (int round = 0; round < count; round++) {
             MerkleDb.resetDefaultInstancePath();
             final SignedState signedState = new RandomSignedStateGenerator(random)
-                    .setAddressBook(addressBook)
+                    .setRoster(roster)
                     .setRound(round)
                     .setSignatures(new HashMap<>())
                     .build();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesRestartTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesRestartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.Signature;
@@ -31,13 +33,14 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.platform.system.address.Address;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder.WeightDistributionStrategy;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
+import java.security.PublicKey;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -55,9 +58,9 @@ public class SequentialSignaturesRestartTest extends AbstractStateSignatureColle
 
     private final int roundAgeToSign = 3;
 
-    private final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+    private final Roster roster = RandomRosterBuilder.create(random)
             .withSize(4)
-            .withWeightDistributionStrategy(RandomAddressBookBuilder.WeightDistributionStrategy.BALANCED)
+            .withWeightDistributionStrategy(WeightDistributionStrategy.BALANCED)
             .build();
 
     private final long firstRound = 50;
@@ -110,12 +113,14 @@ public class SequentialSignaturesRestartTest extends AbstractStateSignatureColle
         // Simulate a restart (i.e. loading a state from disk)
         final Hash stateHash = randomHash(random);
         final Map<NodeId, Signature> signatures = new HashMap<>();
-        for (final Address address : addressBook) {
-            signatures.put(address.getNodeId(), buildFakeSignature(address.getSigPublicKey(), stateHash));
+        for (final RosterEntry node : roster.rosterEntries()) {
+            final PublicKey publicKey =
+                    RosterUtils.fetchGossipCaCertificate(node).getPublicKey();
+            signatures.put(NodeId.of(node.nodeId()), buildFakeSignature(publicKey, stateHash));
         }
 
         final SignedState stateFromDisk = new RandomSignedStateGenerator(random)
-                .setAddressBook(addressBook)
+                .setRoster(roster)
                 .setRound(firstRound)
                 .setSignatures(signatures)
                 .build();
@@ -133,7 +138,7 @@ public class SequentialSignaturesRestartTest extends AbstractStateSignatureColle
         for (int round = (int) firstRound + 1; round < count + firstRound; round++) {
             MerkleDb.resetDefaultInstancePath();
             final SignedState signedState = new RandomSignedStateGenerator(random)
-                    .setAddressBook(addressBook)
+                    .setRoster(roster)
                     .setRound(round)
                     .setSignatures(new HashMap<>())
                     .build();
@@ -145,11 +150,23 @@ public class SequentialSignaturesRestartTest extends AbstractStateSignatureColle
 
             // Add some signatures to one of the previous states
             final long roundToSign = round - roundAgeToSign;
-            addSignature(manager, roundToSign, addressBook.getNodeId(0));
-            addSignature(manager, roundToSign, addressBook.getNodeId(1));
-            addSignature(manager, roundToSign, addressBook.getNodeId(2));
+            addSignature(
+                    manager,
+                    roundToSign,
+                    NodeId.of(roster.rosterEntries().get(0).nodeId()));
+            addSignature(
+                    manager,
+                    roundToSign,
+                    NodeId.of(roster.rosterEntries().get(1).nodeId()));
+            addSignature(
+                    manager,
+                    roundToSign,
+                    NodeId.of(roster.rosterEntries().get(2).nodeId()));
             if (random.nextBoolean()) {
-                addSignature(manager, roundToSign, addressBook.getNodeId(1));
+                addSignature(
+                        manager,
+                        roundToSign,
+                        NodeId.of(roster.rosterEntries().get(1).nodeId()));
             }
 
             try (final ReservedSignedState lastCompletedState = manager.getLatestSignedState("test")) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
@@ -29,8 +31,8 @@ import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder.WeightDistributionStrategy;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import java.util.HashMap;
 import org.junit.jupiter.api.AfterEach;
@@ -48,9 +50,9 @@ public class SequentialSignaturesTest extends AbstractStateSignatureCollectorTes
 
     private final int roundAgeToSign = 3;
 
-    private final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+    private final Roster roster = RandomRosterBuilder.create(random)
             .withSize(4)
-            .withWeightDistributionStrategy(RandomAddressBookBuilder.WeightDistributionStrategy.BALANCED)
+            .withWeightDistributionStrategy(WeightDistributionStrategy.BALANCED)
             .build();
 
     /**
@@ -103,7 +105,7 @@ public class SequentialSignaturesTest extends AbstractStateSignatureCollectorTes
         for (int round = 0; round < count; round++) {
             MerkleDb.resetDefaultInstancePath();
             final SignedState signedState = new RandomSignedStateGenerator(random)
-                    .setAddressBook(addressBook)
+                    .setRoster(roster)
                     .setRound(round)
                     .setSignatures(new HashMap<>())
                     .build();
@@ -115,12 +117,27 @@ public class SequentialSignaturesTest extends AbstractStateSignatureCollectorTes
 
             // Add some signatures to one of the previous states
             final long roundToSign = round - roundAgeToSign;
-            addSignature(manager, roundToSign, addressBook.getNodeId(0));
-            addSignature(manager, roundToSign, addressBook.getNodeId(1));
-            addSignature(manager, roundToSign, addressBook.getNodeId(2));
+            addSignature(
+                    manager,
+                    roundToSign,
+                    NodeId.of(roster.rosterEntries().get(0).nodeId()));
+            addSignature(
+                    manager,
+                    roundToSign,
+                    NodeId.of(roster.rosterEntries().get(1).nodeId()));
+            addSignature(
+                    manager,
+                    roundToSign,
+                    NodeId.of(roster.rosterEntries().get(2).nodeId()));
             if (random.nextBoolean()) {
-                addSignature(manager, roundToSign, addressBook.getNodeId(1));
-                addSignature(manager, roundToSign, addressBook.getNodeId(1));
+                addSignature(
+                        manager,
+                        roundToSign,
+                        NodeId.of(roster.rosterEntries().get(1).nodeId()));
+                addSignature(
+                        manager,
+                        roundToSign,
+                        NodeId.of(roster.rosterEntries().get(1).nodeId()));
             }
 
             try (final ReservedSignedState lastCompletedState = manager.getLatestSignedState("test")) {

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static com.swirlds.platform.test.fixtures.state.FakeMerkleStateLifecycles
 import static com.swirlds.platform.test.fixtures.state.FakeMerkleStateLifecycles.registerMerkleStateRootClassIds;
 
 import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.Reservable;
 import com.swirlds.common.context.PlatformContext;
@@ -37,7 +38,6 @@ import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.crypto.SignatureVerifier;
-import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.MinimumJudgeInfo;
@@ -46,8 +46,8 @@ import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.SoftwareVersion;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder.WeightDistributionStrategy;
 import com.swirlds.platform.test.fixtures.state.manager.SignatureVerificationTestUtils;
 import com.swirlds.state.State;
 import com.swirlds.state.merkle.MerkleStateRoot;
@@ -80,7 +80,7 @@ public class RandomSignedStateGenerator {
     private MerkleRoot state;
     private Long round;
     private Hash legacyRunningEventHash;
-    private AddressBook addressBook;
+    private Roster roster;
     private Instant consensusTimestamp;
     private Boolean freezeState = false;
     private SoftwareVersion softwareVersion;
@@ -122,15 +122,14 @@ public class RandomSignedStateGenerator {
      * @return a new signed state
      */
     public SignedState build() {
-        final AddressBook addressBookInstance;
-        if (addressBook == null) {
-            addressBookInstance = RandomAddressBookBuilder.create(random)
-                    .withWeightDistributionStrategy(RandomAddressBookBuilder.WeightDistributionStrategy.BALANCED)
+        final Roster rosterInstance;
+        if (roster == null) {
+            rosterInstance = RandomRosterBuilder.create(random)
+                    .withWeightDistributionStrategy(WeightDistributionStrategy.BALANCED)
                     .build();
         } else {
-            addressBookInstance = addressBook;
+            rosterInstance = roster;
         }
-        final Roster rosterInstance = RosterRetriever.buildRoster(addressBookInstance);
 
         final SoftwareVersion softwareVersionInstance;
         if (softwareVersion == null) {
@@ -246,9 +245,10 @@ public class RandomSignedStateGenerator {
             final List<NodeId> signingNodeIdsInstance;
             if (signingNodeIds == null) {
                 signingNodeIdsInstance = new LinkedList<>();
-                if (addressBookInstance.getSize() > 0) {
-                    for (int i = 0; i < addressBookInstance.getSize() / 3 + 1; i++) {
-                        signingNodeIdsInstance.add(addressBookInstance.getNodeId(i));
+                if (!rosterInstance.rosterEntries().isEmpty()) {
+                    for (int i = 0; i < rosterInstance.rosterEntries().size() / 3 + 1; i++) {
+                        final RosterEntry node = rosterInstance.rosterEntries().get(i);
+                        signingNodeIdsInstance.add(NodeId.of(node.nodeId()));
                     }
                 }
             } else {
@@ -331,12 +331,12 @@ public class RandomSignedStateGenerator {
     }
 
     /**
-     * Set the address book.
+     * Set the roster.
      *
      * @return this object
      */
-    public RandomSignedStateGenerator setAddressBook(final AddressBook addressBook) {
-        this.addressBook = addressBook;
+    public RandomSignedStateGenerator setRoster(final Roster roster) {
+        this.roster = roster;
         return this;
     }
 


### PR DESCRIPTION
**Description**:
Replace usage of AddressBook in RandomSignedStateGenerator with Roster.

**Related issue(s)**:

Fixes #17087 

**Notes for reviewer**: None

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
