### PR TITLE
perf: `MerkleHashBuilder` does not scale

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -58,7 +58,7 @@ import com.hedera.node.config.data.VersionConfig;
 import com.hedera.node.config.types.BlockStreamWriterMode;
 import com.hedera.node.config.types.DiskNetworkExport;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.component.framework.tasks.AbstractTask;
+import com.swirlds.common.concurrent.AbstractTask;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -53,7 +53,6 @@ module com.hedera.node.app {
     requires com.hedera.node.app.service.network.admin;
     requires com.hedera.node.app.service.util;
     requires com.swirlds.base;
-    requires com.swirlds.component.framework;
     requires com.swirlds.config.extensions;
     requires com.swirlds.logging;
     requires com.swirlds.merkle;

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/concurrent/AbstractTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/concurrent/AbstractTask.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.swirlds.component.framework.tasks;
+package com.swirlds.common.concurrent;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.ForkJoinPool;

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/MerkleCryptographyFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/MerkleCryptographyFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@
  */
 
 package com.swirlds.common.merkle.crypto;
-
-import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
 
 import com.swirlds.common.crypto.Cryptography;
 import com.swirlds.common.crypto.config.CryptoConfig;
@@ -41,7 +39,6 @@ public final class MerkleCryptographyFactory {
     @NonNull
     public static MerkleCryptography create(
             @NonNull final Configuration configuration, @NonNull final Cryptography cryptography) {
-        return new MerkleCryptoEngine(
-                getStaticThreadManager(), cryptography, configuration.getConfigData(CryptoConfig.class));
+        return new MerkleCryptoEngine(cryptography, configuration.getConfigData(CryptoConfig.class));
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleCryptoEngine.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/crypto/internal/MerkleCryptoEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.crypto.MerkleCryptography;
 import com.swirlds.common.merkle.hash.MerkleHashBuilder;
-import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.logging.legacy.LogMarker;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -52,19 +51,15 @@ public class MerkleCryptoEngine implements MerkleCryptography {
     /**
      * Create a new merkle crypto engine.
      *
-     * @param threadManager
-     * 		responsible for thread lifecycle management
      * @param cryptography
      * 		provides cryptographic primitives
      * @param settings
      * 		provides settings for cryptography
      */
-    public MerkleCryptoEngine(
-            final ThreadManager threadManager, final Cryptography cryptography, final CryptoConfig settings) {
+    public MerkleCryptoEngine(final Cryptography cryptography, final CryptoConfig settings) {
         basicCryptoEngine = cryptography;
         this.merkleInternalDigestProvider = new MerkleInternalDigestProvider();
-        this.merkleHashBuilder =
-                new MerkleHashBuilder(threadManager, this, cryptography, settings.computeCpuDigestThreadCount());
+        this.merkleHashBuilder = new MerkleHashBuilder(this, cryptography, settings.computeCpuDigestThreadCount());
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/FutureMerkleHash.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/FutureMerkleHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.swirlds.common.merkle.hash;
 
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.merkle.MerkleNode;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -51,10 +52,10 @@ public class FutureMerkleHash implements Future<Hash> {
     /**
      * This method is used to register that an exception was encountered while hashing the tree.
      */
-    public synchronized void cancelWithException(final Throwable exception) {
-        if (exception != null) {
+    public synchronized void cancelWithException(@NonNull final Throwable t) {
+        if (exception == null) {
             // Only the first exception gets rethrown
-            this.exception = exception;
+            exception = t;
             latch.countDown();
         }
     }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
@@ -16,9 +16,7 @@
 
 package com.swirlds.common.merkle.hash;
 
-import static com.swirlds.common.crypto.engine.CryptoEngine.THREAD_COMPONENT_NAME;
 import static com.swirlds.common.merkle.utility.MerkleConstants.MERKLE_DIGEST_TYPE;
-import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 
 import com.swirlds.common.concurrent.AbstractTask;
 import com.swirlds.common.crypto.Cryptography;
@@ -26,21 +24,15 @@ import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.crypto.MerkleCryptography;
-import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.common.threading.futures.StandardFuture;
-import com.swirlds.common.threading.manager.ThreadManager;
 import java.util.Iterator;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * This class is responsible for hashing a merkle tree.
  */
 public class MerkleHashBuilder {
-    private static final Logger logger = LogManager.getLogger(MerkleHashBuilder.class);
 
     private final ForkJoinPool threadPool;
 
@@ -51,31 +43,15 @@ public class MerkleHashBuilder {
     /**
      * Construct an object which calculates the hash of a merkle tree.
      *
-     * @param threadManager
-     * 		responsible for managing thread lifecycles
      * @param cryptography
      * 		the {@link Cryptography} implementation to use
      * @param cpuThreadCount
      * 		the number of threads to be used for computing hash
      */
     public MerkleHashBuilder(
-            final ThreadManager threadManager,
-            final MerkleCryptography merkleCryptography,
-            final Cryptography cryptography,
-            final int cpuThreadCount) {
+            final MerkleCryptography merkleCryptography, final Cryptography cryptography, final int cpuThreadCount) {
         this.merkleCryptography = merkleCryptography;
         this.cryptography = cryptography;
-
-        final ThreadFactory threadFactory = new ThreadConfiguration(threadManager)
-                .setDaemon(true)
-                .setComponent(THREAD_COMPONENT_NAME)
-                .setThreadName("merkle hash")
-                .setPriority(Thread.NORM_PRIORITY)
-                .setExceptionHandler((t, ex) -> {
-                    logger.error(EXCEPTION.getMarker(), "Uncaught exception in MerkleHashBuilder thread pool", ex);
-                })
-                .buildFactory();
-
         this.threadPool = new ForkJoinPool(cpuThreadCount);
     }
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
@@ -113,14 +113,12 @@ public class MerkleHashBuilder {
         } else if (root.getHash() != null) {
             return new StandardFuture<>(root.getHash());
         } else {
-            resultFuture = new FutureMerkleHash();
+            FutureMerkleHash resultFuture = new FutureMerkleHash();
             ResultTask resultTask = new ResultTask(root, resultFuture);
             new TraverseTask(root, resultTask).send();
             return resultFuture;
         }
     }
-
-    FutureMerkleHash resultFuture;
 
     /**
      * The root of a merkle tree.
@@ -177,7 +175,7 @@ public class MerkleHashBuilder {
                     }
                 }
             } catch (Exception ex) {
-                resultFuture.cancelWithException(ex);
+                out.completeExceptionally(ex);
             }
             return true;
         }
@@ -202,6 +200,12 @@ public class MerkleHashBuilder {
             out.send();
             return true;
         }
+
+        @Override
+        public void completeExceptionally(Throwable ex) {
+            out.completeExceptionally(ex);
+            super.completeExceptionally(ex);
+        }
     }
 
     /**
@@ -221,6 +225,12 @@ public class MerkleHashBuilder {
         protected boolean exec() {
             future.set(root.getHash());
             return true;
+        }
+
+        @Override
+        public void completeExceptionally(Throwable ex) {
+            future.cancelWithException(ex);
+            super.completeExceptionally(ex);
         }
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
@@ -140,6 +140,10 @@ public class MerkleHashBuilder {
         }
     }
 
+    /**
+     * TraverseTask processes the current node in the tree and either hashes it or adds
+     * to a parallel structure of ComputeTasks and creates TraverseTasks for its children.
+     */
     class TraverseTask extends AbstractTask {
         final MerkleNode node;
         final AbstractTask out;
@@ -156,13 +160,13 @@ public class MerkleHashBuilder {
                 if (node == null || node.getHash() != null) {
                     out.send();
                 } else if (node.isLeaf()) {
-                    merkleCryptography.digestSync(node, MERKLE_DIGEST_TYPE);
+                    merkleCryptography.digestSync(node.asLeaf(), MERKLE_DIGEST_TYPE);
                     out.send();
                 } else {
                     MerkleInternal internal = node.asInternal();
                     int nChildren = internal.getNumberOfChildren();
                     if (nChildren == 0) {
-                        merkleCryptography.digestSync(node, MERKLE_DIGEST_TYPE);
+                        merkleCryptography.digestSync(internal, MERKLE_DIGEST_TYPE);
                         out.send();
                     } else {
                         ComputeTask compute = new ComputeTask(internal, nChildren, out);
@@ -179,6 +183,9 @@ public class MerkleHashBuilder {
         }
     }
 
+    /**
+     * ComputeTask computes internal node's hash once all its children have their hashes computed.
+     */
     class ComputeTask extends AbstractTask {
         final MerkleInternal internal;
         final AbstractTask out;
@@ -197,6 +204,9 @@ public class MerkleHashBuilder {
         }
     }
 
+    /**
+     * ResultTask connects asynchronous parallel execution to FutureMerkleHash.
+     */
     class ResultTask extends AbstractTask {
         final FutureMerkleHash future;
         final MerkleNode root;

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
@@ -176,6 +176,7 @@ public class MerkleHashBuilder {
                 }
             } catch (Exception ex) {
                 out.completeExceptionally(ex);
+                return false;
             }
             return true;
         }
@@ -203,8 +204,11 @@ public class MerkleHashBuilder {
 
         @Override
         public void completeExceptionally(Throwable ex) {
-            out.completeExceptionally(ex);
             super.completeExceptionally(ex);
+            // Try to reduce exception propagation; OK if multiple exceptions reported to out
+            if (!out.isCompletedAbnormally()) {
+                out.completeExceptionally(ex);
+            }
         }
     }
 
@@ -229,8 +233,10 @@ public class MerkleHashBuilder {
 
         @Override
         public void completeExceptionally(Throwable ex) {
-            future.cancelWithException(ex);
             super.completeExceptionally(ex);
+            if (!future.isCancelled()) {
+                future.cancelWithException(ex);
+            }
         }
     }
 }

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/ConcurrentTask.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/ConcurrentTask.java
@@ -16,8 +16,8 @@
 
 package com.swirlds.component.framework.schedulers.internal;
 
+import com.swirlds.common.concurrent.AbstractTask;
 import com.swirlds.component.framework.counters.ObjectCounter;
-import com.swirlds.component.framework.tasks.AbstractTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.lang.Thread.UncaughtExceptionHandler;

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/SequentialTask.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/SequentialTask.java
@@ -16,9 +16,9 @@
 
 package com.swirlds.component.framework.schedulers.internal;
 
+import com.swirlds.common.concurrent.AbstractTask;
 import com.swirlds.common.metrics.extensions.FractionalTimer;
 import com.swirlds.component.framework.counters.ObjectCounter;
-import com.swirlds.component.framework.tasks.AbstractTask;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.lang.Thread.UncaughtExceptionHandler;

--- a/platform-sdk/swirlds-component-framework/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/module-info.java
@@ -23,7 +23,6 @@ module com.swirlds.component.framework {
     exports com.swirlds.component.framework.schedulers;
     exports com.swirlds.component.framework.schedulers.builders;
     exports com.swirlds.component.framework.schedulers.internal;
-    exports com.swirlds.component.framework.tasks;
     exports com.swirlds.component.framework.transformers;
     exports com.swirlds.component.framework.wires;
     exports com.swirlds.component.framework.wires.input;

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.component.framework.tasks.AbstractTask;
+import com.swirlds.common.concurrent.AbstractTask;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.merkledb.FileStatisticAware;
 import com.swirlds.merkledb.Snapshotable;

--- a/platform-sdk/swirlds-merkledb/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/module-info.java
@@ -28,7 +28,6 @@ open module com.swirlds.merkledb {
 
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.common;
-    requires transitive com.swirlds.component.framework;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;
     requires transitive com.swirlds.virtualmap;

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,9 +35,6 @@ import java.time.Duration;
  * @param percentHashThreads
  * 		Gets the percentage (from 0.0 to 100.0) of available processors to devote to hashing
  * 		threads. Ignored if an explicit number of threads is given via {@code virtualMap.numHashThreads}.
- * @param numHashThreads
- * 		The number of threads to devote to hashing. If not set, defaults to the number of threads implied by
- *        {@code virtualMap.percentHashThreads} and {@link Runtime#availableProcessors()}.
  * @param virtualHasherChunkHeight
  *      The number of ranks minus one to handle in a single virtual hasher task. That is, when height is
  *      1, every task takes 2 inputs. Height 2 corresponds to tasks with 4 inputs. And so on.
@@ -92,7 +89,6 @@ import java.time.Duration;
 public record VirtualMapConfig(
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "50.0")
                 double percentHashThreads, // FUTURE WORK: We need to add min/max support for double values
-        @Min(-1) @ConfigProperty(defaultValue = "-1") int numHashThreads,
         @Min(1) @Max(64) @ConfigProperty(defaultValue = "3") int virtualHasherChunkHeight,
         @ConfigProperty(defaultValue = PUSH) String reconnectMode,
         @Min(0) @ConfigProperty(defaultValue = "500000") int reconnectFlushInterval,
@@ -141,14 +137,6 @@ public record VirtualMapConfig(
                     "virtualMapWarningThreshold must be <=  maximumVirtualMapSize");
         }
         return null;
-    }
-
-    public int getNumHashThreads() {
-        final int threads = (numHashThreads() == -1)
-                ? (int) (Runtime.getRuntime().availableProcessors() * (percentHashThreads() / UNIT_FRACTION_PERCENT))
-                : numHashThreads();
-
-        return Math.max(1, threads);
     }
 
     public int getNumCleanerThreads() {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/module-info.java
@@ -38,7 +38,6 @@ open module com.swirlds.virtualmap {
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;
     requires com.swirlds.base;
-    requires com.swirlds.component.framework;
     requires com.swirlds.config.extensions;
     requires com.swirlds.logging;
     requires java.management; // Test dependency


### PR DESCRIPTION
**Description**:
* reimplemented MerkleHashBuilder using the task framework; eliminated thread contention
* moved AbstractTask from the wiring framework to swirlds-common (removed unjustified dependencies)
* merged two thread pools used by `MerkleHashBuilder` and `VirtualHasher`

**Related issue(s)**:

Fixes #7582

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
