### PR TITLE
chore: Synchronize around local reference to collection instead of synchronizing on the getter result directly

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabAddresses.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/internal/WinTabAddresses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,12 @@ import static com.swirlds.platform.gui.GuiUtils.wrap;
 import static com.swirlds.platform.gui.internal.BrowserWindowManager.getPlatforms;
 
 import com.hedera.hapi.node.state.roster.RosterEntry;
+import com.swirlds.platform.SwirldsPlatform;
 import com.swirlds.platform.gui.GuiUtils;
 import com.swirlds.platform.gui.components.PrePaintableJPanel;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.system.Platform;
+import java.util.Collection;
 import javax.swing.JTextArea;
 
 /**
@@ -51,8 +53,10 @@ class WinTabAddresses extends PrePaintableJPanel {
         }
         redoWindow = false;
         String s = "";
-        synchronized (getPlatforms()) {
-            for (final Platform p : getPlatforms()) {
+        final Collection<SwirldsPlatform> platforms = getPlatforms();
+
+        synchronized (platforms) {
+            for (final Platform p : platforms) {
                 final RosterEntry entry =
                         RosterUtils.getRosterEntry(p.getRoster(), p.getSelfId().id());
                 final String name = RosterUtils.formatNodeName(entry.nodeId());


### PR DESCRIPTION
**Description**:
Instead of synchronizing on the getter value, capture the value in a local variable and synchronize around that and also use it to generate the output string instead of making the getter call again.

**Related issue(s)**:

Fixes #16726 

**Notes for reviewer**:
This change should be non-impactful and as such all tests that worked before should continue to work.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
