### PR TITLE
chore: Enable RPC sync

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/ProtocolConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/ProtocolConfig.java
@@ -18,4 +18,4 @@ import com.swirlds.config.api.ConfigProperty;
 public record ProtocolConfig(
         @ConfigProperty(defaultValue = "false") boolean tolerateMismatchedVersion,
         @ConfigProperty(defaultValue = "false") boolean tolerateMismatchedEpochHash,
-        @ConfigProperty(defaultValue = "false") boolean rpcGossip) {}
+        @ConfigProperty(defaultValue = "true") boolean rpcGossip) {}


### PR DESCRIPTION
**Description**:
Enable RPC sync which was added as part of https://github.com/hiero-ledger/hiero-consensus-node/pull/19269/, but then disabled due to VirtualMegaMap investigation.

**Related issue(s)**:

Fixes #20644 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
