### PR TITLE
ci: Remove duplicate report for SDK TCK test results

### DIFF
--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -346,15 +346,7 @@ jobs:
           }
           EOF
 
-      - name: Report Status to TCK Working Group
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.slack-tck-report-webhook }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json
-
-      - name: Report Status to TCK Working Group
+      - name: Report Status to CITR Detailed Test Results
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.slack-detailed-report-webhook }}


### PR DESCRIPTION
## Description

This pull request updates the Slack notification step in the `.github/workflows/zxc-tck-regression.yaml` workflow to change which Slack channel receives the detailed test results. The step that previously reported status to the TCK Working Group has been replaced with a step that reports status to the CITR Detailed Test Results channel.

Notification workflow update:

* The Slack notification step now sends detailed test results to the CITR Detailed Test Results channel using the `slack-detailed-report-webhook` secret, instead of notifying the TCK Working Group via the `slack-tck-report-webhook` secret. (`.github/workflows/zxc-tck-regression.yaml`)

### Related Issue(s)

Closes #21594 

### Testing

- [x] ✅ [XTS Dry Run (TCK Only)](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18504565066/job/52730067212)