### PR TITLE
fix: 21954: HDHM should skip writing unchanged buckets to disk

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/BucketMutation.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/BucketMutation.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  * A simple linked-list of "mutations" for a bucket.
  *     The key.
  */
-class BucketMutation {
+final class BucketMutation {
 
     private final Bytes keyBytes;
     private final int keyHashCode;
@@ -93,38 +93,23 @@ class BucketMutation {
         return size;
     }
 
-    // For testing purposes
+    Bytes getKeyBytes() {
+        return keyBytes;
+    }
+
+    int getKeyHashCode() {
+        return keyHashCode;
+    }
+
     long getValue() {
         return value;
     }
 
-    // For testing purposes
     long getOldValue() {
         return oldValue;
     }
 
-    // For testing purposes
     BucketMutation getNext() {
         return next;
-    }
-
-    /**
-     * Visit each mutation in the list, starting from this mutation.
-     * @param consumer
-     * 		The callback. Cannot be null.
-     */
-    void forEachKeyValue(MutationCallback consumer) {
-        BucketMutation mutation = this;
-        while (mutation != null) {
-            consumer.accept(mutation.keyBytes, mutation.keyHashCode, mutation.oldValue, mutation.value);
-            mutation = mutation.next;
-        }
-    }
-
-    /**
-     * A simple callback for {@link BucketMutation#forEachKeyValue(MutationCallback)}.
-     */
-    interface MutationCallback {
-        void accept(final Bytes keyBytes, final int keyHashCode, final long oldValue, final long value);
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -588,12 +588,14 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             throw new IllegalStateException("Tried calling endWriting with different thread to startWriting()");
         }
         final int size = oneTransactionsData.size();
-        logger.info(
-                MERKLE_DB.getMarker(),
-                "Finishing writing to {}, num of changed bins = {}, num of changed keys = {}",
-                storeName,
-                size,
-                oneTransactionsData.stream().mapToLong(BucketMutation::size).sum());
+        if (logger.isDebugEnabled(MERKLE_DB.getMarker())) {
+            logger.debug(
+                    MERKLE_DB.getMarker(),
+                    "Finishing writing to {}, num of changed bins = {}, num of changed keys = {}",
+                    storeName,
+                    size,
+                    oneTransactionsData.stream().mapToLong(BucketMutation::size).sum());
+        }
         final DataFileReader dataFileReader;
         try {
             if (size > 0) {
@@ -687,6 +689,20 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
         }
     }
 
+    // This is a helper method used in ReadUpdateBucketTask and StoreBucketTask, when a bucket
+    // is processed (either no updates to the bucket, or it has been written to disk).
+    private void bucketProcessed() {
+        // Let the current submit task know that a bucket is fully processed, and
+        // the task can be run
+        if (bucketPermits.getAndIncrement() == 0) {
+            // If a submit task is currently running in parallel, it must have already created
+            // a new "current" submit task and permits have been set to 0, otherwise the
+            // getAndIncrement() above couldn't return 0. It means, notifyBucketProcessed()
+            // will be called on a different submit task than the one currently running
+            currentSubmitTask.get().notifyBucketProcessed();
+        }
+    }
+
     /**
      * A task to read a bucket identified by the given idex from disk and apply a list of
      * updates to the keys to it. The task has no dependencies, it's executed right after
@@ -706,25 +722,36 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             this.keyUpdates = keyUpdates;
         }
 
-        private void createAndScheduleStoreTask(final Bucket bucket) {
-            // Create a subsequent "store bucket" task for the bucket
-            final StoreBucketTask storeTask = new StoreBucketTask(getPool(), bucket);
-            // The last created "store bucket" task. storeTask above will be set as an
-            // output dependency for that task to make sure tasks are running only one at
-            // a time. See StoreBucketTask for details
-            final StoreBucketTask prevTask = lastStoreTask.getAndSet(storeTask);
-            if (prevTask != null) {
-                // This will trigger prevTask execution as soon as its prev task is complete
-                prevTask.setNext(storeTask);
+        private void createAndScheduleStoreTask(final Bucket bucket, final boolean bucketChanged) throws IOException {
+            if (bucketChanged) {
+                // Create a subsequent "store bucket" task for the bucket
+                final StoreBucketTask storeTask = new StoreBucketTask(getPool(), bucket);
+                // The last created "store bucket" task. storeTask above will be set as an
+                // output dependency for that task to make sure tasks are running only one at
+                // a time. See StoreBucketTask for details
+                final StoreBucketTask prevTask = lastStoreTask.getAndSet(storeTask);
+                if (prevTask != null) {
+                    // This will trigger prevTask execution as soon as its prev task is complete
+                    prevTask.setNext(storeTask);
+                } else {
+                    // The first task: no dependency on the prev task, can be executed rightaway
+                    storeTask.send();
+                }
             } else {
-                // The first task: no dependency on the prev task, can be executed rightaway
-                storeTask.send();
+                // Just close the bucket and mark it as processed
+                bucket.close();
+                bucketProcessed();
             }
             if (storeBucketTasksCreated.incrementAndGet() == updatedBucketsCount.get()) {
                 // The last task: no dependency on the next task, can be executed as soon as
                 // its prev task is complete, no need to wait until the next task dependency
                 // is set
-                lastStoreTask.get().setNext(notifyTaskRef.get());
+                final StoreBucketTask lastTask = lastStoreTask.get();
+                if (lastTask != null) {
+                    lastTask.setNext(notifyTaskRef.get());
+                } else {
+                    notifyTaskRef.get().send();
+                }
             }
         }
 
@@ -733,6 +760,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             BufferedData bucketData = fileCollection.readDataItemUsingIndex(bucketIndexToBucketLocation, bucketIndex);
             // The bucket will be closed by StoreBucketTask
             final Bucket bucket = bucketPool.getBucket();
+            boolean bucketChanged = false;
             if (bucketData == null) {
                 // An empty bucket
                 bucket.setBucketIndex(bucketIndex);
@@ -753,12 +781,18 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                     bucket.clear();
                 }
                 // Clear old bucket entries with wrong hash codes
-                bucket.sanitize(bucketIndex, bucketMaskBits.get());
+                if (bucket.sanitize(bucketIndex, bucketMaskBits.get())) {
+                    bucketChanged = true;
+                }
             }
             // Apply all updates
-            keyUpdates.forEachKeyValue(bucket::putValue);
+            for (BucketMutation m = keyUpdates; m != null; m = m.getNext()) {
+                if (bucket.putValue(m.getKeyBytes(), m.getKeyHashCode(), m.getOldValue(), m.getValue())) {
+                    bucketChanged = true;
+                }
+            }
             // Schedule a "store bucket" task for this bucket
-            createAndScheduleStoreTask(bucket);
+            createAndScheduleStoreTask(bucket, bucketChanged);
             return true;
         }
 
@@ -817,15 +851,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                 }
                 return true;
             } finally {
-                // Let the current submit task know that a bucket is fully processed, and
-                // the task can be run
-                if (bucketPermits.getAndIncrement() == 0) {
-                    // If a submit task is currently running in parallel, it must have already created
-                    // a new "current" submit task and permits have been set to 0, otherwise the
-                    // getAndIncrement() above couldn't return 0. It means, notifyBucketProcessed()
-                    // will be called on a different submit task than the one currently running
-                    currentSubmitTask.get().notifyBucketProcessed();
-                }
+                bucketProcessed();
                 next.send();
             }
         }


### PR DESCRIPTION
Fix summary:
* When HDHM buckets are processed, a check if added if a bucket has really been updated or not
* If a bucket is not updated, the corresponding StoreBucketTask is not scheduled, the bucket is just closed
* A new unit test is added for a corner case, when there are some dirty leaves during flush, but all of them are at the same path

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21954
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
