### PR TITLE
fix(18458): Pces file writer rollback 

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
@@ -97,5 +97,5 @@ public record PcesConfig(
         @ConfigProperty(defaultValue = "1ms") Duration replayHealthThreshold,
         @ConfigProperty(defaultValue = "true") boolean limitReplayFrequency,
         @ConfigProperty(defaultValue = "5000") int maxEventReplayFrequency,
-        @ConfigProperty(defaultValue = "EVERY_EVENT") FileSyncOption inlinePcesSyncOption,
+        @ConfigProperty(defaultValue = "EVERY_SELF_EVENT") FileSyncOption inlinePcesSyncOption,
         @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType pcesFileWriterType) {}


### PR DESCRIPTION
**Description**:
In: [Guarantee events needed to reach consensus on a round are on disk before handling that round](https://github.com/hiero-ledger/hiero-consensus-node/issues/18458), we changed how we write events into the pces files (we now sync on every event and write using the strongest available guarantee). It produced an increased i/o activity on the disks.
This configuration rollbacks the change.


**Related issue(s)**:

Reverts #19067 