### PR TITLE
test: fix `MerkleRehashTests.failedRehash()` unit test

### DIFF
--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleRehashTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleRehashTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,8 +160,10 @@ class MerkleRehashTests {
     @DisplayName("Failed Rehash Behavior")
     public void failedRehash() {
 
-        DummyMerkleNode root = spy(generateRandomTree(0, 2, 1, 1, 0, 3, 1, 0.25));
-        when(root.getHash()).then(new Answer<Hash>() {
+        DummyMerkleNode root = generateRandomTree(0, 2, 1, 1, 0, 3, 1, 0.25);
+        MerkleNode child = spy(root.asInternal().getChild(0).copy());
+        root.asInternal().setChild(0, child);
+        when(child.getHash()).then(new Answer<Hash>() {
             private int count = 0;
 
             @Override


### PR DESCRIPTION
**Description**:
Backported #17575 from main.

> The test hangs after https://github.com/hashgraph/hedera-services/pull/17437 due to inducing an exception in a situation impossible in actual code.
Moved throwing exception from root (internal node) to the first child (leaf node).

**Related issue(s)**:

#17437
#17575

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
