### PR TITLE
docs: Tweak block stream protocol to allow no txn result, one-to-many outputs

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/block_item.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/block_item.proto
@@ -46,9 +46,9 @@ import "block/stream/trace/trace_data.proto";
  * - A block SHALL start with a `header`.
  * - A block SHALL end with a `state_proof`.
  * - A `block_header` SHALL be followed by an `event_header`.
- * - An `event_header` SHOULD be followed by one or more
+ * - An `event_header` SHALL be followed by one or more
  *   `event_transaction` items.
- * - An `event_transaction` SHALL be followed by a `transaction_result`.
+ * - An `event_transaction` SHOULD be followed by a `transaction_result`.
  * - A `transaction_result` MAY be followed by one or more `transaction_output`s.
  * - A `transaction_result` (or a `transaction_output`, if present) MAY be
  *     followed by one or more `state_changes`.


### PR DESCRIPTION
### **Description**:

This PR makes two tweaks to the block stream protocol concerning the required sequence of streamed block items. Details for each change follow below.

Part of #21179 

### First change: Transaction result _SHOULD_ follow an event transaction

Efforts to verify the ongoing event hashes have surfaced a case over an upgrade boundary that requires a tweak to the block stream protocol. When an event `E` is created by a consensus node running version `V` just prior to a freeze, there's a corner case where handling transactions from `E` with consensus node version `V+1` can lead to an ISS. Since the network can't downgrade its version, the result is that transactions from `E` _will not be handled_. 

Consider the effect of this situation on each event hash: in order to correctly construct an event's hash, which includes all its transactions as one of its inputs, then we must make all transaction bytes available; in order to make them available, they must each be published to the block stream. _Therefore, after an upgrade, we must publish all of event `E`'s old transactions to the block stream. However, since we can't handle such events, it follows that a transaction result shouldn't be required in all cases._ 

This is why the wording about a transaction result following a transaction must change from `SHALL` to `SHOULD`. 

### Second change: One _or more_ transaction outputs

This change isn't technically required, but it's restrictive to mandate that a single transaction output effectively carry the interface for all different transaction types. Therefore, while we have no plans to change the current implementation of transaction output block items, we slightly relax the requirement in the spec. 