### PR TITLE
ci(bug): fix broken workflow files by removing erroneous secret passing

### DIFF
--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -132,7 +132,6 @@ jobs:
       delete-namespace: ${{ inputs.delete-namespace }}
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
-      rootly-api-token: ${{ secrets.ROOTLY_API_TOKEN }}
 
   tag-sdlt-result:
     name: Tag SDLT Result

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -139,7 +139,6 @@ jobs:
       delete-namespace: ${{ inputs.delete-namespace }}
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
-      rootly-api-token: ${{ secrets.ROOTLY_API_TOKEN }}
 
   tag-sdpt-result:
     name: Tag SDPT Result


### PR DESCRIPTION
## Description

This pull request makes a small update to two GitHub Actions workflow files. The change removes the `rootly-api-token` secret from the list of secrets passed to certain jobs, likely as part of a cleanup or because it is no longer needed.

- Removed the `rootly-api-token` secret from the `jobs` section in `.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml`
- Removed the `rootly-api-token` secret from the `jobs` section in `.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml`

