### PR TITLE
chore: cryptography better loading

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
@@ -293,7 +293,7 @@ public class EnhancedKeyStoreLoader {
         final KeyStore legacyPublicStore = resolveLegacyPublicStore();
 
         iterateAddressBook(addressBook, (i, nodeId, address) -> {
-            logger.debug(STARTUP.getMarker(), "Attempting to locate key stores for node {} [ id = {}]", i, nodeId);
+            logger.debug(STARTUP.getMarker(), "Attempting to locate key stores for nodeId {} [ id = {}]", i, nodeId);
 
             if (localNodes.contains(address.getNodeId())) {
                 sigPrivateKeys.compute(nodeId, (k, v) -> resolveNodePrivateKey(nodeId, KeyCertPurpose.SIGNING));
@@ -329,6 +329,9 @@ public class EnhancedKeyStoreLoader {
                 // recover signing key pair to be root of trust on agreement certificate
                 final PrivateKey privateSigningKey = sigPrivateKeys.get(node);
                 final X509Certificate signingCert = (X509Certificate) sigCertificates.get(node);
+                if (privateSigningKey == null || signingCert == null) {
+                    continue;
+                }
                 final PublicKey publicSigningKey = signingCert.getPublicKey();
                 final KeyPair signingKeyPair = new KeyPair(publicSigningKey, privateSigningKey);
 
@@ -380,27 +383,32 @@ public class EnhancedKeyStoreLoader {
         }
 
         iterateAddressBook(validatingBook, (i, nodeId, address) -> {
-            if (localNodes.contains(address.getNodeId())) {
-                if (!sigPrivateKeys.containsKey(nodeId)) {
-                    throw new KeyLoadingException("No private key found for node %s [ purpose = %s ]"
+            try {
+                if (localNodes.contains(address.getNodeId())) {
+                    if (!sigPrivateKeys.containsKey(nodeId)) {
+                        throw new KeyLoadingException("No private key found for nodeId %s [ purpose = %s ]"
+                                .formatted(nodeId, KeyCertPurpose.SIGNING));
+                    }
+
+                    if (!agrPrivateKeys.containsKey(nodeId)) {
+                        throw new KeyLoadingException("No private key found for nodeId %s [purpose = %s ]"
+                                .formatted(nodeId, KeyCertPurpose.AGREEMENT));
+                    }
+
+                    // the agreement certificate must be present for local nodes
+                    if (!agrCertificates.containsKey(nodeId)) {
+                        throw new KeyLoadingException("No certificate found for nodeId %s [purpose = %s ]"
+                                .formatted(nodeId, KeyCertPurpose.AGREEMENT));
+                    }
+                }
+
+                if (!sigCertificates.containsKey(nodeId)) {
+                    throw new KeyLoadingException("No certificate found for nodeId %s [purpose = %s ]"
                             .formatted(nodeId, KeyCertPurpose.SIGNING));
                 }
-
-                if (!agrPrivateKeys.containsKey(nodeId)) {
-                    throw new KeyLoadingException("No private key found for node %s [purpose = %s ]"
-                            .formatted(nodeId, KeyCertPurpose.AGREEMENT));
-                }
-
-                // the agreement certificate must be present for local nodes
-                if (!agrCertificates.containsKey(nodeId)) {
-                    throw new KeyLoadingException("No certificate found for node %s [purpose = %s ]"
-                            .formatted(nodeId, KeyCertPurpose.AGREEMENT));
-                }
-            }
-
-            if (!sigCertificates.containsKey(nodeId)) {
-                throw new KeyLoadingException(
-                        "No certificate found for node %s [purpose = %s ]".formatted(nodeId, KeyCertPurpose.SIGNING));
+            } catch (KeyLoadingException e) {
+                logger.warn(STARTUP.getMarker(), e.getMessage());
+                throw e;
             }
         });
 
@@ -443,7 +451,7 @@ public class EnhancedKeyStoreLoader {
             final X509Certificate sigCert = publicStores.getCertificate(KeyCertPurpose.SIGNING, nodeId);
 
             if (sigCert == null) {
-                throw new KeyLoadingException("No signing certificate found for node %s".formatted(nodeId));
+                throw new KeyLoadingException("No signing certificate found for nodeId: %s".formatted(nodeId));
             }
 
             if (localNodes.contains(nodeId)) {
@@ -452,16 +460,16 @@ public class EnhancedKeyStoreLoader {
                 final PrivateKey agrPrivateKey = agrPrivateKeys.get(nodeId);
 
                 if (sigPrivateKey == null) {
-                    throw new KeyLoadingException("No signing private key found for node %s".formatted(nodeId));
+                    throw new KeyLoadingException("No signing private key found for nodeId: %s".formatted(nodeId));
                 }
 
                 if (agrPrivateKey == null) {
-                    throw new KeyLoadingException("No agreement private key found for node %s".formatted(nodeId));
+                    throw new KeyLoadingException("No agreement private key found for nodeId: %s".formatted(nodeId));
                 }
 
                 // the agreement certificate must be present for local nodes
                 if (agrCert == null) {
-                    throw new KeyLoadingException("No agreement certificate found for node %s".formatted(nodeId));
+                    throw new KeyLoadingException("No agreement certificate found for nodeId: %s".formatted(nodeId));
                 }
 
                 final KeyPair sigKeyPair = new KeyPair(sigCert.getPublicKey(), sigPrivateKey);
@@ -527,7 +535,7 @@ public class EnhancedKeyStoreLoader {
             final Certificate agrCert = agrCertificates.get(nodeId);
 
             if (!(sigCert instanceof X509Certificate)) {
-                throw new KeyLoadingException("Illegal signing certificate type for node %s [ purpose = %s ]"
+                throw new KeyLoadingException("Illegal signing certificate type for nodeId: %s [ purpose = %s ]"
                         .formatted(nodeId, KeyCertPurpose.SIGNING));
             }
 
@@ -535,10 +543,10 @@ public class EnhancedKeyStoreLoader {
                 // The agreement certificate is loaded by the local nodes and provided to peers through mTLS handshaking
                 logger.trace(
                         STARTUP.getMarker(),
-                        "Injecting agreement certificate for local node {} into public stores",
+                        "Injecting agreement certificate for local nodeId {} into public stores",
                         nodeId);
                 if (!(agrCert instanceof X509Certificate)) {
-                    throw new KeyLoadingException("Illegal agreement certificate type for node %s [ purpose = %s ]"
+                    throw new KeyLoadingException("Illegal agreement certificate type for nodeId: %s [ purpose = %s ]"
                             .formatted(nodeId, KeyCertPurpose.AGREEMENT));
                 }
                 publicStores.setCertificate(KeyCertPurpose.AGREEMENT, (X509Certificate) agrCert, nodeId);
@@ -599,7 +607,7 @@ public class EnhancedKeyStoreLoader {
         if (Files.exists(ksLocation)) {
             logger.trace(
                     STARTUP.getMarker(),
-                    "Found enhanced private key store for node {} [ purpose = {}, fileName = {} ]",
+                    "Found enhanced private key store for nodeId: {} [ purpose = {}, fileName = {} ]",
                     nodeId,
                     purpose,
                     ksLocation.getFileName());
@@ -611,7 +619,7 @@ public class EnhancedKeyStoreLoader {
         if (Files.exists(ksLocation)) {
             logger.trace(
                     STARTUP.getMarker(),
-                    "Found legacy private key store for node {} [ purpose = {}, fileName = {} ]",
+                    "Found legacy private key store for nodeId: {} [ purpose = {}, fileName = {} ]",
                     nodeId,
                     purpose,
                     ksLocation.getFileName());
@@ -620,7 +628,7 @@ public class EnhancedKeyStoreLoader {
 
         // No keys were found so return null. Missing keys will be detected during a call to
         // EnhancedKeyStoreLoader::verify() or EnhancedKeyStoreLoader::keysAndCerts().
-        logger.warn(STARTUP.getMarker(), "No private key store found for node {} [ purpose = {} ]", nodeId, purpose);
+        logger.warn(STARTUP.getMarker(), "No private key store found for nodeId: {} [ purpose = {} ]", nodeId, purpose);
         return null;
     }
 
@@ -657,7 +665,7 @@ public class EnhancedKeyStoreLoader {
         if (Files.exists(ksLocation)) {
             logger.trace(
                     STARTUP.getMarker(),
-                    "Found enhanced certificate store for node {} [ purpose = {}, fileName = {} ]",
+                    "Found enhanced certificate store for nodeId: {} [ purpose = {}, fileName = {} ]",
                     nodeId,
                     purpose,
                     ksLocation.getFileName());
@@ -669,7 +677,7 @@ public class EnhancedKeyStoreLoader {
         if (Files.exists(ksLocation)) {
             logger.trace(
                     STARTUP.getMarker(),
-                    "Found legacy certificate store for node {} [ purpose = {}, fileName = {} ]",
+                    "Found legacy certificate store for nodeId: {} [ purpose = {}, fileName = {} ]",
                     nodeId,
                     purpose,
                     ksLocation.getFileName());
@@ -678,7 +686,7 @@ public class EnhancedKeyStoreLoader {
 
         // No certificates were found so return null. Missing certificates will be detected during a call to
         // EnhancedKeyStoreLoader::verify() or EnhancedKeyStoreLoader::keysAndCerts().
-        logger.warn(STARTUP.getMarker(), "No certificate store found for node {} [ purpose = {} ]", nodeId, purpose);
+        logger.warn(STARTUP.getMarker(), "No certificate store found for nodeId: {} [ purpose = {} ]", nodeId, purpose);
         return null;
     }
 
@@ -702,7 +710,7 @@ public class EnhancedKeyStoreLoader {
         } catch (KeyLoadingException e) {
             logger.warn(
                     STARTUP.getMarker(),
-                    "Unable to load the enhanced certificate store for node {} [ fileName = {} ]",
+                    "Unable to load the enhanced certificate store for nodeId: {} [ fileName = {} ]",
                     nodeId,
                     location.getFileName(),
                     e);
@@ -738,7 +746,7 @@ public class EnhancedKeyStoreLoader {
             if (cert == null) {
                 logger.warn(
                         STARTUP.getMarker(),
-                        "No certificate found for node {} [ entryName = {} ]",
+                        "No certificate found for nodeId: {} [ entryName = {} ]",
                         nodeId,
                         purpose.storeName(nodeId));
             }
@@ -774,7 +782,7 @@ public class EnhancedKeyStoreLoader {
         } catch (KeyLoadingException e) {
             logger.warn(
                     STARTUP.getMarker(),
-                    "Unable to load the enhanced private key store for node {} [ fileName = {} ]",
+                    "Unable to load the enhanced private key store for nodeId: {} [ fileName = {} ]",
                     nodeId,
                     location.getFileName(),
                     e);
@@ -805,7 +813,10 @@ public class EnhancedKeyStoreLoader {
 
             if (!(k instanceof PrivateKey)) {
                 logger.warn(
-                        STARTUP.getMarker(), "No private key found for node {} [ entryName = {} ]", nodeId, entryName);
+                        STARTUP.getMarker(),
+                        "No private key found for nodeId: {} [ entryName = {} ]",
+                        nodeId,
+                        entryName);
             }
 
             return (k instanceof PrivateKey pk) ? pk : null;
@@ -1210,7 +1221,7 @@ public class EnhancedKeyStoreLoader {
                 if (!Files.exists(sPrivateKeyLocation) && Files.exists(ksLocation)) {
                     logger.trace(
                             STARTUP.getMarker(),
-                            "Extracting private signing key for node {} from file {}",
+                            "Extracting private signing key for nodeId: {} from file {}",
                             nodeId,
                             ksLocation.getFileName());
                     final PrivateKey privateKey =
@@ -1219,14 +1230,14 @@ public class EnhancedKeyStoreLoader {
                     if (privateKey == null) {
                         logger.error(
                                 ERROR.getMarker(),
-                                "Failed to extract private signing key for node {} from file {}",
+                                "Failed to extract private signing key for nodeId: {} from file {}",
                                 nodeId,
                                 ksLocation.getFileName());
                         errorCount.incrementAndGet();
                     } else {
                         logger.trace(
                                 STARTUP.getMarker(),
-                                "Writing private signing key for node {} to PEM file {}",
+                                "Writing private signing key for nodeId: {} to PEM file {}",
                                 nodeId,
                                 sPrivateKeyLocation.getFileName());
                         try {
@@ -1234,7 +1245,7 @@ public class EnhancedKeyStoreLoader {
                         } catch (final IOException e) {
                             logger.error(
                                     ERROR.getMarker(),
-                                    "Failed to write private key for node {} to PEM file {}",
+                                    "Failed to write private key for nodeId: {} to PEM file {}",
                                     nodeId,
                                     sPrivateKeyLocation.getFileName());
                             errorCount.incrementAndGet();
@@ -1250,7 +1261,7 @@ public class EnhancedKeyStoreLoader {
             if (!Files.exists(sCertificateLocation) && Files.exists(ksLocation)) {
                 logger.trace(
                         STARTUP.getMarker(),
-                        "Extracting signing certificate for node {} from file {} ",
+                        "Extracting signing certificate for nodeId: {} from file {} ",
                         nodeId,
                         ksLocation.getFileName());
                 final Certificate certificate =
@@ -1259,14 +1270,14 @@ public class EnhancedKeyStoreLoader {
                 if (certificate == null) {
                     logger.error(
                             ERROR.getMarker(),
-                            "Failed to extract signing certificate for node {} from file {}",
+                            "Failed to extract signing certificate for nodeId: {} from file {}",
                             nodeId,
                             ksLocation.getFileName());
                     errorCount.incrementAndGet();
                 } else {
                     logger.trace(
                             STARTUP.getMarker(),
-                            "Writing signing certificate for node {} to PEM file {}",
+                            "Writing signing certificate for nodeId: {} to PEM file {}",
                             nodeId,
                             sCertificateLocation.getFileName());
                     try {
@@ -1274,7 +1285,7 @@ public class EnhancedKeyStoreLoader {
                     } catch (final CertificateEncodingException | IOException e) {
                         logger.error(
                                 ERROR.getMarker(),
-                                "Failed to write signing certificate for node {} to PEM file {}",
+                                "Failed to write signing certificate for nodeId: {} to PEM file {}",
                                 nodeId,
                                 sCertificateLocation.getFileName());
                         errorCount.incrementAndGet();
@@ -1307,7 +1318,8 @@ public class EnhancedKeyStoreLoader {
                         || !Arrays.equals(
                                 pemPrivateKey.getEncoded(),
                                 pfxPrivateKeys.get(nodeId).getEncoded())) {
-                    logger.error(ERROR.getMarker(), "Private key for node {} does not match the migrated key", nodeId);
+                    logger.error(
+                            ERROR.getMarker(), "Private key for nodeId: {} does not match the migrated key", nodeId);
                     errorCount.incrementAndGet();
                 }
             }
@@ -1323,12 +1335,13 @@ public class EnhancedKeyStoreLoader {
                                     pfxCertificates.get(nodeId).getEncoded())) {
                         logger.error(
                                 ERROR.getMarker(),
-                                "Certificate for node {} does not match the migrated certificate",
+                                "Certificate for nodeId: {} does not match the migrated certificate",
                                 nodeId);
                         errorCount.incrementAndGet();
                     }
                 } catch (final CertificateEncodingException e) {
-                    logger.error(ERROR.getMarker(), "Encoding error while validating certificate for node {}.", nodeId);
+                    logger.error(
+                            ERROR.getMarker(), "Encoding error while validating certificate for nodeId: {}.", nodeId);
                     errorCount.incrementAndGet();
                 }
             }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
@@ -200,7 +200,7 @@ class EnhancedKeyStoreLoaderTest {
         assertThat(loader).isNotNull();
         assertThatCode(loader::migrate).doesNotThrowAnyException();
         assertThatCode(loader::scan).doesNotThrowAnyException();
-        assertThatCode(loader::generate).isInstanceOf(KeyGeneratingException.class);
+        assertThatCode(loader::generate).doesNotThrowAnyException();
         assertThatCode(loader::verify).isInstanceOf(KeyLoadingException.class);
         assertThatCode(loader::injectInAddressBook).isInstanceOf(KeyLoadingException.class);
         assertThatCode(loader::keysAndCerts).isInstanceOf(KeyLoadingException.class);


### PR DESCRIPTION
**Description**:
This fix helps with better reporting cases where the cryptography material for a node is not present.

**Related issue(s)**:

Fixes #17871