### PR TITLE
chore: Make sure we are in expected state during RPC sync interactions

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
@@ -221,6 +221,10 @@ public class RpcPeerHandler implements GossipRpcReceiver {
     @Override
     public void receiveTips(@NonNull final List<Boolean> remoteTipKnowledge) {
 
+        if (state.remoteSyncData == null) {
+            throw new IllegalStateException("Need sync data before receiving tips from " + peerId);
+        }
+
         // Add each tip they know to the known set
         final List<ShadowEvent> knownTips = getMyTipsTheyKnow(peerId, state.myTips, remoteTipKnowledge);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerState.java
@@ -79,6 +79,11 @@ class RpcPeerState {
      * @param syncMessage synchronization data peer has passed to us
      */
     public void syncInitiated(final SyncData syncMessage) {
+        if (remoteSyncData != null) {
+            throw new IllegalStateException(
+                    "Already received remoteSyncData " + remoteSyncData + " but got it again with " + syncMessage);
+        }
+
         // if they are sending us sync data, they are no longer behind compared to the self node
         peerIsBehind = false;
         peerStillSendingEvents = false;


### PR DESCRIPTION
**Description**:
Perform extra checks to make sure we are in expected state during RPC sync interactions. In particular, make sure that:
- we are not getting two sync data requests in the row
- we are not getting two tip data informations in the row
- we are not getting tip data information before sync data was received

**Related issue(s)**:

Fixes #20096

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
