### PR TITLE
refactor: use preferred headlong API when decoding RLP

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ public record EthTxData(
                 return populateLegacyEthTxData(rlpItem, data);
             }
 
-            return switch (rlpItem.asByte()) {
+            return switch (asByte(rlpItem)) {
                 case 1 -> populateEip2390EthTxData(decoder.next(), data);
                 case 2 -> populateEip1559EthTxData(decoder.next(), data);
                 case 3 -> null; // We don't currently support Cancun "blob" transactions
@@ -401,11 +401,11 @@ public record EthTxData(
                 rawTx,
                 EthTransactionType.LEGACY_ETHEREUM,
                 chainId,
-                rlpList.get(0).asLong(), // nonce
+                asLong(rlpList.get(0)), // nonce
                 rlpList.get(1).asBytes(), // gasPrice
                 null, // maxPriorityGas
                 null, // maxGas
-                rlpList.get(2).asLong(), // gasLimit
+                asLong(rlpList.get(2)), // gasLimit
                 rlpList.get(3).data(), // to
                 rlpList.get(4).asBigInt(), // value
                 rlpList.get(5).data(), // callData
@@ -436,16 +436,16 @@ public record EthTxData(
                 rawTx,
                 EthTransactionType.EIP1559,
                 rlpList.get(0).data(), // chainId
-                rlpList.get(1).asLong(), // nonce
+                asLong(rlpList.get(1)), // nonce
                 null, // gasPrice
                 rlpList.get(2).data(), // maxPriorityGas
                 rlpList.get(3).data(), // maxGas
-                rlpList.get(4).asLong(), // gasLimit
+                asLong(rlpList.get(4)), // gasLimit
                 rlpList.get(5).data(), // to
                 rlpList.get(6).asBigInt(), // value
                 rlpList.get(7).data(), // callData
                 rlpList.get(8).data(), // accessList
-                rlpList.get(9).asByte(), // recId
+                asByte(rlpList.get(9)), // recId
                 null, // v
                 rlpList.get(10).data(), // r
                 rlpList.get(11).data() // s
@@ -471,16 +471,16 @@ public record EthTxData(
                 rawTx,
                 EthTransactionType.EIP2930,
                 rlpList.get(0).data(), // chainId
-                rlpList.get(1).asLong(), // nonce
+                asLong(rlpList.get(1)), // nonce
                 rlpList.get(2).data(), // gasPrice
                 null, // maxPriorityGas
                 null, // maxGas
-                rlpList.get(3).asLong(), // gasLimit
+                asLong(rlpList.get(3)), // gasLimit
                 rlpList.get(4).data(), // to
                 rlpList.get(5).asBigInt(), // value
                 rlpList.get(6).data(), // callData
                 rlpList.get(7).data(), // accessList
-                rlpList.get(8).asByte(), // recId
+                asByte(rlpList.get(8)), // recId
                 null, // v
                 rlpList.get(9).data(), // r
                 rlpList.get(10).data() // s
@@ -491,5 +491,32 @@ public record EthTxData(
     // (unprotected) ethereum transactions is either 27 or 28
     private static boolean isLegacyUnprotectedEtx(@NonNull BigInteger vBI) {
         return vBI.compareTo(LEGACY_V_BYTE_SIGNATURE_0) == 0 || vBI.compareTo(LEGACY_V_BYTE_SIGNATURE_1) == 0;
+    }
+
+    // `asByte` and `asLong` always return positive values by replacing out of range values with
+    // `MAX_VALUE`.  (`RLPItem.asBigInt` cannot return negative values: Negative values cannot be
+    // encoded in RLP.)
+
+    private static byte asByte(@NonNull final RLPItem rlpItem) {
+        var v = rlpItem.asBigInt(false);
+        if (v.compareTo(BigInteger.ZERO) < 0) throwOutOfRange();
+        if (v.compareTo(BigInteger.valueOf(Byte.MAX_VALUE)) > 0) throwOutOfRange();
+        return v.byteValueExact();
+    }
+
+    private static long asLong(@NonNull final RLPItem rlpItem) {
+        var v = rlpItem.asBigInt(false);
+        if (v.compareTo(BigInteger.ZERO) < 0) throwOutOfRange();
+        if (v.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0) throwOutOfRange();
+        return v.longValueExact();
+    }
+
+    private static void throwOutOfRange() {
+        class OutOfRangeException extends IllegalArgumentException {
+            public OutOfRangeException() {
+                super("EthTxData has RLPItem out of range");
+            }
+        }
+        throw new OutOfRangeException();
     }
 }

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
+import com.esaulpaugh.headlong.util.Integers;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
 import com.swirlds.common.utility.CommonUtils;
@@ -355,6 +356,7 @@ class EthTxDataTest {
     @Test
     void parsingErrors() {
         final var wrongData = Hex.encode(ByteString.copyFromUtf8("wrong").toByteArray());
+        final var negativeInteger = Integers.toBytes(Long.MIN_VALUE);
 
         // invalid nonce
         var normalData = normalRlpData();
@@ -363,12 +365,19 @@ class EthTxDataTest {
 
         assertNull(EthTxData.populateEthTxData(RLPEncoder.encodeSequentially(new byte[] {2}, invalidNonceData)));
 
-        // invalid gasLimit
+        // invalid gasLimit: too large
         normalData = normalRlpData();
         normalData[4] = wrongData;
         final var invalidGasLimitData = Arrays.asList(normalData);
 
         assertNull(EthTxData.populateEthTxData(RLPEncoder.encodeSequentially(new byte[] {2}, invalidGasLimitData)));
+
+        // invalid gaslimit: negative
+        normalData = normalRlpData();
+        normalData[4] = negativeInteger;
+        final var invalidGasDataNegative = Arrays.asList(normalData);
+
+        assertNull(EthTxData.populateEthTxData(RLPEncoder.encodeSequentially(new byte[] {2}, invalidGasDataNegative)));
 
         // invalid recId
         normalData = normalRlpData();


### PR DESCRIPTION
**Description**:

Headlong's `RLPItem.asBigInt` preferred over `asByte/asInt/asLong`.

**Related issue(s)**:

Fixes #17523 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
