### PR TITLE
ci: Integrate rootly with Prepare XTS

### DIFF
--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -116,7 +116,24 @@ jobs:
           git tag --annotate "${XTS_CANDIDATE_TAG}" --message "chore: tagging commit for XTS promotion"
           git push --set-upstream origin --tags
 
-      - name: Report failure
+      - name: Report Failure (Rootly)
+        if: ${{ !inputs.dry-run-enabled && !cancelled() && failure() && always() }}
+        uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        with:
+          api_key: ${{ secrets.ROOTLY_API_KEY }}
+          summary: "Hiero Consensus Node - XTS Candidate Tagging Failed"
+          details: |
+            The tagging of commit `${{ inputs.ref }}` for the Extended Test Suite (XTS) promotion has failed.
+            Please investigate the issue to ensure the commit is properly tagged for further testing and deployment processes.
+          notification_target_type: Service
+          notification_target: CI/CD Workflows
+          set_as_noise: true
+          alert_urgency: High
+          environments: CITR
+          external_id: ${{ github.run_id }}
+          external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Report Failure (Slack)
         if: ${{ !inputs.dry-run-enabled && !cancelled() && failure() && always() }}
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:


### PR DESCRIPTION
**Description**:

This pull request updates the `.github/workflows/zxf-prepare-extended-test-suite.yaml` workflow to enhance failure reporting when tagging a commit for the Extended Test Suite (XTS) promotion. The main change is the addition of a Rootly alert step, which improves incident visibility and notification alongside the existing Slack notification.

### Notification Improvements

* Both Rootly and Slack notifications are now triggered on failure, ensuring stakeholders are promptly informed via multiple channels.

**Related issue(s)**:

Fixes #20779 

