### PR TITLE
chore: only override weights for new node ids

### DIFF
--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -18,6 +18,8 @@ nodes.enableDAB=true
 blockStream.blockFileDir=data/blockStreams
 addressBook.useRosterLifecycle=true
 grpc.nodeOperatorPortEnabled=true
+# For CI tests we want to override roster weights from override-network.json
+networkAdmin.preserveStateWeightsDuringOverride=false
 # (FUTURE) Remove this when roster lifecycle is permanently adopted; used to simplify
 # the transition to the new roster lifecycle by always exporting both config.txt and
 # candidate-roster.json on handling a PREPARE_UPGRADE transaction

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/RosterTransplantSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/RosterTransplantSchema.java
@@ -1,8 +1,27 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.node.app.roster.schemas;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.node.app.roster.RosterService;
 import com.swirlds.platform.config.AddressBookConfig;
 import com.swirlds.platform.roster.RosterUtils;
@@ -11,6 +30,8 @@ import com.swirlds.state.lifecycle.MigrationContext;
 import com.swirlds.state.lifecycle.Schema;
 import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Map;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -41,12 +62,33 @@ public interface RosterTransplantSchema {
                 final long activeRoundNumber = roundNumber + 1;
                 log.info("Adopting roster from override network in round {}", activeRoundNumber);
                 final var rosterStore = rosterStoreFactory.apply(ctx.newStates());
-                final var roster = RosterUtils.rosterFrom(network);
+                final var roster =
+                        withExtantNodeWeights(RosterUtils.rosterFrom(network), rosterStore.getActiveRoster());
                 rosterStore.putActiveRoster(roster, activeRoundNumber);
                 startupNetworks.setOverrideRound(roundNumber);
             });
             return overrideNetwork.isPresent();
         }
         return false;
