### PR TITLE
ci: Update XTS and Build Promotion cron schedules

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -9,8 +9,8 @@ on:
         type: string
         default: ""
   schedule:
-    # Runs Extended Test Suite every three hours
-    - cron: "0 */3 * * *"
+    # Runs Extended Test Suite every three hours Monday to Friday
+    - cron: "0 */3 * * 1-5"
 
 permissions:
   id-token: write

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -3,8 +3,9 @@ name: "ZXCron: [CITR] Promote Build Candidate"
 on:
   workflow_dispatch:
   schedule:
-    # Runs Promote Build Candidate at 0100 hours UTC (8:00 PM CDT)
-    - cron: "0 1 * * *"
+    # Runs Promote Build Candidate at 0100 hours UTC Tuesday to Saturday
+    # (8:00 PM CDT Monday to Friday)
+    - cron: "0 1 * * 2-6"
 
 permissions:
   actions: write


### PR DESCRIPTION
## Description

**ZXCron: [CITR] Extended Test Suite**:
- Updated the cron schedule to run every three hours for Monday through Friday. Given that this is in UTC time this means the jobs will run from 2000 US Central Sundays through 1900 US Central Fridays once every three hours.

**ZXCron: [CITR] Promote Build Candidate**:
- Updated the cron schedule to run every day Tuesday - Saturday at 0100 UTC. This equates to Monday - Friday at 2000 US Centraal.

### Related Issue(s)

- Closes #20733
