### PR TITLE
chore: automate lifecycle of TransactionGenerator

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
@@ -57,13 +57,11 @@ public class BirthRoundFreezeTest {
                     .set(PcesConfig_.PCES_FILE_WRITER_TYPE, PcesFileWriterType.OUTPUT_STREAM.toString());
         }
         network.start(ONE_MINUTE);
-        env.transactionGenerator().start();
 
         // Wait for 30 seconds
         timeManager.waitFor(THIRTY_SECONDS);
 
         // Initiate the migration
-        env.transactionGenerator().stop();
         network.freeze(ONE_MINUTE);
         network.shutdown(ONE_MINUTE);
 
@@ -82,7 +80,6 @@ public class BirthRoundFreezeTest {
 
         // Restart the network. The version before and after this freeze have birth rounds enabled.
         network.resume(ONE_MINUTE);
-        env.transactionGenerator().start();
 
         // Wait for 30 seconds
         timeManager.waitFor(THIRTY_SECONDS);

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationAndFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationAndFreezeTest.java
@@ -55,13 +55,11 @@ public class BirthRoundMigrationAndFreezeTest {
                     .set(PcesConfig_.PCES_FILE_WRITER_TYPE, PcesFileWriterType.OUTPUT_STREAM.toString());
         }
         network.start(ONE_MINUTE);
-        env.transactionGenerator().start();
 
         // Wait for 30 seconds
         timeManager.waitFor(THIRTY_SECONDS);
 
         // Initiate the migration
-        env.transactionGenerator().stop();
         network.freeze(ONE_MINUTE);
         network.shutdown(ONE_MINUTE);
 
@@ -73,13 +71,11 @@ public class BirthRoundMigrationAndFreezeTest {
 
         // Restart the network and perform birth round migration
         network.resume(ONE_MINUTE);
-        env.transactionGenerator().start();
 
         // Wait for 30 seconds
         timeManager.waitFor(THIRTY_SECONDS);
 
         // Initiate the migration
-        env.transactionGenerator().stop();
         network.freeze(ONE_MINUTE);
         network.shutdown(ONE_MINUTE);
 
@@ -94,7 +90,6 @@ public class BirthRoundMigrationAndFreezeTest {
 
         // Restart the network. The version before and after this freeze have birth rounds enabled.
         network.resume(ONE_MINUTE);
-        env.transactionGenerator().start();
 
         // Wait for 30 seconds
         timeManager.waitFor(THIRTY_SECONDS);

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationTest.java
@@ -45,13 +45,11 @@ class BirthRoundMigrationTest {
                     .set(PcesConfig_.PCES_FILE_WRITER_TYPE, PcesFileWriterType.OUTPUT_STREAM.toString());
         }
         network.start(ONE_MINUTE);
-        env.transactionGenerator().start();
 
         // Wait for 30 seconds
         timeManager.waitFor(THIRTY_SECONDS);
 
         // Initiate the migration
-        env.transactionGenerator().stop();
         network.freeze(ONE_MINUTE);
         network.shutdown(ONE_MINUTE);
 
@@ -74,7 +72,6 @@ class BirthRoundMigrationTest {
 
         // restart the network
         network.resume(ONE_MINUTE);
-        env.transactionGenerator().start();
 
         // Wait for 30 seconds
         timeManager.waitFor(THIRTY_SECONDS);

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/HappyPathTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/HappyPathTest.java
@@ -32,7 +32,6 @@ public class HappyPathTest {
         network.addNodes(4);
         assertContinuouslyThat(network.getConsensusResults()).haveEqualRounds();
         network.start(Duration.ofMinutes(1L));
-        env.transactionGenerator().start();
 
         // Wait for two minutes
         timeManager.waitFor(Duration.ofMinutes(1L));

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
@@ -31,7 +31,6 @@ public class SandboxTest {
         // Setup simulation
         final List<Node> nodes = network.addNodes(4);
         network.start(ONE_MINUTE);
-        env.transactionGenerator().start();
 
         // Wait for two minutes
         timeManager.waitFor(TWO_MINUTES);
@@ -66,9 +65,8 @@ public class SandboxTest {
         network.addNodes(3);
         final InstrumentedNode nodeX = network.addInstrumentedNode();
         network.start(ONE_MINUTE);
-        env.transactionGenerator().start();
 
-        // Wait for one minute
+        // Wait for ten seconds
         timeManager.waitFor(TEN_SECONDS);
 
         // Start branching

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Node.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Node.java
@@ -2,8 +2,10 @@
 package org.hiero.otter.fixtures;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Duration;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.otter.fixtures.result.SingleNodeConsensusResult;
 import org.hiero.otter.fixtures.result.SingleNodeLogResult;
 import org.hiero.otter.fixtures.result.SingleNodePcesResult;
@@ -73,6 +75,14 @@ public interface Node {
      */
     @NonNull
     NodeId getSelfId();
+
+    /**
+     * Returns the status of the platform while the node is running or {@code null} if not.
+     *
+     * @return the status of the platform
+     */
+    @Nullable
+    PlatformStatus platformStatus();
 
     /**
      * Gets the consensus rounds of the node.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TransactionGenerator.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TransactionGenerator.java
@@ -13,13 +13,16 @@ public interface TransactionGenerator {
     int TPS = 100;
 
     /**
-     * Start the generation of transactions with the default transaction factory that uses
-     * random {@code int} values.
+     * Start the generation of transactions.
+     *
+     * <p>This method is idempotent, meaning that it is safe to call multiple times.
      */
     void start();
 
     /**
      * Stop the transaction generation.
+     *
+     * <p>This method is idempotent, meaning that it is safe to call multiple times.
      */
     void stop();
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -65,6 +65,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
     private final TurtleLogging logging;
     private final Path rootOutputDirectory;
     private final List<TurtleNode> nodes = new ArrayList<>();
+    private final TurtleTransactionGenerator transactionGenerator;
 
     private List<Node> publicNodes = List.of();
     private ExecutorService executorService;
@@ -79,16 +80,19 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
      * @param timeManager the time manager
      * @param logging the logging utility
      * @param rootOutputDirectory the directory where the node output will be stored, like saved state and so on
+     * @param transactionGenerator the transaction generator that generates a steady flow of transactions to all nodes
      */
     public TurtleNetwork(
             @NonNull final Randotron randotron,
             @NonNull final TurtleTimeManager timeManager,
             @NonNull final TurtleLogging logging,
-            @NonNull final Path rootOutputDirectory) {
+            @NonNull final Path rootOutputDirectory,
+            @NonNull final TurtleTransactionGenerator transactionGenerator) {
         this.randotron = requireNonNull(randotron);
         this.timeManager = requireNonNull(timeManager);
         this.logging = requireNonNull(logging);
         this.rootOutputDirectory = requireNonNull(rootOutputDirectory);
+        this.transactionGenerator = requireNonNull(transactionGenerator);
     }
 
     /**
@@ -147,6 +151,8 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
             node.start(Duration.ZERO);
         }
 
+        transactionGenerator.start();
+
         log.debug("Waiting for nodes to become active...");
         if (!timeManager.waitForCondition(allNodesInStatus(ACTIVE), timeout)) {
             fail("Timeout while waiting for nodes to become active.");
@@ -189,6 +195,8 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         if (!timeManager.waitForCondition(allNodesInStatus(FREEZE_COMPLETE), timeout)) {
             fail("Timeout while waiting for all nodes to freeze.");
         }
+
+        transactionGenerator.stop();
     }
 
     /**
@@ -204,6 +212,8 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         for (final TurtleNode node : nodes) {
             node.killImmediately(Duration.ZERO);
         }
+
+        transactionGenerator.stop();
     }
 
     /**
@@ -215,6 +225,8 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         for (final TurtleNode node : nodes) {
             node.start(Duration.ZERO);
         }
+
+        transactionGenerator.start();
 
         log.debug("Waiting for nodes to become active again...");
         if (!timeManager.waitForCondition(allNodesInStatus(ACTIVE), timeout)) {
@@ -277,6 +289,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         }
 
         simulatedNetwork.tick(now);
+        transactionGenerator.tick(now, publicNodes);
 
         // Iteration order over nodes does not need to be deterministic -- nodes are not permitted to communicate with
         // each other during the tick phase, and they run on separate threads to boot.
@@ -294,6 +307,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
      */
     public void destroy() throws InterruptedException {
         log.info("Destroying network...");
+        transactionGenerator.stop();
         for (final TurtleNode node : nodes) {
             node.destroy();
         }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -155,12 +155,11 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
     }
 
     /**
-     * Returns the status of the platform while the node is running or {@code null} if not.
-     *
-     * @return the status of the platform
+     * {@inheritDoc}
      */
+    @Override
     @Nullable
-    PlatformStatus platformStatus() {
+    public PlatformStatus platformStatus() {
         return platformStatus;
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -39,7 +39,7 @@ public class TurtleTestEnvironment implements TestEnvironment {
     static final Duration STANDARD_DEVIATION_NETWORK_DELAY = Duration.ofMillis(10);
 
     private final TurtleNetwork network;
-    private final TurtleTransactionGenerator generator;
+    private final TurtleTransactionGenerator transactionGenerator;
     private final TurtleTimeManager timeManager;
 
     /**
@@ -52,7 +52,7 @@ public class TurtleTestEnvironment implements TestEnvironment {
                 FileUtils.deleteDirectory(rootOutputDirectory);
             }
             Files.createDirectories(rootOutputDirectory);
-        } catch (IOException ex) {
+        } catch (final IOException ex) {
             log.warn("Failed to delete directory: {}", rootOutputDirectory, ex);
         }
 
@@ -76,12 +76,10 @@ public class TurtleTestEnvironment implements TestEnvironment {
 
         timeManager = new TurtleTimeManager(time, GRANULARITY);
 
-        network = new TurtleNetwork(randotron, timeManager, logging, rootOutputDirectory);
-
-        generator = new TurtleTransactionGenerator(network, randotron);
+        transactionGenerator = new TurtleTransactionGenerator(randotron);
+        network = new TurtleNetwork(randotron, timeManager, logging, rootOutputDirectory, transactionGenerator);
 
         timeManager.addTimeTickReceiver(network);
-        timeManager.addTimeTickReceiver(generator);
     }
 
     /**
@@ -108,7 +106,7 @@ public class TurtleTestEnvironment implements TestEnvironment {
     @Override
     @NonNull
     public TransactionGenerator transactionGenerator() {
-        return generator;
+        return transactionGenerator;
     }
 
     /**
@@ -116,7 +114,6 @@ public class TurtleTestEnvironment implements TestEnvironment {
      */
     @Override
     public void destroy() throws InterruptedException {
-        generator.stop();
         network.destroy();
         ConstructableRegistry.getInstance().reset();
         RuntimeObjectRegistry.reset();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTransactionGenerator.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTransactionGenerator.java
@@ -5,31 +5,40 @@ import static java.util.Objects.requireNonNull;
 
 import com.swirlds.common.test.fixtures.Randotron;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
+import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.TransactionGenerator;
-import org.hiero.otter.fixtures.turtle.TurtleTimeManager.TimeTickReceiver;
 
-public class TurtleTransactionGenerator implements TransactionGenerator, TimeTickReceiver {
+/**
+ * A transaction generator for the Turtle framework.
+ *
+ * <p>This class implements the {@link TransactionGenerator} interface and generates transactions at a fixed rate
+ * to be submitted to the active nodes in the Turtle network.
+ */
+public class TurtleTransactionGenerator implements TransactionGenerator {
 
     private static final Duration CYCLE_DURATION = Duration.ofSeconds(1).dividedBy(TransactionGenerator.TPS);
 
-    private final TurtleNetwork network;
     private final Randotron randotron;
 
+    @Nullable
     private Instant startTime;
+
+    @Nullable
     private Instant lastTimestamp;
+
     private boolean running;
 
     /**
      * Constructor for the {@link TurtleTransactionGenerator} class.
      *
-     * @param network the turtle network
      * @param randotron the random number generator
      */
-    public TurtleTransactionGenerator(@NonNull final TurtleNetwork network, @NonNull final Randotron randotron) {
-        this.network = requireNonNull(network);
+    public TurtleTransactionGenerator(@NonNull final Randotron randotron) {
         this.randotron = requireNonNull(randotron);
     }
 
@@ -54,20 +63,26 @@ public class TurtleTransactionGenerator implements TransactionGenerator, TimeTic
     }
 
     /**
-     * {@inheritDoc}
+     * Generates and submits transactions to the active nodes in the network at a fixed rate.
+     *
+     * @param now the current time
+     * @param nodes the list of nodes in the network
      */
-    @Override
-    public void tick(@NonNull Instant now) {
+    public void tick(@NonNull final Instant now, @NonNull final List<Node> nodes) {
         if (!running) {
             return;
         }
 
         if (lastTimestamp != null) {
+            assert startTime != null; // startTime must be initialized if lastTimestamp is not null
             final long previousCount =
                     Duration.between(startTime, lastTimestamp).dividedBy(CYCLE_DURATION);
             final long currentCount = Duration.between(startTime, now).dividedBy(CYCLE_DURATION);
+            final List<Node> activeNodes = nodes.stream()
+                    .filter(node -> node.platformStatus() == PlatformStatus.ACTIVE)
+                    .toList();
             for (long i = previousCount; i < currentCount; i++) {
-                for (final Node node : network.getNodes()) {
+                for (final Node node : activeNodes) {
                     // Generate a random transaction and submit it to the node.
                     final byte[] transaction = TransactionFactory.createEmptyTransaction(randotron.nextInt())
                             .toByteArray();


### PR DESCRIPTION
**Description**:

This PR ensures we start and stop `TurtleTransactionGenerator` automatically when the `TurtleNetwork` is started and stopped. This avoids dealing with the `TransactionGenerator` in almost all tests.

(The only tests I can think of right now that require using the `TransactionGenerator` are tests related to quiescence.)


**Related issue(s)**:

Fixes #19251 