### PR TITLE
chore: Configurable services

### DIFF
--- a/platform-sdk/consensus-otter-docker-app/src/testFixtures/java/org/hiero/consensus/otter/docker/app/platform/ConsensusNodeManager.java
+++ b/platform-sdk/consensus-otter-docker-app/src/testFixtures/java/org/hiero/consensus/otter/docker/app/platform/ConsensusNodeManager.java
@@ -125,7 +125,7 @@ public class ConsensusNodeManager {
         final PlatformContext platformContext = PlatformContext.create(
                 platformConfig, Time.getCurrent(), metrics, fileSystemManager, recycleBin, merkleCryptography);
 
-        otterApp = new OtterApp(version);
+        otterApp = new OtterApp(platformConfig, version);
 
         final HashedReservedSignedState reservedState = loadInitialState(
                 recycleBin,

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/OtterApp.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/OtterApp.java
@@ -13,10 +13,12 @@ import com.swirlds.platform.system.Platform;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.event.ConsensusEvent;
@@ -27,7 +29,6 @@ import org.hiero.consensus.model.transaction.ConsensusTransaction;
 import org.hiero.consensus.model.transaction.ScopedSystemTransaction;
 import org.hiero.consensus.model.transaction.Transaction;
 import org.hiero.otter.fixtures.app.services.consistency.ConsistencyService;
-import org.hiero.otter.fixtures.app.services.iss.IssService;
 import org.hiero.otter.fixtures.app.services.platform.PlatformStateService;
 import org.hiero.otter.fixtures.app.services.roster.RosterService;
 import org.hiero.otter.fixtures.app.state.OtterStateInitializer;
@@ -62,16 +63,32 @@ public class OtterApp implements ConsensusStateEventHandler<OtterAppState> {
     /**
      * Create the app and its services.
      *
+     * @param configuration the configuration to use to create the app and its services
      * @param version the software version to set in the state
      */
-    public OtterApp(@NonNull final SemanticVersion version) {
+    public OtterApp(@NonNull final Configuration configuration, @NonNull final SemanticVersion version) {
         this.version = requireNonNull(version);
 
-        final IssService issService = new IssService();
-        final ConsistencyService consistencyService = new ConsistencyService();
+        final OtterAppConfig appConfig = configuration.getConfigData(OtterAppConfig.class);
+        this.appServices =
+                appConfig.services().stream().map(OtterApp::instantiateService).toList();
+        this.allServices = Stream.concat(
+                        appServices.stream(), Stream.of(new PlatformStateService(), new RosterService()))
+                .toList();
+    }
 
-        this.appServices = List.of(consistencyService, issService);
-        this.allServices = List.of(consistencyService, issService, new PlatformStateService(), new RosterService());
+    @NonNull
+    private static OtterService instantiateService(@NonNull final String className) {
+        try {
+            return (OtterService)
+                    Class.forName(className).getDeclaredConstructor().newInstance();
+        } catch (final ClassNotFoundException
+                | NoSuchMethodException
+                | InstantiationException
+                | IllegalAccessException
+                | InvocationTargetException e) {
+            throw new IllegalStateException("Failed to instantiate service: " + className, e);
+        }
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/OtterAppConfig.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/OtterAppConfig.java
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.app;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import java.util.List;
+
+/**
+ * Configuration for the Otter application.
+ *
+ * @param services A comma-separated list of service class names to include in the Otter application.
+ */
+@ConfigData("event")
+public record OtterAppConfig(
+        @ConfigProperty(
+                        defaultValue = "org.hiero.otter.fixtures.app.services.consistency.ConsistencyService,"
+                                + "org.hiero.otter.fixtures.app.services.iss.IssService")
+                List<String> services) {}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/helpers/Utils.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/helpers/Utils.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.Marker;
+import org.hiero.otter.fixtures.app.OtterAppConfig;
 import org.hiero.otter.fixtures.app.services.consistency.ConsistencyServiceConfig;
 
 /**
@@ -65,6 +66,7 @@ public class Utils {
         requireNonNull(overriddenProperties, "Overridden properties must not be null");
         return new TestConfigBuilder()
                 .withSource(new SimpleConfigSource(overriddenProperties))
+                .withConfigDataType(OtterAppConfig.class)
                 .withConfigDataType(ConsistencyServiceConfig.class)
                 .getOrCreateConfig();
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -105,8 +105,7 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
     private final TurtleMarkerFileObserver markerFileObserver;
     private final Path outputDirectory;
 
-    private PlatformContext platformContext;
-
+    @NonNull
     private QuiescenceCommand quiescenceCommand = QuiescenceCommand.DONT_QUIESCE;
 
     @Nullable
@@ -207,7 +206,7 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
                     fileSystemManager,
                     selfId);
 
-            platformContext = TestPlatformContextBuilder.create()
+            final PlatformContext platformContext = TestPlatformContextBuilder.create()
                     .withTime(timeManager.time())
                     .withConfiguration(currentConfiguration)
                     .withFileSystemManager(fileSystemManager)
@@ -220,7 +219,7 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
                     .withUncaughtExceptionHandler((t, e) -> fail("Unexpected exception in wiring framework", e))
                     .build();
 
-            otterApp = new OtterApp(version);
+            otterApp = new OtterApp(currentConfiguration, version);
 
             final HashedReservedSignedState reservedState = loadInitialState(
                     recycleBin,
@@ -336,7 +335,10 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
             platformStatus = null;
             platform = null;
             platformComponent = null;
+            executionLayer = null;
+            otterApp = null;
             model = null;
+            quiescenceCommand = QuiescenceCommand.DONT_QUIESCE;
             lifeCycle = SHUTDOWN;
 
             // Wait a bit to allow a simulated gossip cycle to pass.
@@ -435,7 +437,8 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
     @Override
     @NonNull
     public SingleNodePcesResult newPcesResult() {
-        return new SingleNodePcesResultImpl(selfId(), platformContext.getConfiguration());
+        final Configuration currentConfiguration = configuration().current();
+        return new SingleNodePcesResultImpl(selfId(), currentConfiguration);
     }
 
     /**


### PR DESCRIPTION
**Description**:

This PR introduces functionality that allows for the configuration of which `OtterService`s should be started.

**Related issue(s)**:

Fixes #21484 