+    }
+
+    /**
+     * If there are weights to copy to the first roster from the (possibly null) second roster, then does so and
+     * returns a new roster with the result.
+     * @param to the roster to copy weights to
+     * @param from the roster to copy weights from
+     * @return a roster with any weights copied by matching node id
+     */
+    private static Roster withExtantNodeWeights(@NonNull final Roster to, @Nullable final Roster from) {
+        if (from == null) {
+            return to;
+        }
+        final Map<Long, Long> fromNodeWeights =
+                from.rosterEntries().stream().collect(toMap(RosterEntry::nodeId, RosterEntry::weight));
+        return new Roster(to.rosterEntries().stream()
+                .map(entry -> entry.copyBuilder()
+                        .weight(fromNodeWeights.getOrDefault(entry.nodeId(), entry.weight()))
+                        .build())
+                .collect(toList()));
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/MerkleStateLifecyclesImpl.java
@@ -16,16 +16,10 @@
 
 package com.hedera.node.app.state;
 
-import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.STAKING_INFO_KEY;
 import static java.util.Objects.requireNonNull;
 
-import com.hedera.hapi.node.state.common.EntityNumber;
-import com.hedera.hapi.node.state.token.StakingNodeInfo;
 import com.hedera.node.app.Hedera;
-import com.hedera.node.app.service.token.TokenService;
 import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.platform.NodeId;
-import com.swirlds.common.threading.manager.AdHocThreadManager;
 import com.swirlds.platform.state.MerkleStateLifecycles;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
@@ -35,58 +29,17 @@ import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.Event;
 import com.swirlds.state.State;
 import com.swirlds.state.merkle.MerkleStateRoot;
-import com.swirlds.state.merkle.disk.OnDiskKey;
-import com.swirlds.state.merkle.disk.OnDiskValue;
-import com.swirlds.virtualmap.VirtualMap;
-import com.swirlds.virtualmap.VirtualMapMigration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.function.BiConsumer;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
- * Implements the major lifecycle events for Hedera Services, primarily by delegating to a Hedera instance.
+ * Implements the major lifecycle events for Hedera Services by delegating to a Hedera instance.
  */
 public class MerkleStateLifecyclesImpl implements MerkleStateLifecycles {
-    private static final Logger logger = LogManager.getLogger(MerkleStateLifecyclesImpl.class);
-
-    private static final BiConsumer<
-                    VirtualMap<OnDiskKey<EntityNumber>, OnDiskValue<StakingNodeInfo>>,
-                    BiConsumer<EntityNumber, StakingNodeInfo>>
-            WEIGHT_UPDATE_VISITOR = (map, visitor) -> {
-                try {
-                    VirtualMapMigration.extractVirtualMapData(
-                            AdHocThreadManager.getStaticThreadManager(),
-                            map,
-                            pair -> visitor.accept(
-                                    pair.key().getKey(), pair.value().getValue()),
-                            1);
-                } catch (InterruptedException e) {
-                    logger.error("Interrupted while updating weights", e);
-                    throw new IllegalStateException(e);
-                }
-            };
-
     private final Hedera hedera;
-    private final BiConsumer<
-                    VirtualMap<OnDiskKey<EntityNumber>, OnDiskValue<StakingNodeInfo>>,
-                    BiConsumer<EntityNumber, StakingNodeInfo>>
-            weightUpdateVisitor;
 
     public MerkleStateLifecyclesImpl(@NonNull final Hedera hedera) {
-        this(hedera, WEIGHT_UPDATE_VISITOR);
-    }
-
-    public MerkleStateLifecyclesImpl(
-            @NonNull final Hedera hedera,
-            @NonNull
-                    final BiConsumer<
-                                    VirtualMap<OnDiskKey<EntityNumber>, OnDiskValue<StakingNodeInfo>>,
-                                    BiConsumer<EntityNumber, StakingNodeInfo>>
-                            weightUpdateVisitor) {
         this.hedera = requireNonNull(hedera);
-        this.weightUpdateVisitor = requireNonNull(weightUpdateVisitor);
     }
 
     @Override
@@ -120,36 +73,7 @@ public class MerkleStateLifecyclesImpl implements MerkleStateLifecycles {
             @NonNull final MerkleStateRoot stateRoot,
             @NonNull final AddressBook configAddressBook,
             @NonNull final PlatformContext context) {
-        // Get all nodeIds added in the config.txt
-        final var nodeIdsLeftToUpdate = configAddressBook.getNodeIdSet();
-        final var stakingInfoIndex = stateRoot.findNodeIndex(TokenService.NAME, STAKING_INFO_KEY);
-        if (stakingInfoIndex == -1) {
-            logger.warn("Staking info not found in state, skipping weight update");
-            return;
-        }
-        @SuppressWarnings("unchecked")
-        final var stakingInfoVMap = (VirtualMap<OnDiskKey<EntityNumber>, OnDiskValue<StakingNodeInfo>>)
-                stateRoot.getChild(stakingInfoIndex);
-        // Since it is much easier to modify the in-state staking info after schemas
-        // are registered with MerkleStateRoot, we do that work later in the token
-        // service schema's restart() hook. Here we only update the address book weights
-        // based on the staking info in the state.
-        weightUpdateVisitor.accept(stakingInfoVMap, (node, info) -> {
-            final var nodeId = NodeId.of(node.number());
-            // If present in the address book, remove this node id from the
-            // set of node ids left to update and update its weight
-            if (nodeIdsLeftToUpdate.remove(nodeId)) {
-                configAddressBook.updateWeight(nodeId, info.weight());
-            } else {
-                logger.info(
-                        "Node {} is no longer in address book; restart() will ensure its staking info is marked deleted",
-                        nodeId);
-            }
-        });
-        nodeIdsLeftToUpdate.forEach(nodeId -> {
-            configAddressBook.updateWeight(nodeId, 0);
-            logger.info("Found new node {}; restart() will add its staking info", nodeId);
-        });
+        // No-op
     }
 
     @Override

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.node.app.roster.schemas;
 
 import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
@@ -267,6 +282,26 @@ class V0540RosterSchemaTest {
         subject.restart(ctx);
 
         verify(rosterStore).putActiveRoster(ROSTER, ROUND_NO + 1L);
+        verify(startupNetworks).setOverrideRound(ROUND_NO);
+    }
+
+    @Test
+    void restartSetsActiveRosterFromOverrideWithPreservedWeightsIfPresent() {
+        given(ctx.appConfig()).willReturn(WITH_ROSTER_LIFECYCLE);
+        given(ctx.startupNetworks()).willReturn(startupNetworks);
+        given(ctx.roundNumber()).willReturn(ROUND_NO);
+        given(ctx.newStates()).willReturn(writableStates);
+        given(rosterStoreFactory.apply(writableStates)).willReturn(rosterStore);
+        given(rosterStore.getActiveRoster())
+                .willReturn(new Roster(
+                        List.of(RosterEntry.newBuilder().nodeId(1L).weight(42L).build())));
+        given(startupNetworks.overrideNetworkFor(ROUND_NO)).willReturn(Optional.of(NETWORK));
+        final var adaptedRoster = new Roster(
+                List.of(RosterEntry.newBuilder().nodeId(1L).weight(42L).build()));
+
+        subject.restart(ctx);
+
+        verify(rosterStore).putActiveRoster(adaptedRoster, ROUND_NO + 1L);
         verify(startupNetworks).setOverrideRound(ROUND_NO);
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/MerkleStateLifecyclesImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/MerkleStateLifecyclesImplTest.java
@@ -16,33 +16,19 @@
 
 package com.hedera.node.app.state;
 
-import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.STAKING_INFO_KEY;
-import static com.swirlds.platform.test.fixtures.addressbook.AddresBookUtils.createPretendBookFrom;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.hedera.hapi.node.state.common.EntityNumber;
-import com.hedera.hapi.node.state.token.StakingNodeInfo;
 import com.hedera.node.app.Hedera;
-import com.hedera.node.app.service.token.TokenService;
 import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.Round;
+import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.Event;
 import com.swirlds.platform.test.fixtures.state.MerkleTestBase;
 import com.swirlds.state.merkle.MerkleStateRoot;
-import com.swirlds.state.merkle.disk.OnDiskKey;
-import com.swirlds.state.merkle.disk.OnDiskValue;
-import com.swirlds.virtualmap.VirtualMap;
-import java.util.NoSuchElementException;
-import java.util.function.BiConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,8 +37,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MerkleStateLifecyclesImplTest extends MerkleTestBase {
-    private static final int PRETEND_STAKING_INFO_CHILD_INDEX = 7;
-
     @Mock
     private Hedera hedera;
 
@@ -71,17 +55,11 @@ class MerkleStateLifecyclesImplTest extends MerkleTestBase {
     @Mock
     private MerkleStateRoot merkleStateRoot;
 
-    @Mock
-    private BiConsumer<
-                    VirtualMap<OnDiskKey<EntityNumber>, OnDiskValue<StakingNodeInfo>>,
-                    BiConsumer<EntityNumber, StakingNodeInfo>>
-            weightUpdateVisitor;
-
     private MerkleStateLifecyclesImpl subject;
 
     @BeforeEach
     void setUp() {
-        subject = new MerkleStateLifecyclesImpl(hedera, weightUpdateVisitor);
+        subject = new MerkleStateLifecyclesImpl(hedera);
     }
 
     @Test
@@ -113,189 +91,7 @@ class MerkleStateLifecyclesImplTest extends MerkleTestBase {
     }
 
     @Test
-    void updatesAddressBookWithZeroWeightOnGenesisStart() {
-        final var node0 = NodeId.of(0);
-        final var node1 = NodeId.of(1);
-        given(platform.getSelfId()).willReturn(node0);
-
-        final var pretendAddressBook = createPretendBookFrom(platform, true);
-
-        assertEquals(10L, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(10L, pretendAddressBook.getAddress(node1).getWeight());
-
-        subject.onUpdateWeight(merkleStateRoot, pretendAddressBook, platform.getContext());
-
-        // if staking info map has node with 0 weight and a new node is added,
-        // both gets weight of 0
-        assertEquals(0L, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(0L, pretendAddressBook.getAddress(node1).getWeight());
-    }
-
-    @Test
-    void updatesAddressBookWithZeroWeightForNewNodes() {
-        final var node0 = NodeId.of(0);
-        final var node1 = NodeId.of(1);
-        given(platform.getSelfId()).willReturn(node0);
-        final var pretendAddressBook = createPretendBookFrom(platform, true);
-        given(merkleStateRoot.findNodeIndex(TokenService.NAME, STAKING_INFO_KEY))
-                .willReturn(PRETEND_STAKING_INFO_CHILD_INDEX);
-        doAnswer(invocationOnMock -> {
-                    final BiConsumer<EntityNumber, StakingNodeInfo> visitor = invocationOnMock.getArgument(1);
-                    visitor.accept(
-                            EntityNumber.newBuilder().number(0L).build(),
-                            StakingNodeInfo.newBuilder()
-                                    .nodeNumber(0L)
-                                    .stake(1000L)
-                                    .weight(500)
-                                    .build());
-                    return null;
-                })
-                .when(weightUpdateVisitor)
-                .accept(any(), any());
-
-        subject.onUpdateWeight(merkleStateRoot, pretendAddressBook, platform.getContext());
-
-        // if staking info map has node with 0 weight and a new node is added,
-        // new nodes gets weight of 0
-        assertEquals(500, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(0L, pretendAddressBook.getAddress(node1).getWeight());
-    }
-
-    @Test
-    void doesntUpdateAddressBookIfNodeIdFromStateDoesntExist() {
-        final var node0 = NodeId.of(0);
-        final var node1 = NodeId.of(1);
-        final var node2 = NodeId.of(2);
-        given(platform.getSelfId()).willReturn(node0);
-
-        final var pretendAddressBook = createPretendBookFrom(platform, true);
-        given(merkleStateRoot.findNodeIndex(TokenService.NAME, STAKING_INFO_KEY))
-                .willReturn(PRETEND_STAKING_INFO_CHILD_INDEX);
-        doAnswer(invocationOnMock -> {
-                    final BiConsumer<EntityNumber, StakingNodeInfo> visitor = invocationOnMock.getArgument(1);
-                    visitor.accept(
-                            EntityNumber.newBuilder().number(0L).build(),
-                            StakingNodeInfo.newBuilder()
-                                    .nodeNumber(0L)
-                                    .stake(1000L)
-                                    .weight(100)
-                                    .build());
-                    visitor.accept(
-                            EntityNumber.newBuilder().number(1L).build(),
-                            StakingNodeInfo.newBuilder()
-                                    .nodeNumber(1L)
-                                    .stake(1000L)
-                                    .weight(200)
-                                    .build());
-                    visitor.accept(
-                            EntityNumber.newBuilder().number(2L).build(),
-                            StakingNodeInfo.newBuilder()
-                                    .nodeNumber(2L)
-                                    .stake(1000L)
-                                    .weight(200)
-                                    .build());
-                    return null;
-                })
-                .when(weightUpdateVisitor)
-                .accept(any(), any());
-        // there is no node2 in the addressBook
-        assertEquals(10L, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(10L, pretendAddressBook.getAddress(node1).getWeight());
-        assertThrows(NoSuchElementException.class, () -> pretendAddressBook.getAddress(node2));
-
-        assertDoesNotThrow(() -> subject.onUpdateWeight(merkleStateRoot, pretendAddressBook, platform.getContext()));
-
-        // if staking info map has node with 0 weight and a new node is added,
-        // new nodes gets weight of 0
-        assertEquals(100, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(200, pretendAddressBook.getAddress(node1).getWeight());
-        assertThrows(NoSuchElementException.class, () -> pretendAddressBook.getAddress(node2));
-    }
-
-    @Test
-    void updatesAddressBookWithNonZeroWeightsOnGenesisStartIfStakesExist() {
-        final var node0 = NodeId.of(0);
-        final var node1 = NodeId.of(1);
-        given(platform.getSelfId()).willReturn(node0);
-
-        final var pretendAddressBook = createPretendBookFrom(platform, true);
-        given(merkleStateRoot.findNodeIndex(TokenService.NAME, STAKING_INFO_KEY))
-                .willReturn(PRETEND_STAKING_INFO_CHILD_INDEX);
-        doAnswer(invocationOnMock -> {
-                    final BiConsumer<EntityNumber, StakingNodeInfo> visitor = invocationOnMock.getArgument(1);
-                    visitor.accept(
-                            EntityNumber.newBuilder().number(0L).build(),
-                            StakingNodeInfo.newBuilder()
-                                    .nodeNumber(0L)
-                                    .stake(1000L)
-                                    .weight(250)
-                                    .build());
-                    visitor.accept(
-                            EntityNumber.newBuilder().number(1L).build(),
-                            StakingNodeInfo.newBuilder()
-                                    .nodeNumber(0L)
-                                    .stake(1000L)
-                                    .weight(250)
-                                    .build());
-                    return null;
-                })
-                .when(weightUpdateVisitor)
-                .accept(any(), any());
-
-        assertEquals(10L, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(10L, pretendAddressBook.getAddress(node1).getWeight());
-
-        subject.onUpdateWeight(merkleStateRoot, pretendAddressBook, platform.getContext());
-
-        // if staking info map has node with 250L weight and a new node is added,
-        // both gets weight of 250L
-        assertEquals(250L, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(250L, pretendAddressBook.getAddress(node1).getWeight());
-    }
-
-    @Test
-    void marksNonExistingNodesToDeletedInStateAndAddsNewNodesToState() {
-        given(merkleStateRoot.findNodeIndex(TokenService.NAME, STAKING_INFO_KEY))
-                .willReturn(PRETEND_STAKING_INFO_CHILD_INDEX);
-        doAnswer(invocationOnMock -> {
-                    final BiConsumer<EntityNumber, StakingNodeInfo> visitor = invocationOnMock.getArgument(1);
-                    visitor.accept(
-                            EntityNumber.newBuilder().number(2L).build(),
-                            StakingNodeInfo.newBuilder()
-                                    .nodeNumber(2L)
-                                    .stake(1000L)
-                                    .weight(250)
-                                    .build());
-                    visitor.accept(
-                            EntityNumber.newBuilder().number(1L).build(),
-                            StakingNodeInfo.newBuilder()
-                                    .nodeNumber(1L)
-                                    .stake(1000L)
-                                    .weight(250)
-                                    .build());
-                    return null;
-                })
-                .when(weightUpdateVisitor)
-                .accept(any(), any());
-
-        final var node0 = NodeId.of(0);
-        final var node1 = NodeId.of(1);
-
-        given(platform.getSelfId()).willReturn(node0);
-
-        // platform addressBook has nodes 0, 1
-        final var pretendAddressBook = createPretendBookFrom(platform, true);
-        // stakingInfo has 1, 2
-        assertEquals(10L, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(10L, pretendAddressBook.getAddress(node1).getWeight());
-
-        subject.onUpdateWeight(merkleStateRoot, pretendAddressBook, platformContext);
-
-        // node 0 is added so the weight of new node is 0
-        // node 1 weight will be updated
-        // node 2 is deleted so , it is marked deleted weight will be 0
-
-        assertEquals(0L, pretendAddressBook.getAddress(node0).getWeight());
-        assertEquals(250L, pretendAddressBook.getAddress(node1).getWeight());
+    void onUpdateWeightIsNoop() {
+        assertDoesNotThrow(() -> subject.onUpdateWeight(merkleStateRoot, mock(AddressBook.class), platformContext));
     }
 }

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.node.config.data;
 
 import com.hedera.node.config.NetworkProperty;
@@ -35,4 +50,5 @@ public record NetworkAdminConfig(
         @ConfigProperty(defaultValue = "network.json") @NodeProperty String diskNetworkExportFile,
         @ConfigProperty(defaultValue = "NEVER") DiskNetworkExport diskNetworkExport,
         @ConfigProperty(defaultValue = "false") @NodeProperty boolean exportCandidateRoster,
-        @ConfigProperty(defaultValue = "candidate-roster.json") @NodeProperty String candidateRosterExportFile) {}
+        @ConfigProperty(defaultValue = "candidate-roster.json") @NodeProperty String candidateRosterExportFile,
+        @ConfigProperty(defaultValue = "true") @NodeProperty boolean preserveStateWeightsDuringOverride) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateLifecycles.java
@@ -74,13 +74,15 @@ public interface MerkleStateLifecycles {
             @Nullable SoftwareVersion previousVersion);
 
     /**
-     * Called when the platform needs to update the weights in the network
-     * address book
+     * Called when the platform needs to update the weights in the network address book; deprecated since 0.58
+     * because the application now directly decides what weights to put in address book (or, once roster lifecycle
+     * is fully enabled, the roster).
      *
      * @param state the working state of the network
      * @param configAddressBook the address book used to configure the network
      * @param context the current platform context
      */
+    @Deprecated(forRemoval = true)
     void onUpdateWeight(
             @NonNull MerkleStateRoot state, @NonNull AddressBook configAddressBook, @NonNull PlatformContext context);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/schemas/V058RosterLifecycleTransitionSchema.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/schemas/V058RosterLifecycleTransitionSchema.java
@@ -26,11 +26,15 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.config.AddressBookConfig;
 import com.swirlds.platform.state.service.WritablePlatformStateStore;
 import com.swirlds.platform.system.SoftwareVersion;
+import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.state.lifecycle.MigrationContext;
 import com.swirlds.state.lifecycle.Schema;
 import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -79,18 +83,44 @@ public class V058RosterLifecycleTransitionSchema extends Schema {
         requireNonNull(ctx);
         final var addressBookConfig = ctx.appConfig().getConfigData(AddressBookConfig.class);
         if (!addressBookConfig.useRosterLifecycle() && !ctx.isGenesis()) {
-            final boolean addressBookChanged = ctx.isUpgrade(
-                            config -> new Semver(appVersionFn.apply(config).getPbjSemanticVersion()), Semver::new)
-                    || addressBookConfig.forceUseOfConfigAddressBook();
+            final boolean isOverride = addressBookConfig.forceUseOfConfigAddressBook();
+            final boolean addressBookChanged = isOverride
+                    || ctx.isUpgrade(
+                            config -> new Semver(appVersionFn.apply(config).getPbjSemanticVersion()), Semver::new);
             if (addressBookChanged) {
                 final var stateStore = platformStateStoreFn.apply(ctx.newStates());
                 final var currentBook = stateStore.getAddressBook();
+                final var diskBook = requireNonNull(addressBook.get()).copy();
+                final var nextBook = isOverride ? withExtantNodeWeights(diskBook, currentBook) : diskBook;
                 stateStore.bulkUpdate(v -> {
                     v.setPreviousAddressBook(currentBook == null ? null : currentBook.copy());
-                    v.setAddressBook(requireNonNull(addressBook.get()).copy());
+                    v.setAddressBook(nextBook);
                 });
             }
         }
+    }
+
+    /**
+     * If there are weights to copy to the first address book from the (possibly null) second address book,
+     * then does so and returns a new address book with the result.
+     * @param to the address book to copy weights to
+     * @param from the address book to copy weights from
+     * @return a address book with any weights copied by matching node id
+     */
+    private AddressBook withExtantNodeWeights(@NonNull final AddressBook to, @Nullable final AddressBook from) {
+        if (from == null) {
+            return to;
+        }
+        final List<Address> addresses = new ArrayList<>();
+        for (final var toAddress : to) {
+            if (from.contains(toAddress.getNodeId())) {
+                final var fromAddress = from.getAddress(toAddress.getNodeId());
+                addresses.add(toAddress.copySetWeight(fromAddress.getWeight()));
+            } else {
+                addresses.add(toAddress);
+            }
+        }
+        return new AddressBook(addresses);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/schemas/V058RosterLifecycleTransitionSchemaTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/schemas/V058RosterLifecycleTransitionSchemaTest.java
@@ -17,20 +17,25 @@
 package com.swirlds.platform.state.service.schemas;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.hapi.platform.state.PlatformState;
+import com.swirlds.common.platform.NodeId;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.config.AddressBookConfig;
 import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.service.WritablePlatformStateStore;
 import com.swirlds.platform.system.SoftwareVersion;
+import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.state.lifecycle.MigrationContext;
 import com.swirlds.state.spi.WritableSingletonState;
 import com.swirlds.state.spi.WritableStates;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
@@ -129,7 +134,7 @@ class V058RosterLifecycleTransitionSchemaTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void changesWhenForced() {
+    void changesWhenForcedWithoutExtantBook() {
         final ArgumentCaptor<Consumer<PlatformStateModifier>> captor = ArgumentCaptor.forClass(Consumer.class);
         given(ctx.appConfig()).willReturn(config);
         given(config.getConfigData(AddressBookConfig.class)).willReturn(addressBookConfig);
@@ -142,5 +147,37 @@ class V058RosterLifecycleTransitionSchemaTest {
         captor.getValue().accept(platformStateStore);
         verify(platformStateStore).setPreviousAddressBook(null);
         verify(platformStateStore).setAddressBook(addressBook);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void changesWhenForcedWithExtantBook() {
+        final ArgumentCaptor<Consumer<PlatformStateModifier>> captor = ArgumentCaptor.forClass(Consumer.class);
+        given(ctx.appConfig()).willReturn(config);
+        given(config.getConfigData(AddressBookConfig.class)).willReturn(addressBookConfig);
+        given(addressBookConfig.forceUseOfConfigAddressBook()).willReturn(true);
+        given(addressBook.copy()).willReturn(addressBook);
+        final var matchingAddress = mock(Address.class);
+        final var matchingNodeId = NodeId.of(42L);
+        final var matchingWeight = 42L;
+        given(matchingAddress.getNodeId()).willReturn(matchingNodeId);
+        final var newAddress = mock(Address.class);
+        given(newAddress.getNodeId()).willReturn(NodeId.of(43L));
+        given(addressBook.iterator())
+                .willReturn(List.of(matchingAddress, newAddress).iterator());
+        given(ctx.newStates()).willReturn(writableStates);
+        given(platformStateStoreFn.apply(writableStates)).willReturn(platformStateStore);
+        final var currentBook = mock(AddressBook.class);
+        given(currentBook.copy()).willReturn(currentBook);
+        given(currentBook.contains(matchingNodeId)).willReturn(true);
+        given(currentBook.getAddress(matchingNodeId)).willReturn(matchingAddress);
+        given(matchingAddress.getWeight()).willReturn(matchingWeight);
+        given(matchingAddress.copySetWeight(matchingWeight)).willReturn(matchingAddress);
+        given(platformStateStore.getAddressBook()).willReturn(currentBook);
+        subject.restart(ctx);
+        verify(platformStateStore).bulkUpdate(captor.capture());
+        captor.getValue().accept(platformStateStore);
+        verify(platformStateStore).setPreviousAddressBook(currentBook);
+        verify(platformStateStore).setAddressBook(argThat(book -> book.getSize() == 2));
     }
 }


### PR DESCRIPTION
**Description**:
 - Closes #17171 
 - Makes `MerkleStateLifecyclesImpl#onUpdateWeight()` an explicit no-op since it no longer affects startup phase state changes.