### PR TITLE
chore: fix scope of 'com.github.spotbugs.annotations'

### DIFF
--- a/platform-sdk/event-creator-impl/src/main/java/module-info.java
+++ b/platform-sdk/event-creator-impl/src/main/java/module-info.java
@@ -7,7 +7,7 @@ module org.hiero.event.creator.impl {
     requires transitive com.swirlds.config.api;
     requires transitive org.hiero.event.creator;
     requires com.swirlds.base;
-    requires com.github.spotbugs.annotations;
+    requires static transitive com.github.spotbugs.annotations;
 
     provides org.hiero.event.creator.EventCreator with
             org.hiero.event.creator.impl.EventCreatorImpl;


### PR DESCRIPTION
**Description**:

Same scope as for all other usages of the annotation library.
