### PR TITLE
fix: StateAnalyzer throws IndexOutOfBoundsException

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validators/merkledb/StateAnalyzer.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validators/merkledb/StateAnalyzer.java
@@ -123,7 +123,6 @@ public class StateAnalyzer {
 
                 while (dataIterator.next()) {
                     try {
-                        // int itemSize = dataIterator.getDataItemData().remaining();
                         int itemSize = 0;
                         final long path;
                         Object dataItemData = deser.apply(dataIterator.getDataItemData());
@@ -144,11 +143,15 @@ public class StateAnalyzer {
                             throw new UnsupportedOperationException("Unsupported data item type");
                         }
 
-                        long oldVal = itemCountByPath.getAndIncrement(path);
-                        if (oldVal > 0) {
+                        if (path >= indexSize) {
                             wastedSpaceInBytes.addAndGet(itemSize);
-                            if (oldVal == 1) {
-                                duplicateItemCount.incrementAndGet();
+                        } else {
+                            long oldVal = itemCountByPath.getAndIncrement(path);
+                            if (oldVal > 0) {
+                                wastedSpaceInBytes.addAndGet(itemSize);
+                                if (oldVal == 1) {
+                                    duplicateItemCount.incrementAndGet();
+                                }
                             }
                         }
                     } catch (Exception e) {


### PR DESCRIPTION
**Description**:
* count items with `path` >= `indexSize` as wasted space; prevent `IndexOutOfBoundsException` in `itemCountByPath.getAndIncrement(path)`

**Related issue(s)**:

Fixes #20828

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
