### PR TITLE
refactor: write current roster with state snapshot

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public final class SignedStateFileUtils {
     /**
      * The name of the file that contains the human-readable address book in the saved state
      */
-    public static final String CURRENT_ADDRESS_BOOK_FILE_NAME = "currentAddressBook.txt";
+    public static final String CURRENT_ROSTER_FILE_NAME = "currentRoster.txt";
 
     /**
      * The initial version of the signature set file

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileUtils.java
@@ -30,7 +30,7 @@ public final class SignedStateFileUtils {
     /**
      * The name of the file that contains the human-readable address book in the saved state
      */
-    public static final String CURRENT_ROSTER_FILE_NAME = "currentRoster.txt";
+    public static final String CURRENT_ROSTER_FILE_NAME = "currentRoster.json";
 
     /**
      * The initial version of the signature set file

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,12 @@ import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.logging.legacy.LogMarker.STATE_TO_DISK;
 import static com.swirlds.platform.config.internal.PlatformConfigUtils.writeSettingsUsed;
 import static com.swirlds.platform.event.preconsensus.BestEffortPcesFileCopy.copyPcesFilesRetryOnFailure;
-import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.CURRENT_ADDRESS_BOOK_FILE_NAME;
+import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.CURRENT_ROSTER_FILE_NAME;
 import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.HASH_INFO_FILE_NAME;
 import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.INIT_SIG_SET_FILE_VERSION;
 import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.SIGNATURE_SET_FILE_NAME;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.io.streams.MerkleDataOutputStream;
 import com.swirlds.common.merkle.utility.MerkleTreeVisualizer;
@@ -34,11 +35,9 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.logging.legacy.payload.StateSavedToDiskPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.recovery.emergencyfile.EmergencyRecoveryFile;
-import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.SigSet;
 import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.BufferedWriter;
@@ -157,9 +156,9 @@ public final class SignedStateFileWriter {
         writeHashInfoFile(platformContext, directory, signedState.getState());
         writeMetadataFile(selfId, directory, signedState);
         writeEmergencyRecoveryFile(directory, signedState);
-        if (!signedState.isGenesisState()) {
-            // Genesis states do not have address books.
-            writeStateAddressBookFile(directory, RosterUtils.buildAddressBook(signedState.getRoster()));
+        final Roster currentRoster = signedState.getRoster();
+        if (currentRoster != null) {
+            writeRosterFile(directory, currentRoster);
         }
         writeSettingsUsed(directory, platformContext.getConfiguration());
 
@@ -174,17 +173,17 @@ public final class SignedStateFileWriter {
     }
 
     /**
-     * Write the state's address book in human-readable form.
+     * Write the state's roster in human-readable form.
      *
-     * @param directory   the directory to write to
-     * @param addressBook the address book to write
+     * @param directory the directory to write to
+     * @param roster    the roster to write
      */
-    private static void writeStateAddressBookFile(@NonNull final Path directory, @NonNull final AddressBook addressBook)
+    private static void writeRosterFile(@NonNull final Path directory, @NonNull final Roster roster)
             throws IOException {
-        final Path addressBookFile = directory.resolve(CURRENT_ADDRESS_BOOK_FILE_NAME);
+        final Path rosterFile = directory.resolve(CURRENT_ROSTER_FILE_NAME);
 
-        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(addressBookFile.toFile()))) {
-            writer.write(addressBook.toConfigText());
+        try (final BufferedWriter writer = new BufferedWriter(new FileWriter(rosterFile.toFile()))) {
+            writer.write(Roster.JSON.toJSON(roster));
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -18,7 +18,7 @@ package com.swirlds.platform;
 
 import static com.swirlds.common.io.utility.FileUtils.throwIfFileExists;
 import static com.swirlds.platform.state.snapshot.SignedStateFileReader.readStateFile;
-import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.CURRENT_ADDRESS_BOOK_FILE_NAME;
+import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.CURRENT_ROSTER_FILE_NAME;
 import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.HASH_INFO_FILE_NAME;
 import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.SIGNATURE_SET_FILE_NAME;
 import static com.swirlds.platform.state.snapshot.SignedStateFileWriter.writeHashInfoFile;
@@ -173,7 +173,7 @@ class SignedStateFileReadWriteTest {
         final Path stateFile = directory.resolve(SIGNED_STATE_FILE_NAME);
         final Path hashInfoFile = directory.resolve(HASH_INFO_FILE_NAME);
         final Path settingsUsedFile = directory.resolve("settingsUsed.txt");
-        final Path addressBookFile = directory.resolve(CURRENT_ADDRESS_BOOK_FILE_NAME);
+        final Path addressBookFile = directory.resolve(CURRENT_ROSTER_FILE_NAME);
 
         throwIfFileExists(stateFile, hashInfoFile, settingsUsedFile, directory);
         final String configDir = testDirectory.resolve("data/saved").toString();


### PR DESCRIPTION
**Description**:
This PR swaps writing the current address book with the state snapshot to writing the current roster.  The code was already changing the roster to an address book.  This removes the translation and adjusts variable names appropriately. 

Fixes #17089 