### PR TITLE
chore: CN buffer restart integration tests

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferRestartIntegrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferRestartIntegrationTest.java
@@ -161,7 +161,7 @@ class BlockBufferRestartIntegrationTest extends BlockNodeCommunicationTestBase {
 
             // Process items to create requests (simulate streaming preparation)
             final BlockState blockState = blockBufferService.getBlockState(blockNum);
-            assert blockState != null;
+            assertThat(blockState).isNotNull();
             blockState.processPendingItems(BATCH_SIZE);
         }
 
@@ -253,7 +253,7 @@ class BlockBufferRestartIntegrationTest extends BlockNodeCommunicationTestBase {
             blockBufferService.closeBlock(blockNum);
 
             final BlockState blockState = blockBufferService.getBlockState(blockNum);
-            assert blockState != null;
+            assertThat(blockState).isNotNull();
             blockState.processPendingItems(BATCH_SIZE);
 
             // Make first half of blocks "old" by manipulating their timestamps


### PR DESCRIPTION
**Description**:
- BlockNodeSimulatorSuite.testBlockBufferDurability() already provides good coverage of the described scenarios.
- Added BlockBufferRestartIntegrationTest class with integration tests for BlockBufferService restart scenarios, covering:
 * Buffer is restart-safe
 * Buffer is full before restart and block production continues after acknowledgement and pruning of the buffer
 * Buffer allows successful Block Node catch-up

**Related issue(s)**:
Closes #18484