### PR TITLE
fix: Reference correct `main` obj in test

### DIFF
--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/PlatformTestingToolStateTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/PlatformTestingToolStateTest.java
@@ -372,7 +372,7 @@ class PlatformTestingToolStateTest {
         givenRoundAndEvent();
 
         // When
-        final boolean result = stateLifecycles.onSealConsensusRound(round, state);
+        final boolean result = main.stateLifecycles.onSealConsensusRound(round, state);
 
         // Then
         assertThat(result).isTrue();


### PR DESCRIPTION
Fixes compiler error for the `compileTestJava` task