### PR TITLE
ci: Remove rootly incident creation and rely on alerts alone

### DIFF
--- a/.github/workflows/zxc-single-day-longevity-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-test.yaml
@@ -651,22 +651,6 @@ jobs:
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           environments: "CITR"
 
-      - name: Create Rootly Incident
-        if: ${{ steps.check-test-asset.outputs.is-adhoc == 'false' }}
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        with:
-          api_key: ${{ secrets.rootly-api-token }}
-          title: ${{ steps.rootly-summary.outputs.title }}
-          kind: "normal"
-          create_public_incident: "false"
-          summary: ${{ steps.rootly-summary.outputs.summary }}
-          severity: "Triage Event"
-          alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Performance Engineering,Platform CI"
-
   longevity-report-to-Slack:
     runs-on: hiero-citr-linux-medium
     needs:

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -1308,22 +1308,6 @@ jobs:
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           environments: "CITR"
 
-      - name: Create Rootly Incident
-        if: ${{ steps.check-test-asset.outputs.is-adhoc == 'false' }}
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        with:
-          api_key: ${{ secrets.rootly-api-token }}
-          title: ${{ steps.rootly-summary.outputs.title }}
-          kind: "normal"
-          create_public_incident: "false"
-          summary: ${{ steps.rootly-summary.outputs.summary }}
-          severity: "Triage Event"
-          alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Performance Engineering,Platform CI"
-
   performance-report-to-slack:
     runs-on: hiero-citr-linux-medium
     needs:

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -622,22 +622,6 @@ jobs:
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           environments: "CITR"
 
-      - name: Create Rootly Incident
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        continue-on-error: true # continue on error so we can get the slack reporting
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Platform CI"
-
       - name: Build Slack Payload Message
         id: payload
         run: |

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -308,6 +308,7 @@ jobs:
 
       - name: Report Failure (Rootly)
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
         with:
           api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: ${{ steps.rootly-summary.outputs.summary }}

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -119,6 +119,7 @@ jobs:
       - name: Report Failure (Rootly)
         if: ${{ !inputs.dry-run-enabled && !cancelled() && failure() && always() }}
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
         with:
           api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: "Hiero Consensus Node - XTS Candidate Tagging Failed"

--- a/.github/workflows/zxf-single-day-canonical-test.yaml
+++ b/.github/workflows/zxf-single-day-canonical-test.yaml
@@ -309,17 +309,6 @@ jobs:
           fi
           echo "service=${ROOTLY_SERVICE}" >> "${GITHUB_OUTPUT}"
 
-      - name: Set Incident Creation Flag
-        id: set-create-incident
-        run: |
-          CREATE_INCIDENT="false"
-          if [[ "${{ needs.canonical-test.outputs.start-canonical-test }}" == "failure" ]] \
-            || [[ "${{ needs.canonical-test.outputs.check-if-exist }}" == "failure" ]] \
-            || [[ "${{ needs.canonical-test.outputs.parameters }}" == "failure" ]]; then
-            CREATE_INCIDENT="true"
-          fi
-          echo "create=${CREATE_INCIDENT}" >> "${GITHUB_OUTPUT}"
-
       - name: Build Rootly Summary
         id: rootly-summary
         run: |
@@ -368,19 +357,3 @@ jobs:
           environments: "CITR"
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Create Rootly Incident
-        if: ${{ steps.set-create-incident.outputs.create == 'true' }}
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Platform CI,Performance Engineering"

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -456,6 +456,7 @@ jobs:
       - name: Create Rootly Alert
         if: ${{ steps.set-alert-flag.outputs.create == 'true' }}
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
         with:
           api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: ${{ steps.rootly-summary.outputs.summary }}

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -408,22 +408,6 @@ jobs:
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Create Rootly Incident
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        continue-on-error: true # continue on error so we can get the slack reporting
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Platform CI,Performance Engineering"
-
       - name: Build Slack Payload Message
         id: payload
         run: |

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -462,6 +462,7 @@ jobs:
       - name: Create Rootly Alert
         if: ${{ steps.set-alert-flag.outputs.create == 'true' }}
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
         with:
           api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: ${{ steps.rootly-summary.outputs.summary }}

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -408,22 +408,6 @@ jobs:
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Create Rootly Incident
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        continue-on-error: true # continue on error so we can get the slack reporting
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Platform CI,Performance Engineering"
-
       - name: Build Slack Payload Message
         id: payload
         run: |


### PR DESCRIPTION
## Description

This pull request makes significant changes to the GitHub Actions workflows related to Rootly incident and alert reporting. The main updates involve removing several steps that create Rootly incidents across multiple test workflows and standardizing error handling for Rootly alert actions by adding `continue-on-error: true`. These changes streamline incident reporting and make alert handling cleaner.

**Incident Reporting Removal:**

* Removed the "Create Rootly Incident" step from the following workflows, which previously created Rootly incidents on test failures or specific conditions:
  - `.github/workflows/zxc-single-day-longevity-test.yaml`
  - `.github/workflows/zxc-single-day-performance-test.yaml`
  - `.github/workflows/zxcron-extended-test-suite.yaml`
  - `.github/workflows/zxf-single-day-canonical-test.yaml`
  - `.github/workflows/zxf-single-day-longevity-test-controller.yaml`
  - `.github/workflows/zxf-single-day-performance-test-controller.yaml`

* Removed the step for setting the incident creation flag in `.github/workflows/zxf-single-day-canonical-test.yaml`, which determined whether to create an incident based on test results.

**Alert Reporting Improvements:**

* Added `continue-on-error: true` to all uses of the Rootly alert action, ensuring workflows do not fail if alert reporting encounters an error:
  - `.github/workflows/zxcron-promote-build-candidate.yaml`
  - `.github/workflows/zxf-prepare-extended-test-suite.yaml`
  - `.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml`
  - `.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml`

These changes help simplify workflow logic and improve reliability by focusing on alert reporting and reducing incident channel spam in slack.

### Related Issue(s)

Closes #21089 