### PR TITLE
build: bump Gradle and module versions 

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -22,7 +22,7 @@ mainModuleInfo {
 
 testModuleInfo {
     requires("com.fasterxml.jackson.databind")
-    requires("com.google.jimfs")
+    requires("com.google.common.jimfs")
     requires("com.hedera.node.app")
     requires("com.hedera.node.app.spi.test.fixtures")
     requires("com.hedera.node.config.test.fixtures")

--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 plugins {
     id("org.hiero.gradle.module.library")
     id("org.hiero.gradle.feature.benchmark")

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -73,7 +73,7 @@ dependencies.constraints {
     }
     api("com.google.guava:guava:33.3.1-jre") { because("com.google.common") }
     api("com.google.j2objc:j2objc-annotations:3.0.0") { because("com.google.j2objc.annotations") }
-    api("com.google.jimfs:jimfs:1.2") { because("com.google.jimfs") }
+    api("com.google.jimfs:jimfs:1.3.0") { because("com.google.common.jimfs") }
     api("com.google.protobuf:protobuf-java:$protobuf") { because("com.google.protobuf") }
     api("com.google.protobuf:protobuf-java-util:$protobuf") { because("com.google.protobuf.util") }
     api("com.hedera.pbj:pbj-runtime:0.9.2") { because("com.hedera.pbj.runtime") }
@@ -97,7 +97,7 @@ dependencies.constraints {
     api("com.goterl:lazysodium-java:5.1.4") { because("lazysodium.java") }
     api("net.i2p.crypto:eddsa:0.3.0") { because("net.i2p.crypto.eddsa") }
     api("org.antlr:antlr4-runtime:4.13.2") { because("org.antlr.antlr4.runtime") }
-    api("commons-codec:commons-codec:1.15") { because("org.apache.commons.codec") }
+    api("commons-codec:commons-codec:1.17.1") { because("org.apache.commons.codec") }
     api("org.apache.commons:commons-collections4:4.4") {
         because("org.apache.commons.collections4")
     }
@@ -124,6 +124,7 @@ dependencies.constraints {
     api("org.hyperledger.besu:secp256k1:0.8.2") {
         because("org.hyperledger.besu.nativelib.secp256k1")
     }
+    api("org.jetbrains:annotations:26.0.1") { because("org.jetbrains.annotations") }
     api("org.json:json:20231013") { because("org.json") }
     api("org.junit.jupiter:junit-jupiter-api:$junit5") { because("org.junit.jupiter.api") }
     api("org.junit.jupiter:junit-jupiter-engine:$junit5") { because("org.junit.jupiter.engine") }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("org.hiero.gradle.build") version "0.1.4" }
+plugins { id("org.hiero.gradle.build") version "0.2.0" }
 
 javaModules {
     // This "intermediate parent project" should be removed


### PR DESCRIPTION
**Description**:
- Gradle 8.12
- com.google.jimfs:jimfs:1.3.0 - now has an Automatic-Module-Name
- commons-codec:commons-codec:1.17.1 - now has a `module-info`
- org.jetbrains:annotations:26.0.1 - now has a `module-info`
