### PR TITLE
test: enhance Turtle with temporary test directory

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/Turtle.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/Turtle.java
@@ -127,7 +127,7 @@ public class Turtle {
                     addressBook,
                     addressBookBuilder.getPrivateKeys(nodeId),
                     network,
-                    builder.getTestDirectory().resolve("node-" + nodeId.id())));
+                    builder.getOutputDirectory().resolve("node-" + nodeId.id())));
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleBuilder.java
@@ -43,7 +43,7 @@ public class TurtleBuilder {
     private Duration simulationGranularity = Duration.ofMillis(10);
     private int nodeCount = 4;
     private boolean timeReportingEnabled;
-    private Path testDirectory;
+    private Path outputDirectory;
 
     /**
      * Create a new TurtleBuilder.
@@ -143,12 +143,12 @@ public class TurtleBuilder {
     /**
      * Set node output directory.
      *
-     * @param testDirectory the directory where node output will be stored, like saved state and so on
+     * @param outputDirectory the directory where node output will be stored, like saved state and so on
      * @return this builder
      */
     @NonNull
-    public TurtleBuilder withTestDirectory(@NonNull final Path testDirectory) {
-        this.testDirectory = testDirectory;
+    public TurtleBuilder withOutputDirectory(@NonNull final Path outputDirectory) {
+        this.outputDirectory = outputDirectory;
         return this;
     }
 
@@ -158,8 +158,8 @@ public class TurtleBuilder {
      * @return the directory where the node output will be stored, like saved state and so on
      */
     @NonNull
-    Path getTestDirectory() {
-        return testDirectory;
+    Path getOutputDirectory() {
+        return outputDirectory;
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
@@ -82,7 +82,7 @@ public class TurtleNode {
      * @param addressBook the address book for the network
      * @param privateKeys the private keys for this node
      * @param network     the simulated network
-     * @param testDirectory the directory where the node output will be stored, like saved state and so on
+     * @param outputDirectory the directory where the node output will be stored, like saved state and so on
      */
     TurtleNode(
             @NonNull final Randotron randotron,
@@ -91,13 +91,13 @@ public class TurtleNode {
             @NonNull final AddressBook addressBook,
             @NonNull final KeysAndCerts privateKeys,
             @NonNull final SimulatedNetwork network,
-            @NonNull final Path testDirectory) {
+            @NonNull final Path outputDirectory) {
 
         final Configuration configuration = new TestConfigBuilder()
                 .withValue(PlatformSchedulersConfig_.CONSENSUS_EVENT_STREAM, "NO_OP")
                 .withValue(BasicConfig_.JVM_PAUSE_DETECTOR_SLEEP_MS, "0")
-                .withValue(StateCommonConfig_.SAVED_STATE_DIRECTORY, testDirectory.toString())
-                .withValue(FileSystemManagerConfig_.ROOT_PATH, testDirectory.toString())
+                .withValue(StateCommonConfig_.SAVED_STATE_DIRECTORY, outputDirectory.toString())
+                .withValue(FileSystemManagerConfig_.ROOT_PATH, outputDirectory.toString())
                 .getOrCreateConfig();
 
         setupGlobalMetrics(configuration);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTests.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 class TurtleTests {
 
     @TempDir
-    Path testDirectory;
+    Path outputDirectory;
 
     /**
      * Simulate a turtle network for 5 minutes.
@@ -51,7 +51,7 @@ class TurtleTests {
                 .withNodeCount(4)
                 .withSimulationGranularity(Duration.ofMillis(10))
                 .withTimeReportingEnabled(true)
-                .withTestDirectory(testDirectory)
+                .withOutputDirectory(outputDirectory)
                 .build();
 
         turtle.start();


### PR DESCRIPTION
**Description**:

Currently, when TurtleTests are run, they save some data in platform-sdk/swirlds-platform-core/data/saved.

Instead of using a folder from the project root, redirect all test output writing to a TempDir folder used for tests only.

**Related issue(s)**:

Fixes #17645 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
