### PR TITLE
chore: 21761: VirtualNodeCache: no need to purge filtered mutations

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -1251,6 +1251,11 @@ public final class VirtualNodeCache implements FastCopyable, SelfSerializable {
             final Map<K, Mutation<K, V>> index,
             @NonNull final VirtualMapConfig virtualMapConfig) {
         array.parallelTraverse(getCleaningPool(virtualMapConfig), element -> {
+            // If a cache copy is released after flush, some mutations may be already marked as
+            // filtered in dirtyLeavesForFlush() and dirtyHashesForFlush(). When a mutation is
+            // filtered, it means there is a newer mutation for the same key in the same cache
+            // copy. When this newer mutation is purged, it also takes care of the filtered
+            // mutation, so there is no need to handle filtered mutations explicitly
             if (element.notFiltered()) {
                 index.compute(element.key, (key, mutation) -> {
                     if ((mutation == null) || element.equals(mutation)) {


### PR DESCRIPTION
Fix summary:

* `VirtualNodeCache.purge()`: a check is added to avoid processing filtered mutations.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21761
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
