### PR TITLE
fix: reconnect leaves event creation manager in OVERLOADED state

### DIFF
--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/model/TraceableWiringModel.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/model/TraceableWiringModel.java
@@ -225,7 +225,7 @@ public abstract class TraceableWiringModel implements WiringModel {
             @NonNull final SolderType solderType) {
         throwIfStarted();
 
-        final boolean blockingEdge = solderType == SolderType.PUT;
+        final boolean blockingEdge = solderType == SolderType.PUT || solderType == SolderType.DIRECT;
 
         final ModelVertex origin = getVertex(originVertex);
         final ModelVertex destination = getVertex(destinationVertex);

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/wires/SolderType.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/wires/SolderType.java
@@ -35,5 +35,7 @@ public enum SolderType {
      * When data is passed to the input wire, call {@link InputWire#offer(Object)}. If the input wire has backpressure
      * enabled and the input wire is full, then the data will be dropped.
      */
-    OFFER
+    OFFER,
+
+    DIRECT
 }

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/wires/input/InputWire.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/wires/input/InputWire.java
@@ -109,6 +109,10 @@ public abstract class InputWire<IN> {
         taskSchedulerInput.inject(handler, data);
     }
 
+    public void direct(final IN data) {
+        handler.accept(data);
+    }
+
     /**
      * Set the method that will handle data traveling over this wire.
      *

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/wires/output/OutputWire.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/wires/output/OutputWire.java
@@ -140,6 +140,7 @@ public abstract class OutputWire<OUT> {
             case PUT -> addForwardingDestination(inputWire::put);
             case INJECT -> addForwardingDestination(inputWire::inject);
             case OFFER -> addForwardingDestination(inputWire::offer);
+            case DIRECT -> addForwardingDestination(inputWire::direct);
             default -> throw new IllegalArgumentException("Unknown solder type: " + solderType);
         }
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -18,6 +18,7 @@ package com.swirlds.platform.wiring;
 
 import static com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration.DIRECT_THREADSAFE_CONFIGURATION;
 import static com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration.NO_OP_CONFIGURATION;
+import static com.swirlds.component.framework.wires.SolderType.DIRECT;
 import static com.swirlds.component.framework.wires.SolderType.INJECT;
 import static com.swirlds.component.framework.wires.SolderType.OFFER;
 import static com.swirlds.platform.event.stale.StaleEventDetectorOutput.SELF_EVENT;
@@ -446,7 +447,8 @@ public class PlatformWiring {
         }
 
         model.getHealthMonitorWire()
-                .solderTo(eventCreationManagerWiring.getInputWire(EventCreationManager::reportUnhealthyDuration));
+                .solderTo(
+                        eventCreationManagerWiring.getInputWire(EventCreationManager::reportUnhealthyDuration), DIRECT);
 
         model.getHealthMonitorWire().solderTo(gossipWiring.getSystemHealthInput());
 


### PR DESCRIPTION
**Description**:
* introduced DIRECT input wire
* used DIRECT input wire to report unhealthy duration to event creation manager

**Related issue(s)**:

Fixes #17180

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
