### PR TITLE
test: Disable flaky AtomicRecordsSuite suite

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/batch/AtomicRecordsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/batch/AtomicRecordsSuite.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes32;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -64,6 +65,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @HapiTestLifecycle
 @DisplayName("Records Suite")
+@Disabled
 public class AtomicRecordsSuite {
 
     public static final String LOG_NOW = "logNow";


### PR DESCRIPTION
**Description**:
* The atomic batch is disabled, so it's not a problem to disable this test suite. The test suite is flaky, and we do have a fix https://github.com/hiero-ledger/hiero-consensus-node/pull/20256, but the `StreamValidator` is failing. Until we figure out a solution, we will disable this suite to unblock the pipeline.