### PR TITLE
fix: 17625: Ease exception handling for tasks

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -570,7 +570,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         }
 
         @Override
-        protected boolean exec() {
+        protected boolean execImpl() {
             Bytes bytes = BlockItem.PROTOBUF.toBytes(item);
 
             final var kind = item.item().kind();
@@ -605,7 +605,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         }
 
         @Override
-        protected boolean exec() {
+        protected boolean execImpl() {
             final var kind = item.item().kind();
             switch (kind) {
                 case EVENT_HEADER, EVENT_TRANSACTION, ROUND_HEADER -> inputTreeHasher.addLeaf(hash);

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/concurrent/AbstractTask.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/concurrent/AbstractTask.java
@@ -77,11 +77,33 @@ public abstract class AbstractTask extends ForkJoinTask<Void> {
         }
     }
 
+    @Override
+    protected final boolean exec() {
+        try {
+            return execImpl();
+        } catch (final Throwable t) {
+            completeExceptionally(t);
+            return false;
+        }
+    }
+
     /**
-     * Execute the work represented by this task.
+     * Implement this method in subclasses to run this task. If an exception occurs while
+     * running the task, use {@link #completeExceptionally(Throwable)} to report it.
      *
      * @return true if this task is known to have been completed normally
      */
+    protected abstract boolean execImpl();
+
     @Override
-    protected abstract boolean exec();
+    public final void completeExceptionally(final Throwable t) {
+        super.completeExceptionally(t);
+        completeExceptionallyImpl(t);
+    }
+
+    /**
+     * Implement this method in subclasses to handle exceptions occurred in {@link #execImpl()}
+     * or in dependency tasks.
+     */
+    protected void completeExceptionallyImpl(final Throwable t) {}
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/hash/MerkleHashBuilder.java
@@ -153,7 +153,7 @@ public class MerkleHashBuilder {
         }
 
         @Override
-        protected boolean exec() {
+        protected boolean execImpl() {
             try {
                 if (node == null || node.getHash() != null) {
                     out.send();
@@ -196,15 +196,14 @@ public class MerkleHashBuilder {
         }
 
         @Override
-        protected boolean exec() {
+        protected boolean execImpl() {
             merkleCryptography.digestSync(internal, MERKLE_DIGEST_TYPE);
             out.send();
             return true;
         }
 
         @Override
-        public void completeExceptionally(Throwable ex) {
-            super.completeExceptionally(ex);
+        public void completeExceptionallyImpl(Throwable ex) {
             // Try to reduce exception propagation; OK if multiple exceptions reported to out
             if (!out.isCompletedAbnormally()) {
                 out.completeExceptionally(ex);
@@ -226,14 +225,13 @@ public class MerkleHashBuilder {
         }
 
         @Override
-        protected boolean exec() {
+        protected boolean execImpl() {
             future.set(root.getHash());
             return true;
         }
 
         @Override
-        public void completeExceptionally(Throwable ex) {
-            super.completeExceptionally(ex);
+        public void completeExceptionallyImpl(Throwable ex) {
             if (!future.isCancelled()) {
                 future.cancelWithException(ex);
             }

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/ConcurrentTask.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/ConcurrentTask.java
@@ -61,14 +61,22 @@ class ConcurrentTask extends AbstractTask {
      * {@inheritDoc}
      */
     @Override
-    protected boolean exec() {
+    protected boolean execImpl() {
         try {
             handler.accept(data);
         } catch (final Throwable t) {
-            uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), t);
+            completeExceptionallyImpl(t);
         } finally {
             offRamp.offRamp();
         }
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void completeExceptionallyImpl(final Throwable t) {
+        uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), t);
     }
 }

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/SequentialTask.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/SequentialTask.java
@@ -83,15 +83,15 @@ class SequentialTask extends AbstractTask {
     }
 
     /**
-     * Execute this task.
+     * {@inheritDoc}
      */
     @Override
-    public boolean exec() {
+    public boolean execImpl() {
         busyTimer.activate();
         try {
             handler.accept(data);
         } catch (final Throwable t) {
-            uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), t);
+            completeExceptionally(t);
         } finally {
             offRamp.offRamp();
             busyTimer.deactivate();
@@ -101,5 +101,13 @@ class SequentialTask extends AbstractTask {
             nextTask.send();
         }
         return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void completeExceptionallyImpl(final Throwable t) {
+        uncaughtExceptionHandler.uncaughtException(Thread.currentThread(), t);
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
@@ -147,7 +147,7 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
         }
 
         @Override
-        protected boolean exec() {
+        protected boolean execImpl() {
             return true;
         }
 
@@ -191,15 +191,14 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
         }
 
         @Override
-        public void completeExceptionally(Throwable ex) {
+        public void completeExceptionallyImpl(Throwable ex) {
             if (out != null) {
                 out.completeExceptionally(ex);
             }
-            super.completeExceptionally(ex);
         }
 
         @Override
-        protected boolean exec() {
+        protected boolean execImpl() {
             try {
                 final Hash hash;
                 if (leaf != null) {
@@ -236,7 +235,7 @@ public final class VirtualHasher<K extends VirtualKey, V extends VirtualValue> {
                 return true;
             } catch (final Throwable e) {
                 completeExceptionally(e);
-                throw e;
+                return false;
             }
         }
 

--- a/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/internal/merkle/VirtualRootNodeTest.java
@@ -809,6 +809,27 @@ class VirtualRootNodeTest extends VirtualTestBase {
     }
 
     @Test
+    void deleteLastLeaf() {
+        VirtualRootNode<TestKey, TestValue> root = createRoot();
+        root.put(new TestKey(1), new TestValue(1000000));
+
+        final VirtualRootNode<TestKey, TestValue> copy = root.copy();
+        copy.postInit(root.getState());
+        copy.remove(new TestKey(1));
+
+        final VirtualRootNode<TestKey, TestValue> copyCopy = copy.copy();
+        copyCopy.postInit(root.getState());
+
+        final VirtualLeafRecord<TestKey, TestValue> leaf = copy.getCache().lookupLeafByPath(1, false);
+        assertTrue(leaf == null || leaf == VirtualNodeCache.DELETED_LEAF_RECORD);
+        assertNull(copy.get(new TestKey(1)));
+        assertNull(copyCopy.get(new TestKey(1)));
+        assertEquals(1, copy.getCache().deletedLeaves().toList().size());
+
+        root.release();
+    }
+
+    @Test
     @DisplayName("Copy of a root node with terminated pipeline")
     void copyOfRootNodeWithTerminatedPipeline() {
         VirtualRootNode<TestKey, TestValue> root = createRoot();


### PR DESCRIPTION
Fix summary:

* `AbstractTask` got two methods: `execImpl()` and `completeExceptionallyImpl()`, both names are TBD
* All existing tasks are changed to override these methods rather than `exec()` and `completeExceptionally()`
* Some tasks are simplified, so they don't have to call super methods or catch extra exceptions, this is now taken care of in `AbstractTask`
* A new unit test is added for `AbstractTask`

Fixes: https://github.com/hashgraph/hedera-services/issues/17625
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
