### PR TITLE
chore: Refactor InvalidRosterException to be a checked exception

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/RosterTransplantSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/RosterTransplantSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,8 @@ public interface RosterTransplantSchema {
      */
     default boolean restart(
             @NonNull final MigrationContext ctx,
-            @NonNull final Function<WritableStates, WritableRosterStore> rosterStoreFactory) throws InvalidRosterException {
+            @NonNull final Function<WritableStates, WritableRosterStore> rosterStoreFactory)
+            throws InvalidRosterException {
         requireNonNull(ctx);
         if (ctx.appConfig().getConfigData(AddressBookConfig.class).useRosterLifecycle()) {
             final long roundNumber = ctx.roundNumber();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.node.app.roster.schemas;
 
 import static java.util.Objects.requireNonNull;
@@ -117,8 +132,8 @@ public class V0540RosterSchema extends Schema implements RosterTransplantSchema 
                     }
                 }
             }
-        } catch (InvalidRosterException e) {
-            throw new RuntimeException("Invalid roster", e);
+        } catch (final InvalidRosterException e) {
+            throw new IllegalArgumentException("Invalid roster", e);
         }
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
@@ -30,6 +30,7 @@ import com.swirlds.platform.state.service.WritableRosterStore;
 import com.swirlds.platform.state.service.schemas.V0540RosterBaseSchema;
 import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.MigrationContext;
+import com.swirlds.state.lifecycle.RestartException;
 import com.swirlds.state.lifecycle.Schema;
 import com.swirlds.state.lifecycle.StateDefinition;
 import com.swirlds.state.spi.WritableStates;
@@ -102,7 +103,7 @@ public class V0540RosterSchema extends Schema implements RosterTransplantSchema 
     }
 
     @Override
