### PR TITLE
refactor: Remove configuration parameter after Mega Map migration

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WrappedState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/WrappedState.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.swirlds.base.time.Time;
 import com.swirlds.common.merkle.crypto.MerkleCryptography;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableStates;
@@ -40,13 +39,8 @@ public class WrappedState implements State, Hashable {
      * {@inheritDoc}
      */
     @Override
-    public void init(
-            Time time,
-            Configuration configuration,
-            Metrics metrics,
-            MerkleCryptography merkleCryptography,
-            LongSupplier roundSupplier) {
-        delegate.init(time, configuration, metrics, merkleCryptography, roundSupplier);
+    public void init(Time time, Metrics metrics, MerkleCryptography merkleCryptography, LongSupplier roundSupplier) {
+        delegate.init(time, metrics, merkleCryptography, roundSupplier);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImpl.java
@@ -44,7 +44,6 @@ import com.hedera.node.app.workflows.handle.stack.savepoints.FollowingSavepoint;
 import com.hedera.node.config.types.StreamMode;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.merkle.crypto.MerkleCryptography;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.ReadableStates;
@@ -198,13 +197,8 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
     }
 
     @Override
-    public void init(
-            Time time,
-            Configuration configuration,
-            Metrics metrics,
-            MerkleCryptography merkleCryptography,
-            LongSupplier roundSupplier) {
-        state.init(time, configuration, metrics, merkleCryptography, roundSupplier);
+    public void init(Time time, Metrics metrics, MerkleCryptography merkleCryptography, LongSupplier roundSupplier) {
+        state.init(time, metrics, merkleCryptography, roundSupplier);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -206,7 +206,6 @@ class SerializationTest extends MerkleTestBase {
 
         originalTree.init(
                 context.getTime(),
-                context.getConfiguration(),
                 context.getMetrics(),
                 context.getMerkleCryptography(),
                 () -> TEST_PLATFORM_STATE_FACADE
@@ -293,7 +292,7 @@ class SerializationTest extends MerkleTestBase {
                 migrationStateChanges,
                 startupNetworks,
                 TEST_PLATFORM_STATE_FACADE);
-        loadedTree.getRoot().migrate(CONFIGURATION, MINIMUM_SUPPORTED_VERSION);
+        loadedTree.getRoot().migrate(MINIMUM_SUPPORTED_VERSION);
     }
 
     private MerkleNodeState createMerkleHederaState(Schema schemaV1) {

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeState.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeState.java
@@ -9,7 +9,6 @@ import static java.util.Objects.requireNonNull;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.crypto.MerkleCryptography;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.state.MerkleNodeState;
 import com.swirlds.platform.test.fixtures.state.TestVirtualMapState;
@@ -261,12 +260,7 @@ public class FakeState implements MerkleNodeState {
     }
 
     @Override
-    public void init(
-            Time time,
-            Configuration configuration,
-            Metrics metrics,
-            MerkleCryptography merkleCryptography,
-            LongSupplier roundSupplier) {
+    public void init(Time time, Metrics metrics, MerkleCryptography merkleCryptography, LongSupplier roundSupplier) {
         // no-op
     }
 

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/com/swirlds/demo/consistency/ConsistencyTestingToolState.java
@@ -9,7 +9,6 @@ import static org.hiero.base.utility.NonCryptographicHashing.hash64;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.hedera.pbj.runtime.ParseException;
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.MerkleNodeState;
 import com.swirlds.state.test.fixtures.merkle.MerkleStateRoot;
 import com.swirlds.state.test.fixtures.merkle.singleton.StringLeaf;
@@ -266,7 +265,7 @@ public class ConsistencyTestingToolState extends MerkleStateRoot<ConsistencyTest
     }
 
     @Override
-    public MerkleNode migrate(@NonNull final Configuration configuration, int version) {
+    public MerkleNode migrate(int version) {
         return this;
     }
 }

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/com/swirlds/demo/iss/ISSTestingToolState.java
@@ -16,7 +16,6 @@ import static com.swirlds.platform.test.fixtures.state.TestingAppStateInitialize
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.MerkleNodeState;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
@@ -90,7 +89,6 @@ public class ISSTestingToolState extends MerkleStateRoot<ISSTestingToolState> im
         final PlatformContext platformContext = platform.getContext();
         super.init(
                 platformContext.getTime(),
-                platformContext.getConfiguration(),
                 platformContext.getMetrics(),
                 platformContext.getMerkleCryptography(),
                 () -> DEFAULT_PLATFORM_STATE_FACADE.roundOf(this));
@@ -221,7 +219,7 @@ public class ISSTestingToolState extends MerkleStateRoot<ISSTestingToolState> im
 
     // FUTURE WORK: https://github.com/hiero-ledger/hiero-consensus-node/issues/19002
     @Override
-    public MerkleNode migrate(@NonNull final Configuration configuration, int version) {
+    public MerkleNode migrate(int version) {
         return this;
     }
 }

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolState.java
@@ -117,7 +117,7 @@ public class MigrationTestingToolState extends MerkleStateRoot<MigrationTestingT
     }
 
     @Override
-    public MerkleNode migrate(@NonNull final Configuration configuration, int version) {
+    public MerkleNode migrate(int version) {
         if (version == ClassVersion.VIRTUAL_MAP) {
             TestingAppStateInitializer.DEFAULT.initRosterState(this);
             return this;

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/build.gradle.kts
@@ -36,7 +36,6 @@ timingSensitiveModuleInfo {
     requires("com.swirlds.merkle.test.fixtures")
     requires("com.swirlds.platform.core")
     requires("com.swirlds.platform.core.test.fixtures")
-    requires("com.swirlds.config.api")
     requires("org.hiero.base.crypto")
     requires("org.hiero.base.crypto.test.fixtures")
     requires("org.hiero.base.utility")

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/platform/PlatformTestingToolState.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.utility.ThresholdLimitingHandler;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.demo.merkle.map.FCMConfig;
 import com.swirlds.demo.merkle.map.FCMFamily;
 import com.swirlds.demo.merkle.map.internal.ExpectedFCMFamily;
@@ -204,7 +203,7 @@ public class PlatformTestingToolState extends MerkleStateRoot<PlatformTestingToo
 
     // FUTURE WORK: https://github.com/hiero-ledger/hiero-consensus-node/issues/19002
     @Override
-    public MerkleNode migrate(@NonNull final Configuration configuration, int version) {
+    public MerkleNode migrate(int version) {
         return this;
     }
 

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/MapValueSerializableTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/MapValueSerializableTest.java
@@ -2,7 +2,6 @@
 package com.swirlds.demo.platform;
 
 import static com.swirlds.merkle.test.fixtures.map.pta.TransactionRecord.DEFAULT_EXPIRATION_TIME;
-import static com.swirlds.platform.test.fixtures.config.ConfigUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -318,8 +317,7 @@ class MapValueSerializableTest {
 
             final ByteArrayInputStream inStream = new ByteArrayInputStream(outStream.toByteArray());
             final MerkleDataInputStream inputStream = new MerkleDataInputStream(inStream);
-            final MerkleMap<MapKey, T> deserializedMap =
-                    inputStream.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+            final MerkleMap<MapKey, T> deserializedMap = inputStream.readMerkleTree(testDirectory, Integer.MAX_VALUE);
             cryptography.digestTreeSync(deserializedMap);
 
             assertEquals(map, deserializedMap);

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/timingSensitive/java/com/swirlds/demo/merkle/map/MapValueFCQTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/timingSensitive/java/com/swirlds/demo/merkle/map/MapValueFCQTests.java
@@ -5,7 +5,6 @@ import static com.swirlds.demo.platform.TestUtil.generateRandomContent;
 import static com.swirlds.demo.platform.TestUtil.generateTxRecord;
 import static com.swirlds.merkle.test.fixtures.map.lifecycle.EntityType.FCQ;
 import static com.swirlds.platform.state.service.PlatformStateFacade.DEFAULT_PLATFORM_STATE_FACADE;
-import static com.swirlds.platform.test.fixtures.config.ConfigUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -115,7 +114,7 @@ public class MapValueFCQTests {
             io.getOutput().writeMerkleTree(testDirectory, fcm);
             io.startReading();
             final MerkleMap<MapKey, MapValueFCQ<TransactionRecord>> deserialized =
-                    io.getInput().readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+                    io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
             cryptography.digestTreeSync(deserialized);
 
             assertEquals(fcm, deserialized);

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/BenchmarkMerkleInternal.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/BenchmarkMerkleInternal.java
@@ -4,8 +4,6 @@ package com.swirlds.benchmark.reconnect;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 
@@ -120,7 +118,7 @@ public class BenchmarkMerkleInternal extends PartialNaryMerkleInternal implement
      * in position 0, and that leaf will equal this node.
      */
     @Override
-    public MerkleNode migrate(@NonNull final Configuration configuration, final int version) {
+    public MerkleNode migrate(final int version) {
         return migrationMapper.apply(this, version);
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/DebuggableMerkleDataInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/DebuggableMerkleDataInputStream.java
@@ -5,7 +5,6 @@ import com.swirlds.base.function.CheckedFunction;
 import com.swirlds.common.io.streams.internal.SerializationOperation;
 import com.swirlds.common.io.streams.internal.SerializationStack;
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
@@ -593,13 +592,12 @@ public class DebuggableMerkleDataInputStream extends MerkleDataInputStream {
      * {@inheritDoc}
      */
     @Override
-    public <T extends MerkleNode> T readMerkleTree(
-            @NonNull final Configuration configuration, final Path directory, final int maxNumberOfNodes)
+    public <T extends MerkleNode> T readMerkleTree(final Path directory, final int maxNumberOfNodes)
             throws IOException {
 
         startOperation(SerializationOperation.READ_MERKLE_TREE);
         try {
-            return super.readMerkleTree(configuration, directory, maxNumberOfNodes);
+            return super.readMerkleTree(directory, maxNumberOfNodes);
         } finally {
             finishOperation();
         }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/MerkleDataInputStream.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/MerkleDataInputStream.java
@@ -14,7 +14,6 @@ import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.exceptions.IllegalChildCountException;
-import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
@@ -178,8 +177,6 @@ public class MerkleDataInputStream extends SerializableDataInputStream {
     /**
      * Read a merkle tree from a stream.
      *
-     * @param configuration
-     *      the configuration for this node
      * @param directory
      * 		the directory from which data is being read
      * @param maxNumberOfNodes
@@ -190,8 +187,7 @@ public class MerkleDataInputStream extends SerializableDataInputStream {
      * @throws IOException
      * 		thrown when version or the options or nodes count are invalid
      */
-    public <T extends MerkleNode> T readMerkleTree(
-            @NonNull final Configuration configuration, final Path directory, final int maxNumberOfNodes)
+    public <T extends MerkleNode> T readMerkleTree(final Path directory, final int maxNumberOfNodes)
             throws IOException {
 
         validateDirectory(directory);
@@ -220,8 +216,7 @@ public class MerkleDataInputStream extends SerializableDataInputStream {
             readNextNode(directory, deserializedVersions);
         }
 
-        final MerkleNode migratedRoot =
-                initializeAndMigrateTreeAfterDeserialization(configuration, root, deserializedVersions);
+        final MerkleNode migratedRoot = initializeAndMigrateTreeAfterDeserialization(root, deserializedVersions);
 
         if (migratedRoot == null) {
             return null;

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/SerializationOperation.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/streams/internal/SerializationOperation.java
@@ -2,7 +2,6 @@
 package com.swirlds.common.io.streams.internal;
 
 import com.swirlds.common.io.streams.MerkleDataInputStream;
-import com.swirlds.config.api.Configuration;
 import java.io.DataInputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -190,12 +189,12 @@ public enum SerializationOperation {
     READ_SERIALIZABLE_LIST,
 
     /**
-     * {@link MerkleDataInputStream#readMerkleTree(Configuration, Path, int)}
+     * {@link MerkleDataInputStream#readMerkleTree(Path, int)}
      */
     READ_MERKLE_TREE,
 
     /**
-     * Called every time {@link MerkleDataInputStream#readMerkleTree(Configuration, Path, int)} deserializes
+     * Called every time {@link MerkleDataInputStream#readMerkleTree(Path, int)} deserializes
      * a merkle node.
      */
     READ_MERKLE_NODE

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/MerkleNode.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/MerkleNode.java
@@ -9,8 +9,6 @@ import com.swirlds.common.merkle.iterators.MerkleIterator;
 import com.swirlds.common.merkle.route.MerkleRoute;
 import com.swirlds.common.merkle.route.MerkleRouteIterator;
 import com.swirlds.common.merkle.synchronization.views.MaybeCustomReconnectRoot;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hiero.base.crypto.Hashable;
 import org.hiero.base.io.SerializableDet;
 
@@ -43,7 +41,7 @@ public interface MerkleNode
      * {@inheritDoc}
      */
     @Override
-    default MerkleNode migrate(@NonNull final Configuration configuration, final int version) {
+    default MerkleNode migrate(final int version) {
         return this;
     }
 

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/copy/MerkleInitialize.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/copy/MerkleInitialize.java
@@ -4,8 +4,6 @@ package com.swirlds.common.merkle.copy;
 import com.swirlds.common.io.ExternalSelfSerializable;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -19,18 +17,13 @@ public final class MerkleInitialize {
 
     /**
      * Initialize the tree after deserialization.
-     * @param configuration
-     *      the configuration for this node
-     * @param root
-     * 		the tree (or subtree) to initialize
-     * @param deserializationVersions
-     * 		the versions of classes at deserialization
+     *
+     * @param root                    the tree (or subtree) to initialize
+     * @param deserializationVersions the versions of classes at deserialization
      * @return the root of the tree, possibly different than original root if the root has been migrated
      */
     public static MerkleNode initializeAndMigrateTreeAfterDeserialization(
-            @NonNull final Configuration configuration,
-            final MerkleNode root,
-            final Map<Long /* class ID */, Integer /* version */> deserializationVersions) {
+            final MerkleNode root, final Map<Long /* class ID */, Integer /* version */> deserializationVersions) {
 
         if (root == null) {
             return null;
@@ -60,7 +53,7 @@ public final class MerkleInitialize {
                                 deserializationVersions.get(child.getClassId()),
                                 "class not discovered during deserialization");
 
-                        final MerkleNode migratedChild = child.migrate(configuration, deserializationVersion);
+                        final MerkleNode migratedChild = child.migrate(deserializationVersion);
                         if (migratedChild != child) {
                             internal.setChild(childIndex, migratedChild);
                         }
@@ -72,9 +65,7 @@ public final class MerkleInitialize {
         final int deserializationVersion = Objects.requireNonNull(
                 deserializationVersions.get(root.getClassId()), "class not discovered during deserialization");
 
-        // The configuration should be passed to the root during its migration,
-        // as it is required for creating the Virtual Map (Mega Map).
-        final MerkleNode migratedRoot = root.migrate(configuration, deserializationVersion);
+        final MerkleNode migratedRoot = root.migrate(deserializationVersion);
         if (migratedRoot != root) {
             root.release();
         }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleMigratable.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/interfaces/MerkleMigratable.java
@@ -4,8 +4,6 @@ package com.swirlds.common.merkle.interfaces;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.route.MerkleRoute;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Handles migration of merkle node types.
@@ -14,28 +12,27 @@ public interface MerkleMigratable {
 
     /**
      * <p>
-     * Optionally migrate this merkle node to a new type. Called when the state is deserialized. If
-     * the node returned is not this node, then the returned node is inserted into the tree in the place
-     * of this node.
+     * Optionally migrate this merkle node to a new type. Called when the state is deserialized. If the node returned is
+     * not this node, then the returned node is inserted into the tree in the place of this node.
      * </p>
      *
      * <p>
-     * Even if this node is not migrated to a new type, it is considered to be a supported use case to use this
-     * method to reorganize data in this object or in the subtree below this object. In this use case,
-     * this method should just return the original node.
+     * Even if this node is not migrated to a new type, it is considered to be a supported use case to use this method
+     * to reorganize data in this object or in the subtree below this object. In this use case, this method should just
+     * return the original node.
      * </p>
      *
      * <p>
      * For internal nodes, this method is guaranteed to be called after all descendant nodes have been added, migrated,
-     * and initialized; and after {@link MerkleInternal#rebuild()} is called on itself. Note that a new node
-     * created by the migrate method will not be automatically initialized.
+     * and initialized; and after {@link MerkleInternal#rebuild()} is called on itself. Note that a new node created by
+     * the migrate method will not be automatically initialized.
      * </p>
      *
      * <p>
-     * It is suggested that the replacement node be setup with the same {@link MerkleRoute} as the original node
-     * BEFORE it is returned by this method. This is especially important if the replacement node is a large subtree.
-     * If the replacement node does not have the same route, then the merkle utilities will iterate over the
-     * replacement subtree and update all of the merkle routes. This can be costly for large subtrees.
+     * It is suggested that the replacement node be setup with the same {@link MerkleRoute} as the original node BEFORE
+     * it is returned by this method. This is especially important if the replacement node is a large subtree. If the
+     * replacement node does not have the same route, then the merkle utilities will iterate over the replacement
+     * subtree and update all of the merkle routes. This can be costly for large subtrees.
      * </p>
      *
      * <p>
@@ -43,11 +40,10 @@ public interface MerkleMigratable {
      * automatically migrated by the merkle utilities.
      * </p>
      *
-     * @param configuration the configuration for this node
-     * @param version       the version of this class when it was deserialized. This parameter may be useful if migration needs
-     *                      to be performed only on transitions between specific versions.
-     * @return this node if no migration is needed, a new node if this node should be replaced, or null if this
-     * node should be deleted and not replaced
+     * @param version the version of this class when it was deserialized. This parameter may be useful if migration
+     *                needs to be performed only on transitions between specific versions.
+     * @return this node if no migration is needed, a new node if this node should be replaced, or null if this node
+     * should be deleted and not replaced
      */
-    MerkleNode migrate(@NonNull final Configuration configuration, final int version);
+    MerkleNode migrate(final int version);
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleTreeSnapshotReader.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/merkle/utility/MerkleTreeSnapshotReader.java
@@ -5,7 +5,6 @@ import static com.swirlds.common.io.streams.StreamDebugUtils.deserializeAndDebug
 
 import com.swirlds.common.io.streams.MerkleDataInputStream;
 import com.swirlds.common.merkle.MerkleNode;
-import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
@@ -50,14 +49,12 @@ public class MerkleTreeSnapshotReader {
     /**
      * Reads a state file from disk
      *
-     * @param configuration the configuration for this node
      * @param stateFile the file to read from
      * @return a signed state with it's associated hash (as computed when the state was serialized)
      * @throws IOException if there is any problems with reading from a file
      */
     @NonNull
-    public static StateFileData readStateFileData(
-            @NonNull final Configuration configuration, @NonNull final Path stateFile) throws IOException {
+    public static StateFileData readStateFileData(@NonNull final Path stateFile) throws IOException {
         return deserializeAndDebugOnFailure(
                 () -> new BufferedInputStream(new FileInputStream(stateFile.toFile())),
                 (final MerkleDataInputStream in) -> {
@@ -65,7 +62,7 @@ public class MerkleTreeSnapshotReader {
 
                     final Path directory = stateFile.getParent();
                     if (fileVersion == SIG_SET_SEPARATE_STATE_FILE_VERSION) {
-                        return readStateFileData(configuration, stateFile, in, directory);
+                        return readStateFileData(stateFile, in, directory);
                     } else {
                         throw new IOException("Unsupported state file version: " + fileVersion);
                     }
@@ -77,13 +74,10 @@ public class MerkleTreeSnapshotReader {
      */
     @NonNull
     private static StateFileData readStateFileData(
-            @NonNull final Configuration configuration,
-            @NonNull final Path stateFile,
-            @NonNull final MerkleDataInputStream in,
-            @NonNull final Path directory)
+            @NonNull final Path stateFile, @NonNull final MerkleDataInputStream in, @NonNull final Path directory)
             throws IOException {
         try {
-            final MerkleNode state = in.readMerkleTree(configuration, directory, MAX_MERKLE_NODES_IN_STATE);
+            final MerkleNode state = in.readMerkleTree(directory, MAX_MERKLE_NODES_IN_STATE);
             final Hash hash = in.readSerializable();
             return new StateFileData(state, hash);
 

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyMerkleInternal.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyMerkleInternal.java
@@ -4,8 +4,6 @@ package com.swirlds.common.test.fixtures.merkle.dummy;
 import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.impl.PartialNaryMerkleInternal;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 
@@ -149,7 +147,7 @@ public class DummyMerkleInternal extends PartialNaryMerkleInternal implements Du
      * in position 0, and that leaf will equal this node.
      */
     @Override
-    public MerkleNode migrate(@NonNull final Configuration configuration, final int version) {
+    public MerkleNode migrate(final int version) {
         return migrationMapper.apply(this, version);
     }
 }

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyMerkleLeaf.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/dummy/DummyMerkleLeaf.java
@@ -6,8 +6,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -188,7 +186,7 @@ public class DummyMerkleLeaf extends PartialMerkleLeaf implements DummyMerkleNod
      * in position 0, and that leaf will equal this node.
      */
     @Override
-    public MerkleNode migrate(@NonNull final Configuration configuration, final int version) {
+    public MerkleNode migrate(final int version) {
         return migrationMapper.apply(this, version);
     }
 }

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleSerializeUtils.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/merkle/util/MerkleSerializeUtils.java
@@ -15,7 +15,7 @@ public class MerkleSerializeUtils {
             final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
             io.getOutput().writeMerkleTree(directory, root);
             io.startReading();
-            return io.getInput().readMerkleTree(configuration, directory, Integer.MAX_VALUE);
+            return io.getInput().readMerkleTree(directory, Integer.MAX_VALUE);
         }
     }
 }

--- a/platform-sdk/swirlds-merkle/build.gradle.kts
+++ b/platform-sdk/swirlds-merkle/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 testModuleInfo {
-    requires("com.swirlds.config.api")
     requires("com.swirlds.base")
     requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.merkle.test.fixtures")

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MerkleMapEntryKeyTests.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MerkleMapEntryKeyTests.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkle.test.map;
 
-import static com.swirlds.merkle.test.fixtures.map.util.ConfigUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -126,7 +125,7 @@ class MerkleMapEntryKeyTests {
                 new MerkleDataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
 
         final MerkleMapEntryKey<SerializableLong> deserializedKey =
-                merkleIn.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+                merkleIn.readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
         assertEquals(key, deserializedKey, "deserialized key should match");
         assertNotSame(key, deserializedKey, "there is no way that the new object should be the same as the old one");

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MerkleMapEntryTests.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MerkleMapEntryTests.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkle.test.map;
 
-import static com.swirlds.merkle.test.fixtures.map.util.ConfigUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -172,7 +171,7 @@ class MerkleMapEntryTests {
                 new MerkleDataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
 
         final MerkleMapEntry<SerializableLong, KeyedMerkleLong<SerializableLong>> deserializedEntry =
-                merkleIn.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+                merkleIn.readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
         assertEquals(entry, deserializedEntry, "deserialized entry should match");
         assertNotSame(

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSerializationTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSerializationTests.java
@@ -7,7 +7,6 @@ import static com.swirlds.common.test.fixtures.merkle.util.MerkleTestUtils.areTr
 import static com.swirlds.common.test.fixtures.merkle.util.MerkleTestUtils.buildLessSimpleTree;
 import static com.swirlds.common.test.fixtures.merkle.util.MerkleTestUtils.buildLessSimpleTreeExtended;
 import static com.swirlds.common.test.fixtures.merkle.util.MerkleTestUtils.isFullyInitialized;
-import static com.swirlds.merkle.test.fixtures.map.util.ConfigUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -92,8 +91,7 @@ class MerkleSerializationTests {
         final MerkleDataInputStream inputStream =
                 new MerkleDataInputStream(new ByteArrayInputStream(baseStream.toByteArray()));
 
-        final DummyMerkleNode deserializedTree =
-                inputStream.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+        final DummyMerkleNode deserializedTree = inputStream.readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
         if (root == null) {
             assertNull(deserializedTree, "tree should be null");
@@ -136,8 +134,7 @@ class MerkleSerializationTests {
 
         MerkleDataInputStream inputStream =
                 new MerkleDataInputStream(new ByteArrayInputStream(baseStream.toByteArray()));
-        final DummyMerkleNode deserialized =
-                inputStream.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+        final DummyMerkleNode deserialized = inputStream.readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
         assertTrue(areTreesEqual(tree, deserialized), "tree should match generated");
         assertTrue(isFullyInitialized(deserialized), "tree should be initialized");
@@ -173,7 +170,7 @@ class MerkleSerializationTests {
         final MerkleDataInputStream dataStream = new MerkleDataInputStream(
                 getClass().getResourceAsStream("/merkle/serialized-tree-v3/serialized-tree-v3.dat"));
         dataStream.readProtocolVersion();
-        final DummyMerkleNode tree = dataStream.readMerkleTree(CONFIGURATION, dir, Integer.MAX_VALUE);
+        final DummyMerkleNode tree = dataStream.readMerkleTree(dir, Integer.MAX_VALUE);
         assertTrue(
                 areTreesEqual(MerkleTestUtils.buildTreeWithExternalData(), tree),
                 "deserialized should match constructed");
@@ -192,7 +189,7 @@ class MerkleSerializationTests {
 
         assertThrows(
                 InvalidVersionException.class,
-                () -> inputStream.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE),
+                () -> inputStream.readMerkleTree(testDirectory, Integer.MAX_VALUE),
                 "expected error during deserialization");
     }
 
@@ -315,7 +312,7 @@ class MerkleSerializationTests {
         final MerkleDataInputStream in =
                 new DebuggableMerkleDataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
 
-        final MerkleInternal deserializedRoot = in.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+        final MerkleInternal deserializedRoot = in.readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
         // The root is untouched
         assertTrue(deserializedRoot instanceof DummyMerkleInternal, "incorrect node type");
@@ -410,7 +407,7 @@ class MerkleSerializationTests {
         final MerkleDataInputStream in =
                 new DebuggableMerkleDataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
 
-        final MerkleInternal deserializedRoot = in.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+        final MerkleInternal deserializedRoot = in.readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
         assertTrue(areTreesEqual(newRoot, deserializedRoot), "deserialized tree should match new root");
         assertNotNull(deserializedRootBeforeMigration.get(), "deserialized root should have been set");
@@ -436,9 +433,7 @@ class MerkleSerializationTests {
         final MerkleDataOutputStream out = new MerkleDataOutputStream(new ByteArrayOutputStream());
 
         assertThrows(
-                NullPointerException.class,
-                () -> in.readMerkleTree(CONFIGURATION, null, 0),
-                "null directory should not be permitted");
+                NullPointerException.class, () -> in.readMerkleTree(null, 0), "null directory should not be permitted");
         assertThrows(
                 IllegalArgumentException.class,
                 () -> out.writeMerkleTree(null, null),
@@ -447,7 +442,7 @@ class MerkleSerializationTests {
         final Path nonExistentDirectory = new File("if/this/actually/exists/I/will/eat/my/hat").toPath();
         assertThrows(
                 IllegalArgumentException.class,
-                () -> in.readMerkleTree(CONFIGURATION, nonExistentDirectory, 0),
+                () -> in.readMerkleTree(nonExistentDirectory, 0),
                 "directory must exist");
         assertThrows(
                 IllegalArgumentException.class,
@@ -461,7 +456,7 @@ class MerkleSerializationTests {
         fOut.close();
         assertThrows(
                 IllegalArgumentException.class,
-                () -> in.readMerkleTree(CONFIGURATION, notADirectory, 0),
+                () -> in.readMerkleTree(notADirectory, 0),
                 "must be an actual directory");
         assertThrows(
                 IllegalArgumentException.class,
@@ -473,7 +468,7 @@ class MerkleSerializationTests {
         writeProtectedDirectory.toFile().setWritable(false);
         assertThrows(
                 EOFException.class,
-                () -> in.readMerkleTree(CONFIGURATION, writeProtectedDirectory, 0),
+                () -> in.readMerkleTree(writeProtectedDirectory, 0),
                 "should pass directory validation and fail later in the operation, write permission not needed");
         assertThrows(
                 IllegalArgumentException.class,
@@ -486,7 +481,7 @@ class MerkleSerializationTests {
         readProtectedDirectory.toFile().setReadable(false);
         assertThrows(
                 IllegalArgumentException.class,
-                () -> in.readMerkleTree(CONFIGURATION, readProtectedDirectory, 0),
+                () -> in.readMerkleTree(readProtectedDirectory, 0),
                 "must have read permissions");
         assertThrows(
                 IllegalArgumentException.class,

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/map/MerkleMapTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/map/MerkleMapTests.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkle.test.map;
 
-import static com.swirlds.merkle.test.fixtures.map.util.ConfigUtils.CONFIGURATION;
 import static java.util.Map.Entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -780,8 +779,7 @@ class MerkleMapTests {
             io.getOutput().writeMerkleTree(testDirectory, map);
             io.startReading();
 
-            final MerkleMap<?, ?> deserializedMap =
-                    io.getInput().readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+            final MerkleMap<?, ?> deserializedMap = io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
             cryptography.digestTreeSync(deserializedMap);
 
@@ -809,8 +807,7 @@ class MerkleMapTests {
             try (final MerkleDataInputStream inputStream =
                     new MerkleDataInputStream(new ByteArrayInputStream(baseStream.toByteArray()))) {
 
-                final MerkleMap<Key, V> deserializeMM =
-                        inputStream.readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+                final MerkleMap<Key, V> deserializeMM = inputStream.readMerkleTree(testDirectory, Integer.MAX_VALUE);
                 assertEquals("foobar", deserializeMM.getLabel());
                 cryptography.digestTreeSync(deserializeMM);
 
@@ -1102,7 +1099,7 @@ class MerkleMapTests {
 
         final MerkleDataInputStream in = new MerkleDataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
         final MerkleMap<SerializableLong, KeyedMerkleLong<SerializableLong>> mm4 =
-                in.readMerkleTree(CONFIGURATION, testDirectory, 1000);
+                in.readMerkleTree(testDirectory, 1000);
 
         assertEquals("foobarbaz", mm4.getLabel());
 

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/tree/MerkleBinaryTreeTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/tree/MerkleBinaryTreeTests.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkle.test.tree;
 
-import static com.swirlds.merkle.test.fixtures.map.util.ConfigUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -912,7 +911,7 @@ class MerkleBinaryTreeTests {
 
             io.startReading();
             final MerkleBinaryTree<Value> deserializedTree =
-                    io.getInput().readMerkleTree(CONFIGURATION, testDirectory, Integer.MAX_VALUE);
+                    io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
 
             assertEquals(tree.size(), deserializedTree.size(), "Size should match after deserialization");
 

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -219,7 +219,7 @@ class MerkleDbBuilderTest {
 
         final MerkleDataInputStream in =
                 new MerkleDataInputStream(Files.newInputStream(snapshotFile, StandardOpenOption.READ));
-        final MerkleInternal restoredStateRoot = in.readMerkleTree(CONFIGURATION, snapshotDir, Integer.MAX_VALUE);
+        final MerkleInternal restoredStateRoot = in.readMerkleTree(snapshotDir, Integer.MAX_VALUE);
 
         verify(restoredStateRoot);
 
@@ -282,7 +282,7 @@ class MerkleDbBuilderTest {
 
         final MerkleDataInputStream in =
                 new MerkleDataInputStream(Files.newInputStream(snapshotFile, StandardOpenOption.READ));
-        final MerkleInternal restoredStateRoot = in.readMerkleTree(CONFIGURATION, snapshotDir, Integer.MAX_VALUE);
+        final MerkleInternal restoredStateRoot = in.readMerkleTree(snapshotDir, Integer.MAX_VALUE);
 
         verify(restoredStateRoot);
 

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/VirtualMapSerializationTests.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/VirtualMapSerializationTests.java
@@ -226,7 +226,7 @@ class VirtualMapSerializationTests {
 
         final MerkleDataInputStream in = new MerkleDataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
 
-        final VirtualMap deserializedMap = in.readMerkleTree(CONFIGURATION, savedStateDirectory, Integer.MAX_VALUE);
+        final VirtualMap deserializedMap = in.readMerkleTree(savedStateDirectory, Integer.MAX_VALUE);
 
         assertMapsAreEqual(map, deserializedMap);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLoad.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLoad.java
@@ -13,10 +13,7 @@ import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.route.MerkleRoute;
 import com.swirlds.common.merkle.route.MerkleRouteIterator;
-import com.swirlds.config.api.Configuration;
-import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.logging.legacy.LogMarker;
-import com.swirlds.platform.config.DefaultConfiguration;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
@@ -66,11 +63,7 @@ public class StateEditorLoad extends StateEditorOperation {
         final MerkleNode subtree;
         try (final MerkleDataInputStream in =
                 new MerkleDataInputStream(new BufferedInputStream(new FileInputStream(fileName.toFile())))) {
-
-            final Configuration configuration =
-                    DefaultConfiguration.buildBasicConfiguration(ConfigurationBuilder.create());
-
-            subtree = in.readMerkleTree(configuration, fileName.getParent(), Integer.MAX_VALUE);
+            subtree = in.readMerkleTree(fileName.getParent(), Integer.MAX_VALUE);
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -209,7 +209,6 @@ public class SignedState {
     public void init(@NonNull PlatformContext platformContext) {
         state.init(
                 platformContext.getTime(),
-                platformContext.getConfiguration(),
                 platformContext.getMetrics(),
                 platformContext.getMerkleCryptography(),
                 () -> {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
@@ -65,7 +65,7 @@ public final class SignedStateFileReader {
         checkSignedStatePath(stateFile);
 
         final DeserializedSignedState returnState;
-        final MerkleTreeSnapshotReader.StateFileData data = MerkleTreeSnapshotReader.readStateFileData(conf, stateFile);
+        final MerkleTreeSnapshotReader.StateFileData data = MerkleTreeSnapshotReader.readStateFileData(stateFile);
         final File sigSetFile =
                 stateFile.getParent().resolve(SIGNATURE_SET_FILE_NAME).toFile();
         final SigSet sigSet = deserializeAndDebugOnFailure(

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.test.fixtures.state;
 
-import static com.swirlds.platform.test.fixtures.state.TestingAppStateInitializer.CONFIGURATION;
 import static com.swirlds.platform.test.fixtures.state.manager.SignatureVerificationTestUtils.buildFakeSignature;
 import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomHash;
 import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomHashBytes;
@@ -157,7 +156,6 @@ public class RandomSignedStateGenerator {
             stateInstance = TestVirtualMapState.createInstanceWithVirtualMapLabel(virtualMapLabel);
             stateInstance.init(
                     Time.getCurrent(),
-                    CONFIGURATION,
                     new NoOpMetrics(),
                     TestMerkleCryptoFactory.getInstance(),
                     () -> platformStateFacade.roundOf(stateInstance));

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/State.java
@@ -4,7 +4,6 @@ package com.swirlds.state;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.FastCopyable;
 import com.swirlds.common.merkle.crypto.MerkleCryptography;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.spi.CommittableWritableStates;
 import com.swirlds.state.spi.ReadableKVState;
@@ -27,18 +26,13 @@ import org.hiero.base.crypto.Hashable;
 public interface State extends FastCopyable, Hashable {
     /**
      * Initializes the state with the given parameters.
-     * @param time The time provider.
-     * @param configuration The platform configuration.
-     * @param metrics The metrics provider.
+     *
+     * @param time               The time provider.
+     * @param metrics            The metrics provider.
      * @param merkleCryptography The merkle cryptography provider.
-     * @param roundSupplier The round supplier.
+     * @param roundSupplier      The round supplier.
      */
-    void init(
-            Time time,
-            Configuration configuration,
-            Metrics metrics,
-            MerkleCryptography merkleCryptography,
-            LongSupplier roundSupplier);
+    void init(Time time, Metrics metrics, MerkleCryptography merkleCryptography, LongSupplier roundSupplier);
 
     /**
      * Returns a {@link ReadableStates} for the given named service. If such a service doesn't

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapState.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapState.java
@@ -111,8 +111,6 @@ public abstract class VirtualMapState<T extends VirtualMapState<T>> implements S
      */
     private final List<StateChangeListener> listeners = new ArrayList<>();
 
-    private Configuration configuration;
-
     private LongSupplier roundSupplier;
 
     private VirtualMap virtualMap;
@@ -149,7 +147,6 @@ public abstract class VirtualMapState<T extends VirtualMapState<T>> implements S
      */
     protected VirtualMapState(@NonNull final VirtualMapState<T> from) {
         this.virtualMap = from.virtualMap.copy();
-        this.configuration = from.configuration;
         this.roundSupplier = from.roundSupplier;
         this.startupMode = from.startupMode;
         this.listeners.addAll(from.listeners);
@@ -160,14 +157,8 @@ public abstract class VirtualMapState<T extends VirtualMapState<T>> implements S
         }
     }
 
-    public void init(
-            Time time,
-            Configuration configuration,
-            Metrics metrics,
-            MerkleCryptography merkleCryptography,
-            LongSupplier roundSupplier) {
+    public void init(Time time, Metrics metrics, MerkleCryptography merkleCryptography, LongSupplier roundSupplier) {
         this.time = time;
-        this.configuration = configuration;
         this.metrics = metrics;
         this.snapshotMetrics = new MerkleRootSnapshotMetrics(metrics);
         this.roundSupplier = roundSupplier;
@@ -264,8 +255,8 @@ public abstract class VirtualMapState<T extends VirtualMapState<T>> implements S
      */
     @Override
     public T loadSnapshot(@NonNull Path targetPath) throws IOException {
-        final MerkleNode root = MerkleTreeSnapshotReader.readStateFileData(configuration, targetPath)
-                .stateRoot();
+        final MerkleNode root =
+                MerkleTreeSnapshotReader.readStateFileData(targetPath).stateRoot();
         if (!(root instanceof VirtualMap readVirtualMap)) {
             throw new IllegalStateException(
                     "Root should be a VirtualMap, but it is " + root.getClass().getSimpleName() + " instead");

--- a/platform-sdk/swirlds-state-impl/src/test/java/com/swirlds/state/merkle/VirtualMapStateTest.java
+++ b/platform-sdk/swirlds-state-impl/src/test/java/com/swirlds/state/merkle/VirtualMapStateTest.java
@@ -67,7 +67,6 @@ public class VirtualMapStateTest extends MerkleTestBase {
         virtualMapState = new TestVirtualMapState(CONFIGURATION, new NoOpMetrics());
         virtualMapState.init(
                 new FakeTime(),
-                CONFIGURATION,
                 new NoOpMetrics(),
                 mock(MerkleCryptography.class),
                 () -> PlatformStateAccessor.GENESIS_ROUND);
@@ -746,8 +745,7 @@ public class VirtualMapStateTest extends MerkleTestBase {
             final MerkleCryptography merkleCryptography = MerkleCryptographyFactory.create(ConfigurationBuilder.create()
                     .withConfigDataType(CryptoConfig.class)
                     .build());
-            virtualMapState.init(
-                    new FakeTime(), CONFIGURATION, new NoOpMetrics(), merkleCryptography, () -> GENESIS_ROUND);
+            virtualMapState.init(new FakeTime(), new NoOpMetrics(), merkleCryptography, () -> GENESIS_ROUND);
         }
 
         @Test

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleStateRoot.java
@@ -17,7 +17,6 @@ import com.swirlds.common.merkle.utility.MerkleTreeSnapshotWriter;
 import com.swirlds.common.utility.Labeled;
 import com.swirlds.common.utility.RuntimeObjectRecord;
 import com.swirlds.common.utility.RuntimeObjectRegistry;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.State;
 import com.swirlds.state.StateChangeListener;
@@ -112,10 +111,6 @@ public abstract class MerkleStateRoot<T extends MerkleStateRoot<T>> extends Part
         return services;
     }
 
-    private Configuration configuration;
-
-    private Metrics metrics;
-
     /**
      * Metrics for the snapshot creation process
      */
@@ -154,15 +149,8 @@ public abstract class MerkleStateRoot<T extends MerkleStateRoot<T>> extends Part
         this.registryRecord = RuntimeObjectRegistry.createRecord(getClass());
     }
 
-    public void init(
-            Time time,
-            Configuration configuration,
-            Metrics metrics,
-            MerkleCryptography merkleCryptography,
-            LongSupplier roundSupplier) {
+    public void init(Time time, Metrics metrics, MerkleCryptography merkleCryptography, LongSupplier roundSupplier) {
         this.time = time;
-        this.configuration = configuration;
-        this.metrics = metrics;
         this.merkleCryptography = merkleCryptography;
         this.roundSupplier = roundSupplier;
         snapshotMetrics = new MerkleRootSnapshotMetrics(metrics);
@@ -870,7 +858,6 @@ public abstract class MerkleStateRoot<T extends MerkleStateRoot<T>> extends Part
     @SuppressWarnings("unchecked")
     @Override
     public T loadSnapshot(@NonNull Path targetPath) throws IOException {
-        return (T) MerkleTreeSnapshotReader.readStateFileData(configuration, targetPath)
-                .stateRoot();
+        return (T) MerkleTreeSnapshotReader.readStateFileData(targetPath).stateRoot();
     }
 }

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleTestBase.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleTestBase.java
@@ -211,7 +211,7 @@ public class MerkleTestBase extends StateTestBase {
             throws IOException {
         final var byteInputStream = new ByteArrayInputStream(state);
         try (final var in = new MerkleDataInputStream(byteInputStream)) {
-            return in.readMerkleTree(CONFIGURATION, tempDir, 100);
+            return in.readMerkleTree(tempDir, 100);
         }
     }
 

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -1540,7 +1540,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
     }
 
     @Override
-    public MerkleNode migrate(@NonNull final Configuration configuration, int version) {
+    public MerkleNode migrate(int version) {
         if (version < ClassVersion.NO_VIRTUAL_ROOT_NODE) {
             // removing VirtualMapMetadata
             super.setChild(0, null);


### PR DESCRIPTION
**Description**:
This PR removes configuration from the migrate method along with other places where it was added to achieve Mega Map migration.

**Related issue(s)**:
Fixes #19308

