### PR TITLE
chore: Fix `BalanceValidation` flake

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -183,7 +183,7 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
      * stake weights change each stake period boundary.
      * @param stakerIds the set of staker IDs to use
      */
-    public static void setStakerIds(@NonNull final Set<AccountID> stakerIds) {
+    public static void setStakerIds(@Nullable final Set<AccountID> stakerIds) {
         HapiSpec.stakerIds = stakerIds;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/StreamValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/validation/StreamValidationTest.java
@@ -5,6 +5,7 @@ import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateStreams;
 
 import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.spec.HapiSpec;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Order;
@@ -16,6 +17,8 @@ import org.junit.jupiter.api.Tag;
 public class StreamValidationTest {
     @LeakyHapiTest
     final Stream<DynamicTest> streamsAreValid() {
+        // Ensure we don't trigger any stake rebalancing that could interfere with later record-derived validation
+        HapiSpec.setStakerIds(null);
         return hapiTest(validateStreams());
     }
 }


### PR DESCRIPTION
Disable auto-stake rebalancing before doing stream validation to fix `BalanceValidation` flake. 

The reason this happens is we get the expected state changes to validate balances before doing the stake rebalancing and compare the balances. This will miss the last stake update balance change and test fails. It is purely a timing issue.

The fix is to disable the stake rebalancing in middle of the validations.