### PR TITLE
ci(bug): Use correct ref in build-application when finding commit info

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -263,9 +263,10 @@ jobs:
       - name: Get Commit Information
         id: fetch-commit-info
         run: |
-          echo "commit-hash=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-          echo "commit-author=$(git log -1 --pretty=format:'%an <%ae>' HEAD)" >> "${GITHUB_OUTPUT}"
-          echo "commit-email=$(git log -1 --pretty=format:'%ae' HEAD)" >> "${GITHUB_OUTPUT}"
+          COMMIT_SHA="${{ github.sha }}"
+          echo "commit-hash=${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "commit-author=$(git log -1 --pretty=format:'%an <%ae>' ${COMMIT_SHA})" >> "${GITHUB_OUTPUT}"
+          echo "commit-email=$(git log -1 --pretty=format:'%ae' ${COMMIT_SHA})" >> "${GITHUB_OUTPUT}"
 
       - name: Find Commit Author in Slack
         id: find-commit-author-slack


### PR DESCRIPTION
## Description

This pull request updates the way commit information is retrieved in the `.github/workflows/node-flow-build-application.yaml` workflow. The change improves reliability by ensuring all git commands use the commit SHA provided by GitHub Actions, rather than relying on the current HEAD.

Improvements to commit information retrieval:

* The workflow now uses the `${{ github.sha }}` environment variable for all commit-related git commands, ensuring consistency and accuracy when fetching the commit hash, author, and email.

### Related Issue(s)

- Fixes #20936 