### PR TITLE
fix: 21677: (0.67) Virtual pipeline should ignore detached copies

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -298,8 +298,6 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
      */
     private final AtomicBoolean merged = new AtomicBoolean(false);
 
-    private final AtomicBoolean detached = new AtomicBoolean(false);
-
     /**
      * Created at the beginning of reconnect as a <strong>learner</strong>, this iterator allows
      * for other threads to feed its leaf records to be used during hashing.
@@ -797,8 +795,8 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
     @Override
     public void merge() {
         final long start = System.currentTimeMillis();
-        if (!(isDestroyed() || isDetached())) {
-            throw new IllegalStateException("merge is legal only after this node is destroyed or detached");
+        if (!isDestroyed()) {
+            throw new IllegalStateException("merge is legal only after this node is destroyed");
         }
         if (!isImmutable()) {
             throw new IllegalStateException("merge is only allowed on immutable copies");
@@ -1153,17 +1151,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             throw new IllegalStateException("Can't make data source copy: virtual map copy isn't hashed");
         }
 
-        detached.set(true);
-
         return dataSourceBuilder.snapshot(null, dataSource);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean isDetached() {
-        return detached.get();
     }
 
     /*

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -391,7 +391,7 @@ public class VirtualPipeline {
      */
     private boolean shouldBeFlushed(final VirtualRoot copy) {
         return copy.shouldBeFlushed() // either explicitly marked to flush or based on its size
-                && (copy.isDestroyed() || copy.isDetached()); // destroyed or detached
+                && copy.isDestroyed();
     }
 
     /**
@@ -435,7 +435,7 @@ public class VirtualPipeline {
         final PipelineListNode<VirtualRoot> mergeTarget = mergeCandidate.getNext();
 
         return !copy.shouldBeFlushed() // shouldn't be flushed
-                && (copy.isDestroyed() || copy.isDetached()) // copy must be destroyed or detached
+                && copy.isDestroyed() // copy must be destroyed
                 && mergeTarget != null // target must exist
                 && mergeTarget.getValue().isImmutable(); // target must be immutable
     }
@@ -618,7 +618,6 @@ public class VirtualPipeline {
             sb.append(", flushed = ").append(uppercaseBoolean(copy.isMerged()));
             sb.append(", destroyed = ").append(uppercaseBoolean(copy.isDestroyed()));
             sb.append(", hashed = ").append(uppercaseBoolean(copy.isHashed()));
-            sb.append(", detached = ").append(uppercaseBoolean(copy.isDetached()));
             sb.append("\n");
 
             index++;

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualRoot.java
@@ -90,13 +90,6 @@ public interface VirtualRoot extends MerkleNode {
     RecordAccessor detach();
 
     /**
-     * Gets whether this copy is detached.
-     *
-     * @return Whether this copy is detached.
-     */
-    boolean isDetached();
-
-    /**
      * Check if this virtual root is registered to a given pipeline. Used for sanity checks.
      *
      * @param pipeline

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -1393,7 +1393,6 @@ class VirtualMapTests extends VirtualTestBase {
         final RecordAccessor snapshot = original.getPipeline().pausePipelineAndRun("snapshot", () -> {
             return original.detach();
         });
-        assertTrue(original.isDetached(), "root should be detached");
 
         original.release();
         copy.release();
@@ -1457,7 +1456,6 @@ class VirtualMapTests extends VirtualTestBase {
         original.getHash(); // forces copy to become hashed
 
         final RecordAccessor detachedCopy = original.getPipeline().pausePipelineAndRun("copy", original::detach);
-        assertTrue(original.isDetached(), "root should be detached");
         assertNotNull(detachedCopy);
 
         VirtualMapMetadata originalMetadata = original.getMetadata();

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/NoOpVirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/NoOpVirtualRoot.java
@@ -81,11 +81,6 @@ public final class NoOpVirtualRoot extends PartialMerkleLeaf implements VirtualR
     }
 
     @Override
-    public boolean isDetached() {
-        return false;
-    }
-
-    @Override
     public boolean isRegisteredToPipeline(final VirtualPipeline pipeline) {
         return true;
     }


### PR DESCRIPTION
Fix summary: direct backport of https://github.com/hiero-ledger/hiero-consensus-node/pull/21465 to the `release/0.67` branch.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21677
Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21549
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
