### PR TITLE
ci(bug): Fix rootly incident creation in SDPT and SDLT

### DIFF
--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -661,7 +661,7 @@ jobs:
           create_public_incident: "false"
           summary: ${{ steps.rootly-summary.outputs.summary }}
           severity: "Triage Event"
-          alert_ids: ${{ steps.rootly-alert.outputs.alert_ids }} || '' }}
+          alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
           environments: "CITR"
           incident_types: "Performance Engineering,Platform CI"
           services: ${{ steps.set-rootly-service.outputs.service }}

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -1318,7 +1318,7 @@ jobs:
           create_public_incident: "false"
           summary: ${{ steps.rootly-summary.outputs.summary }}
           severity: "Triage Event"
-          alert_ids: ${{ steps.rootly-alert.outputs.alert_ids }} || '' }}
+          alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
           environments: "CITR"
           incident_types: "Performance Engineering,Platform CI"
           services: ${{ steps.set-rootly-service.outputs.service }}


### PR DESCRIPTION
## Description

This pull request makes a small update to the incident creation steps in two GitHub Actions workflow files. The change corrects the syntax for setting the `alert_ids` parameter to ensure it defaults to an empty string if no alert IDs are present.

* Corrected the syntax for setting `alert_ids` in `.github/workflows/zxc-single-day-longevity-nlg-test.yaml` to use the proper default value fallback.
* Corrected the syntax for setting `alert_ids` in `.github/workflows/zxc-single-day-performance-test.yaml` to use the proper default value fallback.

### Related Issue(s)

Fixes #21040 