### PR TITLE
ci: remove windows-2019 runner option

### DIFF
--- a/.github/workflows/docs/required_checks.md
+++ b/.github/workflows/docs/required_checks.md
@@ -5,6 +5,7 @@
 - Snyk Scan / Standard - :x:
 - Gradle Determinism / Generate Baseline - :x:
 - Gradle Determinism / Verify Artifacts (windows-2022) - :x:
+- Gradle Determinism / Verify Artifacts (windows-2025) - :x:
 - Gradle Determinism / Verify Artifacts (ubuntu-22.04) - :x:
 - Gradle Determinism / Verify Artifacts (hiero-network-node-linux-large) - :x:
 - Gradle Determinism / Verify Artifacts (hiero-network-node-linux-medium) - :x:

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -135,6 +135,7 @@ jobs:
           #- macos-12
           #- macos-11
           - windows-2022
+          - windows-2025
           - hiero-network-node-linux-medium
           - hiero-network-node-linux-large
     steps:


### PR DESCRIPTION
**Description**:

GitHub is removing support for the windows-2019 runner type. This PR removes the references to it.

**Related Issue(s)**:

Fixes #19490

