### PR TITLE
chore: Fix typo in word 'parameters' on block-node-regression-panel check

### DIFF
--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -96,10 +96,6 @@ jobs:
           echo "helm-release-name=${HELM_NAME}" >> "${GITHUB_OUTPUT}"
           echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
 
-          if [[ "${{ inputs.enable-block-node-regression-panel }}" == "true" ]] && [[ "${SOLO_GE_0440}" == "true" ]]; then
-            echo "Block Node Regression Panel will be enabled."
-          fi
-
   xts-timing-sensitive-tests:
     name: XTS Timing Sensitive Tests
     if: ${{ inputs.enable-extended-test-suite == true }}
@@ -266,7 +262,7 @@ jobs:
     name: Block Node Regression Panel
     needs:
       - parameters
-    if: ${{ inputs.enable-block-node-regression-panel == true && needs.paramseters.outputs.solo-ge-0440 == 'true' }}
+    if: ${{ inputs.enable-block-node-regression-panel == true && needs.parameters.outputs.solo-ge-0440 == 'true' }}
     uses: ./.github/workflows/zxc-block-node-regression.yaml
     with:
       ref: ${{ inputs.commit_sha }} # pass the xts-candidate tag to the BN panel for checkout


### PR DESCRIPTION
## Description

This pull request fixes a typo in the conditional statement for the "Block Node Regression Panel" job in the `.github/workflows/zxf-dry-run-extended-test-suite.yaml` workflow file.

* Corrected the spelling of `needs.paramseters` to `needs.parameters` in the `if` condition, ensuring the job executes as intended.

## Testing

- [x] [Block node regression panel is running](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18601828489) ✅ 

## Related Issue(s)

Resolves #21705 