### PR TITLE
chore: rename SDLT workflow to standard naming convention

### DIFF
--- a/.github/workflows/zxf-single-day-longevity-nlg-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-nlg-test-controller-adhoc.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "ZXF: [CITR] Adhoc - Single Day Longevity NLG Test Controller"
+name: "ZXF: [CITR] Adhoc - Single Day Longevity Test Controller"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "ZXF: [CITR] Single Day Longevity NLG Test Controller"
+name: "ZXF: [CITR] Single Day Longevity Test Controller"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
**Description**:

Rename the SDLT workflow to our standard naming convention.

**Related Issue(s)**:

Fixes #20542
