### PR TITLE
chore: fix JRS tests failing because of PCES

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileIterator.java
@@ -94,7 +94,6 @@ public class PcesFileIterator implements IOIterator<PlatformEvent> {
                 // This is possible (if not likely) when a node is shut down abruptly.
                 hasPartialEvent = true;
                 closeFile();
-                throw e;
             } catch (final NullPointerException e) {
                 // The PlatformEvent constructor can throw this if the event is malformed.
                 hasPartialEvent = true;

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesReadWriteTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/event/preconsensus/PcesReadWriteTests.java
@@ -284,14 +284,7 @@ class PcesReadWriteTests {
         final PcesFileIterator iterator = file.iterator(Long.MIN_VALUE);
         final List<PlatformEvent> deserializedEvents = new ArrayList<>();
 
-        if (truncateOnBoundary) {
-            iterator.forEachRemaining(deserializedEvents::add);
-        } else {
-            assertThrows(
-                    IOException.class,
-                    () -> iterator.forEachRemaining(deserializedEvents::add),
-                    "A partial event should have been detected and an IOException should have been thrown");
-        }
+        iterator.forEachRemaining(deserializedEvents::add);
 
         assertEquals(truncateOnBoundary, !iterator.hasPartialEvent());
 
@@ -363,7 +356,7 @@ class PcesReadWriteTests {
             assertEquals(events.get(i), iterator.next());
         }
 
-        assertThrows(IOException.class, iterator::next);
+        assertThrows(Exception.class, iterator::next);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
quick fix for #17500

In [this PR](https://github.com/hashgraph/hedera-services/pull/17312) I unsuppressed these exceptions and now they are breaking JRS tests. This is a quick fix to get the tests running while the issue is investigated more.