### PR TITLE
chore: Make NodeConfiguration.setEndpoints internal

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/container/ContainerNodeConfigurationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/container/ContainerNodeConfigurationTest.java
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.container;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.sources.SimpleConfigSource;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.platform.gossip.config.NetworkEndpoint;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.hiero.otter.fixtures.internal.AbstractNode.LifeCycle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ContainerNodeConfigurationTest {
+
+    private LifeCycle lifeCycle;
+
+    private ContainerNodeConfiguration subject;
+
+    @BeforeEach
+    void setUp() {
+        lifeCycle = LifeCycle.INIT;
+        subject = new TestNodeConfiguration(() -> lifeCycle);
+    }
+
+    @ParameterizedTest
+    @MethodSource("networkEndpointListProvider")
+    void testNetworkEndpointListProperty(final List<NetworkEndpoint> endpoints) {
+        subject.setNetworkEndpoints("myEndpointList", endpoints);
+        final Configuration config = subject.current();
+        final TestConfigData configData = config.getConfigData(TestConfigData.class);
+        assertThat(configData.myEndpointList()).isEqualTo(endpoints);
+    }
+
+    private static Stream<Arguments> networkEndpointListProvider() throws UnknownHostException {
+        return Stream.of(
+                // Empty list
+                Arguments.of(List.of()),
+                // Single endpoint with node ID 42
+                Arguments.of(List.of(new NetworkEndpoint(42L, InetAddress.getByName("192.168.1.1"), 8080))),
+                // Multiple endpoints with various node IDs and ports
+                Arguments.of(List.of(
+                        new NetworkEndpoint(100L, InetAddress.getByName("172.16.0.1"), 8080),
+                        new NetworkEndpoint(200L, InetAddress.getByName("172.16.0.2"), 9090),
+                        new NetworkEndpoint(300L, InetAddress.getByName("172.16.0.3"), 7070),
+                        new NetworkEndpoint(999L, InetAddress.getByName("172.16.0.4"), 6060))));
+    }
+
+    private static class TestNodeConfiguration extends ContainerNodeConfiguration {
+
+        public TestNodeConfiguration(@NonNull final Supplier<LifeCycle> lifeCycleSupplier) {
+            super(lifeCycleSupplier);
+        }
+
+        @NonNull
+        @Override
+        public Configuration current() {
+            return new TestConfigBuilder()
+                    .withSource(new SimpleConfigSource(overriddenProperties))
+                    .withConfigDataType(ContainerNodeConfigurationTest.TestConfigData.class)
+                    .getOrCreateConfig();
+        }
+    }
+
+    /**
+     * Test configuration data record with various property types.
+     */
+    @ConfigData
+    public record TestConfigData(@ConfigProperty(defaultValue = "") List<NetworkEndpoint> myEndpointList) {}
+}

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/internal/AbstractNodeConfigurationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/internal/AbstractNodeConfigurationTest.java
@@ -13,11 +13,8 @@ import com.swirlds.config.api.ConfigProperty;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.sources.SimpleConfigSource;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import com.swirlds.platform.gossip.config.NetworkEndpoint;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Supplier;
@@ -125,33 +122,10 @@ public class AbstractNodeConfigurationTest {
     @ValueSource(strings = {"foo,bar,baz", "single", ""})
     void testStringListProperty(final String value) {
         final List<String> list = value.isEmpty() ? List.of() : List.of(value.split(","));
-        subject.setStrings("myStringList", list);
+        subject.set("myStringList", list);
         final Configuration config = subject.current();
         final TestConfigData configData = config.getConfigData(TestConfigData.class);
         assertThat(configData.myStringList()).isEqualTo(list);
-    }
-
-    @ParameterizedTest
-    @MethodSource("networkEndpointListProvider")
-    void testNetworkEndpointListProperty(final List<NetworkEndpoint> endpoints) {
-        subject.setNetworkEndpoints("myEndpointList", endpoints);
-        final Configuration config = subject.current();
-        final TestConfigData configData = config.getConfigData(TestConfigData.class);
-        assertThat(configData.myEndpointList()).isEqualTo(endpoints);
-    }
-
-    private static Stream<Arguments> networkEndpointListProvider() throws UnknownHostException {
-        return Stream.of(
-                // Empty list
-                Arguments.of(List.of()),
-                // Single endpoint with node ID 42
-                Arguments.of(List.of(new NetworkEndpoint(42L, InetAddress.getByName("192.168.1.1"), 8080))),
-                // Multiple endpoints with various node IDs and ports
-                Arguments.of(List.of(
-                        new NetworkEndpoint(100L, InetAddress.getByName("172.16.0.1"), 8080),
-                        new NetworkEndpoint(200L, InetAddress.getByName("172.16.0.2"), 9090),
-                        new NetworkEndpoint(300L, InetAddress.getByName("172.16.0.3"), 7070),
-                        new NetworkEndpoint(999L, InetAddress.getByName("172.16.0.4"), 6060))));
     }
 
     @ParameterizedTest
@@ -272,6 +246,5 @@ public class AbstractNodeConfigurationTest {
             @ConfigProperty(defaultValue = "PT15M") Duration myDurationValue,
             @ConfigProperty(defaultValue = "") List<String> myStringList,
             @ConfigProperty(defaultValue = "") List<NodeId> myNodeIdList,
-            @ConfigProperty(defaultValue = "") List<NetworkEndpoint> myEndpointList,
             @ConfigProperty(defaultValue = "") TaskSchedulerConfiguration mySchedulerConfiguration) {}
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/NodeConfiguration.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/NodeConfiguration.java
@@ -3,7 +3,6 @@ package org.hiero.otter.fixtures;
 
 import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.config.api.Configuration;
-import com.swirlds.platform.gossip.config.NetworkEndpoint;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -100,7 +99,7 @@ public interface NodeConfiguration {
      * @return this {@code NodeConfiguration} instance for method chaining
      */
     @NonNull
-    NodeConfiguration setStrings(@NonNull String key, List<String> values);
+    NodeConfiguration set(@NonNull String key, List<String> values);
 
     /**
      * Updates a single property of the configuration to a file path. Can only be invoked when the
@@ -112,17 +111,6 @@ public interface NodeConfiguration {
      */
     @NonNull
     NodeConfiguration set(@NonNull String key, @NonNull Path path);
-
-    /**
-     * Updates a single property of the configuration to a {@link List} of {@link NetworkEndpoint}.
-     * Can only be invoked when the node is not running.
-     *
-     * @param key the key of the property
-     * @param endpoints the list of network endpoints to set
-     * @return this {@code NodeConfiguration} instance for method chaining
-     */
-    @NonNull
-    NodeConfiguration setNetworkEndpoints(@NonNull String key, @NonNull List<NetworkEndpoint> endpoints);
 
     /**
      * Updates a single property of the configuration to a {@link TaskSchedulerConfiguration}. Can

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNetwork.java
@@ -135,7 +135,9 @@ public class ContainerNetwork extends AbstractNetwork {
                     .filter(receiver -> !receiver.equals(sender))
                     .map(receiver -> networkBehavior.getProxyEndpoint(sender, receiver))
                     .toList();
-            sender.configuration().setNetworkEndpoints(GossipConfig_.ENDPOINT_OVERRIDES, endpointOverrides);
+            ((ContainerNode) sender)
+                    .configuration()
+                    .setNetworkEndpoints(GossipConfig_.ENDPOINT_OVERRIDES, endpointOverrides);
         }
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNode.java
@@ -37,7 +37,6 @@ import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.otter.fixtures.KeysAndCertsConverter;
 import org.hiero.otter.fixtures.Node;
-import org.hiero.otter.fixtures.NodeConfiguration;
 import org.hiero.otter.fixtures.ProtobufConverter;
 import org.hiero.otter.fixtures.container.proto.ContainerControlServiceGrpc;
 import org.hiero.otter.fixtures.container.proto.EventMessage;
@@ -268,7 +267,7 @@ public class ContainerNode extends AbstractNode implements Node, TimeTickReceive
      */
     @Override
     @NonNull
-    public NodeConfiguration configuration() {
+    public ContainerNodeConfiguration configuration() {
         return nodeConfiguration;
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNodeConfiguration.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNodeConfiguration.java
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures.container;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature;
+import com.swirlds.platform.gossip.config.NetworkEndpoint;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.hiero.otter.fixtures.NodeConfiguration;
 import org.hiero.otter.fixtures.internal.AbstractNode.LifeCycle;
 import org.hiero.otter.fixtures.internal.AbstractNodeConfiguration;
@@ -12,7 +19,11 @@ import org.hiero.otter.fixtures.internal.AbstractNodeConfiguration;
 /**
  * An implementation of {@link NodeConfiguration} for a container environment.
  */
+@SuppressWarnings("UnusedReturnValue")
 public class ContainerNodeConfiguration extends AbstractNodeConfiguration {
+
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper(new YAMLFactory().disable(Feature.WRITE_DOC_START_MARKER));
 
     /**
      * Constructor for the {@link ContainerNodeConfiguration} class.
@@ -22,6 +33,33 @@ public class ContainerNodeConfiguration extends AbstractNodeConfiguration {
     public ContainerNodeConfiguration(@NonNull final Supplier<LifeCycle> lifecycleSupplier) {
         super(lifecycleSupplier);
         overriddenProperties.put("event.eventsLogDir", "/opt/DockerApp/hgcapp");
+    }
+
+    /**
+     * Updates a single property of the configuration to a {@link List} of {@link NetworkEndpoint}.
+     * Can only be invoked when the node is not running.
+     *
+     * @param key the key of the property
+     * @param endpoints the list of network endpoints to set
+     * @return this {@code NodeConfiguration} instance for method chaining
+     */
+    @NonNull
+    public NodeConfiguration setNetworkEndpoints(@NonNull String key, @NonNull List<NetworkEndpoint> endpoints) {
+        throwIfNodeIsRunning();
+        final String value = endpoints.stream()
+                .map(ContainerNodeConfiguration::convertEndpoint)
+                .collect(Collectors.joining(","));
+        overriddenProperties.put(key, value);
+        return this;
+    }
+
+    private static String convertEndpoint(@NonNull final NetworkEndpoint endpoint) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(endpoint).replaceAll("\"", "\\\"");
+        } catch (final JsonProcessingException e) {
+            // This should not happen as the list is expected to be serializable
+            throw new RuntimeException("Exception while serializing endpoints", e);
+        }
     }
 
     /**


### PR DESCRIPTION
**Description**:

This PR removes `NodeConfiguration.setEndpoints()` from the public API and makes it internal as it should not be used from tests.

**Related issue(s)**:

Fixes #21223 