### PR TITLE
chore: 19576: A typo in VirtualNodeCache.merge()

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -512,7 +512,7 @@ public final class VirtualNodeCache<K extends VirtualKey, V extends VirtualValue
                         "Merged version {}, {} dirty leaves, {} dirty internals",
                         fastCopyVersion,
                         dirtyLeaves.size(),
-                        dirtyHashes.seal());
+                        dirtyHashes.size());
             }
         }
     }


### PR DESCRIPTION

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/19576
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
