### PR TITLE
fix(bug): Fix typo in GitHub release step condition

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -863,7 +863,7 @@ jobs:
           echo "create-release=${CREATE_RELEASE}" >> "${GITHUB_OUTPUT}"
 
       - name: Create github release
-        if: ${{ steps.set-gh-release-flag.outputs.create-release == 'true' }}
+        if: ${{ steps.set-gh-release-flags.outputs.create-release == 'true' }}
         uses: step-security/release-action@03a57407052f15d1537fd5469a6fbbc536aba326 # v1.20.0
         with:
           tag: ${{ inputs.ref-name }}


### PR DESCRIPTION
## Description

This pull request makes a small correction in the GitHub Actions workflow for building and releasing artifacts. The change fixes a typo in the step condition, ensuring it references the correct output variable.

- Workflow correction:
  * [`.github/workflows/node-zxc-build-release-artifact.yaml`](diffhunk://#diff-c4507eafecb6e04bf4d768bd725d1f4ac3707e6c7524678afeadbd40f421bd0bL866-R866): Fixed a typo in the `if` condition for the "Create github release" step, changing `steps.set-gh-release-flag.outputs` to `steps.set-gh-release-flags.outputs` to match the correct step name.

### Related Issue(s)

Fixes #21562 