### PR TITLE
ci: update release-action to step-security provided version

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -864,7 +864,7 @@ jobs:
 
       - name: Create github release
         if: ${{ steps.set-gh-release-flag.outputs.create-release == 'true' }}
-        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
+        uses: step-security/release-action@03a57407052f15d1537fd5469a6fbbc536aba326 # v1.20.0
         with:
           tag: ${{ inputs.ref-name }}
           prerelease: false


### PR DESCRIPTION
**Description**:

Replace the `ncipollo` version of `release-action` with `step-security` version of the action.

**Related Issue(s)**:

Implements #21199
