### PR TITLE
fix(bug): (cherry-pick) Fix typo in GitHub release step (#21563)

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -863,7 +863,7 @@ jobs:
           echo "create-release=${CREATE_RELEASE}" >> "${GITHUB_OUTPUT}"
 
       - name: Create github release
-        if: ${{ steps.set-gh-release-flag.outputs.create-release == 'true' }}
+        if: ${{ steps.set-gh-release-flags.outputs.create-release == 'true' }}
         uses: step-security/release-action@03a57407052f15d1537fd5469a6fbbc536aba326 # v1.20.0
         with:
           tag: ${{ inputs.ref-name }}


### PR DESCRIPTION
**Description**:

Fix a typo in the GitHub release step. This is the cherry pick back to `release/0.67` branch.

**Related issue(s)**: 

Fixes #21562 
