### PR TITLE
ci: Update rootly integration to use both rootly-alert-action and rootly-incident-action

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -165,8 +165,6 @@ jobs:
           else
             gh run cancel "${{ github.run_id }}"
           fi
-        
-          exit 1 # EXIT FOR TESTING PURPOSE ONLY
 
   extended-test-suite:
     name: Execute eXtended Test Suite
@@ -569,7 +567,7 @@ jobs:
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
         continue-on-error: true
         with:
-          api_key: dummyvalue # force a failure
+          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: "${{ steps.rootly-summary.outputs.title }}"
           details: "${{ steps.rootly-summary.outputs.summary }}"
           notification_target_type: "Service"


### PR DESCRIPTION
## Description

This pull request updates the workflow for Rootly alerting and incident reporting in `.github/workflows/zxcron-extended-test-suite.yaml`. The main improvements include adding a dedicated step for creating Rootly alerts and upgrading the Rootly incident action to a newer version with updated parameters for better integration and reliability.

**Rootly integration improvements:**

* Added a new step to create a Rootly alert using the `rootly-alert-action`, passing relevant details such as summary, service, urgency, and environment.
* Upgraded the Rootly incident reporting step to use `rootly-incident-action` v2.0.0, with revised parameters including `kind` and linking to alert IDs generated in the previous step.
* Updated the incident reporting configuration to ensure correct mapping of services, teams, and incident types, and improved summary and title handling.

**Minor formatting fix:**

* Fixed a formatting issue in the summary output by correcting the echo statement for the Rootly service section.

### Related issue(s)

Resolves #20804

### Testing

- [x] Test [alert/incident](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/17212189120)
- [x] Test [create incident after alert create failure](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/17212965320/job/48829356547)