### PR TITLE
fix: 21669 Fixed OOM in blockstream diff testing

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -25,7 +25,9 @@ import com.swirlds.state.spi.CommittableWritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 import org.hiero.base.constructable.ConstructableRegistryException;
 import org.hiero.consensus.model.node.NodeId;
 
@@ -67,17 +69,17 @@ public class BlockStreamRecoveryWorkflow {
         workflow.applyBlocks(blocks, selfId, PLATFORM_CONTEXT);
     }
 
-    public void applyBlocks(@NonNull final List<Block> blocks, NodeId selfId, PlatformContext platformContext) {
-        boolean foundStartingRound = false;
+    public void applyBlocks(@NonNull final Stream<Block> blocks, NodeId selfId, PlatformContext platformContext) {
+        AtomicBoolean foundStartingRound = new AtomicBoolean();
         final long initRound = DEFAULT_PLATFORM_STATE_FACADE.roundOf(state);
         final long firstRoundToApply = initRound + 1;
-        long currentRound = initRound;
-        outer:
-        for (final Block block : blocks) {
+        AtomicLong currentRound = new AtomicLong(initRound);
+
+        blocks.forEach(block -> {
             for (final BlockItem item : block.items()) {
                 // if the first block item belongs to the round after the first round to apply, we can't proceed
                 // as the block stream is incomplete
-                if (!foundStartingRound
+                if (!foundStartingRound.get()
                         && item.hasRoundHeader()
                         && item.roundHeader().roundNumber() > firstRoundToApply) {
                     throw new RuntimeException(
@@ -88,11 +90,11 @@ public class BlockStreamRecoveryWorkflow {
                                             item.roundHeader().roundNumber()));
                 }
 
-                foundStartingRound |=
-                        item.hasRoundHeader() && item.roundHeader().roundNumber() == firstRoundToApply;
+                foundStartingRound.set(foundStartingRound.get()
+                        || (item.hasRoundHeader() && item.roundHeader().roundNumber() == firstRoundToApply));
 
                 // skip forward to the starting round
-                if (!foundStartingRound) {
+                if (!foundStartingRound.get()) {
                     continue;
                 }
 
@@ -100,13 +102,13 @@ public class BlockStreamRecoveryWorkflow {
                 if (item.hasRoundHeader()) {
                     long itemRound = item.roundHeader().roundNumber();
                     if (itemRound > targetRound) {
-                        break outer;
+                        return;
                     } else {
-                        if (itemRound != currentRound + 1) {
+                        if (itemRound != currentRound.get() + 1) {
                             throw new RuntimeException("Unexpected round number. Expected = %d, actual = %d"
-                                    .formatted(currentRound + 1, itemRound));
+                                    .formatted(currentRound.get() + 1, itemRound));
                         }
-                        currentRound++;
+                        currentRound.incrementAndGet();
                     }
                 }
 
@@ -114,12 +116,12 @@ public class BlockStreamRecoveryWorkflow {
                     applyStateChanges(item.stateChangesOrThrow());
                 }
             }
-        }
+        });
 
-        if (targetRound != DEFAULT_TARGET_ROUND && currentRound != targetRound) {
+        if (targetRound != DEFAULT_TARGET_ROUND && currentRound.get() != targetRound) {
             throw new RuntimeException(
                     "Block stream is incomplete. Expected target round is %d, last applied round is %d"
-                            .formatted(targetRound, currentRound));
+                            .formatted(targetRound, currentRound.get()));
         }
 
         // To make sure that VirtualMapMetadata is persisted after all changes from the block stream were applied

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamUtils.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamUtils.java
@@ -22,6 +22,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -135,10 +136,10 @@ public class BlockStreamUtils {
      * ascending order of block number.
      *
      * @param path the path to read blocks from
-     * @return the list of blocks
+     * @return the stream of blocks
      * @throws UncheckedIOException if an I/O error occurs
      */
-    public static List<Block> readBlocks(@NonNull final Path path) {
+    public static Stream<Block> readBlocks(@NonNull final Path path) {
         return readBlocks(path, true);
     }
     /**
@@ -146,14 +147,12 @@ public class BlockStreamUtils {
      * ascending order of block number.
      *
      * @param path the path to read blocks from
-     * @return the list of blocks
+     * @return the stream of blocks
      * @throws UncheckedIOException if an I/O error occurs
      */
-    public static List<Block> readBlocks(@NonNull final Path path, boolean checkForMarkerFiles) {
+    public static Stream<Block> readBlocks(@NonNull final Path path, boolean checkForMarkerFiles) {
         try {
-            return orderedBlocksFrom(path, checkForMarkerFiles).stream()
-                    .map(BlockStreamUtils::blockFrom)
-                    .toList();
+            return orderedBlocksFrom(path, checkForMarkerFiles).stream().map(BlockStreamUtils::blockFrom);
         } catch (IOException e) {
             log.error("Failed to read blocks from path {}", path, e);
             throw new UncheckedIOException(e);


### PR DESCRIPTION
**Description**:

This PR fixes `OutOfMemoryError` that may be happenning during the validation testing. Instead of loading all the blocks into memory it utilizes a stream instead. According to [this run](https://github.com/hashgraph/hedera-state-validator/actions/runs/18567087736/job/52933432603) the fix helped.

**Related issue(s)**:

Fixes #21669 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
