### PR TITLE
ci: Split XTS Dry Run and SDPT SDLT adhoc solo versions

### DIFF
--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Print Params
         id: params
         run: |
-          SOLO_GE_0440=$([[ "$(printf '%s\n' "${{vars.ADHOC_SOLO_VERSION}}" "v0.44.0" | sort -V | head -n1)" == "v0.44.0" ]] && echo "true" || echo "false")
+          SOLO_GE_0440=$([[ "$(printf '%s\n' "${{vars.ADHOC_XTS_SOLO_VERSION}}" "v0.44.0" | sort -V | head -n1)" == "v0.44.0" ]] && echo "true" || echo "false")
           HELM_NAME="mirror"
           if [[ "${SOLO_GE_0440}" == "true" ]]; then
             HELM_NAME="mirror-1"
@@ -89,10 +89,10 @@ jobs:
           echo "Enable JSON-RPC Relay Regression Panel: ${{ inputs.enable-rpc-relay-regression-panel }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Enable Block Node Regression Panel: ${{ inputs.enable-block-node-regression-panel }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Additional Parameters: ${{ inputs.additional-parameters }}" | tee -a "${GITHUB_STEP_SUMMARY}"
-          echo "Solo Version: ${{ vars.ADHOC_SOLO_VERSION }}" | tee -a "${GITHUB_STEP_SUMMARY}"
+          echo "Solo Version: ${{ vars.ADHOC_XTS_SOLO_VERSION }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Helm Release Name: ${HELM_NAME}" | tee -a "${GITHUB_STEP_SUMMARY}"
 
-          echo "solo-version=${{ vars.ADHOC_SOLO_VERSION }}" >> "${GITHUB_OUTPUT}"
+          echo "solo-version=${{ vars.ADHOC_XTS_SOLO_VERSION }}" >> "${GITHUB_OUTPUT}"
           echo "helm-release-name=${HELM_NAME}" >> "${GITHUB_OUTPUT}"
           echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## Description

This pull request updates the workflow configuration to consistently use the `ADHOC_XTS_SOLO_VERSION` variable instead of `ADHOC_SOLO_VERSION` in the extended test suite workflow. This ensures that the correct version variable is referenced throughout the workflow steps.

Key changes to workflow variable usage:

* Updated all references in the workflow from `vars.ADHOC_SOLO_VERSION` to `vars.ADHOC_XTS_SOLO_VERSION` for determining the Solo version and related outputs in `.github/workflows/zxf-dry-run-extended-test-suite.yaml` [[1]](diffhunk://#diff-b58cd895cfd227abeaa0e2ef58894fd6cd09317a50827362dce2f3f6bd29568cL77-R77) [[2]](diffhunk://#diff-b58cd895cfd227abeaa0e2ef58894fd6cd09317a50827362dce2f3f6bd29568cL92-R95).

## Related Issue(s)

Closes #21822 

## Testing

- [x] [Dry Run XTS](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18750771205)