### PR TITLE
chore: Schedule release 0.59 branch creation

### DIFF
--- a/.github/workflows/config/node-release.yaml
+++ b/.github/workflows/config/node-release.yaml
@@ -3,9 +3,9 @@ release:
     execution:
       time: "20:00:00"
     schedule:
-      - on: "2024-12-20"
-        name: release/0.58
+      - on: "2025-01-24"
+        name: release/0.59
         initial-tag:
           create: true
-          name: v0.58.0-alpha.0
+          name: v0.59.0-alpha.0
 

--- a/.github/workflows/config/node-release.yaml
+++ b/.github/workflows/config/node-release.yaml
@@ -1,3 +1,19 @@
+##
+# Copyright (C) 2025 Hedera Hashgraph, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
 release:
   branching:
     execution:
@@ -8,4 +24,3 @@ release:
         initial-tag:
           create: true
           name: v0.59.0-alpha.0
-


### PR DESCRIPTION
**Description**:
This pull request updates the release schedule in the `node-release.yaml` configuration file. The most important change is the rescheduling of the release date and the corresponding version update.

Release schedule update:

* [`.github/workflows/config/node-release.yaml`](diffhunk://#diff-0eafb62babc7f1fe6968a22d9623ac6b5dfb99d2100f819a024f89f953d749e4L6-R10): Changed the release date from "2024-12-20" to "2025-01-24" and updated the release name from "release/0.58" to "release/0.59" along with the initial tag name from "v0.58.0-alpha.0" to "v0.59.0-alpha.0".