### PR TITLE
fix: 17803: LongListOffHeap snapshots + updates are broken

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1081,6 +1081,10 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                             (System.currentTimeMillis() - START) * UnitConstants.MILLISECONDS_TO_SECONDS);
                     return true; // turns this into a callable, so it can throw checked
                     // exceptions
+                } catch (final Throwable t) {
+                    // log and rethrow
+                    logger.error(EXCEPTION.getMarker(), "[{}] Snapshot {} failed", tableName, taskName, t);
+                    throw t;
                 } finally {
                     countDownLatch.countDown();
                 }

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
@@ -307,8 +307,7 @@ public abstract class AbstractLongList<C> implements LongList {
 
     /**
      * Reads a specified range of elements from a file channel into the given buffer, starting from
-     * the given start index (inc) and up to the given end index (exc). After this call, buffer
-     * possible will be set to 0, and buffer limit will be set to its capacity.
+     * the given start index (inc) and up to the given end index (exc).
      * <p>
      * This method computes the appropriate byte offsets within the buffer and the number of bytes
      * to read based on the provided {@code startIndex} and {@code endIndex}. It then performs a
@@ -341,10 +340,6 @@ public abstract class AbstractLongList<C> implements LongList {
             throw new IOException("Failed to read chunks, chunkIndex=" + chunkIndex + " expected=" + bytesToRead
                     + " actual=" + bytesRead);
         }
-
-        // Clear buffer position / limit. Some long list implementations (e.g. off-heap lists) may
-        // use the buffer internally. Let them handle the position and the limit as needed.
-        buffer.clear();
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
@@ -306,7 +306,9 @@ public abstract class AbstractLongList<C> implements LongList {
     }
 
     /**
-     * Reads a specified range of elements from a file channel into the given buffer.
+     * Reads a specified range of elements from a file channel into the given buffer, starting from
+     * the given start index (inc) and up to the given end index (exc). After this call, buffer
+     * possible will be set to 0, and buffer limit will be set to its capacity.
      * <p>
      * This method computes the appropriate byte offsets within the buffer and the number of bytes
      * to read based on the provided {@code startIndex} and {@code endIndex}. It then performs a
@@ -339,6 +341,10 @@ public abstract class AbstractLongList<C> implements LongList {
             throw new IOException("Failed to read chunks, chunkIndex=" + chunkIndex + " expected=" + bytesToRead
                     + " actual=" + bytesRead);
         }
+
+        // Clear buffer position / limit. Some long list implementations (e.g. off-heap lists) may
+        // use the buffer internally. Let them handle the position and the limit as needed.
+        buffer.clear();
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
@@ -300,7 +300,7 @@ public class LongListDisk extends AbstractLongList<Long> {
                 }
                 if (i == (totalNumOfChunks - 1)) {
                     // the last array, so set limit to only the data needed
-                    final long bytesWrittenSoFar = (long) memoryChunkSize * (long) i;
+                    final long bytesWrittenSoFar = (long) memoryChunkSize * i;
                     final long remainingBytes = (size() * Long.BYTES) - bytesWrittenSoFar;
                     transferBuffer.limit(toIntExact(remainingBytes));
                 } else {

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListHeap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListHeap.java
@@ -108,8 +108,11 @@ public final class LongListHeap extends AbstractLongList<AtomicLongArray> {
         AtomicLongArray chunk = createChunk();
 
         readDataIntoBuffer(fileChannel, chunkIndex, startIndex, endIndex, initReadBuffer);
+
         final int startOffset = startIndex * Long.BYTES;
+        final int endOffset = endIndex * Long.BYTES;
         initReadBuffer.position(startOffset);
+        initReadBuffer.limit(endOffset);
 
         while (initReadBuffer.hasRemaining()) {
             int index = initReadBuffer.position() / Long.BYTES;

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
@@ -91,6 +91,8 @@ public final class LongListOffHeap extends AbstractLongList<ByteBuffer> implemen
             throws IOException {
         ByteBuffer chunk = createChunk();
         readDataIntoBuffer(fileChannel, chunkIndex, startIndex, endIndex, chunk);
+        // Chunk position is now 0 and its limit is memoryChunkSize. When this long list is
+        // written to a file, chunk position and limit are taken care of
         return chunk;
     }
 
@@ -152,8 +154,8 @@ public final class LongListOffHeap extends AbstractLongList<ByteBuffer> implemen
                 }
                 if (i == (totalNumOfChunks - 1)) {
                     // last array, so set limit to only the data needed
-                    final long bytesWrittenSoFar = (long) memoryChunkSize * (long) i;
-                    final long remainingBytes = (size() * Long.BYTES) - bytesWrittenSoFar;
+                    final long bytesWrittenSoFar = (long) memoryChunkSize * i;
+                    final long remainingBytes = size() * Long.BYTES - bytesWrittenSoFar;
                     buf.limit(toIntExact(remainingBytes));
                 } else {
                     buf.limit(buf.capacity());

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListOffHeap.java
@@ -91,8 +91,10 @@ public final class LongListOffHeap extends AbstractLongList<ByteBuffer> implemen
             throws IOException {
         ByteBuffer chunk = createChunk();
         readDataIntoBuffer(fileChannel, chunkIndex, startIndex, endIndex, chunk);
-        // Chunk position is now 0 and its limit is memoryChunkSize. When this long list is
-        // written to a file, chunk position and limit are taken care of
+        // All chunks (byte buffers) in LongListOffHeap are stored with position == 0 and
+        // limit == capacity. When this list is written to a file, the first and the last
+        // chunk positions and limits are taken care of
+        chunk.clear();
         return chunk;
     }
 

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -495,6 +495,38 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
         }
     }
 
+    @Test
+    void testUpdateSnapshotUpdate() throws IOException {
+        try (final LongList longList = createFullyParameterizedLongListWith(100, MAX_LONGS)) {
+            longList.updateValidRange(0, 50);
+            longList.put(2, 1002);
+            final Path tmpDir = Files.createTempDirectory("testUpdateSnapshotUpdate");
+            final Path tmpFile = tmpDir.resolve("snapshot");
+            longList.writeToFile(tmpFile);
+            try (final LongList restored = createLongListFromFile(tmpFile)) {
+                restored.updateValidRange(0, 50);
+                assertEquals(3, restored.size());
+                assertEquals(1002, restored.get(2));
+                restored.put(3, 1003);
+                final Path tmpDir2 = Files.createTempDirectory("testUpdateSnapshotUpdate");
+                final Path tmpFile2 = tmpDir2.resolve("snapshot");
+                restored.writeToFile(tmpFile2);
+                try (final LongList restored2 = createLongListFromFile(tmpFile2)) {
+                    restored2.updateValidRange(0, 50);
+                    assertEquals(4, restored2.size());
+                    assertEquals(1002, restored2.get(2));
+                    assertEquals(1003, restored2.get(3));
+                } finally {
+                    Files.delete(tmpFile2);
+                    Files.delete(tmpDir2);
+                }
+            } finally {
+                Files.delete(tmpFile);
+                Files.delete(tmpDir);
+            }
+        }
+    }
+
     // Parametrized tests to test cross compatibility between the Long List implementations
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -496,11 +496,11 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
     }
 
     @Test
-    void testUpdateSnapshotUpdate() throws IOException {
+    void testRestoreUpdateSnapshot() throws IOException {
         try (final LongList longList = createFullyParameterizedLongListWith(100, MAX_LONGS)) {
             longList.updateValidRange(0, 50);
             longList.put(2, 1002);
-            final Path tmpDir = Files.createTempDirectory("testUpdateSnapshotUpdate");
+            final Path tmpDir = Files.createTempDirectory("testRestoreUpdateSnapshot");
             final Path tmpFile = tmpDir.resolve("snapshot");
             longList.writeToFile(tmpFile);
             try (final LongList restored = createLongListFromFile(tmpFile)) {
@@ -508,7 +508,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 assertEquals(3, restored.size());
                 assertEquals(1002, restored.get(2));
                 restored.put(3, 1003);
-                final Path tmpDir2 = Files.createTempDirectory("testUpdateSnapshotUpdate");
+                final Path tmpDir2 = Files.createTempDirectory("testRestoreUpdateSnapshot");
                 final Path tmpFile2 = tmpDir2.resolve("snapshot");
                 restored.writeToFile(tmpFile2);
                 try (final LongList restored2 = createLongListFromFile(tmpFile2)) {


### PR DESCRIPTION
Fix summary:
* `AbstractLongList.readDataIntoBuffer()` is changed, so it doesn't set buffer position/limit
* In case of `LongListHeap` and `LongListDisk` the returned buffer isn't used directly, and they set the position/limit anyway
* In case of `LongListOffHeap` the buffer is used directly as a chunk. It's now consistent with all other chunks, they never have position/limit set
* When a `LongListOffHeap` is written to a file, the first and the last chunks are handled appropriately, no need to change that code
* A new unit test is provided

Fixes: https://github.com/hashgraph/hedera-services/issues/17803
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
