### PR TITLE
feat: Command line tool for converting stats csv files to openmetrics format

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/StatsToPrometheusCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/StatsToPrometheusCommand.java
@@ -20,11 +20,11 @@ import java.util.stream.IntStream;
 import picocli.CommandLine;
 
 @CommandLine.Command(
-        name = "stats-to-open-metrics",
+        name = "stats-to-prometheus",
         mixinStandardHelpOptions = true,
-        description = "Converts list of stat CSV files to OpenMetrics format")
+        description = "Converts list of stat CSV files to prometheus format")
 @SubcommandOf(PlatformCli.class)
-public class StatsToOpenMetricCommand extends AbstractCommand {
+public class StatsToPrometheusCommand extends AbstractCommand {
 
     private List<Path> csvFiles;
     private BufferedReader lineReader;


### PR DESCRIPTION
**Description**:

Sometimes we are only getting historical stat files from some run (for example performance tests). Browsing them in PDF generated by insight tool is nice for general overview, but cannot be used reliably for correlating various metrics or zooming into specific areas during long runs.

Here is POC of tools which converts the csv files into openmetrics format, which can be then loaded into prometheus with `promtool  tsdb create-blocks-from openmetrics filename.openmetrics /prometheus` and then viewed in grafana.

Docker compose script and bash file to setup up everything will come in separate PR.

**Related issue(s)**:

Fixes #21195

**Notes for reviewer**:

Tool is hacky, as we don't want to write super proper CSV parser (stat file format is bit broken). If possible, focus on possible improvements of the _output_ - should more labels be added or can it be made to be more useful for grafana consumption.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
