### PR TITLE
fix: Set `BlockHeader.first_transaction_consensus_time`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -69,7 +69,9 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.system.Round;
+import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.state.notifications.StateHashedNotification;
+import com.swirlds.platform.system.transaction.ConsensusTransaction;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.CommittableWritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -84,6 +86,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -240,18 +243,40 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             outputTreeHasher = new ConcurrentStreamingTreeHasher(executor, hashCombineBatchSize);
             blockNumber = blockStreamInfo.blockNumber() + 1;
             pendingItems = new ArrayList<>();
-
+            final var firstTransactionTimestamp = getFirstTransactionTimestamp(round);
             pendingItems.add(BlockItem.newBuilder()
                     .blockHeader(BlockHeader.newBuilder()
                             .number(blockNumber)
                             .previousBlockHash(lastBlockHash)
                             .hashAlgorithm(SHA2_384)
                             .softwareVersion(platformState.creationSoftwareVersionOrThrow())
-                            .hapiProtoVersion(hapiVersion))
+                            .hapiProtoVersion(hapiVersion)
+                            .firstTransactionConsensusTime(firstTransactionTimestamp))
                     .build());
 
             writer.openBlock(blockNumber);
         }
+    }
+
+    /**
+     * Returns the consensus timestamp of the first transaction in the given round, or {@code null} if no such
+     * transaction is found.
+     *
+     * @param round the round
+     * @return the consensus timestamp of the first transaction in the given round, or {@code null} if no such
+     */
+    @Nullable
+    private Timestamp getFirstTransactionTimestamp(final @NonNull Round round) {
+        for (final ConsensusEvent event : round) {
+            final Iterator<ConsensusTransaction> txnIterator = event.consensusTransactionIterator();
+            while (txnIterator.hasNext()) {
+                final ConsensusTransaction transaction = txnIterator.next();
+                if (transaction.getConsensusTimestamp() != null) {
+                    return asTimestamp(transaction.getConsensusTimestamp());
+                }
+            }
+        }
+        return null;
     }
 
     @Override
@@ -409,7 +434,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
      * Synchronized to ensure that block proofs are always written in order, even in edge cases where multiple
      * pending block proofs become available at the same time.
      *
-     * @param blockHash   the block hash to finish the block proof for
+     * @param blockHash      the block hash to finish the block proof for
      * @param blockSignature the signature to use in the block proof
      */
     private synchronized void finishProofWithSignature(

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
@@ -67,7 +67,10 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.system.Round;
+import com.swirlds.platform.system.events.ConsensusEvent;
 import com.swirlds.platform.system.state.notifications.StateHashedNotification;
+import com.swirlds.platform.system.transaction.ConsensusTransaction;
+import com.swirlds.platform.system.transaction.TransactionWrapper;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.CommittableWritableStates;
 import com.swirlds.state.spi.ReadableStates;
@@ -76,6 +79,7 @@ import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
@@ -136,6 +140,21 @@ class BlockStreamManagerImplTest {
 
     @Mock
     private Round round;
+
+    @Mock
+    private Iterator<ConsensusEvent> eventIterator;
+
+    @Mock
+    private Iterator<ConsensusTransaction> transactionIterator;
+
+    @Mock
+    private TransactionWrapper transaction1;
+
+    @Mock
+    private TransactionWrapper transaction2;
+
+    @Mock
+    private ConsensusEvent event;
 
     @Mock
     private State state;
@@ -484,6 +503,14 @@ class BlockStreamManagerImplTest {
             @NonNull final PlatformState platformState,
             @NonNull final BlockItemWriter... writers) {
         given(round.getConsensusTimestamp()).willReturn(CONSENSUS_NOW);
+        given(round.iterator()).willReturn(eventIterator);
+        given(eventIterator.hasNext()).willReturn(true, false);
+        given(eventIterator.next()).willReturn(event);
+        given(event.consensusTransactionIterator()).willReturn(transactionIterator);
+        given(transactionIterator.hasNext()).willReturn(true).willReturn(true).willReturn(false);
+        given(transactionIterator.next()).willReturn(transaction1).willReturn(transaction2);
+        given(transaction1.getConsensusTimestamp()).willReturn(null);
+        given(transaction2.getConsensusTimestamp()).willReturn(CONSENSUS_NOW);
         final AtomicInteger nextWriter = new AtomicInteger(0);
         final var config = HederaTestConfigBuilder.create()
                 .withValue("blockStream.roundsPerBlock", roundsPerBlock)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockContentsValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockContentsValidator.java
@@ -26,7 +26,6 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -71,10 +70,6 @@ public class BlockContentsValidator implements BlockStreamValidator {
         // A block SHALL start with a `header`.
         if (!blockItems.getFirst().hasBlockHeader()) {
             Assertions.fail("Block does not start with a block header");
-        }
-
-        if (!Objects.requireNonNull(blockItems.getFirst().blockHeaderOrThrow()).hasFirstTransactionConsensusTime()) {
-            Assertions.fail("Block header doesn't have first transaction consensus time set");
         }
 
         // A block SHALL end with a `state_proof`.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockContentsValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockContentsValidator.java
@@ -24,9 +24,11 @@ import com.hedera.services.bdd.junit.support.BlockStreamAccess;
 import com.hedera.services.bdd.junit.support.BlockStreamValidator;
 import com.hedera.services.bdd.spec.HapiSpec;
 import edu.umd.cs.findbugs.annotations.NonNull;
+
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -73,7 +75,7 @@ public class BlockContentsValidator implements BlockStreamValidator {
             Assertions.fail("Block does not start with a block header");
         }
 
-        if (Objects.requireNonNull(blockItems.getFirst().blockHeaderOrThrow()).hasFirstTransactionConsensusTime()) {
+        if (!Objects.requireNonNull(blockItems.getFirst().blockHeaderOrThrow()).hasFirstTransactionConsensusTime()) {
             Assertions.fail("Block header doesn't have first transaction consensus time set");
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockContentsValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockContentsValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -70,6 +71,10 @@ public class BlockContentsValidator implements BlockStreamValidator {
         // A block SHALL start with a `header`.
         if (!blockItems.getFirst().hasBlockHeader()) {
             Assertions.fail("Block does not start with a block header");
+        }
+
+        if (Objects.requireNonNull(blockItems.getFirst().blockHeaderOrThrow()).hasFirstTransactionConsensusTime()) {
+            Assertions.fail("Block header doesn't have first transaction consensus time set");
         }
 
         // A block SHALL end with a `state_proof`.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockContentsValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockContentsValidator.java
@@ -24,11 +24,9 @@ import com.hedera.services.bdd.junit.support.BlockStreamAccess;
 import com.hedera.services.bdd.junit.support.BlockStreamValidator;
 import com.hedera.services.bdd.spec.HapiSpec;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
Fixes https://github.com/hashgraph/hedera-services/issues/17202

Adds `BlockHeader. first_transaction_consensus_time` by iterating through `ConsensusTransaction` in the round and set the first non-null consensus time.