### PR TITLE
chore: Enable XTS Block Node Regression Panel

### DIFF
--- a/.github/workflows/zxc-block-node-regression.yaml
+++ b/.github/workflows/zxc-block-node-regression.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "ZXC: Block Node Explorer Regression"
+name: "ZXC: Block Node Regression"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -357,7 +357,7 @@ jobs:
     with:
       ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }} # pass the xts-candidate tag to the JRS panel for checkout
       custom-job-name: "Block Node Regression"
-      solo-version: 'v0.46.1'
+      solo-version: "v0.46.1"
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}


### PR DESCRIPTION
**Description**:
Enable XTS Block Node Regression Panel

**Related issue(s)**:

Fixes #21645 

**Notes for reviewer**:
This enables a slim set of tests confirm getStatus, getBlock and then a slim set of TCK tests.
We plan to expand TCK test usage out over time.

Recent dry-run examples
- https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18542373665
- https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18514791659

Solo version is hard coded for now until we've confirmed default used 0.46.1 and above which has supporting logic for BN chart resources

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
