### PR TITLE
chore: (cherry-pick to tag 0.61.10) Disable the defaults for `contracts.evm.ethTransaction.zeroHapiFees.enabled` and `nodes.nodeRewardsEnabled`

### DIFF
--- a/hedera-node/configuration/mainnet/application.properties
+++ b/hedera-node/configuration/mainnet/application.properties
@@ -7,5 +7,3 @@
 
 #Overrides that differ based on the network
 ledger.id=0x00
-nodes.nodeRewardsEnabled=false
-contracts.evm.ethTransaction.zeroHapiFees.enabled=false

--- a/hedera-node/configuration/previewnet/application.properties
+++ b/hedera-node/configuration/previewnet/application.properties
@@ -11,5 +11,3 @@ contracts.systemContract.updateNFTsMetadata.enabled=true
 ledger.id=0x02
 entities.unlimitedAutoAssociationsEnabled=true
 contracts.systemContract.metadataKeyAndFieldSupport.enabled=true
-nodes.nodeRewardsEnabled=false
-contracts.evm.ethTransaction.zeroHapiFees.enabled=false

--- a/hedera-node/configuration/testnet/application.properties
+++ b/hedera-node/configuration/testnet/application.properties
@@ -8,5 +8,3 @@
 bootstrap.genesisPublicKey=e06b22e0966108fa5d63fc6ae53f9824319b891cd4d6050dbf2b242be7e13344
 contracts.chainId=296
 ledger.id=0x01
-nodes.nodeRewardsEnabled=false
-contracts.evm.ethTransaction.zeroHapiFees.enabled=false

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/NodeRewardManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/NodeRewardManagerTest.java
@@ -109,6 +109,7 @@ class NodeRewardManagerTest {
                 withSettings().extraInterfaces(CommittableWritableStates.class).strictness(Strictness.LENIENT));
         final var config = HederaTestConfigBuilder.create()
                 .withValue("staking.periodMins", 1)
+                .withValue("nodes.nodeRewardsEnabled", true)
                 .getOrCreateConfig();
         given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(config, 1));
         nodeRewardManager = new NodeRewardManager(

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -109,7 +109,7 @@ public record ContractsConfig(
                 boolean systemContractSetUnlimitedAutoAssociationsEnabled,
         @ConfigProperty(value = "systemContract.hts.addresses", defaultValue = "359") // 359 = 0x167, 364 = 0x16C
                 Set<Long> callableHTSAddresses,
-        @ConfigProperty(value = "evm.ethTransaction.zeroHapiFees.enabled", defaultValue = "true") @NetworkProperty
+        @ConfigProperty(value = "evm.ethTransaction.zeroHapiFees.enabled", defaultValue = "false") @NetworkProperty
                 boolean evmEthTransactionZeroHapiFeesEnabled,
         @ConfigProperty(value = "evm.allowCallsToNonContractAccounts", defaultValue = "true") @NetworkProperty
                 boolean evmAllowCallsToNonContractAccounts,

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NodesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NodesConfig.java
@@ -33,7 +33,7 @@ public record NodesConfig(
         @ConfigProperty(defaultValue = "253") @NetworkProperty int maxFqdnSize,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean updateAccountIdAllowed,
         /* Node rewards HIP-1064 configurations */
-        @ConfigProperty(defaultValue = "true") @NetworkProperty boolean nodeRewardsEnabled,
+        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean nodeRewardsEnabled,
         @ConfigProperty(defaultValue = "0") @NetworkProperty long minPerPeriodNodeRewardUsd,
         @ConfigProperty(defaultValue = "25000") @NetworkProperty long targetYearlyNodeRewardsUsd,
         @ConfigProperty(defaultValue = "365") @NetworkProperty long numPeriodsToTargetUsd,


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/19522
Disable the defaults for `contracts.evm.ethTransaction.zeroHapiFees.enabled` and `nodes.nodeRewardsEnabled` and removed overrides in application.properties