### PR TITLE
chore: UnzipUtility constraints not needed

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java
@@ -17,21 +17,11 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * Utility class to unzip a zip file.
- * <p>
- * This class was copied from hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/UnzipUtility.java
- * Once we are wholly migrated to the modularized services, we can remove the other location.
  * */
 public final class UnzipUtility {
     private static final Logger log = LogManager.getLogger(UnzipUtility.class);
 
     private static final int BUFFER_SIZE = 4096;
-
-    // these constants are used to prevent Zip Bomb Attacks
-    private static final int THRESHOLD_ENTRIES = 10000; // max # of entries to allow in zip files
-    private static final int THRESHOLD_ZIP_SIZE = 1000000000; // 1 GB - max allowed total size of all uncompressed files
-    private static final int THRESHOLD_ENTRY_SIZE = 100000000; // 100 MB - max allowed size of one uncompressed file
-    // max allowed ratio between uncompressed and compressed file size
-    private static final double THRESHOLD_RATIO = 100;
 
     private UnzipUtility() {}
 
@@ -45,9 +35,6 @@ public final class UnzipUtility {
         requireNonNull(bytes);
         requireNonNull(dstDir);
 
-        int totalSizeArchive = 0; // total size of the zip archive once uncompressed
-        int totalEntryArchive = 0; // total number of entries in the zip archive
-
         try (final var zipIn = new ZipInputStream(new ByteArrayInputStream(bytes))) {
             ZipEntry entry = zipIn.getNextEntry();
 
@@ -55,10 +42,6 @@ public final class UnzipUtility {
                 throw new IOException("No zip entry found in bytes");
             }
             while (entry != null) {
-                totalEntryArchive++;
-                if (totalEntryArchive > THRESHOLD_ENTRIES) {
-                    throw new IOException("Zip file entry count exceeds threshold: " + THRESHOLD_ENTRIES);
-                }
                 Path filePath = dstDir.resolve(entry.getName());
                 final File fileOrDir = filePath.toFile();
                 final String canonicalPath = fileOrDir.getCanonicalPath();
@@ -72,10 +55,7 @@ public final class UnzipUtility {
                 }
 
                 if (!entry.isDirectory()) {
-                    totalSizeArchive += extractSingleFile(zipIn, filePath, entry.getCompressedSize());
-                    if (totalSizeArchive > THRESHOLD_ZIP_SIZE) {
-                        throw new IOException("Zip file size exceeds threshold: " + THRESHOLD_ZIP_SIZE);
-                    }
+                    extractSingleFile(zipIn, filePath);
                     log.info(" - Extracted update file {}", filePath);
                 } else {
                     if (!fileOrDir.exists() && !fileOrDir.mkdirs()) {
@@ -94,33 +74,19 @@ public final class UnzipUtility {
      *
      * @param inputStream Input stream of zip file content
      * @param filePath Output file name
-     * @param compressedSize Size of this zip entry while still compressed in bytes
-     * @return Size of this zip entry once uncompressed
      * @throws IOException if the file can't be written
      */
-    public static int extractSingleFile(
-            @NonNull ZipInputStream inputStream, @NonNull Path filePath, long compressedSize) throws IOException {
+    public static void extractSingleFile(@NonNull ZipInputStream inputStream, @NonNull Path filePath)
+            throws IOException {
         requireNonNull(inputStream);
         requireNonNull(filePath);
-        int totalSizeEntry = 0; // size of this zip entry once uncompressed
 
         try (var bos = new BufferedOutputStream(new FileOutputStream(filePath.toFile()))) {
             final var bytesIn = new byte[BUFFER_SIZE];
             int read;
             while ((read = inputStream.read(bytesIn)) != -1) {
-                totalSizeEntry += read;
-                if (totalSizeEntry > THRESHOLD_ENTRY_SIZE) {
-                    // the uncompressed file size is too large, could be a zip bomb attack
-                    throw new IOException("Zip bomb attack detected, aborting unzip!");
-                }
-                if ((double) totalSizeEntry / compressedSize > THRESHOLD_RATIO) {
-                    // the uncompressed file size is too large compared to the compressed size,
-                    // could be a zip bomb attack
-                    throw new IOException("Zip bomb attack detected, aborting unzip!");
-                }
                 bos.write(bytesIn, 0, read);
             }
         }
-        return totalSizeEntry;
     }
 }


### PR DESCRIPTION
**Description**:
This pull request removes zip bomb protection logic from the `UnzipUtility` class and updates the corresponding tests to reflect these changes. The zip bomb protection code, which previously limited the number and size of entries in zip files and total size, has been eliminated. The test suite has been refactored to remove tests for these protections, add new tests for directory-only and empty zip files, and improve coverage for error cases such as zip slip attacks and invalid parameters.

See #20687 for more information

### Removal of zip bomb protection logic

* Removed all threshold constants and checks in `UnzipUtility` that previously protected against zip bomb attacks by limiting the number of entries, total uncompressed size, individual entry size, and compression ratio. (`hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java`)

### Refactoring and enhancement of tests

* Removed tests and code related to large zip files and zip bomb detection, and introduced new tests for directory-only and empty zip files, as well as improved error case coverage (e.g., invalid zips, zip slip, directory creation failures, and null parameters). (`hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/UnzipUtilityTest.java`)

**Related issue(s)**:

Fixes #20687

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
