### PR TITLE
chore(17592): Remove unsafe cast in TaskScheduler

### DIFF
--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/component/ComponentWiring.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/component/ComponentWiring.java
@@ -173,13 +173,12 @@ public class ComponentWiring<COMPONENT_TYPE, OUTPUT_TYPE> {
             schedulerName = schedulerLabelAnnotation.value();
         }
 
-        this.scheduler = model.schedulerBuilder(schedulerName)
+        this.scheduler = model.<OUTPUT_TYPE>schedulerBuilder(schedulerName)
                 .configure(schedulerConfiguration)
                 // FUTURE WORK: all components not currently in platform core should move there
                 .withHyperlink(platformCoreHyperlink(clazz))
                 .withDataCounter(dataCounter)
-                .build()
-                .cast();
+                .build();
 
         if (!clazz.isInterface()) {
             throw new IllegalArgumentException("Component class " + clazz.getName() + " is not an interface.");

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/TaskScheduler.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/TaskScheduler.java
@@ -183,23 +183,6 @@ public abstract class TaskScheduler<OUT> extends TaskSchedulerInput<OUT> {
     }
 
     /**
-     * Cast this scheduler into whatever a variable is expecting. Sometimes the compiler gets confused with generics,
-     * and path of least resistance is to just cast to the proper data type.
-     *
-     * <p>
-     * Warning: this will appease the compiler, but it is possible to cast a scheduler into a data type that will cause
-     * runtime exceptions. Use with appropriate caution.
-     *
-     * @param <X> the type to cast to
-     * @return this, cast into whatever type is requested
-     */
-    @NonNull
-    @SuppressWarnings("unchecked")
-    public final <X> TaskScheduler<X> cast() {
-        return (TaskScheduler<X>) this;
-    }
-
-    /**
      * Get the number of unprocessed tasks. A task is considered to be unprocessed until the data has been passed to the
      * handler method (i.e. the one given to {@link BindableInputWire#bind(Function)} or
      * {@link BindableInputWire#bindConsumer(Consumer)}) and that handler method has returned.

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/transformers/WireFilter.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/transformers/WireFilter.java
@@ -54,10 +54,9 @@ public class WireFilter<T> {
 
         Objects.requireNonNull(predicate);
 
-        final TaskScheduler<T> taskScheduler = model.schedulerBuilder(filterName)
+        final TaskScheduler<T> taskScheduler = model.<T>schedulerBuilder(filterName)
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
-                .build()
-                .cast();
+                .build();
 
         inputWire = taskScheduler.buildInputWire(filterInputName);
         inputWire.bind(t -> {
@@ -79,10 +78,9 @@ public class WireFilter<T> {
     public WireFilter(
             @NonNull final WiringModel model, @NonNull final String filterName, @NonNull final String filterInputName) {
 
-        final TaskScheduler<T> taskScheduler = model.schedulerBuilder(filterName)
+        final TaskScheduler<T> taskScheduler = model.<T>schedulerBuilder(filterName)
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
-                .build()
-                .cast();
+                .build();
 
         inputWire = taskScheduler.buildInputWire(filterInputName);
         outputWire = taskScheduler.getOutputWire();

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/transformers/WireListSplitter.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/transformers/WireListSplitter.java
@@ -48,10 +48,9 @@ public class WireListSplitter<T> {
             @NonNull final WiringModel model,
             @NonNull final String splitterName,
             @NonNull final String splitterInputName) {
-        final TaskScheduler<T> taskScheduler = model.schedulerBuilder(splitterName)
+        final TaskScheduler<T> taskScheduler = model.<T>schedulerBuilder(splitterName)
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
-                .build()
-                .cast();
+                .build();
 
         inputWire = taskScheduler.buildInputWire(splitterInputName);
         outputWire = (StandardOutputWire<T>) taskScheduler.getOutputWire();

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/transformers/WireRouter.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/transformers/WireRouter.java
@@ -55,10 +55,9 @@ public class WireRouter<ROUTER_TYPE extends Enum<ROUTER_TYPE>> {
             @NonNull final String routerName,
             @NonNull final String routerInputName,
             @NonNull final Class<ROUTER_TYPE> clazz) {
-        final TaskScheduler<Void> scheduler = model.schedulerBuilder(routerName)
+        final TaskScheduler<Void> scheduler = model.<Void>schedulerBuilder(routerName)
                 .withType(DIRECT_THREADSAFE)
-                .build()
-                .cast();
+                .build();
 
         outputWires = new ArrayList<>(clazz.getEnumConstants().length);
         for (int index = 0; index < clazz.getEnumConstants().length; index++) {

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/transformers/WireTransformer.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/transformers/WireTransformer.java
@@ -55,10 +55,9 @@ public class WireTransformer<A, B> {
             @NonNull final Function<A, B> transformer) {
         Objects.requireNonNull(transformer);
 
-        final TaskScheduler<B> taskScheduler = model.schedulerBuilder(transformerName)
+        final TaskScheduler<B> taskScheduler = model.<B>schedulerBuilder(transformerName)
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
-                .build()
-                .cast();
+                .build();
 
         inputWire = taskScheduler.buildInputWire(transformerInputName);
         inputWire.bind(transformer);
@@ -77,10 +76,9 @@ public class WireTransformer<A, B> {
             @NonNull final String transformerName,
             @NonNull final String transformerInputName) {
 
-        final TaskScheduler<B> taskScheduler = model.schedulerBuilder(transformerName)
+        final TaskScheduler<B> taskScheduler = model.<B>schedulerBuilder(transformerName)
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
-                .build()
-                .cast();
+                .build();
 
         inputWire = taskScheduler.buildInputWire(transformerInputName);
         outputWire = taskScheduler.getOutputWire();

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/wires/output/OutputWire.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/wires/output/OutputWire.java
@@ -165,10 +165,9 @@ public abstract class OutputWire<OUT> {
             @NonNull final String inputWireLabel,
             @NonNull final Consumer<OUT> handler) {
 
-        final TaskScheduler<Void> directScheduler = model.schedulerBuilder(handlerName)
+        final TaskScheduler<Void> directScheduler = model.<Void>schedulerBuilder(handlerName)
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<OUT, Void> directSchedulerInputWire = directScheduler.buildInputWire(inputWireLabel);
         directSchedulerInputWire.bindConsumer(handler);

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/benchmark/WiringBenchmark.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/benchmark/WiringBenchmark.java
@@ -62,28 +62,27 @@ class WiringBenchmark {
         // Ensures that we have no more than 10,000 events in the pipeline at any given time
         final ObjectCounter backpressure = new BackpressureObjectCounter("backpressure", 10_000, Duration.ZERO);
 
-        final TaskScheduler<WiringBenchmarkEvent> verificationTaskScheduler = model.schedulerBuilder("verification")
+        final TaskScheduler<WiringBenchmarkEvent> verificationTaskScheduler = model.<WiringBenchmarkEvent>
+                        schedulerBuilder("verification")
                 .withPool(executor)
                 .withType(TaskSchedulerType.CONCURRENT)
                 .withOnRamp(backpressure)
                 .withExternalBackPressure(true)
-                .build()
-                .cast();
+                .build();
 
-        final TaskScheduler<WiringBenchmarkEvent> orphanBufferTaskScheduler = model.schedulerBuilder("orphanBuffer")
+        final TaskScheduler<WiringBenchmarkEvent> orphanBufferTaskScheduler = model.<WiringBenchmarkEvent>
+                        schedulerBuilder("orphanBuffer")
                 .withPool(executor)
                 .withType(TaskSchedulerType.SEQUENTIAL)
                 .withExternalBackPressure(true)
-                .build()
-                .cast();
+                .build();
 
-        final TaskScheduler<Void> eventPoolTaskScheduler = model.schedulerBuilder("eventPool")
+        final TaskScheduler<Void> eventPoolTaskScheduler = model.<Void>schedulerBuilder("eventPool")
                 .withPool(executor)
                 .withType(TaskSchedulerType.SEQUENTIAL)
                 .withOffRamp(backpressure)
                 .withExternalBackPressure(true)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<WiringBenchmarkEvent, WiringBenchmarkEvent> eventsToOrphanBuffer =
                 orphanBufferTaskScheduler.buildInputWire("unordered events");

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/component/WiringComponentPerformanceTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/component/WiringComponentPerformanceTests.java
@@ -72,10 +72,9 @@ class WiringComponentPerformanceTests {
                         TestPlatformContextBuilder.create().build())
                 .build();
 
-        final TaskScheduler<Void> scheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> scheduler = model.<Void>schedulerBuilder("test")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+                .build();
 
         final ComponentWiring<SimpleComponent, Void> componentWiring =
                 new ComponentWiring<>(model, SimpleComponent.class, scheduler);

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/model/DeterministicHeartbeatSchedulerTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/model/DeterministicHeartbeatSchedulerTests.java
@@ -42,7 +42,7 @@ public class DeterministicHeartbeatSchedulerTests {
         ;
 
         final TaskScheduler<Void> scheduler =
-                model.schedulerBuilder("test").build().cast();
+                model.<Void>schedulerBuilder("test").build();
 
         final BindableInputWire<Instant, Void> heartbeatBindable = scheduler.buildInputWire("heartbeat");
         model.buildHeartbeatWire(100).solderTo(heartbeatBindable);
@@ -73,7 +73,7 @@ public class DeterministicHeartbeatSchedulerTests {
         ;
 
         final TaskScheduler<Void> scheduler =
-                model.schedulerBuilder("test").build().cast();
+                model.<Void>schedulerBuilder("test").build();
 
         final BindableInputWire<Instant, Void> heartbeatBindable = scheduler.buildInputWire("heartbeat");
         model.buildHeartbeatWire(Duration.ofMillis(10)).solderTo(heartbeatBindable);
@@ -103,10 +103,9 @@ public class DeterministicHeartbeatSchedulerTests {
                 .build();
         ;
 
-        final TaskScheduler<Void> scheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> scheduler = model.<Void>schedulerBuilder("test")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Instant, Void> heartbeatBindableA = scheduler.buildInputWire("heartbeatA");
         final BindableInputWire<Instant, Void> heartbeatBindableB = scheduler.buildInputWire("heartbeatB");

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/model/DeterministicModelTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/model/DeterministicModelTests.java
@@ -158,23 +158,21 @@ class DeterministicModelTests {
         final ReentrantLock lock = new ReentrantLock();
 
         final TaskScheduler<Long> schedulerA = wiringModel
-                .schedulerBuilder("A")
+                .<Long>schedulerBuilder("A")
                 .withType(SEQUENTIAL)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inA = schedulerA.buildInputWire("inA");
         inA.bind(buildHandler(random, 0.01, lock));
         final OutputWire<Long> outA = schedulerA.getOutputWire();
 
         final TaskScheduler<Long> schedulerB = wiringModel
-                .schedulerBuilder("B")
+                .<Long>schedulerBuilder("B")
                 .withType(CONCURRENT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inB = schedulerB.buildInputWire("inB");
         inB.bind(buildHandler(random, 0.01, lock));
         final BindableInputWire<Instant, Long> schedulerBHeartbeat = schedulerB.buildInputWire("heartbeatB");
@@ -186,100 +184,91 @@ class DeterministicModelTests {
         final OutputWire<Long> outB = schedulerB.getOutputWire();
 
         final TaskScheduler<Long> schedulerC = wiringModel
-                .schedulerBuilder("C")
+                .<Long>schedulerBuilder("C")
                 .withType(SEQUENTIAL_THREAD)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inC = schedulerC.buildInputWire("inC");
         inC.bind(buildHandler(random, 0.01, lock));
         final OutputWire<Long> outC = schedulerC.getOutputWire();
 
         final TaskScheduler<Long> schedulerD = wiringModel
-                .schedulerBuilder("D")
+                .<Long>schedulerBuilder("D")
                 .withType(SEQUENTIAL)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inD = schedulerD.buildInputWire("inD");
         inD.bind(buildHandler(random, 0.6, lock)); // This must be >0.5 else risk infinite loop
         final OutputWire<Long> outD = schedulerD.getOutputWire();
 
         final TaskScheduler<Long> schedulerE = wiringModel
-                .schedulerBuilder("E")
+                .<Long>schedulerBuilder("E")
                 .withType(SEQUENTIAL)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inE = schedulerE.buildInputWire("inE");
         inE.bind(buildHandler(random, 0.01, lock));
         final OutputWire<Long> outE = schedulerE.getOutputWire();
 
         final TaskScheduler<Long> schedulerF = wiringModel
-                .schedulerBuilder("F")
+                .<Long>schedulerBuilder("F")
                 .withType(SEQUENTIAL)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inF = schedulerF.buildInputWire("inF");
         inF.bind(buildHandler(random, 0.01, lock));
         final OutputWire<Long> outF = schedulerF.getOutputWire();
 
         final TaskScheduler<Long> schedulerG = wiringModel
-                .schedulerBuilder("G")
+                .<Long>schedulerBuilder("G")
                 .withType(SEQUENTIAL)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inG = schedulerG.buildInputWire("inG");
         inG.bind(buildHandler(random, 0.01, lock));
         final OutputWire<Long> outG = schedulerG.getOutputWire();
 
         final TaskScheduler<Long> schedulerH = wiringModel
-                .schedulerBuilder("H")
+                .<Long>schedulerBuilder("H")
                 .withType(DIRECT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inH = schedulerH.buildInputWire("inH");
         inH.bind(buildHandler(random, 0.01, lock));
         final OutputWire<Long> outH = schedulerH.getOutputWire();
 
         final TaskScheduler<Long> schedulerI = wiringModel
-                .schedulerBuilder("I")
+                .<Long>schedulerBuilder("I")
                 .withType(DIRECT_THREADSAFE)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inI = schedulerI.buildInputWire("inI");
         inI.bind(buildHandler(random, 0.01, lock));
         final OutputWire<Long> outI = schedulerI.getOutputWire();
 
         final TaskScheduler<Long> schedulerJ = wiringModel
-                .schedulerBuilder("J")
+                .<Long>schedulerBuilder("J")
                 .withType(SEQUENTIAL)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inJ = schedulerJ.buildInputWire("inJ");
         inJ.bind(buildHandler(random, 0.01, lock));
         final OutputWire<Long> outJ = schedulerJ.getOutputWire();
 
         final TaskScheduler<Long> schedulerK = wiringModel
-                .schedulerBuilder("K")
+                .<Long>schedulerBuilder("K")
                 .withType(NO_OP)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Long, Long> inK = schedulerK.buildInputWire("inK");
         inK.bind(buildHandler(random, 0.01, lock));
 
@@ -462,26 +451,22 @@ class DeterministicModelTests {
         final AtomicInteger countC = new AtomicInteger();
         final AtomicInteger countD = new AtomicInteger();
 
-        final TaskScheduler<Integer> taskSchedulerToA = model.schedulerBuilder("wireToA")
+        final TaskScheduler<Integer> taskSchedulerToA = model.<Integer>schedulerBuilder("wireToA")
                 .withType(SEQUENTIAL)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> taskSchedulerToB = model.schedulerBuilder("wireToB")
+                .build();
+        final TaskScheduler<Integer> taskSchedulerToB = model.<Integer>schedulerBuilder("wireToB")
                 .withType(SEQUENTIAL_THREAD)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> taskSchedulerToC = model.schedulerBuilder("wireToC")
+                .build();
+        final TaskScheduler<Integer> taskSchedulerToC = model.<Integer>schedulerBuilder("wireToC")
                 .withType(CONCURRENT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> taskSchedulerToD = model.schedulerBuilder("wireToD")
+                .build();
+        final TaskScheduler<Integer> taskSchedulerToD = model.<Integer>schedulerBuilder("wireToD")
                 .withType(DIRECT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Integer, Integer> channelToA = taskSchedulerToA.buildInputWire("channelToA");
         final BindableInputWire<Integer, Integer> channelToB = taskSchedulerToB.buildInputWire("channelToB");

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/model/ModelTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/model/ModelTests.java
@@ -84,10 +84,9 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Void> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Void> taskSchedulerA = model.<Void>schedulerBuilder("A")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
 
         validateModel(model, false, false);
     }
@@ -104,15 +103,17 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
         final TaskScheduler<Void> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+                model.<Void>schedulerBuilder("C").withUnhandledTaskCapacity(1).build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -135,8 +136,9 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
         taskSchedulerA.getOutputWire().solderTo(inputA);
@@ -158,8 +160,9 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
         taskSchedulerA.getOutputWire().solderTo(inputA, SolderType.INJECT);
@@ -181,12 +184,14 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -209,12 +214,14 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -237,14 +244,14 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -267,16 +274,19 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -300,16 +310,19 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -333,18 +346,19 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC = model.schedulerBuilder("C")
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -369,20 +383,24 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -408,22 +426,24 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD = model.schedulerBuilder("D")
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -449,20 +469,24 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -497,44 +521,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -576,44 +610,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -655,46 +699,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD = model.schedulerBuilder("D")
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -736,44 +788,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -819,44 +881,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -902,48 +974,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE = model.schedulerBuilder("E")
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ = model.schedulerBuilder("J")
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -991,44 +1069,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -1075,44 +1163,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -1159,44 +1257,54 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<List<Integer>> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<List<Integer>> taskSchedulerD = model.<List<Integer>>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -1244,46 +1352,56 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD =
-                model.schedulerBuilder("D").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE =
-                model.schedulerBuilder("E").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF =
-                model.schedulerBuilder("F").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG =
-                model.schedulerBuilder("G").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH =
-                model.schedulerBuilder("H").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI =
-                model.schedulerBuilder("I").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final OutputWire<Integer> secondaryOutputI = taskSchedulerI.buildSecondaryOutputWire();
         final OutputWire<Integer> tertiaryOutputI = taskSchedulerI.buildSecondaryOutputWire();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ =
-                model.schedulerBuilder("J").withUnhandledTaskCapacity(1).build().cast();
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
+                .withUnhandledTaskCapacity(1)
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
         final InputWire<Integer> inputJ2 = taskSchedulerJ.buildInputWire("inputJ2");
 
@@ -1337,66 +1455,56 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC = model.schedulerBuilder("C")
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD = model.schedulerBuilder("D")
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
                 .withType(TaskSchedulerType.CONCURRENT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE = model.schedulerBuilder("E")
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
                 .withType(TaskSchedulerType.DIRECT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF = model.schedulerBuilder("F")
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG = model.schedulerBuilder("G")
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH = model.schedulerBuilder("H")
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI = model.schedulerBuilder("I")
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ = model.schedulerBuilder("J")
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -1445,67 +1553,57 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC = model.schedulerBuilder("C")
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD = model.schedulerBuilder("D")
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
                 .withType(TaskSchedulerType.CONCURRENT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE = model.schedulerBuilder("E")
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
                 .withType(TaskSchedulerType.DIRECT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF = model.schedulerBuilder("F")
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
                 .withType(TaskSchedulerType.DIRECT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG = model.schedulerBuilder("G")
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH = model.schedulerBuilder("H")
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI = model.schedulerBuilder("I")
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ = model.schedulerBuilder("J")
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -1556,66 +1654,57 @@ class ModelTests {
 
         */
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
         final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").build().cast();
+                model.<Integer>schedulerBuilder("C").build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD = model.schedulerBuilder("D")
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
                 .withType(TaskSchedulerType.CONCURRENT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE = model.schedulerBuilder("E")
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF = model.schedulerBuilder("F")
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG = model.schedulerBuilder("G")
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
                 .withType(TaskSchedulerType.DIRECT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH = model.schedulerBuilder("H")
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI = model.schedulerBuilder("I")
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ = model.schedulerBuilder("J")
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -1665,64 +1754,55 @@ class ModelTests {
         */
 
         final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").build().cast();
+                model.<Integer>schedulerBuilder("A").build();
         final InputWire<Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Integer> taskSchedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
                 .withType(TaskSchedulerType.SEQUENTIAL_THREAD)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputB = taskSchedulerB.buildInputWire("inputB");
 
-        final TaskScheduler<Integer> taskSchedulerC = model.schedulerBuilder("C")
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputC = taskSchedulerC.buildInputWire("inputC");
 
-        final TaskScheduler<Integer> taskSchedulerD = model.schedulerBuilder("D")
+        final TaskScheduler<Integer> taskSchedulerD = model.<Integer>schedulerBuilder("D")
                 .withType(TaskSchedulerType.DIRECT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputD = taskSchedulerD.buildInputWire("inputD");
 
-        final TaskScheduler<Integer> taskSchedulerE = model.schedulerBuilder("E")
+        final TaskScheduler<Integer> taskSchedulerE = model.<Integer>schedulerBuilder("E")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputE = taskSchedulerE.buildInputWire("inputE");
 
-        final TaskScheduler<Integer> taskSchedulerF = model.schedulerBuilder("F")
+        final TaskScheduler<Integer> taskSchedulerF = model.<Integer>schedulerBuilder("F")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputF = taskSchedulerF.buildInputWire("inputF");
 
-        final TaskScheduler<Integer> taskSchedulerG = model.schedulerBuilder("G")
+        final TaskScheduler<Integer> taskSchedulerG = model.<Integer>schedulerBuilder("G")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputG = taskSchedulerG.buildInputWire("inputG");
 
-        final TaskScheduler<Integer> taskSchedulerH = model.schedulerBuilder("H")
+        final TaskScheduler<Integer> taskSchedulerH = model.<Integer>schedulerBuilder("H")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputH = taskSchedulerH.buildInputWire("inputH");
 
-        final TaskScheduler<Integer> taskSchedulerI = model.schedulerBuilder("I")
+        final TaskScheduler<Integer> taskSchedulerI = model.<Integer>schedulerBuilder("I")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputI = taskSchedulerI.buildInputWire("inputI");
 
-        final TaskScheduler<Integer> taskSchedulerJ = model.schedulerBuilder("J")
+        final TaskScheduler<Integer> taskSchedulerJ = model.<Integer>schedulerBuilder("J")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final InputWire<Integer> inputJ = taskSchedulerJ.buildInputWire("inputJ");
 
         taskSchedulerA.getOutputWire().solderTo(inputB);
@@ -1746,10 +1826,9 @@ class ModelTests {
                         TestPlatformContextBuilder.create().build())
                 .build();
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> inputA = taskSchedulerA.buildInputWire("inputA");
 
         assertTrue(model.checkForUnboundInputWires());

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/ConcurrentTaskSchedulerTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/ConcurrentTaskSchedulerTests.java
@@ -59,11 +59,10 @@ class ConcurrentTaskSchedulerTests {
             }
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(TaskSchedulerType.CONCURRENT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
 
@@ -109,11 +108,10 @@ class ConcurrentTaskSchedulerTests {
             count.addAndGet(x.value);
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(TaskSchedulerType.CONCURRENT)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Operation, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
 
@@ -163,13 +161,12 @@ class ConcurrentTaskSchedulerTests {
             handleCount.incrementAndGet();
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(TaskSchedulerType.CONCURRENT)
                 .withUnhandledTaskCapacity(100)
                 .withFlushingEnabled(true)
                 .withSquelchingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> inputWire = taskScheduler.buildInputWire("channel");
         inputWire.bindConsumer(handler);
 

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/DirectTaskSchedulerTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/DirectTaskSchedulerTests.java
@@ -48,19 +48,17 @@ class DirectTaskSchedulerTests {
 
         final StandardObjectCounter counter = new StandardObjectCounter(Duration.ofMillis(1));
 
-        final TaskScheduler<Integer> schedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> schedulerA = model.<Integer>schedulerBuilder("A")
                 .withType(type)
                 .withOnRamp(counter)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> inA = schedulerA.buildInputWire("inA");
         final OutputWire<Integer> outA = schedulerA.getOutputWire();
 
-        final TaskScheduler<Void> schedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Void> schedulerB = model.<Void>schedulerBuilder("B")
                 .withType(type)
                 .withOffRamp(counter)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> inB = schedulerB.buildInputWire("inB");
 
         final SolderType solderType;
@@ -129,11 +127,10 @@ class DirectTaskSchedulerTests {
             assertEquals("intentional", e.getMessage());
         };
 
-        final TaskScheduler<Void> scheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> scheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUncaughtExceptionHandler(handler)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Integer, Void> in = scheduler.buildInputWire("in");
 
@@ -173,11 +170,10 @@ class DirectTaskSchedulerTests {
         final Thread mainThread = Thread.currentThread();
         final TaskSchedulerType type = threadsafe ? TaskSchedulerType.DIRECT_THREADSAFE : TaskSchedulerType.DIRECT;
 
-        final TaskScheduler<Integer> scheduler = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> scheduler = model.<Integer>schedulerBuilder("A")
                 .withType(type)
                 .withSquelchingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> inputWire = scheduler.buildInputWire("input");
 
         final AtomicInteger handleCount = new AtomicInteger(0);

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/HeartbeatSchedulerTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/HeartbeatSchedulerTests.java
@@ -41,7 +41,7 @@ class HeartbeatSchedulerTests {
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
 
         final TaskScheduler<Void> scheduler =
-                model.schedulerBuilder("test").build().cast();
+                model.<Void>schedulerBuilder("test").build();
 
         final BindableInputWire<Instant, Void> heartbeatBindable = scheduler.buildInputWire("heartbeat");
         model.buildHeartbeatWire(100).solderTo(heartbeatBindable);
@@ -70,7 +70,7 @@ class HeartbeatSchedulerTests {
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
 
         final TaskScheduler<Void> scheduler =
-                model.schedulerBuilder("test").build().cast();
+                model.<Void>schedulerBuilder("test").build();
 
         final BindableInputWire<Instant, Void> heartbeatBindable = scheduler.buildInputWire("heartbeat");
         model.buildHeartbeatWire(Duration.ofMillis(10)).solderTo(heartbeatBindable);
@@ -99,7 +99,7 @@ class HeartbeatSchedulerTests {
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
 
         final TaskScheduler<Void> scheduler =
-                model.schedulerBuilder("test").build().cast();
+                model.<Void>schedulerBuilder("test").build();
 
         final BindableInputWire<Instant, Void> heartbeatBindableA = scheduler.buildInputWire("heartbeatA");
         final BindableInputWire<Instant, Void> heartbeatBindableB = scheduler.buildInputWire("heartbeatB");

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/NoOpTaskSchedulerTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/NoOpTaskSchedulerTests.java
@@ -42,7 +42,7 @@ class NoOpTaskSchedulerTests {
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
 
         final TaskScheduler<List<Integer>> realFakeScheduler =
-                model.schedulerBuilder("A").withType(NO_OP).build().cast();
+                model.<List<Integer>>schedulerBuilder("A").withType(NO_OP).build();
 
         final AtomicBoolean shouldAlwaysBeFalse = new AtomicBoolean(false);
 
@@ -74,10 +74,9 @@ class NoOpTaskSchedulerTests {
         splitter.solderTo("handler", "handler input", value -> shouldAlwaysBeFalse.set(true));
 
         // Solder the fake scheduler to a real one. No data should be passed.
-        final TaskScheduler<Void> realScheduler = model.schedulerBuilder("B")
+        final TaskScheduler<Void> realScheduler = model.<Void>schedulerBuilder("B")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<List<Integer>, Void> realInA = realScheduler.buildInputWire("realInA");
         realInA.bindConsumer((value) -> shouldAlwaysBeFalse.set(true));

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/SequentialTaskSchedulerTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/SequentialTaskSchedulerTests.java
@@ -96,11 +96,10 @@ class SequentialTaskSchedulerTests {
         final AtomicInteger wireValue = new AtomicInteger();
         final Consumer<Integer> handler = x -> wireValue.set(hash32(wireValue.get(), x));
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(-1, taskScheduler.getUnprocessedTaskCount());
@@ -146,11 +145,10 @@ class SequentialTaskSchedulerTests {
             }
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(-1, taskScheduler.getUnprocessedTaskCount());
@@ -186,11 +184,10 @@ class SequentialTaskSchedulerTests {
             wireValue.set(hash32(wireValue.get(), operationCount.getAndIncrement()));
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(-1, taskScheduler.getUnprocessedTaskCount());
@@ -257,11 +254,10 @@ class SequentialTaskSchedulerTests {
             wireValue.set(hash32(wireValue.get(), operationCount.getAndIncrement()));
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(-1, taskScheduler.getUnprocessedTaskCount());
@@ -336,11 +332,10 @@ class SequentialTaskSchedulerTests {
             }
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(-1, taskScheduler.getUnprocessedTaskCount());
@@ -398,12 +393,11 @@ class SequentialTaskSchedulerTests {
             wireValue.set(hash32(wireValue.get(), x));
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskMetricEnabled(true)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(0, taskScheduler.getUnprocessedTaskCount());
@@ -483,12 +477,11 @@ class SequentialTaskSchedulerTests {
 
         final long capacity = 11;
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(capacity)
                 .withSleepDuration(Duration.ofMillis(1))
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(0, taskScheduler.getUnprocessedTaskCount());
@@ -587,11 +580,10 @@ class SequentialTaskSchedulerTests {
             wireValue.set(hash32(wireValue.get(), x));
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(11)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(0, taskScheduler.getUnprocessedTaskCount());
@@ -662,11 +654,10 @@ class SequentialTaskSchedulerTests {
         final AtomicInteger wireValue = new AtomicInteger();
         final Consumer<Integer> handler = x -> wireValue.set(hash32(wireValue.get(), x));
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(-1, taskScheduler.getUnprocessedTaskCount());
@@ -712,26 +703,22 @@ class SequentialTaskSchedulerTests {
         final AtomicInteger countC = new AtomicInteger();
         final AtomicInteger countD = new AtomicInteger();
 
-        final TaskScheduler<Integer> taskSchedulerToA = model.schedulerBuilder("wireToA")
+        final TaskScheduler<Integer> taskSchedulerToA = model.<Integer>schedulerBuilder("wireToA")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> taskSchedulerToB = model.schedulerBuilder("wireToB")
+                .build();
+        final TaskScheduler<Integer> taskSchedulerToB = model.<Integer>schedulerBuilder("wireToB")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> taskSchedulerToC = model.schedulerBuilder("wireToC")
+                .build();
+        final TaskScheduler<Integer> taskSchedulerToC = model.<Integer>schedulerBuilder("wireToC")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> taskSchedulerToD = model.schedulerBuilder("wireToD")
+                .build();
+        final TaskScheduler<Integer> taskSchedulerToD = model.<Integer>schedulerBuilder("wireToD")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Integer, Integer> channelToA = taskSchedulerToA.buildInputWire("channelToA");
         final BindableInputWire<Integer, Integer> channelToB = taskSchedulerToB.buildInputWire("channelToB");
@@ -837,11 +824,10 @@ class SequentialTaskSchedulerTests {
         final Consumer<Boolean> booleanHandler = x -> wireValue.set((x ? -1 : 1) * wireValue.get());
         final Consumer<String> stringHandler = x -> wireValue.set(hash32(wireValue.get(), x.hashCode()));
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Integer, Void> integerChannel = taskScheduler.buildInputWire("integerChannel");
         integerChannel.bindConsumer(integerHandler);
@@ -907,11 +893,10 @@ class SequentialTaskSchedulerTests {
 
         final Consumer<Integer> handler2 = x -> wireValue.set(hash32(wireValue.get(), -x));
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(11)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Integer, Void> channel1 = taskScheduler.buildInputWire("channel1");
         channel1.bindConsumer(handler1);
@@ -998,19 +983,17 @@ class SequentialTaskSchedulerTests {
 
         final ObjectCounter backpressure = new BackpressureObjectCounter("test", 11, Duration.ofMillis(1));
 
-        final TaskScheduler<Void> taskSchedulerA = model.schedulerBuilder("testA")
+        final TaskScheduler<Void> taskSchedulerA = model.<Void>schedulerBuilder("testA")
                 .withType(type)
                 .withOnRamp(backpressure)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
 
-        final TaskScheduler<Void> taskSchedulerB = model.schedulerBuilder("testB")
+        final TaskScheduler<Void> taskSchedulerB = model.<Void>schedulerBuilder("testB")
                 .withType(type)
                 .withOffRamp(backpressure)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Integer, Void> channelA = taskSchedulerA.buildInputWire("channelA");
         final BindableInputWire<Integer, Void> channelB = taskSchedulerB.buildInputWire("channelB");
@@ -1135,12 +1118,11 @@ class SequentialTaskSchedulerTests {
             wireValue.set(hash32(wireValue.get(), x));
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(11)
                 .withFlushingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(0, taskScheduler.getUnprocessedTaskCount());
@@ -1228,11 +1210,10 @@ class SequentialTaskSchedulerTests {
         final WiringModel model = TestWiringModelBuilder.create();
         final TaskSchedulerType type = TaskSchedulerType.valueOf(typeString);
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(10)
-                .build()
-                .cast();
+                .build();
 
         model.start();
 
@@ -1257,12 +1238,11 @@ class SequentialTaskSchedulerTests {
 
         final AtomicInteger exceptionCount = new AtomicInteger();
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUncaughtExceptionHandler((t, e) -> exceptionCount.incrementAndGet())
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> channel = taskScheduler.buildInputWire("channel");
         channel.bindConsumer(handler);
         assertEquals(-1, taskScheduler.getUnprocessedTaskCount());
@@ -1298,27 +1278,24 @@ class SequentialTaskSchedulerTests {
 
         // create 3 wires with the following bindings:
         // a -> b -> c -> latch
-        final TaskScheduler<Void> a = model.schedulerBuilder("a")
+        final TaskScheduler<Void> a = model.<Void>schedulerBuilder("a")
                 .withType(type)
                 .withUnhandledTaskCapacity(2)
                 .withSleepDuration(Duration.ofMillis(1))
                 .withPool(pool)
-                .build()
-                .cast();
-        final TaskScheduler<Void> b = model.schedulerBuilder("b")
+                .build();
+        final TaskScheduler<Void> b = model.<Void>schedulerBuilder("b")
                 .withType(type)
                 .withUnhandledTaskCapacity(2)
                 .withSleepDuration(Duration.ofMillis(1))
                 .withPool(pool)
-                .build()
-                .cast();
-        final TaskScheduler<Void> c = model.schedulerBuilder("c")
+                .build();
+        final TaskScheduler<Void> c = model.<Void>schedulerBuilder("c")
                 .withType(type)
                 .withUnhandledTaskCapacity(2)
                 .withSleepDuration(Duration.ofMillis(1))
                 .withPool(pool)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Object, Void> channelA = a.buildInputWire("channelA");
         final BindableInputWire<Object, Void> channelB = b.buildInputWire("channelB");
@@ -1372,27 +1349,24 @@ class SequentialTaskSchedulerTests {
 
         // create 3 wires with the following bindings:
         // a -> b -> c -> latch
-        final TaskScheduler<Void> a = model.schedulerBuilder("a")
+        final TaskScheduler<Void> a = model.<Void>schedulerBuilder("a")
                 .withType(type)
                 .withUnhandledTaskCapacity(2)
                 .withSleepDuration(Duration.ofMillis(1))
                 .withPool(pool)
-                .build()
-                .cast();
-        final TaskScheduler<Void> b = model.schedulerBuilder("b")
+                .build();
+        final TaskScheduler<Void> b = model.<Void>schedulerBuilder("b")
                 .withType(type)
                 .withUnhandledTaskCapacity(2)
                 .withSleepDuration(Duration.ofMillis(1))
                 .withPool(pool)
-                .build()
-                .cast();
-        final TaskScheduler<Void> c = model.schedulerBuilder("c")
+                .build();
+        final TaskScheduler<Void> c = model.<Void>schedulerBuilder("c")
                 .withType(type)
                 .withUnhandledTaskCapacity(2)
                 .withSleepDuration(Duration.ofMillis(1))
                 .withPool(pool)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Object, Void> channelA = a.buildInputWire("channelA");
         final BindableInputWire<Object, Void> channelB = b.buildInputWire("channelB");
@@ -1446,13 +1420,13 @@ class SequentialTaskSchedulerTests {
         final TaskSchedulerType type = TaskSchedulerType.valueOf(typeString);
 
         final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("A").withType(type).build();
         final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("B").withType(type).build();
         final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("C").withType(type).build();
         final TaskScheduler<Void> taskSchedulerD =
-                model.schedulerBuilder("D").withType(type).build().cast();
+                model.<Void>schedulerBuilder("D").withType(type).build();
 
         final BindableInputWire<Integer, Integer> inputA = taskSchedulerA.buildInputWire("inputA");
         final BindableInputWire<Integer, Integer> inputB = taskSchedulerB.buildInputWire("inputB");
@@ -1515,13 +1489,13 @@ class SequentialTaskSchedulerTests {
         final TaskSchedulerType type = TaskSchedulerType.valueOf(typeString);
 
         final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("A").withType(type).build();
         final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("B").withType(type).build();
         final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("C").withType(type).build();
         final TaskScheduler<Void> taskSchedulerD =
-                model.schedulerBuilder("D").withType(type).build().cast();
+                model.<Void>schedulerBuilder("D").withType(type).build();
 
         final BindableInputWire<Integer, Integer> inputA = taskSchedulerA.buildInputWire("inputA");
         final BindableInputWire<Integer, Integer> inputB = taskSchedulerB.buildInputWire("inputB");
@@ -1593,25 +1567,25 @@ class SequentialTaskSchedulerTests {
         // X, Y, and Z pass data to B
 
         final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("A").withType(type).build();
         final BindableInputWire<Integer, Integer> addNewValueToA = taskSchedulerA.buildInputWire("addNewValueToA");
         final BindableInputWire<Boolean, Integer> setInversionBitInA =
                 taskSchedulerA.buildInputWire("setInversionBitInA");
 
         final TaskScheduler<Integer> taskSchedulerX =
-                model.schedulerBuilder("X").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("X").withType(type).build();
         final BindableInputWire<Integer, Integer> inputX = taskSchedulerX.buildInputWire("inputX");
 
         final TaskScheduler<Integer> taskSchedulerY =
-                model.schedulerBuilder("Y").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("Y").withType(type).build();
         final BindableInputWire<Integer, Integer> inputY = taskSchedulerY.buildInputWire("inputY");
 
         final TaskScheduler<Integer> taskSchedulerZ =
-                model.schedulerBuilder("Z").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("Z").withType(type).build();
         final BindableInputWire<Integer, Integer> inputZ = taskSchedulerZ.buildInputWire("inputZ");
 
         final TaskScheduler<Void> taskSchedulerB =
-                model.schedulerBuilder("B").withType(type).build().cast();
+                model.<Void>schedulerBuilder("B").withType(type).build();
         final BindableInputWire<Integer, Void> inputB = taskSchedulerB.buildInputWire("inputB");
 
         taskSchedulerA.getOutputWire().solderTo(inputX);
@@ -1711,25 +1685,22 @@ class SequentialTaskSchedulerTests {
         // In this test, wires A and B are connected to the input of wire C, which has a maximum capacity.
         // Wire A respects back pressure, but wire B uses injection and can ignore it.
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> inA = taskSchedulerA.buildInputWire("inA");
 
-        final TaskScheduler<Integer> taskSchedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
                 .withType(type)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> inB = taskSchedulerB.buildInputWire("inB");
 
-        final TaskScheduler<Void> taskSchedulerC = model.schedulerBuilder("C")
+        final TaskScheduler<Void> taskSchedulerC = model.<Void>schedulerBuilder("C")
                 .withType(type)
                 .withUnhandledTaskCapacity(10)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> inC = taskSchedulerC.buildInputWire("inC");
 
         taskSchedulerA.getOutputWire().solderTo(inC); // respects capacity
@@ -1832,13 +1803,13 @@ class SequentialTaskSchedulerTests {
         final TaskSchedulerType type = TaskSchedulerType.valueOf(typeString);
 
         final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("A").withType(type).build();
         final TaskScheduler<Integer> taskSchedulerB =
-                model.schedulerBuilder("B").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("B").withType(type).build();
         final TaskScheduler<Integer> taskSchedulerC =
-                model.schedulerBuilder("C").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("C").withType(type).build();
         final TaskScheduler<Void> taskSchedulerD =
-                model.schedulerBuilder("D").withType(type).build().cast();
+                model.<Void>schedulerBuilder("D").withType(type).build();
 
         final BindableInputWire<Integer, Integer> inputA = taskSchedulerA.buildInputWire("inputA");
         final BindableInputWire<Integer, Integer> inputB = taskSchedulerB.buildInputWire("inputB");
@@ -1928,30 +1899,26 @@ class SequentialTaskSchedulerTests {
         final WiringModel model = TestWiringModelBuilder.create();
         final TaskSchedulerType type = TaskSchedulerType.valueOf(typeString);
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withType(type)
                 .withBusyFractionMetricsEnabled(true)
                 .withUnhandledTaskMetricEnabled(true)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> taskSchedulerB = model.schedulerBuilder("B")
+                .build();
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
                 .withType(type)
                 .withBusyFractionMetricsEnabled(true)
                 .withUnhandledTaskMetricEnabled(false)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> taskSchedulerC = model.schedulerBuilder("C")
+                .build();
+        final TaskScheduler<Integer> taskSchedulerC = model.<Integer>schedulerBuilder("C")
                 .withType(type)
                 .withBusyFractionMetricsEnabled(false)
                 .withUnhandledTaskMetricEnabled(true)
-                .build()
-                .cast();
-        final TaskScheduler<Void> taskSchedulerD = model.schedulerBuilder("D")
+                .build();
+        final TaskScheduler<Void> taskSchedulerD = model.<Void>schedulerBuilder("D")
                 .withType(type)
                 .withBusyFractionMetricsEnabled(false)
                 .withUnhandledTaskMetricEnabled(false)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Integer, Integer> inputA = taskSchedulerA.buildInputWire("inputA");
         final BindableInputWire<Integer, Integer> inputB = taskSchedulerB.buildInputWire("inputB");
@@ -2011,13 +1978,13 @@ class SequentialTaskSchedulerTests {
         final TaskSchedulerType type = TaskSchedulerType.valueOf(typeString);
 
         final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").withType(type).build().cast();
+                model.<Integer>schedulerBuilder("A").withType(type).build();
         final BindableInputWire<Integer, Integer> aIn = taskSchedulerA.buildInputWire("aIn");
         final StandardOutputWire<Boolean> aOutBoolean = taskSchedulerA.buildSecondaryOutputWire();
         final StandardOutputWire<String> aOutString = taskSchedulerA.buildSecondaryOutputWire();
 
         final TaskScheduler<Void> taskSchedulerB =
-                model.schedulerBuilder("B").withType(type).build().cast();
+                model.<Void>schedulerBuilder("B").withType(type).build();
         final BindableInputWire<Integer, Void> bInInteger = taskSchedulerB.buildInputWire("bIn1");
         final BindableInputWire<Boolean, Void> bInBoolean = taskSchedulerB.buildInputWire("bIn2");
         final BindableInputWire<String, Void> bInString = taskSchedulerB.buildInputWire("bIn3");
@@ -2079,30 +2046,27 @@ class SequentialTaskSchedulerTests {
 
         final ObjectCounter counter = new BackpressureObjectCounter("test", 10, Duration.ofMillis(1));
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withType(type)
                 .withOnRamp(counter)
                 .withExternalBackPressure(true)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> aIn = taskSchedulerA.buildInputWire("aIn");
 
-        final TaskScheduler<Integer> taskSchedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
                 .withType(type)
                 .withExternalBackPressure(true)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> bIn = taskSchedulerB.buildInputWire("bIn");
 
-        final TaskScheduler<Void> taskSchedulerC = model.schedulerBuilder("C")
+        final TaskScheduler<Void> taskSchedulerC = model.<Void>schedulerBuilder("C")
                 .withType(type)
                 .withOffRamp(counter)
                 .withExternalBackPressure(true)
                 .withUnhandledTaskCapacity(UNLIMITED_CAPACITY)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> cIn = taskSchedulerC.buildInputWire("cIn");
 
         taskSchedulerA.getOutputWire().solderTo(bIn);
@@ -2209,30 +2173,27 @@ class SequentialTaskSchedulerTests {
 
         final ObjectCounter counter = new BackpressureObjectCounter("test", 10, Duration.ofMillis(1));
 
-        final TaskScheduler<Integer> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> taskSchedulerA = model.<Integer>schedulerBuilder("A")
                 .withType(type)
                 .withOnRamp(counter)
                 .withExternalBackPressure(true)
                 .withUnhandledTaskCapacity(5)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> aIn = taskSchedulerA.buildInputWire("aIn");
 
-        final TaskScheduler<Integer> taskSchedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Integer> taskSchedulerB = model.<Integer>schedulerBuilder("B")
                 .withType(type)
                 .withExternalBackPressure(true)
                 .withUnhandledTaskCapacity(5)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> bIn = taskSchedulerB.buildInputWire("bIn");
 
-        final TaskScheduler<Void> taskSchedulerC = model.schedulerBuilder("C")
+        final TaskScheduler<Void> taskSchedulerC = model.<Void>schedulerBuilder("C")
                 .withType(type)
                 .withOffRamp(counter)
                 .withExternalBackPressure(true)
                 .withUnhandledTaskCapacity(5)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> cIn = taskSchedulerC.buildInputWire("cIn");
 
         taskSchedulerA.getOutputWire().solderTo(bIn);
@@ -2332,18 +2293,16 @@ class SequentialTaskSchedulerTests {
 
         final TaskSchedulerType type = TaskSchedulerType.valueOf(typeString);
 
-        final TaskScheduler<Integer> schedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<Integer> schedulerA = model.<Integer>schedulerBuilder("A")
                 .withType(type)
                 .withUnhandledTaskCapacity(10)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Integer> inputA = schedulerA.buildInputWire("inputA");
 
-        final TaskScheduler<Void> schedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Void> schedulerB = model.<Void>schedulerBuilder("B")
                 .withType(type)
                 .withUnhandledTaskCapacity(10)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> inputB = schedulerB.buildInputWire("inputB");
 
         schedulerA.getOutputWire().solderTo(inputB, SolderType.OFFER);
@@ -2441,13 +2400,12 @@ class SequentialTaskSchedulerTests {
             }
         };
 
-        final TaskScheduler<Void> taskScheduler = model.schedulerBuilder("test")
+        final TaskScheduler<Void> taskScheduler = model.<Void>schedulerBuilder("test")
                 .withType(type)
                 .withUnhandledTaskCapacity(100)
                 .withFlushingEnabled(true)
                 .withSquelchingEnabled(true)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<Integer, Void> inputWire = taskScheduler.buildInputWire("channel");
         inputWire.bindConsumer(handler);
 

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/transformers/TaskSchedulerTransformersTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/transformers/TaskSchedulerTransformersTests.java
@@ -51,19 +51,19 @@ class TaskSchedulerTransformersTests {
         // Components B and C want individual integers. Component D wants the full list of integers.
 
         final TaskScheduler<List<Integer>> taskSchedulerA =
-                model.schedulerBuilder("A").build().cast();
+                model.<List<Integer>>schedulerBuilder("A").build();
         final BindableInputWire<Integer, List<Integer>> wireAIn = taskSchedulerA.buildInputWire("A in");
 
         final TaskScheduler<Void> taskSchedulerB =
-                model.schedulerBuilder("B").build().cast();
+                model.<Void>schedulerBuilder("B").build();
         final BindableInputWire<Integer, Void> wireBIn = taskSchedulerB.buildInputWire("B in");
 
         final TaskScheduler<Void> taskSchedulerC =
-                model.schedulerBuilder("C").build().cast();
+                model.<Void>schedulerBuilder("C").build();
         final BindableInputWire<Integer, Void> wireCIn = taskSchedulerC.buildInputWire("C in");
 
         final TaskScheduler<Void> taskSchedulerD =
-                model.schedulerBuilder("D").build().cast();
+                model.<Void>schedulerBuilder("D").build();
         final BindableInputWire<List<Integer>, Void> wireDIn = taskSchedulerD.buildInputWire("D in");
 
         final OutputWire<Integer> splitter =
@@ -121,15 +121,15 @@ class TaskSchedulerTransformersTests {
         // B wants all of A's data, but C and the lambda only want even values.
 
         final TaskScheduler<Integer> taskSchedulerA =
-                model.schedulerBuilder("A").build().cast();
+                model.<Integer>schedulerBuilder("A").build();
         final BindableInputWire<Integer, Integer> inA = taskSchedulerA.buildInputWire("A in");
 
         final TaskScheduler<Void> taskSchedulerB =
-                model.schedulerBuilder("B").build().cast();
+                model.<Void>schedulerBuilder("B").build();
         final BindableInputWire<Integer, Void> inB = taskSchedulerB.buildInputWire("B in");
 
         final TaskScheduler<Void> taskSchedulerC =
-                model.schedulerBuilder("C").build().cast();
+                model.<Void>schedulerBuilder("C").build();
         final BindableInputWire<Integer, Void> inC = taskSchedulerC.buildInputWire("C in");
 
         final AtomicInteger countA = new AtomicInteger(0);
@@ -184,19 +184,19 @@ class TaskSchedulerTransformersTests {
         // B wants all of A's data, C wants the integer values, and D wants the boolean values.
 
         final TaskScheduler<TestData> taskSchedulerA =
-                model.schedulerBuilder("A").build().cast();
+                model.<TestData>schedulerBuilder("A").build();
         final BindableInputWire<TestData, TestData> inA = taskSchedulerA.buildInputWire("A in");
 
         final TaskScheduler<Void> taskSchedulerB =
-                model.schedulerBuilder("B").build().cast();
+                model.<Void>schedulerBuilder("B").build();
         final BindableInputWire<TestData, Void> inB = taskSchedulerB.buildInputWire("B in");
 
         final TaskScheduler<Void> taskSchedulerC =
-                model.schedulerBuilder("C").build().cast();
+                model.<Void>schedulerBuilder("C").build();
         final BindableInputWire<Integer, Void> inC = taskSchedulerC.buildInputWire("C in");
 
         final TaskScheduler<Void> taskSchedulerD =
-                model.schedulerBuilder("D").build().cast();
+                model.<Void>schedulerBuilder("D").build();
         final BindableInputWire<Boolean, Void> inD = taskSchedulerD.buildInputWire("D in");
 
         taskSchedulerA.getOutputWire().solderTo(inB);
@@ -263,19 +263,19 @@ class TaskSchedulerTransformersTests {
         // B wants all of A's data, C wants the integer values, and D wants the boolean values.
 
         final TaskScheduler<TestData> taskSchedulerA =
-                model.schedulerBuilder("A").build().cast();
+                model.<TestData>schedulerBuilder("A").build();
         final BindableInputWire<TestData, TestData> inA = taskSchedulerA.buildInputWire("A in");
 
         final TaskScheduler<Void> taskSchedulerB =
-                model.schedulerBuilder("B").build().cast();
+                model.<Void>schedulerBuilder("B").build();
         final BindableInputWire<TestData, Void> inB = taskSchedulerB.buildInputWire("B in");
 
         final TaskScheduler<Void> taskSchedulerC =
-                model.schedulerBuilder("C").build().cast();
+                model.<Void>schedulerBuilder("C").build();
         final BindableInputWire<Integer, Void> inC = taskSchedulerC.buildInputWire("C in");
 
         final TaskScheduler<Void> taskSchedulerD =
-                model.schedulerBuilder("D").build().cast();
+                model.<Void>schedulerBuilder("D").build();
         final BindableInputWire<Boolean, Void> inD = taskSchedulerD.buildInputWire("D in");
 
         taskSchedulerA.getOutputWire().solderTo(inB);
@@ -391,38 +391,33 @@ class TaskSchedulerTransformersTests {
         final AtomicBoolean error = new AtomicBoolean(false);
         final UncaughtExceptionHandler exceptionHandler = (t, e) -> error.set(true);
 
-        final TaskScheduler<FooBar> taskSchedulerA = model.schedulerBuilder("A")
+        final TaskScheduler<FooBar> taskSchedulerA = model.<FooBar>schedulerBuilder("A")
                 .withUncaughtExceptionHandler(exceptionHandler)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<FooBar, FooBar> inA = taskSchedulerA.buildInputWire("A in");
         final OutputWire<FooBar> outA = taskSchedulerA.getOutputWire();
         final OutputWire<FooBar> outAReserved = outA.buildAdvancedTransformer(new AdvancedTransformationHelper<>(
                 "reserveFooBar", FooBar::copyAndReserve, FooBar::release, FooBar::release));
 
-        final TaskScheduler<Void> taskSchedulerB = model.schedulerBuilder("B")
+        final TaskScheduler<Void> taskSchedulerB = model.<Void>schedulerBuilder("B")
                 .withUncaughtExceptionHandler(exceptionHandler)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<FooBar, Void> inB = taskSchedulerB.buildInputWire("B in");
 
-        final TaskScheduler<Void> taskSchedulerC = model.schedulerBuilder("C")
+        final TaskScheduler<Void> taskSchedulerC = model.<Void>schedulerBuilder("C")
                 .withUncaughtExceptionHandler(exceptionHandler)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<FooBar, Void> inC = taskSchedulerC.buildInputWire("C in");
 
-        final TaskScheduler<Void> taskSchedulerD = model.schedulerBuilder("D")
+        final TaskScheduler<Void> taskSchedulerD = model.<Void>schedulerBuilder("D")
                 .withUncaughtExceptionHandler(exceptionHandler)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<FooBar, Void> inD = taskSchedulerD.buildInputWire("D in");
 
-        final TaskScheduler<Void> taskSchedulerE = model.schedulerBuilder("E")
+        final TaskScheduler<Void> taskSchedulerE = model.<Void>schedulerBuilder("E")
                 .withUncaughtExceptionHandler(exceptionHandler)
                 .withUnhandledTaskCapacity(1)
-                .build()
-                .cast();
+                .build();
         final BindableInputWire<FooBar, Void> inE = taskSchedulerE.buildInputWire("E in");
 
         outAReserved.solderTo(inB);

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/wires/OutputWireTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/wires/OutputWireTests.java
@@ -50,18 +50,15 @@ public class OutputWireTests {
                 TestPlatformContextBuilder.create().build();
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
 
-        final TaskScheduler<Integer> intForwarder = model.schedulerBuilder("intForwarder")
+        final TaskScheduler<Integer> intForwarder = model.<Integer>schedulerBuilder("intForwarder")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
-        final TaskScheduler<Void> firstComponent = model.schedulerBuilder("firstComponent")
+                .build();
+        final TaskScheduler<Void> firstComponent = model.<Void>schedulerBuilder("firstComponent")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
-        final TaskScheduler<Void> secondComponent = model.schedulerBuilder("secondComponent")
+                .build();
+        final TaskScheduler<Void> secondComponent = model.<Void>schedulerBuilder("secondComponent")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<Integer, Integer> intInput = intForwarder.buildInputWire("intInput");
         final BindableInputWire<Integer, Void> firstComponentInput = firstComponent.buildInputWire("ints");
@@ -106,14 +103,12 @@ public class OutputWireTests {
                 TestPlatformContextBuilder.create().build();
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
 
-        final TaskScheduler<Integer> schedulerA = model.schedulerBuilder("schedulerA")
+        final TaskScheduler<Integer> schedulerA = model.<Integer>schedulerBuilder("schedulerA")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
-        final TaskScheduler<Integer> schedulerB = model.schedulerBuilder("schedulerB")
+                .build();
+        final TaskScheduler<Integer> schedulerB = model.<Integer>schedulerBuilder("schedulerB")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+                .build();
 
         InputWire<Integer> inputWire = schedulerB.buildInputWire("inputWire");
         assertThrows(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/DiagramLegendCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/DiagramLegendCommand.java
@@ -58,28 +58,23 @@ public final class DiagramLegendCommand extends AbstractCommand {
 
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
 
-        final TaskScheduler<Integer> sequentialScheduler = model.schedulerBuilder("SequentialScheduler")
+        final TaskScheduler<Integer> sequentialScheduler = model.<Integer>schedulerBuilder("SequentialScheduler")
                 .withType(TaskSchedulerType.SEQUENTIAL)
                 .withUnhandledTaskCapacity(1)
-                .build()
-                .cast();
-        final TaskScheduler<Void> sequentialThreadScheduler = model.schedulerBuilder("SequentialThreadScheduler")
+                .build();
+        final TaskScheduler<Void> sequentialThreadScheduler = model.<Void>schedulerBuilder("SequentialThreadScheduler")
                 .withType(TaskSchedulerType.SEQUENTIAL_THREAD)
                 .withUnhandledTaskCapacity(1)
-                .build()
-                .cast();
-        final TaskScheduler<Void> directScheduler = model.schedulerBuilder("DirectScheduler")
+                .build();
+        final TaskScheduler<Void> directScheduler = model.<Void>schedulerBuilder("DirectScheduler")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
-        final TaskScheduler<Void> directThreadsafeScheduler = model.schedulerBuilder("DirectThreadsafeScheduler")
+                .build();
+        final TaskScheduler<Void> directThreadsafeScheduler = model.<Void>schedulerBuilder("DirectThreadsafeScheduler")
                 .withType(TaskSchedulerType.DIRECT_THREADSAFE)
-                .build()
-                .cast();
-        final TaskScheduler<Void> concurrentScheduler = model.schedulerBuilder("ConcurrentScheduler")
+                .build();
+        final TaskScheduler<Void> concurrentScheduler = model.<Void>schedulerBuilder("ConcurrentScheduler")
                 .withType(TaskSchedulerType.CONCURRENT)
-                .build()
-                .cast();
+                .build();
 
         final String wireSubstitutionString = "wire substitution (for readability)";
         sequentialScheduler.getOutputWire().solderTo(sequentialThreadScheduler.buildInputWire(wireSubstitutionString));

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/GossipWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/GossipWiring.java
@@ -90,13 +90,12 @@ public class GossipWiring {
     public GossipWiring(@NonNull final PlatformContext platformContext, @NonNull final WiringModel model) {
         this.model = model;
 
-        scheduler = model.schedulerBuilder("gossip")
+        scheduler = model.<Void>schedulerBuilder("gossip")
                 .configure(platformContext
                         .getConfiguration()
                         .getConfigData(PlatformSchedulersConfig.class)
                         .gossip())
-                .build()
-                .cast();
+                .build();
 
         eventInput = scheduler.buildInputWire("events to gossip");
         eventWindowInput = scheduler.buildInputWire("event window");

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/PassThroughWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/PassThroughWiring.java
@@ -69,10 +69,9 @@ public class PassThroughWiring<DATA_TYPE> {
         this(
                 model,
                 inputLabel,
-                model.schedulerBuilder(Objects.requireNonNull(componentName))
+                model.<DATA_TYPE>schedulerBuilder(Objects.requireNonNull(componentName))
                         .withType(Objects.requireNonNull(schedulerType))
-                        .build()
-                        .cast());
+                        .build());
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/PcesReplayerWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/PcesReplayerWiring.java
@@ -52,11 +52,10 @@ public record PcesReplayerWiring(
      */
     @NonNull
     public static PcesReplayerWiring create(@NonNull final WiringModel model) {
-        final TaskScheduler<NoInput> taskScheduler = model.schedulerBuilder("pcesReplayer")
+        final TaskScheduler<NoInput> taskScheduler = model.<NoInput>schedulerBuilder("pcesReplayer")
                 .withType(DIRECT)
                 .withHyperlink(platformCoreHyperlink(PcesReplayer.class))
-                .build()
-                .cast();
+                .build();
 
         return new PcesReplayerWiring(
                 taskScheduler.buildInputWire("event files to replay"),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/RunningEventHashOverrideWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/RunningEventHashOverrideWiring.java
@@ -46,11 +46,11 @@ public record RunningEventHashOverrideWiring(
     @NonNull
     public static RunningEventHashOverrideWiring create(@NonNull final WiringModel model) {
 
-        final TaskScheduler<RunningEventHashOverride> taskScheduler = model.schedulerBuilder("RunningEventHashOverride")
+        final TaskScheduler<RunningEventHashOverride> taskScheduler = model.<RunningEventHashOverride>schedulerBuilder(
+                        "RunningEventHashOverride")
                 .withType(DIRECT_THREADSAFE)
                 .withHyperlink(platformCoreHyperlink(RunningEventHashOverrideWiring.class))
-                .build()
-                .cast();
+                .build();
 
         final BindableInputWire<RunningEventHashOverride, RunningEventHashOverride> inputWire =
                 taskScheduler.buildInputWire("hash override");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/EventWindowManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/components/EventWindowManagerTests.java
@@ -42,10 +42,9 @@ public class EventWindowManagerTests {
         final ComponentWiring<EventWindowManager, EventWindow> wiring = new ComponentWiring<>(
                 model,
                 EventWindowManager.class,
-                model.schedulerBuilder("eventWindowManager")
+                model.<EventWindow>schedulerBuilder("eventWindowManager")
                         .withType(TaskSchedulerType.DIRECT_THREADSAFE)
-                        .build()
-                        .cast());
+                        .build());
         wiring.bind(eventWindowManager);
 
         final AtomicReference<EventWindow> output = new AtomicReference<>(null);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stream/ConsensusEventStreamTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stream/ConsensusEventStreamTest.java
@@ -63,10 +63,9 @@ class ConsensusEventStreamTest {
         final ComponentWiring<ConsensusEventStream, Void> wiring = new ComponentWiring<>(
                 model,
                 ConsensusEventStream.class,
-                model.schedulerBuilder("eventStreamManager")
+                model.<Void>schedulerBuilder("eventStreamManager")
                         .withType(TaskSchedulerType.DIRECT)
-                        .build()
-                        .cast());
+                        .build());
         wiring.bind(CONSENSUS_EVENT_STREAM);
 
         wiring.getInputWire(ConsensusEventStream::addEvents).inject(List.of(freezeEvent));
@@ -92,10 +91,9 @@ class ConsensusEventStreamTest {
         final ComponentWiring<ConsensusEventStream, Void> wiring = new ComponentWiring<>(
                 model,
                 ConsensusEventStream.class,
-                model.schedulerBuilder("eventStreamManager")
+                model.<Void>schedulerBuilder("eventStreamManager")
                         .withType(TaskSchedulerType.DIRECT)
-                        .build()
-                        .cast());
+                        .build());
         wiring.bind(CONSENSUS_EVENT_STREAM);
 
         wiring.getInputWire(ConsensusEventStream::legacyHashOverride)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/gossip/SimulatedGossipTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/gossip/SimulatedGossipTests.java
@@ -98,10 +98,9 @@ class SimulatedGossipTests {
                     .withDeterministicModeEnabled(true)
                     .build();
 
-            final TaskScheduler<Void> eventInputShim = model.schedulerBuilder("eventInputShim")
+            final TaskScheduler<Void> eventInputShim = model.<Void>schedulerBuilder("eventInputShim")
                     .configure(DIRECT_THREADSAFE_CONFIGURATION)
-                    .build()
-                    .cast();
+                    .build();
 
             final List<PlatformEvent> receivedEventsForNode = new ArrayList<>();
             receivedEvents.put(nodeId, receivedEventsForNode);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/SignedStateReserverTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/SignedStateReserverTest.java
@@ -58,10 +58,10 @@ class SignedStateReserverTest {
                 false);
 
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
-        final TaskScheduler<ReservedSignedState> taskScheduler = model.schedulerBuilder("scheduler")
+        final TaskScheduler<ReservedSignedState> taskScheduler = model.<ReservedSignedState>schedulerBuilder(
+                        "scheduler")
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+                .build();
         final OutputWire<ReservedSignedState> outputWire =
                 taskScheduler.getOutputWire().buildAdvancedTransformer(new SignedStateReserver("reserver"));
         final BindableInputWire<ReservedSignedState, ReservedSignedState> inputWire =

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/consensus/TestIntake.java
@@ -185,9 +185,8 @@ public class TestIntake {
     }
 
     public <X> TaskScheduler<X> directScheduler(final String name) {
-        return model.schedulerBuilder(name)
+        return model.<X>schedulerBuilder(name)
                 .withType(TaskSchedulerType.DIRECT)
-                .build()
-                .cast();
+                .build();
     }
 }


### PR DESCRIPTION
**Description**:
Removes the unsafe `cast()` method from TaskScheduler and replaces its uses with the correct generics invocation.
**Related issue(s)**:

Fixes #17592 