-    public void restart(@NonNull final MigrationContext ctx) {
+    public void restart(@NonNull final MigrationContext ctx) throws RestartException {
         requireNonNull(ctx);
         try {
             if (!RosterTransplantSchema.super.restart(ctx, rosterStoreFactory)
@@ -133,7 +134,7 @@ public class V0540RosterSchema extends Schema implements RosterTransplantSchema 
                 }
             }
         } catch (final InvalidRosterException e) {
-            throw new IllegalArgumentException("Invalid roster", e);
+            throw new RestartException("Invalid roster", e);
         }
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/StakePeriodChanges.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/StakePeriodChanges.java
@@ -144,8 +144,8 @@ public class StakePeriodChanges {
                     startKeyingCandidateRoster(dispatch.handleContext(), newWritableRosterStore(stack, config));
                 }
             } catch (final InvalidRosterException e) {
-                logger.error("CATASTROPHIC failure loading candidate roster", e);
-                stack.rollbackFullStack();
+                // Do not rollback
+                logger.error("Failure loading candidate roster", e);
             }
         }
         return !isGenesis && isStakePeriodBoundary;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/StakePeriodChanges.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/StakePeriodChanges.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,7 +193,8 @@ public class StakePeriodChanges {
     }
 
     private void startKeyingCandidateRoster(
-            @NonNull final HandleContext handleContext, @NonNull final WritableRosterStore rosterStore) throws InvalidRosterException {
+            @NonNull final HandleContext handleContext, @NonNull final WritableRosterStore rosterStore)
+            throws InvalidRosterException {
         final var storeFactory = handleContext.storeFactory();
         final var nodeStore = storeFactory.readableStore(ReadableNodeStore.class);
         final var roster = nodeStore.snapshotOfFutureRoster();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
@@ -38,6 +38,7 @@ import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.node.internal.network.Network;
 import com.hedera.node.internal.network.NodeMetadata;
 import com.swirlds.common.RosterStateId;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.service.PbjConverter;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.ReadablePlatformStateStore;
@@ -147,7 +148,7 @@ class V0540RosterSchemaTest {
     }
 
     @Test
-    void usesGenesisRosterIfLifecycleEnabledAndApropros() {
+    void usesGenesisRosterIfLifecycleEnabledAndApropros() throws InvalidRosterException {
         given(ctx.appConfig()).willReturn(WITH_ROSTER_LIFECYCLE);
         given(ctx.newStates()).willReturn(writableStates);
         given(ctx.isGenesis()).willReturn(true);
@@ -162,7 +163,7 @@ class V0540RosterSchemaTest {
     }
 
     @Test
-    void usesAdaptedAddressBookAndMigrationRosterIfLifecycleEnabledIfApropos() {
+    void usesAdaptedAddressBookAndMigrationRosterIfLifecycleEnabledIfApropos() throws InvalidRosterException {
         given(ctx.appConfig()).willReturn(WITH_ROSTER_LIFECYCLE);
         given(ctx.newStates()).willReturn(writableStates);
         given(ctx.startupNetworks()).willReturn(startupNetworks);
@@ -243,7 +244,7 @@ class V0540RosterSchemaTest {
     }
 
     @Test
-    void adoptsCandidateRosterIfTestPasses() {
+    void adoptsCandidateRosterIfTestPasses() throws InvalidRosterException {
         given(ctx.appConfig()).willReturn(WITH_ROSTER_LIFECYCLE);
         given(ctx.newStates()).willReturn(writableStates);
         given(ctx.startupNetworks()).willReturn(startupNetworks);
@@ -271,7 +272,7 @@ class V0540RosterSchemaTest {
     }
 
     @Test
-    void restartSetsActiveRosterFromOverrideIfPresent() {
+    void restartSetsActiveRosterFromOverrideIfPresent() throws InvalidRosterException {
         given(ctx.appConfig()).willReturn(WITH_ROSTER_LIFECYCLE);
         given(ctx.startupNetworks()).willReturn(startupNetworks);
         given(ctx.roundNumber()).willReturn(ROUND_NO);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
@@ -287,7 +287,7 @@ class V0540RosterSchemaTest {
     }
 
     @Test
-    void restartSetsActiveRosterFromOverrideWithPreservedWeightsIfPresent() {
+    void restartSetsActiveRosterFromOverrideWithPreservedWeightsIfPresent() throws InvalidRosterException {
         given(ctx.appConfig()).willReturn(WITH_ROSTER_LIFECYCLE);
         given(ctx.startupNetworks()).willReturn(startupNetworks);
         given(ctx.roundNumber()).willReturn(ROUND_NO);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -42,6 +42,7 @@ import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.config.StateConfig_;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.InitTrigger;
@@ -193,7 +194,7 @@ class SerializationTest extends MerkleTestBase {
      */
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void simpleReadAndWrite(boolean forceFlush) throws IOException, ConstructableRegistryException {
+    void simpleReadAndWrite(boolean forceFlush) throws IOException, ConstructableRegistryException, InvalidRosterException {
         final var schemaV1 = createV1Schema();
         final var originalTree = createMerkleHederaState(schemaV1);
 
@@ -217,7 +218,7 @@ class SerializationTest extends MerkleTestBase {
     }
 
     @Test
-    void snapshot() throws IOException {
+    void snapshot() throws IOException, InvalidRosterException {
         final var schemaV1 = createV1Schema();
         final var originalTree = createMerkleHederaState(schemaV1);
         final var tempDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory(config);
@@ -257,7 +258,7 @@ class SerializationTest extends MerkleTestBase {
      * After it gets saved to disk again, and then loaded back in, it results in ClassCastException due to incorrect classId.
      */
     @Test
-    void dualReadAndWrite() throws IOException, ConstructableRegistryException {
+    void dualReadAndWrite() throws IOException, ConstructableRegistryException, InvalidRosterException {
         final var schemaV1 = createV1Schema();
         final var originalTree = createMerkleHederaState(schemaV1);
 
@@ -322,7 +323,7 @@ class SerializationTest extends MerkleTestBase {
         loadedTree.migrate(MerkleStateRoot.CURRENT_VERSION);
     }
 
-    private PlatformMerkleStateRoot createMerkleHederaState(Schema schemaV1) {
+    private PlatformMerkleStateRoot createMerkleHederaState(Schema schemaV1) throws InvalidRosterException {
         final SignedState randomState =
                 new RandomSignedStateGenerator().setRound(1).build();
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -194,7 +194,8 @@ class SerializationTest extends MerkleTestBase {
      */
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void simpleReadAndWrite(boolean forceFlush) throws IOException, ConstructableRegistryException, InvalidRosterException {
+    void simpleReadAndWrite(boolean forceFlush)
+            throws IOException, ConstructableRegistryException, InvalidRosterException {
         final var schemaV1 = createV1Schema();
         final var originalTree = createMerkleHederaState(schemaV1);
 
@@ -323,7 +324,7 @@ class SerializationTest extends MerkleTestBase {
         loadedTree.migrate(MerkleStateRoot.CURRENT_VERSION);
     }
 
-    private PlatformMerkleStateRoot createMerkleHederaState(Schema schemaV1) throws InvalidRosterException {
+    private PlatformMerkleStateRoot createMerkleHederaState(Schema schemaV1) {
         final SignedState randomState =
                 new RandomSignedStateGenerator().setRound(1).build();
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -42,7 +42,6 @@ import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.config.StateConfig_;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.InitTrigger;
@@ -194,8 +193,7 @@ class SerializationTest extends MerkleTestBase {
      */
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    void simpleReadAndWrite(boolean forceFlush)
-            throws IOException, ConstructableRegistryException, InvalidRosterException {
+    void simpleReadAndWrite(boolean forceFlush) throws IOException, ConstructableRegistryException {
         final var schemaV1 = createV1Schema();
         final var originalTree = createMerkleHederaState(schemaV1);
 
@@ -219,7 +217,7 @@ class SerializationTest extends MerkleTestBase {
     }
 
     @Test
-    void snapshot() throws IOException, InvalidRosterException {
+    void snapshot() throws IOException {
         final var schemaV1 = createV1Schema();
         final var originalTree = createMerkleHederaState(schemaV1);
         final var tempDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory(config);
@@ -259,7 +257,7 @@ class SerializationTest extends MerkleTestBase {
      * After it gets saved to disk again, and then loaded back in, it results in ClassCastException due to incorrect classId.
      */
     @Test
-    void dualReadAndWrite() throws IOException, ConstructableRegistryException, InvalidRosterException {
+    void dualReadAndWrite() throws IOException, ConstructableRegistryException {
         final var schemaV1 = createV1Schema();
         final var originalTree = createMerkleHederaState(schemaV1);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/TssBaseServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/TssBaseServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/TssBaseServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/TssBaseServiceTest.java
@@ -18,7 +18,6 @@ package com.hedera.node.app.tss;
 
 import static com.hedera.node.app.tss.handlers.TssShareSignatureHandlerTest.PRIVATE_KEY;
 import static com.hedera.node.app.tss.handlers.TssShareSignatureHandlerTest.PUBLIC_KEY;
-import static com.hedera.node.app.tss.handlers.TssShareSignatureHandlerTest.TSS_KEYS;
 import static com.hedera.node.app.workflows.handle.steps.NodeStakeUpdatesTest.RosterCase.ACTIVE_ROSTER;
 import static com.hedera.node.app.workflows.handle.steps.NodeStakeUpdatesTest.RosterCase.CURRENT_CANDIDATE_ROSTER;
 import static com.hedera.node.app.workflows.handle.steps.NodeStakeUpdatesTest.RosterCase.ROSTER_NODE_1;
@@ -49,6 +48,7 @@ import com.hedera.node.app.tss.stores.ReadableTssStore;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.service.ReadableRosterStore;
 import com.swirlds.platform.state.service.WritableRosterStore;
 import com.swirlds.state.lifecycle.info.NetworkInfo;
@@ -140,7 +140,7 @@ public class TssBaseServiceTest {
 
     @Test
     @DisplayName("Service won't set the current candidate roster as the new candidate roster")
-    void doesntSetSameCandidateRoster() {
+    void doesntSetSameCandidateRoster() throws InvalidRosterException {
         given(storeFactory.readableStore(ReadableTssStore.class)).willReturn(readableTssStore);
         // Simulate CURRENT_CANDIDATE_ROSTER and ACTIVE_ROSTER
         mockWritableRosterStore();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/tss/RekeyScenarioOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/tss/RekeyScenarioOp.java
@@ -460,7 +460,7 @@ public class RekeyScenarioOp extends UtilOp implements BlockStreamAssertion {
         try {
             rosterStore.putActiveRoster(roster, roundNumber);
         } catch (final InvalidRosterException e) {
-            throw new IllegalArgumentException("Invalid roster", e);
+            throw new IllegalStateException("Invalid roster", e);
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/tss/RekeyScenarioOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/tss/RekeyScenarioOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -460,8 +460,7 @@ public class RekeyScenarioOp extends UtilOp implements BlockStreamAssertion {
         try {
             rosterStore.putActiveRoster(roster, roundNumber);
         } catch (final InvalidRosterException e) {
-            //
-            throw new RuntimeException("Roster is invalid", e);
+            throw new IllegalArgumentException("Invalid roster", e);
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/InvalidRosterException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/InvalidRosterException.java
@@ -19,12 +19,12 @@ package com.swirlds.platform.roster;
 /**
  * An exception thrown by the RosterValidator when a given Roster is invalid.
  */
-public class InvalidRosterException extends RuntimeException {
+public class InvalidRosterException extends Exception {
     /**
      * A default constructor.
      * @param message a message
      */
-    public InvalidRosterException(String message) {
+    public InvalidRosterException(final String message) {
         super(message);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/InvalidRosterException.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/InvalidRosterException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package com.swirlds.platform.roster;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+
 /**
  * An exception thrown by the RosterValidator when a given Roster is invalid.
  */
@@ -24,7 +26,7 @@ public class InvalidRosterException extends Exception {
      * A default constructor.
      * @param message a message
      */
-    public InvalidRosterException(final String message) {
+    public InvalidRosterException(@Nullable final String message) {
         super(message);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -300,8 +300,9 @@ public final class RosterUtils {
      * @param state a state to set a Roster in
      * @param roster a Roster to set as active
      * @param round a round number since which the roster is considered active
+     * @throws InvalidRosterException when the roster is invalid
      */
-    public static void setActiveRoster(@NonNull final State state, @NonNull final Roster roster, final long round) {
+    public static void setActiveRoster(@NonNull final State state, @NonNull final Roster roster, final long round) throws InvalidRosterException {
         final WritableStates writableStates = state.getWritableStates(RosterStateId.NAME);
         final WritableRosterStore writableRosterStore = new WritableRosterStore(writableStates);
         writableRosterStore.putActiveRoster(roster, round);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -302,7 +302,8 @@ public final class RosterUtils {
      * @param round a round number since which the roster is considered active
      * @throws InvalidRosterException when the roster is invalid
      */
-    public static void setActiveRoster(@NonNull final State state, @NonNull final Roster roster, final long round) throws InvalidRosterException {
+    public static void setActiveRoster(@NonNull final State state, @NonNull final Roster roster, final long round)
+            throws InvalidRosterException {
         final WritableStates writableStates = state.getWritableStates(RosterStateId.NAME);
         final WritableRosterStore writableRosterStore = new WritableRosterStore(writableStates);
         writableRosterStore.putActiveRoster(roster, round);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterValidator.java
@@ -19,7 +19,7 @@ package com.swirlds.platform.roster;
 import com.hedera.hapi.node.base.ServiceEndpoint;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
-import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +36,7 @@ public final class RosterValidator {
      *
      * @param roster a roster to validate
      */
-    public static void validate(@NonNull final Roster roster) {
+    public static void validate(@Nullable final Roster roster) throws InvalidRosterException {
         if (roster == null) {
             throw new InvalidRosterException("roster is null");
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritableRosterStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritableRosterStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritableRosterStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritableRosterStore.java
@@ -25,6 +25,7 @@ import com.hedera.hapi.node.state.roster.RosterState.Builder;
 import com.hedera.hapi.node.state.roster.RoundRosterPair;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.roster.RosterValidator;
 import com.swirlds.state.spi.WritableKVState;
@@ -75,8 +76,9 @@ public class WritableRosterStore extends ReadableRosterStoreImpl {
     /**
      * Adopts the candidate roster as the active roster, starting in the given round.
      * @param roundNumber the round number in which the candidate roster should be adopted as the active roster
+     * @throws InvalidRosterException when the adopting candidate roster is invalid
      */
-    public void adoptCandidateRoster(final long roundNumber) {
+    public void adoptCandidateRoster(final long roundNumber) throws InvalidRosterException {
         putActiveRoster(requireNonNull(getCandidateRoster()), roundNumber);
     }
 
@@ -85,8 +87,9 @@ public class WritableRosterStore extends ReadableRosterStoreImpl {
      * Setting the candidate roster indicates that this roster should be adopted as the active roster when required.
      *
      * @param candidateRoster a candidate roster to set. It must be a valid roster.
+     * @throws InvalidRosterException when the candidate roster is invalid
      */
-    public void putCandidateRoster(@NonNull final Roster candidateRoster) {
+    public void putCandidateRoster(@NonNull final Roster candidateRoster) throws InvalidRosterException {
         requireNonNull(candidateRoster);
         RosterValidator.validate(candidateRoster);
 
@@ -112,8 +115,9 @@ public class WritableRosterStore extends ReadableRosterStoreImpl {
      * @param roster an active roster to set
      * @param round the round number in which the roster became active.
      *              It must be a positive number greater than the round number of the current active roster.
+     * @throws InvalidRosterException when the active roster is invalid
      */
-    public void putActiveRoster(@NonNull final Roster roster, final long round) {
+    public void putActiveRoster(@NonNull final Roster roster, final long round) throws InvalidRosterException {
         requireNonNull(roster);
         RosterValidator.validate(roster);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -35,6 +35,7 @@ import com.swirlds.platform.config.BasicConfig;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.internal.SignedStateLoadingException;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
@@ -78,6 +79,7 @@ public final class StartupStateUtils {
      * @return the initial state to be used by this node
      * @throws SignedStateLoadingException if there was a problem parsing states on disk and we are not configured to
      *                                     delete malformed states
+     * @throws InvalidRosterException when the roster is invalid
      */
     @NonNull
     @Deprecated(forRemoval = true)
@@ -90,7 +92,7 @@ public final class StartupStateUtils {
             @NonNull final String swirldName,
             @NonNull final NodeId selfId,
             @NonNull final AddressBook configAddressBook)
-            throws SignedStateLoadingException {
+            throws SignedStateLoadingException, InvalidRosterException {
 
         requireNonNull(configuration);
         requireNonNull(mainClassName);
@@ -321,12 +323,13 @@ public final class StartupStateUtils {
      * @param appVersion            the software version of the app
      * @param stateRoot             the merkle root node of the state
      * @return a reserved genesis signed state
+     * @throws InvalidRosterException when the roster is invalid
      */
     private static ReservedSignedState buildGenesisState(
             @NonNull final Configuration configuration,
             @NonNull final AddressBook addressBook,
             @NonNull final SoftwareVersion appVersion,
-            @NonNull final PlatformMerkleStateRoot stateRoot) {
+            @NonNull final PlatformMerkleStateRoot stateRoot) throws InvalidRosterException {
 
         if (!configuration.getConfigData(AddressBookConfig.class).useRosterLifecycle()) {
             initGenesisState(configuration, stateRoot, stateRoot.getWritablePlatformState(), addressBook, appVersion);
@@ -344,13 +347,14 @@ public final class StartupStateUtils {
      * @param platformState the platform state to initialize
      * @param addressBook the current address book
      * @param appVersion the software version of the app
+     * @throws InvalidRosterException when the roster is invalid
      */
     private static void initGenesisState(
             final Configuration configuration,
             final State state,
             final PlatformStateModifier platformState,
             final AddressBook addressBook,
-            final SoftwareVersion appVersion) {
+            final SoftwareVersion appVersion) throws InvalidRosterException {
         final long round = 0L;
 
         platformState.bulkUpdate(v -> {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -241,14 +241,13 @@ public class AddressBookUtils {
      * @param bootstrapAddressBook the bootstrap address book
      * @param platformContext      the platform context
      * @return the initialized address book
-     * @throws InvalidRosterException when the roster is invalid
      */
     public static @NonNull AddressBook initializeAddressBook(
             @NonNull final NodeId selfId,
             @NonNull final SoftwareVersion version,
             @NonNull final ReservedSignedState initialState,
             @NonNull final AddressBook bootstrapAddressBook,
-            @NonNull final PlatformContext platformContext) throws InvalidRosterException {
+            @NonNull final PlatformContext platformContext) {
         final boolean softwareUpgrade = detectSoftwareUpgrade(version, initialState.get());
         // Initialize the address book from the configuration and platform saved state.
         final AddressBookInitializer addressBookInitializer = new AddressBookInitializer(
@@ -276,10 +275,14 @@ public class AddressBookUtils {
                 }
             }
 
-            RosterUtils.setActiveRoster(
-                    state,
-                    RosterRetriever.buildRoster(addressBookInitializer.getCurrentAddressBook()),
-                    RosterRetriever.getRound(state));
+            try {
+                RosterUtils.setActiveRoster(
+                        state,
+                        RosterRetriever.buildRoster(addressBookInitializer.getCurrentAddressBook()),
+                        RosterRetriever.getRound(state));
+            } catch (final InvalidRosterException e) {
+                throw new IllegalArgumentException("Invalid roster", e);
+            }
         }
 
         // At this point the initial state must have the current address book set.  If not, something is wrong.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -24,6 +24,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.formatting.TextTable;
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.address.AddressBookInitializer;
@@ -240,13 +241,14 @@ public class AddressBookUtils {
      * @param bootstrapAddressBook the bootstrap address book
      * @param platformContext      the platform context
      * @return the initialized address book
+     * @throws InvalidRosterException when the roster is invalid
      */
     public static @NonNull AddressBook initializeAddressBook(
             @NonNull final NodeId selfId,
             @NonNull final SoftwareVersion version,
             @NonNull final ReservedSignedState initialState,
             @NonNull final AddressBook bootstrapAddressBook,
-            @NonNull final PlatformContext platformContext) {
+            @NonNull final PlatformContext platformContext) throws InvalidRosterException {
         final boolean softwareUpgrade = detectSoftwareUpgrade(version, initialState.get());
         // Initialize the address book from the configuration and platform saved state.
         final AddressBookInitializer addressBookInitializer = new AddressBookInitializer(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -47,6 +47,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.config.StateConfig;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
@@ -101,7 +102,7 @@ class SignedStateFileReadWriteTest {
 
     @Test
     @DisplayName("writeHashInfoFile() Test")
-    void writeHashInfoFileTest() throws IOException {
+    void writeHashInfoFileTest() throws IOException, InvalidRosterException {
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
         final SignedState signedState = new RandomSignedStateGenerator()
@@ -130,7 +131,7 @@ class SignedStateFileReadWriteTest {
 
     @Test
     @DisplayName("Write Then Read State File Test")
-    void writeThenReadStateFileTest() throws IOException {
+    void writeThenReadStateFileTest() throws IOException, InvalidRosterException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
         final Path stateFile = testDirectory.resolve(SIGNED_STATE_FILE_NAME);
         final Path signatureSetFile = testDirectory.resolve(SIGNATURE_SET_FILE_NAME);
@@ -164,7 +165,7 @@ class SignedStateFileReadWriteTest {
 
     @Test
     @DisplayName("writeSavedStateToDisk() Test")
-    void writeSavedStateToDiskTest() throws IOException {
+    void writeSavedStateToDiskTest() throws IOException, InvalidRosterException {
         final SignedState signedState = new RandomSignedStateGenerator()
                 .setSoftwareVersion(new BasicSoftwareVersion(platformVersion.minor()))
                 .build();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.config.StateConfig;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
@@ -102,7 +101,7 @@ class SignedStateFileReadWriteTest {
 
     @Test
     @DisplayName("writeHashInfoFile() Test")
-    void writeHashInfoFileTest() throws IOException, InvalidRosterException {
+    void writeHashInfoFileTest() throws IOException {
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
         final SignedState signedState = new RandomSignedStateGenerator()
@@ -131,7 +130,7 @@ class SignedStateFileReadWriteTest {
 
     @Test
     @DisplayName("Write Then Read State File Test")
-    void writeThenReadStateFileTest() throws IOException, InvalidRosterException {
+    void writeThenReadStateFileTest() throws IOException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
         final Path stateFile = testDirectory.resolve(SIGNED_STATE_FILE_NAME);
         final Path signatureSetFile = testDirectory.resolve(SIGNATURE_SET_FILE_NAME);
@@ -165,7 +164,7 @@ class SignedStateFileReadWriteTest {
 
     @Test
     @DisplayName("writeSavedStateToDisk() Test")
-    void writeSavedStateToDiskTest() throws IOException, InvalidRosterException {
+    void writeSavedStateToDiskTest() throws IOException {
         final SignedState signedState = new RandomSignedStateGenerator()
                 .setSoftwareVersion(new BasicSoftwareVersion(platformVersion.minor()))
                 .build();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,6 @@ import com.swirlds.platform.components.DefaultSavedStateController;
 import com.swirlds.platform.components.SavedStateController;
 import com.swirlds.platform.config.StateConfig_;
 import com.swirlds.platform.internal.ConsensusRound;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.DefaultStateSnapshotManager;
@@ -181,7 +180,7 @@ class StateFileManagerTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Standard Operation Test")
-    void standardOperationTest(final boolean successExpected) throws IOException, InvalidRosterException {
+    void standardOperationTest(final boolean successExpected) throws IOException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
         makeImmutable(signedState);
 
@@ -208,7 +207,7 @@ class StateFileManagerTests {
 
     @Test
     @DisplayName("Save Fatal Signed State")
-    void saveFatalSignedState() throws InterruptedException, IOException, InvalidRosterException {
+    void saveFatalSignedState() throws InterruptedException, IOException {
         final SignedState signedState =
                 new RandomSignedStateGenerator().setUseBlockingState(true).build();
         ((BlockingSwirldState) signedState.getSwirldState()).enableBlockingSerialization();
@@ -237,7 +236,7 @@ class StateFileManagerTests {
 
     @Test
     @DisplayName("Save ISS Signed State")
-    void saveISSignedState() throws IOException, InvalidRosterException {
+    void saveISSignedState() throws IOException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
 
         final StateSnapshotManager manager =
@@ -257,7 +256,7 @@ class StateFileManagerTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Sequence Of States Test")
-    void sequenceOfStatesTest(final boolean startAtGenesis) throws IOException, InvalidRosterException {
+    void sequenceOfStatesTest(final boolean startAtGenesis) throws IOException {
 
         final Random random = getRandomPrintSeed();
 
@@ -390,7 +389,7 @@ class StateFileManagerTests {
     @SuppressWarnings("resource")
     @Test
     @DisplayName("State Deletion Test")
-    void stateDeletionTest() throws IOException, InvalidRosterException {
+    void stateDeletionTest() throws IOException {
         final Random random = getRandomPrintSeed();
         final int statesOnDisk = 3;
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -50,6 +50,7 @@ import com.swirlds.platform.components.DefaultSavedStateController;
 import com.swirlds.platform.components.SavedStateController;
 import com.swirlds.platform.config.StateConfig_;
 import com.swirlds.platform.internal.ConsensusRound;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.DefaultStateSnapshotManager;
@@ -180,7 +181,7 @@ class StateFileManagerTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Standard Operation Test")
-    void standardOperationTest(final boolean successExpected) throws IOException {
+    void standardOperationTest(final boolean successExpected) throws IOException, InvalidRosterException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
         makeImmutable(signedState);
 
@@ -207,7 +208,7 @@ class StateFileManagerTests {
 
     @Test
     @DisplayName("Save Fatal Signed State")
-    void saveFatalSignedState() throws InterruptedException, IOException {
+    void saveFatalSignedState() throws InterruptedException, IOException, InvalidRosterException {
         final SignedState signedState =
                 new RandomSignedStateGenerator().setUseBlockingState(true).build();
         ((BlockingSwirldState) signedState.getSwirldState()).enableBlockingSerialization();
@@ -236,7 +237,7 @@ class StateFileManagerTests {
 
     @Test
     @DisplayName("Save ISS Signed State")
-    void saveISSignedState() throws IOException {
+    void saveISSignedState() throws IOException, InvalidRosterException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
 
         final StateSnapshotManager manager =
@@ -256,7 +257,7 @@ class StateFileManagerTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Sequence Of States Test")
-    void sequenceOfStatesTest(final boolean startAtGenesis) throws IOException {
+    void sequenceOfStatesTest(final boolean startAtGenesis) throws IOException, InvalidRosterException {
 
         final Random random = getRandomPrintSeed();
 
@@ -389,7 +390,7 @@ class StateFileManagerTests {
     @SuppressWarnings("resource")
     @Test
     @DisplayName("State Deletion Test")
-    void stateDeletionTest() throws IOException {
+    void stateDeletionTest() throws IOException, InvalidRosterException {
         final Random random = getRandomPrintSeed();
         final int statesOnDisk = 3;
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
@@ -33,6 +33,7 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.crypto.SignatureVerifier;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateInvalidException;
 import com.swirlds.platform.state.signed.SignedStateValidationData;
@@ -266,7 +267,7 @@ class DefaultSignedStateValidatorTests {
     @ParameterizedTest
     @MethodSource({"staticNodeParams", "randomizedNodeParams"})
     @DisplayName("Signed State Validation")
-    void testSignedStateValidationRandom(final String desc, final List<Node> nodes, final List<Node> signingNodes) {
+    void testSignedStateValidationRandom(final String desc, final List<Node> nodes, final List<Node> signingNodes) throws InvalidRosterException {
         final Randotron randotron = Randotron.create();
         roster = createRoster(randotron, nodes);
 
@@ -331,7 +332,7 @@ class DefaultSignedStateValidatorTests {
      * @param signingNodes the node ids signing the state
      * @return the signed state
      */
-    private SignedState stateSignedByNodes(final List<Node> signingNodes) {
+    private SignedState stateSignedByNodes(final List<Node> signingNodes) throws InvalidRosterException {
 
         final Hash stateHash = randomHash();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.crypto.SignatureVerifier;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateInvalidException;
 import com.swirlds.platform.state.signed.SignedStateValidationData;
@@ -267,7 +266,7 @@ class DefaultSignedStateValidatorTests {
     @ParameterizedTest
     @MethodSource({"staticNodeParams", "randomizedNodeParams"})
     @DisplayName("Signed State Validation")
-    void testSignedStateValidationRandom(final String desc, final List<Node> nodes, final List<Node> signingNodes) throws InvalidRosterException {
+    void testSignedStateValidationRandom(final String desc, final List<Node> nodes, final List<Node> signingNodes) {
         final Randotron randotron = Randotron.create();
         roster = createRoster(randotron, nodes);
 
@@ -332,7 +331,7 @@ class DefaultSignedStateValidatorTests {
      * @param signingNodes the node ids signing the state
      * @return the signed state
      */
-    private SignedState stateSignedByNodes(final List<Node> signingNodes) throws InvalidRosterException {
+    private SignedState stateSignedByNodes(final List<Node> signingNodes) {
 
         final Hash stateHash = randomHash();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.protocol.Protocol;
 import com.swirlds.platform.network.protocol.ProtocolFactory;
 import com.swirlds.platform.network.protocol.ReconnectProtocolFactory;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -188,7 +187,7 @@ class ReconnectProtocolTests {
     @DisplayName("Test the conditions under which the protocol should accept protocol initiation")
     @ParameterizedTest
     @MethodSource("acceptParams")
-    void testShouldAccept(final AcceptParams params) throws InvalidRosterException {
+    void testShouldAccept(final AcceptParams params) {
         final ReconnectThrottle teacherThrottle = mock(ReconnectThrottle.class);
         when(teacherThrottle.initiateReconnect(any())).thenReturn(!params.teacherIsThrottled);
 
@@ -279,7 +278,7 @@ class ReconnectProtocolTests {
 
     @DisplayName("Tests if teacher throttle gets released")
     @Test
-    void testTeacherThrottleReleased() throws InvalidRosterException {
+    void testTeacherThrottleReleased() {
         final FallenBehindManager fallenBehindManager = mock(FallenBehindManager.class);
         final Configuration config = new TestConfigBuilder()
                 // we don't want the time based throttle to interfere
@@ -381,7 +380,7 @@ class ReconnectProtocolTests {
 
     @Test
     @DisplayName("Aborted Teacher")
-    void abortedTeacher() throws InvalidRosterException {
+    void abortedTeacher() {
         final ReconnectThrottle reconnectThrottle = mock(ReconnectThrottle.class);
         when(reconnectThrottle.initiateReconnect(any())).thenReturn(true);
         final ValueReference<Boolean> throttleReleased = new ValueReference<>(false);
@@ -460,7 +459,7 @@ class ReconnectProtocolTests {
 
     @Test
     @DisplayName("Teacher doesn't have a status of ACTIVE")
-    void teacherNotActive() throws InvalidRosterException {
+    void teacherNotActive() {
         final FallenBehindManager fallenBehindManager = mock(FallenBehindManager.class);
         when(fallenBehindManager.hasFallenBehind()).thenReturn(false);
 
@@ -490,7 +489,7 @@ class ReconnectProtocolTests {
 
     @Test
     @DisplayName("Teacher holds the learner permit while teaching")
-    void teacherHoldsLearnerPermit() throws InvalidRosterException {
+    void teacherHoldsLearnerPermit() {
         final SignedState signedState = spy(new RandomSignedStateGenerator().build());
         when(signedState.isComplete()).thenReturn(true);
         signedState.reserve("test");
@@ -534,7 +533,7 @@ class ReconnectProtocolTests {
 
     @Test
     @DisplayName("Teacher holds the learner permit while teaching")
-    void teacherCantAcquireLearnerPermit() throws InvalidRosterException {
+    void teacherCantAcquireLearnerPermit() {
         final SignedState signedState = spy(new RandomSignedStateGenerator().build());
         when(signedState.isComplete()).thenReturn(true);
         signedState.reserve("test");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectProtocolTests.java
@@ -47,6 +47,7 @@ import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.protocol.Protocol;
 import com.swirlds.platform.network.protocol.ProtocolFactory;
 import com.swirlds.platform.network.protocol.ReconnectProtocolFactory;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -187,7 +188,7 @@ class ReconnectProtocolTests {
     @DisplayName("Test the conditions under which the protocol should accept protocol initiation")
     @ParameterizedTest
     @MethodSource("acceptParams")
-    void testShouldAccept(final AcceptParams params) {
+    void testShouldAccept(final AcceptParams params) throws InvalidRosterException {
         final ReconnectThrottle teacherThrottle = mock(ReconnectThrottle.class);
         when(teacherThrottle.initiateReconnect(any())).thenReturn(!params.teacherIsThrottled);
 
@@ -278,7 +279,7 @@ class ReconnectProtocolTests {
 
     @DisplayName("Tests if teacher throttle gets released")
     @Test
-    void testTeacherThrottleReleased() {
+    void testTeacherThrottleReleased() throws InvalidRosterException {
         final FallenBehindManager fallenBehindManager = mock(FallenBehindManager.class);
         final Configuration config = new TestConfigBuilder()
                 // we don't want the time based throttle to interfere
@@ -380,7 +381,7 @@ class ReconnectProtocolTests {
 
     @Test
     @DisplayName("Aborted Teacher")
-    void abortedTeacher() {
+    void abortedTeacher() throws InvalidRosterException {
         final ReconnectThrottle reconnectThrottle = mock(ReconnectThrottle.class);
         when(reconnectThrottle.initiateReconnect(any())).thenReturn(true);
         final ValueReference<Boolean> throttleReleased = new ValueReference<>(false);
@@ -459,7 +460,7 @@ class ReconnectProtocolTests {
 
     @Test
     @DisplayName("Teacher doesn't have a status of ACTIVE")
-    void teacherNotActive() {
+    void teacherNotActive() throws InvalidRosterException {
         final FallenBehindManager fallenBehindManager = mock(FallenBehindManager.class);
         when(fallenBehindManager.hasFallenBehind()).thenReturn(false);
 
@@ -489,7 +490,7 @@ class ReconnectProtocolTests {
 
     @Test
     @DisplayName("Teacher holds the learner permit while teaching")
-    void teacherHoldsLearnerPermit() {
+    void teacherHoldsLearnerPermit() throws InvalidRosterException {
         final SignedState signedState = spy(new RandomSignedStateGenerator().build());
         when(signedState.isComplete()).thenReturn(true);
         signedState.reserve("test");
@@ -533,7 +534,7 @@ class ReconnectProtocolTests {
 
     @Test
     @DisplayName("Teacher holds the learner permit while teaching")
-    void teacherCantAcquireLearnerPermit() {
+    void teacherCantAcquireLearnerPermit() throws InvalidRosterException {
         final SignedState signedState = spy(new RandomSignedStateGenerator().build());
         when(signedState.isComplete()).thenReturn(true);
         signedState.reserve("test");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -39,6 +39,7 @@ import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.SocketConnection;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
@@ -95,7 +96,7 @@ final class ReconnectTest {
 
     @Test
     @DisplayName("Successfully reconnects multiple times and stats are updated")
-    void statsTrackSuccessfulReconnect() throws IOException, InterruptedException {
+    void statsTrackSuccessfulReconnect() throws IOException, InterruptedException, InvalidRosterException {
         final int numberOfReconnects = 11;
 
         final ReconnectMetrics reconnectMetrics = mock(ReconnectMetrics.class);
@@ -111,7 +112,7 @@ final class ReconnectTest {
         }
     }
 
-    private void executeReconnect(final ReconnectMetrics reconnectMetrics) throws InterruptedException, IOException {
+    private void executeReconnect(final ReconnectMetrics reconnectMetrics) throws InterruptedException, IOException, InvalidRosterException {
 
         final long weightPerNode = 100L;
         final int numNodes = 4;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.SocketConnection;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
@@ -96,7 +95,7 @@ final class ReconnectTest {
 
     @Test
     @DisplayName("Successfully reconnects multiple times and stats are updated")
-    void statsTrackSuccessfulReconnect() throws IOException, InterruptedException, InvalidRosterException {
+    void statsTrackSuccessfulReconnect() throws IOException, InterruptedException {
         final int numberOfReconnects = 11;
 
         final ReconnectMetrics reconnectMetrics = mock(ReconnectMetrics.class);
@@ -112,7 +111,7 @@ final class ReconnectTest {
         }
     }
 
-    private void executeReconnect(final ReconnectMetrics reconnectMetrics) throws InterruptedException, IOException, InvalidRosterException {
+    private void executeReconnect(final ReconnectMetrics reconnectMetrics) throws InterruptedException, IOException {
 
         final long weightPerNode = 100L;
         final int numNodes = 4;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterValidatorTests.java
@@ -16,6 +16,7 @@
 
 package com.swirlds.platform.roster;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -409,6 +410,6 @@ public class RosterValidatorTests {
 
     @Test
     void validTest() {
-        RosterValidator.validate(buildValidRoster());
+        assertDoesNotThrow(() -> RosterValidator.validate(buildValidRoster()));
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
@@ -27,6 +27,7 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.event.AncientMode;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -53,7 +54,7 @@ class BirthRoundStateMigrationTests {
     }
 
     @NonNull
-    private SignedState generateSignedState(@NonNull final Random random) {
+    private SignedState generateSignedState(@NonNull final Random random) throws InvalidRosterException {
 
         final long round = random.nextLong(1, 1_000_000);
 
@@ -85,7 +86,7 @@ class BirthRoundStateMigrationTests {
     }
 
     @Test
-    void generationModeTest() {
+    void generationModeTest() throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
         final SignedState signedState = generateSignedState(random);
         final Hash originalHash = signedState.getState().getHash();
@@ -107,7 +108,7 @@ class BirthRoundStateMigrationTests {
     }
 
     @Test
-    void alreadyMigratedTest() {
+    void alreadyMigratedTest() throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final SignedState signedState = generateSignedState(random);
@@ -141,7 +142,7 @@ class BirthRoundStateMigrationTests {
     }
 
     @Test
-    void migrationTest() {
+    void migrationTest() throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
         final SignedState signedState = generateSignedState(random);
         final Hash originalHash = signedState.getState().getHash();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.event.AncientMode;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -54,7 +53,7 @@ class BirthRoundStateMigrationTests {
     }
 
     @NonNull
-    private SignedState generateSignedState(@NonNull final Random random) throws InvalidRosterException {
+    private SignedState generateSignedState(@NonNull final Random random) {
 
         final long round = random.nextLong(1, 1_000_000);
 
@@ -86,7 +85,7 @@ class BirthRoundStateMigrationTests {
     }
 
     @Test
-    void generationModeTest() throws InvalidRosterException {
+    void generationModeTest() {
         final Random random = getRandomPrintSeed();
         final SignedState signedState = generateSignedState(random);
         final Hash originalHash = signedState.getState().getHash();
@@ -108,7 +107,7 @@ class BirthRoundStateMigrationTests {
     }
 
     @Test
-    void alreadyMigratedTest() throws InvalidRosterException {
+    void alreadyMigratedTest() {
         final Random random = getRandomPrintSeed();
 
         final SignedState signedState = generateSignedState(random);
@@ -142,7 +141,7 @@ class BirthRoundStateMigrationTests {
     }
 
     @Test
-    void migrationTest() throws InvalidRosterException {
+    void migrationTest() {
         final Random random = getRandomPrintSeed();
         final SignedState signedState = generateSignedState(random);
         final Hash originalHash = signedState.getState().getHash();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateReferenceTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateReferenceTests.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import com.swirlds.merkledb.MerkleDb;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateReference;
@@ -43,7 +44,7 @@ class SignedStateReferenceTests {
     /**
      * Build a signed state.
      */
-    public static SignedState buildSignedState() {
+    public static SignedState buildSignedState() throws InvalidRosterException  {
         return new RandomSignedStateGenerator().build();
     }
 
@@ -93,7 +94,7 @@ class SignedStateReferenceTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Initial Value Constructor Test")
-    void initialValueTest(final boolean defaultValue) {
+    void initialValueTest(final boolean defaultValue) throws InvalidRosterException {
 
         final SignedState state = spy(buildSignedState());
         doReturn(1234L).when(state).getRound();
@@ -124,7 +125,7 @@ class SignedStateReferenceTests {
 
     @Test
     @DisplayName("Replacement Test")
-    void replacementTest() {
+    void replacementTest() throws InvalidRosterException {
         MerkleDb.resetDefaultInstancePath();
         final SignedState state1 = buildSignedState();
         MerkleDb.resetDefaultInstancePath();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateReferenceTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateReferenceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 import com.swirlds.merkledb.MerkleDb;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateReference;
@@ -44,7 +43,7 @@ class SignedStateReferenceTests {
     /**
      * Build a signed state.
      */
-    public static SignedState buildSignedState() throws InvalidRosterException  {
+    public static SignedState buildSignedState() {
         return new RandomSignedStateGenerator().build();
     }
 
@@ -94,7 +93,7 @@ class SignedStateReferenceTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Initial Value Constructor Test")
-    void initialValueTest(final boolean defaultValue) throws InvalidRosterException {
+    void initialValueTest(final boolean defaultValue) {
 
         final SignedState state = spy(buildSignedState());
         doReturn(1234L).when(state).getRound();
@@ -125,7 +124,7 @@ class SignedStateReferenceTests {
 
     @Test
     @DisplayName("Replacement Test")
-    void replacementTest() throws InvalidRosterException {
+    void replacementTest() {
         MerkleDb.resetDefaultInstancePath();
         final SignedState state1 = buildSignedState();
         MerkleDb.resetDefaultInstancePath();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ class SignedStateTests {
     /**
      * Generate a signed state.
      */
-    private SignedState generateSignedState(final Random random, final PlatformMerkleStateRoot state) throws InvalidRosterException {
+    private SignedState generateSignedState(final Random random, final PlatformMerkleStateRoot state) {
         return new RandomSignedStateGenerator(random).setState(state).build();
     }
 
@@ -76,11 +76,15 @@ class SignedStateTests {
      * @param releaseCallback this method is called when the State is released
      */
     private PlatformMerkleStateRoot buildMockState(
-            final Random random, final Runnable reserveCallback, final Runnable releaseCallback) throws InvalidRosterException {
+            final Random random, final Runnable reserveCallback, final Runnable releaseCallback) {
         final var real = new PlatformMerkleStateRoot(
                 FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
         FAKE_MERKLE_STATE_LIFECYCLES.initStates(real);
-        RosterUtils.setActiveRoster(real, RandomRosterBuilder.create(random).build(), 0L);
+        try {
+            RosterUtils.setActiveRoster(real, RandomRosterBuilder.create(random).build(), 0L);
+        } catch (final InvalidRosterException e) {
+            throw new IllegalArgumentException("Invalid roster", e);
+        }
         final PlatformMerkleStateRoot state = spy(real);
 
         final PlatformStateModifier platformState = new PlatformState();
@@ -108,7 +112,7 @@ class SignedStateTests {
 
     @Test
     @DisplayName("Reservation Test")
-    void reservationTest() throws InterruptedException, InvalidRosterException {
+    void reservationTest() throws InterruptedException {
         final Random random = new Random();
 
         final AtomicBoolean reserved = new AtomicBoolean(false);
@@ -167,7 +171,7 @@ class SignedStateTests {
      */
     @Test
     @DisplayName("No Garbage Collector Test")
-    void noGarbageCollectorTest() throws InvalidRosterException {
+    void noGarbageCollectorTest() {
         final Random random = new Random();
 
         final AtomicBoolean reserved = new AtomicBoolean(false);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -32,6 +32,7 @@ import com.swirlds.common.exceptions.ReferenceCountException;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.crypto.SignatureVerifier;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -54,7 +55,7 @@ class SignedStateTests {
     /**
      * Generate a signed state.
      */
-    private SignedState generateSignedState(final Random random, final PlatformMerkleStateRoot state) {
+    private SignedState generateSignedState(final Random random, final PlatformMerkleStateRoot state) throws InvalidRosterException {
         return new RandomSignedStateGenerator(random).setState(state).build();
     }
 
@@ -75,7 +76,7 @@ class SignedStateTests {
      * @param releaseCallback this method is called when the State is released
      */
     private PlatformMerkleStateRoot buildMockState(
-            final Random random, final Runnable reserveCallback, final Runnable releaseCallback) {
+            final Random random, final Runnable reserveCallback, final Runnable releaseCallback) throws InvalidRosterException {
         final var real = new PlatformMerkleStateRoot(
                 FAKE_MERKLE_STATE_LIFECYCLES, version -> new BasicSoftwareVersion(version.major()));
         FAKE_MERKLE_STATE_LIFECYCLES.initStates(real);
@@ -107,7 +108,7 @@ class SignedStateTests {
 
     @Test
     @DisplayName("Reservation Test")
-    void reservationTest() throws InterruptedException {
+    void reservationTest() throws InterruptedException, InvalidRosterException {
         final Random random = new Random();
 
         final AtomicBoolean reserved = new AtomicBoolean(false);
@@ -166,7 +167,7 @@ class SignedStateTests {
      */
     @Test
     @DisplayName("No Garbage Collector Test")
-    void noGarbageCollectorTest() {
+    void noGarbageCollectorTest() throws InvalidRosterException {
         final Random random = new Random();
 
         final AtomicBoolean reserved = new AtomicBoolean(false);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,6 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.merkledb.MerkleDb;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
@@ -81,7 +80,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Add Valid Signatures Test")
-    void addValidSignaturesTest(final boolean evenWeighting) throws InvalidRosterException {
+    void addValidSignaturesTest(final boolean evenWeighting) {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -181,7 +180,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Add Invalid Signatures Test")
-    void addInvalidSignaturesTest(final boolean evenWeighting) throws InvalidRosterException {
+    void addInvalidSignaturesTest(final boolean evenWeighting) {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -275,7 +274,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Signature Becomes Invalid Test")
-    void signatureBecomesInvalidTest(final boolean evenWeighting) throws InvalidRosterException {
+    void signatureBecomesInvalidTest(final boolean evenWeighting) {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -360,7 +359,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("All Signatures Become Invalid Test")
-    void allSignaturesBecomeInvalidTest(final boolean evenWeighting) throws InvalidRosterException {
+    void allSignaturesBecomeInvalidTest(final boolean evenWeighting) {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -404,7 +403,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Signatures Invalid With Different Roster Test")
-    void signaturesInvalidWithDifferentRosterTest(final boolean evenWeighting) throws CertificateEncodingException, InvalidRosterException {
+    void signaturesInvalidWithDifferentRosterTest(final boolean evenWeighting) throws CertificateEncodingException {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -459,7 +458,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Signatures Invalid Due To Zero Weight")
-    void signaturesInvalidDueToZeroWeightTest(final boolean evenWeighting) throws InvalidRosterException {
+    void signaturesInvalidDueToZeroWeightTest(final boolean evenWeighting) {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -523,7 +522,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Recovery State Is Complete Test")
-    void recoveryStateIsCompleteTest(final boolean evenWeighting) throws InvalidRosterException {
+    void recoveryStateIsCompleteTest(final boolean evenWeighting) {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateSigningTests.java
@@ -38,6 +38,7 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.merkledb.MerkleDb;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
@@ -80,7 +81,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Add Valid Signatures Test")
-    void addValidSignaturesTest(final boolean evenWeighting) {
+    void addValidSignaturesTest(final boolean evenWeighting) throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -180,7 +181,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Add Invalid Signatures Test")
-    void addInvalidSignaturesTest(final boolean evenWeighting) {
+    void addInvalidSignaturesTest(final boolean evenWeighting) throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -274,7 +275,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Signature Becomes Invalid Test")
-    void signatureBecomesInvalidTest(final boolean evenWeighting) {
+    void signatureBecomesInvalidTest(final boolean evenWeighting) throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -359,7 +360,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("All Signatures Become Invalid Test")
-    void allSignaturesBecomeInvalidTest(final boolean evenWeighting) {
+    void allSignaturesBecomeInvalidTest(final boolean evenWeighting) throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -403,7 +404,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Signatures Invalid With Different Roster Test")
-    void signaturesInvalidWithDifferentRosterTest(final boolean evenWeighting) throws CertificateEncodingException {
+    void signaturesInvalidWithDifferentRosterTest(final boolean evenWeighting) throws CertificateEncodingException, InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -458,7 +459,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Signatures Invalid Due To Zero Weight")
-    void signaturesInvalidDueToZeroWeightTest(final boolean evenWeighting) {
+    void signaturesInvalidDueToZeroWeightTest(final boolean evenWeighting) throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
@@ -522,7 +523,7 @@ class StateSigningTests {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Recovery State Is Complete Test")
-    void recoveryStateIsCompleteTest(final boolean evenWeighting) {
+    void recoveryStateIsCompleteTest(final boolean evenWeighting) throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -30,6 +30,7 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.SwirldsPlatform;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.Round;
@@ -89,7 +90,7 @@ class SwirldStateManagerTests {
 
     @Test
     @DisplayName("Load From Signed State - state reference counts")
-    void loadFromSignedStateRefCount() {
+    void loadFromSignedStateRefCount() throws InvalidRosterException {
         final SignedState ss1 = newSignedState();
         MerkleDb.resetDefaultInstancePath();
         swirldStateManager.loadFromSignedState(ss1);
@@ -139,7 +140,7 @@ class SwirldStateManagerTests {
         return state;
     }
 
-    private static SignedState newSignedState() {
+    private static SignedState newSignedState() throws InvalidRosterException {
         final SignedState ss = new RandomSignedStateGenerator().build();
         assertEquals(
                 1,

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldStateManagerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.SwirldsPlatform;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.Round;
@@ -90,7 +89,7 @@ class SwirldStateManagerTests {
 
     @Test
     @DisplayName("Load From Signed State - state reference counts")
-    void loadFromSignedStateRefCount() throws InvalidRosterException {
+    void loadFromSignedStateRefCount() {
         final SignedState ss1 = newSignedState();
         MerkleDb.resetDefaultInstancePath();
         swirldStateManager.loadFromSignedState(ss1);
@@ -140,7 +139,7 @@ class SwirldStateManagerTests {
         return state;
     }
 
-    private static SignedState newSignedState() throws InvalidRosterException {
+    private static SignedState newSignedState() {
         final SignedState ss = new RandomSignedStateGenerator().build();
         assertEquals(
                 1,

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/AddIncompleteStateTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/AddIncompleteStateTest.java
@@ -31,6 +31,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.SignedState;
@@ -95,7 +96,7 @@ class AddIncompleteStateTest extends AbstractStateSignatureCollectorTest {
 
     @Test
     @DisplayName("Add Incomplete State Test")
-    void addIncompleteStateTest() {
+    void addIncompleteStateTest() throws InvalidRosterException {
 
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/AddIncompleteStateTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/AddIncompleteStateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.SignedState;
@@ -96,7 +95,7 @@ class AddIncompleteStateTest extends AbstractStateSignatureCollectorTest {
 
     @Test
     @DisplayName("Add Incomplete State Test")
-    void addIncompleteStateTest() throws InvalidRosterException {
+    void addIncompleteStateTest() {
 
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/EarlySignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/EarlySignaturesTest.java
@@ -30,6 +30,7 @@ import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
 import com.swirlds.platform.config.StateConfig;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
@@ -94,7 +95,7 @@ public class EarlySignaturesTest extends AbstractStateSignatureCollectorTest {
 
     @Test
     @DisplayName("Early Signatures Test")
-    void earlySignaturesTest() throws InterruptedException {
+    void earlySignaturesTest() throws InterruptedException, InvalidRosterException {
         final int count = 100;
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/EarlySignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/EarlySignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
 import com.swirlds.platform.config.StateConfig;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
@@ -95,7 +94,7 @@ public class EarlySignaturesTest extends AbstractStateSignatureCollectorTest {
 
     @Test
     @DisplayName("Early Signatures Test")
-    void earlySignaturesTest() throws InterruptedException, InvalidRosterException {
+    void earlySignaturesTest() throws InterruptedException {
         final int count = 100;
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/OldCompleteStateEventuallyReleasedTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/OldCompleteStateEventuallyReleasedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
@@ -91,7 +90,7 @@ class OldCompleteStateEventuallyReleasedTest extends AbstractStateSignatureColle
      */
     @Test
     @DisplayName("Old Complete State Eventually Released")
-    void oldCompleteStateEventuallyReleased() throws InterruptedException, InvalidRosterException {
+    void oldCompleteStateEventuallyReleased() throws InterruptedException {
 
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/OldCompleteStateEventuallyReleasedTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/OldCompleteStateEventuallyReleasedTest.java
@@ -32,6 +32,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
@@ -90,7 +91,7 @@ class OldCompleteStateEventuallyReleasedTest extends AbstractStateSignatureColle
      */
     @Test
     @DisplayName("Old Complete State Eventually Released")
-    void oldCompleteStateEventuallyReleased() throws InterruptedException {
+    void oldCompleteStateEventuallyReleased() throws InterruptedException, InvalidRosterException {
 
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/PostconsensusSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/PostconsensusSignaturesTest.java
@@ -30,6 +30,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.DefaultStateSignatureCollector;
@@ -88,7 +89,7 @@ class PostconsensusSignaturesTest extends AbstractStateSignatureCollectorTest {
 
     @Test
     @DisplayName("Postconsensus signatures")
-    void postconsensusSignatureTests() throws InterruptedException {
+    void postconsensusSignatureTests() throws InterruptedException, InvalidRosterException {
         final int count = 100;
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/PostconsensusSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/PostconsensusSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.DefaultStateSignatureCollector;
@@ -89,7 +88,7 @@ class PostconsensusSignaturesTest extends AbstractStateSignatureCollectorTest {
 
     @Test
     @DisplayName("Postconsensus signatures")
-    void postconsensusSignatureTests() throws InterruptedException, InvalidRosterException {
+    void postconsensusSignatureTests() throws InterruptedException {
         final int count = 100;
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/RegisterStatesWithoutSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/RegisterStatesWithoutSignaturesTest.java
@@ -27,6 +27,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -90,7 +91,7 @@ public class RegisterStatesWithoutSignaturesTest extends AbstractStateSignatureC
      */
     @Test
     @DisplayName("Register States Without Signatures")
-    void registerStatesWithoutSignatures() throws InterruptedException {
+    void registerStatesWithoutSignatures() throws InterruptedException, InvalidRosterException {
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())
                 .build();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/RegisterStatesWithoutSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/RegisterStatesWithoutSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -91,7 +90,7 @@ public class RegisterStatesWithoutSignaturesTest extends AbstractStateSignatureC
      */
     @Test
     @DisplayName("Register States Without Signatures")
-    void registerStatesWithoutSignatures() throws InterruptedException, InvalidRosterException {
+    void registerStatesWithoutSignatures() throws InterruptedException {
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())
                 .build();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesRestartTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesRestartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
@@ -101,7 +100,7 @@ public class SequentialSignaturesRestartTest extends AbstractStateSignatureColle
 
     @Test
     @DisplayName("Sequential Signatures After Restart Test")
-    void sequentialSignaturesAfterRestartTest() throws InterruptedException, InvalidRosterException {
+    void sequentialSignaturesAfterRestartTest() throws InterruptedException {
 
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesRestartTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesRestartTest.java
@@ -33,6 +33,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
@@ -100,7 +101,7 @@ public class SequentialSignaturesRestartTest extends AbstractStateSignatureColle
 
     @Test
     @DisplayName("Sequential Signatures After Restart Test")
-    void sequentialSignaturesAfterRestartTest() throws InterruptedException {
+    void sequentialSignaturesAfterRestartTest() throws InterruptedException, InvalidRosterException {
 
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -91,7 +90,7 @@ public class SequentialSignaturesTest extends AbstractStateSignatureCollectorTes
 
     @Test
     @DisplayName("Sequential Signatures Test")
-    void sequentialSignaturesTest() throws InterruptedException, InvalidRosterException {
+    void sequentialSignaturesTest() throws InterruptedException {
         this.roundsToKeepAfterSigning = 4;
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/manager/SequentialSignaturesTest.java
@@ -28,6 +28,7 @@ import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.components.state.output.StateHasEnoughSignaturesConsumer;
 import com.swirlds.platform.components.state.output.StateLacksSignaturesConsumer;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.StateSignatureCollectorTester;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -90,7 +91,7 @@ public class SequentialSignaturesTest extends AbstractStateSignatureCollectorTes
 
     @Test
     @DisplayName("Sequential Signatures Test")
-    void sequentialSignaturesTest() throws InterruptedException {
+    void sequentialSignaturesTest() throws InterruptedException, InvalidRosterException {
         this.roundsToKeepAfterSigning = 4;
         final PlatformContext platformContext = TestPlatformContextBuilder.create()
                 .withConfiguration(buildStateConfig())

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/nexus/SignedStateNexusTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/nexus/SignedStateNexusTest.java
@@ -28,6 +28,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.consensus.ConsensusConstants;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
@@ -65,7 +66,7 @@ class SignedStateNexusTest {
 
     @ParameterizedTest
     @MethodSource("allInstances")
-    void basicUsage(@NonNull final SignedStateNexus nexus) {
+    void basicUsage(@NonNull final SignedStateNexus nexus) throws InvalidRosterException {
         final int round = 123;
         final ReservedSignedState original =
                 new RandomSignedStateGenerator().setRound(round).build().reserve("test");
@@ -91,7 +92,7 @@ class SignedStateNexusTest {
 
     @ParameterizedTest
     @MethodSource("allInstances")
-    void closedStateTest(@NonNull final SignedStateNexus nexus) {
+    void closedStateTest(@NonNull final SignedStateNexus nexus) throws InvalidRosterException {
         final ReservedSignedState reservedSignedState = realState();
         nexus.setState(reservedSignedState);
         reservedSignedState.close();
@@ -105,7 +106,7 @@ class SignedStateNexusTest {
      */
     @ParameterizedTest
     @MethodSource("raceConditionInstances")
-    void raceConditionTest(@NonNull final SignedStateNexus nexus) throws InterruptedException {
+    void raceConditionTest(@NonNull final SignedStateNexus nexus) throws InterruptedException, InvalidRosterException {
         final ReservedSignedState state1 = mockState();
         final CountDownLatch unblockThread = new CountDownLatch(1);
         final CountDownLatch threadWaiting = new CountDownLatch(1);
@@ -144,7 +145,7 @@ class SignedStateNexusTest {
         assertSame(state2child, threadGetResult.get(), "The nexus should have returned the child of state2");
     }
 
-    private static ReservedSignedState mockState() {
+    private static ReservedSignedState mockState() throws InvalidRosterException {
         final ReservedSignedState state = Mockito.mock(ReservedSignedState.class);
         MerkleDb.resetDefaultInstancePath();
         final SignedState ss = new RandomSignedStateGenerator().build();
@@ -152,7 +153,7 @@ class SignedStateNexusTest {
         return state;
     }
 
-    private static ReservedSignedState realState() {
+    private static ReservedSignedState realState() throws InvalidRosterException {
         MerkleDb.resetDefaultInstancePath();
         return new RandomSignedStateGenerator().build().reserve("test");
     }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/nexus/SignedStateNexusTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/nexus/SignedStateNexusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.consensus.ConsensusConstants;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
@@ -66,7 +65,7 @@ class SignedStateNexusTest {
 
     @ParameterizedTest
     @MethodSource("allInstances")
-    void basicUsage(@NonNull final SignedStateNexus nexus) throws InvalidRosterException {
+    void basicUsage(@NonNull final SignedStateNexus nexus) {
         final int round = 123;
         final ReservedSignedState original =
                 new RandomSignedStateGenerator().setRound(round).build().reserve("test");
@@ -92,7 +91,7 @@ class SignedStateNexusTest {
 
     @ParameterizedTest
     @MethodSource("allInstances")
-    void closedStateTest(@NonNull final SignedStateNexus nexus) throws InvalidRosterException {
+    void closedStateTest(@NonNull final SignedStateNexus nexus) {
         final ReservedSignedState reservedSignedState = realState();
         nexus.setState(reservedSignedState);
         reservedSignedState.close();
@@ -106,7 +105,7 @@ class SignedStateNexusTest {
      */
     @ParameterizedTest
     @MethodSource("raceConditionInstances")
-    void raceConditionTest(@NonNull final SignedStateNexus nexus) throws InterruptedException, InvalidRosterException {
+    void raceConditionTest(@NonNull final SignedStateNexus nexus) throws InterruptedException {
         final ReservedSignedState state1 = mockState();
         final CountDownLatch unblockThread = new CountDownLatch(1);
         final CountDownLatch threadWaiting = new CountDownLatch(1);
@@ -145,7 +144,7 @@ class SignedStateNexusTest {
         assertSame(state2child, threadGetResult.get(), "The nexus should have returned the child of state2");
     }
 
-    private static ReservedSignedState mockState() throws InvalidRosterException {
+    private static ReservedSignedState mockState() {
         final ReservedSignedState state = Mockito.mock(ReservedSignedState.class);
         MerkleDb.resetDefaultInstancePath();
         final SignedState ss = new RandomSignedStateGenerator().build();
@@ -153,7 +152,7 @@ class SignedStateNexusTest {
         return state;
     }
 
-    private static ReservedSignedState realState() throws InvalidRosterException {
+    private static ReservedSignedState realState() {
         MerkleDb.resetDefaultInstancePath();
         return new RandomSignedStateGenerator().build().reserve("test");
     }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/WritableRosterStoreTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/WritableRosterStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/WritableRosterStoreTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/WritableRosterStoreTest.java
@@ -82,7 +82,7 @@ class WritableRosterStoreTest {
     }
 
     @Test
-    void testGetReturnsCorrectRoster() {
+    void testGetReturnsCorrectRoster() throws InvalidRosterException {
         final Roster expectedRoster = createValidTestRoster(1);
         writableRosterStore.putCandidateRoster(expectedRoster);
         final Bytes rosterHash = RosterUtils.hash(expectedRoster).getBytes();
@@ -93,7 +93,7 @@ class WritableRosterStoreTest {
     }
 
     @Test
-    void testGetReturnsNullForInvalidHash() {
+    void testGetReturnsNullForInvalidHash() throws InvalidRosterException {
         final Roster expectedRoster = createValidTestRoster(1);
         writableRosterStore.putCandidateRoster(expectedRoster);
         final Bytes rosterHash = Bytes.EMPTY;
@@ -104,7 +104,7 @@ class WritableRosterStoreTest {
     }
 
     @Test
-    void testSetCandidateRosterReturnsSame() {
+    void testSetCandidateRosterReturnsSame() throws InvalidRosterException {
         final Roster roster1 = createValidTestRoster(1);
         writableRosterStore.putCandidateRoster(roster1);
         assertEquals(
@@ -125,7 +125,7 @@ class WritableRosterStoreTest {
     }
 
     @Test
-    void testInvalidRoundNumberThrowsException() {
+    void testInvalidRoundNumberThrowsException() throws InvalidRosterException {
         writableRosterStore.putActiveRoster(createValidTestRoster(2), 1);
         final Roster roster = createValidTestRoster(1);
         assertThrows(IllegalArgumentException.class, () -> writableRosterStore.putActiveRoster(roster, 0));
@@ -136,7 +136,7 @@ class WritableRosterStoreTest {
      * Tests that setting an active roster returns the active roster when getActiveRoster is called.
      */
     @Test
-    void testGetCandidateRosterWithValidCandidateRoster() {
+    void testGetCandidateRosterWithValidCandidateRoster() throws InvalidRosterException {
         final Roster activeRoster = createValidTestRoster(1);
         assertNull(readableRosterStore.getActiveRoster(), "Active roster should be null initially");
         writableRosterStore.putActiveRoster(activeRoster, 2);
@@ -147,7 +147,7 @@ class WritableRosterStoreTest {
     }
 
     @Test
-    void testSetActiveRosterRemovesExistingCandidateRoster() {
+    void testSetActiveRosterRemovesExistingCandidateRoster() throws InvalidRosterException {
         final Roster activeRoster = createValidTestRoster(1);
         final Roster candidateRoster = createValidTestRoster(2);
         writableRosterStore.putCandidateRoster(candidateRoster);
@@ -170,7 +170,7 @@ class WritableRosterStoreTest {
      */
     @Test
     @DisplayName("Test Oldest Active Roster Cleanup")
-    void testOldestActiveRosterRemoved() throws NoSuchFieldException, IllegalAccessException {
+    void testOldestActiveRosterRemoved() throws NoSuchFieldException, IllegalAccessException, InvalidRosterException {
         final Roster roster1 = createValidTestRoster(3);
         writableRosterStore.putActiveRoster(roster1, 1);
         assertSame(readableRosterStore.getActiveRoster(), roster1, "Returned active roster should be roster1");
@@ -228,7 +228,7 @@ class WritableRosterStoreTest {
      */
     @Test
     @DisplayName("Duplicate Roster Hash")
-    void testRosterHashCollisions() {
+    void testRosterHashCollisions() throws InvalidRosterException {
         final Roster roster1 = createValidTestRoster(3);
         writableRosterStore.putActiveRoster(roster1, 1);
         assertSame(
@@ -256,7 +256,7 @@ class WritableRosterStoreTest {
      */
     @Test
     @DisplayName("Test Roster History")
-    void testRosterHistory() {
+    void testRosterHistory() throws InvalidRosterException {
         final Roster roster1 = createValidTestRoster(3);
         writableRosterStore.putActiveRoster(roster1, 1);
         assertSame(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/ReservedSignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/ReservedSignedStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.common.exceptions.ReferenceCountException;
 import com.swirlds.merkledb.MerkleDb;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,7 +74,7 @@ class ReservedSignedStateTests {
 
     @Test
     @DisplayName("Non-Null State Test")
-    void NonNullStateTest() throws InvalidRosterException {
+    void NonNullStateTest() {
         final SignedState signedState = new RandomSignedStateGenerator().build();
         assertEquals(0, signedState.getReservationCount());
 
@@ -120,7 +119,7 @@ class ReservedSignedStateTests {
 
     @Test
     @DisplayName("Non-Null Bad Lifecycle Test")
-    void nonNullBadLifecycleTest() throws InvalidRosterException {
+    void nonNullBadLifecycleTest() {
         final ReservedSignedState reservedSignedState =
                 ReservedSignedState.createAndReserve(new RandomSignedStateGenerator().build(), "reason");
         reservedSignedState.close();
@@ -135,7 +134,7 @@ class ReservedSignedStateTests {
 
     @Test
     @DisplayName("Try-reserve Paradigm Test")
-    void tryReserveTest() throws InvalidRosterException {
+    void tryReserveTest() {
         final SignedState signedState = new RandomSignedStateGenerator().build();
         assertEquals(0, signedState.getReservationCount());
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/ReservedSignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/ReservedSignedStateTests.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.common.exceptions.ReferenceCountException;
 import com.swirlds.merkledb.MerkleDb;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,7 +75,7 @@ class ReservedSignedStateTests {
 
     @Test
     @DisplayName("Non-Null State Test")
-    void NonNullStateTest() {
+    void NonNullStateTest() throws InvalidRosterException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
         assertEquals(0, signedState.getReservationCount());
 
@@ -119,7 +120,7 @@ class ReservedSignedStateTests {
 
     @Test
     @DisplayName("Non-Null Bad Lifecycle Test")
-    void nonNullBadLifecycleTest() {
+    void nonNullBadLifecycleTest() throws InvalidRosterException {
         final ReservedSignedState reservedSignedState =
                 ReservedSignedState.createAndReserve(new RandomSignedStateGenerator().build(), "reason");
         reservedSignedState.close();
@@ -134,7 +135,7 @@ class ReservedSignedStateTests {
 
     @Test
     @DisplayName("Try-reserve Paradigm Test")
-    void tryReserveTest() {
+    void tryReserveTest() throws InvalidRosterException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
         assertEquals(0, signedState.getReservationCount());
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -47,6 +47,7 @@ import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.config.StateConfig_;
 import com.swirlds.platform.internal.SignedStateLoadingException;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.snapshot.SignedStateFilePath;
 import com.swirlds.platform.state.snapshot.StateToDiskReason;
@@ -135,7 +136,7 @@ public class StartupStateUtilsTests {
             final long round,
             @Nullable final Hash epoch,
             final boolean corrupted)
-            throws IOException {
+            throws IOException, InvalidRosterException {
         MerkleDb.resetDefaultInstancePath();
 
         final SignedState signedState = new RandomSignedStateGenerator(random)
@@ -183,7 +184,7 @@ public class StartupStateUtilsTests {
 
     @Test
     @DisplayName("Normal Restart Test")
-    void normalRestartTest() throws IOException, SignedStateLoadingException {
+    void normalRestartTest() throws IOException, SignedStateLoadingException, InvalidRosterException {
         final Random random = getRandomPrintSeed();
         final PlatformContext platformContext = buildContext(false, TestRecycleBin.getInstance());
 
@@ -217,7 +218,7 @@ public class StartupStateUtilsTests {
 
     @Test
     @DisplayName("Corrupted State No Recycling Test")
-    void corruptedStateNoRecyclingTest() throws IOException {
+    void corruptedStateNoRecyclingTest() throws IOException, InvalidRosterException {
         final Random random = getRandomPrintSeed();
         final PlatformContext platformContext = buildContext(false, TestRecycleBin.getInstance());
 
@@ -245,7 +246,7 @@ public class StartupStateUtilsTests {
     @ValueSource(ints = {1, 2, 3, 4, 5})
     @DisplayName("Corrupted State Recycling Permitted Test")
     void corruptedStateRecyclingPermittedTest(final int invalidStateCount)
-            throws IOException, SignedStateLoadingException {
+            throws IOException, SignedStateLoadingException, InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final AtomicInteger recycleCount = new AtomicInteger(0);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -47,7 +47,6 @@ import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.config.StateConfig_;
 import com.swirlds.platform.internal.SignedStateLoadingException;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.snapshot.SignedStateFilePath;
 import com.swirlds.platform.state.snapshot.StateToDiskReason;
@@ -184,7 +183,7 @@ public class StartupStateUtilsTests {
 
     @Test
     @DisplayName("Normal Restart Test")
-    void normalRestartTest() throws IOException, SignedStateLoadingException, InvalidRosterException {
+    void normalRestartTest() throws IOException, SignedStateLoadingException {
         final Random random = getRandomPrintSeed();
         final PlatformContext platformContext = buildContext(false, TestRecycleBin.getInstance());
 
@@ -218,7 +217,7 @@ public class StartupStateUtilsTests {
 
     @Test
     @DisplayName("Corrupted State No Recycling Test")
-    void corruptedStateNoRecyclingTest() throws IOException, InvalidRosterException {
+    void corruptedStateNoRecyclingTest() throws IOException {
         final Random random = getRandomPrintSeed();
         final PlatformContext platformContext = buildContext(false, TestRecycleBin.getInstance());
 
@@ -246,7 +245,7 @@ public class StartupStateUtilsTests {
     @ValueSource(ints = {1, 2, 3, 4, 5})
     @DisplayName("Corrupted State Recycling Permitted Test")
     void corruptedStateRecyclingPermittedTest(final int invalidStateCount)
-            throws IOException, SignedStateLoadingException, InvalidRosterException {
+            throws IOException, SignedStateLoadingException {
         final Random random = getRandomPrintSeed();
 
         final AtomicInteger recycleCount = new AtomicInteger(0);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,7 +136,7 @@ public class StartupStateUtilsTests {
             final long round,
             @Nullable final Hash epoch,
             final boolean corrupted)
-            throws IOException, InvalidRosterException {
+            throws IOException {
         MerkleDb.resetDefaultInstancePath();
 
         final SignedState signedState = new RandomSignedStateGenerator(random)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StateGarbageCollectorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StateGarbageCollectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.internal.ConsensusRound;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import com.swirlds.platform.wiring.components.StateAndRound;
 import java.util.ArrayList;
@@ -50,7 +49,7 @@ class StateGarbageCollectorTests {
     }
 
     @Test
-    void standardBehaviorTest() throws InvalidRosterException {
+    void standardBehaviorTest() {
         final Random random = getRandomPrintSeed();
 
         final PlatformContext platformContext =

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StateGarbageCollectorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StateGarbageCollectorTests.java
@@ -25,6 +25,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.internal.ConsensusRound;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
 import com.swirlds.platform.wiring.components.StateAndRound;
 import java.util.ArrayList;
@@ -49,7 +50,7 @@ class StateGarbageCollectorTests {
     }
 
     @Test
-    void standardBehaviorTest() {
+    void standardBehaviorTest() throws InvalidRosterException {
         final Random random = getRandomPrintSeed();
 
         final PlatformContext platformContext =

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signer/StateSignerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signer/StateSignerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.crypto.PlatformSigner;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
@@ -51,7 +50,7 @@ public class StateSignerTests {
     }
 
     @Test
-    void doNotSignPcesState() throws InvalidRosterException {
+    void doNotSignPcesState() {
         final Randotron randotron = Randotron.create();
 
         final Hash stateHash = randotron.nextHash();
@@ -70,7 +69,7 @@ public class StateSignerTests {
     }
 
     @Test
-    void signRegularState() throws InvalidRosterException {
+    void signRegularState() {
         final Randotron randotron = Randotron.create();
 
         final Hash stateHash = randotron.nextHash();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signer/StateSignerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signer/StateSignerTests.java
@@ -30,6 +30,7 @@ import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.crypto.PlatformSigner;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
@@ -50,7 +51,7 @@ public class StateSignerTests {
     }
 
     @Test
-    void doNotSignPcesState() {
+    void doNotSignPcesState() throws InvalidRosterException {
         final Randotron randotron = Randotron.create();
 
         final Hash stateHash = randotron.nextHash();
@@ -69,7 +70,7 @@ public class StateSignerTests {
     }
 
     @Test
-    void signRegularState() {
+    void signRegularState() throws InvalidRosterException {
         final Randotron randotron = Randotron.create();
 
         final Hash stateHash = randotron.nextHash();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/Turtle.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/Turtle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/Turtle.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/Turtle.java
@@ -24,6 +24,7 @@ import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.Randotron;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
@@ -96,7 +97,7 @@ public class Turtle {
      *
      * @param builder the turtle builder
      */
-    Turtle(@NonNull final TurtleBuilder builder) {
+    Turtle(@NonNull final TurtleBuilder builder) throws InvalidRosterException {
         final Randotron randotron = builder.getRandotron();
         simulationGranularity = builder.getSimulationGranularity();
         timeReportingEnabled = builder.isTimeReportingEnabled();

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleBuilder.java
@@ -17,6 +17,7 @@
 package com.swirlds.platform.turtle.runner;
 
 import com.swirlds.common.test.fixtures.Randotron;
+import com.swirlds.platform.roster.InvalidRosterException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.util.Objects;
@@ -63,7 +64,7 @@ public class TurtleBuilder {
     }
 
     @NonNull
-    public Turtle build() {
+    public Turtle build() throws InvalidRosterException {
         return new Turtle(this);
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,8 @@ public class TurtleNode {
             @NonNull final NodeId nodeId,
             @NonNull final AddressBook addressBook,
             @NonNull final KeysAndCerts privateKeys,
-            @NonNull final SimulatedNetwork network) throws InvalidRosterException {
+            @NonNull final SimulatedNetwork network)
+            throws InvalidRosterException {
 
         final Configuration configuration = new TestConfigBuilder()
                 .withValue(PlatformSchedulersConfig_.CONSENSUS_EVENT_STREAM, "NO_OP")

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
@@ -36,6 +36,7 @@ import com.swirlds.platform.builder.PlatformBuilder;
 import com.swirlds.platform.builder.PlatformComponentBuilder;
 import com.swirlds.platform.config.BasicConfig_;
 import com.swirlds.platform.crypto.KeysAndCerts;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.system.BasicSoftwareVersion;
@@ -86,7 +87,7 @@ public class TurtleNode {
             @NonNull final NodeId nodeId,
             @NonNull final AddressBook addressBook,
             @NonNull final KeysAndCerts privateKeys,
-            @NonNull final SimulatedNetwork network) {
+            @NonNull final SimulatedNetwork network) throws InvalidRosterException {
 
         final Configuration configuration = new TestConfigBuilder()
                 .withValue(PlatformSchedulersConfig_.CONSENSUS_EVENT_STREAM, "NO_OP")

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTests.java
@@ -17,6 +17,7 @@
 package com.swirlds.platform.turtle.runner;
 
 import com.swirlds.common.test.fixtures.Randotron;
+import com.swirlds.platform.roster.InvalidRosterException;
 import java.time.Duration;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class TurtleTests {
      */
     @Disabled
     @Test
-    void turtleTest() {
+    void turtleTest() throws InvalidRosterException {
         final Randotron randotron = Randotron.create();
 
         final Turtle turtle = TurtleBuilder.create(randotron)

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ public class RandomSignedStateGenerator {
      *
      * @return a new signed state
      */
-    public SignedState build() throws InvalidRosterException {
+    public SignedState build() {
         final Roster rosterInstance;
         if (roster == null) {
             rosterInstance = RandomRosterBuilder.create(random)
@@ -130,8 +130,8 @@ public class RandomSignedStateGenerator {
             rosterInstance = roster;
         }
 
-        final SoftwareVersion softwareVersionInstance = Objects.requireNonNullElseGet(softwareVersion,
-                () -> new BasicSoftwareVersion(random.nextInt(1, 100)));
+        final SoftwareVersion softwareVersionInstance =
+                Objects.requireNonNullElseGet(softwareVersion, () -> new BasicSoftwareVersion(random.nextInt(1, 100)));
 
         final PlatformMerkleStateRoot stateInstance;
         registerMerkleStateRootClassIds();
@@ -148,10 +148,10 @@ public class RandomSignedStateGenerator {
         }
 
         final long roundInstance = Objects.requireNonNullElseGet(round, () -> Math.abs(random.nextLong()));
-        final Hash legacyRunningEventHashInstance = Objects.requireNonNullElseGet(legacyRunningEventHash,
-                () -> randomHash(random));
-        final Instant consensusTimestampInstance = Objects.requireNonNullElseGet(consensusTimestamp,
-                () -> RandomUtils.randomInstant(random));
+        final Hash legacyRunningEventHashInstance =
+                Objects.requireNonNullElseGet(legacyRunningEventHash, () -> randomHash(random));
+        final Instant consensusTimestampInstance =
+                Objects.requireNonNullElseGet(consensusTimestamp, () -> RandomUtils.randomInstant(random));
         final boolean freezeStateInstance = Objects.requireNonNullElseGet(freezeState, random::nextBoolean);
         final int roundsNonAncientInstance = Objects.requireNonNullElse(roundsNonAncient, 26);
 
@@ -180,7 +180,12 @@ public class RandomSignedStateGenerator {
         });
 
         FAKE_MERKLE_STATE_LIFECYCLES.initRosterState(stateInstance);
-        RosterUtils.setActiveRoster(stateInstance, rosterInstance, roundInstance);
+
+        try {
+            RosterUtils.setActiveRoster(stateInstance, rosterInstance, roundInstance);
+        } catch (final InvalidRosterException e) {
+            throw new IllegalArgumentException("Invalid roster", e);
+        }
 
         if (signatureVerifier == null) {
             signatureVerifier = SignatureVerificationTestUtils::verifySignature;
@@ -245,7 +250,7 @@ public class RandomSignedStateGenerator {
      *
      * @param count the number of states to build
      */
-    public List<SignedState> build(final int count) throws InvalidRosterException {
+    public List<SignedState> build(final int count) {
         final List<SignedState> states = new ArrayList<>(count);
 
         for (int i = 0; i < count; i++) {

--- a/platform-sdk/swirlds-platform-core/src/timingSensitive/java/com/swirlds/platform/components/appcomm/LatestCompleteStateNotifierTests.java
+++ b/platform-sdk/swirlds-platform-core/src/timingSensitive/java/com/swirlds/platform/components/appcomm/LatestCompleteStateNotifierTests.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.swirlds.common.notification.NotificationEngine;
+import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.state.notifications.NewSignedStateListener;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
@@ -41,7 +42,7 @@ public class LatestCompleteStateNotifierTests {
 
     @Test
     @DisplayName("NewLatestCompleteStateEventNotification")
-    void testNewLatestCompleteStateEventNotification() throws InterruptedException {
+    void testNewLatestCompleteStateEventNotification() throws InterruptedException, InvalidRosterException {
         final NotificationEngine notificationEngine = NotificationEngine.buildEngine(getStaticThreadManager());
         final SignedState signedState = new RandomSignedStateGenerator().build();
 

--- a/platform-sdk/swirlds-platform-core/src/timingSensitive/java/com/swirlds/platform/components/appcomm/LatestCompleteStateNotifierTests.java
+++ b/platform-sdk/swirlds-platform-core/src/timingSensitive/java/com/swirlds/platform/components/appcomm/LatestCompleteStateNotifierTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.swirlds.common.notification.NotificationEngine;
-import com.swirlds.platform.roster.InvalidRosterException;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.state.notifications.NewSignedStateListener;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
@@ -42,7 +41,7 @@ public class LatestCompleteStateNotifierTests {
 
     @Test
     @DisplayName("NewLatestCompleteStateEventNotification")
-    void testNewLatestCompleteStateEventNotification() throws InterruptedException, InvalidRosterException {
+    void testNewLatestCompleteStateEventNotification() throws InterruptedException {
         final NotificationEngine notificationEngine = NotificationEngine.buildEngine(getStaticThreadManager());
         final SignedState signedState = new RandomSignedStateGenerator().build();
 

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/RestartException.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/RestartException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.state.lifecycle;
+
+/**
+ * Indicates a failure has occurred during a node restart.
+ */
+public class RestartException extends RuntimeException {
+
+    public RestartException(final String message) {
+        super(message);
+    }
+
+    public RestartException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/Schema.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/Schema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,8 +119,9 @@ public abstract class Schema implements Comparable<Schema> {
      * but is provided for completeness.
      *
      * @param ctx {@link MigrationContext} for this schema restart operation
+     * @throws RestartException when there was an error attempting to perform the restart
      */
-    public void restart(@NonNull final MigrationContext ctx) {
+    public void restart(@NonNull final MigrationContext ctx) throws RestartException {
         Objects.requireNonNull(ctx);
     }
 


### PR DESCRIPTION
**Description**:
This refactors `InvalidRosterException` from a runtime exception to a checked exception.

There are some boundaries across modules that do complicate this transition. For example, `V0540RosterSchema` is outside the main platform code and thus instead of propagating the checked exception up, it is converted back to a runtime exception. The question was posed as to whether things like `Schema` should be exposed to the platform module and thus permit the checked exception further in into the services layer, but no feedback was received. Thus, I am looking for some feedback in this PR as to what is the preferred course of action (exposing the checked exception into the services or re-throwing it as a plain `RuntimeException` with the `InvalidRosterException` chained to it). `RekeyScenarioOp` and `StakePeriodChanges` are two other examples that require additional scrutiny.


**Related issue(s)**:

Fixes #15766 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
