### PR TITLE
chore: Move CryptoStatic.decodeCertificate() to CryptoUtils

### DIFF
--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/CryptoUtils.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/CryptoUtils.java
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.crypto;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 
 /**
  * Utility class for cryptographic operations.
@@ -33,5 +40,21 @@ public class CryptoUtils {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Decode a X509Certificate from a byte array that was previously obtained via X509Certificate.getEncoded().
+     *
+     * @param encoded a byte array with an encoded representation of a certificate
+     * @return the certificate reconstructed from its encoded form
+     */
+    @NonNull
+    public static X509Certificate decodeCertificate(@NonNull final byte[] encoded) {
+        try (final InputStream in = new ByteArrayInputStream(encoded)) {
+            final CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            return (X509Certificate) factory.generateCertificate(in);
+        } catch (CertificateException | IOException e) {
+            throw new CryptographyException(e);
+        }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -24,10 +24,8 @@ import com.swirlds.platform.system.address.Address;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.io.ByteArrayInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,7 +43,6 @@ import java.security.SignatureException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -221,22 +218,6 @@ public final class CryptoStatic {
                     .getCertificate(v3CertBldr.build(signerBuilder.build(caPair.getPrivate())));
         } catch (CertificateException | OperatorCreationException e) {
             throw new KeyGeneratingException("Could not generate certificate!", e);
-        }
-    }
-
-    /**
-     * Decode a X509Certificate from a byte array that was previously obtained via X509Certificate.getEncoded().
-     *
-     * @param encoded a byte array with an encoded representation of a certificate
-     * @return the certificate reconstructed from its encoded form
-     */
-    @NonNull
-    public static X509Certificate decodeCertificate(@NonNull final byte[] encoded) {
-        try (final InputStream in = new ByteArrayInputStream(encoded)) {
-            final CertificateFactory factory = CertificateFactory.getInstance("X.509");
-            return (X509Certificate) factory.generateCertificate(in);
-        } catch (CertificateException | IOException e) {
-            throw new CryptographyException(e);
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/roster/RosterUtils.java
@@ -9,7 +9,6 @@ import com.hedera.node.internal.network.Network;
 import com.hedera.node.internal.network.NodeMetadata;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.RosterStateId;
-import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.state.service.ReadableRosterStore;
 import com.swirlds.platform.state.service.WritableRosterStore;
 import com.swirlds.platform.system.address.Address;
@@ -29,6 +28,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.hiero.base.crypto.CryptoUtils;
 import org.hiero.base.crypto.CryptographyException;
 import org.hiero.base.crypto.Hash;
 import org.hiero.consensus.model.node.NodeId;
@@ -75,7 +75,7 @@ public final class RosterUtils {
      */
     public static X509Certificate fetchGossipCaCertificate(@NonNull final RosterEntry entry) {
         try {
-            return CryptoStatic.decodeCertificate(entry.gossipCaCertificate().toByteArray());
+            return CryptoUtils.decodeCertificate(entry.gossipCaCertificate().toByteArray());
         } catch (final CryptographyException e) {
             return null;
         }
@@ -348,7 +348,7 @@ public final class RosterUtils {
 
         X509Certificate sigCert;
         try {
-            sigCert = CryptoStatic.decodeCertificate(entry.gossipCaCertificate().toByteArray());
+            sigCert = CryptoUtils.decodeCertificate(entry.gossipCaCertificate().toByteArray());
         } catch (final CryptographyException e) {
             // Malformed or missing gossip certificates are nullified.
             // https://github.com/hashgraph/hedera-services/issues/16648


### PR DESCRIPTION
**Description**:

This PR moves the method `CryptoStatic.decodeCertificate()` to `CryptoUtils` to make it more available, as it does not depend on application-specific functionality.

**Related issue(s)**:

Part of #18927 