### PR TITLE
test: Add MATS tags for hapiTestCrypto

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -177,6 +177,7 @@ jobs:
       enable-unit-tests: false
       enable-hapi-tests-crypto: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
       enable-network-log-capture: true
+      mats-suffix: MATS
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -123,6 +123,7 @@ jobs:
       enable-unit-tests: false
       enable-hapi-tests-crypto: true
       enable-network-log-capture: true
+      mats-suffix: MATS
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -395,7 +395,7 @@ jobs:
         env:
           LC_ALL: en.UTF-8
           LANG: en_US.UTF-8
-        run: ${GRADLE_EXEC} hapiTestCrypto
+        run: ${GRADLE_EXEC} hapiTestCrypto${{ inputs.mats-suffix || '' }}
 
       - name: Publish HAPI Test (Crypto) Report
         uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationSuite.java
@@ -4,6 +4,7 @@ package com.hedera.services.bdd.suites.crypto;
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccount;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
@@ -156,6 +157,7 @@ public class AutoAccountCreationSuite {
     private static final String FT_XFER = "ftXfer";
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> aliasedPayerDoesntWork() {
         return hapiTest(
                 newKeyNamed(ALIAS),
@@ -393,6 +395,7 @@ public class AutoAccountCreationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> canAutoCreateWithNftTransferToEvmAddress() {
         final var civilianBal = 10 * ONE_HBAR;
         final var nftTransfer = "multiNftTransfer";
@@ -649,6 +652,7 @@ public class AutoAccountCreationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> noStakePeriodStartIfNotStakingToNode() {
         final var user = "user";
         final var contract = "contract";
@@ -665,6 +669,7 @@ public class AutoAccountCreationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountCreationWithCryptoTransfer() {
         final var initialTokenSupply = 1000;
         final AtomicReference<TokenID> ftId = new AtomicReference<>();
@@ -912,6 +917,7 @@ public class AutoAccountCreationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> autoAccountCreationWorksWhenUsingAliasOfDeletedAccount() {
         return hapiTest(
                 newKeyNamed(ALIAS),
@@ -1273,6 +1279,7 @@ public class AutoAccountCreationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferHbarsToECDSAKey() {
 
         final AtomicReference<ByteString> evmAddress = new AtomicReference<>();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationUnlimitedAssociationsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountCreationUnlimitedAssociationsSuite.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.customizedHapiTest;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -87,6 +88,7 @@ public class AutoAccountCreationUnlimitedAssociationsSuite {
     private static final String NFT_CREATE = "nftCreateTxn";
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> autoAccountCreationsUnlimitedAssociationHappyPath() {
         final var creationTime = new AtomicLong();
         final long transferFee = 188608L;
@@ -200,6 +202,7 @@ public class AutoAccountCreationUnlimitedAssociationsSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferHbarsToEVMAddressAliasUnlimitedAssociations() {
         final AtomicReference<AccountID> partyId = new AtomicReference<>();
         final AtomicReference<byte[]> partyAlias = new AtomicReference<>();
@@ -307,6 +310,7 @@ public class AutoAccountCreationUnlimitedAssociationsSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferTokensToEVMAddressAliasUnlimitedAssociations() {
         final AtomicReference<AccountID> partyId = new AtomicReference<>();
         final AtomicReference<byte[]> partyAlias = new AtomicReference<>();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AutoAccountUpdateSuite.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
@@ -87,6 +88,7 @@ public class AutoAccountUpdateSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> updateKeyOnAutoCreatedAccount() {
         final var complexKey = "complexKey";
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
@@ -132,6 +133,7 @@ public class CryptoApproveAllowanceSuite {
     public static final String PAUSE_KEY = "pauseKey";
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferErc20TokenFromContractWithApproval() {
         final var transferFromOtherContractWithSignaturesTxn = "transferFromOtherContractWithSignaturesTxn";
         final var nestedContract = "NestedERC20Contract";
@@ -316,6 +318,7 @@ public class CryptoApproveAllowanceSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> canDeleteAllowanceFromDeletedSpender() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
@@ -774,6 +777,7 @@ public class CryptoApproveAllowanceSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> canHaveMultipleOwners() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
@@ -1108,6 +1112,7 @@ public class CryptoApproveAllowanceSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> tokenNotAssociatedToAccountFails() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
@@ -1205,6 +1210,7 @@ public class CryptoApproveAllowanceSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     public final Stream<DynamicTest> chargedUsdScalesWithAllowances() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
@@ -1489,6 +1495,7 @@ public class CryptoApproveAllowanceSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> scheduledCryptoApproveAllowanceWorks() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -189,6 +190,7 @@ public class CryptoCreateSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> createAnAccountWithStakingFields() {
         return hapiTest(
                 cryptoCreate("civilianWORewardStakingNode")
@@ -766,6 +768,7 @@ public class CryptoCreateSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> createAnAccountWithNoMaxAutoAssocAndBalance() {
         double v13PriceUsd = 0.05;
 
@@ -948,6 +951,7 @@ public class CryptoCreateSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> createAnAccountWithEVMAddressAliasAndECKey() {
         return hapiTest(newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE), withOpContext((spec, opLog) -> {
             final var ecdsaKey = spec.registry().getKey(SECP_256K1_SOURCE_KEY);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountDetails;
@@ -96,6 +97,7 @@ public class CryptoDeleteAllowanceSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> canDeleteAllowanceForDeletedSpender() {
         final String owner = "owner";
         final String spender = "spender";
@@ -274,6 +276,7 @@ public class CryptoDeleteAllowanceSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> feesAsExpected() {
         final String owner = "owner";
         final String spender = "spender";
@@ -353,6 +356,7 @@ public class CryptoDeleteAllowanceSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> succeedsWhenTokenPausedFrozenKycRevoked() {
         final String owner = "owner";
         final String spender = "spender";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteSuite.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccount;
 import static com.hedera.services.bdd.spec.HapiPropertySource.explicitBytesOf;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
@@ -75,6 +76,7 @@ public class CryptoDeleteSuite {
     }
 
     @LeakyHapiTest(requirement = ContextRequirement.SYSTEM_ACCOUNT_BALANCES)
+    @Tag(MATS)
     final Stream<DynamicTest> deletedAccountCannotBePayer() {
         final var submittingNodeAccount = "3";
         final var beneficiaryAccount = "beneficiaryAccountForDeletedAccount";
@@ -122,6 +124,7 @@ public class CryptoDeleteSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> fundsTransferOnDelete() {
         long B = HapiSpecSetup.getDefaultInstance().defaultBalance();
 
@@ -136,6 +139,7 @@ public class CryptoDeleteSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> cannotDeleteAccountsWithNonzeroTokenBalances() {
         return hapiTest(
                 newKeyNamed("admin"),
@@ -191,6 +195,7 @@ public class CryptoDeleteSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> cannotDeleteTreasuryAccount() {
         return hapiTest(
                 cryptoCreate(TREASURY),
@@ -202,6 +207,7 @@ public class CryptoDeleteSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> deleteEcdsaKeyAliasWorked() {
         return hapiTest(
                 createHip32Auto(1, SECP_256K1_SHAPE, i -> ACCOUNT_TO_BE_DELETED),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetInfoRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetInfoRegression.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
@@ -49,6 +50,7 @@ public class CryptoGetInfoRegression {
 
     /** For Demo purpose : The limit on each account info and account balance queries is set to 5 */
     @LeakyHapiTest(overrides = {"tokens.maxRelsPerInfoQuery"})
+    @Tag(MATS)
     final Stream<DynamicTest> fetchesOnlyALimitedTokenAssociations() {
         final var account = "test";
         final var aKey = "tokenKey";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetRecordsRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetRecordsRegression.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.assertions.TransferListAsserts.including;
@@ -35,6 +36,7 @@ public class CryptoGetRecordsRegression {
     private static final String PAYER = "payer";
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> succeedsNormally() {
         String memo = "Dim galleries, dusky corridors got past...";
 
@@ -106,6 +108,7 @@ public class CryptoGetRecordsRegression {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> getAccountRecords_testForDuplicates() {
         return hapiTest(
                 cryptoCreate(ACCOUNT_1).balance(5000000000000L).sendThreshold(1L),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoRecordsSanityCheckSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoRecordsSanityCheckSuite.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.ContextRequirement.SYSTEM_ACCOUNT_BALANCES;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
@@ -52,6 +53,7 @@ public class CryptoRecordsSanityCheckSuite {
     private static final String ORIG_KEY = "origKey";
 
     @LeakyHapiTest(requirement = SYSTEM_ACCOUNT_BALANCES)
+    @Tag(MATS)
     final Stream<DynamicTest> ownershipChangeShowsInRecord() {
         final var firstOwner = "A";
         final var secondOwner = "B";
@@ -92,6 +94,7 @@ public class CryptoRecordsSanityCheckSuite {
     }
 
     @LeakyHapiTest(requirement = SYSTEM_ACCOUNT_BALANCES)
+    @Tag(MATS)
     final Stream<DynamicTest> cryptoDeleteRecordSanityChecks() {
         return hapiTest(flattened(
                 cryptoCreate("test"),
@@ -116,6 +119,7 @@ public class CryptoRecordsSanityCheckSuite {
     }
 
     @LeakyHapiTest(requirement = SYSTEM_ACCOUNT_BALANCES)
+    @Tag(MATS)
     final Stream<DynamicTest> cryptoUpdateRecordSanityChecks() {
         return hapiTest(flattened(
                 cryptoCreate("test"),
@@ -128,6 +132,7 @@ public class CryptoRecordsSanityCheckSuite {
     }
 
     @LeakyHapiTest(requirement = SYSTEM_ACCOUNT_BALANCES)
+    @Tag(MATS)
     final Stream<DynamicTest> insufficientAccountBalanceRecordSanityChecks() {
         final long BALANCE = 500_000_000L;
         return hapiTest(flattened(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -4,6 +4,7 @@ package com.hedera.services.bdd.suites.crypto;
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccount;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTopicString;
@@ -315,6 +316,7 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest // fees differ expected 46889349 actual 46887567
+    @Tag(MATS)
     final Stream<DynamicTest> canUseAliasAndAccountCombinations() {
         final AtomicReference<TokenID> ftId = new AtomicReference<>();
         final AtomicReference<TokenID> nftId = new AtomicReference<>();
@@ -394,6 +396,7 @@ public class CryptoTransferSuite {
 
     // https://github.com/hashgraph/hedera-services/issues/2875
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> canUseMirrorAliasesForNonContractXfers() {
         final AtomicReference<TokenID> ftId = new AtomicReference<>();
         final AtomicReference<TokenID> nftId = new AtomicReference<>();
@@ -477,6 +480,7 @@ public class CryptoTransferSuite {
 
     @SuppressWarnings("java:S5669")
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> canUseEip1014AliasesForXfers() {
         final var partyCreation2 = "partyCreation2";
         final var counterCreation2 = "counterCreation2";
@@ -599,6 +603,7 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> cannotTransferFromImmutableAccounts() {
         final var contract = "PayableConstructor";
         final var multiKey = "swiss";
@@ -759,6 +764,7 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> nftTransfersCannotRepeatSerialNos() {
         final var aParty = "aParty";
         final var bParty = "bParty";
@@ -1037,6 +1043,7 @@ public class CryptoTransferSuite {
 
     @SuppressWarnings("java:S5960")
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> tokenTransferFeesScaleAsExpected() {
         return hapiTest(
                 cryptoCreate("a"),
@@ -1232,6 +1239,7 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> specialAccountsBalanceCheck() {
         return hapiTest(IntStream.concat(IntStream.range(1, 101), IntStream.range(900, 1001))
                 .mapToObj(i -> withOpContext((spec, log) -> allRunFor(spec, getAccountBalance(String.valueOf(i))))
@@ -1414,6 +1422,7 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hapiTransferFromForFungibleTokenWithCustomFeesWithAllowance() {
         final var FUNGIBLE_TOKEN_WITH_FIXED_HBAR_FEE = "fungibleTokenWithFixedHbarFee";
         final var FUNGIBLE_TOKEN_WITH_FIXED_TOKEN_FEE = "fungibleTokenWithFixedTokenFee";
@@ -1657,6 +1666,7 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> netAdjustmentsMustBeZero() {
         final AtomicReference<AccountID> partyId = new AtomicReference<>();
         final AtomicReference<AccountID> counterId = new AtomicReference<>();
@@ -1692,6 +1702,7 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> customFeesCannotCauseOverflow() {
         final var secondFeeCollector = "secondFeeCollector";
         return hapiTest(
@@ -1712,6 +1723,7 @@ public class CryptoTransferSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> createHollowAccountWithNftTransferAndCompleteIt() {
         final var tokenA = "tokenA";
         final var hollowAccountKey = "hollowAccountKey";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -156,6 +157,7 @@ public class CryptoUpdateSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> updateStakingFieldsWorks() {
         final var stakedAccountId = 20;
         return hapiTest(
@@ -190,6 +192,7 @@ public class CryptoUpdateSuite {
     }
 
     @LeakyHapiTest(overrides = {"entities.maxLifetime", "ledger.maxAutoAssociations"})
+    @Tag(MATS)
     final Stream<DynamicTest> usdFeeAsExpectedCryptoUpdate() {
         double baseFee = 0.000214;
         double baseFeeWithExpiry = 0.00022;
@@ -355,6 +358,7 @@ public class CryptoUpdateSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> updateWithOverlappingSigs() {
         return hapiTest(
                 newKeyNamed(TARGET_KEY).shape(twoLevelThresh).labels(overlappingKeys),
@@ -366,6 +370,7 @@ public class CryptoUpdateSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> updateFailsWithContractKey() {
         final var id = new AtomicReference<ContractID>();
         final var CONTRACT = "Multipurpose";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/HollowAccountFinalizationSuite.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -98,6 +99,7 @@ public class HollowAccountFinalizationSuite {
     private static final String VANILLA_TOKEN = "TokenD";
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountCompletionWithEthereumTransaction() {
         final String CONTRACT = "Fuse";
         return hapiTest(
@@ -145,6 +147,7 @@ public class HollowAccountFinalizationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountCompletionWithTokenTransfer() {
         final var fungibleToken = "fungibleToken";
         final AtomicReference<TokenID> ftId = new AtomicReference<>();
@@ -259,6 +262,7 @@ public class HollowAccountFinalizationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountCompletionWithTokenAssociation() {
         return hapiTest(flattened(
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -287,6 +291,7 @@ public class HollowAccountFinalizationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountFinalizationWhenAccountNotPresentInPreHandle() {
         final var ECDSA_2 = "ECDSA_2";
         return hapiTest(
@@ -501,6 +506,7 @@ public class HollowAccountFinalizationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountCompletionWithEthereumContractCreate() {
         final var CONTRACT = "CreateTrivial";
         return hapiTest(flattened(
@@ -830,6 +836,7 @@ public class HollowAccountFinalizationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hollowPayerAndOtherReqSignerBothGetCompletedInASingleTransaction() {
         final var ecdsaKey2 = "ecdsaKey2";
         final var recipientKey = "recipient";
@@ -898,6 +905,7 @@ public class HollowAccountFinalizationSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountCompletionIsPersistedEvenIfTxnFails() {
         return hapiTest(flattened(
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/LeakyCryptoTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/LeakyCryptoTestsSuite.java
@@ -6,6 +6,7 @@ import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubK
 import static com.hedera.services.bdd.junit.ContextRequirement.FEE_SCHEDULE_OVERRIDES;
 import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_SYNCHRONOUS_HANDLE_WORKFLOW;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.customizedHapiTest;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
@@ -382,6 +383,7 @@ public class LeakyCryptoTestsSuite {
     }
 
     @LeakyHapiTest(requirement = FEE_SCHEDULE_OVERRIDES)
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountCreationChargesExpectedFees() {
         final long REDUCED_NODE_FEE = 2L;
         final long REDUCED_NETWORK_FEE = 3L;
@@ -458,6 +460,7 @@ public class LeakyCryptoTestsSuite {
 
     @Order(14)
     @LeakyHapiTest(overrides = {"contracts.evm.version"})
+    @Tag(MATS)
     final Stream<DynamicTest> contractDeployAfterEthereumTransferLazyCreate() {
         final var RECIPIENT_KEY = LAZY_ACCOUNT_RECIPIENT;
         final var lazyCreateTxn = PAY_TXN;
@@ -500,6 +503,7 @@ public class LeakyCryptoTestsSuite {
     }
 
     @LeakyHapiTest(overrides = {"contracts.evm.version"})
+    @Tag(MATS)
     final Stream<DynamicTest> contractCallAfterEthereumTransferLazyCreate() {
         final var RECIPIENT_KEY = LAZY_ACCOUNT_RECIPIENT;
         final var lazyCreateTxn = PAY_TXN;
@@ -547,6 +551,7 @@ public class LeakyCryptoTestsSuite {
 
     @HapiTest
     @Order(17)
+    @Tag(MATS)
     final Stream<DynamicTest> autoAssociationWorksForContracts() {
         final var theContract = "CreateDonor";
         final String tokenA = "tokenA";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/MiscCryptoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/MiscCryptoSuite.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.ContextRequirement.FEE_SCHEDULE_OVERRIDES;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
@@ -69,6 +70,7 @@ public class MiscCryptoSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign() {
         String sysAccount = "977";
         String randomAccountA = "randomAccountA";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccount;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
@@ -66,6 +67,7 @@ public class QueryPaymentSuite {
      * 3. Transaction payer is not involved in transfers for query payment to node and all payers have enough balance
      */
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> queryPaymentsMultiBeneficiarySucceeds() {
         return hapiTest(
                 cryptoCreate("a").balance(1_234L),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFixedFees.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFixedFees.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.customizedHapiTest;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
@@ -431,6 +432,7 @@ public class TransferWithCustomFixedFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferApprovedFungibleWithFixedHtsCustomFeeAsOwner() {
         return hapiTest(
                 cryptoCreate(htsCollector),
@@ -666,6 +668,7 @@ public class TransferWithCustomFixedFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferApprovedNonFungibleWithFixedHtsCustomFeeAsSpender() {
         return hapiTest(
                 newKeyNamed(NFT_KEY),
@@ -817,6 +820,7 @@ public class TransferWithCustomFixedFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferFungibleWithFixedHtsCustomFees2Layers() {
         return hapiTest(
                 cryptoCreate(htsCollector),
@@ -1374,6 +1378,7 @@ public class TransferWithCustomFixedFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferWithFractionalCustomFee() {
         return hapiTest(
                 cryptoCreate(htsCollector).balance(ONE_HUNDRED_HBARS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFractionalFees.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomFractionalFees.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
@@ -310,6 +311,7 @@ public class TransferWithCustomFractionalFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferWithFractionalCustomFeeAllowanceNetOfTransfers() {
         return hapiTest(
                 cryptoCreate(htsCollector).balance(ONE_HUNDRED_HBARS),
@@ -409,6 +411,7 @@ public class TransferWithCustomFractionalFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferWithFractionalCustomFeesThreeCollectors() {
         return hapiTest(
                 cryptoCreate(alice),
@@ -481,6 +484,7 @@ public class TransferWithCustomFractionalFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferWithFractionalCustomFeesDenominatorMax() {
         return hapiTest(
                 cryptoCreate(alice),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomRoyaltyFees.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomRoyaltyFees.java
@@ -4,6 +4,7 @@ package com.hedera.services.bdd.suites.crypto;
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asEvmAddress;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -558,6 +559,7 @@ public class TransferWithCustomRoyaltyFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferNonFungibleWithRoyaltyHtsFee2TokenFees() {
         return hapiTest(
                 newKeyNamed(NFT_KEY),
@@ -909,6 +911,7 @@ public class TransferWithCustomRoyaltyFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferNonFungibleWithRoyaltyAllCollectorsExempt() {
         return hapiTest(
                 newKeyNamed(NFT_KEY),
@@ -1269,6 +1272,7 @@ public class TransferWithCustomRoyaltyFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferNonFungibleWithHollowAccountAndRoyaltyFallbackHbarFee() {
         return hapiTest(flattened(
                 newKeyNamed(NFT_KEY),
@@ -1442,6 +1446,7 @@ public class TransferWithCustomRoyaltyFees {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferRoyaltyFeeLongZeroAddressFungibleSenderIds() {
         final var bufferAccount = "account2";
         final var fungibleToken = "fungibleToken";
@@ -1593,6 +1598,7 @@ public class TransferWithCustomRoyaltyFees {
      * fees.
      */
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> biDirectionalAirdropsCannotTriggerRoyaltyPayments() {
         return hapiTest(
                 newKeyNamed(NFT_KEY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(CRYPTO)
 public class TxnRecordRegression {
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> recordsStillQueryableWithDeletedPayerId() {
         return hapiTest(
                 cryptoCreate("toBeDeletedPayer"),
@@ -114,6 +116,7 @@ public class TxnRecordRegression {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> receiptAvailableWithinCacheTtl() {
         return hapiTest(
                 cryptoCreate("misc").via("success").balance(1_000L),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/batch/AtomicAutoAccountCreationUnlimitedAssociationsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/batch/AtomicAutoAccountCreationUnlimitedAssociationsSuite.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.crypto.batch;
 
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.customizedHapiTest;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -435,6 +436,7 @@ public class AtomicAutoAccountCreationUnlimitedAssociationsSuite {
     }
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> transferNftToEVMAddressAliasUnlimitedAssociations() {
         final AtomicReference<AccountID> partyId = new AtomicReference<>();
         final AtomicReference<byte[]> partyAlias = new AtomicReference<>();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/allowance/AtomicBatchApproveAllowanceTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/allowance/AtomicBatchApproveAllowanceTest.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.hip551.allowance;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
@@ -147,6 +148,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
+    @Tag(MATS)
     public final Stream<DynamicTest> transferErc20TokenFromContractWithApproval() {
         final var transferFromOtherContractWithSignaturesTxn = "transferFromOtherContractWithSignaturesTxn";
         final var nestedContract = "NestedERC20Contract";
@@ -264,6 +266,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
+    @Tag(MATS)
     public final Stream<DynamicTest> cannotPayForAnyTransactionWithContractAccount() {
         final var cryptoAdminKey = "cryptoAdminKey";
         final var contract = "PayableConstructor";
@@ -1479,6 +1482,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
+    @Tag(MATS)
     public final Stream<DynamicTest> cannotHaveMultipleAllowedSpendersForTheSameNftSerial() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -4,6 +4,7 @@ package com.hedera.services.bdd.suites.hip904;
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.ContextRequirement.PROPERTY_OVERRIDES;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.includingFungibleMovement;
@@ -220,6 +221,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
             }
 
             @HapiTest
+            @Tag(MATS)
             final Stream<DynamicTest> nftAirdropToExistingAccountsTransfers() {
                 return hapiTest(
                         // receivers with free auto association slots
@@ -256,6 +258,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
         @DisplayName("without free auto associations slots")
         class AirdropToExistingAccountsWithoutFreeAutoAssociations {
             @HapiTest
+            @Tag(MATS)
             final Stream<DynamicTest> tokenAirdropToExistingAccountsPending() {
                 return hapiTest(
                         tokenAirdrop(
@@ -448,6 +451,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
             @HapiTest
             @DisplayName("with multiple tokens")
+            @Tag(MATS)
             final Stream<DynamicTest> tokenAirdropMultipleTokens() {
                 return hapiTest(
                         createTokenWithName("FT1"),
@@ -541,6 +545,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("airdrop to contract with admin key")
+        @Tag(MATS)
         final Stream<DynamicTest> airdropToContractWithAdminKey() {
             final var testContract = "ToyMaker";
             final var key = "key";
@@ -1264,6 +1269,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("SECP256K1 key account")
+        @Tag(MATS)
         final Stream<DynamicTest> airdropToNonExistingSECP256K1Account() {
             var secp256K1 = "secp256K1";
             return hapiTest(
@@ -1361,6 +1367,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("containing multiple senders")
+        @Tag(MATS)
         final Stream<DynamicTest> airdropWithMultipleSenders() {
             return hapiTest(
                     cryptoCreate("sender1"),
@@ -1483,6 +1490,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("NFT with allowance")
+        @Tag(MATS)
         final Stream<DynamicTest> airdropNftWithAllowance() {
             var spender = "spender";
             return hapiTest(
@@ -2282,6 +2290,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
         // 2 EOA airdrops multiple tokens to a contract that is associated to all of them
         @HapiTest
         @DisplayName("multiple tokens to associated contract should transfer")
+        @Tag(MATS)
         final Stream<DynamicTest> multipleTokensToAssociatedContract() {
             var mutableContract = "PayReceivable";
             return hapiTest(flattened(
@@ -2599,6 +2608,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
 
         @HapiTest
         @DisplayName("when token is frozen")
+        @Tag(MATS)
         final Stream<DynamicTest> whenTokenIsFrozen() {
             final String ALICE = "alice";
             var mutableContract = "PayReceivable";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenCancelAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenCancelAirdropTest.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.hip904;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
@@ -270,6 +271,7 @@ public class TokenCancelAirdropTest extends TokenAirdropBase {
 
     @HapiTest
     @DisplayName("with multiple NFTs")
+    @Tag(MATS)
     final Stream<DynamicTest> multipleNFTs() {
         final var account = "account";
         final var receiver = "receiver";
@@ -478,6 +480,7 @@ public class TokenCancelAirdropTest extends TokenAirdropBase {
 
     @HapiTest
     @DisplayName("when treasury is changed")
+    @Tag(MATS)
     final Stream<DynamicTest> treasuryIsChanged() {
         final var account = "account";
         final var receiver = "receiver";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenClaimAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenClaimAirdropTest.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.hip904;
 
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -231,6 +232,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
 
     @HapiTest
     @DisplayName("not enough Hbar to claim and than enough")
+    @Tag(MATS)
     final Stream<DynamicTest> notEnoughHbarToClaimAndThanEnough() {
         final String ALICE = "ALICE";
         final String BOB = "BOB";
@@ -652,6 +654,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
 
     @HapiTest
     @DisplayName("Claim token airdrop - 2nd account pays")
+    @Tag(MATS)
     final Stream<DynamicTest> claimTokenAirdropOtherAccountPays() {
         return hapiTest(flattened(
                 setUpTokensAndAllReceivers(),
@@ -679,6 +682,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
 
     @HapiTest
     @DisplayName("Claim token airdrop - sender account pays")
+    @Tag(MATS)
     final Stream<DynamicTest> claimTokenAirdropSenderAccountPays() {
         return hapiTest(flattened(
                 setUpTokensAndAllReceivers(),
@@ -1264,6 +1268,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
 
     @HapiTest
     @DisplayName("Hollow account should be created before implementation of HIP-904")
+    @Tag(MATS)
     final Stream<DynamicTest> hollowAccountBehavior() {
         final String ALICE = "ALICE";
         final String BOB = "BOB";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/queries/AsNodeOperatorQueriesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/queries/AsNodeOperatorQueriesTest.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.suites.queries;
 
 import static com.hedera.services.bdd.junit.ContextRequirement.THROTTLE_OVERRIDES;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractBytecode;
@@ -88,6 +89,7 @@ public class AsNodeOperatorQueriesTest extends NodeOperatorQueriesBase {
 
     @HapiTest
     @DisplayName("Only node operators don't need to sign file contents queries")
+    @Tag(MATS)
     final Stream<DynamicTest> fileGetContentsNoSigRequired() {
         final var filename = "anyFile.txt";
         final var someoneElse = "someoneElse";
@@ -220,6 +222,7 @@ public class AsNodeOperatorQueriesTest extends NodeOperatorQueriesBase {
     }
 
     @LeakyHapiTest(requirement = THROTTLE_OVERRIDES)
+    @Tag(MATS)
     final Stream<DynamicTest> nodeOperatorCryptoGetInfoNotThrottled() {
         return hapiTest(flattened(
                 overridingThrottles("testSystemFiles/node-operator-throttles.json"),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/CreateStakersTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/CreateStakersTest.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.staking;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.dsl.operations.transactions.TouchBalancesOperation.touchBalanceOf;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
@@ -35,6 +36,7 @@ public class CreateStakersTest {
     static SpecAccount NODE2_STAKER;
 
     @HapiTest
+    @Tag(MATS)
     final Stream<DynamicTest> createStakers() {
         return hapiTest(
                 ensureStakingActivated(),


### PR DESCRIPTION
**Description**
Continuation of https://github.com/hiero-ledger/hiero-consensus-node/issues/20857 centered on crypto hapi tests.

There are only two types of changes: adding `@Tag(MATS)` to the tests we want to include in the MATS test suite, and enabling `hapiTestCryptoMATS`. Tests were chosen as a best-guess effort at maximizing a functional surface area of all execution tests annotated with `@Tag(CRYPTO)`.