### PR TITLE
ci: Build docker determinism with Jammie & Noble

### DIFF
--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -215,11 +215,11 @@ jobs:
         # not supporting BuildKit and the Buildx plugin.
         # GitHub hosted MacOS and Ubuntu runners are temporarily disabled.
         os:
-          #- ubuntu-24.04
+          - ubuntu-24.04
           #- ubuntu-22.04
           #- macos-12
           #- macos-11
-          - hiero-network-node-linux-medium
+          #- hiero-network-node-linux-medium
           - hiero-network-node-linux-large
     steps:
       - name: Harden Runner


### PR DESCRIPTION
**Description**:

This pull request updates the operating system matrix for the Docker build determinism verification workflow. The main change is re-enabling the `ubuntu-24.04` runner and disabling the `hiero-network-node-linux-medium` runner, which affects which environments the workflow will execute on.

Workflow environment updates:

* Re-enabled the `ubuntu-24.04` runner in the OS matrix for the `zxc-verify-docker-build-determinism.yaml` workflow, allowing the job to run on the latest Ubuntu version.
* Disabled the `hiero-network-node-linux-medium` runner, so jobs will no longer be executed on this environment.

**Related issue(s)**:

Fixes #20852
