### PR TITLE
chore: limit SimulatedGossip event buffer

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/gossip/SimulatedGossip.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/gossip/SimulatedGossip.java
@@ -82,7 +82,7 @@ public class SimulatedGossip implements Gossip {
         this.deterministicWiringModel = (DeterministicWiringModel) requireNonNull(model);
         eventInput.bindConsumer(event -> network.submitEvent(selfId, event));
 
-        eventWindowInput.bindConsumer(ignored -> {});
+        eventWindowInput.bindConsumer(eventWindow -> eventBuffer.removeIf(eventWindow::isAncient));
         startInput.bindConsumer(ignored -> {});
         stopInput.bindConsumer(ignored -> {});
         clearInput.bindConsumer(ignored -> {});


### PR DESCRIPTION
**Description**:

This PR adds a limit to the event buffer in `SimulatedGossip`. By deleting all events that have become ancient, we can limit the size of the buffer.

**Related issue(s)**:

Fixes #21558
