### PR TITLE
fix: fix gradle run task to include a nodeId from cli arguments

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -144,6 +144,9 @@ tasks.register<JavaExec>("run") {
     workingDir = nodeWorkingDir.get().asFile
     jvmArgs = listOf("-cp", "data/lib/*:data/apps/*")
     mainClass.set("com.hedera.node.app.ServicesMain")
+
+    // Add arguments for the application to run a local node
+    args = listOf("-local", "0")
 }
 
 val cleanRun =


### PR DESCRIPTION
The gradle run task is broken , because there are no CLI arguments to run a local node.
Fixed it by adding a nodeId for the `localNodesToRun`