### PR TITLE
chore: Enforce node<id+1> names in EnhancedKeyStoreLoader with RosterUtils

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeId.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/platform/NodeId.java
@@ -141,16 +141,6 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
     }
 
     /**
-     *  Returns the string representing the name of this {@link NodeId} using convention
-     * "nodeX" where X is {@link NodeId#id()} + 1
-     * @return "nodeX" where X = this.id + 1. E.g.: {@link NodeId#FIRST_NODE_ID} is "node1".
-     */
-    @NonNull
-    public String nameString() {
-        return "node" + (id + 1);
-    }
-
-    /**
      * {@inheritDoc}
      */
     @NonNull

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -35,6 +35,7 @@ import com.swirlds.platform.Utilities;
 import com.swirlds.platform.config.BasicConfig;
 import com.swirlds.platform.config.PathsConfig;
 import com.swirlds.platform.network.PeerInfo;
+import com.swirlds.platform.roster.RosterUtils;
 import com.swirlds.platform.system.SystemExitCode;
 import com.swirlds.platform.system.SystemExitUtils;
 import com.swirlds.platform.system.address.Address;
@@ -324,7 +325,7 @@ public final class CryptoStatic {
      * @return the file name that is supposed to store the private key for the supplied member
      */
     private static String getPrivateKeysFileName(final NodeId nodeId) {
-        return "private-" + nodeId.nameString() + ".pfx";
+        return "private-" + RosterUtils.formatNodeName(nodeId) + ".pfx";
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeyCertPurpose.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeyCertPurpose.java
@@ -17,6 +17,7 @@
 package com.swirlds.platform.crypto;
 
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.platform.roster.RosterUtils;
 
 /**
  * Denotes which of the three purposes a key or certificate serves
@@ -37,7 +38,7 @@ public enum KeyCertPurpose {
      * @return the name of the key or certificate used in a KeyStore for this member and key type
      */
     public String storeName(final NodeId nodeId) {
-        return prefix + "-" + nodeId.nameString();
+        return prefix + "-" + RosterUtils.formatNodeName(nodeId);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeysAndCerts.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeysAndCerts.java
@@ -18,6 +18,7 @@ package com.swirlds.platform.crypto;
 
 import com.swirlds.common.crypto.internal.CryptoUtils;
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.platform.roster.RosterUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.Key;
 import java.security.KeyPair;
@@ -172,8 +173,9 @@ public record KeysAndCerts(
         final KeyPair sigKeyPair = sigKeyGen.generateKeyPair();
         final KeyPair agrKeyPair = agrKeyGen.generateKeyPair();
 
-        final String dnS = CryptoStatic.distinguishedName("s-" + nodeId.nameString());
-        final String dnA = CryptoStatic.distinguishedName("a-" + nodeId.nameString());
+        final String nodeName = RosterUtils.formatNodeName(nodeId);
+        final String dnS = CryptoStatic.distinguishedName("s-" + nodeName);
+        final String dnA = CryptoStatic.distinguishedName("a-" + nodeName);
 
         // create the 2 certs (java.security.cert.Certificate)
         // both are signed by sigKeyPair, so sigCert is self-signed

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -71,6 +71,19 @@ public final class RosterUtils {
     }
 
     /**
+     * Formats a "node name" for a given node id, e.g. "node1" for nodeId == 0.
+     * This name can be used for logging purposes, or to support code that
+     * uses strings to identify nodes.
+     *
+     * @param nodeId a node id
+     * @return a "node name"
+     */
+    @NonNull
+    public static String formatNodeName(final @NonNull NodeId nodeId) {
+        return formatNodeName(nodeId.id());
+    }
+
+    /**
      * Fetch the gossip certificate from a given RosterEntry.  If it cannot be parsed successfully, return null.
      *
      * @param entry a RosterEntry


### PR DESCRIPTION
**Description**:
Change discussed with @anthony-swirldslabs  in [#](https://github.com/hashgraph/hedera-services/pull/17487)
Plus extra javadoc change asked by @lpetrovic05 

**Related issue(s)**:

Fixes #15824

