### PR TITLE
fix: 21654: CompactionInterruptTest.startMergeWhileSnapshottingThenInterrupt() test is not stable

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -429,7 +429,25 @@ public class DataFileCompactor {
      * @return true if compaction is currently running, false otherwise.
      */
     public boolean isCompactionRunning() {
-        return currentCompactionStartTime.get() != null;
+        snapshotCompactionLock.lock();
+        try {
+            return currentCompactionStartTime.get() != null;
+        } finally {
+            snapshotCompactionLock.unlock();
+        }
+    }
+
+    /**
+     * @return true if compaction was started and now is complete (successfully or
+     * exceptionally), false otherwise.
+     */
+    public boolean isCompactionComplete() {
+        snapshotCompactionLock.lock();
+        try {
+            return (currentCompactionStartTime.get() == null) && !newCompactedFiles.isEmpty();
+        } finally {
+            snapshotCompactionLock.unlock();
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/CompactionInterruptTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/CompactionInterruptTest.java
@@ -162,24 +162,32 @@ class CompactionInterruptTest {
         }
 
         assertEventuallyTrue(
-                hashStoreCompactor::isCompactionRunning, Duration.ofMillis(10), "hashStoreCompactor should be running");
-        assertEventuallyTrue(
-                pathToKeyValueCompactor::isCompactionRunning,
+                () -> hashStoreCompactor.isCompactionRunning() || hashStoreCompactor.isCompactionComplete(),
                 Duration.ofMillis(10),
-                "pathToKeyValueCompactor should be running");
+                "hashStoreCompactor should be complete or running");
         assertEventuallyTrue(
-                objectKeyToPathCompactor::isCompactionRunning,
+                () -> pathToKeyValueCompactor.isCompactionRunning() || pathToKeyValueCompactor.isCompactionComplete(),
                 Duration.ofMillis(10),
-                "objectKeyToPathCompactor should be running");
+                "pathToKeyValueCompactor should be complete or running");
+        assertEventuallyTrue(
+                () -> objectKeyToPathCompactor.isCompactionRunning() || objectKeyToPathCompactor.isCompactionComplete(),
+                Duration.ofMillis(10),
+                "objectKeyToPathCompactor should be complete or running");
 
         // stopping the compaction
         compactor.stopAndDisableBackgroundCompaction();
 
         assertFalse(compactor.isCompactionEnabled(), "compactionEnabled should be false");
 
-        assertFalse(hashStoreCompactor.notInterrupted(), "hashStoreCompactor should be interrupted");
-        assertFalse(pathToKeyValueCompactor.notInterrupted(), "pathToKeyValueCompactor should be interrupted");
-        assertFalse(objectKeyToPathCompactor.notInterrupted(), "objectKeyToPathCompactor should be interrupted");
+        assertTrue(
+                hashStoreCompactor.isCompactionComplete() || !hashStoreCompactor.notInterrupted(),
+                "hashStoreCompactor should be complete or interrupted");
+        assertTrue(
+                pathToKeyValueCompactor.isCompactionComplete() || !pathToKeyValueCompactor.notInterrupted(),
+                "pathToKeyValueCompactor should be complete or interrupted");
+        assertTrue(
+                objectKeyToPathCompactor.isCompactionComplete() || !objectKeyToPathCompactor.notInterrupted(),
+                "objectKeyToPathCompactor should be interrupted");
         synchronized (compactor) {
             assertTrue(compactor.compactorsByName.isEmpty(), "compactorsByName should be empty");
         }


### PR DESCRIPTION
Fix summary:

* Current test code is to start a compaction task and then check that it's running after a delay. The problem is the task may be complete before the check. This triggers a test failure. The fix is to replace the existing assertion with another one that checks that the task is either running or already complete

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21654
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
