### PR TITLE
ci: Update solo version for SDK TCK and enable block node regression

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -36,6 +36,31 @@ env:
   BUILD_GREP_PATTERN: "build-*"
 
 jobs:
+  parameters:
+    name: Determine Configurable Parameters
+    runs-on: hiero-citr-linux-medium
+    outputs:
+      solo-ge-0440: ${{ steps.set-parameters.outputs.solo-ge-0440 }}
+      helm-release-name: ${{ steps.set-parameters.outputs.helm-release-name }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Set Parameters
+        id: set-parameters
+        run: |
+          SOLO_GE_0440=$([[ "$(printf '%s\n' "${{vars.CITR_SOLO_VERSION}}" "v0.44.0" | sort -V | head -n1)" == "v0.44.0" ]] && echo "true" || echo "false")
+          HELM_NAME="mirror"
+          if [[ "${SOLO_GE_0440}" == "true" ]]; then
+            HELM_NAME="mirror-1"
+          fi
+
+          echo "::debug::SOLO_GE_0440=${SOLO_GE_0440}"
+          echo "helm-release-name=${HELM_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
+
   fetch-xts-candidate:
     name: Fetch XTS Candidate Tag
     runs-on: hiero-citr-linux-medium
@@ -325,14 +350,16 @@ jobs:
 
   mirror-node-regression-panel:
     name: Mirror Node Regression Panel
-    needs: fetch-xts-candidate
+    needs:
+      - fetch-xts-candidate
+      - parameters
     if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
     uses: ./.github/workflows/zxc-mirror-node-regression.yaml
     with:
       ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }} # pass the xts-candidate tag to the JRS panel for checkout
       custom-job-name: "Mirror Node Regression"
       solo-version: ${{ vars.CITR_SOLO_VERSION }}
-      helm-release-name: "mirror" # TODO: Update this to 'mirror-1' when ${vars.CITR_SOLO_VERSION} is >= 0.44.0
+      helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
@@ -350,18 +377,20 @@ jobs:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
-  #  block-node-regression-panel:
-  #    name: Block Node Regression Panel
-  #    needs: fetch-xts-candidate
-  #    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
-  #    uses: ./.github/workflows/zxc-block-node-regression.yaml
-  #    with:
-  #      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }} # pass the xts-candidate tag to the JRS panel for checkout
-  #      custom-job-name: "Block Node Regression"
-  #      solo-version: 'v0.46.1'
-  #    secrets:
-  #      access-token: ${{ secrets.GH_ACCESS_TOKEN }}
-  #      slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+  block-node-regression-panel:
+    name: Block Node Regression Panel
+    needs:
+      - fetch-xts-candidate
+      - parameters
+    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' && needs.parameters.outputs.solo-ge-0440 == 'true' }}
+    uses: ./.github/workflows/zxc-block-node-regression.yaml
+    with:
+      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }} # pass the xts-candidate tag to the JRS panel for checkout
+      custom-job-name: "Block Node Regression"
+      solo-version: ${{ vars.CITR_SOLO_VERSION }}
+    secrets:
+      access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
   tag-for-promotion:
     name: Tag as XTS-Passing


### PR DESCRIPTION
## Description

This pull request introduces a new parameterization step to the `zxcron-extended-test-suite` workflow, enabling dynamic configuration of downstream jobs based on the value of `CITR_SOLO_VERSION`. The main improvements are the extraction of configurable parameters into a dedicated job, conditional logic for job execution, and the re-enabling of the Block Node Regression Panel with appropriate gating.

Key changes:

**Parameterization and Dynamic Configuration:**

* Added a new `parameters` job to determine and expose `solo-ge-0440` and `helm-release-name` as workflow outputs, based on the value of `CITR_SOLO_VERSION`. This centralizes logic for downstream jobs and makes the workflow more maintainable.

**Job Dependency and Conditional Execution:**

* Updated the `mirror-node-regression-panel` job to depend on the new `parameters` job and to use the dynamically set `helm-release-name` output, ensuring correct configuration is always used.
* Re-enabled the `block-node-regression-panel` job, now gated to only run when `CITR_SOLO_VERSION` is greater than or equal to `v0.44.0` by checking the `solo-ge-0440` output from the `parameters` job. This prevents unnecessary runs for unsupported versions and improves workflow efficiency.

## Related issue(s)

Fixes #21715 
Fixes #21645 