### PR TITLE
chore: cherry-pick: 17682 always use current `PreHandleResult` when checking for `STATE_SIGNATURE_TRANSACTION`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,14 @@ public interface BlockRecordManager extends BlockRecordInfo, AutoCloseable {
      * @return true if a new block was created, false otherwise
      */
     boolean startUserTransaction(@NonNull Instant consensusTime, @NonNull State state);
+
+    /**
+     * Check if a user transaction will start a new block, without any side effects.
+     * @param consensusTime the current consensus time
+     * @param state the state to read BlockInfo from
+     * @return true if a new block will be created, false otherwise
+     */
+    boolean willOpenNewBlock(@NonNull Instant consensusTime, @NonNull State state);
 
     /**
      * "Advances the consensus clock" by updating the latest consensus timestamp that the node has handled. This should

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -46,7 +46,6 @@ import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.input.EventHeader;
 import com.hedera.hapi.block.stream.input.RoundHeader;
 import com.hedera.hapi.block.stream.output.StateChanges;
-import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.base.Transaction;
@@ -96,7 +95,6 @@ import com.hedera.node.app.workflows.handle.steps.HollowAccountCompletions;
 import com.hedera.node.app.workflows.handle.steps.StakePeriodChanges;
 import com.hedera.node.app.workflows.handle.steps.UserTxn;
 import com.hedera.node.app.workflows.handle.steps.UserTxnFactory;
-import com.hedera.node.app.workflows.prehandle.PreHandleResult;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.ConsensusConfig;
@@ -367,18 +365,14 @@ public class HandleWorkflow {
             final boolean userTxnHandled) {
         final var handleStart = System.nanoTime();
 
-        // Temporary check until we can deprecate StateSignatureTransaction
-        if (stateSignatureTransactionEncountered(txn, stateSignatureTxnCallback)) {
-            return false;
-        }
-
         // Always use platform-assigned time for user transaction, c.f. https://hips.hedera.com/hip/hip-993
         final var consensusNow = txn.getConsensusTimestamp();
         var type = ORDINARY_TRANSACTION;
         stakePeriodManager.setCurrentStakePeriodFor(consensusNow);
+        boolean startsNewRecordFile = false;
         if (streamMode != BLOCKS) {
-            final var isBoundary = blockRecordManager.startUserTransaction(consensusNow, state);
-            if (streamMode == RECORDS && isBoundary) {
+            startsNewRecordFile = blockRecordManager.willOpenNewBlock(consensusNow, state);
+            if (streamMode == RECORDS && startsNewRecordFile) {
                 type = typeOfBoundary(state);
             }
         }
@@ -389,7 +383,14 @@ public class HandleWorkflow {
                 default -> ORDINARY_TRANSACTION;};
         }
 
-        final var userTxn = userTxnFactory.createUserTxn(state, creator, txn, consensusNow, type);
+        final var userTxn =
+                userTxnFactory.createUserTxn(state, creator, txn, consensusNow, type, stateSignatureTxnCallback);
+        if (userTxn == null) {
+            return false;
+        } else if (streamMode != BLOCKS && startsNewRecordFile) {
+            blockRecordManager.startUserTransaction(consensusNow, state);
+        }
+
         var lastRecordManagerTime = streamMode == RECORDS ? blockRecordManager.consTimeOfLastHandledTxn() : null;
         final var handleOutput = executeTopLevel(userTxn, txnVersion, state);
         if (streamMode != BLOCKS) {
@@ -433,18 +434,6 @@ public class HandleWorkflow {
             }
         }
         return true;
-    }
-
-    private boolean stateSignatureTransactionEncountered(
-            @NonNull final ConsensusTransaction txn,
-            @NonNull final Consumer<StateSignatureTransaction> stateSignatureTxnCallback) {
-        if (txn.getMetadata() instanceof PreHandleResult preHandleResult
-                && preHandleResult.txInfo() != null
-                && preHandleResult.txInfo().functionality() == HederaFunctionality.STATE_SIGNATURE_TRANSACTION) {
-            stateSignatureTxnCallback.accept(preHandleResult.txInfo().txBody().stateSignatureTransactionOrThrow());
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxnFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/UserTxnFactory.java
@@ -16,6 +16,7 @@
 
 package com.hedera.node.app.workflows.handle.steps;
 
+import static com.hedera.hapi.node.base.HederaFunctionality.STATE_SIGNATURE_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.SCHEDULED;
 import static com.hedera.node.app.workflows.handle.TransactionType.GENESIS_TRANSACTION;
@@ -34,6 +35,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.hedera.node.app.blocks.BlockStreamManager;
 import com.hedera.node.app.blocks.impl.BoundaryStateChangeListener;
 import com.hedera.node.app.blocks.impl.KVStateChangeListener;
@@ -84,7 +86,9 @@ import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.info.NetworkInfo;
 import com.swirlds.state.lifecycle.info.NodeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -158,14 +162,16 @@ public class UserTxnFactory {
      * @param platformTxn the transaction itself
      * @param consensusNow the current consensus time
      * @param type the type of the transaction
-     * @return the new user transaction
+     * @param stateSignatureTxnCallback a callback to be called when encountering a {@link StateSignatureTransaction}
+     * @return the new user transaction, or {@code null} if the transaction is not a user transaction
      */
-    public UserTxn createUserTxn(
+    public @Nullable UserTxn createUserTxn(
             @NonNull final State state,
             @NonNull final NodeInfo creatorInfo,
             @NonNull final ConsensusTransaction platformTxn,
             @NonNull final Instant consensusNow,
-            @NonNull final TransactionType type) {
+            @NonNull final TransactionType type,
+            @NonNull final Consumer<StateSignatureTransaction> stateSignatureTxnCallback) {
         requireNonNull(state);
         requireNonNull(creatorInfo);
         requireNonNull(platformTxn);
@@ -174,9 +180,12 @@ public class UserTxnFactory {
         final var config = configProvider.getConfiguration();
         final var stack = createRootSavepointStack(state, type);
         final var readableStoreFactory = new ReadableStoreFactory(stack);
-        final var preHandleResult =
-                preHandleWorkflow.getCurrentPreHandleResult(creatorInfo, platformTxn, readableStoreFactory);
+        final var preHandleResult = preHandleWorkflow.getCurrentPreHandleResult(
+                creatorInfo, platformTxn, readableStoreFactory, stateSignatureTxnCallback);
         final var txnInfo = requireNonNull(preHandleResult.txInfo());
+        if (txnInfo.functionality() == STATE_SIGNATURE_TRANSACTION) {
+            return null;
+        }
         final var tokenContext = new TokenContextImpl(config, storeMetricsService, stack, consensusNow);
         return new UserTxn(
                 type,
@@ -363,7 +372,7 @@ public class UserTxnFactory {
      * @param type the type of the transaction
      * @return the new root savepoint stack
      */
-    private SavepointStackImpl createRootSavepointStack(
+    public SavepointStackImpl createRootSavepointStack(
             @NonNull final State state, @NonNull final TransactionType type) {
         final var config = configProvider.getConfiguration();
         final var consensusConfig = config.getConfigData(ConsensusConfig.class);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflow.java
@@ -102,13 +102,15 @@ public interface PreHandleWorkflow {
      * @param creator the node that created the transaction
      * @param platformTxn the transaction to be verified
      * @param storeFactory the store factory
+     * @param stateSignatureTxnCallback a callback to be called when encountering a {@link StateSignatureTransaction}
      * @return the verification data for the transaction
      */
     @NonNull
     default PreHandleResult getCurrentPreHandleResult(
             @NonNull final NodeInfo creator,
             @NonNull final ConsensusTransaction platformTxn,
-            @NonNull final ReadableStoreFactory storeFactory) {
+            @NonNull final ReadableStoreFactory storeFactory,
+            @NonNull final Consumer<StateSignatureTransaction> stateSignatureTxnCallback) {
         final var metadata = platformTxn.getMetadata();
         final PreHandleResult previousResult;
         if (metadata instanceof PreHandleResult result) {
@@ -131,6 +133,6 @@ public interface PreHandleWorkflow {
                 storeFactory.getStore(ReadableAccountStore.class),
                 platformTxn,
                 previousResult,
-                txns -> {});
+                stateSignatureTxnCallback);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneDispatchFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneDispatchFactory.java
@@ -153,8 +153,8 @@ public class StandaloneDispatchFactory {
         final var readableStoreFactory = new ReadableStoreFactory(stack);
         final var consensusTransaction = consensusTransactionFor(transactionBody);
         final var creatorInfo = creatorInfoFor(transactionBody);
-        final var preHandleResult =
-                preHandleWorkflow.getCurrentPreHandleResult(creatorInfo, consensusTransaction, readableStoreFactory);
+        final var preHandleResult = preHandleWorkflow.getCurrentPreHandleResult(
+                creatorInfo, consensusTransaction, readableStoreFactory, ignore -> {});
         final var tokenContext = new TokenContextImpl(config, storeMetricsService, stack, consensusNow);
         final var txnInfo = requireNonNull(preHandleResult.txInfo());
         final var writableStoreFactory = new WritableStoreFactory(

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockOpeningTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockOpeningTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.records.impl;
+
+import static com.hedera.hapi.util.HapiUtils.asTimestamp;
+import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
+import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCK_INFO_STATE_KEY;
+import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING_HASHES_STATE_KEY;
+import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_KEY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.state.blockrecords.BlockInfo;
+import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.hapi.platform.state.PlatformState;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.VersionedConfigImpl;
+import com.swirlds.state.State;
+import com.swirlds.state.spi.ReadableSingletonState;
+import com.swirlds.state.spi.ReadableStates;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlockOpeningTest {
+    private static final Instant CONSENSUS_NOW = Instant.ofEpochSecond(1_234_567L, 890);
+
+    @Mock
+    private State state;
+
+    @Mock
+    private ConfigProvider configProvider;
+
+    @Mock
+    private ReadableSingletonState<BlockInfo> blockInfoState;
+
+    @Mock
+    private ReadableSingletonState<PlatformState> platformState;
+
+    @Mock
+    private ReadableSingletonState<RunningHashes> runningHashesState;
+
+    @Mock
+    private ReadableStates readableStates;
+
+    @Mock
+    private BlockRecordStreamProducer streamFileProducer;
+
+    private BlockRecordManagerImpl subject;
+
+    @Test
+    void firstTransactionAlwaysOpensBlock() {
+        setupBlockInfo(Instant.EPOCH);
+        assertTrue(subject.willOpenNewBlock(CONSENSUS_NOW, state));
+    }
+
+    @Test
+    void newPeriodOpensBlock() {
+        setupBlockInfo(CONSENSUS_NOW);
+        assertTrue(subject.willOpenNewBlock(CONSENSUS_NOW.plusSeconds(86_400), state));
+    }
+
+    @Test
+    void samePeriodWithNoFreezeTimeDoesntOpenBlock() {
+        setupBlockInfo(CONSENSUS_NOW);
+        given(readableStates.<PlatformState>getSingleton(PLATFORM_STATE_KEY)).willReturn(platformState);
+        given(platformState.get()).willReturn(PlatformState.DEFAULT);
+        assertFalse(subject.willOpenNewBlock(CONSENSUS_NOW, state));
+    }
+
+    @Test
+    void samePeriodWithFreezeTimeOpensBlock() {
+        setupBlockInfo(CONSENSUS_NOW);
+        given(readableStates.<PlatformState>getSingleton(PLATFORM_STATE_KEY)).willReturn(platformState);
+        given(platformState.get())
+                .willReturn(PlatformState.newBuilder()
+                        .freezeTime(Timestamp.DEFAULT)
+                        .lastFrozenTime(Timestamp.DEFAULT)
+                        .build());
+        assertTrue(subject.willOpenNewBlock(CONSENSUS_NOW, state));
+    }
+
+    private void setupBlockInfo(@NonNull final Instant firstConsTimeOfCurrentBlock) {
+        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(DEFAULT_CONFIG, 1));
+        given(state.getReadableStates(any())).willReturn(readableStates);
+        given(readableStates.<BlockInfo>getSingleton(BLOCK_INFO_STATE_KEY)).willReturn(blockInfoState);
+        given(blockInfoState.get())
+                .willReturn(BlockInfo.newBuilder()
+                        .firstConsTimeOfCurrentBlock(asTimestamp(firstConsTimeOfCurrentBlock))
+                        .build());
+        given(readableStates.<RunningHashes>getSingleton(RUNNING_HASHES_STATE_KEY))
+                .willReturn(runningHashesState);
+        given(runningHashesState.get()).willReturn(RunningHashes.DEFAULT);
+
+        subject = new BlockRecordManagerImpl(configProvider, state, streamFileProducer);
+    }
+}


### PR DESCRIPTION
**Description**:
Cherry picks commit `10f1bcf` always use current PreHandleResult when checking for STATE_SIGNATURE_TRANSACTION for release 0.59.

**Related issue(s)**:

Fixes #17682

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
