### PR TITLE
fix: (cherry-pick 0.63): Only accept fully-qualified domain names for web proxy endpoint

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
@@ -97,7 +97,7 @@ public class NodeCreateHandler implements TransactionHandler {
         addressBookValidator.validateServiceEndpoint(op.serviceEndpoint(), nodeConfig);
         if (op.hasGrpcProxyEndpoint()) {
             validateTrue(nodeConfig.webProxyEndpointsEnabled(), GRPC_WEB_PROXY_NOT_SUPPORTED);
-            addressBookValidator.validateEndpoint(op.grpcProxyEndpoint(), nodeConfig);
+            addressBookValidator.validateFqdnEndpoint(op.grpcProxyEndpoint(), nodeConfig);
         }
         handleContext.attributeValidator().validateKey(op.adminKeyOrThrow(), INVALID_ADMIN_KEY);
 

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
@@ -119,7 +119,7 @@ public class NodeUpdateHandler implements TransactionHandler {
         }
         if (op.hasGrpcProxyEndpoint()) {
             validateTrue(nodeConfig.webProxyEndpointsEnabled(), GRPC_WEB_PROXY_NOT_SUPPORTED);
-            addressBookValidator.validateEndpoint(op.grpcProxyEndpoint(), nodeConfig);
+            addressBookValidator.validateFqdnEndpoint(op.grpcProxyEndpoint(), nodeConfig);
         }
 
         final var nodeBuilder = updateNode(op, existingNode);

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/validators/AddressBookValidator.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/validators/AddressBookValidator.java
@@ -152,8 +152,27 @@ public class AddressBookValidator {
         validateFalse(addressLen == 0 && endpoint.domainName().trim().isEmpty(), INVALID_ENDPOINT);
         validateFalse(
                 addressLen != 0 && !endpoint.domainName().trim().isEmpty(), IP_FQDN_CANNOT_BE_SET_FOR_SAME_ENDPOINT);
-        validateFalse(endpoint.domainName().trim().length() > nodesConfig.maxFqdnSize(), FQDN_SIZE_TOO_LARGE);
+        validateFqdnSize(endpoint, nodesConfig);
         validateFalse(addressLen != 0 && addressLen != 4, INVALID_IPV4_ADDRESS);
+    }
+
+    /**
+     * Validates that a {@code ServiceEndpoint} <b>only</b> contains a valid FQDN (with no IPv4 address)
+     *
+     * @param endpoint the endpoint to validate
+     * @param nodesConfig the nodes configuration
+     */
+    public void validateFqdnEndpoint(@NonNull final ServiceEndpoint endpoint, @NonNull final NodesConfig nodesConfig) {
+        requireNonNull(endpoint);
+        requireNonNull(nodesConfig);
+
+        validateFalse(endpoint.domainName().isEmpty(), INVALID_SERVICE_ENDPOINT);
+        validateFqdnSize(endpoint, nodesConfig);
+        validateFalse(endpoint.ipAddressV4().length() > 0, INVALID_SERVICE_ENDPOINT);
+    }
+
+    private void validateFqdnSize(@NonNull final ServiceEndpoint endpoint, @NonNull final NodesConfig nodesConfig) {
+        validateFalse(endpoint.domainName().trim().length() > nodesConfig.maxFqdnSize(), FQDN_SIZE_TOO_LARGE);
     }
 
     /**

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
@@ -505,7 +505,7 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
                 .withAccountId(accountId)
                 .withGossipEndpoint(List.of(endpoint1, endpoint2))
                 .withServiceEndpoint(List.of(endpoint1, endpoint3))
-                .withGrpcWebProxyEndpoint(endpoint1)
+                .withGrpcWebProxyEndpoint(endpoint3)
                 .withAdminKey(invalidKey)
                 .build(payerId);
         setupHandle();
@@ -531,7 +531,7 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
                 .withDescription("Description")
                 .withGossipEndpoint(List.of(endpoint1, endpoint2))
                 .withServiceEndpoint(List.of(endpoint1, endpoint3))
-                .withGrpcWebProxyEndpoint(endpoint1)
+                .withGrpcWebProxyEndpoint(endpoint3)
                 .withGossipCaCertificate(Bytes.wrap(certList.get(0).getEncoded()))
                 .withGrpcCertificateHash(Bytes.wrap("hash"))
                 .withAdminKey(key)

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/validators/AddressBookValidatorTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/validators/AddressBookValidatorTest.java
@@ -1,22 +1,40 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.addressbook.impl.validators;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.FQDN_SIZE_TOO_LARGE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_GOSSIP_CA_CERTIFICATE;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SERVICE_ENDPOINT;
 import static com.hedera.node.app.service.addressbook.AddressBookHelper.writeCertificatePemFile;
 import static com.hedera.node.app.service.addressbook.impl.test.handlers.AddressBookTestBase.generateX509Certificates;
 import static com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator.validateX509Certificate;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.hedera.hapi.node.base.ServiceEndpoint;
+import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
+import com.hedera.node.config.data.NodesConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class AddressBookValidatorTest {
+    private static final ServiceEndpoint GRPC_PROXY_ENDPOINT_FQDN = ServiceEndpoint.newBuilder()
+            .domainName("grpc.web.proxy.com")
+            .port(123)
+            .build();
+    private static final ServiceEndpoint GRPC_PROXY_ENDPOINT_IP = ServiceEndpoint.newBuilder()
+            .ipAddressV4(Bytes.wrap("192.168.1.255"))
+            .port(123)
+            .build();
+
     private static X509Certificate x509Cert;
 
     @BeforeAll
@@ -36,5 +54,69 @@ class AddressBookValidatorTest {
         final var e =
                 assertThrows(PreCheckException.class, () -> validateX509Certificate(Bytes.wrap(baos.toByteArray())));
         assertEquals(INVALID_GOSSIP_CA_CERTIFICATE, e.responseCode());
+    }
+
+    @Test
+    void nullParamsWebProxyEndpointFailsValidation() {
+        final var config = newNodesConfig();
+        //noinspection DataFlowIssue
+        assertThrows(NullPointerException.class, () -> new AddressBookValidator().validateFqdnEndpoint(null, config));
+        //noinspection DataFlowIssue
+        assertThrows(NullPointerException.class, () -> new AddressBookValidator()
+                .validateFqdnEndpoint(GRPC_PROXY_ENDPOINT_FQDN, null));
+    }
+
+    @Test
+    void ipOnlyWebProxyEndpointFailsValidation() {
+        final var e = assertThrows(HandleException.class, () -> new AddressBookValidator()
+                .validateFqdnEndpoint(GRPC_PROXY_ENDPOINT_IP, newNodesConfig()));
+        Assertions.assertThat(e.getStatus()).isEqualTo(INVALID_SERVICE_ENDPOINT);
+    }
+
+    @Test
+    void ipAndfqdnWebProxyEndpointFailsValidation() {
+        final var e = assertThrows(HandleException.class, () -> new AddressBookValidator()
+                .validateFqdnEndpoint(
+                        ServiceEndpoint.newBuilder()
+                                .ipAddressV4(Bytes.wrap("192.168.1.255"))
+                                .domainName("grpc.web.proxy.com")
+                                .port(123)
+                                .build(),
+                        newNodesConfig()));
+        Assertions.assertThat(e.getStatus()).isEqualTo(INVALID_SERVICE_ENDPOINT);
+    }
+
+    @Test
+    void emptyDomainNameWebProxyEndpointFailsValidation() {
+        final var e = assertThrows(HandleException.class, () -> new AddressBookValidator()
+                .validateFqdnEndpoint(
+                        ServiceEndpoint.newBuilder().domainName("").port(123).build(), newNodesConfig()));
+        Assertions.assertThat(e.getStatus()).isEqualTo(INVALID_SERVICE_ENDPOINT);
+    }
+
+    @Test
+    void tooLongFqdnWebProxyEndpointFailsValidation() {
+        // Intentionally reduce the max FQDN size to trigger the validation error
+        final var config = newNodesConfig(10);
+        final var e = assertThrows(HandleException.class, () -> new AddressBookValidator()
+                .validateFqdnEndpoint(GRPC_PROXY_ENDPOINT_FQDN, config));
+        Assertions.assertThat(e.getStatus()).isEqualTo(FQDN_SIZE_TOO_LARGE);
+    }
+
+    @Test
+    void fqdnWebProxyEndpointPassesValidation() {
+        assertDoesNotThrow(
+                () -> new AddressBookValidator().validateFqdnEndpoint(GRPC_PROXY_ENDPOINT_FQDN, newNodesConfig()));
+    }
+
+    private NodesConfig newNodesConfig() {
+        return newNodesConfig(253);
+    }
+
+    private NodesConfig newNodesConfig(final int maxFqdnSize) {
+        return new TestConfigBuilder()
+                .withValue("nodes.maxFqdnSize", maxFqdnSize)
+                .getOrCreateConfig()
+                .getConfigData(NodesConfig.class);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
@@ -28,7 +28,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GOSSIP_ENDPOIN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GRPC_WEB_PROXY_NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ENDPOINT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_GOSSIP_CA_CERTIFICATE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_GOSSIP_ENDPOINT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID;
@@ -140,7 +139,6 @@ public class NodeCreateTest {
      */
     @HapiTest
     final Stream<DynamicTest> failOnInvalidServiceEndpoint() {
-
         return hapiTest(nodeCreate("nodeCreate").serviceEndpoint(List.of()).hasPrecheck(INVALID_SERVICE_ENDPOINT));
     }
 
@@ -295,7 +293,8 @@ public class NodeCreateTest {
         final var nodeCreate = canonicalNodeCreate()
                 .gossipEndpoint(GOSSIP_ENDPOINTS_IPS)
                 .serviceEndpoint(SERVICES_ENDPOINTS_IPS)
-                .grpcWebProxyEndpoint(GRPC_PROXY_ENDPOINT_IP);
+                // The web proxy endpoint can never be an IP address
+                .grpcWebProxyEndpoint(GRPC_PROXY_ENDPOINT_FQDN);
         return hapiTest(
                 overriding("nodes.webProxyEndpointsEnabled", "true"),
                 newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519),
@@ -304,7 +303,7 @@ public class NodeCreateTest {
                 viewNode("nodeCreate", node -> {
                     assertEqualServiceEndpoints(GOSSIP_ENDPOINTS_IPS, node.gossipEndpoint());
                     assertEqualServiceEndpoints(SERVICES_ENDPOINTS_IPS, node.serviceEndpoint());
-                    assertEqualServiceEndpoint(GRPC_PROXY_ENDPOINT_IP, node.grpcProxyEndpoint());
+                    assertEqualServiceEndpoint(GRPC_PROXY_ENDPOINT_FQDN, node.grpcProxyEndpoint());
                 }));
     }
 
@@ -354,6 +353,18 @@ public class NodeCreateTest {
                 overriding("nodes.gossipFqdnRestricted", "false"),
                 newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519),
                 nodeCreate.hasKnownStatus(GRPC_WEB_PROXY_NOT_SUPPORTED));
