### PR TITLE
fix: Restrict inner txn translators with trace data to not use the state changes.

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/impl/SubmitMessageTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/impl/SubmitMessageTranslator.java
@@ -39,13 +39,16 @@ public class SubmitMessageTranslator implements BlockTransactionPartsTranslator 
                     if (parts.status() == SUCCESS) {
                         recordBuilder.assessedCustomFees(parts.assessedCustomFees());
                         receiptBuilder.topicRunningHashVersion(RUNNING_HASH_VERSION);
+
                         // Within batch transactions (inner or their children), state changes from earlier transactions
                         // can be overwritten by subsequent transactions in the same batch (e.g., multiple msg submits).
                         // Therefore, construct the record from trace data when available.
-                        final var maybeTraceData = maybeSubmitMessageTraceData(tracesSoFar);
-                        if (maybeTraceData != null) {
-                            receiptBuilder.topicSequenceNumber(maybeTraceData.sequenceNumber());
-                            receiptBuilder.topicRunningHash(maybeTraceData.runningHash());
+                        if (parts.isInnerBatchTxn()) {
+                            final var maybeTraceData = maybeSubmitMessageTraceData(tracesSoFar);
+                            if (maybeTraceData != null) {
+                                receiptBuilder.topicSequenceNumber(maybeTraceData.sequenceNumber());
+                                receiptBuilder.topicRunningHash(maybeTraceData.runningHash());
+                            }
                             return;
                         }
 
@@ -84,6 +87,7 @@ public class SubmitMessageTranslator implements BlockTransactionPartsTranslator 
                 final var trace = tracesSoFar.get(i);
                 if (trace.hasSubmitMessageTraceData()) {
                     result = trace.submitMessageTraceData();
+                    tracesSoFar.remove(i);
                     break;
                 }
             }


### PR DESCRIPTION

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Restrict translators of the inner batch transactions to use only the trace data and not the state changes.

**Related issue(s)**:

Fixes [#20388](https://github.com/hiero-ledger/hiero-consensus-node/issues/20388)

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
