### PR TITLE
chore: Update codeowners/docs to include platform-ci name change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hashgraph/devops-ci @hashgraph/release-engineering-managers
+*                                               @hashgraph/platform-ci @hashgraph/release-engineering-managers
 #########################
 ##### Example apps ######
 #########################
@@ -29,10 +29,10 @@
 # Hedera Node Deployments - Configuration & Grafana Dashboards
 /hedera-node/configuration/**                   @rbair23 @dalvizu @poulok @netopyr @Nana-EC @SimiHunjan @steven-sheehy @nathanklick
 /hedera-node/configuration/dev/**               @hashgraph/hedera-services
-/hedera-node/infrastructure/**                  @hashgraph/release-engineering-managers @hashgraph/devops-ci @hashgraph/devops @hashgraph/hedera-services
+/hedera-node/infrastructure/**                  @hashgraph/release-engineering-managers @hashgraph/platform-ci @hashgraph/devops @hashgraph/hedera-services
 
 # Hedera Node Docker Definitions
-/hedera-node/docker/                            @hashgraph/hedera-services @hashgraph/devops-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers
+/hedera-node/docker/                            @hashgraph/hedera-services @hashgraph/platform-ci @hashgraph/release-engineering @hashgraph/release-engineering-managers
 
 # Hedera Node Modules
 /hedera-node/hapi*/                             @hashgraph/hedera-services
@@ -102,40 +102,40 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                           @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.github/workflows/                                 @hashgraph/devops-ci @hashgraph/devops-ci-committers
-/.github/workflows/node-zxf-deploy-integration.yaml @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/devops
-/.github/workflows/node-zxf-deploy-preview.yaml     @hashgraph/devops-ci @hashgraph/devops-ci-committers @hashgraph/devops
+/.github/                                           @hashgraph/platform-ci @hashgraph/release-engineering-managers
+/.github/workflows/                                 @hashgraph/platform-ci @hashgraph/platform-ci-committers
+/.github/workflows/node-zxf-deploy-integration.yaml @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/devops
+/.github/workflows/node-zxf-deploy-preview.yaml     @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/devops
 
 # Legacy Maven project files
-**/pom.xml                                          @hashgraph/devops-ci @hashgraph/devops
+**/pom.xml                                          @hashgraph/platform-ci @hashgraph/devops
 
 # Gradle project files and inline plugins
-/gradle/                                            @hashgraph/devops-ci @hashgraph/devops-ci-committers
-gradlew                                             @hashgraph/devops-ci @hashgraph/devops-ci-committers
-gradlew.bat                                         @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/build-logic/                                     @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/gradle.*                                         @hashgraph/devops-ci @hashgraph/devops-ci-committers
-**/*.gradle.*                                       @hashgraph/devops-ci @hashgraph/devops-ci-committers
+/gradle/                                            @hashgraph/platform-ci @hashgraph/platform-ci-committers
+gradlew                                             @hashgraph/platform-ci @hashgraph/platform-ci-committers
+gradlew.bat                                         @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/build-logic/                                     @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/gradle.*                                         @hashgraph/platform-ci @hashgraph/platform-ci-committers
+**/*.gradle.*                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers
 
 # Codacy Tool Configurations
-/config/                                            @hashgraph/devops-ci @hashgraph/release-engineering-managers
-.remarkrc                                           @hashgraph/devops-ci @hashgraph/release-engineering-managers
+/config/                                            @hashgraph/platform-ci @hashgraph/release-engineering-managers
+.remarkrc                                           @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                         @hashgraph/release-engineering-managers
 
 # Protect the repository root files
-/README.md                                          @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/platform-base @hashgraph/hedera-services @hashgraph/platform-hashgraph
+/README.md                                          @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/platform-base @hashgraph/hedera-services @hashgraph/platform-hashgraph
 **/LICENSE                                          @hashgraph/release-engineering-managers
 
 # CodeCov configuration
-**/codecov.yml                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/codecov.yml                                      @hashgraph/platform-ci @hashgraph/release-engineering-managers
 
 # Git Ignore definitions
-**/.gitignore                                       @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/platform-base @hashgraph/hedera-services @hashgraph/platform-hashgraph
-**/.gitignore.*                                     @hashgraph/devops-ci @hashgraph/release-engineering-managers @hashgraph/platform-base @hashgraph/hedera-services @hashgraph/platform-hashgraph
+**/.gitignore                                       @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/platform-base @hashgraph/hedera-services @hashgraph/platform-hashgraph
+**/.gitignore.*                                     @hashgraph/platform-ci @hashgraph/release-engineering-managers @hashgraph/platform-base @hashgraph/hedera-services @hashgraph/platform-hashgraph
 
 # Legacy CircleCI configuration
-.circleci.settings.xml                              @hashgraph/devops-ci @hashgraph/release-engineering-managers
-/.circleci/                                         @hashgraph/devops-ci @hashgraph/release-engineering-managers
+.circleci.settings.xml                              @hashgraph/platform-ci @hashgraph/release-engineering-managers
+/.circleci/                                         @hashgraph/platform-ci @hashgraph/release-engineering-managers

--- a/docs/maintainers-guide.md
+++ b/docs/maintainers-guide.md
@@ -90,9 +90,9 @@ with 0.30 milestone on it.
 
 ![labels-on-issue](./assets/labels-on-issue.png)
 
-### DevOps-CI Responsibilities
+### Platform-CI Responsibilities
 
-The DevOps-CI team will handle the following:
+The Platform-CI team will handle the following:
 
 - Will provide automated release processes and coordinate release schedules
 - Will handle production releases


### PR DESCRIPTION
**Description**:

Rename devops-ci to platform-ci

**Related issue(s)**:

Fixes #17380