+    }
+
+    @LeakyHapiTest(overrides = {"nodes.webProxyEndpointsEnabled"})
+    final Stream<DynamicTest> webProxyAsIpAddressIsRejected() throws CertificateEncodingException {
+        return hapiTest(
+                overriding("nodes.webProxyEndpointsEnabled", "true"),
+                newKeyNamed("adminKey"),
+                nodeCreate("nodeCreate")
+                        .adminKey("adminKey")
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded())
+                        .grpcWebProxyEndpoint(GRPC_PROXY_ENDPOINT_IP)
+                        .hasKnownStatus(INVALID_SERVICE_ENDPOINT));
     }
 
     private static HapiNodeCreate canonicalNodeCreate() throws CertificateEncodingException {
@@ -623,7 +634,7 @@ public class NodeCreateTest {
                         .gossipCaCertificate(gossipCertificates.getFirst().getEncoded())
                         .grpcWebProxyEndpoint(ServiceEndpoint.getDefaultInstance())
                         .description("newNode")
-                        .hasKnownStatus(INVALID_ENDPOINT));
+                        .hasKnownStatus(INVALID_SERVICE_ENDPOINT));
     }
 
     private static void assertEqualServiceEndpoints(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeUpdateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeUpdateTest.java
@@ -26,16 +26,17 @@ import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.NONSENSE_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.GRPC_PROXY_ENDPOINT_FQDN;
+import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.GRPC_PROXY_ENDPOINT_IP;
 import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.generateX509Certificates;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GOSSIP_ENDPOINTS_EXCEEDED_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GOSSIP_ENDPOINT_CANNOT_HAVE_FQDN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GRPC_WEB_PROXY_NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ENDPOINT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_GOSSIP_CA_CERTIFICATE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_IPV4_ADDRESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_DESCRIPTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SERVICE_ENDPOINT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.KEY_REQUIRED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
@@ -45,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.HapiTest;
@@ -169,7 +171,7 @@ public class NodeUpdateTest {
                 nodeUpdate("testNode")
                         .adminKey("adminKey")
                         .grpcProxyEndpoint(invalidServiceEndpoint())
-                        .hasKnownStatus(INVALID_IPV4_ADDRESS));
+                        .hasKnownStatus(INVALID_SERVICE_ENDPOINT));
     }
 
     @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
