### PR TITLE
revert: bump com.esaulpaugh:headlong from 13.2.2 to 13.3.0 in /hiero-dependency-versions

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies.constraints {
     api("io.grpc:grpc-protobuf:$grpc") { because("io.grpc.protobuf") }
     api("io.grpc:grpc-stub:$grpc") { because("io.grpc.stub") }
     api("io.grpc:grpc-netty-shaded:$grpc") { because("io.grpc.netty.shaded") }
-    api("com.esaulpaugh:headlong:13.3.0") { because("com.esaulpaugh.headlong") }
+    api("com.esaulpaugh:headlong:13.2.2") { because("com.esaulpaugh.headlong") }
     api("info.picocli:picocli:4.7.7") { because("info.picocli") }
     api("io.github.classgraph:classgraph:4.8.179") { because("io.github.classgraph") }
     api("io.perfmark:perfmark-api:0.27.0") { because("io.perfmark") }


### PR DESCRIPTION
Reverts hiero-ledger/hiero-consensus-node#19950