### PR TITLE
build: remove hamcrest version from dependency version list

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -121,7 +121,6 @@ dependencies.constraints {
     api("org.eclipse.collections:eclipse-collections:$eclipseCollections") {
         because("org.eclipse.collections.impl")
     }
-    api("org.hamcrest:hamcrest:2.2") { because("org.hamcrest") }
     api("org.hyperledger.besu:besu-datatypes:$besu") { because("org.hyperledger.besu.datatypes") }
     api("org.hyperledger.besu:evm:$besu") { because("org.hyperledger.besu.evm") }
     api("org.hyperledger.besu:secp256k1:0.8.2") {


### PR DESCRIPTION
**Description**:

`hamcrest` is a test assertion library that is not part of the production code. We do not use it (anymore). We use `assertj`, which is an alternative library for test assertions.

This PR removes the version so that we do not track it anymore and have to deal with Dependabot updates.