### PR TITLE
chore: Update callouts to SDPT and SDLT

### DIFF
--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -155,7 +155,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "Trigger ZXF: [CITR] Single Day Performance Test"
+      - name: "Trigger ZXF: [CITR] Single Day Performance Test (SDPT)"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
           workflow: .github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -175,7 +175,7 @@ jobs:
             "disable-notifications": "false"
             }'
 
-      - name: "Trigger ZXF: [CITR] Single Day Longevity Test"
+      - name: "Trigger ZXF: [CITR] Single Day Longevity Test (SDLT)"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
           workflow: .github/workflows/flow-node-performance-tests.yaml

--- a/.github/workflows/zxf-single-day-longevity-test.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "ZXF: [CITR] Single Day Longevity Tests"
+name: "ZXF: [CITR] Single Day Longevity Tests (SDLT)"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "ZXF: [CITR] Single Day Performance Test Controller"
+name: "ZXF: [CITR] Single Day Performance Test Controller (SDPT)"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Description

This pull request updates workflow names in the `.github/workflows` directory to include abbreviations for better clarity and consistency. The changes affect both the workflow files and job definitions within them.

Updates to workflow and job names:

* [`.github/workflows/zxcron-promote-build-candidate.yaml`](diffhunk://#diff-89d3b8a3e8afc59c6f80a6fd05b26af1961d04aeb9b535607cb3bc9d9c403a6aL158-R158): Updated job names to include abbreviations "(SDPT)" for "Single Day Performance Test" and "(SDLT)" for "Single Day Longevity Test." [[1]](diffhunk://#diff-89d3b8a3e8afc59c6f80a6fd05b26af1961d04aeb9b535607cb3bc9d9c403a6aL158-R158) [[2]](diffhunk://#diff-89d3b8a3e8afc59c6f80a6fd05b26af1961d04aeb9b535607cb3bc9d9c403a6aL178-R178)
* [`.github/workflows/zxf-single-day-longevity-test.yaml`](diffhunk://#diff-d9c0c4fdf83408eed781ac403b3b1f6d400b74ff89aa93cb96f0b1280ebf3d52L2-R2): Updated the workflow name to include the abbreviation "(SDLT)."
* [`.github/workflows/zxf-single-day-performance-test-controller.yaml`](diffhunk://#diff-af0846566d395a9cd891f76bc1bafbafa2ab4155371d913cf568171aeab667cfL2-R2): Updated the workflow name to include the abbreviation "(SDPT)."

### Related Issue(s)

- closes #19930