### PR TITLE
fix: 21549: Reconnect: at large state, Learner throws Error "state hash has changed", falls into stream "IllegalStateException: Can't find queue element"

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSourceBuilder.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSourceBuilder.java
@@ -15,7 +15,6 @@ import com.swirlds.merkledb.constructable.constructors.MerkleDbDataSourceBuilder
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -35,7 +34,7 @@ import org.hiero.base.io.streams.SerializableDataOutputStream;
  *
  * <p>When a data source snapshot is taken, or a data source is restored from a snapshot, the
  * builder uses certain sub-folder under snapshot dir as described in {@link #snapshot(Path, VirtualDataSource)}
- * and {@link #build(String, Path, boolean, boolean)} methods.
+ * and {@link #restore(String, Path)} methods.
  */
 @ConstructableClass(
         value = MerkleDbDataSourceBuilder.CLASS_ID,
@@ -79,46 +78,16 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
         this.hashesRamToDiskThreshold = hashesRamToDiskThreshold;
     }
 
-    @SuppressWarnings("deprecation")
-    private Path newDataSourceDir(final String label) {
-        try {
-            return LegacyTemporaryFileBuilder.buildTemporaryFile("merkledb-" + label, configuration);
-        } catch (final IOException z) {
-            throw new UncheckedIOException("Failed to create a new temp MerkleDb folder", z);
-        }
-    }
-
-    private Path snapshotDataDir(final Path snapshotDir, final String label) {
-        return snapshotDir.resolve("data").resolve(label);
+    private Path newDataSourceDir(final String label) throws IOException {
+        return LegacyTemporaryFileBuilder.buildTemporaryFile("merkledb-" + label, configuration);
     }
 
     /**
      * {@inheritDoc}
-     *
-     * <p>If the source directory is provided, this builder assumes the directory is a base
-     * snapshot dir. Data source dir is either baseDir/data/label (new naming schema) or
-     * baseDir/tables/label-ID (legacy naming).
-     *
-     * <p>If the source directory is null, a new empty data source is created in a temp
-     * directory.
      */
     @NonNull
     @Override
-    public VirtualDataSource build(
-            final String label,
-            @Nullable final Path sourceDir,
-            final boolean compactionEnabled,
-            final boolean offlineUse) {
-        if (sourceDir == null) {
-            return buildNewDataSource(label, compactionEnabled, offlineUse);
-        } else {
-            return restoreDataSource(label, sourceDir, compactionEnabled, offlineUse);
-        }
-    }
-
-    @NonNull
-    private VirtualDataSource buildNewDataSource(
-            final String label, final boolean compactionEnabled, final boolean offlineUse) {
+    public VirtualDataSource build(final String label, final boolean dbCompactionEnabled) {
         if (initialCapacity <= 0) {
             throw new IllegalArgumentException("Initial map capacity not set");
         }
@@ -130,8 +99,8 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
                     label,
                     initialCapacity,
                     hashesRamToDiskThreshold,
-                    compactionEnabled,
-                    offlineUse);
+                    dbCompactionEnabled,
+                    false);
         } catch (final IOException ex) {
             throw new UncheckedIOException(ex);
         }
@@ -152,44 +121,71 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
 
     /**
      * {@inheritDoc}
-     *
-     * <p>Data source snapshot is placed under "data/label" sub-folder in the provided
-     * {@code snapshotDir}.
      */
     @NonNull
     @Override
-    public Path snapshot(@Nullable Path snapshotDir, @NonNull final VirtualDataSource dataSource) {
+    public MerkleDbDataSource copy(
+            final VirtualDataSource dataSource, final boolean compactionEnabled, final boolean offlineUse) {
         if (!(dataSource instanceof MerkleDbDataSource merkleDbDataSource)) {
             throw new IllegalArgumentException("The data source must be compatible with the MerkleDb");
         }
         final String label = merkleDbDataSource.getTableName();
-        if (snapshotDir == null) {
-            snapshotDir = newDataSourceDir(label);
+        final long initialCapacity = merkleDbDataSource.getInitialCapacity();
+        final long hashesRamToDiskThreshold = merkleDbDataSource.getHashesRamToDiskThreshold();
+        try {
+            final Path dataSourceDir = newDataSourceDir(label);
+            snapshotDataSource(merkleDbDataSource, dataSourceDir);
+            return new MerkleDbDataSource(
+                    dataSourceDir,
+                    configuration,
+                    label,
+                    initialCapacity,
+                    hashesRamToDiskThreshold,
+                    compactionEnabled,
+                    offlineUse);
+        } catch (final IOException z) {
+            throw new UncheckedIOException(z);
         }
-        final Path snapshotDataSourceDir = snapshotDataDir(snapshotDir, label);
-        snapshotDataSource(merkleDbDataSource, snapshotDataSourceDir);
-        return snapshotDir;
     }
 
     /**
-     * The builder first checks if "data/label" sub-folder exists in the snapshot dir and
+     * {@inheritDoc}
+     *
+     * <p>Data source snapshot is placed under "data/label" sub-folder in the provided
+     * {@code snapshotDir}.
+     */
+    @Override
+    public void snapshot(@NonNull final Path snapshotDir, final VirtualDataSource dataSource) {
+        if (!(dataSource instanceof MerkleDbDataSource merkleDbDataSource)) {
+            throw new IllegalArgumentException("The data source must be compatible with the MerkleDb");
+        }
+        final String label = merkleDbDataSource.getTableName();
+        final Path snapshotDataSourceDir = snapshotDir.resolve("data").resolve(label);
+        snapshotDataSource(merkleDbDataSource, snapshotDataSourceDir);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The builder first checks if "data/label" sub-folder exists in the snapshot dir and
      * restores a data source from there. If the sub-folder doesn't exist, it may be an old
      * snapshot with MerkleDb database metadata available. The metadata is used to find the
      * folder for a data source with the given label. If database metadata file is not found,
      * this method throws an IO exception.
      */
     @NonNull
-    private VirtualDataSource restoreDataSource(
-            final String label,
-            @NonNull final Path snapshotDir,
-            final boolean compactionEnabled,
-            final boolean offlineUse) {
+    @Override
+    public VirtualDataSource restore(final String label, final Path snapshotDir) {
+        return restore(label, snapshotDir, true);
+    }
+
+    protected VirtualDataSource restore(final String label, final Path snapshotDir, final boolean compactionEnabled) {
         try {
             final Path dataSourceDir = newDataSourceDir(label);
-            final Path snapshotDataSourceDir = snapshotDataDir(snapshotDir, label);
+            final Path snapshotDataSourceDir = snapshotDir.resolve("data").resolve(label);
             if (Files.isDirectory(snapshotDataSourceDir)) {
                 hardLinkTree(snapshotDataSourceDir, dataSourceDir);
-                return new MerkleDbDataSource(dataSourceDir, configuration, label, compactionEnabled, offlineUse);
+                return new MerkleDbDataSource(dataSourceDir, configuration, label, compactionEnabled, false);
             }
             final Path legacyDatabaseMetadataPath = snapshotDir.resolve("database_metadata.pbj");
             if (Files.isReadable(legacyDatabaseMetadataPath)) {
@@ -211,8 +207,8 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
                                 label,
                                 initialCapacity,
                                 hashesRamToDiskThreshold,
-                                compactionEnabled,
-                                offlineUse);
+                                true,
+                                false);
                     } else {
                         throw new IOException("Table dir is not found: dir=" + legacySnapshotDataSourceDir);
                     }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -109,7 +109,7 @@ class MerkleDbBuilderTest {
                 new MerkleDbDataSourceBuilder(CONFIGURATION, initialCapacity, hashesRamToDiskThreshold);
         VirtualDataSource dataSource = null;
         try {
-            dataSource = builder.build("test1", null, false, false);
+            dataSource = builder.build("test1", false);
             assertTrue(dataSource instanceof MerkleDbDataSource);
             MerkleDbDataSource merkleDbDataSource = (MerkleDbDataSource) dataSource;
             assertEquals(initialCapacity, merkleDbDataSource.getInitialCapacity());
@@ -128,7 +128,7 @@ class MerkleDbBuilderTest {
         final MerkleDbDataSourceBuilder builder = new MerkleDbDataSourceBuilder(CONFIGURATION, 1024, 0);
         VirtualDataSource dataSource = null;
         try {
-            dataSource = builder.build("test2", null, compactionEnabled, false);
+            dataSource = builder.build("test2", compactionEnabled);
             assertTrue(dataSource instanceof MerkleDbDataSource);
             MerkleDbDataSource merkleDbDataSource = (MerkleDbDataSource) dataSource;
             assertEquals(compactionEnabled, merkleDbDataSource.isCompactionEnabled());
@@ -143,7 +143,7 @@ class MerkleDbBuilderTest {
         VirtualDataSource dataSource = null;
         try {
             final String label = "testSnapshot";
-            dataSource = builder.build(label, null, false, false);
+            dataSource = builder.build(label, false);
             final Path tmpDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshot", CONFIGURATION);
             builder.snapshot(tmpDir, dataSource);
             assertTrue(Files.isDirectory(tmpDir.resolve("data").resolve(label)));
@@ -160,13 +160,13 @@ class MerkleDbBuilderTest {
         VirtualDataSource dataSource = null;
         try {
             final String label = "testSnapshotRestore";
-            dataSource = builder.build(label, null, false, false);
+            dataSource = builder.build(label, false);
             final Path tmpDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshot", CONFIGURATION);
             builder.snapshot(tmpDir, dataSource);
             assertTrue(Files.isDirectory(tmpDir.resolve("data").resolve(label)));
             VirtualDataSource restored = null;
             try {
-                restored = builder.build(label, tmpDir, false, false);
+                restored = builder.restore(label, tmpDir, false);
                 assertNotNull(restored);
                 assertTrue(restored instanceof MerkleDbDataSource);
                 final MerkleDbDataSource merkleDbRestored = (MerkleDbDataSource) restored;
@@ -310,10 +310,9 @@ class MerkleDbBuilderTest {
     @Test
     void testSnapshotAfterReconnect() throws Exception {
         final MerkleDbDataSourceBuilder dsBuilder = createDefaultBuilder();
-        final VirtualDataSource original = dsBuilder.build("vm", null, false, false);
+        final VirtualDataSource original = dsBuilder.build("vm", false);
         // Simulate reconnect as a learner
-        final Path snapshotPath = dsBuilder.snapshot(null, original);
-        final VirtualDataSource copy = dsBuilder.build("vm", snapshotPath, true, false);
+        final VirtualDataSource copy = dsBuilder.copy(original, true, false);
 
         try {
             final Path snapshotDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshot", CONFIGURATION);

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
@@ -17,7 +17,6 @@ import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
 import com.swirlds.virtualmap.datasource.VirtualHashRecord;
 import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Random;
@@ -131,11 +130,7 @@ public class CloseFlushTest {
 
         @NonNull
         @Override
-        public VirtualDataSource build(
-                final String label,
-                @Nullable final Path sourceDir,
-                final boolean compactionEnabled,
-                final boolean offlineUse) {
+        public VirtualDataSource build(final String label, final boolean withDbCompactionEnabled) {
             return new VirtualDataSource() {
                 @Override
                 public void close(boolean keepData) throws IOException {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
@@ -24,7 +24,6 @@ import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import com.swirlds.virtualmap.internal.merkle.ExternalVirtualMapMetadata;
 import com.swirlds.virtualmap.internal.merkle.VirtualRootNode;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -163,21 +162,28 @@ public abstract class VirtualMapReconnectTestBase {
             numTimesBroken = in.readInt();
         }
 
-        @NonNull
         @Override
-        public BreakableDataSource build(
-                final String label,
-                @Nullable final Path sourceDir,
-                final boolean compactionEnabled,
-                final boolean offlineUse) {
-            return new BreakableDataSource(this, delegate.build(label, sourceDir, compactionEnabled, offlineUse));
+        public BreakableDataSource build(final String label, final boolean withDbCompactionEnabled) {
+            return new BreakableDataSource(this, delegate.build(label, withDbCompactionEnabled));
         }
 
-        @NonNull
         @Override
-        public Path snapshot(@Nullable final Path destination, @NonNull final VirtualDataSource snapshotMe) {
+        public BreakableDataSource copy(
+                final VirtualDataSource snapshotMe, final boolean compactionEnabled, final boolean offlineUse) {
             final var breakableSnapshot = (BreakableDataSource) snapshotMe;
-            return delegate.snapshot(destination, breakableSnapshot.delegate);
+            return new BreakableDataSource(
+                    this, delegate.copy(breakableSnapshot.delegate, compactionEnabled, offlineUse));
+        }
+
+        @Override
+        public void snapshot(final Path destination, final VirtualDataSource snapshotMe) {
+            final var breakableSnapshot = (BreakableDataSource) snapshotMe;
+            delegate.snapshot(destination, breakableSnapshot.delegate);
+        }
+
+        @Override
+        public BreakableDataSource restore(final String label, final Path from) {
+            return new BreakableDataSource(this, delegate.restore(label, from));
         }
 
         public void setNumCallsBeforeThrow(int num) {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -89,7 +89,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hiero.base.ValueReference;
 import org.hiero.base.constructable.ConstructableClass;
 import org.hiero.base.constructable.RuntimeConstructable;
 import org.hiero.base.crypto.Hash;
@@ -436,7 +435,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             cache = new VirtualNodeCache(virtualMapConfig);
         }
         if (dataSource == null) {
-            dataSource = dataSourceBuilder.build(metadata.getLabel(), null, true, false);
+            dataSource = dataSourceBuilder.build(metadata.getLabel(), true);
         }
 
         updateShouldBeFlushed();
@@ -1125,37 +1124,58 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
 
     /**
      * {@inheritDoc}
-     *
-     * <p>This method must be called when the lifecycle thread for this virtual map is paused,
-     * or data source flushes are disabled some other way.
      */
     @Override
     public RecordAccessor detach() {
-        final Path snapshotPath = dataSourceSnapshot();
-        final VirtualDataSource dataSourceCopy = dataSourceBuilder.build(getLabel(), snapshotPath, false, false);
+        if (isDestroyed()) {
+            throw new IllegalStateException("detach is illegal on already destroyed copies");
+        }
+        if (!isImmutable()) {
+            throw new IllegalStateException("detach is only allowed on immutable copies");
+        }
+        if (!isHashed()) {
+            throw new IllegalStateException("copy must be hashed before it is detached");
+        }
+
+        detached.set(true);
+
+        // The pipeline is paused while this runs, so I can go ahead and call snapshot on the data
+        // source, and also snapshot the cache. I will create a new "RecordAccessor" for the detached
+        // record state.
+        final VirtualDataSource dataSourceCopy = dataSourceBuilder.copy(dataSource, false, false);
         final VirtualNodeCache cacheSnapshot = cache.snapshot();
         return new RecordAccessor(metadata.copy(), cacheSnapshot, dataSourceCopy);
     }
 
     /**
-     * Creates a snapshot of this map's data source. This method must be called only when
-     * the lifecycle thread is paused to make sure no data is flushed to the data source
-     * while the copy is prepared. The base path to the snapshot is returned.
+     * {@inheritDoc}
      */
-    private Path dataSourceSnapshot() {
+    @Override
+    public void snapshot(@NonNull final Path destination) throws IOException {
+        requireNonNull(destination);
         if (isDestroyed()) {
-            throw new IllegalStateException("Can't make data source copy: virtual map copy is already destroyed");
+            throw new IllegalStateException("snapshot is illegal on already destroyed copies");
         }
         if (!isImmutable()) {
-            throw new IllegalStateException("Can't make data source copy: virtual map copy is mutable");
+            throw new IllegalStateException("snapshot is only allowed on immutable copies");
         }
         if (!isHashed()) {
-            throw new IllegalStateException("Can't make data source copy: virtual map copy isn't hashed");
+            throw new IllegalStateException("copy must be hashed before snapshot");
         }
 
         detached.set(true);
 
-        return dataSourceBuilder.snapshot(null, dataSource);
+        // The pipeline is paused while this runs, so I can go ahead and call snapshot on the data
+        // source, and also snapshot the cache. I will create a new "RecordAccessor" for the detached
+        // record state.
+        final VirtualDataSource dataSourceCopy = dataSourceBuilder.copy(dataSource, false, true);
+        try {
+            final VirtualNodeCache cacheSnapshot = cache.snapshot();
+            flush(cacheSnapshot, metadata, dataSourceCopy);
+            dataSourceBuilder.snapshot(destination, dataSourceCopy);
+        } finally {
+            dataSourceCopy.close();
+        }
     }
 
     /**
@@ -1215,8 +1235,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             originalMap.dataSource.stopAndDisableBackgroundCompaction();
 
             // Take a snapshot, and use the snapshot database as my data source
-            final Path snapshotPath = dataSourceBuilder.snapshot(null, originalMap.dataSource);
-            this.dataSource = dataSourceBuilder.build(originalMap.getLabel(), snapshotPath, true, false);
+            this.dataSource = dataSourceBuilder.copy(originalMap.dataSource, true, false);
 
             // The old map's cache is going to become immutable, but that's OK, because the old map
             // will NEVER be updated again.
@@ -1552,30 +1571,10 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             // FUTURE WORK: get rid of the label once we migrate to Virtual Mega Map
             serout.writeNormalisedString(metadata.getLabel());
             serout.writeLong(metadata.getSize());
-            final ValueReference<VirtualNodeCache> cacheSnapshot = new ValueReference<>();
-            final Path snapshotPath = pipeline.pausePipelineAndRun("detach", () -> {
-                // Lifecycle thread is paused, no cache flushes/merges, it's safe to take cache snapshot
-                cacheSnapshot.setValue(cache.snapshot());
-                // And make a data source snapshot. The snapshot is not loaded here, though, it is
-                // done below
-                return dataSourceSnapshot();
+            pipeline.pausePipelineAndRun("detach", () -> {
+                snapshot(outputDirectory);
+                return null;
             });
-            // build(), flush() and snapshot() below are called outside pausePipelineAndRun() to
-            // unpause the lifecycle thread as quickly as possible. If the lifecycle thread is paused
-            // for too long, unhandled copies pile up in the virtual pipeline, which triggers size
-            // backpressure mechanism
-            VirtualDataSource dataSourceCopy = null;
-            try {
-                dataSourceCopy = dataSourceBuilder.build(getLabel(), snapshotPath, false, true);
-                // Then flush the cache snapshot to the data source copy
-                flush(cacheSnapshot.getValue(), metadata, dataSourceCopy);
-                // And finally snapshot the copy to the target dir
-                dataSourceBuilder.snapshot(outputDirectory, dataSourceCopy);
-            } finally {
-                if (dataSourceCopy != null) {
-                    dataSourceCopy.close();
-                }
-            }
             serout.writeSerializable(dataSourceBuilder, true);
             serout.writeLong(cache.getFastCopyVersion());
         }
@@ -1633,7 +1632,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
     private void loadFromFileV4(Path inputFile, MerkleDataInputStream stream, VirtualMapMetadata virtualMapMetadata)
             throws IOException {
         dataSourceBuilder = stream.readSerializable();
-        dataSource = dataSourceBuilder.build(virtualMapMetadata.getLabel(), inputFile.getParent(), true, false);
+        dataSource = dataSourceBuilder.restore(virtualMapMetadata.getLabel(), inputFile.getParent());
         cache = new VirtualNodeCache(virtualMapConfig, stream.readLong());
         metadata = virtualMapMetadata;
     }
@@ -1647,7 +1646,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             throw new IllegalStateException("Label of the VirtualRootNode is not equal to the label of the VirtualMap");
         }
         dataSourceBuilder = stream.readSerializable();
-        dataSource = dataSourceBuilder.build(label, inputFile.getParent(), true, false);
+        dataSource = dataSourceBuilder.restore(label, inputFile.getParent());
         metadata = externalState;
         if (virtualRootVersion < VirtualRootNode.ClassVersion.VERSION_3_NO_NODE_CACHE) {
             throw new UnsupportedOperationException("Version " + virtualRootVersion + " is not supported");

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSourceBuilder.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSourceBuilder.java
@@ -2,7 +2,6 @@
 package com.swirlds.virtualmap.datasource;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.file.Path;
 import org.hiero.base.io.SelfSerializable;
 
@@ -19,40 +18,75 @@ public interface VirtualDataSourceBuilder extends SelfSerializable {
 
     /**
      * Builds a new {@link VirtualDataSource} using the configuration of this builder and
-     * the given label. If a source directory is provided, data source files are loaded from
-     * it. This must be a directory previously used in the {@link #snapshot(Path, VirtualDataSource)}
-     * method. If the directory is not provided, a new temp directory is created, and an empty
-     * data source is opened in it.
+     * the given label. If a data source with the given label already exists, it's used instead.
      *
      * @param label
      * 		The label. Cannot be null. Labels can be used in logs and stats, and also to build
      * 		full disk paths to store data source files. This is builder implementation specific
+     * @param withDbCompactionEnabled
+     * 		If true then the new database will have background compaction enabled, false and the
+     * 		new database will not have background compaction enabled
+     * @return
+     * 		An opened {@link VirtualDataSource}.
+     */
+    @NonNull
+    VirtualDataSource build(String label, final boolean withDbCompactionEnabled);
+
+    /**
+     * Builds a new {@link VirtualDataSource} using the configuration of this builder by creating
+     * a snapshot of the given data source. The new data source doesn't have background file
+     * compaction enabled.
+     *
+     * <p>This method is used when a virtual map copy is created during reconnects. When a copy is
+     * created on the teacher side, the original data source is preserved as active, i.e. used
+     * to handle transactions. When this method is used on the learner side, it behaves in the
+     * opposite way: the copied data source becomes active, while the original data source isn't
+     * used any longer other than to re-initiate reconnect when failed.
+     *
+     * @param dataSource
+     * 		The dataSource to invoke snapshot on. Cannot be null
      * @param compactionEnabled
      *      Indicates whether background compaction should be enabled in the data source copy
      * @param offlineUse
      *      Indicates that the copied data source should use as little resources as possible. Data
      *      source copies created for offline use should not be used for performance critical tasks
      * @return
-     * 		An opened {@link VirtualDataSource}.
+     * 		An opened {@link VirtualDataSource}
      */
     @NonNull
-    VirtualDataSource build(
-            String label, @Nullable Path sourceDir, final boolean compactionEnabled, boolean offlineUse);
+    VirtualDataSource copy(VirtualDataSource dataSource, boolean compactionEnabled, boolean offlineUse);
 
     /**
-     * Creates a snapshot of the given data source in the specified folder.
+     * Builds a new {@link VirtualDataSource} using the configuration of this builder by creating
+     * a snapshot of the given data source in the specified folder. The new data source doesn't
+     * have background file compaction enabled. Such snapshots should not be used for any time
+     * critical operations, since snapshot data sources are expected to consume as little resources
+     * as possible (e.g. use on-disk rather than in-memory indices) and therefore may be slow.
      *
-     * <p>If the destination folder is not null, the snapshot is created in this folder, and
-     * this folder is returned. If the destination folder is null, the builder creates a new
-     * temp folder, takes the snapshot there, and returns the path to that folder.
+     * <p>This method is used when a virtual map is written to disk during state serialization.
      *
      * @param destination
      * 		The base path into which to snapshot the database. Can be null
      * @param dataSource
      * 		The dataSource to invoke snapshot on. Cannot be null
+     */
+    void snapshot(@NonNull Path destination, VirtualDataSource dataSource);
+
+    /**
+     * Builds a new {@link VirtualDataSource} using the configuration of this builder and
+     * the given label by copying all the database files from the given path into the new
+     * database directory and then opening that database.
+     *
+     * <p>This method is used when a virtual map is deserialized from a state snapshot.
+     * for details.
+     *
+     * @param label
+     * 		The label. Cannot be null. This label must be posix compliant
+     * @param snapshotDir
+     * 		The base path of the database from which to copy all the database files. Cannot be null
      * @return
-     *      The base path where the snapshot is taken
+     * 		An opened {@link VirtualDataSource}
      */
     @NonNull
-    Path snapshot(@Nullable Path destination, @NonNull VirtualDataSource dataSource);
+    VirtualDataSource restore(String label, Path snapshotDir);
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -10,8 +10,11 @@ import com.swirlds.base.function.CheckedSupplier;
 import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
+import com.swirlds.virtualmap.internal.RecordAccessor;
 import com.swirlds.virtualmap.internal.merkle.VirtualMapStatistics;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountDownLatch;
@@ -359,6 +362,50 @@ public class VirtualPipeline {
             scheduleWork();
         }
         return ret;
+    }
+
+    /**
+     * Put a copy into a detached state. A detached copy will split off from the regular chain of caches. This
+     * allows for merges and flushes to continue even if this copy is long-lived.
+     *
+     * <p>This method waits for the current pipeline job to complete, then puts the pipeline on hold, and
+     * calls copy's {@link VirtualRoot#detach()} method on the current thread. It prevents any merging of
+     * flushing while the snapshot is being taken. Then the pipeline is resumed.
+     *
+     * @param copy
+     * 		the copy to detach
+     * @return a reference to the detached state
+     */
+    public RecordAccessor detachCopy(final VirtualRoot copy) {
+        validatePipelineRegistration(copy);
+        final RecordAccessor ret = pausePipelineAndExecute("detach", copy::detach);
+        if (alive) {
+            scheduleWork();
+        }
+        return ret;
+    }
+
+    /**
+     * Takes a snapshot of the given copy to the specified directory.
+     *
+     * <p>This method waits for the current pipeline job to complete, then puts the pipeline on hold, and
+     * calls copy's {@link VirtualRoot#detach()} method on the current thread. It prevents any merging of
+     * flushing while the snapshot is being taken. Then the pipeline is resumed.
+     *
+     * @param copy
+     * 		The copy. Cannot be null. Should be a member of this pipeline, but technically doesn't need to be.
+     * @param targetDirectory
+     * 		the location where detached files are written. If null then default location is used.
+     */
+    public void snapshot(final VirtualRoot copy, final Path targetDirectory) throws IOException {
+        validatePipelineRegistration(copy);
+        pausePipelineAndExecute("snapshot", () -> {
+            copy.snapshot(targetDirectory);
+            return null;
+        });
+        if (alive) {
+            scheduleWork();
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualRoot.java
@@ -3,6 +3,9 @@ package com.swirlds.virtualmap.internal.pipeline;
 
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.virtualmap.internal.RecordAccessor;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * The root of a merkle tree containing virtual nodes (i.e. nodes that can be flushed to disk).
@@ -88,6 +91,17 @@ public interface VirtualRoot extends MerkleNode {
      * @return a reference to the detached state
      */
     RecordAccessor detach();
+
+    /**
+     * Takes a snapshot of this virtual root into the specified location. The snapshot can be loaded
+     * back to memory using {@link com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder#restore(String, Path)}
+     * method. It will contain the same data as this root, but some data may be moved from memory to
+     * disk or vice versa. After snapshot is taken, it does not consume any runtime resources, CPU or memory.
+     *
+     * @param destination the location where snapshot files will be located
+     * @throws IOException if an I/O error occurs
+     */
+    void snapshot(@NonNull final Path destination) throws IOException;
 
     /**
      * Gets whether this copy is detached.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -1386,17 +1386,22 @@ class VirtualMapTests extends VirtualTestBase {
     @Test
     @DisplayName("Snapshot Test")
     void snapshotTest() throws IOException {
-        final VirtualMap original = new VirtualMap("test", new InMemoryBuilder(), CONFIGURATION);
-        final VirtualMap copy = original.copy();
+        final List<Path> paths = new LinkedList<>();
+        paths.add(Path.of("asdf"));
+        for (final Path destination : paths) {
+            final VirtualMap original = new VirtualMap("test", new InMemoryBuilder(), CONFIGURATION);
+            final VirtualMap copy = original.copy();
 
-        original.getHash(); // forces copy to become hashed
-        final RecordAccessor snapshot = original.getPipeline().pausePipelineAndRun("snapshot", () -> {
-            return original.detach();
-        });
-        assertTrue(original.isDetached(), "root should be detached");
+            original.getHash(); // forces copy to become hashed
+            original.getPipeline().pausePipelineAndRun("snapshot", () -> {
+                original.snapshot(destination);
+                return null;
+            });
+            assertTrue(original.isDetached(), "root should be detached");
 
-        original.release();
-        copy.release();
+            original.release();
+            copy.release();
+        }
     }
 
     @Test

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorTest.java
@@ -269,7 +269,7 @@ public class RecordAccessorTest {
 
     private static final class BreakableDataSource implements VirtualDataSource {
 
-        private final InMemoryDataSource delegate = new InMemoryBuilder().build("delegate", null, true, false);
+        private final InMemoryDataSource delegate = new InMemoryBuilder().build("delegate", true);
         boolean throwExceptionOnLoadLeafRecordByKey = false;
         boolean throwExceptionOnLoadLeafRecordByPath = false;
         boolean throwExceptionOnLoadHashByPath = false;

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/DummyVirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/DummyVirtualRoot.java
@@ -10,7 +10,9 @@ import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
 import com.swirlds.virtualmap.internal.RecordAccessor;
 import com.swirlds.virtualmap.internal.merkle.VirtualMapStatistics;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
 import org.hiero.base.crypto.Hash;
@@ -385,6 +387,14 @@ class DummyVirtualRoot extends PartialMerkleLeaf implements VirtualRoot, MerkleL
     public RecordAccessor detach() {
         this.detached = true;
         return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void snapshot(@NonNull final Path destination) {
+        this.detached = true;
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/NoOpVirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/NoOpVirtualRoot.java
@@ -4,7 +4,9 @@ package com.swirlds.virtualmap.internal.pipeline;
 import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import com.swirlds.virtualmap.internal.RecordAccessor;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.hiero.base.constructable.ConstructableIgnored;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
@@ -79,6 +81,9 @@ public final class NoOpVirtualRoot extends PartialMerkleLeaf implements VirtualR
     public RecordAccessor detach() {
         return null;
     }
+
+    @Override
+    public void snapshot(@NonNull final Path destination) {}
 
     @Override
     public boolean isDetached() {

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
@@ -66,8 +66,7 @@ class ReconnectHashListenerTest {
     @ValueSource(ints = {1, 2, 10, 100, 1000, 10_000, 100_000, 1_000_000})
     @DisplayName("Flushed data is always done in the right order")
     void flushOrder(int size) {
-        final VirtualDataSourceSpy ds =
-                new VirtualDataSourceSpy(new InMemoryBuilder().build("flushOrder", null, true, false));
+        final VirtualDataSourceSpy ds = new VirtualDataSourceSpy(new InMemoryBuilder().build("flushOrder", true));
 
         final VirtualMapStatistics statistics = mock(VirtualMapStatistics.class);
         final ReconnectHashLeafFlusher flusher =

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
@@ -26,7 +26,6 @@ import com.swirlds.virtualmap.internal.merkle.VirtualRootNode;
 import com.swirlds.virtualmap.test.fixtures.TestKey;
 import com.swirlds.virtualmap.test.fixtures.TestValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -194,21 +193,28 @@ public abstract class VirtualMapReconnectTestBase {
             numTimesBroken = in.readInt();
         }
 
-        @NonNull
         @Override
-        public BreakableDataSource build(
-                final String label,
-                @Nullable final Path sourceDir,
-                final boolean compactionEnabled,
-                final boolean offlineUse) {
-            return new BreakableDataSource(this, delegate.build(label, sourceDir, compactionEnabled, offlineUse));
+        public BreakableDataSource build(final String label, final boolean withDbCompactionEnabled) {
+            return new BreakableDataSource(this, delegate.build(label, withDbCompactionEnabled));
         }
 
-        @NonNull
         @Override
-        public Path snapshot(@Nullable final Path destination, @NonNull final VirtualDataSource snapshotMe) {
+        public BreakableDataSource copy(
+                final VirtualDataSource snapshotMe, final boolean compactionEnabled, final boolean offlineUse) {
             final var breakableSnapshot = (BreakableDataSource) snapshotMe;
-            return delegate.snapshot(destination, breakableSnapshot.delegate);
+            return new BreakableDataSource(
+                    this, delegate.copy(breakableSnapshot.delegate, compactionEnabled, offlineUse));
+        }
+
+        @Override
+        public void snapshot(final Path destination, final VirtualDataSource snapshotMe) {
+            final var breakableSnapshot = (BreakableDataSource) snapshotMe;
+            delegate.snapshot(destination, breakableSnapshot.delegate);
+        }
+
+        @Override
+        public BreakableDataSource restore(final String label, final Path from) {
+            return new BreakableDataSource(this, delegate.restore(label, from));
         }
 
         public void setNumCallsBeforeThrow(int num) {

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/InMemoryBuilder.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/InMemoryBuilder.java
@@ -4,12 +4,10 @@ package com.swirlds.virtualmap.test.fixtures;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
 
@@ -20,8 +18,7 @@ public class InMemoryBuilder implements VirtualDataSourceBuilder {
 
     private final Map<String, InMemoryDataSource> databases = new ConcurrentHashMap<>();
 
-    private static final AtomicInteger dbIndex = new AtomicInteger(0);
-
+    // Path to data source, used in snapshot() and restore()
     private static final Map<String, InMemoryDataSource> snapshots = new ConcurrentHashMap<>();
 
     private static final long CLASS_ID = 0x29e653a8c81959b8L;
@@ -51,17 +48,8 @@ public class InMemoryBuilder implements VirtualDataSourceBuilder {
      */
     @NonNull
     @Override
-    public InMemoryDataSource build(
-            final String label,
-            @Nullable final Path sourceDir,
-            final boolean compactionEnabled,
-            final boolean offlineUse) {
-        if (sourceDir == null) {
-            return databases.computeIfAbsent(label, (s) -> createDataSource(label));
-        } else {
-            assert snapshots.containsKey(sourceDir.toString());
-            return snapshots.get(sourceDir.toString());
-        }
+    public InMemoryDataSource build(final String label, final boolean withDbCompactionEnabled) {
+        return databases.computeIfAbsent(label, (s) -> createDataSource(label));
     }
 
     /**
@@ -69,15 +57,31 @@ public class InMemoryBuilder implements VirtualDataSourceBuilder {
      */
     @NonNull
     @Override
-    public Path snapshot(@Nullable Path destinationDir, @NonNull final VirtualDataSource snapshotMe) {
-        if (destinationDir == null) {
-            // This doesn't have to be a real path, it's only used a key in the databases field
-            destinationDir = Path.of("inmemory_db_" + dbIndex.getAndIncrement());
-        }
+    public InMemoryDataSource copy(
+            final VirtualDataSource snapshotMe, final boolean compactionEnabled, final boolean offlineUse) {
         final InMemoryDataSource source = (InMemoryDataSource) snapshotMe;
         final InMemoryDataSource snapshot = new InMemoryDataSource(source);
-        snapshots.put(destinationDir.toString(), snapshot);
-        return destinationDir;
+        databases.put(createUniqueDataSourceName(source.getName()), snapshot);
+        return snapshot;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void snapshot(final Path to, final VirtualDataSource snapshotMe) {
+        final InMemoryDataSource source = (InMemoryDataSource) snapshotMe;
+        final InMemoryDataSource snapshot = new InMemoryDataSource(source);
+        snapshots.put(to.toString(), snapshot);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public VirtualDataSource restore(final String label, final Path from) {
+        return snapshots.get(from.toString());
     }
 
     @Override
@@ -95,5 +99,9 @@ public class InMemoryBuilder implements VirtualDataSourceBuilder {
 
     protected InMemoryDataSource createDataSource(final String name) {
         return new InMemoryDataSource(name);
+    }
+
+    private String createUniqueDataSourceName(final String name) {
+        return name + "-" + System.currentTimeMillis();
     }
 }


### PR DESCRIPTION
Fix summary:

* The fix for #19574 is reverted from the `release/0.67` branch. It was backported from `main` to `release/0.67` as https://github.com/hiero-ledger/hiero-consensus-node/issues/21374
* This fix is specific to 0.67, no changes are needed for `main`, no backport/forwardport PRs

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21549
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
