### PR TITLE
fix: Properly cleanup event send status on rpc disconnect

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
@@ -196,7 +196,9 @@ public class RpcPeerHandler implements GossipRpcReceiver {
     // protocol thread (which is equivalent to read-thread)
     public void cleanup() {
         clearInternalState();
+        state.peerStillSendingEvents = false;
         sharedShadowgraphSynchronizer.deregisterPeerHandler(this);
+        this.syncMetrics.reportSyncPhase(peerId, SyncPhase.OUTSIDE_OF_RPC);
     }
 
     // HANDLE INCOMING MESSAGES - all done on dispatch thread
@@ -384,6 +386,10 @@ public class RpcPeerHandler implements GossipRpcReceiver {
         syncMetrics.syncFinished();
     }
 
+    /**
+     * Marks state as finished for our side of the synchronization. It does NOT clear peerStillSendingEvents, this needs
+     * to be cleared explicitly either on disconnect or when remote side tells us to
+     */
     private void clearInternalState() {
         if (state.mySyncData != null) {
             syncGuard.onSyncCompleted(peerId);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerState.java
@@ -57,7 +57,7 @@ class RpcPeerState {
 
     /**
      * Clear internal state in preparation for a new sync in the future. In particular, this method closes
-     * {@link #shadowWindow} if one was allocated previously.
+     * {@link #shadowWindow} if one was allocated previously. It does NOT clear peerStillSendingEvents.
      *
      * @param lastSyncTime time when synchronization has finished, in most cases same as time when this method is
      *                     called


### PR DESCRIPTION
**Description**:
When disconnection happens at exactly wrong moment, when we are finished sending events, but remote peer is still sending events, one of the internal states is not cleared. When we reconnect, we still think that remote side is sending events, so we won't initiate next sync.

**Related issue(s):**
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/21753

**Notes for reviewer**:
Without the fix, if things go wrong (disconnect at wrong time), given pair of nodes won't be able to communicate without one of them restarting (and it will have to be the correct one, not one which dropped the connection previously). This is not very common even on disconnection (thus not found earlier), but can happen.

It is a backport of PR https://github.com/hiero-ledger/hiero-consensus-node/pull/21779


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
