### PR TITLE
fix: Check for deleted accounts in `ConversionUtils.accountNumberForEvmReference`

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorized/IsAuthorizedCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/isauthorized/IsAuthorizedCall.java
@@ -86,8 +86,7 @@ public class IsAuthorizedCall extends AbstractCall {
         final var authorized = verifyMessage(
                 key, wrap(message), MessageType.RAW, sigMap, ky -> SimpleKeyStatus.ONLY_IF_CRYPTO_SIG_VALID);
 
-        final var result = encodedOutput(SUCCESS, authorized, gasRequirement);
-        return result;
+        return encodedOutput(SUCCESS, authorized, gasRequirement);
     }
 
     protected boolean verifyMessage(
@@ -104,8 +103,7 @@ public class IsAuthorizedCall extends AbstractCall {
             final ResponseCodeEnum rce, final boolean authorized, final long gasRequirement) {
         final long code = rce.protoOrdinal();
         final var output = IsAuthorizedTranslator.IS_AUTHORIZED.getOutputs().encode(Tuple.of(code, authorized));
-        final var result = gasOnly(successResult(output, gasRequirement), SUCCESS, true);
-        return result;
+        return gasOnly(successResult(output, gasRequirement), SUCCESS, true);
     }
 
     /**
@@ -137,7 +135,6 @@ public class IsAuthorizedCall extends AbstractCall {
 
     boolean isValidAccount(final long accountNum) {
         // invalid if accountNum is negative
-        if (accountNum < 0) return false;
-        return true;
+        return accountNum >= 0;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -436,7 +436,7 @@ public class ConversionUtils {
         } else {
             final var account = nativeOperations.getAccount(
                     nativeOperations.entityIdFactory().newAccountId(number));
-            if (account == null) {
+            if (account == null || account.deleted()) {
                 return MISSING_ENTITY_NUMBER;
             } else if (!Arrays.equals(explicit, explicitAddressOf(account))) {
                 return NON_CANONICAL_REFERENCE_NUMBER;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
@@ -493,6 +493,10 @@ public class TestHelpers {
                             .spenderId(B_NEW_ACCOUNT_ID)
                             .build())
             .build();
+
+    public static final Account DELETED_SOMEBODY =
+            SOMEBODY.copyBuilder().deleted(true).build();
+
     public static final Account ALIASED_SOMEBODY = Account.newBuilder()
             .accountId(A_NEW_ACCOUNT_ID)
             .alias(tuweniToPbjBytes(EIP_1014_ADDRESS))

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
@@ -9,6 +9,7 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.A_NEW_A
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.BESU_LOG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALLED_CONTRACT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.CALL_DATA;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DELETED_SOMEBODY;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.EIP_1014_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.INVALID_CONTRACT_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.LONG_ZERO_ADDRESS_BYTES;
@@ -127,6 +128,16 @@ class ConversionUtilsTest {
     void returnsMissingIfSmallLongZeroAddressIsMissing() {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         final var address = asHeadlongAddress(Address.fromHexString("0x1234").toArray());
+        final var actual = accountNumberForEvmReference(address, nativeOperations);
+        assertEquals(MISSING_ENTITY_NUMBER, actual);
+    }
+
+    @Test
+    void returnsMissingIfAccountDeleted() {
+        final long number = A_NEW_ACCOUNT_ID.accountNumOrThrow();
+        given(nativeOperations.getAccount(any(AccountID.class))).willReturn(DELETED_SOMEBODY);
+        given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        final var address = asHeadlongAddress(asEvmAddress(number));
         final var actual = accountNumberForEvmReference(address, nativeOperations);
         assertEquals(MISSING_ENTITY_NUMBER, actual);
     }


### PR DESCRIPTION
**Description**:
Add a check for deleted account when using the `ConversionUtils.accountNumberForEvmReference`method

**Related issue(s)**:

Fixes #18002 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
