### PR TITLE
chore: fix GCP artifact upload step

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -366,6 +366,7 @@ jobs:
           path: ${{ steps.artifact-release.outputs.folder }}
           destination: ${{ secrets.bucket-name }}
           parent: false
+          process_gcloudignore: false
 
       - name: Upload Artifacts (CDN Bucket)
         uses: google-github-actions/upload-cloud-storage@386ab77f37fdf51c0e38b3d229fad286861cc0d0 # v2.2.1
@@ -374,6 +375,7 @@ jobs:
           path: ${{ steps.artifact-release.outputs.folder }}
           destination: ${{ secrets.cdn-bucket-name }}/node/software/v${{ needs.validate.outputs.version-prefix }}/
           parent: false
+          process_gcloudignore: false
 
   local-node-images:
     name: Publish Local Node Images


### PR DESCRIPTION
**Description**:
The step Upload Artifacts (GCP Bucket) is displaying some errors.
This seems to be caused by a default 'true' setting of the process_gcloudignore but we aren't actually using a .gcloudignore file.

**Related issue(s)**:

Fixes #17489 

**Notes for reviewer**:
N/A

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
