### PR TITLE
fix: 17283: Backport the fix for #17218 to release 0.58

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1491,54 +1491,65 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
         final Consumer<Mutation<K, V>> action = mutation -> {
             // local variable is required because mutation.next can be changed by another thread to null
             // see https://github.com/hashgraph/hedera-services/issues/7046 for the context
-            Mutation<K, V> nextMutation = mutation.next;
+            final Mutation<K, V> nextMutation = mutation.next;
+            if (nextMutation == null) {
+                return;
+            }
             mutation.next = null;
-            if (nextMutation != null) {
-                assert !nextMutation.isFiltered();
-                // There may be older mutations being purged in parallel, they should not contribute
-                // to the "filtered" counter
-                if (!nextMutation.isFiltered() && (nextMutation.version > lastReleasedVersion)) {
-                    nextMutation.setFiltered();
+            assert !nextMutation.isFiltered();
+            // There may be older mutations being purged in parallel, they should not contribute
+            // to the "filtered" counter
+            if (!nextMutation.isFiltered() && (nextMutation.version > lastReleasedVersion)) {
+                nextMutation.setFiltered();
+                filteredCounter.incrementAndGet();
+            }
+            if (!nextMutation.isNew()) {
+                return;
+            }
+            // nextMutation is to put a new element into a virtual map. The element doesn't
+            // exist in the data source. If this mutation is filtered, there must be a newer
+            // mutation for the same key. If that newer mutation has the "deleted" flag, the
+            // element should never be flushed to disk
+            final Mutation<K, V> latestMutation = index.get(mutation.key);
+            // If latestMutation is null, lookup() can handle it just fine
+            final Mutation<K, V> latestMutationUpToVersion = lookup(latestMutation, newestVersion);
+            if (latestMutationUpToVersion == null) {
+                // Mutations are processed on many threads, see array.parallelTraverse() call
+                // below. The key may be removed from the index or the latest mutation up to
+                // newestVersion may be removed in parallel on a different thread
+                return;
+            }
+            assert !latestMutationUpToVersion.isFiltered();
+            if (latestMutationUpToVersion.isDeleted()) {
+                if (!latestMutationUpToVersion.isFiltered()) {
+                    latestMutationUpToVersion.setFiltered();
                     filteredCounter.incrementAndGet();
                 }
-                if (nextMutation.isNew()) {
-                    // nextMutation is to put a new element into a virtual map. The element doesn't
-                    // exist in the data source. If this mutation is filtered, there must be a newer
-                    // mutation for the same key. If that newer mutation has the "deleted" flag, the
-                    // element should never be flushed to disk
-                    final Mutation<K, V> latestMutation = index.get(mutation.key);
-                    assert latestMutation != null;
-                    final Mutation<K, V> latestMutationUpToVersion = lookup(latestMutation, newestVersion);
-                    assert latestMutationUpToVersion != null;
-                    assert !latestMutationUpToVersion.isFiltered();
-                    if (latestMutationUpToVersion.isDeleted()) {
-                        if (!latestMutationUpToVersion.isFiltered()) {
-                            latestMutationUpToVersion.setFiltered();
-                            filteredCounter.incrementAndGet();
-                        }
-                        // If the latest mutation up to newestVersion is "deleted", and there are no
-                        // newer mutations, the whole entry for the key can be removed from the index.
-                        // It's safe to do so here, as there are no references to copies older than
-                        // newestVersion and there are no mutations in versions newer than newestVersion
-                        index.compute(mutation.key, (k, v) -> {
-                            assert v != null;
-                            if (v == latestMutationUpToVersion) {
-                                return null;
-                            }
-                            Mutation<K, V> m = v;
-                            while (m.next != latestMutationUpToVersion) {
-                                m = m.next;
-                            }
-                            assert !m.isFiltered();
-                            assert m.version > newestVersion;
-                            m.next = null;
-                            return v;
-                        });
-                    } else {
-                        // Propagate the "new" flag to the newer mutation
-                        latestMutationUpToVersion.setNew();
+                // If the latest mutation up to newestVersion is "deleted", and there are no
+                // newer mutations, the whole entry for the key can be removed from the index.
+                // It's safe to do so here, as there are no references to copies older than
+                // newestVersion and there are no mutations in versions newer than newestVersion
+                index.compute(mutation.key, (k, v) -> {
+                    assert v != null;
+                    if (v == latestMutationUpToVersion) {
+                        return null;
                     }
-                }
+                    Mutation<K, V> m = v;
+                    while ((m != null) && (m.next != latestMutationUpToVersion)) {
+                        m = m.next;
+                    }
+                    // m may be null, if latestMutationUpToVersion was removed from the list of
+                    // mutations in a parallel thread
+                    if (m != null) {
+                        assert !m.isFiltered();
+                        assert m.version > newestVersion;
+                        m.next = null;
+                    }
+                    return v;
+                });
+            } else {
+                // Propagate the "new" flag to the newer mutation
+                latestMutationUpToVersion.setNew();
             }
         };
         try {


### PR DESCRIPTION
Fix summary: direct backport of https://github.com/hashgraph/hedera-services/pull/17237 to release 0.58

Fixes: https://github.com/hashgraph/hedera-services/issues/17283
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
