### PR TITLE
test: Enable `MATS` for smart contract MATS test

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -232,6 +232,7 @@ jobs:
       enable-unit-tests: false
       enable-hapi-tests-smart-contract: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
       enable-network-log-capture: true
+      mats-suffix: MATS
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}


### PR DESCRIPTION
**Description**:

ACTUALLY enables the `MATS` tag for smart contract hapi tests