### PR TITLE
fix: EIP-155 support in isAuthorized/isAuthorizedRaw

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorized/IsAuthorizedCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorized/IsAuthorizedCall.java
@@ -122,13 +122,15 @@ public class IsAuthorizedCall extends AbstractCall {
     }
 
     /**
-     * The Ethereum world uses 65 byte EC signatures, our cryptography library uses 64 byte EC signatures.  The
-     * difference is the addition of an extra "parity" byte at the end of the 64 byte signature (used so that
-     * `ECRECOVER` can recover the public key (== Ethereum address) from the signature.
+     * The Ethereum world uses 65+ byte EC signatures, our cryptography library uses 64 byte EC signatures.  The
+     * difference is the addition of an extra "parity" field at the end of the 64 byte signature (used so that
+     * `ECRECOVER` can recover the public key (== Ethereum address) from the signature.  And, the chain id can
+     * be encoded in that field (per EIP-155) and if the chain id is large enough (like Hedera mainnet/testnet
+     * chain ids) that last field can be more than one byte.
      *
-     * This method is a shim for that mismatch. It strips the extra byte off any 65 byte EC signatures it finds.
+     * This method is a shim for that mismatch. It strips the extra bytes off any 65+ byte EC signatures it finds.
      *
-     * @param sigMap Signature map from user - possibly contains 65 byte EC signatures
+     * @param sigMap Signature map from user - possibly contains 65+ byte EC signatures
      * @return Signature map with only 64 byte EC signatures (and all else unchanged)
      */
     public @NonNull SignatureMap fixEcSignaturesInMap(@NonNull final SignatureMap sigMap) {
@@ -136,7 +138,7 @@ public class IsAuthorizedCall extends AbstractCall {
         for (var spair : sigMap.sigPair()) {
             if (spair.hasEcdsaSecp256k1()) {
                 final var ecSig = requireNonNull(spair.ecdsaSecp256k1());
-                if (ecSig.length() == 65) {
+                if (ecSig.length() > 64) {
                     spair = new SignaturePair(
                             spair.pubKeyPrefix(), new OneOf<>(SignatureOneOfType.ECDSA_SECP256K1, ecSig.slice(0, 64)));
                 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SignatureMapUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/SignatureMapUtils.java
@@ -24,6 +24,7 @@ import com.hedera.hapi.node.base.SignaturePair.SignatureOneOfType;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.hedera.pbj.runtime.OneOf;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -64,21 +65,30 @@ public class SignatureMapUtils {
 
     /**
      * Check that the v value in an ECDSA signature matches the chain ID if it is greater than 35 per EIP 155
-     * @param ecSig
-     * @param chainId
+     * @param ecSig (must be >64 bytes)
+     * @param chainId chainId which is to match that encoded in `ecSig`
      * @return true if the v value matches the chain ID or is not relevant, false otherwise
+     * <p>
+     * "Not relevant" means the signature is not EIP-155 encoded, so that the `v` value is simply
+     * the parity bit.
+     * <p>
+     * There's discussion on actually how big the chainid can get.  Some argue for 256 bits, or
+     * maybe just a little less than 255 bits.  Others argue for different numbers.  `long` is
+     * generous now for everything at chainlist.org (though of course someone could get silly later).
+     *
      */
-    public static boolean validChainId(final byte[] ecSig, final int chainId) {
-        int v = 0;
-        for (int i = 64; i < ecSig.length; i++) {
-            v <<= 8;
-            v |= (ecSig[i] & 0xFF);
+    public static boolean validChainId(final byte[] ecSig, final long chainId) {
+        if (ecSig.length <= 64) throw new IllegalArgumentException("signature needs to be at least 65 bytes");
+        try {
+            long v = new BigInteger(+1, ecSig, 64, ecSig.length - 64).longValueExact();
+            if (v >= 35) {
+                // See EIP 155 - https://eips.ethereum.org/EIPS/eip-155
+                final var chainIdParityZero = 35 + (chainId * 2L);
+                return v == chainIdParityZero || v == chainIdParityZero + 1;
+            }
+            return true;
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("EIP-155 encoded chain id too large (longer than long)");
         }
-        if (v >= 35) {
-            // See EIP 155 - https://eips.ethereum.org/EIPS/eip-155
-            final var chainIdParityZero = 35 + (chainId * 2);
-            return v == chainIdParityZero || v == chainIdParityZero + 1;
-        }
-        return true;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.has.
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.MISSING_ENTITY_NUMBER;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isauthorizedraw.IsAuthorizedRawCall.EC_SIGNATURE_MAX_LENGTH;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isauthorizedraw.IsAuthorizedRawCall.EC_SIGNATURE_MIN_LENGTH;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isauthorizedraw.IsAuthorizedRawCall.ED_SIGNATURE_LENGTH;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.APPROVED_HEADLONG_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ACCOUNT;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ACCOUNT_NUM;
@@ -41,6 +44,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isauth
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,10 +66,20 @@ class IsAuthorizedRawCallTest extends CallTestBase {
 
     @BeforeEach
     void setup() {
-        given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
-        given(attempt.enhancement()).willReturn(mockEnhancement());
-        given(attempt.signatureVerifier()).willReturn(signatureVerifier);
+        lenient().when(attempt.systemContractGasCalculator()).thenReturn(gasCalculator);
+        lenient().when(attempt.enhancement()).thenReturn(mockEnhancement());
+        lenient().when(attempt.signatureVerifier()).thenReturn(signatureVerifier);
         lenient().when(frame.getRemainingGas()).thenReturn(10_000_000L);
+    }
+
+    @Test
+    void sanityCheckSignatureLengths() {
+        // Sadly, though AssertJ has `.isBetween` it does _not_ have `.isNotBetween`, or a general
+        // way to negate assertions ...
+
+        final var tooShortForEC = ED_SIGNATURE_LENGTH < EC_SIGNATURE_MIN_LENGTH;
+        final var tooLongForEC = ED_SIGNATURE_LENGTH > EC_SIGNATURE_MAX_LENGTH;
+        assertTrue(tooShortForEC || tooLongForEC);
     }
 
     @Test
@@ -106,10 +120,26 @@ class IsAuthorizedRawCallTest extends CallTestBase {
     }
 
     @ParameterizedTest
-    @CsvSource({"0,27", "1,28", "27,27", "28,28", "45,27", "46,28", "18,"})
-    void reverseVTest(final byte fromV, final Byte expectedV) {
+    @CsvSource({
+        "0,27",
+        "1,28",
+        "27,27",
+        "28,28",
+        "45,27",
+        "46,28",
+        "1000,28",
+        "1001,27",
+        "10000000,28",
+        "10000003,27",
+        "18,"
+    })
+    void reverseVTest(final long fromV, final Byte expectedV) {
         subject = getSubject(APPROVED_HEADLONG_ADDRESS);
-        final var v = subject.reverseV(fromV);
+
+        final var r = asBytes(fromV);
+        final var ecSig = new byte[64 + r.length];
+        System.arraycopy(r, 0, ecSig, 64, r.length);
+        final var v = subject.reverseV(ecSig);
         if (expectedV == null) assertTrue(v.isEmpty());
         else assertEquals(expectedV, v.get());
     }
@@ -117,5 +147,10 @@ class IsAuthorizedRawCallTest extends CallTestBase {
     @NonNull
     IsAuthorizedRawCall getSubject(@NonNull final Address address) {
         return new IsAuthorizedRawCall(attempt, address, messageHash, signature, customGasCalculator);
+    }
+
+    @NonNull
+    byte[] asBytes(final long n) {
+        return BigInteger.valueOf(n).toByteArray();
     }
 }


### PR DESCRIPTION
**Description**:

Need to support chain ids such that encoding them in the `v` part of the signature according to EIP-155 works for "large" chain ids, such as Hedera's own.

**Related issue(s)**:

Fixes #17273

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
