### PR TITLE
ci: Update how we determine branch candidacy

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -102,7 +102,9 @@ jobs:
           DEFAULT_BRANCH_NAME: "main"
         run: |
           # Check if the tag exists and if so grab its commit id
+          echo "::group::Check for XTS Candidate Tag"
           if [[ -n "${RC_TAG}" ]]; then
+            echo "::group::Use RC Tag"
             echo "::debug::Using RC Tag: ${RC_TAG}"
             XTS_COMMIT=$(git rev-list -n 1 "${RC_TAG}") >/dev/null 2>&1
             XTS_COMMIT_FOUND="${?}"
@@ -115,7 +117,9 @@ jobs:
             fi
 
             COMMIT_LIST="$(git log -n 1 --pretty=format:"- [%h: %s](https://github.com/${{ github.repository }}/commit/%H)" "${XTS_COMMIT}")"
+            echo "::endgroup::" # Use RC Tag
           else
+            echo "::group::Use XTS Candidate Tag"
             set +e
             XTS_COMMIT="$(git rev-list -n 1 "${XTS_CANDIDATE_TAG}")" >/dev/null 2>&1
             XTS_COMMIT_FOUND="${?}"
@@ -154,18 +158,19 @@ jobs:
               LATEST_PROMOTED_BUILD_COMMIT="$(git rev-list -n 1 "${LATEST_PROMOTED_BUILD_TAG}")"
               COMMIT_LIST="$(git log --pretty=format:"- [%h: %s](https://github.com/${{ github.repository }}/commit/%H)" "${LATEST_PROMOTED_BUILD_COMMIT}..${XTS_COMMIT}")"
             fi
+            echo "::endgroup::" # Use XTS Candidate Tag
           fi
+          echo "::endgroup::" # Check for XTS Candidate Tag
 
-          # Get the short commit id
-          XTS_SHORT_COMMIT="$(git rev-parse --short "${XTS_COMMIT}")"
-          echo "::debug::XTS_SHORT_COMMIT=${XTS_SHORT_COMMIT}"
-
+          echo "::group::Check if XTS COMMIT is on default branch"
           # Determine which branch the commit belongs to
           XTS_COMMIT_BRANCHES="$(git branch -r --contains "${XTS_COMMIT}" | sed 's/^[ *]*//')"
           echo "::debug::XTS_COMMIT_BRANCHES=${XTS_COMMIT_BRANCHES}"
 
           XTS_COMMIT_BRANCH="${DEFAULT_BRANCH_NAME}"
           COMMIT_ON_DEFAULT_BRANCH=0
+
+          # Check if the commit on the default branch
           if echo "${XTS_COMMIT_BRANCHES}" | grep -qE "(^|/)${DEFAULT_BRANCH_NAME}$"; then
             echo "::debug::Commit ${XTS_COMMIT} found on main branch."
           else
@@ -181,11 +186,19 @@ jobs:
           # Print branch debug info
           echo "::debug::XTS_COMMIT_BRANCH=${XTS_COMMIT_BRANCH}"
           echo "::debug::COMMIT_ON_DEFAULT_BRANCH=${COMMIT_ON_DEFAULT_BRANCH}"
+          echo "::endgroup::" # XTS COMMIT is on default branch
+
+          echo "::group::Get XTS Commit Information"
+          # Get the short commit id
+          XTS_SHORT_COMMIT="$(git rev-parse --short "${XTS_COMMIT}")"
+          echo "::debug::XTS_SHORT_COMMIT=${XTS_SHORT_COMMIT}"
 
           # Get commit author
           AUTHOR_NAME="$(git log -1 --format='%an' "${XTS_COMMIT}")"
           AUTHOR_EMAIL="$(git log -1 --format='%ae' "${XTS_COMMIT}")"
+          echo "::endgroup::" # Get XTS Commit Information
 
+          echo "::group::Set Outputs"
           # If the tag exists on the Main Branch set the output variables as appropriate
           # Otherwise cancel out
           if [[ "${COMMIT_ON_DEFAULT_BRANCH}" -eq 0 ]]; then
@@ -220,6 +233,7 @@ jobs:
             echo "::debug::Commit ${XTS_COMMIT} not found on main branch. Cancelling out."
             gh run cancel "${{ github.run_id }}"
           fi
+          echo "::endgroup::" # Set Outputs
 
   xts-timing-sensitive-tests:
     name: XTS Timing Sensitive Tests


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/zxcron-extended-test-suite.yaml` workflow to improve how the branch associated with a commit is determined, making the process more robust and configurable. The changes introduce a `DEFAULT_BRANCH_NAME` variable and enhance the logic for identifying whether a commit is on the default branch or another branch.

Branch detection improvements:

* Added a `DEFAULT_BRANCH_NAME` environment variable (set to `"main"`) to allow easier configuration of the default branch used in the workflow.
* Updated the logic for determining which branch a commit belongs to: now collects all remote branches containing the commit and checks if it is present on the default branch. If not, it falls back to identifying the specific branch name using `git name-rev`. This makes the workflow more accurate and flexible, especially for repositories with multiple branches or custom default branch names.

## Testing

- [ ] [XTS Check](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18655385953)

## Related Issue(s)

Resolves #21726
