### PR TITLE
chore: Fix build-release-artifact to grab the commit sha properly

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -154,7 +154,7 @@ jobs:
           else
             COMMIT_SHA="${REF_CHECK}"
           fi
-          
+
           echo "COMMIT SHA is: ${COMMIT_SHA}"
           BRANCH_NAME="${{ inputs.ref-name }}"
           BRANCH_NAME="${BRANCH_NAME##origin/}"


### PR DESCRIPTION
**Description**:

This pull request updates the `.github/workflows/node-zxc-build-release-artifact.yaml` file to enhance metadata handling and improve the verification of workflow parameters. The changes focus on refining the logic for commit SHA resolution and adding detailed branch and commit metadata to the workflow summary.

Enhancements to workflow parameter handling:

* Updated the logic for resolving `COMMIT_SHA` to use `git ls-remote` for verifying the reference against the repository URL, ensuring accurate retrieval of commit information.

Improved metadata reporting:

* Added detailed branch and commit metadata to the GitHub step summary, including branch name variations, commit prefix, and both full and short commit SHAs.

**Related issue(s)**:

Fixes #20002 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] [Branch Name Test](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/16052976330)
- [x] [Tag Name Test](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/16052937939)
- [x] [Commit SHA Test](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/16052886412)
