### PR TITLE
chore: Changed Roster to List<PeerInfo> wherever possible, in preparation for dynamic connections

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
@@ -384,7 +384,12 @@ public final class Utilities {
                 .toList();
     }
 
-    public static @NonNull PeerInfo toPeerInfo(RosterEntry entry) {
+    /**
+     * Converts single roster entry to PeerInfo, which is more abstract class representing information about possible node connection
+     * @param entry data to convert
+     * @return PeerInfo with extracted hostname, port and certificate for remote host
+     */
+    public static @NonNull PeerInfo toPeerInfo(@NonNull RosterEntry entry) {
         Objects.requireNonNull(entry);
         return new PeerInfo(
                 NodeId.of(entry.nodeId()),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.swirlds.platform;
 
 import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
 import com.swirlds.common.io.streams.SerializableDataOutputStream;
@@ -379,12 +380,18 @@ public final class Utilities {
                 // Only include peers with valid gossip certificates
                 // https://github.com/hashgraph/hedera-services/issues/16648
                 .filter(entry -> CryptoStatic.checkCertificate((RosterUtils.fetchGossipCaCertificate(entry))))
-                .map(entry -> new PeerInfo(
-                        NodeId.of(entry.nodeId()),
-                        // Assume that the first ServiceEndpoint describes the external hostname,
-                        // which is the same order in which RosterRetriever.buildRoster(AddressBook) lists them.
-                        Objects.requireNonNull(RosterUtils.fetchHostname(entry, 0)),
-                        Objects.requireNonNull(RosterUtils.fetchGossipCaCertificate(entry))))
+                .map(Utilities::toPeerInfo)
                 .toList();
+    }
+
+    public static @NonNull PeerInfo toPeerInfo(RosterEntry entry) {
+        Objects.requireNonNull(entry);
+        return new PeerInfo(
+                NodeId.of(entry.nodeId()),
+                // Assume that the first ServiceEndpoint describes the external hostname,
+                // which is the same order in which RosterRetriever.buildRoster(AddressBook) lists them.
+                Objects.requireNonNull(RosterUtils.fetchHostname(entry, 0)),
+                RosterUtils.fetchPort(entry, 0),
+                Objects.requireNonNull(RosterUtils.fetchGossipCaCertificate(entry)));
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
@@ -205,7 +205,7 @@ public class SyncGossip implements ConnectionTracker, Gossip {
                 NetworkUtils.createSocketFactory(selfId, peers, keysAndCerts, platformContext.getConfiguration());
         // create an instance that can create new outbound connections
         final OutboundConnectionCreator connectionCreator =
-                new OutboundConnectionCreator(platformContext, selfId, this, socketFactory, roster);
+                new OutboundConnectionCreator(platformContext, selfId, this, socketFactory, peers);
         connectionManagers = new StaticConnectionManagers(topology, connectionCreator);
         final InboundConnectionHandler inboundConnectionHandler = new InboundConnectionHandler(
                 platformContext,
@@ -250,7 +250,7 @@ public class SyncGossip implements ConnectionTracker, Gossip {
         networkMetrics = new NetworkMetrics(platformContext.getMetrics(), selfId, peers);
         platformContext.getMetrics().addUpdater(networkMetrics::update);
 
-        reconnectMetrics = new ReconnectMetrics(platformContext.getMetrics(), roster);
+        reconnectMetrics = new ReconnectMetrics(platformContext.getMetrics(), peers);
 
         final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
 
@@ -383,7 +383,7 @@ public class SyncGossip implements ConnectionTracker, Gossip {
                     .setThreadName("SyncProtocolWith" + otherId)
                     .setHangingThreadPeriod(hangingThreadDuration)
                     .setWork(new ProtocolNegotiatorThread(
-                            connectionManagers.getManager(otherId, topology.shouldConnectTo(otherId)),
+                            connectionManagers.getManager(otherId),
                             syncConfig.syncSleepAfterFailedNegotiation(),
                             handshakeProtocols,
                             new NegotiationProtocols(List.of(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/PeerCommunication.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/PeerCommunication.java
@@ -16,19 +16,13 @@
 
 package com.swirlds.platform.gossip.modular;
 
-import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
-
-import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.threading.framework.StoppableThread;
 import com.swirlds.common.threading.framework.config.StoppableThreadConfiguration;
 import com.swirlds.common.threading.manager.ThreadManager;
-import com.swirlds.platform.Utilities;
 import com.swirlds.platform.config.BasicConfig;
 import com.swirlds.platform.config.ThreadConfig;
-import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.crypto.KeysAndCerts;
 import com.swirlds.platform.gossip.sync.config.SyncConfig;
 import com.swirlds.platform.network.*;
@@ -42,12 +36,9 @@ import com.swirlds.platform.network.protocol.Protocol;
 import com.swirlds.platform.network.protocol.ProtocolRunnable;
 import com.swirlds.platform.network.topology.StaticConnectionManagers;
 import com.swirlds.platform.network.topology.StaticTopology;
-import com.swirlds.platform.roster.RosterUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
@@ -63,48 +54,34 @@ public class PeerCommunication implements ConnectionTracker {
 
     private final NetworkMetrics networkMetrics;
     private final StaticTopology topology;
-    private final Roster roster;
     private final KeysAndCerts keysAndCerts;
     private final PlatformContext platformContext;
     private final List<PeerInfo> peers;
+    private final PeerInfo selfPeer;
 
     /**
      * Create manager of communication with neighbouring nodes for exchanging events.
      *
      * @param platformContext               the platform context
-     * @param roster                        the current roster
-     * @param selfId                        this node's ID
+     * @param peers                        the current list of peers
+     * @param selfPeer                        this node's data
      * @param keysAndCerts                  private keys and public certificates
      */
     public PeerCommunication(
             @NonNull final PlatformContext platformContext,
-            @NonNull final Roster roster,
-            @NonNull final NodeId selfId,
+            @NonNull final List<PeerInfo> peers,
+            @NonNull final PeerInfo selfPeer,
             @NonNull final KeysAndCerts keysAndCerts) {
 
-        this.roster = roster;
         this.keysAndCerts = keysAndCerts;
         this.platformContext = platformContext;
+        this.peers = peers;
+        this.selfPeer = selfPeer;
 
-        final RosterEntry selfEntry = RosterUtils.getRosterEntry(roster, selfId.id());
-        final X509Certificate selfCert = RosterUtils.fetchGossipCaCertificate(selfEntry);
-        if (!CryptoStatic.checkCertificate(selfCert)) {
-            // Do not make peer connections if the self node does not have a valid signing certificate in the roster.
-            // https://github.com/hashgraph/hedera-services/issues/16648
-            logger.error(
-                    EXCEPTION.getMarker(),
-                    "The gossip certificate for node {} is missing or invalid. "
-                            + "This node will not connect to any peers.",
-                    selfId);
-            this.peers = Collections.emptyList();
-        } else {
-            this.peers = Utilities.createPeerInfoList(roster, selfId);
-        }
-
-        this.networkMetrics = new NetworkMetrics(platformContext.getMetrics(), selfId, this.peers);
+        this.networkMetrics = new NetworkMetrics(platformContext.getMetrics(), selfPeer.nodeId(), this.peers);
         platformContext.getMetrics().addUpdater(networkMetrics::update);
 
-        this.topology = new StaticTopology(peers, selfId);
+        this.topology = new StaticTopology(peers, selfPeer.nodeId());
     }
 
     /**
@@ -121,6 +98,10 @@ public class PeerCommunication implements ConnectionTracker {
      */
     public NetworkMetrics getNetworkMetrics() {
         return networkMetrics;
+    }
+
+    public List<PeerInfo> getPeers() {
+        return peers;
     }
 
     List<StoppableThread> buildProtocolThreads(
@@ -141,7 +122,7 @@ public class PeerCommunication implements ConnectionTracker {
                 NetworkUtils.createSocketFactory(selfId, peers, keysAndCerts, platformContext.getConfiguration());
         // create an instance that can create new outbound connections
         final OutboundConnectionCreator connectionCreator =
-                new OutboundConnectionCreator(platformContext, selfId, this, socketFactory, roster);
+                new OutboundConnectionCreator(platformContext, selfId, this, socketFactory, peers);
         var connectionManagers = new StaticConnectionManagers(topology, connectionCreator);
         final InboundConnectionHandler inboundConnectionHandler = new InboundConnectionHandler(
                 platformContext,
@@ -151,7 +132,6 @@ public class PeerCommunication implements ConnectionTracker {
                 connectionManagers::newConnection,
                 platformContext.getTime());
         // allow other members to create connections to me
-        final RosterEntry rosterEntry = RosterUtils.getRosterEntry(roster, selfId.id());
         // Assume all ServiceEndpoints use the same port and use the port from the first endpoint.
         // Previously, this code used a "local port" corresponding to the internal endpoint,
         // which should normally be the second entry in the endpoints list if it's obtained via
@@ -159,8 +139,8 @@ public class PeerCommunication implements ConnectionTracker {
         // The assumption must be correct, otherwise, if ports were indeed different, then the old code
         // using the AddressBook would never have listened on a port associated with the external endpoint,
         // thus not allowing anyone to connect to the node from outside the local network, which we'd have noticed.
-        final ConnectionServer connectionServer = new ConnectionServer(
-                threadManager, RosterUtils.fetchPort(rosterEntry, 0), socketFactory, inboundConnectionHandler::handle);
+        final ConnectionServer connectionServer =
+                new ConnectionServer(threadManager, selfPeer.port(), socketFactory, inboundConnectionHandler::handle);
         syncProtocolThreads.add(new StoppableThreadConfiguration<>(threadManager)
                 .setPriority(threadConfig.threadPrioritySync())
                 .setNodeId(selfId)
@@ -180,7 +160,7 @@ public class PeerCommunication implements ConnectionTracker {
                     .setThreadName("SyncProtocolWith" + otherId)
                     .setHangingThreadPeriod(hangingThreadDuration)
                     .setWork(new ProtocolNegotiatorThread(
-                            connectionManagers.getManager(otherId, topology.shouldConnectTo(otherId)),
+                            connectionManagers.getManager(otherId),
                             syncConfig.syncSleepAfterFailedNegotiation(),
                             handshakeProtocols,
                             new NegotiationProtocols(protocolList.stream()

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/PeerCommunication.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/PeerCommunication.java
@@ -100,6 +100,10 @@ public class PeerCommunication implements ConnectionTracker {
         return networkMetrics;
     }
 
+    /**
+     *
+     * @return list of peers for current static topology
+     */
     public List<PeerInfo> getPeers() {
         return peers;
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/SyncGossipModular.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/SyncGossipModular.java
@@ -187,7 +187,8 @@ public class SyncGossipModular implements Gossip {
                 new VersionCompareHandshake(appVersion, !protocolConfig.tolerateMismatchedVersion());
         final List<ProtocolRunnable> handshakeProtocols = List.of(versionCompareHandshake);
 
-        final List<StoppableThread> threads = network.buildProtocolThreads(threadManager, selfId, handshakeProtocols, protocols);
+        final List<StoppableThread> threads =
+                network.buildProtocolThreads(threadManager, selfId, handshakeProtocols, protocols);
 
         controller.registerThingToStartButNotStop(sharedState.shadowgraphExecutor());
         controller.registerThingsToStart(threads);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ReconnectMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/ReconnectMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,16 @@ package com.swirlds.platform.metrics;
 import static com.swirlds.metrics.api.FloatFormats.FORMAT_10_0;
 import static com.swirlds.metrics.api.Metrics.PLATFORM_CATEGORY;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.metrics.extensions.CountPerSecond;
 import com.swirlds.common.units.TimeUnit;
 import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.LongAccumulator;
 import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.network.PeerInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -90,12 +91,12 @@ public class ReconnectMetrics {
      *
      * @param metrics
      * 		reference to the metrics-system
-     * @param roster the roster reflecting the address book to register metrics for
+     * @param peers the list of peers reflecting the address book to register metrics for
      * @throws IllegalArgumentException if {@code metrics} is {@code null}
      */
-    public ReconnectMetrics(@NonNull final Metrics metrics, @NonNull final Roster roster) {
+    public ReconnectMetrics(@NonNull final Metrics metrics, @NonNull final List<PeerInfo> peers) {
         Objects.requireNonNull(metrics, "metrics");
-        Objects.requireNonNull(roster, "roster");
+        Objects.requireNonNull(peers, "peers");
         senderStartTimes = metrics.getOrCreate(SENDER_START_TIMES_CONFIG);
         receiverStartTimes = metrics.getOrCreate(RECEIVER_START_TIMES_CONFIG);
         senderEndTimes = metrics.getOrCreate(SENDER_END_TIMES_CONFIG);
@@ -103,8 +104,8 @@ public class ReconnectMetrics {
         senderReconnectDurationSeconds = metrics.getOrCreate(SENDER_DURATION_CONFIG);
         receiverReconnectDurationSeconds = metrics.getOrCreate(RECEIVER_DURATION_CONFIG);
 
-        roster.rosterEntries().forEach(entry -> {
-            final long nodeId = entry.nodeId();
+        peers.forEach(entry -> {
+            final long nodeId = entry.nodeId().id();
             rejectionFrequency.put(
                     nodeId,
                     new CountPerSecond(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ConnectionManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/ConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,4 +48,11 @@ public interface ConnectionManager {
      * 		thrown if the thread is interrupted while handing over the new connection
      */
     void newConnection(final Connection connection) throws InterruptedException;
+
+    /**
+     * Returns whenever connection is supposed to be outbound
+     *
+     * @return true if connection is outbound (we connect to remote node), false if we are listening for incoming connection
+     */
+    boolean isOutbound();
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/InboundConnectionManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/InboundConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,5 +109,13 @@ public class InboundConnectionManager implements ConnectionManager {
             lockedConn.setResource(connection);
             newConnection.signalAll();
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOutbound() {
+        return false;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/OutboundConnectionManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/OutboundConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,5 +69,13 @@ public class OutboundConnectionManager implements ConnectionManager {
     @Override
     public void newConnection(final Connection connection) {
         throw new UnsupportedOperationException("Does not accept connections");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOutbound() {
+        return true;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
@@ -51,6 +51,6 @@ public record PeerInfo(
                 return peer;
             }
         }
-        throw new RosterEntryNotFoundException("No RosterEntry with nodeId: " + nodeId + " in peer list: " + peers);
+        throw new RosterEntryNotFoundException("No RosterEntry with nodeId: " + nodeId + " in peer list: " + peers.stream().map(it -> it.hostname).toList());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
@@ -52,6 +52,6 @@ public record PeerInfo(
             }
         }
         throw new RosterEntryNotFoundException("No RosterEntry with nodeId: " + nodeId + " in peer list: "
-                + peers.stream().map(it -> it.hostname).toList());
+                + peers.stream().map(it -> it.nodeId).toList());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,11 @@
 package com.swirlds.platform.network;
 
 import com.swirlds.common.platform.NodeId;
+import com.swirlds.platform.roster.RosterEntryNotFoundException;
 import com.swirlds.platform.roster.RosterUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.cert.Certificate;
+import java.util.Collection;
 
 /**
  * A record representing a peer's network information.  If the certificate is not null, it must be encodable as a valid
@@ -27,9 +29,11 @@ import java.security.cert.Certificate;
  *
  * @param nodeId             the ID of the peer
  * @param hostname           the hostname (or IP address) of the peer
+ * @param port               the port on which peer is listening for incoming connections
  * @param signingCertificate the certificate used to validate the peer's TLS certificate, or null.
  */
-public record PeerInfo(@NonNull NodeId nodeId, @NonNull String hostname, @NonNull Certificate signingCertificate) {
+public record PeerInfo(
+        @NonNull NodeId nodeId, @NonNull String hostname, int port, @NonNull Certificate signingCertificate) {
 
     /**
      * Return a "node name" for the peer, e.g. "node1" for a peer with NodeId == 0.
@@ -39,5 +43,14 @@ public record PeerInfo(@NonNull NodeId nodeId, @NonNull String hostname, @NonNul
     @NonNull
     public String nodeName() {
         return RosterUtils.formatNodeName(nodeId.id());
+    }
+
+    public static @NonNull PeerInfo find(@NonNull Collection<PeerInfo> peers, NodeId nodeId) {
+        for (PeerInfo peer : peers) {
+            if (peer.nodeId().equals(nodeId)) {
+                return peer;
+            }
+        }
+        throw new RosterEntryNotFoundException("No RosterEntry with nodeId: " + nodeId + " in peer list: " + peers);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
@@ -45,7 +45,7 @@ public record PeerInfo(
         return RosterUtils.formatNodeName(nodeId.id());
     }
 
-    public static @NonNull PeerInfo find(@NonNull Collection<PeerInfo> peers, NodeId nodeId) {
+    public static @NonNull PeerInfo find(@NonNull Collection<PeerInfo> peers, @NonNull NodeId nodeId) {
         for (PeerInfo peer : peers) {
             if (peer.nodeId().equals(nodeId)) {
                 return peer;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerInfo.java
@@ -51,6 +51,7 @@ public record PeerInfo(
                 return peer;
             }
         }
-        throw new RosterEntryNotFoundException("No RosterEntry with nodeId: " + nodeId + " in peer list: " + peers.stream().map(it -> it.hostname).toList());
+        throw new RosterEntryNotFoundException("No RosterEntry with nodeId: " + nodeId + " in peer list: "
+                + peers.stream().map(it -> it.hostname).toList());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/OutboundConnectionCreator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/connectivity/OutboundConnectionCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,20 @@
 
 package com.swirlds.platform.network.connectivity;
 
-import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
-import static com.swirlds.logging.legacy.LogMarker.NETWORK;
-import static com.swirlds.logging.legacy.LogMarker.SOCKET_EXCEPTIONS;
-import static com.swirlds.logging.legacy.LogMarker.TCP_CONNECT_EXCEPTIONS;
+import static com.swirlds.logging.legacy.LogMarker.*;
 
-import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.gossip.config.GossipConfig;
 import com.swirlds.platform.gossip.config.NetworkEndpoint;
 import com.swirlds.platform.gossip.sync.SyncInputStream;
 import com.swirlds.platform.gossip.sync.SyncOutputStream;
-import com.swirlds.platform.network.Connection;
-import com.swirlds.platform.network.ConnectionTracker;
-import com.swirlds.platform.network.NetworkUtils;
-import com.swirlds.platform.network.SocketConfig;
-import com.swirlds.platform.network.SocketConnection;
+import com.swirlds.platform.network.*;
 import com.swirlds.platform.network.connection.NotConnectedConnection;
-import com.swirlds.platform.roster.RosterUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.Socket;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
+import java.net.*;
+import java.util.List;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -58,20 +45,20 @@ public class OutboundConnectionCreator {
     private final GossipConfig gossipConfig;
     private final ConnectionTracker connectionTracker;
     private final SocketFactory socketFactory;
-    private final Roster roster;
     private final PlatformContext platformContext;
+    private final List<PeerInfo> peers;
 
     public OutboundConnectionCreator(
             @NonNull final PlatformContext platformContext,
             @NonNull final NodeId selfId,
             @NonNull final ConnectionTracker connectionTracker,
             @NonNull final SocketFactory socketFactory,
-            @NonNull final Roster roster) {
+            @NonNull final List<PeerInfo> peers) {
         this.platformContext = Objects.requireNonNull(platformContext);
         this.selfId = Objects.requireNonNull(selfId);
         this.connectionTracker = Objects.requireNonNull(connectionTracker);
         this.socketFactory = Objects.requireNonNull(socketFactory);
-        this.roster = Objects.requireNonNull(roster);
+        this.peers = Objects.requireNonNull(peers);
         this.socketConfig = platformContext.getConfiguration().getConfigData(SocketConfig.class);
         this.gossipConfig = platformContext.getConfiguration().getConfigData(GossipConfig.class);
     }
@@ -84,7 +71,7 @@ public class OutboundConnectionCreator {
      * @return the new connection, or a connection that is not connected if it couldn't connect on the first try
      */
     public Connection createConnection(final NodeId otherId) {
-        final RosterEntry other = RosterUtils.getRosterEntry(roster, otherId.id());
+        final PeerInfo other = PeerInfo.find(peers, otherId);
 
         // NOTE: we always connect to the first ServiceEndpoint, which for now represents a legacy "external" address
         // (which may change in the future as new Rosters get installed).
@@ -95,12 +82,10 @@ public class OutboundConnectionCreator {
         final NetworkEndpoint networkEndpoint = gossipConfig
                 .getEndpointOverride(otherId.id())
                 .orElseGet(() -> {
-                    final String host = RosterUtils.fetchHostname(other, 0);
                     try {
-                        return new NetworkEndpoint(
-                                otherId.id(), InetAddress.getByName(host), RosterUtils.fetchPort(other, 0));
+                        return new NetworkEndpoint(otherId.id(), InetAddress.getByName(other.hostname()), other.port());
                     } catch (UnknownHostException e) {
-                        throw new RuntimeException("Host '" + host + "' not found", e);
+                        throw new RuntimeException("Host '" + other.hostname() + "' not found", e);
                     }
                 });
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ReconnectProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ReconnectProtocol.java
@@ -29,6 +29,7 @@ import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.gossip.modular.GossipController;
 import com.swirlds.platform.gossip.modular.SyncGossipSharedProtocolState;
 import com.swirlds.platform.metrics.ReconnectMetrics;
+import com.swirlds.platform.network.PeerInfo;
 import com.swirlds.platform.reconnect.*;
 import com.swirlds.platform.state.SwirldStateManager;
 import com.swirlds.platform.state.service.PlatformStateFacade;
@@ -38,6 +39,7 @@ import com.swirlds.platform.state.signed.SignedStateValidator;
 import com.swirlds.platform.system.status.PlatformStatus;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
@@ -105,6 +107,7 @@ public class ReconnectProtocol implements Protocol {
      * @param threadManager         the thread manager
      * @param latestCompleteState   holds the latest signed state that has enough signatures to be verifiable
      * @param roster                the current roster
+     * @param peers                 the current list of peers
      * @param loadReconnectState    a method that should be called when a state from reconnect is obtained
      * @param clearAllPipelinesForReconnect this method should be called to clear all pipelines prior to a reconnect
      * @param swirldStateManager    manages the mutable state
@@ -118,6 +121,7 @@ public class ReconnectProtocol implements Protocol {
             @NonNull final ThreadManager threadManager,
             @NonNull final Supplier<ReservedSignedState> latestCompleteState,
             @NonNull final Roster roster,
+            @NonNull final List<PeerInfo> peers,
             @NonNull final Consumer<SignedState> loadReconnectState,
             @NonNull final Runnable clearAllPipelinesForReconnect,
             @NonNull final SwirldStateManager swirldStateManager,
@@ -130,7 +134,7 @@ public class ReconnectProtocol implements Protocol {
 
         var reconnectThrottle = new ReconnectThrottle(reconnectConfig, platformContext.getTime());
 
-        var reconnectMetrics = new ReconnectMetrics(platformContext.getMetrics(), roster);
+        var reconnectMetrics = new ReconnectMetrics(platformContext.getMetrics(), peers);
 
         final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ReconnectProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ReconnectProtocol.java
@@ -132,9 +132,9 @@ public class ReconnectProtocol implements Protocol {
         final ReconnectConfig reconnectConfig =
                 platformContext.getConfiguration().getConfigData(ReconnectConfig.class);
 
-        var reconnectThrottle = new ReconnectThrottle(reconnectConfig, platformContext.getTime());
+        final ReconnectThrottle reconnectThrottle = new ReconnectThrottle(reconnectConfig, platformContext.getTime());
 
-        var reconnectMetrics = new ReconnectMetrics(platformContext.getMetrics(), peers);
+        final ReconnectMetrics reconnectMetrics = new ReconnectMetrics(platformContext.getMetrics(), peers);
 
         final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
 
@@ -148,7 +148,7 @@ public class ReconnectProtocol implements Protocol {
             }
         };
 
-        var reconnectHelper = new ReconnectHelper(
+        final ReconnectHelper reconnectHelper = new ReconnectHelper(
                 gossipController::pause,
                 clearAllPipelinesForReconnect::run,
                 swirldStateManager::getConsensusState,
@@ -169,7 +169,7 @@ public class ReconnectProtocol implements Protocol {
                         platformStateFacade),
                 stateConfig,
                 platformStateFacade);
-        var reconnectController =
+        final ReconnectController reconnectController =
                 new ReconnectController(reconnectConfig, threadManager, reconnectHelper, gossipController::resume);
 
         sharedState.fallenBehindCallback().set(reconnectController::start);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/SyncProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/SyncProtocol.java
@@ -16,7 +16,6 @@
 
 package com.swirlds.platform.network.protocol;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.gossip.IntakeEventCounter;
@@ -88,21 +87,21 @@ public class SyncProtocol implements Protocol {
      * @param platformContext       the platform context
      * @param sharedState           temporary class to share state between various protocols in modularized gossip, to be removed
      * @param intakeEventCounter    keeps track of how many events have been received from each peer
-     * @param roster                the current roster
+     * @param rosterSize            estimated roster size
      * @return constructed SyncProtocol
      */
     public static SyncProtocol create(
             @NonNull final PlatformContext platformContext,
             @NonNull final SyncGossipSharedProtocolState sharedState,
             @NonNull final IntakeEventCounter intakeEventCounter,
-            @NonNull final Roster roster) {
+            final int rosterSize) {
 
         final SyncMetrics syncMetrics = new SyncMetrics(platformContext.getMetrics());
 
         var syncShadowgraphSynchronizer = new ShadowgraphSynchronizer(
                 platformContext,
                 sharedState.shadowgraph(),
-                roster.rosterEntries().size(),
+                rosterSize,
                 syncMetrics,
                 event -> sharedState.receivedEventHandler().accept(event),
                 sharedState.syncManager(),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
@@ -95,6 +95,7 @@ class NetworkPeerIdentifierTest {
                 peer = new PeerInfo(
                         id,
                         "127.0.0.1",
+                        12345,
                         Objects.requireNonNull(publicStores.getCertificate(KeyCertPurpose.SIGNING, id)));
             } catch (final KeyLoadingException e) {
                 throw new RuntimeException(e);

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionCreatorTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionCreatorTest.java
@@ -67,7 +67,10 @@ class OutboundConnectionCreatorTest {
                 .withWeightDistributionStrategy(WeightDistributionStrategy.BALANCED)
                 .build();
         final int thisNodeIndex = r.nextInt(numNodes);
-        final int otherNodeIndex = r.nextInt(numNodes);
+        int otherNodeIndex = r.nextInt(numNodes);
+        while (otherNodeIndex == thisNodeIndex) {
+            otherNodeIndex = r.nextInt(numNodes);
+        }
         final NodeId thisNode =
                 NodeId.of(roster.rosterEntries().get(thisNodeIndex).nodeId());
         final NodeId otherNode =
@@ -152,7 +155,10 @@ class OutboundConnectionCreatorTest {
                 .withWeightDistributionStrategy(WeightDistributionStrategy.BALANCED)
                 .build();
         final int thisNodeIndex = r.nextInt(numNodes);
-        final int otherNodeIndex = r.nextInt(numNodes);
+        int otherNodeIndex = r.nextInt(numNodes);
+        while (otherNodeIndex == thisNodeIndex) {
+            otherNodeIndex = r.nextInt(numNodes);
+        }
         final NodeId thisNode =
                 NodeId.of(roster.rosterEntries().get(thisNodeIndex).nodeId());
         final NodeId otherNode =

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionCreatorTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/OutboundConnectionCreatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.platform.Utilities;
 import com.swirlds.platform.network.ByteConstants;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.ConnectionTracker;
@@ -100,7 +101,11 @@ class OutboundConnectionCreatorTest {
                 .build();
 
         final OutboundConnectionCreator occ = new OutboundConnectionCreator(
-                platformContext, thisNode, mock(ConnectionTracker.class), socketFactory, roster);
+                platformContext,
+                thisNode,
+                mock(ConnectionTracker.class),
+                socketFactory,
+                Utilities.createPeerInfoList(roster, thisNode));
 
         Connection connection = occ.createConnection(otherNode);
         assertTrue(connection instanceof SocketConnection, "the returned connection should be a socket connection");
@@ -181,7 +186,11 @@ class OutboundConnectionCreatorTest {
                 .build();
 
         final OutboundConnectionCreator occ = new OutboundConnectionCreator(
-                platformContext, thisNode, mock(ConnectionTracker.class), socketFactory, roster);
+                platformContext,
+                thisNode,
+                mock(ConnectionTracker.class),
+                socketFactory,
+                Utilities.createPeerInfoList(roster, thisNode));
 
         Connection connection = occ.createConnection(otherNode);
         assertTrue(connection instanceof SocketConnection, "the returned connection should be a socket connection");

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/StaticConnectionManagersTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/StaticConnectionManagersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package com.swirlds.platform.test.network;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,8 +68,9 @@ class StaticConnectionManagersTest {
         final NodeId neighbor = neighbors.get(r.nextInt(neighbors.size()));
 
         if (topology.shouldConnectToMe(neighbor)) {
-            final ConnectionManager manager = managers.getManager(neighbor, false);
+            final ConnectionManager manager = managers.getManager(neighbor);
             assertNotNull(manager, "should have a manager for this connection");
+            assertFalse(manager.isOutbound(), "should be inbound connection");
             final Connection c1 = new FakeConnection(selfId, neighbor);
             managers.newConnection(c1);
             assertSame(c1, manager.waitForConnection(), "the manager should have received the connection supplied");
@@ -80,8 +80,9 @@ class StaticConnectionManagersTest {
             assertFalse(c1.connected(), "the new connection should have disconnected the old one");
             assertSame(c2, manager.waitForConnection(), "c2 should have replaced c1");
         } else {
-            final ConnectionManager manager = managers.getManager(neighbor, false);
-            assertNull(manager, "should not have a manager for this connection");
+            final ConnectionManager manager = managers.getManager(neighbor);
+            assertNotNull(manager, "should have a manager for this connection");
+            assertTrue(manager.isOutbound(), "should be outbound connection");
             final Connection c = new FakeConnection(selfId, neighbor);
             managers.newConnection(c);
             assertFalse(
@@ -108,14 +109,16 @@ class StaticConnectionManagersTest {
                 final NodeId peerId = inv.getArgument(0, NodeId.class);
                 return new FakeConnection(selfId, peerId);
             });
-            final ConnectionManager manager = managers.getManager(neighbor, true);
+            final ConnectionManager manager = managers.getManager(neighbor);
             assertNotNull(manager, "should have a manager for this connection");
+            assertTrue(manager.isOutbound(), "should be outbound connection");
             assertTrue(
                     manager.waitForConnection().connected(),
-                    "outbound connections should be esablished by the manager");
+                    "outbound connections should be established by the manager");
         } else {
-            final ConnectionManager manager = managers.getManager(neighbor, true);
-            assertNull(manager, "should not have a manager for this connection");
+            final ConnectionManager manager = managers.getManager(neighbor);
+            assertNotNull(manager, "should have a manager for this connection");
+            assertFalse(manager.isOutbound(), "should be inbound connection");
         }
     }
 }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/ReturnOnceConnectionManager.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/network/communication/multithreaded/ReturnOnceConnectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2018-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,5 +47,13 @@ public class ReturnOnceConnectionManager implements ConnectionManager {
     @Override
     public void newConnection(final Connection connection) {
         throw new IllegalStateException("unsupported");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isOutbound() {
+        return connection.isOutbound();
     }
 }


### PR DESCRIPTION
**Description**:

This change reduces dependency of gossip network code on Roster class, moving to List/Collection<PeerInfo> instead. This is needed as a preparation for dynamic connections for DynamicAddressBook

* Add port to PeerInfo
* Change Roster to List<PeerInfo> in multiple places
* Reduce dependency on Topology in StaticConnectionManager

**Related issue(s)**:

Fixes #17812

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
