### PR TITLE
fix: solder missing wire for state signature collecting

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -630,7 +630,7 @@ public class PlatformWiring {
                         "system transactions",
                         StateAndRound::systemTransactions);
 
-        hashedStateAndRoundOutputWire.solderTo(stateAndRoundTransformer.getInputWire());
+        stateHasherWiring.getOutputWire().solderTo(stateAndRoundTransformer.getInputWire());
         transactionHandlerWiring.getOutputWire().solderTo(stateAndRoundTransformer.getInputWire());
 
         stateAndRoundTransformer

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -622,12 +622,19 @@ public class PlatformWiring {
                 hashedStateAndRoundOutputWire.buildAdvancedTransformer(
                         new StateAndRoundToStateReserver("postHasher_stateReserver"));
 
-        transactionHandlerWiring
+        // Extract signatures from post-consensus events for input to the StateSignatureCollector.
+        final WireTransformer<StateAndRound, Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
+                stateAndRoundTransformer = new WireTransformer<>(
+                        model,
+                        "getSystemTransactionsFromStateAndRound",
+                        "system transactions",
+                        StateAndRound::systemTransactions);
+
+        hashedStateAndRoundOutputWire.solderTo(stateAndRoundTransformer.getInputWire());
+        transactionHandlerWiring.getOutputWire().solderTo(stateAndRoundTransformer.getInputWire());
+
+        stateAndRoundTransformer
                 .getOutputWire()
-                .buildTransformer(
-                        "getSystemTransactions",
-                        "stateAndRound with system transactions",
-                        StateAndRound::systemTransactions)
                 .solderTo(stateSignatureCollectorWiring.getInputWire(
                         StateSignatureCollector::handlePostconsensusSignatures));
 


### PR DESCRIPTION
**Description**:
This PR adds missing wire soldering that collects state signatures after state hashing.

**Related issue(s)**: #16707 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
