### PR TITLE
ci: Ensure zxf-prepare-extended-test-suite does not alert erroneously

### DIFF
--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -113,7 +113,7 @@ jobs:
             echo "Commit not yet tagged in XTS flow. Proceeding to tag for XTS." >> "${GITHUB_STEP_SUMMARY}"
             echo "xts-checks-required=true" >> "${GITHUB_OUTPUT}"
           fi
-          
+
           # Log dry-run status
           if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
             echo "Dry run enabled. The workflow will not create a tag." >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
## Description

This pull request enhances the `.github/workflows/zxf-prepare-extended-test-suite.yaml` workflow by adding a validation step to ensure that the provided commit reference exists on the `main` branch before proceeding with tagging and promotion. It also introduces a dedicated job for reporting failures if validation or tagging fails. These changes improve the workflow's reliability and error reporting.

**Validation and gating improvements:**
* Added a new `validate-input-ref` job that checks if the input commit reference is present on the `main` branch before allowing further steps. The job outputs a flag used to gate the promotion/tagging step.
* Updated the `tag-for-xts` job to depend on `validate-input-ref` and only run if the commit is present on `main`, preventing accidental promotion of non-main commits.

**Failure reporting enhancements:**
* Introduced a new `report-failures` job that triggers if either the validation or tagging jobs fail, ensuring failures are always reported.
* Centralized failure reporting to Rootly and Slack in the new job, removing redundant conditional logic from individual steps.

## Related Issue(s)

Closes #21795 

## Testing

- [x] [Testing against v0.67.1](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18724732596)