### PR TITLE
chore: BN selection unit tests, improved BNConnectionManagerTest coverage

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -1587,7 +1587,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         doReturn(nodeConfig).when(connection).getNodeConfig();
 
         // Call rescheduleConnection which internally calls handleConnectionCleanupAndReschedule
-        manager.rescheduleConnection(connection, Duration.ofSeconds(5), null);
+        manager.rescheduleConnection(connection, Duration.ofSeconds(5), null, true);
 
         // Verify that scheduleConnectionAttempt was called once with the 5-second delay
         // selectNewBlockNodeForStreaming is NOT called since there's only one node


### PR DESCRIPTION
**Description**:
- The HAPI test case is already covered by BlockNodeSimulatorSuite.node0StreamingBlockNodeConnectionDropsTrickle().
- Added Block Node selection unit tests.
- Improved BlockNodeConnectionManagerTest coverage.

**Related issue(s)**:
Closes #18483

**Notes for reviewer**:
Current BlockNodeConnectionManager.java coverage:
<img width="645" height="56" alt="Screenshot 2025-09-11 at 13 35 34" src="https://github.com/user-attachments/assets/a75a9e30-59af-4f0a-9c81-2ea44770b283" />
Was:
<img width="634" height="51" alt="Screenshot 2025-09-11 at 13 33 42" src="https://github.com/user-attachments/assets/97df7fb1-2f91-4eff-aa25-157f870767f3" />
