### PR TITLE
chore: sync changes from hedera-protobufs

### DIFF
--- a/hapi/hedera-protobufs/block/stream/block_item.proto
+++ b/hapi/hedera-protobufs/block/stream/block_item.proto
@@ -96,8 +96,51 @@ import "stream/output/transaction_result.proto";
  * Items to be hashed MUST NOT be contained within another item.<br/>
  * Items which might be filtered out of the stream MUST NOT be
  * contained in other items.
+ *
+ * ### Forward Compatibility
+ * In order to maximize forward compatibility, and minimize the need to
+ * coordinate deployments of different systems creating and processing
+ * block streams in the future, the following rules SHALL be followed
+ * for field numbering in this message.
+ * - The first 15 field numbers SHALL be assigned to the fields present
+ *   in the first release. Unused fields in this range SHALL remain reserved
+ *   until needed for additional options that do not fit into "input" or
+ *   "output" categories.
+ * - Fields numbered 16 and above MUST be numbered as follows.
+ *    - "input" items MUST use `odd` field numbers.
+ *    - "output" items MUST use `even` field numbers.
+ *
+ * #### Forward Compatibility Example
+ * A future update adding three new items. A "BlockTrailer" item which is
+ * neither input nor output, a new "ConsensusTransom" which is an input,
+ * and a new "BridgeTransform" which is an output.
+ * - The "BlockTrailer" is field 11, which is removed from the `reserved` list.
+ * - The "ConsensusTransom" is an input, so it is field `17` (the first unused
+ *   `odd` field greater than or equal to 16).
+ * - The "BridgeTransform" is an output, so it is field `16` (the first unused
+ *   even field greater than or equal to 16).
+ *
+ * #### Initial Field assignment to "input", "output", and "other" categories.
+ * - Inputs
+ *    - `event_header`
+ *    - `round_header`
+ *    - `event_transaction`
+ * - Outputs
+ *    - `block_header`
+ *    - `transaction_result`
+ *    - `transaction_output`
+ *    - `state_changes`
+ * - Any subtree (depending on what was filtered).
+ *   This item details it's path in the tree.
+ *    - `filtered_item_hash`
+ * - Neither input nor output (and not part of the "proof" merkle tree)
+ *    - `block_proof`
+ *    - `record_file`
  */
 message BlockItem {
+    // Reserved for future items that are neither "input" nor "output".
+    reserved 11,12,13,14,15;
+
     oneof item {
         /**
          * An header for the block, marking the start of a new block.

--- a/hapi/hedera-protobufs/block/stream/record_file_item.proto
+++ b/hapi/hedera-protobufs/block/stream/record_file_item.proto
@@ -35,7 +35,9 @@ option java_package = "com.hedera.hapi.block.stream.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.stream">>> This comment is special code for setting PBJ Compiler java package
 option java_multiple_files = true;
 
+import "basic_types.proto";
 import "timestamp.proto";
+import "sidecar_file.proto";
 
 /**
  * A Block Item for record files.
@@ -81,11 +83,29 @@ message RecordFileItem {
      * The contents of sidecar files for this block.<br/>
      * Each block can have zero or more sidecar files.
      */
-    repeated bytes sidecar_file_contents = 3;
+    repeated proto.SidecarFile sidecar_file_contents = 3;
 
     /**
      * A collection of RSA signatures from consensus nodes.<br/>
      * These signatures validate the hash of the record_file_contents field.
      */
-    repeated bytes record_file_hash_signatures = 4;
+    repeated RecordFileSignature record_file_signatures = 4;
+}
+
+/**
+ * A signature by a node on the SHA384 hash of the record file.
+ */
+message RecordFileSignature {
+    /**
+     * A single RSA signature.<br/>
+     * This is the RSA signature of the node on the SHA384 hash of
+     * the record file
+     */
+    bytes signatures_bytes = 1;
+
+    /**
+     * A unique node identifier.<br/>
+     * This is the node id of the consensus node that created this signature.
+     */
+    int32 node_id = 2;
 }

--- a/hapi/hedera-protobufs/services/node_create.proto
+++ b/hapi/hedera-protobufs/services/node_create.proto
@@ -135,6 +135,7 @@ message NodeCreateTransactionBody {
     * An administrative key controlled by the node operator.
      * <p>
      * This key MUST sign this transaction.<br/>
+     * This key MUST sign each transaction to update this node.<br/>
      * This field MUST contain a valid `Key` value.<br/>
      * This field is REQUIRED and MUST NOT be set to an empty `KeyList`.
      */


### PR DESCRIPTION
**Description**:

There were some small recent changes to the proto definitions in `hedera-protobufs` that need to be reflected in the services code before we sync back to there from `services` the latest up to date protobufs 

**Related issue(s)**:

Fixes #17397 
