### PR TITLE
chore: GrpcConfig nodeOperatorPortEnabled default to true

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/GrpcConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/GrpcConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/GrpcConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/GrpcConfig.java
@@ -46,7 +46,7 @@ import com.swirlds.config.api.validation.annotation.Min;
 public record GrpcConfig(
         @ConfigProperty(defaultValue = "50211") @Min(0) @Max(65535) @NodeProperty int port,
         @ConfigProperty(defaultValue = "50212") @Min(0) @Max(65535) @NodeProperty int tlsPort,
-        @ConfigProperty(defaultValue = "false") @NodeProperty boolean nodeOperatorPortEnabled,
+        @ConfigProperty(defaultValue = "true") @NodeProperty boolean nodeOperatorPortEnabled,
         @ConfigProperty(defaultValue = "50213") @Min(1) @Max(65535) @NodeProperty int nodeOperatorPort,
         @ConfigProperty(defaultValue = "60211") @Min(0) @Max(65535) @NodeProperty int workflowsPort,
         @ConfigProperty(defaultValue = "60212") @Min(0) @Max(65535) @NodeProperty int workflowsTlsPort,


### PR DESCRIPTION
**Description**:
This pull request includes a change to the `GrpcConfig` class in the `hedera-node` project. The change modifies the default value of the `nodeOperatorPortEnabled` property to true.

* [`hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/GrpcConfig.java`](diffhunk://#diff-5a8d1c9a9cc0ddc0d484472309c26bc955ccaabf42f043f6a5a42e198def483fL49-R49): Changed the default value of `nodeOperatorPortEnabled` from false to true.

**Related issue(s)**:

Fixes #17468 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
