### PR TITLE
ci: detect existing minio operator installations correctly - cherry pick to v0.67

### DIFF
--- a/.github/workflows/support/citr/Taskfile.citr.yml
+++ b/.github/workflows/support/citr/Taskfile.citr.yml
@@ -344,7 +344,7 @@ tasks:
     silent: true
     cmds:
       - |
-        if ! kubectl get svc -l app.kubernetes.io/instance=minio-operator --all-namespaces --no-headers | grep -q . ; then
+        if ! kubectl get pods -l app.kubernetes.io/instance=minio-operator -l app.kubernetes.io/name=operator --all-namespaces --no-headers | grep -q . ; then
           echo "No services found with label app.kubernetes.io/name=operator app.kubernetes.io/instance=minio-operator"
           echo "--minio" > {{ .minio_flag_file }}
         else
@@ -361,7 +361,7 @@ tasks:
     cmds:
       - |
         export MINIO_FLAG=$(cat {{ .minio_flag_file }})
-        SOLO_HOME_DIR=${SOLO_HOME_DIR} solo cluster-ref setup --cluster-setup-namespace "${SOLO_CLUSTER_SETUP_NAMESPACE}" ${MINIO_FLAG} ${SOLO_CHARTS_DIR_FLAG} ${CLUSTER_TLS_FLAGS} -q --dev
+        SOLO_HOME_DIR=${SOLO_HOME_DIR} solo cluster-ref setup --cluster-setup-namespace "${SOLO_CLUSTER_SETUP_NAMESPACE}" ${MINIO_FLAG} ${SOLO_CHARTS_DIR_FLAG} ${CLUSTER_TLS_FLAGS} --no-prometheus-stack -q --dev
 
   solo:node:addresses:
     internal: true

--- a/.github/workflows/support/citr/Taskfile.yml
+++ b/.github/workflows/support/citr/Taskfile.yml
@@ -26,7 +26,7 @@ env:
   #EXPLORER_CLUSTER_CONTEXT: "kind-solo-cluster"
   SOLO_DEPLOYMENT: %SOLO_NAMESPACE%-test
   CLUSTER_REF: %SOLO_NAMESPACE%-ref
-  SOLO_CLUSTER_RELEASE_NAME: cluster_name
+  SOLO_CLUSTER_RELEASE_NAME: solo-cluster-setup
   CONTEXT: hashgraph.teleport.sh-k8s.pft.chi.lat.ope.eng.hashgraph.io
   SOLO_CLUSTER_SETUP_NAMESPACE: solo-setup
   SOLO_CLUSTER_NAME: solo-cluster-name


### PR DESCRIPTION
## Description

This pull request updates configuration and setup scripts related to Kubernetes and Solo cluster deployments. The main focus is on improving the detection of the MinIO operator, adjusting cluster setup commands, and standardizing environment variables.

**Kubernetes and Solo cluster setup improvements:**

* Updated the MinIO operator detection logic in `.github/workflows/support/citr/Taskfile.citr.yml` to check for pods (instead of services) with the appropriate labels, making the check more reliable.
* Modified the Solo cluster setup command to always include the `--no-prometheus-stack` flag, preventing Prometheus stack installation in those cases.

**Environment variable standardization:**

* Changed the default value of `SOLO_CLUSTER_RELEASE_NAME` from `cluster_name` to `solo-cluster-setup` in `.github/workflows/support/citr/Taskfile.yml` for consistency across deployments.

### Related Issues

Fixes #21907

