### PR TITLE
feature: Notify application when a self-ISS event is detected by the platform

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -146,6 +146,7 @@ import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.SwirldMain;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.events.Event;
+import com.swirlds.platform.system.state.notifications.AsyncIssListener;
 import com.swirlds.platform.system.state.notifications.StateHashedListener;
 import com.swirlds.platform.system.status.PlatformStatus;
 import com.swirlds.platform.system.transaction.Transaction;
@@ -1003,6 +1004,7 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
             notifications.unregister(PlatformStatusChangeListener.class, this);
             notifications.unregister(ReconnectCompleteListener.class, daggerApp.reconnectListener());
             notifications.unregister(StateWriteToDiskCompleteListener.class, daggerApp.stateWriteToDiskListener());
+            notifications.unregister(AsyncIssListener.class, daggerApp.asyncIssListener());
             if (blockStreamEnabled) {
                 notifications.unregister(StateHashedListener.class, daggerApp.blockStreamManager());
             }
@@ -1056,6 +1058,7 @@ public final class Hedera implements SwirldMain, PlatformStatusChangeListener, A
         notifications.register(PlatformStatusChangeListener.class, this);
         notifications.register(ReconnectCompleteListener.class, daggerApp.reconnectListener());
         notifications.register(StateWriteToDiskCompleteListener.class, daggerApp.stateWriteToDiskListener());
+        notifications.register(AsyncIssListener.class, daggerApp.asyncIssListener());
         if (blockStreamEnabled) {
             notifications.register(StateHashedListener.class, daggerApp.blockStreamManager());
             daggerApp

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
@@ -66,6 +66,7 @@ import com.swirlds.platform.listeners.ReconnectCompleteListener;
 import com.swirlds.platform.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
+import com.swirlds.platform.system.state.notifications.AsyncIssListener;
 import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.StartupNetworks;
 import com.swirlds.state.lifecycle.info.NetworkInfo;
@@ -145,6 +146,8 @@ public interface HederaInjectionComponent {
     StoreMetricsService storeMetricsService();
 
     SubmissionManager submissionManager();
+
+    AsyncIssListener asyncIssListener();
 
     @Component.Builder
     interface Builder {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/PlatformModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/PlatformModule.java
@@ -17,12 +17,14 @@
 package com.hedera.node.app.platform;
 
 import com.hedera.node.app.annotations.CommonExecutor;
+import com.hedera.node.app.state.listeners.IssDetectedListener;
 import com.hedera.node.app.state.listeners.ReconnectListener;
 import com.hedera.node.app.state.listeners.WriteStateToDiskListener;
 import com.swirlds.common.stream.Signer;
 import com.swirlds.platform.listeners.ReconnectCompleteListener;
 import com.swirlds.platform.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.platform.system.Platform;
+import com.swirlds.platform.system.state.notifications.AsyncIssListener;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -68,4 +70,8 @@ public interface PlatformModule {
     @Binds
     @Singleton
     StateWriteToDiskCompleteListener bindStateWrittenToDiskListener(WriteStateToDiskListener writeStateToDiskListener);
+
+    @Binds
+    @Singleton
+    AsyncIssListener bindAsyncIssListener(IssDetectedListener listener);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/IssDetectedListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/IssDetectedListener.java
@@ -1,0 +1,24 @@
+package com.hedera.node.app.state.listeners;
+
+import com.swirlds.platform.system.state.notifications.AsyncIssListener;
+import com.swirlds.platform.system.state.notifications.IssNotification;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+@Singleton
+public class IssDetectedListener implements AsyncIssListener {
+
+    private static final Logger log = LogManager.getLogger(IssDetectedListener.class);
+
+    @Inject
+    public IssDetectedListener()  {
+        // no-op
+    }
+
+    @Override
+    public void notify(final IssNotification data) {
+        log.warn("ISS detected (type={}, round={})", data.getIssType(), data.getRound());
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
@@ -932,7 +932,8 @@ public class PlatformComponentBuilder {
                         // halt without needing to be stopped here. This should eventually be cleaned up.
                     },
                     SystemExitUtils::handleFatalError,
-                    blocks.issScratchpad());
+                    blocks.issScratchpad(),
+                    blocks.notificationEngine());
         }
         return issHandler;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/AsyncIssListener.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/state/notifications/AsyncIssListener.java
@@ -1,0 +1,12 @@
+package com.swirlds.platform.system.state.notifications;
+
+import com.swirlds.common.notification.DispatchMode;
+import com.swirlds.common.notification.DispatchModel;
+import com.swirlds.common.notification.DispatchOrder;
+import com.swirlds.common.notification.Listener;
+
+/**
+ * Async listener for ISS events. If you require ordered, synchronous dispatch use {@link IssListener}.
+ */
+@DispatchModel(mode = DispatchMode.ASYNC, order = DispatchOrder.UNORDERED)
+public interface AsyncIssListener extends Listener<IssNotification> { }


### PR DESCRIPTION
**Description**:
When a self-ISS event is detected by the platform, forward the event to the application for additional handling. This PR creates a new ISS listener called `AsyncIssListener` that compliments the existing `IssListener`. The new listener was created such that the event could be forwarded asynchronously, as opposed to synchronously with the original `IssListener`. If this async nature is not really wanted, then we can fall back to using the original `IssListener` (I think).

Currently, the handler that receives the notification doesn't do anything meaningful, but follow up work will expand its use.

**Related issue(s)**:

Fixes #17266 

**Notes for reviewer**:
I've updated the platform tests to ensure the notification is forwarded in the case of self-ISS events, but I am not familiar with how to test the full path between the platform and app layer to ensure the notification is being received (i.e. making sure the app pieces are set up correctly). If anyone can point me to how to do this, that would be great.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
