### PR TITLE
ci: Disable block node regression panel in XTS

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -275,18 +275,19 @@ jobs:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
-  block-node-regression-panel:
-    name: Block Node Regression Panel
-    needs: fetch-xts-candidate
-    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
-    uses: ./.github/workflows/zxc-block-node-regression.yaml
-    with:
-      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }} # pass the xts-candidate tag to the JRS panel for checkout
-      custom-job-name: "Block Node Regression"
-      solo-version: ${{ vars.CITR_SOLO_VERSION }}
-    secrets:
-      access-token: ${{ secrets.GH_ACCESS_TOKEN }}
-      slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+  #  TODO: Enable block node regression panel when development is further on
+  #  block-node-regression-panel:
+  #    name: Block Node Regression Panel
+  #    needs: fetch-xts-candidate
+  #    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
+  #    uses: ./.github/workflows/zxc-block-node-regression.yaml
+  #    with:
+  #      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }} # pass the xts-candidate tag to the JRS panel for checkout
+  #      custom-job-name: "Block Node Regression"
+  #      solo-version: ${{ vars.CITR_SOLO_VERSION }}
+  #    secrets:
+  #      access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+  #      slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
   tag-for-promotion:
     name: Tag as XTS-Passing


### PR DESCRIPTION
## Description

This pull request makes a change to the `.github/workflows/zxcron-extended-test-suite.yaml` workflow configuration. The main update is the temporary disabling of the "Block Node Regression Panel" job, which is now commented out with a note to re-enable it when development progresses further.

Workflow configuration update:

* Temporarily disabled the `block-node-regression-panel` job in `.github/workflows/zxcron-extended-test-suite.yaml` by commenting out its configuration and adding a TODO note to re-enable it later.

### Related issue(s)

Closes #21189
