### PR TITLE
test: Bugfix for port already in use

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNode.java
@@ -473,12 +473,13 @@ public class ContainerNode extends AbstractNode implements Node, TimeTickReceive
             throw new UncheckedIOException("Failed to copy files from container", e);
         }
 
-        if (lifeCycle == RUNNING) {
-            log.info("Destroying container of node {}...", selfId);
-            containerControlChannel.shutdownNow();
-            nodeCommChannel.shutdownNow();
+        log.info("Destroying container of node {}...", selfId);
+        containerControlChannel.shutdownNow();
+        nodeCommChannel.shutdownNow();
+        if (container.isRunning()) {
             container.stop();
         }
+
         resultsCollector.destroy();
         platformStatus = null;
         lifeCycle = DESTROYED;


### PR DESCRIPTION
**Description**:

This PR fixes a bug where we sometimes see a port already being in use when running multiple tests in the container environment.

**Related issue(s)**:

Fixes #21829
