### PR TITLE
fix: retain override values on `ConfigProviderImpl.update()` (#17424)

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,8 @@ public class ConfigProviderImpl extends ConfigProviderBase {
 
     private final ConfigMetrics configMetrics;
 
+    private final Map<String, String> overrideValues;
+
     /**
      * Create a new instance, particularly from dependency injection.
      */
@@ -92,6 +94,9 @@ public class ConfigProviderImpl extends ConfigProviderBase {
         addFileSources(builder, useGenesisSource);
         if (overrideValues != null) {
             overrideValues.forEach(builder::withValue);
+            this.overrideValues = Map.copyOf(overrideValues);
+        } else {
+            this.overrideValues = Map.of();
         }
         final Configuration config = builder.build();
         configuration = new AtomicReference<>(new VersionedConfigImpl(config, 0));
@@ -124,6 +129,7 @@ public class ConfigProviderImpl extends ConfigProviderBase {
             addFileSources(builder, false);
             addByteSource(builder, networkProperties);
             addByteSource(builder, permissions);
+            overrideValues.forEach(builder::withValue);
             final Configuration config = builder.build();
             configuration.set(
                     new VersionedConfigImpl(config, this.configuration.get().getVersion() + 1));

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/FileUtilities.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/FileUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ public class FileUtilities {
     /**
      * Observes the properties and permissions of the network from a saved state.
      */
+    @FunctionalInterface
     public interface SpecialFilesObserver {
         /**
          * Accepts the properties and permissions of the network from a saved state.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/FacilityInitModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/FacilityInitModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,11 @@ public interface FacilityInitModule {
             if (hasHandledGenesisTxn(state)) {
                 initializeExchangeRateManager(state, configProvider, exchangeRateManager);
                 initializeFeeManager(state, configProvider, feeManager);
-                observePropertiesAndPermissions(state, configProvider.getConfiguration(), configProvider::update);
+                observePropertiesAndPermissions(state, configProvider.getConfiguration(), (properties, permissions) -> {
+                    if (!Bytes.EMPTY.equals(properties) || !Bytes.EMPTY.equals(permissions)) {
+                        configProvider.update(properties, permissions);
+                    }
+                });
                 throttleServiceManager.init(state, throttleDefinitionsFrom(state, configProvider));
             } else {
                 final var schema = fileService.fileSchema();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/config/ConfigProviderImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/config/ConfigProviderImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,10 +178,14 @@ class ConfigProviderImplTest {
     }
 
     @Test
-    void incorporatesOverrideProperties() {
+    void incorporatesOverridePropertiesEvenAfterUpdate() {
         final var subject = new ConfigProviderImpl(false, null, Map.of("baz.test", "789"));
         final var config = subject.getConfiguration();
         assertThat(config.getValue("baz.test")).isEqualTo("789");
+
+        subject.update(Bytes.EMPTY, Bytes.EMPTY);
+        final var postUpdateConfig = subject.getConfiguration();
+        assertThat(postUpdateConfig.getValue("baz.test")).isEqualTo("789");
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick #17424