### PR TITLE
Add configurable EvmReferenceResolver

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/DefaultEvmReferenceResolver.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/DefaultEvmReferenceResolver.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.contract.impl.utils;
+
+import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.MISSING_ENTITY_NUMBER;
+import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.NON_CANONICAL_REFERENCE_NUMBER;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.explicitAddressOf;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.explicitFromHeadlong;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.maybeMissingNumberOf;
+
+import com.esaulpaugh.headlong.abi.Address;
+import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+
+public class DefaultEvmReferenceResolver implements EvmReferenceResolver {
+
+    @Override
+    public long resolve(@NonNull Address address, @NonNull HederaNativeOperations nativeOperations) {
+        final var explicit = explicitFromHeadlong(address);
+        final var number = maybeMissingNumberOf(explicit, nativeOperations);
+        if (number == MISSING_ENTITY_NUMBER) {
+            return MISSING_ENTITY_NUMBER;
+        } else {
+            final var account = nativeOperations.getAccount(
+                    nativeOperations.entityIdFactory().newAccountId(number));
+            if (account == null || account.deleted()) {
+                return MISSING_ENTITY_NUMBER;
+            } else if (!Arrays.equals(explicit, explicitAddressOf(account))) {
+                return NON_CANONICAL_REFERENCE_NUMBER;
+            }
+            return number;
+        }
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/EvmReferenceResolver.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/EvmReferenceResolver.java
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.contract.impl.utils;
+
+import com.esaulpaugh.headlong.abi.Address;
+import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
+
+public interface EvmReferenceResolver {
+    long resolve(Address address, HederaNativeOperations nativeOperations);
+}


### PR DESCRIPTION
**Description**:
This PR makes ConversionUtils.accountNumberForEvmReference behavior pluggable via a new EvmReferenceResolver interface. This allows consumers like Mirror Node to override only the resolution logic without duplicating the entire class.

Mirror Node requires a workaround described in the [modularization breaking changes doc](https://github.com/hiero-ledger/hiero-mirror-node/blob/main/docs/web3/modularized.md) breaking change number 1. Specifically, it needs to allow long-zero addresses based on a system property. This change enables overriding cleanly through dependency injection.

Fixes #

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
