### PR TITLE
fix: change == to .equals for Bytes.EMPTY and other non-primitive types

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ByteStringUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ByteStringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ByteStringUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ByteStringUtils.java
@@ -113,7 +113,7 @@ public final class ByteStringUtils {
         @VisibleForTesting
         static boolean supports(final ByteString byteString) {
             return byteString.size() > UnsafeByteOutput.SIZE
-                    && byteString.getClass() == UnsafeByteOutput.SUPPORTED_CLASS;
+                    && UnsafeByteOutput.SUPPORTED_CLASS.equals(byteString.getClass());
         }
     }
 

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeBuilder.java
@@ -213,7 +213,7 @@ public class FeeBuilder {
         if (key == null) {
             return 0;
         }
-        if (key == Key.getDefaultInstance()) {
+        if (Key.getDefaultInstance().equals(key)) {
             return 0;
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/accounts/BBMHederaAccount.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/accounts/BBMHederaAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/accounts/BBMHederaAccount.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/accounts/BBMHederaAccount.java
@@ -104,7 +104,7 @@ public record BBMHederaAccount(
     }
 
     public int[] getFirstUint256Key() {
-        return firstContractStorageKey == Bytes.EMPTY ? null : toInts(firstContractStorageKey);
+        return Bytes.EMPTY.equals(firstContractStorageKey) ? null : toInts(firstContractStorageKey);
     }
 
     private static int[] toInts(Bytes bytes) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/utils/ThingsToStrings.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/utils/ThingsToStrings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/utils/ThingsToStrings.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/statedumpers/utils/ThingsToStrings.java
@@ -513,7 +513,7 @@ public class ThingsToStrings {
     }
 
     public static boolean getMaybeStringifyByteString(@NonNull final StringBuilder sb, @Nullable final Bytes bytes) {
-        if (bytes == null || bytes == Bytes.EMPTY) {
+        if (bytes == null || Bytes.EMPTY.equals(bytes)) {
             return false;
         }
         sb.append(toStringPossibleHumanReadableByteArray(";", bytes.toByteArray()));

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/WritableFreezeStore.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/WritableFreezeStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/WritableFreezeStore.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/WritableFreezeStore.java
@@ -66,7 +66,7 @@ public class WritableFreezeStore extends ReadableFreezeStoreImpl {
      * Gets the scheduled freeze time. If no freeze has been scheduled, returns null.
      */
     public Timestamp freezeTime() {
-        return freezeTimeState.get() == Timestamp.DEFAULT ? null : freezeTimeState.get();
+        return Timestamp.DEFAULT.equals(freezeTimeState.get()) ? null : freezeTimeState.get();
     }
 
     /**
@@ -89,6 +89,6 @@ public class WritableFreezeStore extends ReadableFreezeStoreImpl {
         if (fileHash == null) {
             return null;
         }
-        return fileHash.value() == Bytes.EMPTY ? null : fileHash.value();
+        return Bytes.EMPTY.equals(fileHash.value()) ? null : fileHash.value();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateSyntheticTxnFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateSyntheticTxnFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateSyntheticTxnFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/create/CreateSyntheticTxnFactory.java
@@ -89,7 +89,7 @@ public class CreateSyntheticTxnFactory {
             @NonNull final TokenCreateWrapper tokenCreateWrapper, final Builder txnBodyBuilder) {
         tokenCreateWrapper.getTokenKeys().forEach(tokenKeyWrapper -> {
             final var key = tokenKeyWrapper.key().asGrpc();
-            if (key == Key.DEFAULT) {
+            if (Key.DEFAULT.equals(key)) {
                 throw new IllegalArgumentException();
             }
             if (tokenKeyWrapper.isUsedForAdminKey()) {


### PR DESCRIPTION
**Description**:
This PR updates all object comparisons to use equals instead of == except for a few instances where reference comparisons are per design.

**Related issue(s)**:
Fixes #16639

**Notes for reviewer**:
A zero-length PBJ Bytes is not necessarily Bytes.EMPTY so nothing should depend on object equality with Bytes.EMPTY. Using == for comparing objects is an anti-pattern in Java. 
