### PR TITLE
fix: add retry logic for flaky throttling and platform activation tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
@@ -15,6 +15,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForFrozenNetwork;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -99,7 +100,10 @@ public class StreamValidationOp extends UtilOp implements LifecycleTest {
                 overriding("nodes.nodeRewardsEnabled", "false"),
                 // Ensure the CryptoTransfer below will be in a new block period
                 sleepFor(MAX_BLOCK_TIME_MS + BUFFER_MS),
-                cryptoTransfer((ignore, b) -> {}).payingWith(GENESIS),
+                cryptoTransfer((ignore, b) -> {})
+                        .payingWith(GENESIS)
+                        .hasRetryPrecheckFrom(PLATFORM_NOT_ACTIVE)
+                        .setRetryLimit(10),
                 // Wait for the final record file to be created
                 sleepFor(2 * BUFFER_MS));
         // Validate the record streams

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/SteadyStateThrottlingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/SteadyStateThrottlingTest.java
@@ -371,8 +371,16 @@ public class SteadyStateThrottlingTest {
             public List<SpecOperation> suggestedInitializers() {
                 return List.of(
                         newKeyNamed(SUPPLY),
-                        cryptoCreate(TOKEN_TREASURY).payingWith(GENESIS).balance(ONE_MILLION_HBARS),
-                        tokenCreate(TOKEN).treasury(TOKEN_TREASURY).supplyKey(SUPPLY));
+                        cryptoCreate(TOKEN_TREASURY)
+                                .payingWith(GENESIS)
+                                .balance(ONE_MILLION_HBARS)
+                                .hasPrecheckFrom(OK, BUSY)
+                                .hasKnownStatusFrom(PERMITTED_STATUSES),
+                        tokenCreate(TOKEN)
+                                .treasury(TOKEN_TREASURY)
+                                .supplyKey(SUPPLY)
+                                .hasPrecheckFrom(OK, BUSY)
+                                .hasKnownStatusFrom(PERMITTED_STATUSES));
             }
 
             @Override


### PR DESCRIPTION
**Description**:
- Add `BUSY` status tolerance to `SteadyStateThrottlingTest` setup operations
- Add `PLATFORM_NOT_ACTIVE` retry logic to `StreamValidationOp` cryptoTransfer
- Fixes intermittent CI failures caused by timing-dependent race conditions

  Resolves flaky test failures in:
  - `SteadyStateThrottlingTest.checkFungibleMintsTps()`
  - `StreamValidationTest.streamsAreValid()`

**Related issue(s)**:

Fixes #19351 

**Notes for reviewer**:
Add status tolerance to setup operations in SteadyStateThrottlingTest and retry mechanism for platform activation in StreamValidationOp to handle timing variations in CI environments.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
