### PR TITLE
fix: OpsDurationCounter.disabled() allocates too much memory

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/OpsDurationCounter.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/OpsDurationCounter.java
@@ -9,12 +9,15 @@ import java.util.Objects;
  * throughout the execution of a single EVM transaction.
  */
 public final class OpsDurationCounter {
+
+    private static final OpsDurationCounter DISABLED = new OpsDurationCounter(OpsDurationSchedule.empty());
+
     private final OpsDurationSchedule schedule;
 
     private long opsDurationUnitsConsumed;
 
     public static OpsDurationCounter disabled() {
-        return new OpsDurationCounter(OpsDurationSchedule.empty());
+        return DISABLED;
     }
 
     public static OpsDurationCounter withSchedule(final OpsDurationSchedule schedule) {


### PR DESCRIPTION
**Description**:

* reuse static DISABLED counter

**Related issue(s)**:

Fixes #21250

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
