### PR TITLE
chore: Additional Block Stream Validators for number and nonce

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockItemNonceValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockItemNonceValidator.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.junit.support.validators.block;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.bdd.junit.support.BlockStreamValidator;
+import com.hedera.services.bdd.spec.HapiSpec;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * A validator that ensures nonces are properly incremented for related transactions.
+ * For transactions with the same accountID and validStart, nonces should increment by 1.
+ */
+public class BlockItemNonceValidator implements BlockStreamValidator {
+    private static final Logger logger = LogManager.getLogger(BlockItemNonceValidator.class);
+
+    public static final Factory FACTORY = new Factory() {
+        @NonNull
+        @Override
+        public BlockStreamValidator create(@NonNull final HapiSpec spec) {
+            return new BlockItemNonceValidator();
+        }
+    };
+
+    private TransactionID getTransactionIdFromBlockItem(BlockItem item) throws ParseException {
+        if (item.hasEventTransaction()) {
+            Bytes txnBytes = Objects.requireNonNull(item.eventTransaction()).applicationTransactionOrThrow();
+            Transaction txn = Transaction.PROTOBUF.parse(txnBytes);
+            TransactionBody body = txn.bodyOrThrow();
+            return body.transactionIDOrThrow();
+        }
+        return null;
+    }
+
+    @Override
+    public void validateBlocks(@NonNull final List<Block> blocks) {
+        logger.info("Beginning validation of BlockItem nonces");
+
+        // Track highest nonce seen for each account+validStart combination
+        Map<String, Integer> highestNonces = new HashMap<>();
+
+        for (Block block : blocks) {
+            for (BlockItem item : block.items()) {
+                TransactionID txnId = null;
+                try {
+                    txnId = getTransactionIdFromBlockItem(item);
+                } catch (ParseException e) {
+                    throw new RuntimeException(e);
+                }
+
+                if (txnId != null) {
+                    // Create key from accountID and validStart
+                    String key = txnId.accountID().toString() + ":"
+                            + txnId.transactionValidStart().toString();
+                    int nonce = txnId.nonce();
+
+                    // If we've seen this account+validStart before, verify nonce increment
+                    if (highestNonces.containsKey(key)) {
+                        int prevNonce = highestNonces.get(key);
+                        if (nonce != prevNonce + 1) {
+                            Assertions.fail(String.format(
+                                    "Invalid nonce increment for transaction with account=%s, validStart=%s: previous=%d, current=%d",
+                                    txnId.accountID(), txnId.transactionValidStart(), prevNonce, nonce));
+                        }
+                    }
+
+                    // Update highest nonce seen for this account+validStart
+                    highestNonces.put(key, nonce);
+                }
+            }
+        }
+
+        logger.info("BlockItem nonce validation completed successfully");
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockNumberSequenceValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockNumberSequenceValidator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.junit.support.validators.block;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.services.bdd.junit.support.BlockStreamValidator;
+import com.hedera.services.bdd.spec.HapiSpec;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * A validator that ensures block numbers are sequential and not repeated in the block stream.
+ */
+public class BlockNumberSequenceValidator implements BlockStreamValidator {
+    private static final Logger logger = LogManager.getLogger(BlockNumberSequenceValidator.class);
+
+    public static final Factory FACTORY = new Factory() {
+        @NonNull
+        @Override
+        public BlockStreamValidator create(@NonNull final HapiSpec spec) {
+            return new BlockNumberSequenceValidator();
+        }
+    };
+
+    @Override
+    public void validateBlocks(@NonNull final List<Block> blocks) {
+        logger.info("Beginning validation of block number sequence");
+
+        Set<Long> seenBlockNumbers = new HashSet<>();
+        long expectedBlockNumber = -1;
+
+        for (int i = 0; i < blocks.size(); i++) {
+            Block block = blocks.get(i);
+            long currentBlockNumber = Objects.requireNonNull(
+                            block.items().getFirst().blockHeader())
+                    .number();
+
+            // Check if block number is repeated
+            if (!seenBlockNumbers.add(currentBlockNumber)) {
+                Assertions.fail(String.format("Block number %d is repeated at position %d", currentBlockNumber, i));
+            }
+
+            // Check if block number is sequential
+            if (expectedBlockNumber >= 0 && currentBlockNumber != expectedBlockNumber) {
+                Assertions.fail(String.format(
+                        "Block number %d at position %d is not sequential. Expected %d",
+                        currentBlockNumber, i, expectedBlockNumber));
+            }
+
+            expectedBlockNumber = currentBlockNumber + 1;
+        }
+
+        logger.info("Block number sequence validation completed successfully");
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.services.bdd.spec.utilops.streams;
 
 import static com.hedera.node.config.types.StreamMode.RECORDS;
@@ -28,6 +43,8 @@ import com.hedera.services.bdd.junit.support.validators.ExpiryRecordsValidator;
 import com.hedera.services.bdd.junit.support.validators.TokenReconciliationValidator;
 import com.hedera.services.bdd.junit.support.validators.TransactionBodyValidator;
 import com.hedera.services.bdd.junit.support.validators.block.BlockContentsValidator;
+import com.hedera.services.bdd.junit.support.validators.block.BlockItemNonceValidator;
+import com.hedera.services.bdd.junit.support.validators.block.BlockNumberSequenceValidator;
 import com.hedera.services.bdd.junit.support.validators.block.StateChangesValidator;
 import com.hedera.services.bdd.junit.support.validators.block.TransactionRecordParityValidator;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -65,7 +82,11 @@ public class StreamValidationOp extends UtilOp {
             new TokenReconciliationValidator());
 
     private static final List<BlockStreamValidator.Factory> BLOCK_STREAM_VALIDATOR_FACTORIES = List.of(
-            TransactionRecordParityValidator.FACTORY, StateChangesValidator.FACTORY, BlockContentsValidator.FACTORY);
+            TransactionRecordParityValidator.FACTORY,
+            StateChangesValidator.FACTORY,
+            BlockContentsValidator.FACTORY,
+            BlockNumberSequenceValidator.FACTORY,
+            BlockItemNonceValidator.FACTORY);
 
     public static void main(String[] args) {}
 


### PR DESCRIPTION
**Description**:
This pull request introduces two new block validators and updates the `StreamValidationOp` class to incorporate these new validators. 

New validators added:

* [`BlockItemNonceValidator`](diffhunk://#diff-a16779dd197d97a0f5f4c9863b3f5ed21e6640bbbc025938cfcc6c6c93af6bfaR1-R102): Ensures nonces are properly incremented for related transactions.
* [`BlockNumberSequenceValidator`](diffhunk://#diff-84537cd202323508e7d7aa697bf74213cdc12ff66351da1a7d0fd6839a302f34R1-R75): Ensures block numbers are sequential and not repeated in the block stream.

Updates to `StreamValidationOp`:

* Added license header to `StreamValidationOp.java`.
* Imported the new block validators.
* Updated `BLOCK_STREAM_VALIDATOR_FACTORIES` to include the new validators.
**Related issue(s)**:

Fixes #15409 #15378 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
