### PR TITLE
chore: Upload artifacts during SDK TCK regression panel

### DIFF
--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -182,7 +182,7 @@ jobs:
             gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            /repos/hiero-ledger/hiero-consensus-node/actions/jobs/$job_id/logs >> run.log
+            /repos/hiero-ledger/hiero-consensus-node/actions/jobs/"${job_id}"/logs >> run.log
           done
 
       - name: Upload log as artifact


### PR DESCRIPTION
**Description**:

This pull request enhances the GitHub Actions workflow for the TCK regression tests by adding steps to generate and upload test reports, collect run logs, and upload the logs as artifacts. These changes improve traceability and debugging capabilities for the regression test runs.

### Enhancements to GitHub Actions workflow:

* **Test Report Upload**: Added a step to upload the SDK TCK Regression Test Report as an artifact, storing it for 7 days. This ensures test results are accessible for review. (`.github/workflows/zxc-tck-regression.yaml`, [.github/workflows/zxc-tck-regression.yamlR161-R193](diffhunk://#diff-276b3c78510bfe1ba0edc6d1c72256cf2d3c424c7b3733a999efb0f5c7b886cdR161-R193))

* **Log Collection and Upload**:
  * Added a step to collect logs for all jobs in the workflow run, appending them to a single `run.log` file. This aids in debugging by consolidating logs in one place. (`.github/workflows/zxc-tck-regression.yaml`, [.github/workflows/zxc-tck-regression.yamlR161-R193](diffhunk://#diff-276b3c78510bfe1ba0edc6d1c72256cf2d3c424c7b3733a999efb0f5c7b886cdR161-R193))
  * Added a step to upload the consolidated `run.log` file as an artifact, ensuring logs are preserved for further analysis. (`.github/workflows/zxc-tck-regression.yaml`, [.github/workflows/zxc-tck-regression.yamlR161-R193](diffhunk://#diff-276b3c78510bfe1ba0edc6d1c72256cf2d3c424c7b3733a999efb0f5c7b886cdR161-R193))

**Related issue(s)**:

Fixes #19743

**Testing**:

[Test Run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/15711921658/job/44271975610)