### PR TITLE
fix: 17219: WARN EXCEPTION "virtual-map: cache-cleaner StandardFuture: Future has already been cancelled"

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package com.swirlds.virtualmap.internal.cache;
 
+import static com.swirlds.logging.legacy.LogMarker.VIRTUAL_MERKLE_STATS;
+
 import com.swirlds.common.threading.futures.StandardFuture;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -27,6 +29,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * An array-backed concurrent data structure optimized for use by the {@link VirtualNodeCache}.
@@ -58,6 +62,9 @@ import java.util.stream.StreamSupport;
  * 		the element type
  */
 final class ConcurrentArray<T> {
+
+    private static final Logger logger = LogManager.getLogger(ConcurrentArray.class);
+
     /**
      * The default number of elements to store in each array
      */
@@ -338,6 +345,7 @@ final class ConcurrentArray<T> {
         }
 
         final StandardFuture<Void> result = new StandardFuture<>();
+        final AtomicBoolean exceptionThrown = new AtomicBoolean(false);
         final AtomicInteger count = new AtomicInteger(1);
         int nextIndex = 0;
         int numberOfElements = elementCount.get();
@@ -354,7 +362,11 @@ final class ConcurrentArray<T> {
                         result.complete(null);
                     }
                 } catch (Exception e) {
-                    result.cancelWithError(e);
+                    logger.error(VIRTUAL_MERKLE_STATS.getMarker(), "Exception in parallelTraverse", e);
+                    // Don't cancel the result future more than once
+                    if (exceptionThrown.compareAndSet(false, true)) {
+                        result.cancelWithError(e);
+                    }
                 }
             });
             nextIndex += size;

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
@@ -16,7 +16,7 @@
 
 package com.swirlds.virtualmap.internal.cache;
 
-import static com.swirlds.logging.legacy.LogMarker.VIRTUAL_MERKLE_STATS;
+import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 
 import com.swirlds.common.threading.futures.StandardFuture;
 import java.util.NoSuchElementException;
@@ -362,7 +362,7 @@ final class ConcurrentArray<T> {
                         result.complete(null);
                     }
                 } catch (Exception e) {
-                    logger.error(VIRTUAL_MERKLE_STATS.getMarker(), "Exception in parallelTraverse", e);
+                    logger.error(EXCEPTION.getMarker(), "Exception in parallelTraverse", e);
                     // Don't cancel the result future more than once
                     if (exceptionThrown.compareAndSet(false, true)) {
                         result.cancelWithError(e);


### PR DESCRIPTION

Fixes: https://github.com/hashgraph/hedera-services/issues/17219
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
