### PR TITLE
ci: Update schedules for XTS

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -15,7 +15,7 @@ on:
         type: boolean
   schedule:
     # Runs Extended Test Suite every three hours Monday to Friday
-    - cron: "0 */3 * * 1-5"
+    - cron: "0 */3 * * *"
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Description

This pull request makes a minor update to the GitHub Actions workflow schedule. The Extended Test Suite is now set to run every three hours, seven days a week, instead of only Monday to Friday.

* Updated the `cron` schedule in `.github/workflows/zxcron-extended-test-suite.yaml` to run every three hours daily, rather than just on weekdays.

## Related Issue(s)

Closes #21726