### PR TITLE
fix(ci): Add conditionals on Write Artifact Version Descriptor

### DIFF
--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -180,6 +180,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Write Artifact Version Descriptor
+        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
         run: |
           printf "VERSION=%s\nCOMMIT=%s\nDATE=%s" "$(./gradlew -q showVersion)" "$(git log -1 --format='%H' | cut -c1-8)" "$(date -u)" | tee "${{ github.workspace }}/${{ env.DOCKER_CONTEXT_PATH }}/sdk/VERSION"
 


### PR DESCRIPTION
**Description**:

Scopes the usability of `Write Artifact Version Descriptor` to only enable when a baseline exists.

**Related Issue(s)**:

Fixes #17510
