### PR TITLE
build: Roll hiero gradle conventions to version 0.1.4 (#17149)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("org.hiero.gradle.build") version "0.1.2" }
+plugins { id("org.hiero.gradle.build") version "0.1.4" }
 
 javaModules {
     // This "intermediate parent project" should be removed


### PR DESCRIPTION
**Description**:

Cherry-pick the version roll of gradle build conventions to version 0.1.4.

**Related issue(s)**:

Fixes #17148 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
