### PR TITLE
chore: support `maxSignedTxnSize` override in standalone `TransactionExecutor`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/ExecutorComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/ExecutorComponent.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.workflows.standalone;
 
+import com.hedera.node.app.annotations.MaxSignedTxnSize;
 import com.hedera.node.app.authorization.AuthorizerInjectionModule;
 import com.hedera.node.app.config.BootstrapConfigProviderImpl;
 import com.hedera.node.app.config.ConfigProviderImpl;
@@ -85,6 +86,9 @@ public interface ExecutorComponent {
 
         @BindsInstance
         Builder throttleFactory(Throttle.Factory throttleFactory);
+
+        @BindsInstance
+        Builder maxSignedTxnSize(@MaxSignedTxnSize int maxSignedTxnSize);
 
         ExecutorComponent build();
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutor.java
@@ -39,6 +39,7 @@ public interface TransactionExecutor {
      * @param consensusNow the consensus time at which the transaction is to be executed
      * @param operationTracers the Besu {@link OperationTracer} instances to use for contract operations
      * @return one or more {@link SingleTransactionRecord}s for the executed transaction
+     * @throws RuntimeException if the executor cannot build a dispatch from the given transaction
      */
     List<SingleTransactionRecord> execute(
             @NonNull TransactionBody transactionBody,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutors.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutors.java
@@ -20,6 +20,7 @@ import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.
 import static com.hedera.node.app.spi.AppContext.Gossip.UNAVAILABLE_GOSSIP;
 import static com.hedera.node.app.workflows.standalone.impl.NoopVerificationStrategies.NOOP_VERIFICATION_STRATEGIES;
 
+import com.hedera.node.app.Hedera;
 import com.hedera.node.app.config.BootstrapConfigProviderImpl;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.info.NodeInfoImpl;
@@ -47,6 +48,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.InstantSource;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -59,6 +61,7 @@ public enum TransactionExecutors {
     TRANSACTION_EXECUTORS;
 
     public static final NodeInfo DEFAULT_NODE_INFO = new NodeInfoImpl(0, asAccount(3L), 10, List.of(), Bytes.EMPTY);
+    public static final String MAX_SIGNED_TXN_SIZE_PROPERTY = "executor.maxSignedTxnSize";
 
     /**
      * A strategy to bind and retrieve {@link OperationTracer} scoped to a thread.
@@ -137,6 +140,9 @@ public enum TransactionExecutors {
                 .scheduleServiceImpl(scheduleService)
                 .metrics(NO_OP_METRICS)
                 .throttleFactory(appContext.throttleFactory())
+                .maxSignedTxnSize(Optional.ofNullable(properties.get(MAX_SIGNED_TXN_SIZE_PROPERTY))
+                        .map(Integer::parseInt)
+                        .orElse(Hedera.MAX_SIGNED_TXN_SIZE))
                 .build();
         componentRef.set(component);
         return component;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneModule.java
@@ -17,8 +17,6 @@
 package com.hedera.node.app.workflows.standalone.impl;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.node.app.Hedera;
-import com.hedera.node.app.annotations.MaxSignedTxnSize;
 import com.hedera.node.app.annotations.NodeSelfId;
 import com.hedera.node.app.metrics.StoreMetricsServiceImpl;
 import com.hedera.node.app.spi.metrics.StoreMetricsService;
@@ -61,13 +59,6 @@ public interface StandaloneModule {
     @Singleton
     static InstantSource provideInstantSource() {
         return InstantSource.system();
-    }
-
-    @Provides
-    @Singleton
-    @MaxSignedTxnSize
-    static int maxSignedTxnSize() {
-        return Hedera.MAX_SIGNED_TXN_SIZE;
     }
 
     @Provides


### PR DESCRIPTION
**Description**:
 - Closes #17099 