### PR TITLE
chore: Update XTS dry run workflow name

### DIFF
--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "ZXF: [CITR] Extended Test Suite - Dry Run"
+name: "ZXF: [CITR] XTS Dry Run"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This pull request makes a minor update to the workflow name in `.github/workflows/zxf-dry-run-extended-test-suite.yaml` to use a shorter and clearer title.