### PR TITLE
fix: failing BN communication XTS suite test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSoftwareUpgradeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSoftwareUpgradeSuite.java
@@ -95,7 +95,7 @@ public class BlockNodeSoftwareUpgradeSuite implements LifecycleTest {
                 assertHgcaaLogContainsTimeframe(
                         byNodeId(0),
                         timeRef::get,
-                        Duration.ofMinutes(1),
+                        Duration.ofMinutes(2),
                         Duration.ofSeconds(45),
                         "No initial block node configuration file found. Waiting for updates."),
                 burstOfTps(MIXED_OPS_BURST_TPS, Duration.ofSeconds(30)),


### PR DESCRIPTION
**Description**:
Simple fix for `upgradeFromFileToFileAndGrpc` suite test in `BlockNodeSoftwareUpgradeSuite` failing in XTS

[Successful XTS run on this branch](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18401149854)

**Related issue(s)**:

Fixes #21534 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
