### PR TITLE
fix(test): resolve flaky ScheduleExecutionTest by specifying explicit payer

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionTest.java
@@ -1326,7 +1326,7 @@ public class ScheduleExecutionTest {
                         .via(CREATE_TXN),
                 recordFeeAmount(CREATE_TXN, SCHEDULE_CREATE_FEE),
                 cryptoDelete(PAYING_ACCOUNT),
-                scheduleSign(BASIC_XFER).alsoSigningWith(SENDER).hasKnownStatus(SUCCESS),
+                scheduleSign(BASIC_XFER).alsoSigningWith(SENDER).payingWith(DEFAULT_PAYER).hasKnownStatus(SUCCESS),
                 getScheduleInfo(BASIC_XFER).isExecuted(),
                 getTxnRecord(CREATE_TXN)
                         .scheduled()


### PR DESCRIPTION
**Description**:
Fix flaky test by specifying explicit payer for scheduleSign operation to prevent INSUFFICIENT_TX_FEE errors.

* Add explicit `.payingWith(DEFAULT_PAYER)` to scheduleSign operation
* Ensure adequate funding for transaction fee payment
* Separate schedule signing payment from scheduled transaction execution concerns


**Related issue(s)**:
https://github.com/hiero-ledger/hiero-consensus-node/issues/19370

**Notes for reviewer**:
The test was failing because the `SENDER` account (with only 1 tiny bar) was implicitly being used to pay for the `scheduleSign` transaction fee. By explicitly specifying `DEFAULT_PAYER` (with 1B+ tiny bars), we ensure sufficient funds are available for the signing operation while maintaining the test's original intent to verify scheduled transaction execution failure when the designated payer account is deleted.


**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
