### PR TITLE
feat: PCLI should not swallow error codes

### DIFF
--- a/platform-sdk/swirlds-cli/pcli.sh
+++ b/platform-sdk/swirlds-cli/pcli.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -o pipefail
 
 #
 # Copyright 2016-2022 Hedera Hashgraph, LLC


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/20392

pcli.sh now forwards any non-zero exit code returned by the Java command.

When running a wrong command:
```
$ ./pcli.sh state migrate /tmp -ac
 .----------------.  .----------------.  .----------------.  .----------------.
| .--------------. || .--------------. || .--------------. || .--------------. |
| |   ______     | || |     ______   | || |   _____      | || |     _____    | |
| |  |_   __ \   | || |   .' ___  |  | || |  |_   _|     | || |    |_   _|   | |
| |    | |__) |  | || |  / .'   \_|  | || |    | |       | || |      | |     | |
| |    |  ___/   | || |  | |         | || |    | |   _   | || |      | |     | |
| |   _| |_      | || |  \ `.___.'\  | || |   _| |__/ |  | || |     _| |_    | |
| |  |_____|     | || |   `._____.'  | || |  |________|  | || |    |_____|   | |
| |              | || |              | || |              | || |              | |
| '--------------' || '--------------' || '--------------' || '--------------' |
 '----------------'  '----------------'  '----------------'  '----------------'
Unmatched arguments from index 1: 'migrate', '/tmp', '-ac'
Did you mean: state validate or state validateAddressBook or state transplant?
2025-07-29 16:56:44.187 1        INFO  STARTUP          <<browser: shutdown-hook>> Log4jSetup: JVM is shutting down.
$ echo $?
2
```

Error inside a command:
```
$ ./pcli.sh state transplant /not-a-state -ac
 .----------------.  .----------------.  .----------------.  .----------------.
| .--------------. || .--------------. || .--------------. || .--------------. |
| |   ______     | || |     ______   | || |   _____      | || |     _____    | |
| |  |_   __ \   | || |   .' ___  |  | || |  |_   _|     | || |    |_   _|   | |
| |    | |__) |  | || |  / .'   \_|  | || |    | |       | || |      | |     | |
| |    |  ___/   | || |  | |         | || |    | |   _   | || |      | |     | |
| |   _| |_      | || |  \ `.___.'\  | || |   _| |__/ |  | || |     _| |_    | |
| |  |_____|     | || |   `._____.'  | || |  |________|  | || |    |_____|   | |
| |              | || |              | || |              | || |              | |
| '--------------' || '--------------' || '--------------' || '--------------' |
 '----------------'  '----------------'  '----------------'  '----------------'
Transplanting state from: /not-a-state
java.nio.file.NoSuchFileException: /not-a-state/preconsensus-events
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystem.move(UnixFileSystem.java:886)
	at java.base/sun.nio.fs.UnixFileSystemProvider.move(UnixFileSystemProvider.java:309)
	at java.base/java.nio.file.Files.move(Files.java:1430)
	at com.swirlds.platform.state.SavedStateUtils.prepareStateForTransplant(SavedStateUtils.java:45)
	at com.swirlds.platform.cli.PrepareForTransplantCommand.call(PrepareForTransplantCommand.java:84)
	at com.swirlds.platform.cli.PrepareForTransplantCommand.call(PrepareForTransplantCommand.java:21)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2031)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2469)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2423)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2277)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2425)
	at picocli.CommandLine.execute(CommandLine.java:2174)
	at com.swirlds.cli.PlatformCli.main(PlatformCli.java:180)
2025-07-29 16:56:57.676 1        INFO  STARTUP          <<browser: shutdown-hook>> Log4jSetup: JVM is shutting down.
$ echo $?
1
```