### PR TITLE
fix(bug): Clear backticks

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -145,7 +145,8 @@ jobs:
             echo "xts-tag-commit-email=${AUTHOR_EMAIL}" >> "${GITHUB_OUTPUT}"
             echo "xts-info=${XTS_COMMIT_BRANCH} - ${XTS_SHORT_COMMIT}" >> "${GITHUB_OUTPUT}"
 
-            ESCAPED_COMMIT_LIST=$(jq -Rs . <<< "${COMMIT_LIST}")
+            CLEANED_COMMIT_LIST="${COMMIT_LIST//\`/}"
+            ESCAPED_COMMIT_LIST=$(jq -Rs . <<< "${CLEANED_COMMIT_LIST}")
             ESCAPED_COMMIT_LIST=${ESCAPED_COMMIT_LIST:1:-1}
             echo "commit-list=${ESCAPED_COMMIT_LIST}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## Description

This pull request makes a small but important improvement to the workflow script by ensuring that backtick characters are removed from the commit list before it is processed and output. This helps prevent formatting issues or errors when the commit list is handled downstream. 

* Workflow script improvement:
  * In `.github/workflows/zxcron-extended-test-suite.yaml`, backticks are stripped from the `COMMIT_LIST` variable before escaping it with `jq`, ensuring cleaner and safer output.

### Related Issue(s)

Fixes #21506 