### PR TITLE
ci(bug): add adhoc- prefix for xts pass tags for commit list

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -403,7 +403,7 @@ jobs:
           TAG_WITH_EPOCH: ${{ inputs.enable-promotion || 'false' }}
         run: |
           if [[ -n "${RC_TAG}" ]] && [[ "${TAG_WITH_EPOCH}" == "false" ]]; then
-            TAG="xts-pass-${RC_TAG}"
+            TAG="adhoc-xts-pass-${RC_TAG}"
 
             set +e
               TAG_COMMIT="$(git rev-list -n 1 "${TAG}")" >/dev/null 2>&1


### PR DESCRIPTION
**Description**:

Add `adhoc-` prefix to XTS pass tags to fix the commit list being generated. The current naming scheme means that `xts-pass-build-xxxxx` will be compared with other `xts-pass-<timestamp>` which did not do the comparison.

**Related Issue(s)**:

Fixes #21479
