### PR TITLE
chore: reduce logging levels to DEBUG for BN communication

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -323,7 +323,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
         // Check if we've exceeded the EndOfStream rate limit
         if (hasExceededEndOfStreamLimit()) {
             close();
-            logger.warn(
+            logger.debug(
                     "[{}] Block node has exceeded the allowed number of EndOfStream responses (received={}, "
                             + "permitted={}, timeWindow={}); reconnection scheduled for {}",
                     this,
@@ -343,7 +343,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
                 // The block node had an end of stream error and cannot continue processing.
                 // We should wait for a short period before attempting to retry
                 // to avoid overwhelming the node if it's having issues
-                logger.warn(
+                logger.debug(
                         "[{}] Block node reported an error at block {}. Will attempt to reestablish the stream later.",
                         this,
                         blockNumber);
@@ -355,7 +355,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
                 // We should restart the stream at the block immediately
                 // following the last verified and persisted block number
                 final long restartBlockNumber = blockNumber == Long.MAX_VALUE ? 0 : blockNumber + 1;
-                logger.warn(
+                logger.debug(
                         "[{}] Block node reported status indicating immediate restart should be attempted. "
                                 + "Will restart stream at block {}.",
                         this,
@@ -367,7 +367,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
                 close();
                 // The block node orderly ended the stream. In this case, no errors occurred.
                 // We should wait for a longer period before attempting to retry.
-                logger.warn("[{}] Block node orderly ended the stream at block {}", this, blockNumber);
+                logger.debug("[{}] Block node orderly ended the stream at block {}", this, blockNumber);
                 blockNodeConnectionManager.rescheduleAndSelectNewNode(this, LONGER_RETRY_DELAY);
             }
             case Code.BEHIND -> {
@@ -376,7 +376,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
                 final long restartBlockNumber = blockNumber == Long.MAX_VALUE ? 0 : blockNumber + 1;
                 if (blockBufferService.getBlockState(restartBlockNumber) != null) {
                     close();
-                    logger.warn(
+                    logger.debug(
                             "[{}] Block node reported it is behind. Will restart stream at block {}.",
                             this,
                             restartBlockNumber);
@@ -385,7 +385,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
                 } else {
                     // If we don't have the block state, we schedule retry for this connection and establish new one
                     // with different block node
-                    logger.warn("[{}] Block node is behind and block state is not available.", this);
+                    logger.debug("[{}] Block node is behind and block state is not available.", this);
 
                     // Indicate that the block node should recover and catch up from another trustworthy block node
                     endTheStreamWith(TOO_FAR_BEHIND);
@@ -443,7 +443,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
         } else {
             // If we don't have the block state, we schedule retry for this connection and establish new one
             // with different block node
-            logger.warn(
+            logger.debug(
                     "[{}] Block node requested a ResendBlock for block {} but that block does not exist on this "
                             + "consensus node. Closing connection and will retry later",
                     this,
@@ -606,7 +606,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
             handleResendBlock(response.resendBlock());
         } else {
             blockStreamMetrics.incrementUnknownResponseCount();
-            logger.warn("[{}] Unexpected response received: {}", this, response);
+            logger.debug("[{}] Unexpected response received: {}", this, response);
         }
     }
 
@@ -618,7 +618,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
      */
     @Override
     public void onError(final Throwable error) {
-        logger.warn("[{}] Stream encountered an error", this, error);
+        logger.debug("[{}] Stream encountered an error", this, error);
         blockStreamMetrics.incrementOnErrorCount();
         handleStreamFailure();
     }
@@ -633,7 +633,7 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
             logger.debug("[{}] Stream completed (stream close was in progress)", this);
             streamShutdownInProgress.set(false);
         } else {
-            logger.warn("[{}] Stream completed unexpectedly", this);
+            logger.debug("[{}] Stream completed unexpectedly", this);
             handleStreamFailure();
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -301,7 +301,7 @@ public class BlockNodeConnectionManager {
         requireNonNull(connection);
         requireNonNull(initialDelay);
 
-        logger.warn("[{}] Rescheduling connection for reconnect attempt", connection);
+        logger.debug("[{}] Rescheduling connection for reconnect attempt", connection);
 
         // Schedule retry for the failed connection after a delay (initialDelay)
         scheduleConnectionAttempt(connection, initialDelay, null, false);
@@ -387,7 +387,7 @@ public class BlockNodeConnectionManager {
             try {
                 connection.close();
             } catch (final RuntimeException e) {
-                logger.warn(
+                logger.debug(
                         "[{}] Error while closing connection during connection manager shutdown; ignoring",
                         connection,
                         e);
@@ -435,7 +435,7 @@ public class BlockNodeConnectionManager {
         final BlockNodeConfig selectedNode = getNextPriorityBlockNode();
 
         if (selectedNode == null) {
-            logger.warn("No block nodes found for attempted streaming");
+            logger.debug("No block nodes found for attempted streaming");
             return false;
         }
 
@@ -539,7 +539,7 @@ public class BlockNodeConnectionManager {
 
         final BlockNodeConnection activeConnection = activeConnectionRef.get();
         if (activeConnection == null) {
-            logger.warn("No active connections available for streaming block {}", blockNumber);
+            logger.debug("No active connections available for streaming block {}", blockNumber);
             return;
         }
 
@@ -788,14 +788,14 @@ public class BlockNodeConnectionManager {
                     try {
                         activeConnection.close();
                     } catch (final RuntimeException e) {
-                        logger.warn(
+                        logger.debug(
                                 "[{}] Failed to shutdown connection (shutdown reason: another connection was elevated to active)",
                                 activeConnection,
                                 e);
                     }
                 }
             } catch (final Exception e) {
-                logger.warn("[{}] Failed to establish connection to block node; will schedule a retry", connection);
+                logger.debug("[{}] Failed to establish connection to block node; will schedule a retry", connection);
                 reschedule();
             }
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSimulatorSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSimulatorSuite.java
@@ -201,7 +201,7 @@ public class BlockNodeSimulatorSuite {
                                 "[localhost:%s/ACTIVE] Connection state transitioned from PENDING to ACTIVE",
                                 portNumbers.get(1)),
                         String.format(
-                                "[localhost:%s/ACTIVE] Scheduled periodic stream reset every PT1M",
+                                "[localhost:%s/ACTIVE] Scheduled periodic stream reset every PT24H",
                                 portNumbers.get(1)))),
                 waitUntilNextBlocks(10).withBackgroundTraffic(true),
                 doingContextual(spec -> connectionDropTime.set(Instant.now())),
@@ -224,7 +224,7 @@ public class BlockNodeSimulatorSuite {
                                 "[localhost:%s/ACTIVE] Connection state transitioned from PENDING to ACTIVE",
                                 portNumbers.get(2)),
                         String.format(
-                                "[localhost:%s/ACTIVE] Scheduled periodic stream reset every PT1M",
+                                "[localhost:%s/ACTIVE] Scheduled periodic stream reset every PT24H",
                                 portNumbers.get(2)))),
                 waitUntilNextBlocks(10).withBackgroundTraffic(true),
                 doingContextual(spec -> connectionDropTime.set(Instant.now())),
@@ -247,7 +247,7 @@ public class BlockNodeSimulatorSuite {
                                 "[localhost:%s/ACTIVE] Connection state transitioned from PENDING to ACTIVE",
                                 portNumbers.get(3)),
                         String.format(
-                                "[localhost:%s/ACTIVE] Scheduled periodic stream reset every PT1M",
+                                "[localhost:%s/ACTIVE] Scheduled periodic stream reset every PT24H",
                                 portNumbers.get(3)))),
                 waitUntilNextBlocks(10).withBackgroundTraffic(true),
                 doingContextual(spec -> connectionDropTime.set(Instant.now())),
@@ -265,7 +265,8 @@ public class BlockNodeSimulatorSuite {
                                 "[localhost:%s/ACTIVE] Connection state transitioned from PENDING to ACTIVE",
                                 portNumbers.get(1)),
                         String.format(
-                                "[localhost:%s/ACTIVE] Scheduled periodic stream reset every PT1M", portNumbers.get(1)),
+                                "[localhost:%s/ACTIVE] Scheduled periodic stream reset every PT24H",
+                                portNumbers.get(1)),
                         String.format("[localhost:%s/ACTIVE] Closing connection...", portNumbers.get(3)),
                         String.format(
                                 "[localhost:%s/UNINITIALIZED] Connection state transitioned from ACTIVE to UNINITIALIZED",


### PR DESCRIPTION
**Description**:
Reviewed all WARN-level logging related to block node communication. Adjusted to DEBUG where appropriate to reduce log noise.

Affected classes:
* BlockNodeConnection
* BlockNodeConnectionManager

**Related issue(s)**:
Fixes #20821

**Notes for reviewer**:
Kept WARN in catch clauses of closeObserver and close methods in BlockNodeConnection for now; open to reducing those to DEBUG if preferred.
