### PR TITLE
fix: 21691: Temporary snapshots are not removed from data/saved/swirlds-tmp/

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -1556,13 +1556,17 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             // backpressure mechanism
             VirtualDataSource dataSourceCopy = null;
             try {
+                // Restore a data source into memory from the snapshot. It will use its own directory
+                // to store data files
                 dataSourceCopy = dataSourceBuilder.build(getLabel(), snapshotPath, false, true);
                 // Then flush the cache snapshot to the data source copy
                 flush(cacheSnapshot.getValue(), metadata, dataSourceCopy);
                 // And finally snapshot the copy to the target dir
                 dataSourceBuilder.snapshot(outputDirectory, dataSourceCopy);
             } finally {
+                // Delete the snapshot directory
                 FileUtils.deleteDirectory(snapshotPath);
+                // And delete the data source copy directory
                 if (dataSourceCopy != null) {
                     dataSourceCopy.close();
                 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSourceBuilder.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSourceBuilder.java
@@ -21,8 +21,8 @@ public interface VirtualDataSourceBuilder extends SelfSerializable {
      * Builds a new {@link VirtualDataSource} using the configuration of this builder and
      * the given label. If a source directory is provided, data source files are loaded from
      * it. This must be a directory previously used in the {@link #snapshot(Path, VirtualDataSource)}
-     * method. If the directory is not provided, a new temp directory is created, and an empty
-     * data source is opened in it.
+     * method. If the directory is not provided, an empty data source is created. Regardless of
+     * the source directory, the new data source will use its own directory to store data files.
      *
      * @param label
      * 		The label. Cannot be null. Labels can be used in logs and stats, and also to build


### PR DESCRIPTION
Fix summary: temporary MerkleDb directory is removed after snapshot is taken.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21691
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
