### PR TITLE
chore(ci): update TCK regression workflow to use solo action

### DIFF
--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -176,9 +176,9 @@ jobs:
         run: |
           version=$(solo --version | grep Version | awk '{print $3}')
           if [[ "$(printf '%s\n' "$version" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]]; then
-            solo ledger account create --dev --ed25519-private-key "${{ steps.solo-action.outputs.ed25519PrivateKey }}" --deployment ${{ steps.solo-action.outputs.deployment }} --hbar-amount 1000000
+            solo ledger account create --dev --ed25519-private-key "${{ env.OPERATOR_ACCOUNT_PRIVATE_KEY }}" --deployment ${{ steps.solo-action.outputs.deployment }} --hbar-amount 1000000
           else
-            solo account create --dev --ed25519-private-key "${{ steps.solo-action.outputs.ed25519PrivateKey }}" --deployment ${{ steps.solo-action.outputs.deployment }} --hbar-amount 1000000
+            solo account create --dev --ed25519-private-key "${{ env.OPERATOR_ACCOUNT_PRIVATE_KEY }}" --deployment ${{ steps.solo-action.outputs.deployment }} --hbar-amount 1000000
           fi
           cp .env.custom_node .env
           npm run test


### PR DESCRIPTION
**Description**:

Update the TCK Regression workflow to use the solo action instead of direct solo calls.

**Testing**:
`solo` input version `v0.46.1` [here](https://github.com/hiero-ledger/hiero-consensus-node/pull/21686). ✅ 

**Related Issue(s)**:

Implements #21685
