### PR TITLE
chore: refactor DefaultIssDetector to use rosters

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
@@ -1,10 +1,24 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.swirlds.platform.builder;
 
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getGlobalMetrics;
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getMetricsProvider;
 import static com.swirlds.platform.gui.internal.BrowserWindowManager.getPlatforms;
-import static com.swirlds.platform.roster.RosterUtils.buildAddressBook;
 import static com.swirlds.platform.state.iss.IssDetector.DO_NOT_IGNORE_ROUNDS;
 
 import com.swirlds.common.merkle.utility.SerializableLong;
@@ -876,7 +890,7 @@ public class PlatformComponentBuilder {
 
             issDetector = new DefaultIssDetector(
                     blocks.platformContext(),
-                    buildAddressBook(blocks.rosterHistory().getCurrentRoster()),
+                    blocks.rosterHistory().getCurrentRoster(),
                     blocks.appVersion().getPbjSemanticVersion(),
                     ignorePreconsensusSignatures,
                     roundToIgnore);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/IssMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/IssMetrics.java
@@ -16,13 +16,14 @@
 
 package com.swirlds.platform.metrics;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.metrics.api.IntegerGauge;
 import com.swirlds.metrics.api.LongGauge;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.platform.system.address.Address;
-import com.swirlds.platform.system.address.AddressBook;
+import com.swirlds.platform.roster.RosterUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +34,7 @@ import java.util.Objects;
  */
 public class IssMetrics {
 
-    private final AddressBook addressBook;
+    private final Roster roster;
 
     /**
      * The current number of nodes experiencing an ISS.
@@ -109,9 +110,9 @@ public class IssMetrics {
      * @throws IllegalArgumentException
      * 		if {@code metrics} is {@code null}
      */
-    public IssMetrics(@NonNull final Metrics metrics, @NonNull final AddressBook addressBook) {
+    public IssMetrics(@NonNull final Metrics metrics, @NonNull final Roster roster) {
         Objects.requireNonNull(metrics, "metrics must not be null");
-        this.addressBook = Objects.requireNonNull(addressBook, "addressBook must not be null");
+        this.roster = Objects.requireNonNull(roster, "roster must not be null");
 
         issCountGauge = metrics.getOrCreate(new IntegerGauge.Config(Metrics.INTERNAL_CATEGORY, "issCount")
                 .withDescription("the number of nodes that currently disagree with the consensus hash"));
@@ -119,8 +120,8 @@ public class IssMetrics {
         issWeightGage = metrics.getOrCreate(new LongGauge.Config(Metrics.INTERNAL_CATEGORY, "issWeight")
                 .withDescription("the amount of weight tied up by ISS events"));
 
-        for (final Address address : addressBook) {
-            issDataByNode.put(address.getNodeId(), new IssStatus());
+        for (final RosterEntry node : roster.rosterEntries()) {
+            issDataByNode.put(NodeId.of(node.nodeId()), new IssStatus());
         }
     }
 
@@ -176,7 +177,7 @@ public class IssMetrics {
         issStatus.setRound(round);
 
         if (issStatus.hasIss() != hasIss) {
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = RosterUtils.getRosterEntry(roster, nodeId.id()).weight();
             if (hasIss) {
                 issCount++;
                 issWeight += weight;
@@ -208,8 +209,8 @@ public class IssMetrics {
             status.setRound(round);
         }
 
-        issCount = addressBook.getSize();
-        issWeight = addressBook.getTotalWeight();
+        issCount = roster.rosterEntries().size();
+        issWeight = RosterUtils.computeTotalWeight(roster);
 
         issCountGauge.set(issCount);
         issWeightGage.set(issWeight);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
@@ -21,6 +21,8 @@ import static com.swirlds.logging.legacy.LogMarker.STARTUP;
 import static com.swirlds.logging.legacy.LogMarker.STATE_HASH;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.Hash;
@@ -31,13 +33,13 @@ import com.swirlds.platform.components.transaction.system.ScopedSystemTransactio
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.metrics.IssMetrics;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.sequence.map.ConcurrentSequenceMap;
 import com.swirlds.platform.sequence.map.SequenceMap;
 import com.swirlds.platform.state.iss.internal.ConsensusHashFinder;
 import com.swirlds.platform.state.iss.internal.HashValidityStatus;
 import com.swirlds.platform.state.iss.internal.RoundHashValidator;
 import com.swirlds.platform.state.signed.ReservedSignedState;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.state.notifications.IssNotification;
 import com.swirlds.platform.system.state.notifications.IssNotification.IssType;
 import com.swirlds.platform.util.MarkerFileWriter;
@@ -64,9 +66,9 @@ public class DefaultIssDetector implements IssDetector {
     private long previousRound = -1;
 
     /**
-     * The address book of this network.
+     * The roster of this network.
      */
-    private final AddressBook addressBook;
+    private final Roster roster;
 
     /**
      * The current software version
@@ -117,7 +119,7 @@ public class DefaultIssDetector implements IssDetector {
      * Create an object that tracks reported hashes and detects ISS events.
      *
      * @param platformContext              the platform context
-     * @param addressBook                  the address book for the network
+     * @param roster                       the roster for the network
      * @param currentSoftwareVersion       the current software version
      * @param ignorePreconsensusSignatures If true, ignore signatures from the preconsensus event stream, otherwise
      *                                     validate them like normal.
@@ -126,7 +128,7 @@ public class DefaultIssDetector implements IssDetector {
      */
     public DefaultIssDetector(
             @NonNull final PlatformContext platformContext,
-            @NonNull final AddressBook addressBook,
+            @NonNull final Roster roster,
             @NonNull final SemanticVersion currentSoftwareVersion,
             final boolean ignorePreconsensusSignatures,
             final long ignoredRound) {
@@ -142,7 +144,7 @@ public class DefaultIssDetector implements IssDetector {
         selfIssRateLimiter = new RateLimiter(platformContext.getTime(), timeBetweenIssLogs);
         catastrophicIssRateLimiter = new RateLimiter(platformContext.getTime(), timeBetweenIssLogs);
 
-        this.addressBook = Objects.requireNonNull(addressBook);
+        this.roster = Objects.requireNonNull(roster);
         this.currentSoftwareVersion = Objects.requireNonNull(currentSoftwareVersion);
 
         this.roundData = new ConcurrentSequenceMap<>(
@@ -157,7 +159,7 @@ public class DefaultIssDetector implements IssDetector {
         if (ignoredRound != DO_NOT_IGNORE_ROUNDS) {
             logger.warn(STARTUP.getMarker(), "No ISS detection will be performed for round {}", ignoredRound);
         }
-        this.issMetrics = new IssMetrics(platformContext.getMetrics(), addressBook);
+        this.issMetrics = new IssMetrics(platformContext.getMetrics(), roster);
     }
 
     /**
@@ -214,7 +216,8 @@ public class DefaultIssDetector implements IssDetector {
 
         previousRound = roundNumber;
 
-        roundData.put(roundNumber, new RoundHashValidator(roundNumber, addressBook.getTotalWeight(), issMetrics));
+        roundData.put(
+                roundNumber, new RoundHashValidator(roundNumber, RosterUtils.computeTotalWeight(roster), issMetrics));
 
         return removedRounds.stream()
                 .map(this::handleRemovedRound)
@@ -341,7 +344,9 @@ public class DefaultIssDetector implements IssDetector {
             return null;
         }
 
-        if (!addressBook.contains(signerId)) {
+        final RosterEntry node = RosterUtils.getRosterEntryOrNull(roster, signerId.id());
+
+        if (node == null) {
             // we don't care about nodes not in the address book
             return null;
         }
@@ -351,8 +356,6 @@ public class DefaultIssDetector implements IssDetector {
             return null;
         }
 
-        final long nodeWeight = addressBook.getAddress(signerId).getWeight();
-
         final RoundHashValidator roundValidator = roundData.get(signaturePayload.round());
         if (roundValidator == null) {
             // We are being asked to validate a signature from the far future or far past, or a round that has already
@@ -361,7 +364,7 @@ public class DefaultIssDetector implements IssDetector {
         }
 
         final boolean decided =
-                roundValidator.reportHashFromNetwork(signerId, nodeWeight, new Hash(signaturePayload.hash()));
+                roundValidator.reportHashFromNetwork(signerId, node.weight(), new Hash(signaturePayload.hash()));
         if (decided) {
             return checkValidity(roundValidator);
         }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssDetectorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssDetectorTests.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -41,18 +43,17 @@ import com.swirlds.platform.components.transaction.system.SystemTransactionExtra
 import com.swirlds.platform.consensus.ConsensusConfig;
 import com.swirlds.platform.internal.ConsensusRound;
 import com.swirlds.platform.internal.EventImpl;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MerkleRoot;
 import com.swirlds.platform.state.iss.DefaultIssDetector;
 import com.swirlds.platform.state.iss.IssDetector;
 import com.swirlds.platform.state.iss.internal.HashValidityStatus;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.platform.system.address.Address;
-import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.state.notifications.IssNotification;
 import com.swirlds.platform.system.state.notifications.IssNotification.IssType;
 import com.swirlds.platform.test.PlatformTest;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.event.EventImplTestUtils;
 import com.swirlds.platform.test.fixtures.event.TestingEventBuilder;
 import com.swirlds.platform.wiring.components.StateAndRound;
@@ -62,6 +63,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -108,20 +110,21 @@ class IssDetectorTests extends PlatformTest {
      * consistent hash.
      *
      * @param random      a source of randomness
-     * @param addressBook the address book to use to generate the signature transactions
+     * @param roster      the roster to use to generate the signature transactions
      * @param roundNumber the round that signature transactions will be for
      * @param roundHash   the hash that all signature transactions will be made on
      * @return a list of events, each containing a signature transaction from a node for the given round
      */
     private static List<EventImpl> generateEventsWithConsistentSignatures(
             @NonNull final Randotron random,
-            @NonNull final AddressBook addressBook,
+            @NonNull final Roster roster,
             final long roundNumber,
             @NonNull final Hash roundHash) {
         final List<RoundHashValidatorTests.NodeHashInfo> nodeHashInfos = new ArrayList<>();
 
-        addressBook.forEach(address -> nodeHashInfos.add(
-                new RoundHashValidatorTests.NodeHashInfo(address.getNodeId(), roundHash, roundNumber)));
+        roster.rosterEntries()
+                .forEach(node -> nodeHashInfos.add(
+                        new RoundHashValidatorTests.NodeHashInfo(NodeId.of(node.nodeId()), roundHash, roundNumber)));
 
         // create signature transactions for this round
         return generateEventsContainingSignatures(
@@ -172,7 +175,7 @@ class IssDetectorTests extends PlatformTest {
     @DisplayName("No ISSes Test")
     void noIss() {
         final Randotron random = Randotron.create();
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(100)
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
@@ -180,8 +183,8 @@ class IssDetectorTests extends PlatformTest {
 
         final PlatformContext platformContext = createDefaultPlatformContext();
 
-        final IssDetector issDetector = new DefaultIssDetector(
-                platformContext, addressBook, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
+        final IssDetector issDetector =
+                new DefaultIssDetector(platformContext, roster, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
         final IssDetectorTestHelper issDetectorTestHelper = new IssDetectorTestHelper(issDetector);
 
         // signature events are generated for each round when that round is handled, and then are included randomly
@@ -196,8 +199,7 @@ class IssDetectorTests extends PlatformTest {
             final Hash roundHash = randomHash(random);
 
             // create signature transactions for this round
-            signatureEvents.addAll(
-                    generateEventsWithConsistentSignatures(random, addressBook, currentRound, roundHash));
+            signatureEvents.addAll(generateEventsWithConsistentSignatures(random, roster, currentRound, roundHash));
 
             // randomly select half of unsubmitted signature events to include in this round
             final List<EventImpl> eventsToInclude = selectRandomEvents(random, signatureEvents);
@@ -238,7 +240,7 @@ class IssDetectorTests extends PlatformTest {
     void mixedOrderTest() {
         final Randotron random = Randotron.create();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(Math.max(10, random.nextInt(1000)))
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
@@ -246,7 +248,7 @@ class IssDetectorTests extends PlatformTest {
 
         final PlatformContext platformContext = createDefaultPlatformContext();
 
-        final NodeId selfId = addressBook.getNodeId(0);
+        final NodeId selfId = NodeId.of(roster.rosterEntries().getFirst().nodeId());
         final int roundsNonAncient = platformContext
                 .getConfiguration()
                 .getConfigData(ConsensusConfig.class)
@@ -264,7 +266,7 @@ class IssDetectorTests extends PlatformTest {
 
             if (random.nextDouble() < 2.0 / 3) {
                 // Choose hashes so that there is a valid consensus hash
-                data = generateRegularNodeHashes(random, addressBook, round);
+                data = generateRegularNodeHashes(random, roster, round);
 
                 HashValidityStatus expectedStatus = null;
 
@@ -288,7 +290,7 @@ class IssDetectorTests extends PlatformTest {
                 expectedRoundStatus.add(expectedStatus);
             } else {
                 // Choose hashes that will result in a catastrophic ISS
-                data = generateCatastrophicNodeHashes(random, addressBook, round);
+                data = generateCatastrophicNodeHashes(random, roster, round);
                 roundData.add(data);
                 expectedRoundStatus.add(HashValidityStatus.CATASTROPHIC_ISS);
                 expectedCatastrophicIssCount++;
@@ -304,8 +306,8 @@ class IssDetectorTests extends PlatformTest {
             }
         }
 
-        final IssDetector issDetector = new DefaultIssDetector(
-                platformContext, addressBook, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
+        final IssDetector issDetector =
+                new DefaultIssDetector(platformContext, roster, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
         final IssDetectorTestHelper issDetectorTestHelper = new IssDetectorTestHelper(issDetector);
 
         long currentRound = 0;
@@ -387,15 +389,15 @@ class IssDetectorTests extends PlatformTest {
         final Randotron random = Randotron.create();
         final PlatformContext platformContext = createDefaultPlatformContext();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(100)
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
-        final NodeId selfId = addressBook.getNodeId(0);
+        final NodeId selfId = NodeId.of(roster.rosterEntries().getFirst().nodeId());
 
-        final IssDetector issDetector = new DefaultIssDetector(
-                platformContext, addressBook, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
+        final IssDetector issDetector =
+                new DefaultIssDetector(platformContext, roster, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
         final IssDetectorTestHelper issDetectorTestHelper = new IssDetectorTestHelper(issDetector);
 
         long currentRound = 0;
@@ -406,7 +408,7 @@ class IssDetectorTests extends PlatformTest {
 
         // the round after the initial state will have a catastrophic iss
         final RoundHashValidatorTests.HashGenerationData catastrophicHashData =
-                generateCatastrophicNodeHashes(random, addressBook, currentRound);
+                generateCatastrophicNodeHashes(random, roster, currentRound);
         final Hash selfHashForCatastrophicRound = catastrophicHashData.nodeList().stream()
                 .filter(info -> info.nodeId() == selfId)
                 .findFirst()
@@ -434,13 +436,15 @@ class IssDetectorTests extends PlatformTest {
                     mockState(currentRound, randomHash()), anotherRound, systemTransactionsForRoundWithoutSignatures));
         }
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
+
         // submit signatures on the ISS round that represent a minority of the weight
         long submittedWeight = 0;
         final List<EventImpl> signaturesToSubmit = new ArrayList<>();
         for (final EventImpl signatureEvent : signaturesOnCatastrophicRound) {
             final long weight =
-                    addressBook.getAddress(signatureEvent.getCreatorId()).getWeight();
-            if (MAJORITY.isSatisfiedBy(submittedWeight + weight, addressBook.getTotalWeight())) {
+                    nodesById.get(signatureEvent.getCreatorId().id()).weight();
+            if (MAJORITY.isSatisfiedBy(submittedWeight + weight, RosterUtils.computeTotalWeight(roster))) {
                 // If we add less than a majority then we won't be able to detect the ISS no matter what
                 break;
             }
@@ -482,7 +486,7 @@ class IssDetectorTests extends PlatformTest {
      * signatures being on an incorrect hash.
      */
     private static List<RoundHashValidatorTests.NodeHashInfo> generateCatastrophicTimeoutIss(
-            final Random random, final AddressBook addressBook, final long targetRound) {
+            final Random random, final Roster roster, final long targetRound) {
 
         final List<RoundHashValidatorTests.NodeHashInfo> data = new LinkedList<>();
 
@@ -493,13 +497,13 @@ class IssDetectorTests extends PlatformTest {
 
         final Hash almostConsensusHash = randomHash(random);
         long almostConsensusWeight = 0;
-        for (final Address address : addressBook) {
-            if (MAJORITY.isSatisfiedBy(almostConsensusWeight + address.getWeight(), addressBook.getTotalWeight())) {
-                data.add(new RoundHashValidatorTests.NodeHashInfo(address.getNodeId(), randomHash(), targetRound));
+        for (final RosterEntry node : roster.rosterEntries()) {
+            final NodeId nodeId = NodeId.of(node.nodeId());
+            if (MAJORITY.isSatisfiedBy(almostConsensusWeight + node.weight(), RosterUtils.computeTotalWeight(roster))) {
+                data.add(new RoundHashValidatorTests.NodeHashInfo(nodeId, randomHash(), targetRound));
             } else {
-                almostConsensusWeight += address.getWeight();
-                data.add(new RoundHashValidatorTests.NodeHashInfo(
-                        address.getNodeId(), almostConsensusHash, targetRound));
+                almostConsensusWeight += node.weight();
+                data.add(new RoundHashValidatorTests.NodeHashInfo(nodeId, almostConsensusHash, targetRound));
             }
         }
 
@@ -521,21 +525,21 @@ class IssDetectorTests extends PlatformTest {
                 .getConfiguration()
                 .getConfigData(ConsensusConfig.class)
                 .roundsNonAncient();
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(100)
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
-        final NodeId selfId = addressBook.getNodeId(0);
+        final NodeId selfId = NodeId.of(roster.rosterEntries().getFirst().nodeId());
 
-        final IssDetector issDetector = new DefaultIssDetector(
-                platformContext, addressBook, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
+        final IssDetector issDetector =
+                new DefaultIssDetector(platformContext, roster, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
         final IssDetectorTestHelper issDetectorTestHelper = new IssDetectorTestHelper(issDetector);
 
         long currentRound = 0;
 
         final List<RoundHashValidatorTests.NodeHashInfo> catastrophicData =
-                generateCatastrophicTimeoutIss(random, addressBook, currentRound);
+                generateCatastrophicTimeoutIss(random, roster, currentRound);
         final Hash selfHashForCatastrophicRound = catastrophicData.stream()
                 .filter(info -> info.nodeId() == selfId)
                 .findFirst()
@@ -544,18 +548,19 @@ class IssDetectorTests extends PlatformTest {
         final List<EventImpl> signaturesOnCatastrophicRound = generateEventsContainingSignatures(
                 random, currentRound, new RoundHashValidatorTests.HashGenerationData(catastrophicData, null));
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         long submittedWeight = 0;
         final List<EventImpl> signaturesToSubmit = new ArrayList<>();
         for (final EventImpl signatureEvent : signaturesOnCatastrophicRound) {
             final long weight =
-                    addressBook.getAddress(signatureEvent.getCreatorId()).getWeight();
+                    nodesById.get(signatureEvent.getCreatorId().id()).weight();
 
             signaturesToSubmit.add(signatureEvent);
 
             // Stop once we have added >2/3. We should not have decided yet, but will
             // have gathered enough to declare a catastrophic ISS
             submittedWeight += weight;
-            if (SUPER_MAJORITY.isSatisfiedBy(submittedWeight, addressBook.getTotalWeight())) {
+            if (SUPER_MAJORITY.isSatisfiedBy(submittedWeight, RosterUtils.computeTotalWeight(roster))) {
                 break;
             }
         }
@@ -619,15 +624,15 @@ class IssDetectorTests extends PlatformTest {
                 .getConfiguration()
                 .getConfigData(ConsensusConfig.class)
                 .roundsNonAncient();
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(100)
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
-        final NodeId selfId = addressBook.getNodeId(0);
+        final NodeId selfId = NodeId.of(roster.rosterEntries().getFirst().nodeId());
 
-        final IssDetector issDetector = new DefaultIssDetector(
-                platformContext, addressBook, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
+        final IssDetector issDetector =
+                new DefaultIssDetector(platformContext, roster, SemanticVersion.DEFAULT, false, DO_NOT_IGNORE_ROUNDS);
         final IssDetectorTestHelper issDetectorTestHelper = new IssDetectorTestHelper(issDetector);
 
         long currentRound = 0;
@@ -637,7 +642,7 @@ class IssDetectorTests extends PlatformTest {
         currentRound++;
 
         final List<RoundHashValidatorTests.NodeHashInfo> catastrophicData =
-                generateCatastrophicTimeoutIss(random, addressBook, currentRound);
+                generateCatastrophicTimeoutIss(random, roster, currentRound);
         final Hash selfHashForCatastrophicRound = catastrophicData.stream()
                 .filter(info -> info.nodeId() == selfId)
                 .findFirst()
@@ -656,17 +661,18 @@ class IssDetectorTests extends PlatformTest {
                 catastrophicRound,
                 systemTransactionsForCatastrophicRound));
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         long submittedWeight = 0;
         final List<EventImpl> signaturesToSubmit = new ArrayList<>();
         for (final EventImpl signatureEvent : signaturesOnCatastrophicRound) {
             final long weight =
-                    addressBook.getAddress(signatureEvent.getCreatorId()).getWeight();
+                    nodesById.get(signatureEvent.getCreatorId().id()).weight();
 
             // Stop once we have added >2/3. We should not have decided yet, but will have gathered enough to declare a
             // catastrophic ISS
             submittedWeight += weight;
             signaturesToSubmit.add(signatureEvent);
-            if (SUPER_MAJORITY.isSatisfiedBy(submittedWeight + weight, addressBook.getTotalWeight())) {
+            if (SUPER_MAJORITY.isSatisfiedBy(submittedWeight + weight, RosterUtils.computeTotalWeight(roster))) {
                 break;
             }
         }
@@ -702,7 +708,7 @@ class IssDetectorTests extends PlatformTest {
     void ignoredRoundTest() {
         final Randotron random = Randotron.create();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(100)
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
@@ -715,7 +721,7 @@ class IssDetectorTests extends PlatformTest {
                 .roundsNonAncient();
 
         final IssDetector issDetector =
-                new DefaultIssDetector(platformContext, addressBook, SemanticVersion.DEFAULT, false, 1);
+                new DefaultIssDetector(platformContext, roster, SemanticVersion.DEFAULT, false, 1);
         final IssDetectorTestHelper issDetectorTestHelper = new IssDetectorTestHelper(issDetector);
 
         long currentRound = 0;
@@ -724,7 +730,7 @@ class IssDetectorTests extends PlatformTest {
         currentRound++;
 
         final List<RoundHashValidatorTests.NodeHashInfo> catastrophicData =
-                generateCatastrophicTimeoutIss(random, addressBook, currentRound);
+                generateCatastrophicTimeoutIss(random, roster, currentRound);
         final List<EventImpl> signaturesOnCatastrophicRound = generateEventsContainingSignatures(
                 random, currentRound, new RoundHashValidatorTests.HashGenerationData(catastrophicData, null));
 

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssMetricsTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/IssMetricsTests.java
@@ -21,14 +21,15 @@ import static com.swirlds.common.test.fixtures.RandomUtils.randomHash;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.metrics.IssMetrics;
-import com.swirlds.platform.system.address.Address;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.roster.RosterUtils;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import java.util.Random;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,16 +41,16 @@ class IssMetricsTests {
     @DisplayName("Update Non-Existent Node")
     void updateNonExistentNode() {
         final Randotron randotron = Randotron.create();
-
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(randotron).withSize(100).build();
-
-        final IssMetrics issMetrics = new IssMetrics(new NoOpMetrics(), addressBook);
+        final Roster roster =
+                RandomRosterBuilder.create(randotron).withSize(100).build();
+        final IssMetrics issMetrics = new IssMetrics(new NoOpMetrics(), roster);
+        final Hash hashA = randomHash();
+        final Hash hashB = randomHash();
+        final NodeId nodeId = NodeId.of(Integer.MAX_VALUE);
 
         assertThrows(
                 IllegalArgumentException.class,
-                () -> issMetrics.stateHashValidityObserver(
-                        0L, NodeId.of(Integer.MAX_VALUE), randomHash(), randomHash()),
+                () -> issMetrics.stateHashValidityObserver(0L, nodeId, hashA, hashB),
                 "should not be able to update stats for non-existent node");
     }
 
@@ -61,10 +62,9 @@ class IssMetricsTests {
         final Hash hashA = randomHash(random);
         final Hash hashB = randomHash(random);
 
-        final AddressBook addressBook =
-                RandomAddressBookBuilder.create(random).withSize(100).build();
+        final Roster roster = RandomRosterBuilder.create(random).withSize(100).build();
 
-        final IssMetrics issMetrics = new IssMetrics(new NoOpMetrics(), addressBook);
+        final IssMetrics issMetrics = new IssMetrics(new NoOpMetrics(), roster);
 
         assertEquals(0, issMetrics.getIssCount(), "there shouldn't be any nodes in an ISS state");
         assertEquals(0, issMetrics.getIssWeight(), "there shouldn't be any weight in an ISS state");
@@ -74,13 +74,14 @@ class IssMetricsTests {
         long expectedIssweight = 0;
 
         // Change even numbered nodes to have an ISS
-        for (final Address address : addressBook) {
-            if (address.getNodeId().id() % 2 == 0) {
-                issMetrics.stateHashValidityObserver(round, address.getNodeId(), hashA, hashB);
+        for (final RosterEntry node : roster.rosterEntries()) {
+            final NodeId nodeId = NodeId.of(node.nodeId());
+            if (node.nodeId() % 2 == 0) {
+                issMetrics.stateHashValidityObserver(round, nodeId, hashA, hashB);
                 expectedIssCount++;
-                expectedIssweight += address.getWeight();
+                expectedIssweight += node.weight();
             } else {
-                issMetrics.stateHashValidityObserver(round, address.getNodeId(), hashA, hashA);
+                issMetrics.stateHashValidityObserver(round, nodeId, hashA, hashA);
             }
             assertEquals(expectedIssCount, issMetrics.getIssCount(), "unexpected ISS count");
             assertEquals(expectedIssweight, issMetrics.getIssWeight(), "unexpected ISS weight");
@@ -88,38 +89,39 @@ class IssMetricsTests {
 
         // For the next round, report the same statuses. No change is expected.
         round++;
-        for (final Address address : addressBook) {
-            final Hash hash = address.getNodeId().id() % 2 != 0 ? hashA : hashB;
-            issMetrics.stateHashValidityObserver(round, address.getNodeId(), hashA, hash);
+        for (final RosterEntry node : roster.rosterEntries()) {
+            final Hash hash = node.nodeId() % 2 != 0 ? hashA : hashB;
+            issMetrics.stateHashValidityObserver(round, NodeId.of(node.nodeId()), hashA, hash);
             assertEquals(expectedIssCount, issMetrics.getIssCount(), "unexpected ISS count");
             assertEquals(expectedIssweight, issMetrics.getIssWeight(), "unexpected ISS weight");
         }
 
         // Report data from the same round number. This is expected to be ignored.
-        for (final Address address : addressBook) {
-            issMetrics.stateHashValidityObserver(round, address.getNodeId(), hashA, hashA);
+        for (final RosterEntry node : roster.rosterEntries()) {
+            issMetrics.stateHashValidityObserver(round, NodeId.of(node.nodeId()), hashA, hashA);
             assertEquals(expectedIssCount, issMetrics.getIssCount(), "unexpected ISS count");
             assertEquals(expectedIssweight, issMetrics.getIssWeight(), "unexpected ISS weight");
         }
 
         // Report data from a lower round number. This is expected to be ignored.
-        for (final Address address : addressBook) {
-            issMetrics.stateHashValidityObserver(round - 1, address.getNodeId(), hashA, hashA);
+        for (final RosterEntry node : roster.rosterEntries()) {
+            issMetrics.stateHashValidityObserver(round - 1, NodeId.of(node.nodeId()), hashA, hashA);
             assertEquals(expectedIssCount, issMetrics.getIssCount(), "unexpected ISS count");
             assertEquals(expectedIssweight, issMetrics.getIssWeight(), "unexpected ISS weight");
         }
 
         // Switch the status of each node.
         round++;
-        for (final Address address : addressBook) {
-            if (address.getNodeId().id() % 2 == 0) {
-                issMetrics.stateHashValidityObserver(round, address.getNodeId(), hashA, hashA);
+        for (final RosterEntry node : roster.rosterEntries()) {
+            final NodeId nodeId = NodeId.of(node.nodeId());
+            if (node.nodeId() % 2 == 0) {
+                issMetrics.stateHashValidityObserver(round, nodeId, hashA, hashA);
                 expectedIssCount--;
-                expectedIssweight -= address.getWeight();
+                expectedIssweight -= node.weight();
             } else {
-                issMetrics.stateHashValidityObserver(round, address.getNodeId(), hashA, hashB);
+                issMetrics.stateHashValidityObserver(round, nodeId, hashA, hashB);
                 expectedIssCount++;
-                expectedIssweight += address.getWeight();
+                expectedIssweight += node.weight();
             }
             assertEquals(expectedIssCount, issMetrics.getIssCount(), "unexpected ISS count");
             assertEquals(expectedIssweight, issMetrics.getIssWeight(), "unexpected ISS weight");
@@ -133,17 +135,17 @@ class IssMetricsTests {
         // Report a catastrophic ISS.
         round++;
         issMetrics.catastrophicIssObserver(round);
-        expectedIssCount = addressBook.getSize();
-        expectedIssweight = addressBook.getTotalWeight();
+        expectedIssCount = roster.rosterEntries().size();
+        expectedIssweight = RosterUtils.computeTotalWeight(roster);
         assertEquals(expectedIssCount, issMetrics.getIssCount(), "unexpected ISS count");
         assertEquals(expectedIssweight, issMetrics.getIssWeight(), "unexpected ISS weight");
 
         // Heal all nodes.
         round++;
-        for (final Address address : addressBook) {
-            issMetrics.stateHashValidityObserver(round, address.getNodeId(), hashA, hashA);
+        for (final RosterEntry node : roster.rosterEntries()) {
+            issMetrics.stateHashValidityObserver(round, NodeId.of(node.nodeId()), hashA, hashA);
             expectedIssCount--;
-            expectedIssweight -= address.getWeight();
+            expectedIssweight -= node.weight();
             assertEquals(expectedIssCount, issMetrics.getIssCount(), "unexpected ISS count");
             assertEquals(expectedIssweight, issMetrics.getIssWeight(), "unexpected ISS weight");
         }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/RoundHashValidatorTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/state/RoundHashValidatorTests.java
@@ -24,17 +24,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.metrics.IssMetrics;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.iss.internal.HashValidityStatus;
 import com.swirlds.platform.state.iss.internal.RoundHashValidator;
-import com.swirlds.platform.system.address.AddressBook;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -75,19 +78,19 @@ class RoundHashValidatorTests {
      * Based on the desired network status, generate hashes for all nodes.
      *
      * @param random                a source of randomness
-     * @param addressBook           the address book for the round
+     * @param roster                the roster for the round
      * @param desiredValidityStatus the desired validity status
      * @return a list of node IDs in the order they should be added to the hash validator
      */
     static HashGenerationData generateNodeHashes(
             final Random random,
-            final AddressBook addressBook,
+            final Roster roster,
             final HashValidityStatus desiredValidityStatus,
             final long round) {
         if (desiredValidityStatus == HashValidityStatus.VALID || desiredValidityStatus == HashValidityStatus.SELF_ISS) {
-            return generateRegularNodeHashes(random, addressBook, round);
+            return generateRegularNodeHashes(random, roster, round);
         } else if (desiredValidityStatus == HashValidityStatus.CATASTROPHIC_ISS) {
-            return generateCatastrophicNodeHashes(random, addressBook, round);
+            return generateCatastrophicNodeHashes(random, roster, round);
         } else {
             throw new IllegalArgumentException("Unsupported case " + desiredValidityStatus);
         }
@@ -96,8 +99,7 @@ class RoundHashValidatorTests {
     /**
      * Generate node hashes without there being a catastrophic ISS.
      */
-    static HashGenerationData generateRegularNodeHashes(
-            final Random random, final AddressBook addressBook, final long round) {
+    static HashGenerationData generateRegularNodeHashes(final Random random, final Roster roster, final long round) {
 
         // Greater than 1/2 must have the same hash. But all other nodes are free to take whatever other hash
         // they want. Choose that fraction randomly.
@@ -105,10 +107,10 @@ class RoundHashValidatorTests {
         final List<NodeHashInfo> nodes = new LinkedList<>();
 
         final List<NodeId> randomNodeOrder = new LinkedList<>();
-        addressBook.iterator().forEachRemaining(address -> randomNodeOrder.add(address.getNodeId()));
+        roster.rosterEntries().forEach(node -> randomNodeOrder.add(NodeId.of(node.nodeId())));
         Collections.shuffle(randomNodeOrder, random);
 
-        final long totalWeight = addressBook.getTotalWeight();
+        final long totalWeight = RosterUtils.computeTotalWeight(roster);
 
         // This is the hash we want to be chosen for the consensus hash.
         final Hash consensusHash = randomHash(random);
@@ -124,8 +126,9 @@ class RoundHashValidatorTests {
         final List<NodeId> randomHashNodes = new LinkedList<>();
 
         // Assign each node to one of the hashing strategies described above.
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeId nodeId : randomNodeOrder) {
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
 
             if (!MAJORITY.isSatisfiedBy(correctHashWeight, totalWeight)) {
                 correctHashNodes.add(nodeId);
@@ -146,7 +149,7 @@ class RoundHashValidatorTests {
 
         // Now, decide what order the hashes should be processed. Make sure that the
         // consensus hash is the first to reach a strong minority.
-        while (nodes.size() < addressBook.getSize()) {
+        while (nodes.size() < roster.rosterEntries().size()) {
             final double choice = random.nextDouble();
 
             allowedIterations--;
@@ -155,14 +158,14 @@ class RoundHashValidatorTests {
             if (choice < 1.0 / 3) {
                 if (!correctHashNodes.isEmpty()) {
                     final NodeId nodeId = correctHashNodes.remove(0);
-                    final long weight = addressBook.getAddress(nodeId).getWeight();
+                    final long weight = nodesById.get(nodeId.id()).weight();
                     nodes.add(new NodeHashInfo(nodeId, consensusHash, round));
                     correctHashWeight += weight;
                 }
             } else if (choice < 2.0 / 3) {
                 if (!otherHashNodes.isEmpty()) {
                     final NodeId nodeId = otherHashNodes.get(0);
-                    final long weight = addressBook.getAddress(nodeId).getWeight();
+                    final long weight = nodesById.get(nodeId.id()).weight();
 
                     if (MAJORITY.isSatisfiedBy(otherHashWeight + weight, totalWeight)) {
                         // We don't want to allow the other hash to accumulate >1/2
@@ -172,7 +175,7 @@ class RoundHashValidatorTests {
                     otherHashNodes.remove(0);
 
                     nodes.add(new NodeHashInfo(nodeId, otherHash, round));
-                    otherHashWeight += addressBook.getAddress(nodeId).getWeight();
+                    otherHashWeight += nodesById.get(nodeId.id()).weight();
                 }
             } else {
                 // The random hashes will never reach a majority, so they can go in whenever
@@ -190,24 +193,25 @@ class RoundHashValidatorTests {
      * Generate node hashes that result in a catastrophic ISS.
      */
     static HashGenerationData generateCatastrophicNodeHashes(
-            final Random random, final AddressBook addressBook, final long round) {
+            final Random random, final Roster roster, final long round) {
 
         // There should exist no group of nodes with the same hash that >1/2
 
         final List<NodeHashInfo> nodes = new ArrayList<>();
 
-        final long totalWeight = addressBook.getTotalWeight();
+        final long totalWeight = RosterUtils.computeTotalWeight(roster);
 
         final List<NodeId> randomNodeOrder = new LinkedList<>();
-        addressBook.iterator().forEachRemaining(address -> randomNodeOrder.add(address.getNodeId()));
+        roster.rosterEntries().forEach(node -> randomNodeOrder.add(NodeId.of(node.nodeId())));
         Collections.shuffle(randomNodeOrder, random);
 
         // A large group of nodes may decide to use this hash. But it won't become the consensus hash.
         final Hash otherHash = randomHash(random);
         long otherHashWeight = 0;
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeId nodeId : randomNodeOrder) {
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
 
             final double choice = random.nextDouble();
             if (choice < 1.0 / 3 && !MAJORITY.isSatisfiedBy(otherHashWeight + weight, totalWeight)) {
@@ -260,24 +264,25 @@ class RoundHashValidatorTests {
     void selfSignatureLastTest(final HashValidityStatus expectedStatus) {
         final Random random = getRandomPrintSeed();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(Math.max(10, random.nextInt(1000)))
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
 
-        final HashGenerationData hashGenerationData = generateNodeHashes(random, addressBook, expectedStatus, 0);
+        final HashGenerationData hashGenerationData = generateNodeHashes(random, roster, expectedStatus, 0);
         final NodeHashInfo thisNode = chooseSelfNode(random, hashGenerationData, expectedStatus);
 
         final long round = random.nextInt(1000);
         final RoundHashValidator validator =
-                new RoundHashValidator(round, addressBook.getTotalWeight(), Mockito.mock(IssMetrics.class));
+                new RoundHashValidator(round, RosterUtils.computeTotalWeight(roster), Mockito.mock(IssMetrics.class));
 
         boolean decided = false;
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeHashInfo nodeHashInfo : hashGenerationData.nodeList) {
             final NodeId nodeId = nodeHashInfo.nodeId;
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
             final Hash hash = nodeHashInfo.nodeStateHash;
 
             final boolean operationCausedDecision = validator.reportHashFromNetwork(nodeId, weight, hash);
@@ -306,18 +311,18 @@ class RoundHashValidatorTests {
     void selfSignatureFirstTest(final HashValidityStatus expectedStatus) {
         final Random random = getRandomPrintSeed();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(Math.max(10, random.nextInt(1000)))
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
 
-        final HashGenerationData hashGenerationData = generateNodeHashes(random, addressBook, expectedStatus, 0);
+        final HashGenerationData hashGenerationData = generateNodeHashes(random, roster, expectedStatus, 0);
         final NodeHashInfo thisNode = chooseSelfNode(random, hashGenerationData, expectedStatus);
 
         final long round = random.nextInt(1000);
         final RoundHashValidator validator =
-                new RoundHashValidator(round, addressBook.getTotalWeight(), Mockito.mock(IssMetrics.class));
+                new RoundHashValidator(round, RosterUtils.computeTotalWeight(roster), Mockito.mock(IssMetrics.class));
 
         boolean decided = false;
 
@@ -325,9 +330,10 @@ class RoundHashValidatorTests {
                 validator.reportSelfHash(thisNode.nodeStateHash),
                 "we should need to gather more data before becoming decided");
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeHashInfo nodeHashInfo : hashGenerationData.nodeList) {
             final NodeId nodeId = nodeHashInfo.nodeId;
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
             final Hash hash = nodeHashInfo.nodeStateHash;
 
             final boolean operationCausedDecision = validator.reportHashFromNetwork(nodeId, weight, hash);
@@ -350,27 +356,28 @@ class RoundHashValidatorTests {
     void selfSignatureInMiddleTest(final HashValidityStatus expectedStatus) {
         final Random random = getRandomPrintSeed();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(Math.max(10, random.nextInt(1000)))
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
 
-        final HashGenerationData hashGenerationData = generateNodeHashes(random, addressBook, expectedStatus, 0);
+        final HashGenerationData hashGenerationData = generateNodeHashes(random, roster, expectedStatus, 0);
         final NodeHashInfo thisNode = chooseSelfNode(random, hashGenerationData, expectedStatus);
 
         final long round = random.nextInt(1000);
         final RoundHashValidator validator =
-                new RoundHashValidator(round, addressBook.getTotalWeight(), Mockito.mock(IssMetrics.class));
+                new RoundHashValidator(round, RosterUtils.computeTotalWeight(roster), Mockito.mock(IssMetrics.class));
 
         boolean decided = false;
 
-        final int addSelfHashIndex = random.nextInt(addressBook.getSize() - 1);
+        final int addSelfHashIndex = random.nextInt(roster.rosterEntries().size() - 1);
         int index = 0;
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeHashInfo nodeHashInfo : hashGenerationData.nodeList) {
             final NodeId nodeId = nodeHashInfo.nodeId;
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
             final Hash hash = nodeHashInfo.nodeStateHash;
 
             if (index == addSelfHashIndex) {
@@ -400,22 +407,22 @@ class RoundHashValidatorTests {
     void timeoutSelfHashTest() {
         final Random random = getRandomPrintSeed();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(Math.max(10, random.nextInt(1000)))
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
 
-        final HashGenerationData hashGenerationData =
-                generateNodeHashes(random, addressBook, HashValidityStatus.VALID, 0);
+        final HashGenerationData hashGenerationData = generateNodeHashes(random, roster, HashValidityStatus.VALID, 0);
 
         final long round = random.nextInt(1000);
         final RoundHashValidator validator =
-                new RoundHashValidator(round, addressBook.getTotalWeight(), Mockito.mock(IssMetrics.class));
+                new RoundHashValidator(round, RosterUtils.computeTotalWeight(roster), Mockito.mock(IssMetrics.class));
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeHashInfo nodeHashInfo : hashGenerationData.nodeList) {
             final NodeId nodeId = nodeHashInfo.nodeId;
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
             final Hash hash = nodeHashInfo.nodeStateHash;
 
             assertFalse(validator.reportHashFromNetwork(nodeId, weight, hash), "insufficient data to make decision");
@@ -433,25 +440,24 @@ class RoundHashValidatorTests {
     void timeoutSelfHashAndSignaturesTest() {
         final Random random = getRandomPrintSeed();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(Math.max(10, random.nextInt(1000)))
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
-        final long totalWeight = addressBook.getTotalWeight();
+        final long totalWeight = RosterUtils.computeTotalWeight(roster);
 
-        final HashGenerationData hashGenerationData =
-                generateNodeHashes(random, addressBook, HashValidityStatus.VALID, 0);
+        final HashGenerationData hashGenerationData = generateNodeHashes(random, roster, HashValidityStatus.VALID, 0);
 
         final long round = random.nextInt(1000);
-        final RoundHashValidator validator =
-                new RoundHashValidator(round, addressBook.getTotalWeight(), Mockito.mock(IssMetrics.class));
+        final RoundHashValidator validator = new RoundHashValidator(round, totalWeight, Mockito.mock(IssMetrics.class));
 
         long addedWeight = 0;
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeHashInfo nodeHashInfo : hashGenerationData.nodeList) {
             final NodeId nodeId = nodeHashInfo.nodeId;
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
             final Hash hash = nodeHashInfo.nodeStateHash;
 
             if (MAJORITY.isSatisfiedBy(addedWeight + weight, totalWeight)) {
@@ -474,28 +480,27 @@ class RoundHashValidatorTests {
     void timeoutSignaturesTest() {
         final Random random = getRandomPrintSeed();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(Math.max(10, random.nextInt(1000)))
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
-        final long totalWeight = addressBook.getTotalWeight();
+        final long totalWeight = RosterUtils.computeTotalWeight(roster);
 
-        final HashGenerationData hashGenerationData =
-                generateNodeHashes(random, addressBook, HashValidityStatus.VALID, 0);
+        final HashGenerationData hashGenerationData = generateNodeHashes(random, roster, HashValidityStatus.VALID, 0);
         final NodeHashInfo thisNode = chooseSelfNode(random, hashGenerationData, HashValidityStatus.VALID);
 
         final long round = random.nextInt(1000);
-        final RoundHashValidator validator =
-                new RoundHashValidator(round, addressBook.getTotalWeight(), Mockito.mock(IssMetrics.class));
+        final RoundHashValidator validator = new RoundHashValidator(round, totalWeight, Mockito.mock(IssMetrics.class));
 
         assertFalse(validator.reportSelfHash(thisNode.nodeStateHash), "should not allow a decision");
 
         long addedWeight = 0;
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeHashInfo nodeHashInfo : hashGenerationData.nodeList) {
             final NodeId nodeId = nodeHashInfo.nodeId;
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
             final Hash hash = nodeHashInfo.nodeStateHash;
 
             if (MAJORITY.isSatisfiedBy(addedWeight + weight, totalWeight)) {
@@ -519,28 +524,28 @@ class RoundHashValidatorTests {
     void timeoutWithSuperMajorityTest() {
         final Random random = getRandomPrintSeed();
 
-        final AddressBook addressBook = RandomAddressBookBuilder.create(random)
+        final Roster roster = RandomRosterBuilder.create(random)
                 .withSize(Math.max(10, random.nextInt(1000)))
                 .withAverageWeight(100)
                 .withWeightStandardDeviation(50)
                 .build();
-        final long totalWeight = addressBook.getTotalWeight();
+        final long totalWeight = RosterUtils.computeTotalWeight(roster);
 
         final HashGenerationData hashGenerationData =
-                generateNodeHashes(random, addressBook, HashValidityStatus.CATASTROPHIC_ISS, 0);
+                generateNodeHashes(random, roster, HashValidityStatus.CATASTROPHIC_ISS, 0);
         final NodeHashInfo thisNode = chooseSelfNode(random, hashGenerationData, HashValidityStatus.CATASTROPHIC_ISS);
 
         final long round = random.nextInt(1000);
-        final RoundHashValidator validator =
-                new RoundHashValidator(round, addressBook.getTotalWeight(), Mockito.mock(IssMetrics.class));
+        final RoundHashValidator validator = new RoundHashValidator(round, totalWeight, Mockito.mock(IssMetrics.class));
 
         assertFalse(validator.reportSelfHash(thisNode.nodeStateHash), "should not allow a decision");
 
         long addedWeight = 0;
 
+        final Map<Long, RosterEntry> nodesById = RosterUtils.toMap(roster);
         for (final NodeHashInfo nodeHashInfo : hashGenerationData.nodeList) {
             final NodeId nodeId = nodeHashInfo.nodeId;
-            final long weight = addressBook.getAddress(nodeId).getWeight();
+            final long weight = nodesById.get(nodeId.id()).weight();
             final Hash hash = nodeHashInfo.nodeStateHash;
 
             boolean decided = validator.reportHashFromNetwork(nodeId, weight, hash);


### PR DESCRIPTION
**Description**:
Replaces usage of AddressBook with Roster in DefaultIssDetector.

**Related issue(s)**:

Fixes #16741 

**Notes for reviewer**:
None

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
