### PR TITLE
fix: revert unnecessary output wire

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -622,19 +622,12 @@ public class PlatformWiring {
                 hashedStateAndRoundOutputWire.buildAdvancedTransformer(
                         new StateAndRoundToStateReserver("postHasher_stateReserver"));
 
-        // Extract signatures from post-consensus events for input to the StateSignatureCollector.
-        final WireTransformer<StateAndRound, Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
-                stateAndRoundTransformer = new WireTransformer<>(
-                        model,
-                        "getSystemTransactionsFromStateAndRound",
-                        "system transactions",
-                        StateAndRound::systemTransactions);
-
-        stateHasherWiring.getOutputWire().solderTo(stateAndRoundTransformer.getInputWire());
-        transactionHandlerWiring.getOutputWire().solderTo(stateAndRoundTransformer.getInputWire());
-
-        stateAndRoundTransformer
+        transactionHandlerWiring
                 .getOutputWire()
+                .buildTransformer(
+                        "getSystemTransactions",
+                        "stateAndRound with system transactions",
+                        StateAndRound::systemTransactions)
                 .solderTo(stateSignatureCollectorWiring.getInputWire(
                         StateSignatureCollector::handlePostconsensusSignatures));
 


### PR DESCRIPTION
**Description**:
This PR removes changes from a previous commit that adds unnecessary output wire.

**Related issue(s)**: #16707 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
