### PR TITLE
chore: Update commit list to use latest promoted build if no xts-pass tags

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -117,10 +117,10 @@ jobs:
               echo "Latest XTS Pass Tag: ${LATEST_XTS_PASS_TAG}"
               LATEST_XTS_PASS_COMMIT="$(git rev-list -n 1 "${LATEST_XTS_PASS_TAG}")"
               COMMIT_LIST="$(git log --pretty=format:"- [%h: %s](https://github.com/${{ github.repository }}/commit/%H)" "${LATEST_XTS_PASS_COMMIT}..${XTS_COMMIT}")"
-            else [[ -n "${LATEST_PROMOTED_BUILD_TAG}" ]]; then
+            elif [[ -n "${LATEST_PROMOTED_BUILD_TAG}" ]]; then
               echo "Latest Promoted Tag: ${LATEST_PROMOTED_BUILD_TAG}"
               LATEST_PROMOTED_BUILD_COMMIT="$(git rev-list -n 1 "${LATEST_PROMOTED_BUILD_TAG}")"
-              COMMIT_LIST="$(git log --pretty=format:"- [%h: %s](https://github.com/${{ github.repository }}/commit/%H)" "${LATEST_PROMOTED_BUILD_TAG}..${XTS_COMMIT}")"
+              COMMIT_LIST="$(git log --pretty=format:"- [%h: %s](https://github.com/${{ github.repository }}/commit/%H)" "${LATEST_PROMOTED_BUILD_COMMIT}..${XTS_COMMIT}")"
             fi
           fi
 


### PR DESCRIPTION
## Description

This pull request updates the `zxcron-extended-test-suite` GitHub Actions workflow to improve how it identifies and logs the most recent build and test tags. The main changes enhance the flexibility and robustness of the tag selection logic, allowing the workflow to fall back to promoted build tags if no XTS pass tag is found.

Tag selection and environment variable improvements:

* Added a new environment variable `BUILD_GREP_PATTERN` (`build-*`) to the workflow for more flexible build tag matching.
* Passed the new `BUILD_GREP_PATTERN` as `BUILD_PATTERN` to job steps, making it available for use in scripts.

Tag lookup logic enhancements:

* Updated the commit list generation logic to:
  * Use the environment variable for XTS pass tag lookup.
  * Add a fallback to search for the latest promoted build tag using the new pattern if no XTS pass tag is found.
  * Log the most recent promoted build tag and use it to determine the commit list when necessary.

### Related Issue(s)

closes #21519 