### PR TITLE
refactor: 17357 Introduced `PlatformStateFacade` and used it where applicable

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -149,6 +149,7 @@ import com.swirlds.platform.listeners.StateWriteToDiskCompleteListener;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.StateLifecycles;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.ReadablePlatformStateStore;
 import com.swirlds.platform.state.service.ReadableRosterStore;
@@ -292,6 +293,12 @@ public final class Hedera
     private final BlockStreamService blockStreamService;
 
     /**
+     * The platform state facade singleton, kept as a field here to avoid constructing twice`
+     * (once in constructor to register schemas, again inside Dagger component).
+     */
+    private final PlatformStateFacade platformStateFacade;
+
+    /**
      * The block hash signer factory.
      */
     private final BlockHashSignerFactory blockHashSignerFactory;
@@ -433,6 +440,7 @@ public final class Hedera
      * @param historyServiceFactory  the factory for the history service
      * @param blockHashSignerFactory the factory for the block hash signer
      * @param metrics                the metrics object to use for reporting
+     * @param platformStateFacade    the facade object to access platform state
      */
     public Hedera(
             @NonNull final ConstructableRegistry constructableRegistry,
@@ -443,7 +451,8 @@ public final class Hedera
             @NonNull final HintsServiceFactory hintsServiceFactory,
             @NonNull final HistoryServiceFactory historyServiceFactory,
             @NonNull final BlockHashSignerFactory blockHashSignerFactory,
-            @NonNull final Metrics metrics) {
+            @NonNull final Metrics metrics,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         requireNonNull(registryFactory);
         requireNonNull(constructableRegistry);
         requireNonNull(hintsServiceFactory);
@@ -453,6 +462,7 @@ public final class Hedera
         this.startupNetworksFactory = requireNonNull(startupNetworksFactory);
         this.blockHashSignerFactory = requireNonNull(blockHashSignerFactory);
         this.storeMetricsService = new StoreMetricsServiceImpl(metrics);
+        this.platformStateFacade = requireNonNull(platformStateFacade);
         logger.info(
                 """
 
@@ -518,7 +528,11 @@ public final class Hedera
                         new CongestionThrottleService(),
                         new NetworkServiceImpl(),
                         new AddressBookServiceImpl(),
-                        new RosterService(this::canAdoptRoster, this::onAdoptRoster, () -> requireNonNull(initState)),
+                        new RosterService(
+                                this::canAdoptRoster,
+                                this::onAdoptRoster,
+                                () -> requireNonNull(initState),
+                                platformStateFacade),
                         PLATFORM_STATE_SERVICE)
                 .forEach(servicesRegistry::register);
         try {
@@ -618,7 +632,7 @@ public final class Hedera
         requireNonNull(state);
         requireNonNull(platformConfig);
         this.configProvider = new ConfigProviderImpl(trigger == GENESIS, metrics);
-        final var deserializedVersion = serviceMigrator.creationVersionOf(state);
+        final var deserializedVersion = platformStateFacade.creationSemanticVersionOf(state);
         logger.info(
                 "Initializing Hedera state version {} in {} mode with trigger {} and previous version {}",
                 version,
@@ -650,8 +664,8 @@ public final class Hedera
         final var readableStore = new ReadablePlatformStateStore(state.getReadableStates(PlatformStateService.NAME));
         logger.info(
                 "Platform state includes freeze time={} and last frozen={}",
-                readableStore.getFreezeTime(),
-                readableStore.getLastFrozenTime());
+                platformStateFacade.freezeTimeOf(state),
+                platformStateFacade.lastFrozenTimeOf(state));
     }
 
     /**
@@ -740,7 +754,8 @@ public final class Hedera
                 metrics,
                 startupNetworks,
                 storeMetricsService,
-                configProvider);
+                configProvider,
+                platformStateFacade);
         this.initState = null;
         migrationStateChanges = new ArrayList<>(migrationChanges);
         kvStateChangeListener.reset();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -54,6 +54,7 @@ import com.hedera.node.app.services.OrderedServiceMigrator;
 import com.hedera.node.app.services.ServicesRegistryImpl;
 import com.hedera.node.app.state.StateLifecyclesImpl;
 import com.hedera.node.app.tss.TssBlockHashSigner;
+import com.hedera.node.app.version.ServicesSoftwareVersion;
 import com.hedera.node.internal.network.Network;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.constructable.ConstructableRegistry;
@@ -84,6 +85,7 @@ import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.StateLifecycles;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.ReadableRosterStoreImpl;
 import com.swirlds.platform.state.signed.HashedReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
@@ -282,7 +284,8 @@ public class ServicesMain implements SwirldMain<PlatformMerkleStateRoot> {
         // --- Initialize the platform metrics and the Hedera instance ---
         setupGlobalMetrics(platformConfig);
         metrics = getMetricsProvider().createPlatformMetrics(selfId);
-        hedera = newHedera(metrics);
+        final PlatformStateFacade platformStateFacade = new PlatformStateFacade(ServicesSoftwareVersion::new);
+        hedera = newHedera(metrics, platformStateFacade);
         final var version = hedera.getSoftwareVersion();
         final var isGenesis = new AtomicBoolean(false);
         logger.info("Starting node {} with version {}", selfId, version);
@@ -314,7 +317,8 @@ public class ServicesMain implements SwirldMain<PlatformMerkleStateRoot> {
                 },
                 Hedera.APP_NAME,
                 Hedera.SWIRLD_NAME,
-                selfId);
+                selfId,
+                platformStateFacade);
         final var initialState = reservedState.state();
         final var state = initialState.get().getState();
         if (!isGenesis.get()) {
@@ -352,7 +356,8 @@ public class ServicesMain implements SwirldMain<PlatformMerkleStateRoot> {
                         stateLifecycles,
                         selfId,
                         canonicalEventStreamLoc(selfId.id(), state),
-                        rosterHistory)
+                        rosterHistory,
+                        platformStateFacade)
                 .withPlatformContext(platformContext)
                 .withConfiguration(platformConfig)
                 .withKeysAndCerts(keysAndCerts)
@@ -382,9 +387,11 @@ public class ServicesMain implements SwirldMain<PlatformMerkleStateRoot> {
      * Creates a canonical {@link Hedera} instance for the given node id and metrics.
      *
      * @param metrics  the metrics
+     * @param platformStateFacade an object to access the platform state
      * @return the {@link Hedera} instance
      */
-    public static Hedera newHedera(@NonNull final Metrics metrics) {
+    public static Hedera newHedera(
+            @NonNull final Metrics metrics, @NonNull final PlatformStateFacade platformStateFacade) {
         requireNonNull(metrics);
         return new Hedera(
                 ConstructableRegistry.getInstance(),
@@ -402,7 +409,8 @@ public class ServicesMain implements SwirldMain<PlatformMerkleStateRoot> {
                         HISTORY_LIBRARY_CODEC,
                         bootstrapConfig),
                 TssBlockHashSigner::new,
-                metrics);
+                metrics,
+                platformStateFacade);
     }
 
     /**
@@ -483,6 +491,7 @@ public class ServicesMain implements SwirldMain<PlatformMerkleStateRoot> {
      * @param mainClassName       the name of the app's SwirldMain class
      * @param swirldName          the name of this swirld
      * @param selfId              the node id of this node
+     * @param platformStateFacade an object to access the platform state
      * @return the initial state to be used by this node
      */
     @NonNull
@@ -493,24 +502,32 @@ public class ServicesMain implements SwirldMain<PlatformMerkleStateRoot> {
             @NonNull final Supplier<PlatformMerkleStateRoot> stateRootSupplier,
             @NonNull final String mainClassName,
             @NonNull final String swirldName,
-            @NonNull final NodeId selfId) {
+            @NonNull final NodeId selfId,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         final var loadedState = StartupStateUtils.loadStateFile(
-                configuration, recycleBin, selfId, mainClassName, swirldName, softwareVersion);
+                configuration, recycleBin, selfId, mainClassName, swirldName, softwareVersion, platformStateFacade);
         try (loadedState) {
             if (loadedState.isNotNull()) {
                 logger.info(
                         STARTUP.getMarker(),
                         new SavedStateLoadedPayload(
                                 loadedState.get().getRound(), loadedState.get().getConsensusTimestamp()));
-                return copyInitialSignedState(configuration, loadedState.get());
+                return copyInitialSignedState(configuration, loadedState.get(), platformStateFacade);
             }
         }
         final var stateRoot = stateRootSupplier.get();
         final var signedState = new SignedState(
-                configuration, CryptoStatic::verifySignature, stateRoot, "genesis state", false, false, false);
+                configuration,
+                CryptoStatic::verifySignature,
+                stateRoot,
+                "genesis state",
+                false,
+                false,
+                false,
+                platformStateFacade);
         final var reservedSignedState = signedState.reserve("initial reservation on genesis state");
         try (reservedSignedState) {
-            return copyInitialSignedState(configuration, reservedSignedState.get());
+            return copyInitialSignedState(configuration, reservedSignedState.get(), platformStateFacade);
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -28,7 +28,7 @@ import static com.hedera.node.app.blocks.schemas.V0560BlockStreamSchema.BLOCK_ST
 import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
 import static com.hedera.node.app.records.BlockRecordService.EPOCH;
 import static com.hedera.node.app.records.impl.BlockRecordInfoUtils.HASH_SIZE;
-import static com.swirlds.platform.state.SwirldStateManagerUtils.isInFreezePeriod;
+import static com.swirlds.platform.state.service.PlatformStateFacade.isInFreezePeriod;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -60,6 +60,7 @@ import com.hedera.node.config.types.DiskNetworkExport;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.concurrent.AbstractTask;
 import com.swirlds.config.api.Configuration;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.system.Round;
@@ -103,6 +104,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
     private final DiskNetworkExport diskNetworkExport;
     private final Supplier<BlockItemWriter> writerSupplier;
     private final BoundaryStateChangeListener boundaryStateChangeListener;
+    private final PlatformStateFacade platformStateFacade;
 
     private final BlockHashManager blockHashManager;
     private final RunningHashManager runningHashManager;
@@ -176,12 +178,14 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             @NonNull final ConfigProvider configProvider,
             @NonNull final BoundaryStateChangeListener boundaryStateChangeListener,
             @NonNull final InitialStateHash initialStateHash,
-            @NonNull final SemanticVersion version) {
+            @NonNull final SemanticVersion version,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         this.blockHashSigner = requireNonNull(blockHashSigner);
         this.version = requireNonNull(version);
         this.writerSupplier = requireNonNull(writerSupplier);
         this.executor = (ForkJoinPool) requireNonNull(executor);
         this.boundaryStateChangeListener = requireNonNull(boundaryStateChangeListener);
+        this.platformStateFacade = platformStateFacade;
         requireNonNull(configProvider);
         final var config = configProvider.getConfiguration();
         this.hapiVersion = hapiVersionFrom(config);
@@ -386,7 +390,8 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                         "Writing network info to disk @ {} (REASON = {})",
                         exportPath.toAbsolutePath(),
                         diskNetworkExport);
-                DiskStartupNetworks.writeNetworkInfo(state, exportPath, EnumSet.allOf(InfoType.class));
+                DiskStartupNetworks.writeNetworkInfo(
+                        state, exportPath, EnumSet.allOf(InfoType.class), platformStateFacade);
             }
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
@@ -40,6 +40,7 @@ import com.swirlds.platform.config.AddressBookConfig;
 import com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.roster.RosterRetriever;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.StartupNetworks;
@@ -186,12 +187,15 @@ public class DiskStartupNetworks implements StartupNetworks {
      * @param path the path to write the JSON network information to.
      */
     public static void writeNetworkInfo(
-            @NonNull final State state, @NonNull final Path path, @NonNull final Set<InfoType> infoTypes) {
+            @NonNull final State state,
+            @NonNull final Path path,
+            @NonNull final Set<InfoType> infoTypes,
+            @NonNull PlatformStateFacade platformStateFacade) {
         requireNonNull(state);
         final var entityIdStore = new ReadableEntityIdStoreImpl(state.getReadableStates(EntityIdService.NAME));
         final var nodeStore =
                 new ReadableNodeStoreImpl(state.getReadableStates(AddressBookService.NAME), entityIdStore);
-        Optional.ofNullable(RosterRetriever.retrieveActiveOrGenesisRoster(state))
+        Optional.ofNullable(RosterRetriever.retrieveActiveOrGenesisRoster(state, platformStateFacade))
                 .ifPresent(activeRoster -> {
                     final var network = Network.newBuilder();
                     final List<NodeMetadata> nodeMetadata = new ArrayList<>();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/PlatformStateModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/platform/PlatformStateModule.java
@@ -18,6 +18,7 @@ package com.hedera.node.app.platform;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.version.ServicesSoftwareVersion;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.SoftwareVersion;
 import dagger.Module;
 import dagger.Provides;
@@ -31,5 +32,11 @@ public interface PlatformStateModule {
     @Singleton
     static Function<SemanticVersion, SoftwareVersion> softwareVersionFactory() {
         return ServicesSoftwareVersion::new;
+    }
+
+    @Provides
+    @Singleton
+    static PlatformStateFacade platformStateFacade(Function<SemanticVersion, SoftwareVersion> softwareVersionFactory) {
+        return new PlatformStateFacade(ServicesSoftwareVersion::new);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/RosterService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/RosterService.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.node.app.roster.schemas.V0540RosterSchema;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.WritableRosterStore;
 import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.SchemaRegistry;
@@ -55,13 +56,17 @@ public class RosterService implements Service {
     @Deprecated
     private final Supplier<State> stateSupplier;
 
+    private final PlatformStateFacade platformStateFacade;
+
     public RosterService(
             @NonNull final Predicate<Roster> canAdopt,
             @NonNull final Runnable onAdopt,
-            @NonNull final Supplier<State> stateSupplier) {
+            @NonNull final Supplier<State> stateSupplier,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         this.onAdopt = requireNonNull(onAdopt);
         this.canAdopt = requireNonNull(canAdopt);
         this.stateSupplier = requireNonNull(stateSupplier);
+        this.platformStateFacade = platformStateFacade;
     }
 
     @NonNull
@@ -78,6 +83,7 @@ public class RosterService implements Service {
     @Override
     public void registerSchemas(@NonNull final SchemaRegistry registry) {
         requireNonNull(registry);
-        registry.register(new V0540RosterSchema(onAdopt, canAdopt, WritableRosterStore::new, stateSupplier));
+        registry.register(
+                new V0540RosterSchema(onAdopt, canAdopt, WritableRosterStore::new, stateSupplier, platformStateFacade));
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServiceMigrator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/ServiceMigrator.java
@@ -17,11 +17,11 @@
 package com.hedera.node.app.services;
 
 import com.hedera.hapi.block.stream.output.StateChanges;
-import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.metrics.StoreMetricsServiceImpl;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.StartupNetworks;
@@ -50,6 +50,7 @@ public interface ServiceMigrator {
      * @param startupNetworks     The startup networks to use for the migrations
      * @param storeMetricsService The store metrics service to use for the migrations
      * @param configProvider     The config provider to use for the migrations
+     * @param platformStateFacade  The facade object to access platform state properties
      * @return The list of builders for state changes that occurred during the migrations
      */
     List<StateChanges.Builder> doMigrations(
@@ -62,14 +63,7 @@ public interface ServiceMigrator {
             @Nullable NetworkInfo genesisNetworkInfo,
             @NonNull Metrics metrics,
             @NonNull StartupNetworks startupNetworks,
-            @NonNull final StoreMetricsServiceImpl storeMetricsService,
-            @NonNull final ConfigProviderImpl configProvider);
-
-    /**
-     * Given a {@link State}, returns the creation version of the state if it was deserialized, or null otherwise.
-     * @param state the state
-     * @return the version of the state if it was deserialized, otherwise null
-     */
-    @Nullable
-    SemanticVersion creationVersionOf(@NonNull State state);
+            @NonNull StoreMetricsServiceImpl storeMetricsService,
+            @NonNull ConfigProviderImpl configProvider,
+            @NonNull PlatformStateFacade platformStateFacade);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import static com.hedera.node.app.state.merkle.SchemaApplicationType.STATE_DEFIN
 import static com.hedera.node.app.state.merkle.VersionUtils.alreadyIncludesStateDefs;
 import static com.hedera.node.app.state.merkle.VersionUtils.isSoOrdered;
 import static com.hedera.node.app.workflows.handle.metric.UnavailableMetrics.UNAVAILABLE_METRICS;
-import static com.swirlds.platform.state.service.PlatformStateService.PLATFORM_STATE_SERVICE;
 import static com.swirlds.state.merkle.StateUtils.registerWithSystem;
 import static java.util.Objects.requireNonNull;
 
@@ -39,6 +38,7 @@ import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.MerkleDbTableConfig;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.MigrationContext;
 import com.swirlds.state.lifecycle.Schema;
@@ -180,6 +180,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
      * @param sharedValues A map of shared values for cross-service migration patterns
      * @param migrationStateChanges Tracker for state changes during migration
      * @param startupNetworks The startup networks to use for the migrations
+     * @param platformStateFacade The platform state facade to use for the migrations
      * @throws IllegalArgumentException if the {@code currentVersion} is not at least the
      * {@code previousVersion} or if the {@code state} is not an instance of {@link MerkleStateRoot}
      */
@@ -196,7 +197,8 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
             @Nullable final WritableEntityIdStore entityIdStore,
             @NonNull final Map<String, Object> sharedValues,
             @NonNull final MigrationStateChanges migrationStateChanges,
-            @NonNull final StartupNetworks startupNetworks) {
+            @NonNull final StartupNetworks startupNetworks,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         requireNonNull(state);
         requireNonNull(currentVersion);
         requireNonNull(appConfig);
@@ -210,7 +212,7 @@ public class MerkleSchemaRegistry implements SchemaRegistry {
         if (!(state instanceof MerkleStateRoot stateRoot)) {
             throw new IllegalArgumentException("The state must be an instance of " + MerkleStateRoot.class.getName());
         }
-        final long roundNumber = PLATFORM_STATE_SERVICE.roundOf(stateRoot);
+        final long roundNumber = platformStateFacade.roundOf(stateRoot);
         if (schemas.isEmpty()) {
             logger.info("Service {} does not use state", serviceName);
             return;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
@@ -28,6 +28,7 @@ import static com.hedera.node.app.blocks.schemas.V0560BlockStreamSchema.BLOCK_ST
 import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -218,7 +219,8 @@ class BlockStreamManagerImplTest {
                 configProvider,
                 boundaryStateChangeListener,
                 hashInfo,
-                SemanticVersion.DEFAULT);
+                SemanticVersion.DEFAULT,
+                TEST_PLATFORM_STATE_FACADE);
         assertSame(Instant.EPOCH, subject.lastIntervalProcessTime());
         subject.setLastIntervalProcessTime(CONSENSUS_NOW);
         assertEquals(CONSENSUS_NOW, subject.lastIntervalProcessTime());
@@ -238,7 +240,8 @@ class BlockStreamManagerImplTest {
                 configProvider,
                 boundaryStateChangeListener,
                 hashInfo,
-                SemanticVersion.DEFAULT);
+                SemanticVersion.DEFAULT,
+                TEST_PLATFORM_STATE_FACADE);
         assertThrows(IllegalStateException.class, () -> subject.startRound(round, state));
     }
 
@@ -624,7 +627,8 @@ class BlockStreamManagerImplTest {
                 configProvider,
                 boundaryStateChangeListener,
                 hashInfo,
-                SemanticVersion.DEFAULT);
+                SemanticVersion.DEFAULT,
+                TEST_PLATFORM_STATE_FACADE);
         given(state.getReadableStates(BlockStreamService.NAME)).willReturn(readableStates);
         given(state.getReadableStates(PlatformStateService.NAME)).willReturn(readableStates);
         infoRef.set(blockStreamInfo);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/WritableHintsStoreImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/WritableHintsStoreImplTest.java
@@ -24,6 +24,7 @@ import static com.hedera.node.app.hints.schemas.V059HintsSchema.NEXT_HINT_CONSTR
 import static com.hedera.node.app.roster.ActiveRosters.Phase.BOOTSTRAP;
 import static com.hedera.node.app.roster.ActiveRosters.Phase.HANDOFF;
 import static com.hedera.node.app.roster.ActiveRosters.Phase.TRANSITION;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
@@ -419,7 +420,8 @@ class WritableHintsStoreImplTest {
                 NO_OP_METRICS,
                 startupNetworks,
                 storeMetricsService,
-                configProvider);
+                configProvider,
+                TEST_PLATFORM_STATE_FACADE);
         return state;
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WritableHistoryStoreImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WritableHistoryStoreImplTest.java
@@ -25,6 +25,7 @@ import static com.hedera.node.app.history.schemas.V059HistorySchema.PROOF_VOTES_
 import static com.hedera.node.app.roster.ActiveRosters.Phase.BOOTSTRAP;
 import static com.hedera.node.app.roster.ActiveRosters.Phase.HANDOFF;
 import static com.hedera.node.app.roster.ActiveRosters.Phase.TRANSITION;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
@@ -434,7 +435,8 @@ class WritableHistoryStoreImplTest {
                 NO_OP_METRICS,
                 startupNetworks,
                 storeMetricsService,
-                configProvider);
+                configProvider,
+                TEST_PLATFORM_STATE_FACADE);
         return state;
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/DiskStartupNetworksTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/DiskStartupNetworksTest.java
@@ -27,6 +27,7 @@ import static com.hedera.node.app.service.addressbook.impl.schemas.V053AddressBo
 import static com.hedera.node.app.workflows.standalone.TransactionExecutorsTest.FAKE_NETWORK_INFO;
 import static com.hedera.node.app.workflows.standalone.TransactionExecutorsTest.NO_OP_METRICS;
 import static com.swirlds.platform.state.service.PlatformStateService.PLATFORM_STATE_SERVICE;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
@@ -253,7 +254,7 @@ class DiskStartupNetworksTest {
     void writesExpectedStateInfo() throws IOException, ParseException {
         final var state = stateContainingInfoFrom(NETWORK);
         final var loc = tempDir.resolve("reproduced-network.json");
-        DiskStartupNetworks.writeNetworkInfo(state, loc, EnumSet.allOf(InfoType.class));
+        DiskStartupNetworks.writeNetworkInfo(state, loc, EnumSet.allOf(InfoType.class), TEST_PLATFORM_STATE_FACADE);
         try (final var fin = Files.newInputStream(loc)) {
             final var network = Network.JSON.parse(new ReadableStreamingData(fin));
             Assertions.assertThat(network).isEqualTo(NETWORK);
@@ -277,7 +278,7 @@ class DiskStartupNetworksTest {
                         tssBaseService,
                         PLATFORM_STATE_SERVICE,
                         new EntityIdService(),
-                        new RosterService(roster -> true, () -> {}, () -> state),
+                        new RosterService(roster -> true, () -> {}, () -> state, TEST_PLATFORM_STATE_FACADE),
                         new AddressBookServiceImpl())
                 .forEach(servicesRegistry::register);
         final var migrator = new FakeServiceMigrator();
@@ -294,7 +295,8 @@ class DiskStartupNetworksTest {
                 NO_OP_METRICS,
                 startupNetworks,
                 storeMetricsService,
-                configProvider);
+                configProvider,
+                TEST_PLATFORM_STATE_FACADE);
         addRosterInfo(state, network);
         addAddressBookInfo(state, network);
         return state;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/RosterServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/RosterServiceTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.roster;
 
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,7 +52,7 @@ class RosterServiceTest {
 
     @BeforeEach
     void setUp() {
-        rosterService = new RosterService(canAdopt, onAdopt, stateSupplier);
+        rosterService = new RosterService(canAdopt, onAdopt, stateSupplier, TEST_PLATFORM_STATE_FACADE);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
@@ -33,7 +33,6 @@ import static org.mockito.Mockito.when;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.hapi.node.state.roster.RosterState;
-import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.node.internal.network.Network;
 import com.hedera.node.internal.network.NodeMetadata;
 import com.swirlds.common.RosterStateId;
@@ -77,9 +76,6 @@ class V0540RosterSchemaTest {
     private MigrationContext ctx;
 
     @Mock
-    private ReadableStates readableStates;
-
-    @Mock
     private WritableStates writableStates;
 
     @Mock
@@ -106,12 +102,6 @@ class V0540RosterSchemaTest {
     private State getState() {
         return state;
     }
-
-    @Mock
-    private ReadableSingletonState<PlatformState> platformStateSingleton;
-
-    @Mock
-    private PlatformState platformState;
 
     private V0540RosterSchema subject;
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/roster/schemas/V0540RosterSchemaTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
@@ -36,10 +37,8 @@ import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.node.internal.network.Network;
 import com.hedera.node.internal.network.NodeMetadata;
 import com.swirlds.common.RosterStateId;
-import com.swirlds.platform.state.service.PbjConverter;
-import com.swirlds.platform.state.service.PlatformStateService;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.WritableRosterStore;
-import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.MigrationContext;
@@ -101,6 +100,9 @@ class V0540RosterSchemaTest {
     @Mock
     private State state;
 
+    @Mock
+    private PlatformStateFacade platformStateFacade;
+
     private State getState() {
         return state;
     }
@@ -115,7 +117,7 @@ class V0540RosterSchemaTest {
 
     @BeforeEach
     void setUp() {
-        subject = new V0540RosterSchema(onAdopt, canAdopt, rosterStoreFactory, this::getState);
+        subject = new V0540RosterSchema(onAdopt, canAdopt, rosterStoreFactory, this::getState, platformStateFacade);
     }
 
     @Test
@@ -151,12 +153,8 @@ class V0540RosterSchemaTest {
 
         // Setup PlatformService states to return a given ADDRESS_BOOK,
         // and the readable RosterService states to be empty:
-        doReturn(readableStates).when(state).getReadableStates(PlatformStateService.NAME);
-        doReturn(platformStateSingleton).when(readableStates).getSingleton(V0540PlatformStateSchema.PLATFORM_STATE_KEY);
-        doReturn(platformState).when(platformStateSingleton).get();
-        doReturn(PbjConverter.toPbjAddressBook(ADDRESS_BOOK))
-                .when(platformState)
-                .addressBook();
+        when(platformStateFacade.roundOf(state)).thenReturn(ROUND_NO);
+        when(platformStateFacade.addressBookOf(state)).thenReturn(ADDRESS_BOOK);
         final ReadableStates rosterReadableStates = mock(ReadableStates.class);
         doReturn(rosterReadableStates).when(state).getReadableStates(RosterStateId.NAME);
         final ReadableSingletonState<RosterState> rosterStateSingleton = mock(ReadableSingletonState.class);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/DependencyMigrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/DependencyMigrationTest.java
@@ -19,6 +19,7 @@ package com.hedera.node.app.state.merkle;
 import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
 import static com.hedera.node.app.ids.schemas.V0490EntityIdSchema.ENTITY_ID_STATE_KEY;
 import static com.hedera.node.app.ids.schemas.V0590EntityIdSchema.ENTITY_COUNTS_KEY;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static com.swirlds.state.test.fixtures.merkle.TestSchema.CURRENT_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -111,7 +112,8 @@ class DependencyMigrationTest extends MerkleTestBase {
                             mock(Metrics.class),
                             startupNetworks,
                             storeMetricsService,
-                            configProvider))
+                            configProvider,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -129,7 +131,8 @@ class DependencyMigrationTest extends MerkleTestBase {
                             mock(Metrics.class),
                             startupNetworks,
                             storeMetricsService,
-                            configProvider))
+                            configProvider,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -147,7 +150,8 @@ class DependencyMigrationTest extends MerkleTestBase {
                             mock(Metrics.class),
                             startupNetworks,
                             storeMetricsService,
-                            configProvider))
+                            configProvider,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -165,7 +169,8 @@ class DependencyMigrationTest extends MerkleTestBase {
                             null,
                             startupNetworks,
                             storeMetricsService,
-                            configProvider))
+                            configProvider,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
     }
@@ -213,7 +218,8 @@ class DependencyMigrationTest extends MerkleTestBase {
                 mock(Metrics.class),
                 startupNetworks,
                 storeMetricsService,
-                configProvider);
+                configProvider,
+                TEST_PLATFORM_STATE_FACADE);
 
         // Then: we verify the migrations had the desired effects on both entity ID state and DependentService state
         // First check that the entity ID service has an updated entity ID, despite its schema migration not doing
@@ -325,7 +331,8 @@ class DependencyMigrationTest extends MerkleTestBase {
                 mock(Metrics.class),
                 startupNetworks,
                 storeMetricsService,
-                configProvider);
+                configProvider,
+                TEST_PLATFORM_STATE_FACADE);
 
         // Then: we verify the migrations were run in the expected order
         Assertions.assertThat(orderedInvocations)

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/MerkleSchemaRegistryTest.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.state.merkle;
 
 import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.lenient;
@@ -204,7 +205,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     mock(WritableEntityIdStore.class),
                     new HashMap<>(),
                     migrationStateChanges,
-                    startupNetworks);
+                    startupNetworks,
+                    TEST_PLATFORM_STATE_FACADE);
         }
     }
 
@@ -240,7 +242,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             mock(WritableEntityIdStore.class),
                             new HashMap<>(),
                             migrationStateChanges,
-                            startupNetworks))
+                            startupNetworks,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -259,7 +262,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             mock(WritableEntityIdStore.class),
                             new HashMap<>(),
                             migrationStateChanges,
-                            startupNetworks))
+                            startupNetworks,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -278,7 +282,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             mock(WritableEntityIdStore.class),
                             new HashMap<>(),
                             migrationStateChanges,
-                            startupNetworks))
+                            startupNetworks,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -297,7 +302,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             mock(WritableEntityIdStore.class),
                             new HashMap<>(),
                             migrationStateChanges,
-                            startupNetworks))
+                            startupNetworks,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -316,7 +322,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             mock(WritableEntityIdStore.class),
                             new HashMap<>(),
                             migrationStateChanges,
-                            startupNetworks))
+                            startupNetworks,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(NullPointerException.class);
         }
 
@@ -335,7 +342,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                             mock(WritableEntityIdStore.class),
                             new HashMap<>(),
                             migrationStateChanges,
-                            startupNetworks))
+                            startupNetworks,
+                            TEST_PLATFORM_STATE_FACADE))
                     .isInstanceOf(IllegalArgumentException.class);
         }
 
@@ -358,7 +366,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     mock(WritableEntityIdStore.class),
                     new HashMap<>(),
                     migrationStateChanges,
-                    startupNetworks);
+                    startupNetworks,
+                    TEST_PLATFORM_STATE_FACADE);
 
             // Then nothing happens
             Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any());
@@ -383,7 +392,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     mock(WritableEntityIdStore.class),
                     new HashMap<>(),
                     migrationStateChanges,
-                    startupNetworks);
+                    startupNetworks,
+                    TEST_PLATFORM_STATE_FACADE);
 
             // Then migration doesn't happen but restart is called
             Mockito.verify(schema, Mockito.times(0)).migrate(Mockito.any());
@@ -409,7 +419,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     mock(WritableEntityIdStore.class),
                     new HashMap<>(),
                     migrationStateChanges,
-                    startupNetworks);
+                    startupNetworks,
+                    TEST_PLATFORM_STATE_FACADE);
 
             // Then migration doesn't happen but restart is called
             Mockito.verify(schema, Mockito.times(1)).migrate(Mockito.any());
@@ -443,7 +454,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                     mock(WritableEntityIdStore.class),
                     new HashMap<>(),
                     migrationStateChanges,
-                    startupNetworks);
+                    startupNetworks,
+                    TEST_PLATFORM_STATE_FACADE);
 
             // Then each of v1, v4, and v6 are called
             assertThat(called).hasSize(3);
@@ -615,7 +627,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                         mock(WritableEntityIdStore.class),
                         new HashMap<>(),
                         migrationStateChanges,
-                        startupNetworks);
+                        startupNetworks,
+                        TEST_PLATFORM_STATE_FACADE);
 
                 // Then we see that the values for A, B, and C are available
                 final var readableStates = merkleTree.getReadableStates(FIRST_SERVICE);
@@ -645,7 +658,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                         mock(WritableEntityIdStore.class),
                         new HashMap<>(),
                         migrationStateChanges,
-                        startupNetworks);
+                        startupNetworks,
+                        TEST_PLATFORM_STATE_FACADE);
 
                 // We should see the v2 state (the delta from v2 after applied atop v1)
                 final var readableStates = merkleTree.getReadableStates(FIRST_SERVICE);
@@ -686,7 +700,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                         mock(WritableEntityIdStore.class),
                         new HashMap<>(),
                         migrationStateChanges,
-                        startupNetworks);
+                        startupNetworks,
+                        TEST_PLATFORM_STATE_FACADE);
 
                 // We should see the v3 state (the delta from v3 after applied atop v2 and v1)
                 final var readableStates = merkleTree.getReadableStates(FIRST_SERVICE);
@@ -732,7 +747,8 @@ class MerkleSchemaRegistryTest extends MerkleTestBase {
                                 mock(WritableEntityIdStore.class),
                                 new HashMap<>(),
                                 migrationStateChanges,
-                                startupNetworks))
+                                startupNetworks,
+                                TEST_PLATFORM_STATE_FACADE))
                         .isInstanceOf(RuntimeException.class)
                         .hasMessage("Bad");
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -17,6 +17,7 @@
 package com.hedera.node.app.state.merkle;
 
 import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
@@ -313,8 +314,9 @@ class SerializationTest extends MerkleTestBase {
                 mock(WritableEntityIdStore.class),
                 new HashMap<>(),
                 migrationStateChanges,
-                startupNetworks);
-        loadedTree.migrate(MerkleStateRoot.CURRENT_VERSION);
+                startupNetworks,
+                TEST_PLATFORM_STATE_FACADE);
+        (loadedTree).migrate(MerkleStateRoot.CURRENT_VERSION);
     }
 
     private PlatformMerkleStateRoot createMerkleHederaState(Schema schemaV1) {
@@ -336,7 +338,8 @@ class SerializationTest extends MerkleTestBase {
                 mock(WritableEntityIdStore.class),
                 new HashMap<>(),
                 migrationStateChanges,
-                startupNetworks);
+                startupNetworks,
+                TEST_PLATFORM_STATE_FACADE);
         return originalTree;
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
@@ -24,6 +24,7 @@ import static com.hedera.node.app.util.FileUtilities.createFileID;
 import static com.hedera.node.app.workflows.standalone.TransactionExecutors.DEFAULT_NODE_INFO;
 import static com.hedera.node.app.workflows.standalone.TransactionExecutors.MAX_SIGNED_TXN_SIZE_PROPERTY;
 import static com.hedera.node.app.workflows.standalone.TransactionExecutors.TRANSACTION_EXECUTORS;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -410,7 +411,8 @@ public class TransactionExecutorsTest {
                 NO_OP_METRICS,
                 startupNetworks,
                 storeMetricsService,
-                configProvider);
+                configProvider,
+                TEST_PLATFORM_STATE_FACADE);
         final var writableStates = state.getWritableStates(FileService.NAME);
         final var readableStates = state.getReadableStates(AddressBookService.NAME);
         final var entityIdStore = new ReadableEntityIdStoreImpl(state.getReadableStates(EntityIdService.NAME));

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeServiceMigrator.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeServiceMigrator.java
@@ -19,7 +19,6 @@ package com.hedera.node.app.fixtures.state;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.block.stream.output.StateChanges;
-import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.metrics.StoreMetricsServiceImpl;
@@ -28,6 +27,7 @@ import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.config.data.HederaConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.StartupNetworks;
@@ -58,7 +58,8 @@ public class FakeServiceMigrator implements ServiceMigrator {
             @NonNull final Metrics metrics,
             @NonNull final StartupNetworks startupNetworks,
             @NonNull final StoreMetricsServiceImpl storeMetricsService,
-            @NonNull final ConfigProviderImpl configProvider) {
+            @NonNull final ConfigProviderImpl configProvider,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         requireNonNull(state);
         requireNonNull(servicesRegistry);
         requireNonNull(currentVersion);
@@ -122,14 +123,5 @@ public class FakeServiceMigrator implements ServiceMigrator {
         mapWritableStates.getSingleton(NAME_OF_ENTITY_ID_SINGLETON).put(new EntityNumber(prevEntityNum.get()));
         mapWritableStates.commit();
         return List.of();
-    }
-
-    @Override
-    public SemanticVersion creationVersionOf(@NonNull final State state) {
-        if (!(state instanceof FakeState)) {
-            throw new IllegalArgumentException("Can only be used with FakeState instances");
-        }
-        // Fake states are always from genesis and have no creation version
-        return null;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -64,6 +64,7 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader;
 import com.swirlds.platform.listeners.PlatformStatusChangeNotification;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
@@ -176,7 +177,8 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
                 (appContext, bootstrapConfig) -> this.historyService = new FakeHistoryService(),
                 (hints, history, configProvider) ->
                         this.blockHashSigner = new LapsingBlockHashSigner(hints, history, configProvider),
-                metrics);
+                metrics,
+                new PlatformStateFacade(ServicesSoftwareVersion::new));
         version = (ServicesSoftwareVersion) hedera.getSoftwareVersion();
         blockStreamEnabled = hedera.isBlockStreamEnabled();
         Runtime.getRuntime().addShutdownHook(new Thread(executorService::shutdownNow));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
@@ -61,6 +61,7 @@ import com.hedera.node.app.blocks.impl.NaiveStreamingTreeHasher;
 import com.hedera.node.app.config.BootstrapConfigProviderImpl;
 import com.hedera.node.app.ids.EntityIdService;
 import com.hedera.node.app.info.DiskStartupNetworks;
+import com.hedera.node.app.version.ServicesSoftwareVersion;
 import com.hedera.node.config.data.VersionConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.hedera.subprocess.SubProcessNetwork;
@@ -75,6 +76,7 @@ import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.state.lifecycle.Service;
 import com.swirlds.state.merkle.MerkleStateRoot;
@@ -215,7 +217,7 @@ public class StateChangesValidator implements BlockStreamValidator {
         final var servicesVersion = versionConfig.servicesVersion();
         final var addressBook = loadLegacyBookWithGeneratedCerts(pathToAddressBook);
         final var metrics = new NoOpMetrics();
-        final var hedera = ServicesMain.newHedera(metrics);
+        final var hedera = ServicesMain.newHedera(metrics, new PlatformStateFacade(ServicesSoftwareVersion::new));
         this.state = hedera.newMerkleStateRoot();
         final var platformConfig = ServicesMain.buildPlatformConfig();
         hedera.initializeStatesApi(

--- a/platform-sdk/swirlds-merkle/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-merkle/src/testFixtures/java/module-info.java
@@ -25,6 +25,7 @@ open module com.swirlds.merkle.test.fixtures {
 
     requires transitive com.swirlds.common.test.fixtures;
     requires transitive com.swirlds.common;
+    requires transitive com.swirlds.merkle;
     requires transitive com.fasterxml.jackson.annotation;
     requires transitive com.fasterxml.jackson.core;
     requires transitive com.fasterxml.jackson.databind;
@@ -33,7 +34,6 @@ open module com.swirlds.merkle.test.fixtures {
     requires com.swirlds.fchashmap;
     requires com.swirlds.fcqueue;
     requires com.swirlds.logging;
-    requires com.swirlds.merkle;
     requires org.apache.logging.log4j.core;
     requires org.apache.logging.log4j;
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -71,6 +71,7 @@ import com.swirlds.platform.gui.model.InfoMember;
 import com.swirlds.platform.gui.model.InfoSwirld;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateLifecycles;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.HashedReservedSignedState;
 import com.swirlds.platform.system.SwirldMain;
 import com.swirlds.platform.system.SystemExitCode;
@@ -271,6 +272,7 @@ public class Browser {
                     MerkleCryptographyFactory.create(configuration, CryptographyHolder.get()));
             // Each platform needs a different temporary state on disk.
             MerkleDb.resetDefaultInstancePath();
+            PlatformStateFacade platformStateFacade = new PlatformStateFacade(v -> appMain.getSoftwareVersion());
             // Create the initial state for the platform
             StateLifecycles stateLifecycles = appMain.newStateLifecycles();
             final HashedReservedSignedState reservedState = getInitialState(
@@ -281,7 +283,8 @@ public class Browser {
                     appMain.getClass().getName(),
                     appDefinition.getSwirldName(),
                     nodeId,
-                    appDefinition.getConfigAddressBook());
+                    appDefinition.getConfigAddressBook(),
+                    platformStateFacade);
             final var initialState = reservedState.state();
 
             // Initialize the address book
@@ -291,7 +294,8 @@ public class Browser {
                     initialState,
                     appDefinition.getConfigAddressBook(),
                     platformContext,
-                    stateLifecycles);
+                    stateLifecycles,
+                    platformStateFacade);
 
             // Build the platform with the given values
             final PlatformBuilder builder = PlatformBuilder.create(
@@ -302,7 +306,8 @@ public class Browser {
                     stateLifecycles,
                     nodeId,
                     AddressBookUtils.formatConsensusEventStreamName(addressBook, nodeId),
-                    RosterUtils.buildRosterHistory(initialState.get().getState()));
+                    RosterUtils.buildRosterHistory(initialState.get().getState(), platformStateFacade),
+                    platformStateFacade);
             if (showUi && index == 0) {
                 builder.withPreconsensusEventCallback(guiEventStorage::handlePreconsensusEvent);
                 builder.withConsensusSnapshotOverrideCallback(guiEventStorage::handleSnapshotOverride);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
@@ -41,7 +41,7 @@ import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.status.actions.ReconnectCompleteAction;
 import com.swirlds.platform.wiring.PlatformWiring;
-import com.swirlds.state.State;
+import com.swirlds.state.merkle.MerkleStateRoot;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
@@ -113,12 +113,10 @@ public class ReconnectStateLoader {
             // It's important to call init() before loading the signed state. The loading process makes copies
             // of the state, and we want to be sure that the first state in the chain of copies has been initialized.
             final Hash reconnectHash = signedState.getState().getHash();
-            final State state = signedState.getState();
-            final SoftwareVersion creationSoftwareVersion =
-                    platformStateFacade.creationSoftwareVersionOf(signedState.getState());
+            final MerkleStateRoot<?> state = signedState.getState();
+            final SoftwareVersion creationSoftwareVersion = platformStateFacade.creationSoftwareVersionOf(state);
             signedState.init(platformContext);
-            stateLifecycles.onStateInitialized(
-                    signedState.getState(), platform, InitTrigger.RECONNECT, creationSoftwareVersion);
+            stateLifecycles.onStateInitialized(state, platform, InitTrigger.RECONNECT, creationSoftwareVersion);
 
             if (!Objects.equals(signedState.getState().getHash(), reconnectHash)) {
                 throw new IllegalStateException(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
@@ -34,6 +34,7 @@ import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.state.StateLifecycles;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.nexus.SignedStateNexus;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
@@ -62,6 +63,7 @@ public class ReconnectStateLoader {
     private final SavedStateController savedStateController;
     private final Roster roster;
     private final StateLifecycles stateLifecycles;
+    private final PlatformStateFacade platformStateFacade;
 
     /**
      * Constructor.
@@ -83,7 +85,8 @@ public class ReconnectStateLoader {
             @NonNull final SignedStateNexus latestImmutableStateNexus,
             @NonNull final SavedStateController savedStateController,
             @NonNull final Roster roster,
-            @NonNull final StateLifecycles stateLifecycles) {
+            @NonNull final StateLifecycles stateLifecycles,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         this.platform = Objects.requireNonNull(platform);
         this.platformContext = Objects.requireNonNull(platformContext);
         this.platformWiring = Objects.requireNonNull(platformWiring);
@@ -92,6 +95,7 @@ public class ReconnectStateLoader {
         this.savedStateController = Objects.requireNonNull(savedStateController);
         this.roster = Objects.requireNonNull(roster);
         this.stateLifecycles = stateLifecycles;
+        this.platformStateFacade = platformStateFacade;
     }
 
     /**
@@ -109,8 +113,9 @@ public class ReconnectStateLoader {
             // It's important to call init() before loading the signed state. The loading process makes copies
             // of the state, and we want to be sure that the first state in the chain of copies has been initialized.
             final Hash reconnectHash = signedState.getState().getHash();
-            SoftwareVersion creationSoftwareVersion =
-                    signedState.getState().getReadablePlatformState().getCreationSoftwareVersion();
+            final State state = signedState.getState();
+            final SoftwareVersion creationSoftwareVersion =
+                    platformStateFacade.creationSoftwareVersionOf(signedState.getState());
             signedState.init(platformContext);
             stateLifecycles.onStateInitialized(
                     signedState.getState(), platform, InitTrigger.RECONNECT, creationSoftwareVersion);
@@ -123,8 +128,7 @@ public class ReconnectStateLoader {
             }
 
             // Before attempting to load the state, verify that the platform roster matches the state roster.
-            final State state = signedState.getState();
-            final Roster stateRoster = RosterRetriever.retrieveActiveOrGenesisRoster(state);
+            final Roster stateRoster = RosterRetriever.retrieveActiveOrGenesisRoster(state, platformStateFacade);
             if (!roster.equals(stateRoster)) {
                 throw new IllegalStateException("Current roster and state-based roster do not contain the same nodes "
                         + " (currentRoster=" + Roster.JSON.toJSON(roster) + ") (stateRoster="
@@ -148,10 +152,10 @@ public class ReconnectStateLoader {
             platformWiring
                     .getSignatureCollectorStateInput()
                     .put(signedState.reserve("loading reconnect state into sig collector"));
-            platformWiring.consensusSnapshotOverride(Objects.requireNonNull(
-                    signedState.getState().getReadablePlatformState().getSnapshot()));
+            platformWiring.consensusSnapshotOverride(
+                    Objects.requireNonNull(platformStateFacade.consensusSnapshotOf(state)));
 
-            final Roster previousRoster = RosterRetriever.retrievePreviousRoster(state);
+            final Roster previousRoster = RosterRetriever.retrievePreviousRoster(state, platformStateFacade);
             platformWiring.getRosterUpdateInput().inject(new RosterUpdate(previousRoster, roster));
 
             final AncientMode ancientMode = platformContext
@@ -161,12 +165,12 @@ public class ReconnectStateLoader {
 
             platformWiring.updateEventWindow(new EventWindow(
                     signedState.getRound(),
-                    signedState.getState().getReadablePlatformState().getAncientThreshold(),
-                    signedState.getState().getReadablePlatformState().getAncientThreshold(),
+                    platformStateFacade.ancientThresholdOf(state),
+                    platformStateFacade.ancientThresholdOf(state),
                     ancientMode));
 
-            final RunningEventHashOverride runningEventHashOverride = new RunningEventHashOverride(
-                    signedState.getState().getReadablePlatformState().getLegacyRunningEventHash(), true);
+            final RunningEventHashOverride runningEventHashOverride =
+                    new RunningEventHashOverride(platformStateFacade.legacyRunningEventHashOf(state), true);
             platformWiring.updateRunningHash(runningEventHashOverride);
             platformWiring.getPcesWriterRegisterDiscontinuityInput().inject(signedState.getRound());
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
@@ -27,6 +27,7 @@ import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.StateLifecycles;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
@@ -59,7 +60,8 @@ public final class StateInitializer {
             @NonNull final Platform platform,
             @NonNull final PlatformContext platformContext,
             @NonNull final SignedState signedState,
-            @NonNull final StateLifecycles stateLifecycles) {
+            @NonNull final StateLifecycles stateLifecycles,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         final SoftwareVersion previousSoftwareVersion;
         final InitTrigger trigger;
@@ -68,8 +70,7 @@ public final class StateInitializer {
             previousSoftwareVersion = NO_VERSION;
             trigger = GENESIS;
         } else {
-            previousSoftwareVersion =
-                    signedState.getState().getReadablePlatformState().getCreationSoftwareVersion();
+            previousSoftwareVersion = platformStateFacade.creationSoftwareVersionOf(signedState.getState());
             trigger = RESTART;
         }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -58,6 +58,7 @@ import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.StateLifecycles;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.iss.IssScratchpad;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -88,6 +89,7 @@ public final class PlatformBuilder {
     private final ReservedSignedState initialState;
 
     private final StateLifecycles<PlatformMerkleStateRoot> stateLifecycles;
+    private final PlatformStateFacade platformStateFacade;
 
     private final NodeId selfId;
     private final String swirldName;
@@ -159,6 +161,7 @@ public final class PlatformBuilder {
      * @param stateLifecycles          the state lifecycle events handler
      * @param selfId                   the ID of this node
      * @param consensusEventStreamName a part of the name of the directory where the consensus event stream is written
+     * @param platformStateFacade      the facade to access the platform state
      * @param rosterHistory            the roster history provided by the application to use at startup
      */
     @NonNull
@@ -170,7 +173,8 @@ public final class PlatformBuilder {
             @NonNull final StateLifecycles stateLifecycles,
             @NonNull final NodeId selfId,
             @NonNull final String consensusEventStreamName,
-            @NonNull final RosterHistory rosterHistory) {
+            @NonNull final RosterHistory rosterHistory,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         return new PlatformBuilder(
                 appName,
                 swirldName,
@@ -179,7 +183,8 @@ public final class PlatformBuilder {
                 stateLifecycles,
                 selfId,
                 consensusEventStreamName,
-                rosterHistory);
+                rosterHistory,
+                platformStateFacade);
     }
 
     /**
@@ -194,6 +199,7 @@ public final class PlatformBuilder {
      * @param selfId                   the ID of this node
      * @param consensusEventStreamName a part of the name of the directory where the consensus event stream is written
      * @param rosterHistory            the roster history provided by the application to use at startup
+     * @param platformStateFacade      the facade to access the platform state
      */
     private PlatformBuilder(
             @NonNull final String appName,
@@ -203,7 +209,8 @@ public final class PlatformBuilder {
             @NonNull final StateLifecycles stateLifecycles,
             @NonNull final NodeId selfId,
             @NonNull final String consensusEventStreamName,
-            @NonNull final RosterHistory rosterHistory) {
+            @NonNull final RosterHistory rosterHistory,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         this.appName = Objects.requireNonNull(appName);
         this.swirldName = Objects.requireNonNull(swirldName);
@@ -213,6 +220,7 @@ public final class PlatformBuilder {
         this.selfId = Objects.requireNonNull(selfId);
         this.consensusEventStreamName = Objects.requireNonNull(consensusEventStreamName);
         this.rosterHistory = Objects.requireNonNull(rosterHistory);
+        this.platformStateFacade = Objects.requireNonNull(platformStateFacade);
     }
 
     /**
@@ -449,7 +457,8 @@ public final class PlatformBuilder {
                 selfId,
                 x -> statusActionSubmitterAtomicReference.get().submitStatusAction(x),
                 softwareVersion,
-                stateLifecycles);
+                stateLifecycles,
+                platformStateFacade);
 
         if (model == null) {
             final WiringConfig wiringConfig = platformContext.getConfiguration().getConfigData(WiringConfig.class);
@@ -505,7 +514,8 @@ public final class PlatformBuilder {
                 new AtomicReference<>(),
                 new AtomicReference<>(),
                 firstPlatform,
-                stateLifecycles);
+                stateLifecycles,
+                platformStateFacade);
 
         return new PlatformComponentBuilder(buildingBlocks);
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
@@ -33,6 +33,7 @@ import com.swirlds.platform.scratchpad.Scratchpad;
 import com.swirlds.platform.state.StateLifecycles;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.iss.IssScratchpad;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -95,6 +96,7 @@ import java.util.function.Supplier;
  * @param swirldStateManager                     responsible for the mutable state, this is exposed here due to
  *                                               reconnect, can be removed once reconnect is made compatible with the
  *                                               wiring framework
+ * @param platformStateFacade                    the facade to access the platform state
  */
 public record PlatformBuildingBlocks(
         @NonNull PlatformContext platformContext,
@@ -124,7 +126,8 @@ public record PlatformBuildingBlocks(
         @NonNull AtomicReference<Consumer<SignedState>> loadReconnectStateReference,
         @NonNull AtomicReference<Runnable> clearAllPipelinesForReconnectReference,
         boolean firstPlatform,
-        @NonNull StateLifecycles stateLifecycles) {
+        @NonNull StateLifecycles stateLifecycles,
+        @NonNull PlatformStateFacade platformStateFacade) {
 
     public PlatformBuildingBlocks {
         requireNonNull(platformContext);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
@@ -1084,7 +1084,8 @@ public class PlatformComponentBuilder {
                         () -> blocks.clearAllPipelinesForReconnectReference()
                                 .get()
                                 .run(),
-                        blocks.intakeEventCounter());
+                        blocks.intakeEventCounter(),
+                        blocks.platformStateFacade());
             } else {
                 gossip = new SyncGossip(
                         blocks.platformContext(),
@@ -1100,7 +1101,8 @@ public class PlatformComponentBuilder {
                         () -> blocks.clearAllPipelinesForReconnectReference()
                                 .get()
                                 .run(),
-                        blocks.intakeEventCounter());
+                        blocks.intakeEventCounter(),
+                        blocks.platformStateFacade());
             }
         }
         return gossip;
@@ -1169,7 +1171,11 @@ public class PlatformComponentBuilder {
             final String actualMainClassName = stateConfig.getMainClassName(blocks.mainClassName());
 
             stateSnapshotManager = new DefaultStateSnapshotManager(
-                    blocks.platformContext(), actualMainClassName, blocks.selfId(), blocks.swirldName());
+                    blocks.platformContext(),
+                    actualMainClassName,
+                    blocks.selfId(),
+                    blocks.swirldName(),
+                    blocks.platformStateFacade());
         }
         return stateSnapshotManager;
     }
@@ -1200,7 +1206,7 @@ public class PlatformComponentBuilder {
     @NonNull
     public HashLogger buildHashLogger() {
         if (hashLogger == null) {
-            hashLogger = new DefaultHashLogger(blocks.platformContext());
+            hashLogger = new DefaultHashLogger(blocks.platformContext(), blocks.platformStateFacade());
         }
         return hashLogger;
     }
@@ -1331,7 +1337,8 @@ public class PlatformComponentBuilder {
                     blocks.platformContext(),
                     blocks.swirldStateManager(),
                     blocks.statusActionSubmitterReference().get(),
-                    blocks.appVersion());
+                    blocks.appVersion(),
+                    blocks.platformStateFacade());
         }
         return transactionHandler;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CompareStatesCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CompareStatesCommand.java
@@ -17,6 +17,7 @@
 package com.swirlds.platform.cli;
 
 import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
+import static com.swirlds.platform.state.service.PlatformStateFacade.DEFAULT_PLATFORM_STATE_FACADE;
 
 import com.swirlds.cli.commands.StateCommand;
 import com.swirlds.cli.utility.AbstractCommand;
@@ -136,7 +137,7 @@ public final class CompareStatesCommand extends AbstractCommand {
         logger.info(LogMarker.CLI.getMarker(), "Loading state from {}", statePath);
 
         final ReservedSignedState signedState = SignedStateFileReader.readStateFile(
-                        platformContext.getConfiguration(), statePath)
+                        platformContext.getConfiguration(), statePath, DEFAULT_PLATFORM_STATE_FACADE)
                 .reservedSignedState();
         logger.info(LogMarker.CLI.getMarker(), "Hashing state");
         try {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamRecoverCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/EventStreamRecoverCommand.java
@@ -18,6 +18,7 @@ package com.swirlds.platform.cli;
 
 import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.platform.recovery.EventRecoveryWorkflow.recoverState;
+import static com.swirlds.platform.state.service.PlatformStateFacade.DEFAULT_PLATFORM_STATE_FACADE;
 
 import com.swirlds.cli.commands.EventStreamCommand;
 import com.swirlds.cli.utility.AbstractCommand;
@@ -136,7 +137,8 @@ public final class EventStreamRecoverCommand extends AbstractCommand {
                 finalRound,
                 outputPath,
                 selfId,
-                loadSigningKeys);
+                loadSigningKeys,
+                DEFAULT_PLATFORM_STATE_FACADE);
         return 0;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
@@ -16,6 +16,8 @@
 
 package com.swirlds.platform.cli;
 
+import static com.swirlds.platform.state.service.PlatformStateFacade.DEFAULT_PLATFORM_STATE_FACADE;
+
 import com.swirlds.cli.commands.StateCommand;
 import com.swirlds.cli.utility.AbstractCommand;
 import com.swirlds.cli.utility.SubcommandOf;
@@ -70,7 +72,7 @@ public class ValidateAddressBookStateCommand extends AbstractCommand {
 
         System.out.printf("Reading state from %s %n", statePath.toAbsolutePath());
         final DeserializedSignedState deserializedSignedState =
-                SignedStateFileReader.readStateFile(configuration, statePath);
+                SignedStateFileReader.readStateFile(configuration, statePath, DEFAULT_PLATFORM_STATE_FACADE);
 
         System.out.printf("Reading address book from %s %n", addressBookPath.toAbsolutePath());
         final String addressBookString = Files.readString(addressBookPath);
@@ -80,7 +82,7 @@ public class ValidateAddressBookStateCommand extends AbstractCommand {
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
             System.out.printf("Extracting the state address book for comparison %n");
             stateAddressBook = RosterUtils.buildAddressBook(RosterRetriever.retrieveActiveOrGenesisRoster(
-                    reservedSignedState.get().getState()));
+                    reservedSignedState.get().getState(), DEFAULT_PLATFORM_STATE_FACADE));
         }
 
         System.out.printf("Validating address book %n");

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
@@ -77,6 +77,7 @@ import com.swirlds.platform.reconnect.ReconnectLearnerThrottle;
 import com.swirlds.platform.reconnect.ReconnectThrottle;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.SwirldStateManager;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -158,6 +159,7 @@ public class SyncGossip implements ConnectionTracker, Gossip {
      * @param loadReconnectState            a method that should be called when a state from reconnect is obtained
      * @param clearAllPipelinesForReconnect this method should be called to clear all pipelines prior to a reconnect
      * @param intakeEventCounter            keeps track of the number of events in the intake pipeline from each peer
+     * @param platformStateFacade           a facade for accessing the platform state
      */
     public SyncGossip(
             @NonNull final PlatformContext platformContext,
@@ -171,7 +173,8 @@ public class SyncGossip implements ConnectionTracker, Gossip {
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final Consumer<SignedState> loadReconnectState,
             @NonNull final Runnable clearAllPipelinesForReconnect,
-            @NonNull final IntakeEventCounter intakeEventCounter) {
+            @NonNull final IntakeEventCounter intakeEventCounter,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         shadowgraph = new Shadowgraph(platformContext, roster.rosterEntries().size(), intakeEventCounter);
 
@@ -272,8 +275,14 @@ public class SyncGossip implements ConnectionTracker, Gossip {
                     syncManager.resetFallenBehind();
                 },
                 new ReconnectLearnerFactory(
-                        platformContext, threadManager, roster, reconnectConfig.asyncStreamTimeout(), reconnectMetrics),
-                stateConfig);
+                        platformContext,
+                        threadManager,
+                        roster,
+                        reconnectConfig.asyncStreamTimeout(),
+                        reconnectMetrics,
+                        platformStateFacade),
+                stateConfig,
+                platformStateFacade);
         this.intakeEventCounter = Objects.requireNonNull(intakeEventCounter);
 
         syncConfig = platformContext.getConfiguration().getConfigData(SyncConfig.class);
@@ -316,7 +325,8 @@ public class SyncGossip implements ConnectionTracker, Gossip {
                 currentPlatformStatus::get,
                 hangingThreadDuration,
                 protocolConfig,
-                reconnectConfig);
+                reconnectConfig,
+                platformStateFacade);
 
         thingsToStart.add(() -> syncProtocolThreads.forEach(StoppableThread::start));
     }
@@ -331,7 +341,8 @@ public class SyncGossip implements ConnectionTracker, Gossip {
             final Supplier<PlatformStatus> platformStatusSupplier,
             final Duration hangingThreadDuration,
             final ProtocolConfig protocolConfig,
-            final ReconnectConfig reconnectConfig) {
+            final ReconnectConfig reconnectConfig,
+            final PlatformStateFacade platformStateFacade) {
 
         final Protocol syncProtocol = new SyncProtocol(
                 platformContext,
@@ -352,10 +363,11 @@ public class SyncGossip implements ConnectionTracker, Gossip {
                 reconnectConfig.asyncStreamTimeout(),
                 reconnectMetrics,
                 reconnectController,
-                new DefaultSignedStateValidator(platformContext),
+                new DefaultSignedStateValidator(platformContext, platformStateFacade),
                 fallenBehindManager,
                 platformStatusSupplier,
-                platformContext.getConfiguration());
+                platformContext.getConfiguration(),
+                platformStateFacade);
 
         final Protocol heartbeatProtocol = new HeartbeatProtocol(
                 Duration.ofMillis(syncConfig.syncProtocolHeartbeatPeriod()), networkMetrics, platformContext.getTime());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/SyncGossipModular.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/SyncGossipModular.java
@@ -39,6 +39,7 @@ import com.swirlds.platform.gossip.sync.config.SyncConfig;
 import com.swirlds.platform.network.communication.handshake.VersionCompareHandshake;
 import com.swirlds.platform.network.protocol.*;
 import com.swirlds.platform.state.SwirldStateManager;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -98,7 +99,8 @@ public class SyncGossipModular implements Gossip {
             @NonNull final StatusActionSubmitter statusActionSubmitter,
             @NonNull final Consumer<SignedState> loadReconnectState,
             @NonNull final Runnable clearAllPipelinesForReconnect,
-            @NonNull final IntakeEventCounter intakeEventCounter) {
+            @NonNull final IntakeEventCounter intakeEventCounter,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         this.network = new PeerCommunication(platformContext, roster, selfId, keysAndCerts);
 
@@ -149,7 +151,8 @@ public class SyncGossipModular implements Gossip {
                         clearAllPipelinesForReconnect,
                         swirldStateManager,
                         selfId,
-                        controller),
+                        controller,
+                        platformStateFacade),
                 SyncProtocol.create(platformContext, sharedState, intakeEventCounter, roster));
 
         final ProtocolConfig protocolConfig = platformContext.getConfiguration().getConfigData(ProtocolConfig.class);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ReconnectProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ReconnectProtocol.java
@@ -31,6 +31,7 @@ import com.swirlds.platform.gossip.modular.SyncGossipSharedProtocolState;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.reconnect.*;
 import com.swirlds.platform.state.SwirldStateManager;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
@@ -56,6 +57,7 @@ public class ReconnectProtocol implements Protocol {
     private final SignedStateValidator validator;
     private final ThreadManager threadManager;
     private final FallenBehindManager fallenBehindManager;
+    private final PlatformStateFacade platformStateFacade;
 
     /**
      * Provides the platform status.
@@ -78,7 +80,8 @@ public class ReconnectProtocol implements Protocol {
             @NonNull final SignedStateValidator validator,
             @NonNull final FallenBehindManager fallenBehindManager,
             final Supplier<PlatformStatus> platformStatusSupplier,
-            @NonNull final Configuration configuration) {
+            @NonNull final Configuration configuration,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         this.platformContext = Objects.requireNonNull(platformContext);
         this.threadManager = Objects.requireNonNull(threadManager);
@@ -89,6 +92,7 @@ public class ReconnectProtocol implements Protocol {
         this.reconnectController = Objects.requireNonNull(reconnectController);
         this.validator = Objects.requireNonNull(validator);
         this.fallenBehindManager = Objects.requireNonNull(fallenBehindManager);
+        this.platformStateFacade = platformStateFacade;
         this.platformStatusSupplier = Objects.requireNonNull(platformStatusSupplier);
         this.configuration = Objects.requireNonNull(configuration);
         this.time = Objects.requireNonNull(platformContext.getTime());
@@ -118,7 +122,8 @@ public class ReconnectProtocol implements Protocol {
             @NonNull final Runnable clearAllPipelinesForReconnect,
             @NonNull final SwirldStateManager swirldStateManager,
             @NonNull final NodeId selfId,
-            @NonNull final GossipController gossipController) {
+            @NonNull final GossipController gossipController,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         final ReconnectConfig reconnectConfig =
                 platformContext.getConfiguration().getConfigData(ReconnectConfig.class);
@@ -152,8 +157,14 @@ public class ReconnectProtocol implements Protocol {
                             .resetFallenBehind(); // this is almost direct communication to SyncProtocol
                 },
                 new ReconnectLearnerFactory(
-                        platformContext, threadManager, roster, reconnectConfig.asyncStreamTimeout(), reconnectMetrics),
-                stateConfig);
+                        platformContext,
+                        threadManager,
+                        roster,
+                        reconnectConfig.asyncStreamTimeout(),
+                        reconnectMetrics,
+                        platformStateFacade),
+                stateConfig,
+                platformStateFacade);
         var reconnectController =
                 new ReconnectController(reconnectConfig, threadManager, reconnectHelper, gossipController::resume);
 
@@ -167,10 +178,11 @@ public class ReconnectProtocol implements Protocol {
                 reconnectConfig.asyncStreamTimeout(),
                 reconnectMetrics,
                 reconnectController,
-                new DefaultSignedStateValidator(platformContext),
+                new DefaultSignedStateValidator(platformContext, platformStateFacade),
                 sharedState.syncManager(),
                 sharedState.currentPlatformStatus()::get,
-                platformContext.getConfiguration());
+                platformContext.getConfiguration(),
+                platformStateFacade);
     }
 
     /**
@@ -192,6 +204,7 @@ public class ReconnectProtocol implements Protocol {
                 fallenBehindManager,
                 platformStatusSupplier,
                 configuration,
-                time);
+                time,
+                platformStateFacade);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectHelper.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectHelper.java
@@ -26,9 +26,11 @@ import com.swirlds.logging.legacy.payload.ReconnectStartPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -63,15 +65,19 @@ public class ReconnectHelper {
     /** configuration for the state from the platform */
     private final StateConfig stateConfig;
 
+    /** provides access to the platform state */
+    private final PlatformStateFacade platformStateFacade;
+
     public ReconnectHelper(
-            final Runnable pauseGossip,
-            final Clearable clearAll,
-            final Supplier<PlatformMerkleStateRoot> workingStateSupplier,
-            final LongSupplier lastCompleteRoundSupplier,
-            final ReconnectLearnerThrottle reconnectLearnerThrottle,
-            final Consumer<SignedState> loadSignedState,
-            final ReconnectLearnerFactory reconnectLearnerFactory,
-            StateConfig stateConfig) {
+            @NonNull final Runnable pauseGossip,
+            @NonNull final Clearable clearAll,
+            @NonNull final Supplier<PlatformMerkleStateRoot> workingStateSupplier,
+            @NonNull final LongSupplier lastCompleteRoundSupplier,
+            @NonNull final ReconnectLearnerThrottle reconnectLearnerThrottle,
+            @NonNull final Consumer<SignedState> loadSignedState,
+            @NonNull final ReconnectLearnerFactory reconnectLearnerFactory,
+            @NonNull final StateConfig stateConfig,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         this.pauseGossip = pauseGossip;
         this.clearAll = clearAll;
         this.workingStateSupplier = workingStateSupplier;
@@ -80,6 +86,7 @@ public class ReconnectHelper {
         this.loadSignedState = loadSignedState;
         this.reconnectLearnerFactory = reconnectLearnerFactory;
         this.stateConfig = stateConfig;
+        this.platformStateFacade = platformStateFacade;
     }
 
     /**
@@ -147,7 +154,7 @@ public class ReconnectHelper {
                 """
                 Information for state received during reconnect:
                 {}""",
-                () -> reservedState.get().getState().getInfoString(stateConfig.debugHashDepth()));
+                () -> platformStateFacade.getInfoString(reservedState.get().getState(), stateConfig.debugHashDepth()));
 
         return reservedState;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearnerFactory.java
@@ -22,6 +22,7 @@ import com.swirlds.common.threading.manager.ThreadManager;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.util.Objects;
@@ -35,6 +36,7 @@ public class ReconnectLearnerFactory {
     private final ReconnectMetrics statistics;
     private final ThreadManager threadManager;
     private final PlatformContext platformContext;
+    private final PlatformStateFacade platformStateFacade;
 
     /**
      * @param platformContext the platform context
@@ -42,18 +44,21 @@ public class ReconnectLearnerFactory {
      * @param roster                 the current roster
      * @param reconnectSocketTimeout the socket timeout to use during the reconnect
      * @param statistics             reconnect metrics
+     * @param platformStateFacade    the facade to access the platform state
      */
     public ReconnectLearnerFactory(
             @NonNull final PlatformContext platformContext,
             @NonNull final ThreadManager threadManager,
             @NonNull final Roster roster,
             @NonNull final Duration reconnectSocketTimeout,
-            @NonNull final ReconnectMetrics statistics) {
+            @NonNull final ReconnectMetrics statistics,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         this.platformContext = Objects.requireNonNull(platformContext);
         this.threadManager = Objects.requireNonNull(threadManager);
         this.roster = Objects.requireNonNull(roster);
         this.reconnectSocketTimeout = Objects.requireNonNull(reconnectSocketTimeout);
         this.statistics = Objects.requireNonNull(statistics);
+        this.platformStateFacade = platformStateFacade;
     }
 
     /**
@@ -65,6 +70,13 @@ public class ReconnectLearnerFactory {
      */
     public ReconnectLearner create(final Connection conn, final PlatformMerkleStateRoot workingState) {
         return new ReconnectLearner(
-                platformContext, threadManager, conn, roster, workingState, reconnectSocketTimeout, statistics);
+                platformContext,
+                threadManager,
+                conn,
+                roster,
+                workingState,
+                reconnectSocketTimeout,
+                statistics,
+                platformStateFacade);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectPeerProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectPeerProtocol.java
@@ -30,6 +30,7 @@ import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.NetworkProtocolException;
 import com.swirlds.platform.network.protocol.PeerProtocol;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedStateValidator;
 import com.swirlds.platform.system.status.PlatformStatus;
@@ -56,6 +57,7 @@ public class ReconnectPeerProtocol implements PeerProtocol {
     private final ReconnectMetrics reconnectMetrics;
     private final ReconnectController reconnectController;
     private final SignedStateValidator validator;
+    private final PlatformStateFacade platformStateFacade;
     private InitiatedBy initiatedBy = InitiatedBy.NO_ONE;
     private final ThreadManager threadManager;
     private final FallenBehindManager fallenBehindManager;
@@ -99,6 +101,7 @@ public class ReconnectPeerProtocol implements PeerProtocol {
      * @param platformStatusSupplier  provides the platform status
      * @param configuration           platform configuration
      * @param time                    the time object to use
+     * @param platformStateFacade     provides access to the platform state
      */
     public ReconnectPeerProtocol(
             @NonNull final PlatformContext platformContext,
@@ -113,7 +116,8 @@ public class ReconnectPeerProtocol implements PeerProtocol {
             @NonNull final FallenBehindManager fallenBehindManager,
             @NonNull final Supplier<PlatformStatus> platformStatusSupplier,
             @NonNull final Configuration configuration,
-            @NonNull final Time time) {
+            @NonNull final Time time,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         this.platformContext = Objects.requireNonNull(platformContext);
         this.threadManager = Objects.requireNonNull(threadManager);
@@ -127,6 +131,7 @@ public class ReconnectPeerProtocol implements PeerProtocol {
         this.fallenBehindManager = Objects.requireNonNull(fallenBehindManager);
         this.platformStatusSupplier = Objects.requireNonNull(platformStatusSupplier);
         this.configuration = Objects.requireNonNull(configuration);
+        this.platformStateFacade = Objects.requireNonNull(platformStateFacade);
         Objects.requireNonNull(time);
 
         final Duration minimumTimeBetweenReconnects =
@@ -314,7 +319,8 @@ public class ReconnectPeerProtocol implements PeerProtocol {
                             connection.getOtherId(),
                             state.get().getRound(),
                             reconnectMetrics,
-                            configuration)
+                            configuration,
+                            platformStateFacade)
                     .execute(state.get());
         } finally {
             teacherThrottle.reconnectAttemptFinished();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.roster.RosterUtils;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedState;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -71,6 +72,8 @@ public class ReconnectTeacher {
     private final Time time;
     private final PlatformContext platformContext;
 
+    private final PlatformStateFacade platformStateFacade;
+
     /**
      * @param platformContext        the platform context
      * @param threadManager          responsible for managing thread lifecycles
@@ -81,6 +84,7 @@ public class ReconnectTeacher {
      * @param lastRoundReceived      the round of the state
      * @param statistics             reconnect metrics
      * @param configuration          the configuration
+     * @param platformStateFacade    the facade to access the platform state
      */
     public ReconnectTeacher(
             @NonNull final PlatformContext platformContext,
@@ -92,7 +96,8 @@ public class ReconnectTeacher {
             @NonNull final NodeId otherId,
             final long lastRoundReceived,
             @NonNull final ReconnectMetrics statistics,
-            @NonNull final Configuration configuration) {
+            @NonNull final Configuration configuration,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         this.platformContext = Objects.requireNonNull(platformContext);
         this.time = Objects.requireNonNull(time);
@@ -105,6 +110,7 @@ public class ReconnectTeacher {
         this.lastRoundReceived = lastRoundReceived;
         this.statistics = Objects.requireNonNull(statistics);
         this.configuration = Objects.requireNonNull(configuration);
+        this.platformStateFacade = platformStateFacade;
     }
 
     /**
@@ -194,7 +200,7 @@ public class ReconnectTeacher {
                 """
                         The following state will be sent to the learner:
                         {}""",
-                () -> signedState.getState().getInfoString(stateConfig.debugHashDepth()));
+                () -> platformStateFacade.getInfoString(signedState.getState(), stateConfig.debugHashDepth()));
     }
 
     private void logReconnectFinish() {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -53,9 +53,8 @@ import com.swirlds.platform.recovery.internal.RecoveredState;
 import com.swirlds.platform.recovery.internal.RecoveryPlatform;
 import com.swirlds.platform.recovery.internal.StreamedRound;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
-import com.swirlds.platform.state.PlatformStateAccessor;
-import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.StateLifecycles;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.snapshot.SignedStateFileReader;
@@ -107,6 +106,7 @@ public final class EventRecoveryWorkflow {
      * @param allowPartialRounds      if true then allow the last round to be missing events, if false then ignore the
      *                                last round if it does not have all of its events
      * @param loadSigningKeys         if true then load the signing keys
+     * @param platformStateFacade     the facade to access the platform state
      */
     public static void recoverState(
             @NonNull final PlatformContext platformContext,
@@ -118,7 +118,8 @@ public final class EventRecoveryWorkflow {
             @NonNull final Long finalRound,
             @NonNull final Path resultingStateDirectory,
             @NonNull final NodeId selfId,
-            final boolean loadSigningKeys)
+            final boolean loadSigningKeys,
+            @NonNull final PlatformStateFacade platformStateFacade)
             throws IOException {
         Objects.requireNonNull(platformContext);
         Objects.requireNonNull(signedStateFile, "signedStateFile must not be null");
@@ -151,7 +152,7 @@ public final class EventRecoveryWorkflow {
         logger.info(STARTUP.getMarker(), "Loading state from {}", signedStateFile);
 
         try (final ReservedSignedState initialState = SignedStateFileReader.readStateFile(
-                        platformContext.getConfiguration(), signedStateFile)
+                        platformContext.getConfiguration(), signedStateFile, platformStateFacade)
                 .reservedSignedState()) {
             logger.info(
                     STARTUP.getMarker(),
@@ -174,7 +175,8 @@ public final class EventRecoveryWorkflow {
                     roundIterator,
                     finalRound,
                     selfId,
-                    loadSigningKeys);
+                    loadSigningKeys,
+                    platformStateFacade);
 
             logger.info(
                     STARTUP.getMarker(),
@@ -189,7 +191,8 @@ public final class EventRecoveryWorkflow {
                     platformContext,
                     selfId,
                     resultingStateDirectory,
-                    recoveredState.state().get());
+                    recoveredState.state().get(),
+                    platformStateFacade);
             final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
             updateEmergencyRecoveryFile(
                     stateConfig, resultingStateDirectory, initialState.get().getConsensusTimestamp());
@@ -288,7 +291,8 @@ public final class EventRecoveryWorkflow {
             @NonNull final IOIterator<StreamedRound> roundIterator,
             final long finalRound,
             @NonNull final NodeId selfId,
-            final boolean loadSigningKeys)
+            final boolean loadSigningKeys,
+            @NonNull final PlatformStateFacade platformStateFacade)
             throws IOException {
 
         Objects.requireNonNull(platformContext, "platformContext must not be null");
@@ -308,7 +312,7 @@ public final class EventRecoveryWorkflow {
 
         StateLifecycles stateLifecycles = appMain.newStateLifecycles();
         SoftwareVersion softwareVersion =
-                initialState.get().getState().getReadablePlatformState().getCreationSoftwareVersion();
+                platformStateFacade.creationSoftwareVersionOf(initialState.get().getState());
         initialState.get().init(platformContext);
         final var notificationEngine = platform.getNotificationEngine();
         notificationEngine.register(
@@ -337,7 +341,8 @@ public final class EventRecoveryWorkflow {
                     platformContext,
                     signedState,
                     round,
-                    configuration.getConfigData(ConsensusConfig.class));
+                    configuration.getConfigData(ConsensusConfig.class),
+                    platformStateFacade);
             platform.setLatestState(signedState.get());
             lastEvent = getLastEvent(round);
         }
@@ -345,7 +350,7 @@ public final class EventRecoveryWorkflow {
         logger.info(STARTUP.getMarker(), "Hashing resulting signed state");
         try {
             MerkleCryptoFactory.getInstance()
-                    .digestTreeAsync(signedState.get().getState())
+                    .digestTreeAsync(signedState.get().getState().cast())
                     .get();
         } catch (final InterruptedException e) {
             throw new RuntimeException("interrupted while attempting to hash the state", e);
@@ -366,7 +371,7 @@ public final class EventRecoveryWorkflow {
      * Apply a single round and generate a new state. The previous state is released.
      *
      * @param platformContext the current context
-     * @param previousState   the previous round's signed state
+     * @param previousSignedState   the previous round's signed state
      * @param round           the next round
      * @param config          the consensus configuration
      * @return the resulting signed state
@@ -374,39 +379,36 @@ public final class EventRecoveryWorkflow {
     private static ReservedSignedState handleNextRound(
             @NonNull final StateLifecycles stateLifecycles,
             @NonNull final PlatformContext platformContext,
-            @NonNull final ReservedSignedState previousState,
+            @NonNull final ReservedSignedState previousSignedState,
             @NonNull final StreamedRound round,
-            @NonNull final ConsensusConfig config) {
+            @NonNull final ConsensusConfig config,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         final Instant currentRoundTimestamp = getRoundTimestamp(round);
-        previousState.get().getState().throwIfImmutable();
-        final PlatformMerkleStateRoot newState = previousState.get().getState().copy();
+        final SignedState previousState = previousSignedState.get();
+        previousState.getState().throwIfImmutable();
+        final PlatformMerkleStateRoot newState = previousState.getState().copy();
         final PlatformEvent lastEvent = ((CesEvent) getLastEvent(round)).getPlatformEvent();
         new DefaultEventHasher().hashEvent(lastEvent);
 
-        final PlatformStateAccessor newReadablePlatformState = newState.getReadablePlatformState();
-        final PlatformStateModifier newWritablePlatformState = newState.getWritablePlatformState();
-        final PlatformStateAccessor previousReadablePlatformState =
-                previousState.get().getState().getReadablePlatformState();
-
-        newWritablePlatformState.bulkUpdate(v -> {
+        platformStateFacade.bulkUpdateOf(newState, v -> {
             v.setRound(round.getRoundNum());
             v.setLegacyRunningEventHash(
-                    getHashEventsCons(previousReadablePlatformState.getLegacyRunningEventHash(), round));
+                    getHashEventsCons(platformStateFacade.legacyRunningEventHashOf(newState), round));
             v.setConsensusTimestamp(currentRoundTimestamp);
             v.setSnapshot(SyntheticSnapshot.generateSyntheticSnapshot(
                     round.getRoundNum(), lastEvent.getConsensusOrder(), currentRoundTimestamp, config, lastEvent));
-            v.setCreationSoftwareVersion(previousReadablePlatformState.getCreationSoftwareVersion());
+            v.setCreationSoftwareVersion(platformStateFacade.creationSoftwareVersionOf(previousState.getState()));
         });
 
-        applyTransactions(stateLifecycles, previousState.get().getState(), newState.cast(), round);
+        applyTransactions(stateLifecycles, previousState.getState(), newState, round);
 
         final boolean isFreezeState = isFreezeState(
-                previousState.get().getConsensusTimestamp(),
+                previousState.getConsensusTimestamp(),
                 currentRoundTimestamp,
-                newReadablePlatformState.getFreezeTime());
+                platformStateFacade.freezeTimeOf(newState));
         if (isFreezeState) {
-            newWritablePlatformState.setLastFrozenTime(newReadablePlatformState.getFreezeTime());
+            platformStateFacade.setLastFrozenTimeTo(newState, platformStateFacade.freezeTimeOf(newState));
         }
 
         final ReservedSignedState signedState = new SignedState(
@@ -416,9 +418,10 @@ public final class EventRecoveryWorkflow {
                         "EventRecoveryWorkflow.handleNextRound()",
                         isFreezeState,
                         false,
-                        false)
+                        false,
+                        platformStateFacade)
                 .reserve("recovery");
-        previousState.close();
+        previousSignedState.close();
 
         return signedState;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -408,7 +408,7 @@ public final class EventRecoveryWorkflow {
                 currentRoundTimestamp,
                 platformStateFacade.freezeTimeOf(newState));
         if (isFreezeState) {
-            platformStateFacade.setLastFrozenTimeTo(newState, platformStateFacade.freezeTimeOf(newState));
+            platformStateFacade.updateLastFrozenTime(newState);
         }
 
         final ReservedSignedState signedState = new SignedState(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import com.swirlds.common.crypto.CryptographyException;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.crypto.CryptoStatic;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.ReadableRosterStore;
 import com.swirlds.platform.state.service.WritableRosterStore;
 import com.swirlds.platform.system.address.Address;
@@ -259,16 +260,17 @@ public final class RosterUtils {
      */
     @Deprecated(forRemoval = true)
     @NonNull
-    public static RosterHistory buildRosterHistory(final State state) {
+    public static RosterHistory buildRosterHistory(
+            final State state, @NonNull final PlatformStateFacade platformStateFacade) {
         final List<RoundRosterPair> roundRosterPairList = new ArrayList<>();
         final Map<Bytes, Roster> rosterMap = new HashMap<>();
 
-        final Roster currentRoster = RosterRetriever.retrieveActiveOrGenesisRoster(state);
+        final Roster currentRoster = RosterRetriever.retrieveActiveOrGenesisRoster(state, platformStateFacade);
         final Bytes currentHash = RosterUtils.hash(currentRoster).getBytes();
-        roundRosterPairList.add(new RoundRosterPair(RosterRetriever.getRound(state), currentHash));
+        roundRosterPairList.add(new RoundRosterPair(platformStateFacade.roundOf(state), currentHash));
         rosterMap.put(currentHash, currentRoster);
 
-        final Roster previousRoster = RosterRetriever.retrievePreviousRoster(state);
+        final Roster previousRoster = RosterRetriever.retrievePreviousRoster(state, platformStateFacade);
         if (previousRoster != null) {
             final Bytes previousHash = RosterUtils.hash(previousRoster).getBytes();
             roundRosterPairList.add(new RoundRosterPair(0, previousHash));

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateUtils.java
@@ -21,7 +21,6 @@ import com.swirlds.common.formatting.TextTable;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.utility.MerkleTreeVisualizer;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
-import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 
@@ -67,7 +66,7 @@ public class MerkleStateUtils {
                 .render(sb);
 
         sb.append("\n");
-        new MerkleTreeVisualizer((MerkleNode) state).setDepth(hashDepth).render(sb);
+        new MerkleTreeVisualizer(state).setDepth(hashDepth).render(sb);
         return sb.toString();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateUtils.java
@@ -42,7 +42,7 @@ public class MerkleStateUtils {
             int hashDepth,
             @NonNull final PlatformStateAccessor platformState,
             @NonNull final Hash rootHash,
-            @NonNull final State state) {
+            @NonNull final MerkleNode state) {
         final Hash hashEventsCons = platformState.getLegacyRunningEventHash();
 
         final ConsensusSnapshot snapshot = platformState.getSnapshot();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleStateUtils.java
@@ -21,6 +21,7 @@ import com.swirlds.common.formatting.TextTable;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.utility.MerkleTreeVisualizer;
 import com.swirlds.platform.consensus.ConsensusSnapshot;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class MerkleStateUtils {
             int hashDepth,
             @NonNull final PlatformStateAccessor platformState,
             @NonNull final Hash rootHash,
-            @NonNull final MerkleNode state) {
+            @NonNull final State state) {
         final Hash hashEventsCons = platformState.getLegacyRunningEventHash();
 
         final ConsensusSnapshot snapshot = platformState.getSnapshot();
@@ -66,7 +67,7 @@ public class MerkleStateUtils {
                 .render(sb);
 
         sb.append("\n");
-        new MerkleTreeVisualizer(state).setDepth(hashDepth).render(sb);
+        new MerkleTreeVisualizer((MerkleNode) state).setDepth(hashDepth).render(sb);
         return sb.toString();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/address/AddressBookInitializer.java
@@ -25,6 +25,7 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.config.AddressBookConfig;
 import com.swirlds.platform.state.StateLifecycles;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.Address;
@@ -127,7 +128,8 @@ public class AddressBookInitializer {
             @NonNull final SignedState initialState,
             @NonNull final AddressBook configAddressBook,
             @NonNull final PlatformContext platformContext,
-            @NonNull final StateLifecycles stateLifecycles) {
+            @NonNull final StateLifecycles stateLifecycles,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         this.selfId = Objects.requireNonNull(selfId, "The selfId must not be null.");
         this.currentVersion = Objects.requireNonNull(currentVersion, "The currentVersion must not be null.");
         this.softwareUpgrade = softwareUpgrade;
@@ -138,7 +140,7 @@ public class AddressBookInitializer {
                 platformContext.getConfiguration().getConfigData(AddressBookConfig.class);
         this.initialState = Objects.requireNonNull(initialState, "The initialState must not be null.");
 
-        final var book = buildAddressBook(retrieveActiveOrGenesisRoster(initialState.getState()));
+        final var book = buildAddressBook(retrieveActiveOrGenesisRoster(initialState.getState(), platformStateFacade));
         this.stateAddressBook = (book == null || book.getSize() == 0) ? null : book;
         if (stateAddressBook == null && !initialState.isGenesisState()) {
             throw new IllegalStateException("Only genesis states can have null address books.");

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditor.java
@@ -18,6 +18,7 @@ package com.swirlds.platform.state.editor;
 
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatNodeType;
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatRoute;
+import static com.swirlds.platform.state.service.PlatformStateFacade.DEFAULT_PLATFORM_STATE_FACADE;
 
 import com.swirlds.cli.utility.CommandBuilder;
 import com.swirlds.common.context.PlatformContext;
@@ -66,7 +67,7 @@ public class StateEditor {
         platformContext = PlatformContext.create(configuration);
 
         final DeserializedSignedState deserializedSignedState =
-                SignedStateFileReader.readStateFile(configuration, statePath);
+                SignedStateFileReader.readStateFile(configuration, statePath, DEFAULT_PLATFORM_STATE_FACADE);
 
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
             System.out.println("\nLoading state from " + statePath);
@@ -208,7 +209,8 @@ public class StateEditor {
                     "StateEditor.getSignedStateCopy()",
                     reservedSignedState.get().isFreezeState(),
                     false,
-                    false);
+                    false,
+                    DEFAULT_PLATFORM_STATE_FACADE);
 
             signedState.set(newSignedState, "StateEditor.getSignedStateCopy() 2");
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSave.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSave.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.swirlds.platform.state.editor;
 
 import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.swirlds.platform.state.editor.StateEditorUtils.formatFile;
+import static com.swirlds.platform.state.service.PlatformStateFacade.DEFAULT_PLATFORM_STATE_FACADE;
 import static com.swirlds.platform.state.snapshot.SavedStateMetadata.NO_NODE_ID;
 import static com.swirlds.platform.state.snapshot.SignedStateFileWriter.writeSignedStateFilesToDirectory;
 
@@ -76,7 +77,8 @@ public class StateEditorSave extends StateEditorOperation {
             final PlatformContext platformContext = PlatformContext.create(configuration);
 
             try (final ReservedSignedState signedState = getStateEditor().getSignedStateCopy()) {
-                writeSignedStateFilesToDirectory(platformContext, NO_NODE_ID, directory, signedState.get());
+                writeSignedStateFilesToDirectory(
+                        platformContext, NO_NODE_ID, directory, signedState.get(), DEFAULT_PLATFORM_STATE_FACADE);
             }
 
         } catch (final IOException e) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hashlogger/DefaultHashLogger.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hashlogger/DefaultHashLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import static com.swirlds.logging.legacy.LogMarker.STATE_HASH;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.config.StateConfig;
-import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -44,14 +44,16 @@ public class DefaultHashLogger implements HashLogger {
     private final int depth;
     private final Logger logOutput; // NOSONAR: selected logger to output to.
     private final boolean isEnabled;
+    private final PlatformStateFacade platformStateFacade;
 
     /**
      * Construct a HashLogger.
      *
      * @param platformContext the platform context
      */
-    public DefaultHashLogger(@NonNull final PlatformContext platformContext) {
-        this(platformContext, logger);
+    public DefaultHashLogger(
+            @NonNull final PlatformContext platformContext, @NonNull final PlatformStateFacade platformStateFacade) {
+        this(platformContext, logger, platformStateFacade);
     }
 
     /**
@@ -59,12 +61,17 @@ public class DefaultHashLogger implements HashLogger {
      *
      * @param platformContext the platform context
      * @param logOutput       the logger to write to
+     * @param platformStateFacade the facade to access the platform state
      */
-    DefaultHashLogger(@NonNull final PlatformContext platformContext, @NonNull final Logger logOutput) {
+    DefaultHashLogger(
+            @NonNull final PlatformContext platformContext,
+            @NonNull final Logger logOutput,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
         depth = stateConfig.debugHashDepth();
         isEnabled = stateConfig.enableHashStreamLogging();
         this.logOutput = Objects.requireNonNull(logOutput);
+        this.platformStateFacade = platformStateFacade;
     }
 
     /**
@@ -107,8 +114,7 @@ public class DefaultHashLogger implements HashLogger {
      */
     @NonNull
     private Message generateLogMessage(@NonNull final SignedState signedState) {
-        final PlatformMerkleStateRoot state = signedState.getState();
-        final String platformInfo = state.getInfoString(depth);
+        final String platformInfo = platformStateFacade.getInfoString(signedState.getState(), depth);
 
         return MESSAGE_FACTORY.newMessage(
                 """

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.state.service;
+
+import static com.hedera.hapi.util.HapiUtils.asInstant;
+import static com.swirlds.platform.state.MerkleStateUtils.createInfoString;
+import static com.swirlds.platform.state.PlatformStateAccessor.GENESIS_ROUND;
+import static com.swirlds.platform.state.service.PlatformStateService.NAME;
+import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
+import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.UNINITIALIZED_PLATFORM_STATE;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.platform.state.PlatformState;
+import com.swirlds.common.crypto.Hash;
+import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
+import com.swirlds.platform.system.Round;
+import com.swirlds.platform.system.SoftwareVersion;
+import com.swirlds.platform.system.address.AddressBook;
+import com.swirlds.state.State;
+import com.swirlds.state.merkle.MerkleStateRoot;
+import com.swirlds.state.merkle.singleton.SingletonNode;
+import com.swirlds.state.spi.ReadableStates;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * This class is an entry point for the platform state. Though the class itself is stateless, given an instance of {@link State},
+ * it can find an instance of {@link PlatformStateAccessor} or {@link PlatformStateModifier} and provide access to particular properties
+ * of the platform state.
+ */
+public class PlatformStateFacade {
+
+    public static final PlatformStateFacade DEFAULT_PLATFORM_STATE_FACADE =
+            new PlatformStateFacade(v -> SoftwareVersion.NO_VERSION);
+
+    private final Function<SemanticVersion, SoftwareVersion> versionFactory;
+
+    public PlatformStateFacade(Function<SemanticVersion, SoftwareVersion> versionFactory) {
+        this.versionFactory = versionFactory;
+    }
+
+    /**
+     * Given a {@link State}, returns the creation version of the platform state if it exists.
+     * @param root the root to extract the creation version from
+     * @return the creation version of the platform state, or null if the state is a genesis state
+     */
+    public SemanticVersion creationSemanticVersionOf(@NonNull final State root) {
+        requireNonNull(root);
+        final var state = platformStateOf(root);
+        return state == null ? null : state.creationSoftwareVersion();
+    }
+
+    public boolean isFreezeRound(@NonNull final State state, @NonNull final Round round) {
+        final var platformState = platformStateOf(state);
+        return isInFreezePeriod(
+                round.getConsensusTimestamp(),
+                platformState.freezeTime() == null ? null : asInstant(platformState.freezeTime()),
+                platformState.lastFrozenTime() == null ? null : asInstant(platformState.lastFrozenTime()));
+    }
+
+    public boolean isGenesisStateOf(@NonNull final State state) {
+        return readablePlatformStateStore(state).getRound() == GENESIS_ROUND;
+    }
+
+    /**
+     * Determines if a {@code timestamp} is in a freeze period according to the provided timestamps.
+     *
+     * @param consensusTime  the consensus time to check
+     * @param freezeTime     the freeze time
+     * @param lastFrozenTime the last frozen time
+     * @return true is the {@code timestamp} is in a freeze period
+     */
+    public static boolean isInFreezePeriod(
+            @NonNull final Instant consensusTime,
+            @Nullable final Instant freezeTime,
+            @Nullable final Instant lastFrozenTime) {
+
+        // if freezeTime is not set, or consensusTime is before freezeTime, we are not in a freeze period
+        // if lastFrozenTime is equal to or after freezeTime, which means the nodes have been frozen once at/after the
+        // freezeTime, we are not in a freeze period
+        if (freezeTime == null || consensusTime.isBefore(freezeTime)) {
+            return false;
+        }
+        // Now we should check whether the nodes have been frozen at the freezeTime.
+        // when consensusTime is equal to or after freezeTime,
+        // and lastFrozenTime is before freezeTime, we are in a freeze period.
+        return lastFrozenTime == null || lastFrozenTime.isBefore(freezeTime);
+    }
+
+    /**
+     * Given a {@link State}, returns the creation version of the state if it was deserialized, or null otherwise.
+     * @param state the state
+     * @return the version of the state if it was deserialized, otherwise null
+     */
+    @Nullable
+    public SoftwareVersion creationSoftwareVersionOf(@NonNull final State state) {
+        requireNonNull(state);
+        return readablePlatformStateStore(state).getCreationSoftwareVersion();
+    }
+
+    /**
+     * Given a {@link State}, returns the round number of the platform state if it exists.
+     * @param root the root to extract the round number from
+     * @return the round number of the platform state, or zero if the state is a genesis state
+     */
+    public long roundOf(@NonNull final State root) {
+        requireNonNull(root);
+        return readablePlatformStateStore(root).getRound();
+    }
+
+    @SuppressWarnings("unchecked")
+    public @Nullable PlatformState platformStateOf(@NonNull final State root) {
+        ReadableStates readableStates = root.getReadableStates(NAME);
+        if (readableStates.isEmpty()) {
+            // fallback to lookup directly in the Merkle tree, useful for loading the state from disk
+            if (root instanceof MerkleStateRoot<?> merkleStateRoot) {
+                final var index = merkleStateRoot.findNodeIndex(PlatformStateService.NAME, PLATFORM_STATE_KEY);
+                return index == -1
+                        ? UNINITIALIZED_PLATFORM_STATE
+                        : ((SingletonNode<PlatformState>) merkleStateRoot.getChild(index)).getValue();
+            }
+            return null;
+        } else {
+            return (PlatformState)
+                    readableStates.getSingleton(PLATFORM_STATE_KEY).get();
+        }
+    }
+
+    @Nullable
+    public Hash legacyRunningEventHashOf(@NonNull final State root) {
+        return readablePlatformStateStore(root).getLegacyRunningEventHash();
+    }
+
+    public long ancientThresholdOf(@NonNull final State root) {
+        return readablePlatformStateStore(root).getAncientThreshold();
+    }
+
+    @Nullable
+    public com.swirlds.platform.consensus.ConsensusSnapshot consensusSnapshotOf(@NonNull final State root) {
+        return readablePlatformStateStore(root).getSnapshot();
+    }
+
+    protected PlatformStateAccessor getReadablePlatformStateOf(@NonNull final State root) {
+        return new ReadablePlatformStateStore(root.getReadableStates(NAME), versionFactory);
+    }
+
+    @Nullable
+    public SoftwareVersion firstVersionInBirthRoundModeOf(@NonNull final State root) {
+        return readablePlatformStateStore(root).getFirstVersionInBirthRoundMode();
+    }
+
+    public long lastRoundBeforeBirthRoundModeOf(@NonNull final State root) {
+        return readablePlatformStateStore(root).getLastRoundBeforeBirthRoundMode();
+    }
+
+    public long lowestJudgeGenerationBeforeBirthRoundModeOf(@NonNull final State root) {
+        return readablePlatformStateStore(root).getLowestJudgeGenerationBeforeBirthRoundMode();
+    }
+
+    @Nullable
+    public Instant consensusTimestampOf(@NonNull final State root) {
+        return readablePlatformStateStore(root).getConsensusTimestamp();
+    }
+
+    public Instant freezeTimeOf(@NonNull final State root) {
+        return readablePlatformStateStore(root).getFreezeTime();
+    }
+
+    public void updateLastFrozenTime(@NonNull final State root) {
+        getWritablePlatformStateOf(root).setLastFrozenTime(freezeTimeOf(root));
+    }
+
+    @Nullable
+    public Instant lastFrozenTimeOf(State state) {
+        return readablePlatformStateStore(state).getLastFrozenTime();
+    }
+
+    @Nullable
+    public AddressBook addressBookOf(State state) {
+        return readablePlatformStateStore(state).getAddressBook();
+    }
+
+    @Nullable
+    public AddressBook previousAddressBookOf(State state) {
+        return readablePlatformStateStore(state).getPreviousAddressBook();
+    }
+
+    /**
+     * Get writable platform state. Works only on mutable {@link State}.
+     * Call this method only if you need to modify the platform state.
+     *
+     * @return mutable platform state
+     */
+    @NonNull
+    protected PlatformStateModifier getWritablePlatformStateOf(@NonNull final State state) {
+        if (state.isImmutable()) {
+            throw new IllegalStateException("Cannot get writable platform state when state is immutable");
+        }
+        return writablePlatformStateStore(state);
+    }
+
+    /**
+     * This is a convenience method to update multiple fields in the platform state in a single operation.
+     * @param updater a consumer that updates the platform state
+     */
+    public void bulkUpdateOf(@NonNull final State state, @NonNull Consumer<PlatformStateModifier> updater) {
+        getWritablePlatformStateOf(state).bulkUpdate(updater);
+    }
+
+    /**
+     * @param snapshot the consensus snapshot for this round
+     */
+    public void setSnapshotTo(
+            @NonNull final State state, @NonNull com.swirlds.platform.consensus.ConsensusSnapshot snapshot) {
+        getWritablePlatformStateOf(state).setSnapshot(snapshot);
+    }
+
+    /**
+     * Set the legacy running event hash. Used by the consensus event stream.
+     *
+     * @param legacyRunningEventHash a running hash of events
+     */
+    public void setLegacyRunningEventHashTo(@NonNull final State state, @Nullable Hash legacyRunningEventHash) {
+        getWritablePlatformStateOf(state).setLegacyRunningEventHash(legacyRunningEventHash);
+    }
+
+    /**
+     * Set the software version of the application that created this state.
+     *
+     * @param creationVersion the creation version
+     */
+    public void setCreationSoftwareVersionTo(@NonNull final State state, @NonNull SoftwareVersion creationVersion) {
+        getWritablePlatformStateOf(state).setCreationSoftwareVersion(creationVersion);
+    }
+
+    /**
+     * Sets the last freezeTime based on which the nodes were frozen.
+     *
+     * @param lastFrozenTime the last freezeTime based on which the nodes were frozen
+     */
+    public void setLastFrozenTimeTo(@NonNull final State state, @NonNull Instant lastFrozenTime) {
+        getWritablePlatformStateOf(state).setLastFrozenTime(lastFrozenTime);
+    }
+
+    /**
+     * Updates the platform state with the values from the provided instance of {@link PlatformStateModifier}
+     *
+     * @param accessor a source of values
+     */
+    public void updatePlatformState(@NonNull final State state, @NonNull final PlatformStateModifier accessor) {
+        writablePlatformStateStore(state).setAllFrom(accessor);
+    }
+
+    private PlatformStateAccessor readablePlatformStateStore(@NonNull final State state) {
+        ReadableStates readableStates = state.getReadableStates(NAME);
+        if (readableStates.isEmpty()) {
+            return new SnapshotPlatformStateAccessor(platformStateOf(state), versionFactory);
+        }
+        return new ReadablePlatformStateStore(readableStates, versionFactory);
+    }
+
+    private WritablePlatformStateStore writablePlatformStateStore(@NonNull final State state) {
+        return new WritablePlatformStateStore(state.getWritableStates(NAME), versionFactory);
+    }
+
+    /**
+     * Generate a string that describes this state.
+     *
+     * @param hashDepth the depth of the tree to visit and print
+     */
+    @NonNull
+    public String getInfoString(@NonNull final State state, final int hashDepth) {
+        return createInfoString(hashDepth, readablePlatformStateStore(state), state.getHash(), state);
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
@@ -21,6 +21,7 @@ import static com.swirlds.platform.state.MerkleStateUtils.createInfoString;
 import static com.swirlds.platform.state.PlatformStateAccessor.GENESIS_ROUND;
 import static com.swirlds.platform.state.service.PlatformStateService.NAME;
 import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
+import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.UNINITIALIZED_PLATFORM_STATE;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
@@ -153,7 +154,9 @@ public class PlatformStateFacade {
             // fallback to lookup directly in the Merkle tree, useful for loading the state from disk
             if (state instanceof MerkleStateRoot<?> merkleStateRoot) {
                 final int index = merkleStateRoot.findNodeIndex(PlatformStateService.NAME, PLATFORM_STATE_KEY);
-                return index == -1 ? null : ((SingletonNode<PlatformState>) merkleStateRoot.getChild(index)).getValue();
+                return index == -1
+                        ? UNINITIALIZED_PLATFORM_STATE
+                        : ((SingletonNode<PlatformState>) merkleStateRoot.getChild(index)).getValue();
             }
             return null;
         } else {
@@ -190,10 +193,6 @@ public class PlatformStateFacade {
     @Nullable
     public com.swirlds.platform.consensus.ConsensusSnapshot consensusSnapshotOf(@NonNull final State root) {
         return readablePlatformStateStore(root).getSnapshot();
-    }
-
-    protected PlatformStateAccessor getReadablePlatformStateOf(@NonNull final State root) {
-        return new ReadablePlatformStateStore(root.getReadableStates(NAME), versionFactory);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
@@ -27,6 +27,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.platform.state.PlatformStateAccessor;
 import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.Round;
@@ -148,11 +149,11 @@ public class PlatformStateFacade {
      */
     @SuppressWarnings("unchecked")
     public @Nullable PlatformState platformStateOf(@NonNull final State state) {
-        ReadableStates readableStates = state.getReadableStates(NAME);
+        final ReadableStates readableStates = state.getReadableStates(NAME);
         if (readableStates.isEmpty()) {
             // fallback to lookup directly in the Merkle tree, useful for loading the state from disk
             if (state instanceof MerkleStateRoot<?> merkleStateRoot) {
-                final var index = merkleStateRoot.findNodeIndex(PlatformStateService.NAME, PLATFORM_STATE_KEY);
+                final int index = merkleStateRoot.findNodeIndex(PlatformStateService.NAME, PLATFORM_STATE_KEY);
                 return index == -1
                         ? UNINITIALIZED_PLATFORM_STATE
                         : ((SingletonNode<PlatformState>) merkleStateRoot.getChild(index)).getValue();
@@ -357,11 +358,11 @@ public class PlatformStateFacade {
      */
     @NonNull
     public String getInfoString(@NonNull final State state, final int hashDepth) {
-        return createInfoString(hashDepth, readablePlatformStateStore(state), state.getHash(), state);
+        return createInfoString(hashDepth, readablePlatformStateStore(state), state.getHash(), (MerkleNode) state);
     }
 
     private PlatformStateAccessor readablePlatformStateStore(@NonNull final State state) {
-        ReadableStates readableStates = state.getReadableStates(NAME);
+        final ReadableStates readableStates = state.getReadableStates(NAME);
         if (readableStates.isEmpty()) {
             return new SnapshotPlatformStateAccessor(platformStateOf(state), versionFactory);
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
@@ -371,6 +371,4 @@ public class PlatformStateFacade {
     private WritablePlatformStateStore writablePlatformStateStore(@NonNull final State state) {
         return new WritablePlatformStateStore(state.getWritableStates(NAME), versionFactory);
     }
-
-
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
@@ -21,7 +21,6 @@ import static com.swirlds.platform.state.MerkleStateUtils.createInfoString;
 import static com.swirlds.platform.state.PlatformStateAccessor.GENESIS_ROUND;
 import static com.swirlds.platform.state.service.PlatformStateService.NAME;
 import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
-import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.UNINITIALIZED_PLATFORM_STATE;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
@@ -154,9 +153,7 @@ public class PlatformStateFacade {
             // fallback to lookup directly in the Merkle tree, useful for loading the state from disk
             if (state instanceof MerkleStateRoot<?> merkleStateRoot) {
                 final int index = merkleStateRoot.findNodeIndex(PlatformStateService.NAME, PLATFORM_STATE_KEY);
-                return index == -1
-                        ? UNINITIALIZED_PLATFORM_STATE
-                        : ((SingletonNode<PlatformState>) merkleStateRoot.getChild(index)).getValue();
+                return index == -1 ? null : ((SingletonNode<PlatformState>) merkleStateRoot.getChild(index)).getValue();
             }
             return null;
         } else {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateFacade.java
@@ -129,7 +129,14 @@ public class PlatformStateFacade {
     @Nullable
     public SoftwareVersion creationSoftwareVersionOf(@NonNull final State state) {
         requireNonNull(state);
+        if (isPlatformStateEmpty(state)) {
+            return null;
+        }
         return readablePlatformStateStore(state).getCreationSoftwareVersion();
+    }
+
+    private static boolean isPlatformStateEmpty(State state) {
+        return state.getReadableStates(NAME).isEmpty();
     }
 
     /**
@@ -158,7 +165,7 @@ public class PlatformStateFacade {
                         ? UNINITIALIZED_PLATFORM_STATE
                         : ((SingletonNode<PlatformState>) merkleStateRoot.getChild(index)).getValue();
             }
-            return null;
+            return UNINITIALIZED_PLATFORM_STATE;
         } else {
             return (PlatformState)
                     readableStates.getSingleton(PLATFORM_STATE_KEY).get();
@@ -327,24 +334,6 @@ public class PlatformStateFacade {
      */
     public void setCreationSoftwareVersionTo(@NonNull final State state, @NonNull SoftwareVersion creationVersion) {
         getWritablePlatformStateOf(state).setCreationSoftwareVersion(creationVersion);
-    }
-
-    /**
-     * Sets the last freezeTime based on which the nodes were frozen.
-     *
-     * @param lastFrozenTime the last freezeTime based on which the nodes were frozen
-     */
-    public void setLastFrozenTimeTo(@NonNull final State state, @NonNull Instant lastFrozenTime) {
-        getWritablePlatformStateOf(state).setLastFrozenTime(lastFrozenTime);
-    }
-
-    /**
-     * Updates the platform state with the values from the provided instance of {@link PlatformStateModifier}
-     *
-     * @param accessor a source of values
-     */
-    public void updatePlatformState(@NonNull final State state, @NonNull final PlatformStateModifier accessor) {
-        writablePlatformStateStore(state).setAllFrom(accessor);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateService.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateService.java
@@ -16,12 +16,8 @@
 
 package com.swirlds.platform.state.service;
 
-import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
 import static java.util.Objects.requireNonNull;
 
-import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.hapi.platform.state.ConsensusSnapshot;
-import com.hedera.hapi.platform.state.PlatformState;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.state.service.schemas.V059RosterLifecycleTransitionSchema;
@@ -30,9 +26,7 @@ import com.swirlds.state.lifecycle.Schema;
 import com.swirlds.state.lifecycle.SchemaRegistry;
 import com.swirlds.state.lifecycle.Service;
 import com.swirlds.state.merkle.MerkleStateRoot;
-import com.swirlds.state.merkle.singleton.SingletonNode;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -53,7 +47,7 @@ public enum PlatformStateService implements Service {
     /**
      * The schemas to register with the {@link SchemaRegistry}.
      */
-    private static final Collection<Schema> SCHEMAS = List.of(
+    public static final Collection<Schema> SCHEMAS = List.of(
             new V0540PlatformStateSchema(
                     config -> requireNonNull(APP_VERSION_FN.get()).apply(config)),
             new V059RosterLifecycleTransitionSchema());
@@ -78,40 +72,5 @@ public enum PlatformStateService implements Service {
      */
     public void setAppVersionFn(@NonNull final Function<Configuration, SoftwareVersion> appVersionFn) {
         APP_VERSION_FN.set(requireNonNull(appVersionFn));
-    }
-
-    /**
-     * Given a {@link MerkleStateRoot}, returns the creation version of the platform state if it exists.
-     * @param root the root to extract the creation version from
-     * @return the creation version of the platform state, or null if the state is a genesis state
-     */
-    public SemanticVersion creationVersionOf(@NonNull final MerkleStateRoot<?> root) {
-        requireNonNull(root);
-        final var state = platformStateOf(root);
-        return state == null ? null : state.creationSoftwareVersionOrThrow();
-    }
-
-    /**
-     * Given a {@link MerkleStateRoot}, returns the round number of the platform state if it exists.
-     * @param root the root to extract the round number from
-     * @return the round number of the platform state, or zero if the state is a genesis state
-     */
-    public long roundOf(@NonNull final MerkleStateRoot<?> root) {
-        requireNonNull(root);
-        final var platformState = platformStateOf(root);
-        return platformState == null
-                ? 0L
-                : platformState
-                        .consensusSnapshotOrElse(ConsensusSnapshot.DEFAULT)
-                        .round();
-    }
-
-    @SuppressWarnings("unchecked")
-    public @Nullable PlatformState platformStateOf(@NonNull final MerkleStateRoot<?> root) {
-        final var index = root.findNodeIndex(NAME, PLATFORM_STATE_KEY);
-        if (index == -1) {
-            return null;
-        }
-        return ((SingletonNode<PlatformState>) root.getChild(index)).getValue();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateService.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PlatformStateService.java
@@ -47,7 +47,7 @@ public enum PlatformStateService implements Service {
     /**
      * The schemas to register with the {@link SchemaRegistry}.
      */
-    public static final Collection<Schema> SCHEMAS = List.of(
+    private static final Collection<Schema> SCHEMAS = List.of(
             new V0540PlatformStateSchema(
                     config -> requireNonNull(APP_VERSION_FN.get()).apply(config)),
             new V059RosterLifecycleTransitionSchema());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/schemas/V0540PlatformStateSchema.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/schemas/V0540PlatformStateSchema.java
@@ -54,8 +54,8 @@ public class V0540PlatformStateSchema extends Schema {
      * A platform state to be used as the non-null platform state under any circumstance a genesis state
      * is encountered before initializing the States API.
      */
-    public static final PlatformState UNINITIALIZED_PLATFORM_STATE = new PlatformState(
-            SemanticVersion.DEFAULT, 0, ConsensusSnapshot.DEFAULT, null, null, Bytes.EMPTY, 0L, 0L, null, null, null);
+    public static final PlatformState UNINITIALIZED_PLATFORM_STATE =
+            new PlatformState(null, 0, ConsensusSnapshot.DEFAULT, null, null, Bytes.EMPTY, 0L, 0L, null, null, null);
 
     private static final SemanticVersion VERSION =
             SemanticVersion.newBuilder().major(0).minor(54).patch(0).build();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -95,7 +95,7 @@ public class SignedState implements SignedStateInfo {
     /**
      * Is this the last state saved before the freeze period
      */
-    private boolean freezeState;
+    private final boolean freezeState;
 
     /**
      * True if this state has been deleted. Used to prevent the same state from being deleted more than once.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -19,7 +19,6 @@ package com.swirlds.platform.state.signed;
 import static com.swirlds.common.utility.Threshold.MAJORITY;
 import static com.swirlds.common.utility.Threshold.SUPER_MAJORITY;
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
-import static com.swirlds.platform.state.PlatformStateAccessor.GENESIS_ROUND;
 import static com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAction.CREATION;
 import static com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAction.RELEASE;
 import static com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAction.RESERVE;
@@ -41,6 +40,7 @@ import com.swirlds.platform.crypto.SignatureVerifier;
 import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedStateHistory.SignedStateAction;
 import com.swirlds.platform.state.snapshot.StateToDiskReason;
 import com.swirlds.platform.system.address.Address;
@@ -166,6 +166,10 @@ public class SignedState implements SignedStateInfo {
      * True if this round reached consensus during the replaying of the preconsensus event stream.
      */
     private final boolean pcesRound;
+    /**
+     * The facade to access the platform state
+     */
+    private final PlatformStateFacade platformStateFacade;
 
     /**
      * Instantiate a signed state.
@@ -183,6 +187,7 @@ public class SignedState implements SignedStateInfo {
      *                                 states that have been sent to the state garbage collector.
      * @param pcesRound                true if this round reached consensus during the replaying of the preconsensus
      *                                 event stream
+     * @param platformStateFacade      the facade to access the platform state
      */
     public SignedState(
             @NonNull final Configuration configuration,
@@ -191,7 +196,9 @@ public class SignedState implements SignedStateInfo {
             @NonNull final String reason,
             final boolean freezeState,
             final boolean deleteOnBackgroundThread,
-            final boolean pcesRound) {
+            final boolean pcesRound,
+            @NonNull final PlatformStateFacade platformStateFacade) {
+        this.platformStateFacade = platformStateFacade;
         state.reserve();
 
         this.signatureVerifier = requireNonNull(signatureVerifier);
@@ -222,7 +229,7 @@ public class SignedState implements SignedStateInfo {
      */
     @Override
     public long getRound() {
-        return state.getReadablePlatformState().getRound();
+        return platformStateFacade.roundOf(state);
     }
 
     /**
@@ -231,7 +238,7 @@ public class SignedState implements SignedStateInfo {
      * @return true if this is the genesis state
      */
     public boolean isGenesisState() {
-        return state.getReadablePlatformState().getRound() == GENESIS_ROUND;
+        return platformStateFacade.isGenesisStateOf(state);
     }
 
     /**
@@ -272,7 +279,7 @@ public class SignedState implements SignedStateInfo {
         Ideally the roster would be captured in the constructor but due to the mutable underlying state, the roster
         can change from underneath us. Therefore, the roster must be regenerated on each access.
          */
-        final Roster roster = RosterRetriever.retrieveActiveOrGenesisRoster(state);
+        final Roster roster = RosterRetriever.retrieveActiveOrGenesisRoster(state, platformStateFacade);
         return requireNonNull(roster, "Roster stored in signed state is null (this should never happen)");
     }
 
@@ -469,7 +476,7 @@ public class SignedState implements SignedStateInfo {
      * @return the consensus timestamp for this signed state.
      */
     public @NonNull Instant getConsensusTimestamp() {
-        return state.getReadablePlatformState().getConsensusTimestamp();
+        return platformStateFacade.consensusTimestampOf(state);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidationData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedStateValidationData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,8 @@ package com.swirlds.platform.state.signed;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.platform.roster.RosterUtils;
-import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.service.PlatformStateFacade;
+import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
@@ -42,12 +43,15 @@ public record SignedStateValidationData(
         @Nullable Hash rosterHash,
         @NonNull Hash consensusEventsRunningHash) {
 
-    public SignedStateValidationData(@NonNull final PlatformStateAccessor that, @Nullable final Roster roster) {
+    public SignedStateValidationData(
+            @NonNull final State that,
+            @Nullable final Roster roster,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         this(
-                that.getRound(),
-                that.getConsensusTimestamp(),
+                platformStateFacade.roundOf(that),
+                platformStateFacade.consensusTimestampOf(that),
                 roster == null ? null : RosterUtils.hash(roster),
-                that.getLegacyRunningEventHash());
+                platformStateFacade.legacyRunningEventHashOf(that));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.payload.InsufficientSignaturesPayload;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.roster.RosterUtils;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.events.EventConstants;
@@ -76,6 +77,8 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
      */
     private final Configuration configuration;
 
+    private final PlatformStateFacade platformStateFacade;
+
     /**
      * the platform context
      */
@@ -98,12 +101,14 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
      * @param mainClassName the main class name of this node
      * @param selfId        the ID of this node
      * @param swirldName    the name of the swirld
+     * @param platformStateFacade the facade to access the platform state
      */
     public DefaultStateSnapshotManager(
             @NonNull final PlatformContext platformContext,
             @NonNull final String mainClassName,
             @NonNull final NodeId selfId,
-            @NonNull final String swirldName) {
+            @NonNull final String swirldName,
+            @NonNull final PlatformStateFacade platformStateFacade) {
 
         this.platformContext = Objects.requireNonNull(platformContext);
         this.time = platformContext.getTime();
@@ -111,6 +116,7 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
         this.mainClassName = Objects.requireNonNull(mainClassName);
         this.swirldName = Objects.requireNonNull(swirldName);
         configuration = platformContext.getConfiguration();
+        this.platformStateFacade = platformStateFacade;
         signedStateFilePath = new SignedStateFilePath(configuration.getConfigData(StateCommonConfig.class));
         metrics = new StateSnapshotManagerMetrics(platformContext);
     }
@@ -176,7 +182,8 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
 
     private boolean saveStateTask(@NonNull final SignedState state, @NonNull final Path directory) {
         try {
-            SignedStateFileWriter.writeSignedStateToDisk(platformContext, selfId, directory, state, getReason(state));
+            SignedStateFileWriter.writeSignedStateToDisk(
+                    platformContext, selfId, directory, state, getReason(state), platformStateFacade);
             return true;
         } catch (final Throwable e) {
             logger.error(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
@@ -26,6 +26,7 @@ import com.swirlds.common.io.streams.MerkleDataInputStream;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
 import com.swirlds.platform.state.service.schemas.V0540RosterBaseSchema;
@@ -62,7 +63,10 @@ public final class SignedStateFileReader {
      * @throws IOException if there is any problems with reading from a file
      */
     public static @NonNull DeserializedSignedState readStateFile(
-            @NonNull final Configuration configuration, @NonNull final Path stateFile) throws IOException {
+            @NonNull final Configuration configuration,
+            @NonNull final Path stateFile,
+            @NonNull final PlatformStateFacade stateFacade)
+            throws IOException {
 
         Objects.requireNonNull(configuration);
         Objects.requireNonNull(stateFile);
@@ -86,7 +90,8 @@ public final class SignedStateFileReader {
                 "SignedStateFileReader.readStateFile()",
                 false,
                 false,
-                false);
+                false,
+                stateFacade);
 
         registerServiceStates(newSignedState);
 
@@ -147,7 +152,7 @@ public final class SignedStateFileReader {
      * @param signedState a signed state to register schemas in
      */
     public static void registerServiceStates(@NonNull final SignedState signedState) {
-        registerServiceStates((MerkleStateRoot) signedState.getState());
+        registerServiceStates(signedState.getState());
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/AddressBookUtils.java
@@ -28,6 +28,7 @@ import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.StateLifecycles;
 import com.swirlds.platform.state.address.AddressBookInitializer;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.state.State;
@@ -248,8 +249,9 @@ public class AddressBookUtils {
             @NonNull final ReservedSignedState initialState,
             @NonNull final AddressBook bootstrapAddressBook,
             @NonNull final PlatformContext platformContext,
-            @NonNull final StateLifecycles<?> stateLifecycles) {
-        final boolean softwareUpgrade = detectSoftwareUpgrade(version, initialState.get());
+            @NonNull final StateLifecycles<?> stateLifecycles,
+            @NonNull final PlatformStateFacade platformStateFacade) {
+        final boolean softwareUpgrade = detectSoftwareUpgrade(version, initialState.get(), platformStateFacade);
         // Initialize the address book from the configuration and platform saved state.
         final AddressBookInitializer addressBookInitializer = new AddressBookInitializer(
                 selfId,
@@ -258,7 +260,8 @@ public class AddressBookUtils {
                 initialState.get(),
                 bootstrapAddressBook.copy(),
                 platformContext,
-                stateLifecycles);
+                stateLifecycles,
+                platformStateFacade);
         final State state = initialState.get().getState();
 
         if (addressBookInitializer.hasAddressBookChanged()) {
@@ -270,27 +273,29 @@ public class AddressBookUtils {
                 // we might as well validate this fact here just to ensure the update is correct.
                 final Roster previousRoster =
                         RosterRetriever.buildRoster(addressBookInitializer.getPreviousAddressBook());
-                if (!previousRoster.equals(RosterRetriever.retrieveActiveOrGenesisRoster(state))
-                        && !previousRoster.equals(RosterRetriever.retrievePreviousRoster(state))) {
+                if (!previousRoster.equals(RosterRetriever.retrieveActiveOrGenesisRoster(state, platformStateFacade))
+                        && !previousRoster.equals(RosterRetriever.retrievePreviousRoster(state, platformStateFacade))) {
                     throw new IllegalStateException(
                             "The previousRoster in the AddressBookInitializer doesn't match either the active or previous roster in state."
                                     + " AddressBookInitializer previousRoster = " + RosterUtils.toString(previousRoster)
                                     + ", state currentRoster = "
-                                    + RosterUtils.toString(RosterRetriever.retrieveActiveOrGenesisRoster(state))
+                                    + RosterUtils.toString(
+                                            RosterRetriever.retrieveActiveOrGenesisRoster(state, platformStateFacade))
                                     + ", state previousRoster = "
-                                    + RosterUtils.toString(RosterRetriever.retrievePreviousRoster(state)));
+                                    + RosterUtils.toString(
+                                            RosterRetriever.retrievePreviousRoster(state, platformStateFacade)));
                 }
             }
 
             RosterUtils.setActiveRoster(
                     state,
                     RosterRetriever.buildRoster(addressBookInitializer.getCurrentAddressBook()),
-                    RosterRetriever.getRound(state));
+                    platformStateFacade.roundOf(state));
         }
 
         // At this point the initial state must have the current address book set.  If not, something is wrong.
         final AddressBook addressBook =
-                RosterUtils.buildAddressBook(RosterRetriever.retrieveActiveOrGenesisRoster(state));
+                RosterUtils.buildAddressBook(RosterRetriever.retrieveActiveOrGenesisRoster(state, platformStateFacade));
         if (addressBook == null) {
             throw new IllegalStateException("The current address book of the initial state is null.");
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/util/BootstrapUtils.java
@@ -50,6 +50,7 @@ import com.swirlds.platform.health.clock.OSClockSpeedSourceChecker;
 import com.swirlds.platform.health.entropy.OSEntropyChecker;
 import com.swirlds.platform.health.filesystem.OSFileSystemChecker;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.swirldapp.AppLoaderException;
 import com.swirlds.platform.swirldapp.SwirldAppLoader;
@@ -227,7 +228,9 @@ public final class BootstrapUtils {
      * @return true if there is a software upgrade, false otherwise
      */
     public static boolean detectSoftwareUpgrade(
-            @NonNull final SoftwareVersion appVersion, @Nullable final SignedState loadedSignedState) {
+            @NonNull final SoftwareVersion appVersion,
+            @Nullable final SignedState loadedSignedState,
+            @NonNull final PlatformStateFacade platformStateFacade) {
         requireNonNull(appVersion, "The app version must not be null.");
 
         final SoftwareVersion loadedSoftwareVersion;
@@ -235,7 +238,7 @@ public final class BootstrapUtils {
             loadedSoftwareVersion = null;
         } else {
             PlatformMerkleStateRoot state = loadedSignedState.getState();
-            loadedSoftwareVersion = state.getReadablePlatformState().getCreationSoftwareVersion();
+            loadedSoftwareVersion = platformStateFacade.creationSoftwareVersionOf(state);
         }
         final int versionComparison = loadedSoftwareVersion == null ? 1 : appVersion.compareTo(loadedSoftwareVersion);
         final boolean softwareUpgrade;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/AddressBookInitializerTest.java
@@ -23,6 +23,7 @@ import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_AD
 import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_NULL;
 import static com.swirlds.platform.state.address.AddressBookInitializer.STATE_ADDRESS_BOOK_USED;
 import static com.swirlds.platform.state.address.AddressBookInitializer.USED_ADDRESS_BOOK_HEADER;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -48,6 +49,7 @@ import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.PlatformStateAccessor;
 import com.swirlds.platform.state.StateLifecycles;
 import com.swirlds.platform.state.address.AddressBookInitializer;
+import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.Address;
@@ -55,6 +57,7 @@ import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
 import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.roster.RosterServiceStateMock;
+import com.swirlds.state.spi.ReadableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
@@ -100,7 +103,8 @@ class AddressBookInitializerTest {
                 signedState,
                 configAddressBook,
                 getPlatformContext(true),
-                stateLifecycles);
+                stateLifecycles,
+                TEST_PLATFORM_STATE_FACADE);
         final AddressBook inititializedAddressBook = initializer.getCurrentAddressBook();
         final AddressBook signedStateAddressBook = buildAddressBook(signedState.getRoster());
         assertEquals(
@@ -131,7 +135,8 @@ class AddressBookInitializerTest {
                 signedState,
                 configAddressBook,
                 getPlatformContext(false),
-                stateLifecycles);
+                stateLifecycles,
+                TEST_PLATFORM_STATE_FACADE);
         final AddressBook inititializedAddressBook = initializer.getCurrentAddressBook();
         final AddressBook signedStateAddressBook = buildAddressBook(signedState.getRoster());
         assertEquals(
@@ -159,7 +164,8 @@ class AddressBookInitializerTest {
                 signedState,
                 configAddressBook,
                 getPlatformContext(false),
-                stateLifecycles);
+                stateLifecycles,
+                TEST_PLATFORM_STATE_FACADE);
         final AddressBook inititializedAddressBook = initializer.getCurrentAddressBook();
         final AddressBook signedStateAddressBook = buildAddressBook(signedState.getRoster());
         assertEquals(
@@ -187,7 +193,8 @@ class AddressBookInitializerTest {
                 signedState,
                 configAddressBook,
                 getPlatformContext(false),
-                stateLifecycles);
+                stateLifecycles,
+                TEST_PLATFORM_STATE_FACADE);
         final AddressBook inititializedAddressBook = initializer.getCurrentAddressBook();
         final AddressBook signedStateAddressBook = buildAddressBook(signedState.getRoster());
         assertEquals(
@@ -218,7 +225,8 @@ class AddressBookInitializerTest {
                 signedState,
                 configAddressBook,
                 getPlatformContext(false),
-                stateLifecycles);
+                stateLifecycles,
+                TEST_PLATFORM_STATE_FACADE);
         final AddressBook inititializedAddressBook = initializer.getCurrentAddressBook();
         final AddressBook signedStateAddressBook = buildAddressBook(signedState.getRoster());
         assertEquals(
@@ -264,7 +272,8 @@ class AddressBookInitializerTest {
                 signedState,
                 configAddressBook,
                 getPlatformContext(false),
-                stateLifecycles);
+                stateLifecycles,
+                TEST_PLATFORM_STATE_FACADE);
         final AddressBook inititializedAddressBook = initializer.getCurrentAddressBook();
         final AddressBook signedStateAddressBook = buildAddressBook(signedState.getRoster());
         assertEquals(
@@ -296,7 +305,8 @@ class AddressBookInitializerTest {
                 signedState,
                 configAddressBook,
                 getPlatformContext(false),
-                stateLifecycles);
+                stateLifecycles,
+                TEST_PLATFORM_STATE_FACADE);
         final AddressBook inititializedAddressBook = initializer.getCurrentAddressBook();
         assertEquals(
                 configAddressBook,
@@ -326,7 +336,8 @@ class AddressBookInitializerTest {
                 signedState,
                 configAddressBook,
                 getPlatformContext(false),
-                stateLifecycles);
+                stateLifecycles,
+                TEST_PLATFORM_STATE_FACADE);
         final AddressBook inititializedAddressBook = initializer.getCurrentAddressBook();
         assertNotEquals(
                 configAddressBook,
@@ -433,11 +444,13 @@ class AddressBookInitializerTest {
         final SoftwareVersion softwareVersion = getMockSoftwareVersion(2);
         configureUpdateWeightForStateLifecycles(weightValue);
         final PlatformMerkleStateRoot state = mock(PlatformMerkleStateRoot.class);
+        ;
+        final ReadableStates readableStates = mock(ReadableStates.class);
         final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
         when(platformState.getCreationSoftwareVersion()).thenReturn(softwareVersion);
+        when(state.getReadableStates(PlatformStateService.NAME)).thenReturn(readableStates);
         RosterServiceStateMock.setup(state, currentRoster, 1L, RosterRetriever.buildRoster(previousAddressBook));
 
-        when(state.getReadablePlatformState()).thenReturn(platformState);
         when(signedState.getState()).thenReturn(state);
         when(signedState.isGenesisState()).thenReturn(fromGenesis);
         when(signedState.getRoster()).thenReturn(currentRoster);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import com.swirlds.platform.state.snapshot.SavedStateMetadataField;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.test.fixtures.roster.RosterServiceStateMock;
+import com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -207,21 +208,25 @@ class SavedStateMetadataTests {
         final SignedState signedState = mock(SignedState.class);
         final SigSet sigSet = mock(SigSet.class);
         final PlatformMerkleStateRoot state = mock(PlatformMerkleStateRoot.class);
-        when(state.getHash()).thenReturn(randomHash(random));
+        final TestPlatformStateFacade platformStateFacade = mock(TestPlatformStateFacade.class);
+        final ConsensusSnapshot consensusSnapshot = mock(ConsensusSnapshot.class);
         final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
-        when(platformState.getLegacyRunningEventHash()).thenReturn(randomHash(random));
-        when(platformState.getSnapshot()).thenReturn(mock(ConsensusSnapshot.class));
+
+        when(state.getHash()).thenReturn(randomHash(random));
+        when(platformStateFacade.legacyRunningEventHashOf(state)).thenReturn(randomHash(random));
+        when(platformStateFacade.consensusSnapshotOf(state)).thenReturn(consensusSnapshot);
 
         final Roster roster = mock(Roster.class);
         RosterServiceStateMock.setup(state, roster);
 
         when(signedState.getState()).thenReturn(state);
-        when(state.getReadablePlatformState()).thenReturn(platformState);
+        when(platformStateFacade.getReadablePlatformStateOf(state)).thenReturn(platformState);
         when(signedState.getSigSet()).thenReturn(sigSet);
         when(sigSet.getSigningNodes())
                 .thenReturn(new ArrayList<>(List.of(NodeId.of(3L), NodeId.of(1L), NodeId.of(2L))));
 
-        final SavedStateMetadata metadata = SavedStateMetadata.create(signedState, NodeId.of(1234), Instant.now());
+        final SavedStateMetadata metadata =
+                SavedStateMetadata.create(signedState, NodeId.of(1234), Instant.now(), platformStateFacade);
 
         assertEquals(List.of(NodeId.of(1L), NodeId.of(2L), NodeId.of(3L)), metadata.signingNodes());
     }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SavedStateMetadataTests.java
@@ -220,7 +220,6 @@ class SavedStateMetadataTests {
         RosterServiceStateMock.setup(state, roster);
 
         when(signedState.getState()).thenReturn(state);
-        when(platformStateFacade.getReadablePlatformStateOf(state)).thenReturn(platformState);
         when(signedState.getSigSet()).thenReturn(sigSet);
         when(sigSet.getSigningNodes())
                 .thenReturn(new ArrayList<>(List.of(NodeId.of(3L), NodeId.of(1L), NodeId.of(2L))));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -23,6 +23,7 @@ import static com.swirlds.platform.state.snapshot.SignedStateFileReader.readStat
 import static com.swirlds.platform.state.snapshot.StateToDiskReason.FATAL_ERROR;
 import static com.swirlds.platform.state.snapshot.StateToDiskReason.ISS;
 import static com.swirlds.platform.state.snapshot.StateToDiskReason.PERIODIC_SNAPSHOT;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static java.nio.file.Files.exists;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -159,8 +160,8 @@ class StateFileManagerTests {
         assertEquals(-1, originalState.getReservationCount(), "invalid reservation count");
 
         MerkleDb.resetDefaultInstancePath();
-        final DeserializedSignedState deserializedSignedState =
-                readStateFile(TestPlatformContextBuilder.create().build().getConfiguration(), stateFile);
+        final DeserializedSignedState deserializedSignedState = readStateFile(
+                TestPlatformContextBuilder.create().build().getConfiguration(), stateFile, TEST_PLATFORM_STATE_FACADE);
         MerkleCryptoFactory.getInstance()
                 .digestTreeSync(
                         deserializedSignedState.reservedSignedState().get().getState());
@@ -193,8 +194,8 @@ class StateFileManagerTests {
             Files.createFile(savedDir);
         }
 
-        final StateSnapshotManager manager =
-                new DefaultStateSnapshotManager(context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME);
+        final StateSnapshotManager manager = new DefaultStateSnapshotManager(
+                context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME, TEST_PLATFORM_STATE_FACADE);
 
         final StateSavingResult stateSavingResult = manager.saveStateTask(signedState.reserve("test"));
 
@@ -213,8 +214,8 @@ class StateFileManagerTests {
                 new RandomSignedStateGenerator().setUseBlockingState(true).build();
         ((BlockingState) signedState.getState()).enableBlockingSerialization();
 
-        final StateSnapshotManager manager =
-                new DefaultStateSnapshotManager(context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME);
+        final StateSnapshotManager manager = new DefaultStateSnapshotManager(
+                context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME, TEST_PLATFORM_STATE_FACADE);
         signedState.markAsStateToSave(FATAL_ERROR);
         makeImmutable(signedState);
 
@@ -240,8 +241,8 @@ class StateFileManagerTests {
     void saveISSignedState() throws IOException {
         final SignedState signedState = new RandomSignedStateGenerator().build();
 
-        final StateSnapshotManager manager =
-                new DefaultStateSnapshotManager(context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME);
+        final StateSnapshotManager manager = new DefaultStateSnapshotManager(
+                context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME, TEST_PLATFORM_STATE_FACADE);
         signedState.markAsStateToSave(ISS);
         makeImmutable(signedState);
         manager.dumpStateTask(StateDumpRequest.create(signedState.reserve("test")));
@@ -281,8 +282,8 @@ class StateFileManagerTests {
         final int averageTimeBetweenStates = 10;
         final double standardDeviationTimeBetweenStates = 0.5;
 
-        final StateSnapshotManager manager =
-                new DefaultStateSnapshotManager(context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME);
+        final StateSnapshotManager manager = new DefaultStateSnapshotManager(
+                context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME, TEST_PLATFORM_STATE_FACADE);
         final SavedStateController controller = new DefaultSavedStateController(context);
 
         Instant timestamp;
@@ -362,7 +363,8 @@ class StateFileManagerTests {
                                             TestPlatformContextBuilder.create()
                                                     .build()
                                                     .getConfiguration(),
-                                            savedStateInfo.stateFile())
+                                            savedStateInfo.stateFile(),
+                                            TEST_PLATFORM_STATE_FACADE)
                                     .reservedSignedState()
                                     .get(),
                             "should be able to read state on disk");
@@ -405,8 +407,8 @@ class StateFileManagerTests {
 
         final int count = 10;
 
-        final StateSnapshotManager manager =
-                new DefaultStateSnapshotManager(context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME);
+        final StateSnapshotManager manager = new DefaultStateSnapshotManager(
+                context, MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME, TEST_PLATFORM_STATE_FACADE);
 
         final Path statesDirectory =
                 signedStateFilePath.getSignedStatesDirectoryForSwirld(MAIN_CLASS_NAME, SELF_ID, SWIRLD_NAME);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
@@ -22,9 +22,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.state.roster.Roster;
+import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.consensus.EventWindow;
 import com.swirlds.platform.consensus.SyntheticSnapshot;
@@ -45,6 +48,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 
 /**
  * Unit tests for {@link DefaultTransactionHandler}.
@@ -141,8 +145,12 @@ class DefaultTransactionHandlerTests {
                 "at least one event with no transactions should have been provided to the app");
         assertNull(tester.getPlatformState().getLastFrozenTime(), "no freeze time should have been set");
 
+        ArgumentCaptor<Hash> hashCaptor = ArgumentCaptor.forClass(Hash.class);
+        verify(tester.getPlatformStateFacade())
+                .setLegacyRunningEventHashTo(same(tester.getConsensusState()), hashCaptor.capture());
+
         assertEquals(
-                tester.getPlatformState().getLegacyRunningEventHash(),
+                hashCaptor.getValue(),
                 consensusRound
                         .getStreamedEvents()
                         .getLast()
@@ -164,7 +172,8 @@ class DefaultTransactionHandlerTests {
     void freezeHandling() throws InterruptedException {
         final TransactionHandlerTester tester = new TransactionHandlerTester(addressBook);
         final ConsensusRound consensusRound = newConsensusRound(false);
-        tester.getPlatformState().setFreezeTime(consensusRound.getConsensusTimestamp());
+        when(tester.getPlatformStateFacade().freezeTimeOf(tester.getConsensusState()))
+                .thenReturn(consensusRound.getConsensusTimestamp());
 
         final StateAndRound handlerOutput = tester.getTransactionHandler().handleConsensusRound(consensusRound);
         assertNotNull(handlerOutput, "new state should have been created");
@@ -180,7 +189,7 @@ class DefaultTransactionHandlerTests {
                 tester.getSubmittedActions().getFirst().getClass());
         assertEquals(1, tester.getHandledRounds().size(), "a round should have been handled");
         assertSame(consensusRound, tester.getHandledRounds().getFirst(), "it should be the round we provided");
-        assertNotNull(tester.getPlatformState().getLastFrozenTime(), "freeze time should have been set");
+        verify(tester.getPlatformStateFacade()).updateLastFrozenTime(tester.getConsensusState());
 
         final ConsensusRound postFreezeConsensusRound = newConsensusRound(false);
         final StateAndRound postFreezeOutput =
@@ -190,8 +199,12 @@ class DefaultTransactionHandlerTests {
         assertEquals(2, tester.getSubmittedActions().size(), "no new status should have been submitted");
         assertEquals(1, tester.getHandledRounds().size(), "no new rounds should have been handled");
         assertSame(consensusRound, tester.getHandledRounds().getFirst(), "it should same round as before");
+        ArgumentCaptor<Hash> hashCaptor = ArgumentCaptor.forClass(Hash.class);
+        verify(tester.getPlatformStateFacade())
+                .setLegacyRunningEventHashTo(same(tester.getConsensusState()), hashCaptor.capture());
+
         assertEquals(
-                tester.getPlatformState().getLegacyRunningEventHash(),
+                hashCaptor.getValue(),
                 consensusRound
                         .getStreamedEvents()
                         .getLast()

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
@@ -30,6 +30,7 @@ import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.StateLifecycles;
 import com.swirlds.platform.state.SwirldStateManager;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.PlatformStateValueAccumulator;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.Round;
@@ -37,6 +38,8 @@ import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.status.StatusActionSubmitter;
 import com.swirlds.platform.system.status.actions.PlatformStatusAction;
+import com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade;
+import com.swirlds.state.State;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +53,8 @@ public class TransactionHandlerTester {
     private final List<PlatformStatusAction> submittedActions = new ArrayList<>();
     private final List<Round> handledRounds = new ArrayList<>();
     private final StateLifecycles<PlatformMerkleStateRoot> stateLifecycles;
+    private final TestPlatformStateFacade platformStateFacade;
+    private final PlatformMerkleStateRoot consensusState;
 
     /**
      * Constructs a new {@link TransactionHandlerTester} with the given {@link AddressBook}.
@@ -61,14 +66,16 @@ public class TransactionHandlerTester {
                 TestPlatformContextBuilder.create().build();
         platformState = new PlatformStateValueAccumulator();
 
-        final PlatformMerkleStateRoot consensusState = mock(PlatformMerkleStateRoot.class);
-        when(consensusState.copy()).thenReturn(consensusState);
-        when(consensusState.getReadablePlatformState()).thenReturn(platformState);
-        when(consensusState.getWritablePlatformState()).thenReturn(platformState);
+        consensusState = mock(PlatformMerkleStateRoot.class);
+        platformStateFacade = mock(TestPlatformStateFacade.class);
 
         stateLifecycles = mock(StateLifecycles.class);
-        when(stateLifecycles.onSealConsensusRound(any(), any())).thenReturn(true);
+        when(consensusState.copy()).thenReturn(consensusState);
+        when(consensusState.cast()).thenReturn(consensusState);
+        when(platformStateFacade.getReadablePlatformStateOf(consensusState)).thenReturn(platformState);
+        when(platformStateFacade.getWritablePlatformStateOf(consensusState)).thenReturn(platformState);
 
+        when(stateLifecycles.onSealConsensusRound(any(), any())).thenReturn(true);
         doAnswer(i -> {
                     handledRounds.add(i.getArgument(0));
                     return null;
@@ -82,10 +89,15 @@ public class TransactionHandlerTester {
                 NodeId.FIRST_NODE_ID,
                 statusActionSubmitter,
                 new BasicSoftwareVersion(1),
-                stateLifecycles);
+                stateLifecycles,
+                platformStateFacade);
         swirldStateManager.setInitialState(consensusState);
         defaultTransactionHandler = new DefaultTransactionHandler(
-                platformContext, swirldStateManager, statusActionSubmitter, mock(SoftwareVersion.class));
+                platformContext,
+                swirldStateManager,
+                statusActionSubmitter,
+                mock(SoftwareVersion.class),
+                platformStateFacade);
     }
 
     /**
@@ -128,5 +140,13 @@ public class TransactionHandlerTester {
      */
     public StateLifecycles<PlatformMerkleStateRoot> getStateLifecycles() {
         return stateLifecycles;
+    }
+
+    public PlatformStateFacade getPlatformStateFacade() {
+        return platformStateFacade;
+    }
+
+    public State getConsensusState() {
+        return consensusState;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
@@ -72,7 +72,6 @@ public class TransactionHandlerTester {
         stateLifecycles = mock(StateLifecycles.class);
         when(consensusState.copy()).thenReturn(consensusState);
         when(consensusState.cast()).thenReturn(consensusState);
-        when(platformStateFacade.getReadablePlatformStateOf(consensusState)).thenReturn(platformState);
         when(platformStateFacade.getWritablePlatformStateOf(consensusState)).thenReturn(platformState);
 
         when(stateLifecycles.onSealConsensusRound(any(), any())).thenReturn(true);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/DefaultSignedStateValidatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.swirlds.platform.reconnect;
 
 import static com.swirlds.common.test.fixtures.RandomUtils.randomHash;
 import static com.swirlds.common.utility.Threshold.MAJORITY;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -273,11 +274,11 @@ class DefaultSignedStateValidatorTests {
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
 
-        validator = new DefaultSignedStateValidator(platformContext);
+        validator = new DefaultSignedStateValidator(platformContext, TEST_PLATFORM_STATE_FACADE);
 
         final SignedState signedState = stateSignedByNodes(signingNodes);
         final SignedStateValidationData originalData =
-                new SignedStateValidationData(signedState.getState().getReadablePlatformState(), roster);
+                new SignedStateValidationData(signedState.getState(), roster, TEST_PLATFORM_STATE_FACADE);
 
         final boolean shouldSucceed = stateHasEnoughWeight(nodes, signingNodes);
         if (shouldSucceed) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectPeerProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectPeerProtocolTests.java
@@ -19,6 +19,7 @@ package com.swirlds.platform.reconnect;
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
 import static com.swirlds.platform.state.signed.ReservedSignedState.createNullReservation;
 import static com.swirlds.platform.system.status.PlatformStatus.ACTIVE;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -176,7 +177,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
 
         assertEquals(
                 params.shouldInitiate,
@@ -219,7 +221,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
 
         assertEquals(
                 params.shouldAccept(),
@@ -253,7 +256,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
 
         // the ReconnectController must be running in order to provide permits
         getStaticThreadManager()
@@ -305,7 +309,8 @@ class ReconnectPeerProtocolTests {
                 fallenBehindManager,
                 () -> ACTIVE,
                 configuration,
-                Time.getCurrent());
+                Time.getCurrent(),
+                TEST_PLATFORM_STATE_FACADE);
         final SignedState signedState = spy(new RandomSignedStateGenerator().build());
         when(signedState.isComplete()).thenReturn(true);
         final PlatformMerkleStateRoot state = mock(PlatformMerkleStateRoot.class);
@@ -326,7 +331,8 @@ class ReconnectPeerProtocolTests {
                 fallenBehindManager,
                 () -> ACTIVE,
                 configuration,
-                Time.getCurrent());
+                Time.getCurrent(),
+                TEST_PLATFORM_STATE_FACADE);
 
         // pretend we have fallen behind
         when(fallenBehindManager.hasFallenBehind()).thenReturn(true);
@@ -370,7 +376,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertTrue(peerProtocol.shouldInitiate());
         peerProtocol.initiateFailed();
@@ -414,7 +421,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
 
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertTrue(peerProtocol.shouldAccept());
@@ -452,7 +460,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertFalse(peerProtocol.shouldAccept());
     }
@@ -482,7 +491,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> PlatformStatus.CHECKING,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertFalse(peerProtocol.shouldAccept());
     }
@@ -508,7 +518,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 mock(FallenBehindManager.class),
                 () -> ACTIVE,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertTrue(peerProtocol.shouldAccept());
 
@@ -554,7 +565,8 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 mock(FallenBehindManager.class),
                 () -> ACTIVE,
-                configuration);
+                configuration,
+                TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertFalse(peerProtocol.shouldAccept());
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterRetrieverTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterRetrieverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.swirlds.platform.roster;
 
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -215,7 +216,7 @@ public class RosterRetrieverTests {
 
     @Test
     void testGetRound() {
-        assertEquals(666L, RosterRetriever.getRound(state));
+        assertEquals(666L, TEST_PLATFORM_STATE_FACADE.roundOf(state));
     }
 
     private static Stream<Arguments> provideArgumentsForGetActiveRosterHash() {
@@ -239,7 +240,7 @@ public class RosterRetrieverTests {
 
     @Test
     void testRetrieveActiveOrGenesisActiveRoster() {
-        assertEquals(ROSTER_666, RosterRetriever.retrieveActiveOrGenesisRoster(state));
+        assertEquals(ROSTER_666, RosterRetriever.retrieveActiveOrGenesisRoster(state, TEST_PLATFORM_STATE_FACADE));
     }
 
     private static Stream<Arguments> provideArgumentsForRetrieveActiveOrGenesisActiveParametrizedRoster() {
@@ -259,7 +260,7 @@ public class RosterRetrieverTests {
     @MethodSource("provideArgumentsForRetrieveActiveOrGenesisActiveParametrizedRoster")
     void testRetrieveActiveOrGenesisActiveParametrizedRoster(final long round, final Roster roster) {
         doReturn(round).when(consensusSnapshot).round();
-        assertEquals(roster, RosterRetriever.retrieveActiveOrGenesisRoster(state));
+        assertEquals(roster, RosterRetriever.retrieveActiveOrGenesisRoster(state, TEST_PLATFORM_STATE_FACADE));
     }
 
     private static Stream<Arguments> provideArgumentsForRetrieveActiveOrGenesisActiveForRoundRoster() {
@@ -285,14 +286,18 @@ public class RosterRetrieverTests {
     void testRetrieveActiveOrGenesisActiveAddressBookRoster() {
         // First try a very old round for which there's not a roster
         doReturn(554L).when(consensusSnapshot).round();
-        assertEquals(ROSTER_FROM_ADDRESS_BOOK, RosterRetriever.retrieveActiveOrGenesisRoster(state));
+        assertEquals(
+                ROSTER_FROM_ADDRESS_BOOK,
+                RosterRetriever.retrieveActiveOrGenesisRoster(state, TEST_PLATFORM_STATE_FACADE));
 
         // Then try a newer round, but remove the roster from the RosterMap
         doReturn(666L).when(consensusSnapshot).round();
         doReturn(null)
                 .when(rosterMap)
                 .get(eq(ProtoBytes.newBuilder().value(HASH_666).build()));
-        assertEquals(ROSTER_FROM_ADDRESS_BOOK, RosterRetriever.retrieveActiveOrGenesisRoster(state));
+        assertEquals(
+                ROSTER_FROM_ADDRESS_BOOK,
+                RosterRetriever.retrieveActiveOrGenesisRoster(state, TEST_PLATFORM_STATE_FACADE));
     }
 
     public static X509Certificate randomX509Certificate() {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/PlatformMerkleStateRootTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/PlatformMerkleStateRootTest.java
@@ -51,8 +51,10 @@ import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.merkle.map.MerkleMap;
 import com.swirlds.platform.state.service.PlatformStateService;
 import com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema;
+import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.test.fixtures.state.FakeStateLifecycles;
 import com.swirlds.platform.test.fixtures.state.MerkleTestBase;
+import com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade;
 import com.swirlds.state.StateChangeListener;
 import com.swirlds.state.lifecycle.StateDefinition;
 import com.swirlds.state.merkle.StateMetadata;
@@ -86,6 +88,8 @@ class PlatformMerkleStateRootTest extends MerkleTestBase {
     /** The merkle tree we will test with */
     private PlatformMerkleStateRoot stateRoot;
 
+    private TestPlatformStateFacade platformStateFacade;
+
     /**
      * Start with an empty Merkle Tree, but with the "fruit" map and metadata created and ready to
      * be added.
@@ -96,6 +100,7 @@ class PlatformMerkleStateRootTest extends MerkleTestBase {
         FakeStateLifecycles.registerMerkleStateRootClassIds();
         setupFruitMerkleMap();
         stateRoot = new PlatformMerkleStateRoot(softwareVersionSupplier);
+        platformStateFacade = new TestPlatformStateFacade(v -> new BasicSoftwareVersion(v.major()));
         FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(stateRoot);
     }
 
@@ -819,7 +824,7 @@ class PlatformMerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Test access to the platform state")
         void testAccessToPlatformStateData() {
-            PlatformStateModifier randomPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
+            PlatformStateModifier randomPlatformState = randomPlatformState(stateRoot, platformStateFacade);
             stateRoot.updatePlatformState(randomPlatformState);
             ReadableSingletonState<PlatformState> readableSingletonState = stateRoot
                     .getReadableStates(PlatformStateService.NAME)
@@ -835,12 +840,12 @@ class PlatformMerkleStateRootTest extends MerkleTestBase {
         @Test
         @DisplayName("Test update of the platform state")
         void testUpdatePlatformStateData() {
-            PlatformStateModifier randomPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
+            PlatformStateModifier randomPlatformState = randomPlatformState(stateRoot, platformStateFacade);
             stateRoot.updatePlatformState(randomPlatformState);
             WritableStates writableStates = stateRoot.getWritableStates(PlatformStateService.NAME);
             WritableSingletonState<PlatformState> writableSingletonState =
                     writableStates.getSingleton(V0540PlatformStateSchema.PLATFORM_STATE_KEY);
-            PlatformStateModifier newPlatformState = randomPlatformState(stateRoot.getWritablePlatformState());
+            PlatformStateModifier newPlatformState = randomPlatformState(stateRoot, platformStateFacade);
             writableSingletonState.put(toPbjPlatformState(newPlatformState));
             ((CommittableWritableStates) writableStates).commit();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import com.swirlds.base.utility.Pair;
 import com.swirlds.common.exceptions.ReferenceCountException;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
@@ -38,6 +39,7 @@ import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator;
+import com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,8 +56,9 @@ class SignedStateTests {
     /**
      * Generate a signed state.
      */
-    private SignedState generateSignedState(final Random random, final PlatformMerkleStateRoot state) {
-        return new RandomSignedStateGenerator(random).setState(state).build();
+    private Pair<SignedState, TestPlatformStateFacade> generateSignedStateFacadePair(
+            final Random random, final PlatformMerkleStateRoot state) {
+        return new RandomSignedStateGenerator(random).setState(state).buildWithFacade();
     }
 
     @BeforeEach
@@ -80,9 +83,6 @@ class SignedStateTests {
         FAKE_MERKLE_STATE_LIFECYCLES.initStates(real);
         RosterUtils.setActiveRoster(real, RandomRosterBuilder.create(random).build(), 0L);
         final PlatformMerkleStateRoot state = spy(real);
-
-        final PlatformStateModifier platformState = new PlatformState();
-        when(state.getWritablePlatformState()).thenReturn(platformState);
         if (reserveCallback != null) {
             doAnswer(invocation -> {
                         reserveCallback.run();
@@ -123,7 +123,11 @@ class SignedStateTests {
                     released.set(true);
                 });
 
-        final SignedState signedState = generateSignedState(random, state);
+        Pair<SignedState, TestPlatformStateFacade> pair = generateSignedStateFacadePair(random, state);
+        final SignedState signedState = pair.left();
+        final TestPlatformStateFacade platformStateFacade = pair.right();
+        final PlatformStateModifier platformState = new PlatformState();
+        when(platformStateFacade.getWritablePlatformStateOf(state)).thenReturn(platformState);
 
         final ReservedSignedState reservedSignedState;
         reservedSignedState = signedState.reserve("test");
@@ -186,7 +190,11 @@ class SignedStateTests {
                     released.set(true);
                 });
 
-        final SignedState signedState = generateSignedState(random, state);
+        Pair<SignedState, TestPlatformStateFacade> pair = generateSignedStateFacadePair(random, state);
+        final SignedState signedState = pair.left();
+        final TestPlatformStateFacade platformStateFacade = pair.right();
+        final PlatformStateModifier platformState = new PlatformState();
+        when(platformStateFacade.getWritablePlatformStateOf(state)).thenReturn(platformState);
 
         final ReservedSignedState reservedSignedState = signedState.reserve("test");
 
@@ -227,8 +235,9 @@ class SignedStateTests {
         final PlatformMerkleStateRoot state =
                 spy(new PlatformMerkleStateRoot(version -> new BasicSoftwareVersion(version.major())));
         final PlatformStateModifier platformState = mock(PlatformStateModifier.class);
+        final TestPlatformStateFacade platformStateFacade = mock(TestPlatformStateFacade.class);
         FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(state);
-        when(state.getReadablePlatformState()).thenReturn(platformState);
+        when(platformStateFacade.getReadablePlatformStateOf(state)).thenReturn(platformState);
         when(platformState.getRound()).thenReturn(0L);
         final SignedState signedState = new SignedState(
                 TestPlatformContextBuilder.create().build().getConfiguration(),
@@ -237,7 +246,8 @@ class SignedStateTests {
                 "test",
                 false,
                 false,
-                false);
+                false,
+                platformStateFacade);
 
         assertFalse(state.isDestroyed(), "state should not yet be destroyed");
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -237,7 +237,6 @@ class SignedStateTests {
         final PlatformStateModifier platformState = mock(PlatformStateModifier.class);
         final TestPlatformStateFacade platformStateFacade = mock(TestPlatformStateFacade.class);
         FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(state);
-        when(platformStateFacade.getReadablePlatformStateOf(state)).thenReturn(platformState);
         when(platformState.getRound()).thenReturn(0L);
         final SignedState signedState = new SignedState(
                 TestPlatformContextBuilder.create().build().getConfiguration(),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateEventHandlerManagerUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateEventHandlerManagerUtilsTests.java
@@ -17,6 +17,7 @@
 package com.swirlds.platform.state;
 
 import static com.swirlds.platform.test.fixtures.state.FakeStateLifecycles.FAKE_MERKLE_STATE_LIFECYCLES;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
@@ -40,7 +41,7 @@ public class StateEventHandlerManagerUtilsTests {
         state.reserve();
         final StateMetrics stats = mock(StateMetrics.class);
         final PlatformMerkleStateRoot result =
-                SwirldStateManagerUtils.fastCopy(state, stats, new BasicSoftwareVersion(1));
+                SwirldStateManagerUtils.fastCopy(state, stats, new BasicSoftwareVersion(1), TEST_PLATFORM_STATE_FACADE);
 
         assertFalse(result.isImmutable(), "The copy state should be mutable.");
         assertEquals(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldsStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldsStateManagerTests.java
@@ -138,10 +138,7 @@ class SwirldsStateManagerTests {
                 new PlatformMerkleStateRoot(version -> new BasicSoftwareVersion(version.major()));
         FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(state);
 
-        final PlatformStateModifier platformState = mock(PlatformStateModifier.class);
-        when(platformState.getCreationSoftwareVersion()).thenReturn(new BasicSoftwareVersion(nextInt(1, 100)));
-
-        platformStateFacade.updatePlatformState(state, platformState);
+        platformStateFacade.setCreationSoftwareVersionTo(state, new BasicSoftwareVersion(nextInt(1, 100)));
 
         assertEquals(0, state.getReservationCount(), "A brand new state should have no references.");
         return state;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldsStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldsStateManagerTests.java
@@ -30,6 +30,7 @@ import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.SwirldsPlatform;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.Round;
@@ -52,7 +53,8 @@ class SwirldsStateManagerTests {
         final SwirldsPlatform platform = mock(SwirldsPlatform.class);
         final Roster roster = RandomRosterBuilder.create(Randotron.create()).build();
         when(platform.getRoster()).thenReturn(roster);
-        initialState = newState();
+        PlatformStateFacade platformStateFacade = new PlatformStateFacade(v -> new BasicSoftwareVersion(v.major()));
+        initialState = newState(platformStateFacade);
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
 
@@ -62,7 +64,8 @@ class SwirldsStateManagerTests {
                 NodeId.of(0L),
                 mock(StatusActionSubmitter.class),
                 new BasicSoftwareVersion(1),
-                FAKE_MERKLE_STATE_LIFECYCLES);
+                FAKE_MERKLE_STATE_LIFECYCLES,
+                platformStateFacade);
         swirldStateManager.setInitialState(initialState);
     }
 
@@ -130,7 +133,7 @@ class SwirldsStateManagerTests {
                         + "decremented.");
     }
 
-    private static PlatformMerkleStateRoot newState() {
+    private static PlatformMerkleStateRoot newState(PlatformStateFacade platformStateFacade) {
         final PlatformMerkleStateRoot state =
                 new PlatformMerkleStateRoot(version -> new BasicSoftwareVersion(version.major()));
         FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(state);
@@ -138,7 +141,7 @@ class SwirldsStateManagerTests {
         final PlatformStateModifier platformState = mock(PlatformStateModifier.class);
         when(platformState.getCreationSoftwareVersion()).thenReturn(new BasicSoftwareVersion(nextInt(1, 100)));
 
-        state.updatePlatformState(platformState);
+        platformStateFacade.updatePlatformState(state, platformState);
 
         assertEquals(0, state.getReservationCount(), "A brand new state should have no references.");
         return state;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
@@ -154,7 +154,6 @@ public class HashLoggerTest {
         final SignedState signedState = mock(SignedState.class);
         final PlatformMerkleStateRoot state = mock(PlatformMerkleStateRoot.class);
         final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
-        when(platformStateFacade.getReadablePlatformStateOf(state)).thenReturn(platformState);
         when(platformState.getRound()).thenReturn(round);
         when(state.getRoute()).thenReturn(merkleNode.getRoute());
         when(state.getHash()).thenReturn(merkleNode.getHash());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.MerkleNode;
@@ -37,9 +36,10 @@ import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.StateConfig_;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.state.State;
+import com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.Logger;
@@ -51,6 +51,7 @@ public class HashLoggerTest {
     private Logger mockLogger;
     private HashLogger hashLogger;
     private List<String> logged;
+    private TestPlatformStateFacade platformStateFacade;
 
     /**
      * Get a regex that will match a log message containing the given round number
@@ -65,11 +66,12 @@ public class HashLoggerTest {
     @BeforeEach
     public void setUp() {
         mockLogger = mock(Logger.class);
+        platformStateFacade = mock(TestPlatformStateFacade.class);
 
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
 
-        hashLogger = new DefaultHashLogger(platformContext, mockLogger);
+        hashLogger = new DefaultHashLogger(platformContext, mockLogger, platformStateFacade);
         logged = new ArrayList<>();
 
         doAnswer(invocation -> {
@@ -129,7 +131,7 @@ public class HashLoggerTest {
                 .withConfiguration(configuration)
                 .build();
 
-        hashLogger = new DefaultHashLogger(platformContext, mockLogger);
+        hashLogger = new DefaultHashLogger(platformContext, mockLogger, platformStateFacade);
         hashLogger.logHashes(createSignedState(1));
         assertThat(logged).isEmpty();
     }
@@ -138,9 +140,10 @@ public class HashLoggerTest {
     public void loggerWithDefaultConstructorWorks() {
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
+        final PlatformStateFacade platformStateFacade = mock(PlatformStateFacade.class);
 
         assertDoesNotThrow(() -> {
-            hashLogger = new DefaultHashLogger(platformContext);
+            hashLogger = new DefaultHashLogger(platformContext, platformStateFacade);
             hashLogger.logHashes(createSignedState(1));
         });
     }
@@ -149,13 +152,10 @@ public class HashLoggerTest {
         final MerkleNode merkleNode = MerkleTestUtils.buildLessSimpleTree();
         MerkleCryptoFactory.getInstance().digestTreeSync(merkleNode);
         final SignedState signedState = mock(SignedState.class);
-        final PlatformMerkleStateRoot state =
-                mock(PlatformMerkleStateRoot.class, withSettings().extraInterfaces(State.class));
+        final PlatformMerkleStateRoot state = mock(PlatformMerkleStateRoot.class);
         final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
-
+        when(platformStateFacade.getReadablePlatformStateOf(state)).thenReturn(platformState);
         when(platformState.getRound()).thenReturn(round);
-
-        when(state.getReadablePlatformState()).thenReturn(platformState);
         when(state.getRoute()).thenReturn(merkleNode.getRoute());
         when(state.getHash()).thenReturn(merkleNode.getHash());
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PlatformStateFacadeTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PlatformStateFacadeTest.java
@@ -14,16 +14,15 @@
  * limitations under the License.
  */
 
-package com.swirlds.platform;
+package com.swirlds.platform.state.service;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.swirlds.platform.state.SwirldStateManagerUtils;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
-class StateEventHandlerManagerFreezePeriodCheckerTest {
+class PlatformStateFacadeTest {
 
     @Test
     void isInFreezePeriodTest() {
@@ -34,24 +33,24 @@ class StateEventHandlerManagerFreezePeriodCheckerTest {
         final Instant t4 = t3.plusSeconds(1);
 
         // No freeze time set
-        assertFalse(SwirldStateManagerUtils.isInFreezePeriod(t1, null, null));
+        assertFalse(PlatformStateFacade.isInFreezePeriod(t1, null, null));
 
         // No freeze time set, previous freeze time set
-        assertFalse(SwirldStateManagerUtils.isInFreezePeriod(t2, null, t1));
+        assertFalse(PlatformStateFacade.isInFreezePeriod(t2, null, t1));
 
         // Freeze time is in the future, never frozen before
-        assertFalse(SwirldStateManagerUtils.isInFreezePeriod(t2, t3, null));
+        assertFalse(PlatformStateFacade.isInFreezePeriod(t2, t3, null));
 
         // Freeze time is in the future, frozen before
-        assertFalse(SwirldStateManagerUtils.isInFreezePeriod(t2, t3, t1));
+        assertFalse(PlatformStateFacade.isInFreezePeriod(t2, t3, t1));
 
         // Freeze time is in the past, never frozen before
-        assertTrue(SwirldStateManagerUtils.isInFreezePeriod(t2, t1, null));
+        assertTrue(PlatformStateFacade.isInFreezePeriod(t2, t1, null));
 
         // Freeze time is in the past, frozen before at an earlier time
-        assertTrue(SwirldStateManagerUtils.isInFreezePeriod(t3, t2, t1));
+        assertTrue(PlatformStateFacade.isInFreezePeriod(t3, t2, t1));
 
         // Freeze time in the past, already froze at that exact time
-        assertFalse(SwirldStateManagerUtils.isInFreezePeriod(t3, t2, t2));
+        assertFalse(PlatformStateFacade.isInFreezePeriod(t3, t2, t2));
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PlatformStateFacadeTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PlatformStateFacadeTest.java
@@ -16,23 +16,34 @@
 
 package com.swirlds.platform.state.service;
 
+import static com.swirlds.common.test.fixtures.RandomUtils.nextLong;
+import static com.swirlds.common.test.fixtures.RandomUtils.randomHash;
+import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.UNINITIALIZED_PLATFORM_STATE;
 import static com.swirlds.platform.test.PlatformStateUtils.randomPlatformState;
 import static com.swirlds.platform.test.fixtures.state.FakeStateLifecycles.FAKE_MERKLE_STATE_LIFECYCLES;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.platform.state.PlatformState;
+import com.swirlds.common.test.fixtures.RandomUtils;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade;
+import com.swirlds.state.State;
+import com.swirlds.state.spi.EmptyReadableStates;
 import java.time.Instant;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class PlatformStateFacadeTest {
 
@@ -83,26 +94,162 @@ class PlatformStateFacadeTest {
     }
 
     @Test
-    public void testCreationSoftwareVersionOf() {
+    void testCreationSoftwareVersionOf() {
         assertEquals(
                 platformStateModifier.getCreationSoftwareVersion().getPbjSemanticVersion(),
                 platformStateFacade.creationSoftwareVersionOf(state).getPbjSemanticVersion());
     }
 
     @Test
-    public void testCreationSoftwareVersionOf_null() {
+    void testCreationSoftwareVersionOf_null() {
         assertNull(platformStateFacade.creationSoftwareVersionOf(emptyState));
     }
 
     @Test
-    public void testRoundOf() {
+    void testRoundOf() {
         assertEquals(platformStateModifier.getRound(), platformStateFacade.roundOf(state));
     }
 
     @Test
-    public void platformStateOf() {
+    void testPlatformStateOf_noPlatformState() {
         final PlatformMerkleStateRoot noPlatformState = new PlatformMerkleStateRoot(VERSION_FACTORY);
         noPlatformState.getReadableStates(PlatformStateService.NAME);
-        platformStateFacade.platformStateOf(noPlatformState);
+        assertSame(UNINITIALIZED_PLATFORM_STATE, platformStateFacade.platformStateOf(noPlatformState));
+    }
+
+    @Test
+    void testPlatformStateOf_unexpectedRootInstance() {
+        final State rootOfUnexpectedType = Mockito.mock(State.class);
+        when(rootOfUnexpectedType.getReadableStates(PlatformStateService.NAME))
+                .thenReturn(EmptyReadableStates.INSTANCE);
+
+        final PlatformState platformState = platformStateFacade.platformStateOf(rootOfUnexpectedType);
+        assertSame(UNINITIALIZED_PLATFORM_STATE, platformState);
+    }
+
+    @Test
+    void testLegacyRunningEventHashOf() {
+        assertEquals(
+                platformStateModifier.getLegacyRunningEventHash(), platformStateFacade.legacyRunningEventHashOf(state));
+    }
+
+    @Test
+    void testAncientThresholdOf() {
+        assertEquals(platformStateModifier.getAncientThreshold(), platformStateFacade.ancientThresholdOf(state));
+    }
+
+    @Test
+    void testConsensusSnapshotOf() {
+        assertEquals(platformStateModifier.getSnapshot(), platformStateFacade.consensusSnapshotOf(state));
+    }
+
+    @Test
+    void testFirstVersionInBirthRoundModeOf() {
+        assertEquals(
+                platformStateModifier.getFirstVersionInBirthRoundMode(),
+                platformStateFacade.firstVersionInBirthRoundModeOf(state));
+    }
+
+    @Test
+    void testLastRoundBeforeBirthRoundModeOf() {
+        assertEquals(
+                platformStateModifier.getLastRoundBeforeBirthRoundMode(),
+                platformStateFacade.lastRoundBeforeBirthRoundModeOf(state));
+    }
+
+    @Test
+    void testLowestJudgeGenerationBeforeBirthRoundModeOf() {
+        assertEquals(
+                platformStateModifier.getLowestJudgeGenerationBeforeBirthRoundMode(),
+                platformStateFacade.lowestJudgeGenerationBeforeBirthRoundModeOf(state));
+    }
+
+    @Test
+    void testConsensusTimestampOf() {
+        assertEquals(platformStateModifier.getConsensusTimestamp(), platformStateFacade.consensusTimestampOf(state));
+    }
+
+    @Test
+    void testFreezeTimeOf() {
+        assertEquals(platformStateModifier.getFreezeTime(), platformStateFacade.freezeTimeOf(state));
+    }
+
+    @Test
+    void testUpdateLastFrozenTime() {
+        final Instant newFreezeTime = Instant.now();
+        platformStateFacade.bulkUpdateOf(state, v -> {
+            v.setFreezeTime(newFreezeTime);
+        });
+        platformStateFacade.updateLastFrozenTime(state);
+        assertEquals(newFreezeTime, platformStateModifier.getLastFrozenTime());
+        assertEquals(newFreezeTime, platformStateFacade.lastFrozenTimeOf(state));
+    }
+
+    @Test
+    void testPreviousAddressBookOf() {
+        assertEquals(platformStateModifier.getPreviousAddressBook(), platformStateFacade.previousAddressBookOf(state));
+    }
+
+    @Test
+    void testBulkUpdateOf() {
+        final Instant newFreezeTime = Instant.now();
+        final Instant lastFrozenTime = Instant.now();
+        final long round = nextLong();
+        platformStateFacade.bulkUpdateOf(state, v -> {
+            v.setFreezeTime(newFreezeTime);
+            v.setRound(round);
+            v.setLastFrozenTime(lastFrozenTime);
+        });
+        assertEquals(newFreezeTime, platformStateModifier.getFreezeTime());
+        assertEquals(lastFrozenTime, platformStateModifier.getLastFrozenTime());
+        assertEquals(round, platformStateModifier.getRound());
+    }
+
+    @Test
+    void testSetSnapshotTo() {
+        PlatformMerkleStateRoot randomState = new PlatformMerkleStateRoot(VERSION_FACTORY);
+        FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(randomState);
+        PlatformStateModifier randomPlatformState = randomPlatformState(randomState, platformStateFacade);
+        final var newSnapshot = randomPlatformState.getSnapshot();
+        platformStateFacade.setSnapshotTo(state, newSnapshot);
+        assertEquals(newSnapshot, platformStateModifier.getSnapshot());
+    }
+
+    @Test
+    void testSetLegacyRunningEventHashTo() {
+        final var newLegacyRunningEventHash = randomHash();
+        platformStateFacade.setLegacyRunningEventHashTo(state, newLegacyRunningEventHash);
+        assertEquals(newLegacyRunningEventHash, platformStateModifier.getLegacyRunningEventHash());
+    }
+
+    @Test
+    void testSetCreationSoftwareVersionTo() {
+        final var newCreationSoftwareVersion = new BasicSoftwareVersion(RandomUtils.nextInt());
+        platformStateFacade.setCreationSoftwareVersionTo(state, newCreationSoftwareVersion);
+        assertEquals(
+                newCreationSoftwareVersion.getVersion(),
+                platformStateModifier.getCreationSoftwareVersion().getVersion());
+    }
+
+    @Test
+    void testGetInfoString() {
+        final var infoString = platformStateFacade.getInfoString(state, 1);
+        System.out.println(infoString);
+        assertThat(infoString)
+                .contains("Round:")
+                .contains("Timestamp:")
+                .contains("Next consensus number:")
+                .contains("Legacy running event hash:")
+                .contains("Legacy running event mnemonic:")
+                .contains("Rounds non-ancient:")
+                .contains("Creation version:")
+                .contains("Minimum judge hash code:")
+                .contains("Root hash:")
+                .contains("First BR Version:")
+                .contains("Last round before BR:")
+                .contains("Lowest Judge Gen before BR")
+                .contains("Lowest Judge Gen before BR")
+                .contains("SingletonNode")
+                .contains("PlatformStateService.PLATFORM_STATE");
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PlatformStateServiceTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PlatformStateServiceTest.java
@@ -17,6 +17,8 @@
 package com.swirlds.platform.state.service;
 
 import static com.swirlds.platform.state.service.PlatformStateService.PLATFORM_STATE_SERVICE;
+import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -30,7 +32,11 @@ import com.swirlds.platform.state.service.schemas.V059RosterLifecycleTransitionS
 import com.swirlds.state.lifecycle.Schema;
 import com.swirlds.state.lifecycle.SchemaRegistry;
 import com.swirlds.state.merkle.MerkleStateRoot;
+import com.swirlds.state.merkle.singleton.ReadableSingletonStateImpl;
 import com.swirlds.state.merkle.singleton.SingletonNode;
+import com.swirlds.state.spi.EmptyReadableStates;
+import com.swirlds.state.test.fixtures.MapReadableStates;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -61,20 +67,20 @@ class PlatformStateServiceTest {
 
     @Test
     void emptyRootIsAtGenesis() {
-        given(root.findNodeIndex(PlatformStateService.NAME, V0540PlatformStateSchema.PLATFORM_STATE_KEY))
-                .willReturn(-1);
-        assertNull(PLATFORM_STATE_SERVICE.creationVersionOf(root));
+        given(root.getReadableStates(PlatformStateService.NAME)).willReturn(EmptyReadableStates.INSTANCE);
+        given(root.findNodeIndex(PlatformStateService.NAME, PLATFORM_STATE_KEY)).willReturn(-1);
+        assertNull(TEST_PLATFORM_STATE_FACADE.creationSemanticVersionOf(root));
     }
 
     @Test
     void rootWithPlatformStateGetsVersionFromPlatformState() {
-        given(root.findNodeIndex(PlatformStateService.NAME, V0540PlatformStateSchema.PLATFORM_STATE_KEY))
-                .willReturn(0);
-        given(root.getChild(0)).willReturn(platformState);
+        MapReadableStates readableStates = new MapReadableStates(
+                Map.of(PLATFORM_STATE_KEY, new ReadableSingletonStateImpl<>(PLATFORM_STATE_KEY, platformState)));
+        given(root.getReadableStates(PlatformStateService.NAME)).willReturn(readableStates);
         given(platformState.getValue())
                 .willReturn(PlatformState.newBuilder()
                         .creationSoftwareVersion(SemanticVersion.DEFAULT)
                         .build());
-        assertSame(SemanticVersion.DEFAULT, PLATFORM_STATE_SERVICE.creationVersionOf(root));
+        assertSame(SemanticVersion.DEFAULT, TEST_PLATFORM_STATE_FACADE.creationSemanticVersionOf(root));
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
@@ -39,8 +39,10 @@ import com.swirlds.platform.builder.PlatformComponentBuilder;
 import com.swirlds.platform.config.BasicConfig_;
 import com.swirlds.platform.crypto.KeysAndCerts;
 import com.swirlds.platform.roster.RosterUtils;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.Platform;
+import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.system.address.AddressBook;
 import com.swirlds.platform.system.address.AddressBookUtils;
 import com.swirlds.platform.test.fixtures.turtle.gossip.SimulatedGossip;
@@ -102,6 +104,9 @@ public class TurtleNode {
         model = WiringModelBuilder.create(platformContext)
                 .withDeterministicModeEnabled(true)
                 .build();
+        final SoftwareVersion softwareVersion = new BasicSoftwareVersion(1);
+        final PlatformStateFacade platformStateFacade = new PlatformStateFacade(v -> softwareVersion);
+        ;
         final var version = new BasicSoftwareVersion(1);
         MerkleDb.resetDefaultInstancePath();
         final var metrics = getMetricsProvider().createPlatformMetrics(nodeId);
@@ -117,17 +122,19 @@ public class TurtleNode {
                 "foo",
                 "bar",
                 nodeId,
-                addressBook);
+                addressBook,
+                platformStateFacade);
         final var initialState = reservedState.state();
         final PlatformBuilder platformBuilder = PlatformBuilder.create(
                         "foo",
                         "bar",
-                        new BasicSoftwareVersion(1),
+                        softwareVersion,
                         initialState,
                         TURTLE_STATE_LIFECYCLES,
                         nodeId,
                         AddressBookUtils.formatConsensusEventStreamName(addressBook, nodeId),
-                        RosterUtils.buildRosterHistory(initialState.get().getState()))
+                        RosterUtils.buildRosterHistory(initialState.get().getState(), platformStateFacade),
+                        platformStateFacade)
                 .withModel(model)
                 .withRandomBuilder(new RandomBuilder(randotron.nextLong()))
                 .withKeysAndCerts(privateKeys)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/SignedStateReserverTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/SignedStateReserverTest.java
@@ -19,6 +19,7 @@ package com.swirlds.platform.wiring;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
@@ -31,13 +32,13 @@ import com.swirlds.component.framework.wires.input.BindableInputWire;
 import com.swirlds.component.framework.wires.output.OutputWire;
 import com.swirlds.platform.crypto.SignatureVerifier;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class SignedStateReserverTest {
 
@@ -50,12 +51,13 @@ class SignedStateReserverTest {
 
         final SignedState signedState = new SignedState(
                 platformContext.getConfiguration(),
-                Mockito.mock(SignatureVerifier.class),
-                Mockito.mock(PlatformMerkleStateRoot.class),
+                mock(SignatureVerifier.class),
+                mock(PlatformMerkleStateRoot.class),
                 "create",
                 false,
                 false,
-                false);
+                false,
+                mock(PlatformStateFacade.class));
 
         final WiringModel model = WiringModelBuilder.create(platformContext).build();
         final TaskScheduler<ReservedSignedState> taskScheduler = model.<ReservedSignedState>schedulerBuilder(

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/BlockingState.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/BlockingState.java
@@ -57,12 +57,18 @@ public class BlockingState extends PlatformMerkleStateRoot {
     private static final long CLASS_ID = 0xa7d6e4b5feda7ce5L;
 
     private final BlockingStringLeaf value;
+    private TestPlatformStateFacade platformStateFacade;
+
+    public BlockingState() {
+        this(new TestPlatformStateFacade(v -> new BasicSoftwareVersion(v.major())));
+    }
 
     /**
      * Constructs a new instance of {@link BlockingState}.
      */
-    public BlockingState() {
+    public BlockingState(TestPlatformStateFacade platformStateFacade) {
         super(version -> new BasicSoftwareVersion(version.major()));
+        this.platformStateFacade = platformStateFacade;
         value = new BlockingStringLeaf();
         setChild(1, value);
     }
@@ -95,7 +101,9 @@ public class BlockingState extends PlatformMerkleStateRoot {
         if (!(obj instanceof final BlockingState that)) {
             return false;
         }
-        return Objects.equals(this.getReadablePlatformState(), that.getReadablePlatformState());
+        return Objects.equals(
+                platformStateFacade.getReadablePlatformStateOf(this),
+                platformStateFacade.getReadablePlatformStateOf(that));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/BlockingState.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/BlockingState.java
@@ -101,9 +101,7 @@ public class BlockingState extends PlatformMerkleStateRoot {
         if (!(obj instanceof final BlockingState that)) {
             return false;
         }
-        return Objects.equals(
-                platformStateFacade.getReadablePlatformStateOf(this),
-                platformStateFacade.getReadablePlatformStateOf(that));
+        return Objects.equals(platformStateFacade.platformStateOf(this), platformStateFacade.platformStateOf(that));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
@@ -21,18 +21,19 @@ import static com.swirlds.common.test.fixtures.RandomUtils.randomHash;
 import static com.swirlds.common.test.fixtures.RandomUtils.randomSignature;
 import static com.swirlds.platform.test.fixtures.state.FakeStateLifecycles.FAKE_MERKLE_STATE_LIFECYCLES;
 import static com.swirlds.platform.test.fixtures.state.FakeStateLifecycles.registerMerkleStateRootClassIds;
+import static org.mockito.Mockito.spy;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.base.time.Time;
+import com.swirlds.base.utility.Pair;
 import com.swirlds.common.Reservable;
-import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.crypto.Hash;
 import com.swirlds.common.crypto.Signature;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
+import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.RandomUtils;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.config.StateConfig;
@@ -41,14 +42,12 @@ import com.swirlds.platform.crypto.SignatureVerifier;
 import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.state.MinimumJudgeInfo;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
-import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import com.swirlds.platform.system.SoftwareVersion;
 import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder.WeightDistributionStrategy;
 import com.swirlds.platform.test.fixtures.state.manager.SignatureVerificationTestUtils;
-import com.swirlds.state.State;
 import com.swirlds.state.merkle.MerkleStateRoot;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
@@ -121,6 +120,16 @@ public class RandomSignedStateGenerator {
      * @return a new signed state
      */
     public SignedState build() {
+        return buildWithFacade().left();
+    }
+
+    /**
+     * Build a pair of new signed state and a platform state facade used for that
+     *
+     * @return a new signed state
+     */
+    public Pair<SignedState, TestPlatformStateFacade> buildWithFacade() {
+
         final Roster rosterInstance;
         if (roster == null) {
             rosterInstance = RandomRosterBuilder.create(random)
@@ -139,22 +148,23 @@ public class RandomSignedStateGenerator {
 
         final PlatformMerkleStateRoot stateInstance;
         registerMerkleStateRootClassIds();
-        if (state == null) {
-            if (useBlockingState) {
-                stateInstance = new BlockingState();
-            } else {
-                stateInstance = new PlatformMerkleStateRoot(version -> new BasicSoftwareVersion(version.major()));
-            }
-            stateInstance.setTime(Time.getCurrent());
-        } else {
-            stateInstance = state;
-        }
-
         final long roundInstance;
         if (round == null) {
             roundInstance = Math.abs(random.nextLong());
         } else {
             roundInstance = round;
+        }
+
+        TestPlatformStateFacade platformStateFacade = new TestPlatformStateFacade((v -> softwareVersionInstance));
+        if (state == null) {
+            if (useBlockingState) {
+                stateInstance = new BlockingState(platformStateFacade);
+            } else {
+                stateInstance = new PlatformMerkleStateRoot(version -> new BasicSoftwareVersion(version.major()));
+            }
+            stateInstance.init(Time.getCurrent(), new NoOpMetrics(), MerkleCryptoFactory.getInstance());
+        } else {
+            stateInstance = state;
         }
 
         final Hash legacyRunningEventHashInstance;
@@ -199,9 +209,8 @@ public class RandomSignedStateGenerator {
             consensusSnapshotInstance = consensusSnapshot;
         }
         FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(stateInstance);
-        final PlatformStateModifier platformState = stateInstance.getWritablePlatformState();
 
-        platformState.bulkUpdate(v -> {
+        platformStateFacade.bulkUpdateOf(stateInstance, v -> {
             v.setSnapshot(consensusSnapshotInstance);
             v.setLegacyRunningEventHash(legacyRunningEventHashInstance);
             v.setCreationSoftwareVersion(softwareVersionInstance);
@@ -210,7 +219,7 @@ public class RandomSignedStateGenerator {
         });
 
         FAKE_MERKLE_STATE_LIFECYCLES.initRosterState(stateInstance);
-        RosterUtils.setActiveRoster((State) stateInstance, rosterInstance, roundInstance);
+        RosterUtils.setActiveRoster(stateInstance, rosterInstance, roundInstance);
 
         if (signatureVerifier == null) {
             signatureVerifier = SignatureVerificationTestUtils::verifySignature;
@@ -220,9 +229,6 @@ public class RandomSignedStateGenerator {
                 .withValue("state.stateHistoryEnabled", true)
                 .withConfigDataType(StateConfig.class)
                 .getOrCreateConfig();
-        final PlatformContext platformContext = TestPlatformContextBuilder.create()
-                .withConfiguration(configuration)
-                .build();
 
         final SignedState signedState = new SignedState(
                 configuration,
@@ -231,9 +237,10 @@ public class RandomSignedStateGenerator {
                 "RandomSignedStateGenerator.build()",
                 freezeStateInstance,
                 deleteOnBackgroundThread,
-                pcesRound);
+                pcesRound,
+                platformStateFacade);
 
-        MerkleCryptoFactory.getInstance().digestTreeSync(stateInstance);
+        MerkleCryptoFactory.getInstance().digestTreeSync(stateInstance.cast());
         if (stateHash != null) {
             stateInstance.setHash(stateHash);
         }
@@ -267,7 +274,7 @@ public class RandomSignedStateGenerator {
         }
 
         builtSignedStates.get().add(signedState);
-        return signedState;
+        return Pair.of(signedState, spy(platformStateFacade));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/TestPlatformStateFacade.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/TestPlatformStateFacade.java
@@ -17,7 +17,6 @@
 package com.swirlds.platform.test.fixtures.state;
 
 import com.hedera.hapi.node.base.SemanticVersion;
-import com.swirlds.platform.state.PlatformStateAccessor;
 import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.SoftwareVersion;
@@ -31,14 +30,6 @@ public class TestPlatformStateFacade extends PlatformStateFacade {
 
     public TestPlatformStateFacade(Function<SemanticVersion, SoftwareVersion> versionFactory) {
         super(versionFactory);
-    }
-
-    /**
-     * The method is made public for testing purposes.
-     */
-    @Override
-    public PlatformStateAccessor getReadablePlatformStateOf(@NonNull State root) {
-        return super.getReadablePlatformStateOf(root);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/TestPlatformStateFacade.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/TestPlatformStateFacade.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.swirlds.platform.test.fixtures.state;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.swirlds.platform.state.PlatformStateAccessor;
+import com.swirlds.platform.state.PlatformStateModifier;
+import com.swirlds.platform.state.service.PlatformStateFacade;
+import com.swirlds.platform.system.SoftwareVersion;
+import com.swirlds.state.State;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.function.Function;
+
+public class TestPlatformStateFacade extends PlatformStateFacade {
+    public static final TestPlatformStateFacade TEST_PLATFORM_STATE_FACADE =
+            new TestPlatformStateFacade(v -> SoftwareVersion.NO_VERSION);
+
+    public TestPlatformStateFacade(Function<SemanticVersion, SoftwareVersion> versionFactory) {
+        super(versionFactory);
+    }
+
+    /**
+     * The method is made public for testing purposes.
+     */
+    @Override
+    public PlatformStateAccessor getReadablePlatformStateOf(@NonNull State root) {
+        return super.getReadablePlatformStateOf(root);
+    }
+
+    /**
+     * The method is made public for testing purposes.
+     */
+    @NonNull
+    @Override
+    public PlatformStateModifier getWritablePlatformStateOf(@NonNull State state) {
+        return super.getWritablePlatformStateOf(state);
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/module-info.java
@@ -17,6 +17,7 @@
 module com.swirlds.platform.core.test.fixtures {
     requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
+    requires transitive com.swirlds.base;
     requires transitive com.swirlds.common.test.fixtures;
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.config.api;
@@ -26,7 +27,6 @@ module com.swirlds.platform.core.test.fixtures {
     requires transitive com.swirlds.state.impl.test.fixtures;
     requires transitive com.swirlds.state.impl;
     requires transitive com.swirlds.virtualmap;
-    requires com.swirlds.base;
     requires com.swirlds.component.framework;
     requires com.swirlds.config.extensions.test.fixtures;
     requires com.swirlds.logging;

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/MigrationContext.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/MigrationContext.java
@@ -122,7 +122,7 @@ public interface MigrationContext {
      * Returns whether this is a genesis migration.
      */
     default boolean isGenesis() {
-        return previousVersion() == null;
+        return previousVersion() == null || previousVersion() == SemanticVersion.DEFAULT;
     }
 
     /**

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateUtils.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import com.swirlds.state.merkle.singleton.SingletonNode;
 import com.swirlds.state.merkle.singleton.StringLeaf;
 import com.swirlds.state.merkle.singleton.ValueLeaf;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -67,12 +68,13 @@ public final class StateUtils {
      * @throws ClassCastException If the object or codec is not for type {@code T}.
      */
     public static <T> int writeToStream(
-            @NonNull final OutputStream out, @NonNull final Codec<T> codec, @NonNull final T object)
+            @NonNull final OutputStream out, @NonNull final Codec<T> codec, @Nullable final T object)
             throws IOException {
+        final var stream = new WritableStreamingData(out);
+
         final var byteStream = new ByteArrayOutputStream();
         codec.write(object, new WritableStreamingData(byteStream));
 
-        final var stream = new WritableStreamingData(out);
         stream.writeInt(byteStream.size());
         stream.writeBytes(byteStream.toByteArray());
         return byteStream.size();
@@ -88,11 +90,12 @@ public final class StateUtils {
      * @throws IOException If the input stream throws it or parsing fails
      * @throws ClassCastException If the object or codec is not for type {@code T}.
      */
-    @NonNull
+    @Nullable
     public static <T> T readFromStream(@NonNull final InputStream in, @NonNull final Codec<T> codec)
             throws IOException {
         final var stream = new ReadableStreamingData(in);
         final var size = stream.readInt();
+
         stream.limit((long) size + Integer.BYTES); // +4 for the size
         try {
             return codec.parse(stream);

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/singleton/ValueLeaf.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/singleton/ValueLeaf.java
@@ -37,8 +37,6 @@ import org.apache.logging.log4j.Logger;
  */
 public class ValueLeaf<T> extends PartialMerkleLeaf implements MerkleLeaf {
 
-    private static final Logger logger = LogManager.getLogger(ValueLeaf.class);
-
     /**
      * {@deprecated} Needed for ConstructableRegistry, TO BE REMOVED ASAP
      */

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/singleton/ValueLeaf.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/singleton/ValueLeaf.java
@@ -84,25 +84,6 @@ public class ValueLeaf<T> extends PartialMerkleLeaf implements MerkleLeaf {
         this.val = value;
     }
 
-    public static String getCallTrace() {
-        StringBuilder traceBuilder = new StringBuilder();
-        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-
-        // Skip the first few elements to remove getStackTrace() and getCallTrace() itself
-        for (int i = 2; i < stackTrace.length; i++) {
-            StackTraceElement element = stackTrace[i];
-            traceBuilder.append(String.format(
-                    "%d. %s.%s(%s:%d)%n",
-                    i - 1, // Adjust index for readability
-                    element.getClassName(),
-                    element.getMethodName(),
-                    element.getFileName(),
-                    element.getLineNumber()));
-        }
-
-        return traceBuilder.toString();
-    }
-
     /** {@inheritDoc} */
     @Override
     public ValueLeaf<T> copy() {

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/singleton/ValueLeaf.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/singleton/ValueLeaf.java
@@ -28,8 +28,6 @@ import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * A Merkle leaf that stores an arbitrary value with delegated serialization based on the {@link

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/singleton/ValueLeaf.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/singleton/ValueLeaf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,12 +28,17 @@ import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A Merkle leaf that stores an arbitrary value with delegated serialization based on the {@link
  * #classId}.
  */
 public class ValueLeaf<T> extends PartialMerkleLeaf implements MerkleLeaf {
+
+    private static final Logger logger = LogManager.getLogger(ValueLeaf.class);
+
     /**
      * {@deprecated} Needed for ConstructableRegistry, TO BE REMOVED ASAP
      */
@@ -43,6 +48,7 @@ public class ValueLeaf<T> extends PartialMerkleLeaf implements MerkleLeaf {
     private final long classId;
     private final Codec<T> codec;
     /** The actual value. For example, it could be an Account or SmartContract. */
+    @Nullable
     private T val;
 
     /**
@@ -76,6 +82,25 @@ public class ValueLeaf<T> extends PartialMerkleLeaf implements MerkleLeaf {
     public ValueLeaf(final long singletonClassId, @NonNull Codec<T> codec, @Nullable final T value) {
         this(singletonClassId, codec);
         this.val = value;
+    }
+
+    public static String getCallTrace() {
+        StringBuilder traceBuilder = new StringBuilder();
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+
+        // Skip the first few elements to remove getStackTrace() and getCallTrace() itself
+        for (int i = 2; i < stackTrace.length; i++) {
+            StackTraceElement element = stackTrace[i];
+            traceBuilder.append(String.format(
+                    "%d. %s.%s(%s:%d)%n",
+                    i - 1, // Adjust index for readability
+                    element.getClassName(),
+                    element.getMethodName(),
+                    element.getFileName(),
+                    element.getLineNumber()));
+        }
+
+        return traceBuilder.toString();
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/build.gradle.kts
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/build.gradle.kts
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 plugins {
     id("java-library")
     id("jacoco")
@@ -29,6 +44,7 @@ testModuleInfo {
     requires("com.swirlds.merkle")
     requires("com.swirlds.base.test.fixtures")
     requires("awaitility")
+    requires("com.swirlds.state.impl")
     requires("org.junit.jupiter.params")
     requires("org.mockito.junit.jupiter")
     requires("com.swirlds.metrics.api")

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/PlatformStateUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/PlatformStateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import com.swirlds.platform.consensus.ConsensusSnapshot;
 import com.swirlds.platform.state.MinimumJudgeInfo;
 import com.swirlds.platform.state.PlatformStateModifier;
 import com.swirlds.platform.system.BasicSoftwareVersion;
+import com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade;
+import com.swirlds.state.State;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -35,16 +37,17 @@ public final class PlatformStateUtils {
     /**
      * Generate a randomized PlatformState object. Values contained internally may be nonsensical.
      */
-    public static PlatformStateModifier randomPlatformState(PlatformStateModifier platformState) {
-        return randomPlatformState(new Random(), platformState);
+    public static PlatformStateModifier randomPlatformState(State state, TestPlatformStateFacade platformState) {
+        return randomPlatformState(new Random(), state, platformState);
     }
 
     /**
      * Generate a randomized PlatformState object. Values contained internally may be nonsensical.
      */
-    public static PlatformStateModifier randomPlatformState(final Random random, PlatformStateModifier platformState) {
+    public static PlatformStateModifier randomPlatformState(
+            final Random random, State state, TestPlatformStateFacade platformStateFacade) {
 
-        platformState.bulkUpdate(v -> {
+        platformStateFacade.bulkUpdateOf(state, v -> {
             v.setLegacyRunningEventHash(randomHash(random));
             v.setRound(random.nextLong());
             v.setConsensusTimestamp(randomInstant(random));
@@ -55,13 +58,15 @@ public final class PlatformStateUtils {
         for (int index = 0; index < 10; index++) {
             minimumJudgeInfo.add(new MinimumJudgeInfo(random.nextLong(), random.nextLong()));
         }
-        platformState.setSnapshot(new ConsensusSnapshot(
-                random.nextLong(),
-                List.of(randomHash(random), randomHash(random), randomHash(random)),
-                minimumJudgeInfo,
-                random.nextLong(),
-                randomInstant(random)));
+        platformStateFacade.setSnapshotTo(
+                state,
+                new ConsensusSnapshot(
+                        random.nextLong(),
+                        List.of(randomHash(random), randomHash(random), randomHash(random)),
+                        minimumJudgeInfo,
+                        random.nextLong(),
+                        randomInstant(random)));
 
-        return platformState;
+        return platformStateFacade.getWritablePlatformStateOf(state);
     }
 }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/SignedStateUtils.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/com/swirlds/platform/test/SignedStateUtils.java
@@ -25,6 +25,7 @@ import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
+import com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade;
 import java.util.Random;
 
 public class SignedStateUtils {
@@ -34,10 +35,12 @@ public class SignedStateUtils {
     }
 
     public static SignedState randomSignedState(Random random) {
+        TestPlatformStateFacade platformStateFacade =
+                new TestPlatformStateFacade(version -> new BasicSoftwareVersion(version.major()));
         PlatformMerkleStateRoot root =
                 new PlatformMerkleStateRoot(version -> new BasicSoftwareVersion(version.minor()));
         FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(root);
-        randomPlatformState(random, root.getWritablePlatformState());
+        randomPlatformState(random, root, platformStateFacade);
         boolean shouldSaveToDisk = random.nextBoolean();
         SignedState signedState = new SignedState(
                 TestPlatformContextBuilder.create().build().getConfiguration(),
@@ -46,7 +49,8 @@ public class SignedStateUtils {
                 "test",
                 shouldSaveToDisk,
                 false,
-                false);
+                false,
+                platformStateFacade);
         signedState.getState().setHash(RandomUtils.randomHash(random));
         return signedState;
     }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/main/java/module-info.java
@@ -21,10 +21,10 @@ module com.swirlds.platform.test {
     requires transitive com.swirlds.component.framework;
     requires transitive com.swirlds.platform.core.test.fixtures;
     requires transitive com.swirlds.platform.core;
+    requires transitive com.swirlds.state.api;
     requires com.hedera.node.hapi;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions.test.fixtures;
-    requires com.swirlds.state.api;
     requires java.desktop;
     requires org.junit.jupiter.api;
     requires static transitive com.github.spotbugs.annotations;

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformStateTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/PlatformStateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,23 @@
 package com.swirlds.platform.test;
 
 import static com.swirlds.platform.test.PlatformStateUtils.randomPlatformState;
+import static com.swirlds.platform.test.fixtures.state.FakeStateLifecycles.FAKE_MERKLE_STATE_LIFECYCLES;
+import static com.swirlds.platform.test.fixtures.state.FakeStateLifecycles.registerMerkleStateRootClassIds;
+import static com.swirlds.platform.test.fixtures.state.TestPlatformStateFacade.TEST_PLATFORM_STATE_FACADE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.constructable.ConstructableRegistryException;
 import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.common.test.fixtures.io.InputOutputStream;
 import com.swirlds.common.test.fixtures.junit.tags.TestComponentTags;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.platform.state.PlatformMerkleStateRoot;
 import com.swirlds.platform.state.PlatformState;
+import com.swirlds.platform.system.BasicSoftwareVersion;
+import com.swirlds.state.merkle.MerkleStateRoot;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -78,19 +83,21 @@ class PlatformStateTests {
     @DisplayName("Platform State Serialization Test")
     @SuppressWarnings("resource")
     void platformStateSerializationTest() throws IOException, ConstructableRegistryException {
-        ConstructableRegistry.getInstance().registerConstructables("com.swirlds");
+        registerMerkleStateRootClassIds();
+        final MerkleStateRoot root = new PlatformMerkleStateRoot(v -> new BasicSoftwareVersion(1));
+        FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(root);
 
         final InputOutputStream io = new InputOutputStream();
-        final PlatformState state = (PlatformState) randomPlatformState(new PlatformState());
-        io.getOutput().writeMerkleTree(testDirectory, state);
+        randomPlatformState(root, TEST_PLATFORM_STATE_FACADE);
+        io.getOutput().writeMerkleTree(testDirectory, root);
 
         io.startReading();
 
-        final PlatformState decodedState = io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
+        final MerkleStateRoot decodedState = io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
-        MerkleCryptoFactory.getInstance().digestTreeSync(state);
+        MerkleCryptoFactory.getInstance().digestTreeSync(root);
         MerkleCryptoFactory.getInstance().digestTreeSync(decodedState);
 
-        assertEquals(state.getHash(), decodedState.getHash(), "expected deserialized object to be equal");
+        assertEquals(root.getHash(), decodedState.getHash(), "expected deserialized object to be equal");
     }
 }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
@@ -28,6 +28,7 @@ import com.swirlds.common.test.fixtures.junit.tags.TestComponentTags;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.state.PlatformMerkleStateRoot;
+import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.BasicSoftwareVersion;
 import java.util.Random;
@@ -93,7 +94,8 @@ class StateTest {
                 "test",
                 shouldSaveToDisk,
                 false,
-                false);
+                false,
+                new PlatformStateFacade(version -> new BasicSoftwareVersion(version.major())));
         signedState.getState().setHash(RandomUtils.randomHash(random));
         return signedState;
     }


### PR DESCRIPTION
**Description**:

This is the second part for the PR that was too big and difficult to review (https://github.com/hashgraph/hedera-services/pull/17585). This part introduces `PlatformStateFacade`, a class that that is responsible for providing access to the platform state. In the follow up PR it will help to get rid of `PlatformMerkleStateRoot`


**Related issue(s)**:

Partially fixes #17357 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
