### PR TITLE
fix: state validator rehash hangs on large states

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validators/ParallelProcessingUtil.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validators/ParallelProcessingUtil.java
@@ -4,6 +4,7 @@ package com.hedera.statevalidation.validators;
 import static com.hedera.statevalidation.validators.Constants.PARALLELISM;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
 import java.util.function.Consumer;
@@ -29,5 +30,9 @@ public class ParallelProcessingUtil {
 
     public static ForkJoinTask<?> doNothing() {
         return VALIDATOR_FORK_JOIN_POOL.submit(() -> {});
+    }
+
+    public static <T> ForkJoinTask<T> submitSingleTask(Callable<T> task) {
+        return VALIDATOR_FORK_JOIN_POOL.submit(task);
     }
 }


### PR DESCRIPTION
**Description**:
* run hasher in parallel with the leaf feeder
* the hasher task is deliberately submitted to the validator `ForkJoinPool` to have single control over parallelism for all validator tasks

**Related issue(s)**:

Fixes #20843

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