@@ -193,7 +195,7 @@ public class NodeUpdateTest {
             reason = NEEDS_STATE_ACCESS,
             overrides = {"nodes.webProxyEndpointsEnabled"})
     final Stream<DynamicTest> updateMultipleFieldsWork() throws CertificateEncodingException {
-        final var proxyWebEndpoint = toPbj(endpointFor("127.0.0.3", 123));
+        final var proxyWebEndpoint = toPbj(endpointFor("grpc.web.proxy.com", 123));
         final var updateOp = nodeUpdate("testNode")
                 .adminKey("adminKey2")
                 .signedBy(DEFAULT_PAYER, "adminKey", "adminKey2")
@@ -366,7 +368,7 @@ public class NodeUpdateTest {
                 nodeUpdate("testNode")
                         .grpcProxyEndpoint(toPbj(ServiceEndpoint.getDefaultInstance()))
                         .signedBy("adminKey", DEFAULT_PAYER)
-                        .hasKnownStatus(INVALID_ENDPOINT));
+                        .hasKnownStatus(INVALID_SERVICE_ENDPOINT));
     }
 
     @LeakyHapiTest(overrides = {"nodes.nodeMaxDescriptionUtf8Bytes"})
@@ -422,5 +424,19 @@ public class NodeUpdateTest {
                         .description("updated description")
                         .via("successUpdate"),
                 getTxnRecord("successUpdate").logged());
+    }
+
+    @LeakyHapiTest(overrides = {"nodes.webProxyEndpointsEnabled"})
+    final Stream<DynamicTest> webProxyAsIpAddressIsRejected() throws CertificateEncodingException {
+        return hapiTest(
+                overriding("nodes.webProxyEndpointsEnabled", "true"),
+                newKeyNamed("adminKey"),
+                nodeCreate("testNode")
+                        .adminKey("adminKey")
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
+                nodeUpdate("testNode")
+                        .signedByPayerAnd("adminKey")
+                        .grpcProxyEndpoint(CommonPbjConverters.toPbj(GRPC_PROXY_ENDPOINT_IP))
+                        .hasKnownStatus(INVALID_SERVICE_ENDPOINT));
     }
 }


### PR DESCRIPTION
Cherry-pick of [this PR](https://github.com/hiero-ledger/hiero-consensus-node/pull/19755) to `release/0.63`.