### PR TITLE
ci: Fix Check Integration Job State step to detect properly

### DIFF
--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -142,7 +142,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
           ref: main
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
@@ -187,7 +187,7 @@ jobs:
           ref: main # ensure we are always using the workflow definition from the main branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
-              "ref": "${{ inputs.ref }}"
+            "ref": "${{ inputs.ref }}"
             }'
 
   update-hedera-protobufs:
@@ -206,13 +206,13 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           ref: main
-          fetch-depth: '0'
+          fetch-depth: "0"
 
       - name: Checkout Hedera Protobufs Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.PROTOBUFS_GH_ACCESS_TOKEN }}
-          fetch-depth: '0'
+          fetch-depth: "0"
           repository: hashgraph/hedera-protobufs
           path: hedera-protobufs
 
@@ -239,7 +239,7 @@ jobs:
       - name: Add & Commit
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
-          cwd: 'hedera-protobufs'
+          cwd: "hedera-protobufs"
           author_name: swirlds-eng-automation
           author_email: ${{ secrets.PROTOBUFS_GPG_USER_EMAIL }}
           commit: --signoff

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -174,7 +174,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           JOB_ENABLED="true"
-          JOB_STATE=$(gh workflow list --all --json name,state | jq -r '.[]|select(.name=="ZXF: [Node] Deploy Integration Network Release")|.state')
+          JOB_STATE=$(gh workflow list --all --json name,state --limit 200 | jq -r '.[]|select(.name=="ZXF: [Node] Deploy Integration Network Release")|.state')
           [[ "${JOB_STATE}" == "disabled_manually" ]] && JOB_ENABLED="false"
           echo "enabled=${JOB_ENABLED}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
**Description**:

The gh workflow list call was not properly scoped to a sufficiently large number of workflows. Adding the `--limit 200` command line argument satisfies the needs of the gh workflow tool.

**Related Issue(s)**:

Fixes #17582

**Checklist**

- [x] Tested in terminal
