### PR TITLE
chore: Cleanup of container environment

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNetwork.java
@@ -168,5 +168,6 @@ public class ContainerNetwork extends AbstractNetwork {
         if (toxiproxyContainer != null) {
             toxiproxyContainer.stop();
         }
+        network.close();
     }
 }


### PR DESCRIPTION
**Description**:

This PR resolves the issue of running out of resources when running too many container tests consecutively. Turned out, we did not close the testcontainer network.

**Related issue(s)**:

Fixes #21800 