### PR TITLE
fix: set default flag for pectra to be on

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -100,7 +100,7 @@ public record ContractsConfig(
         @ConfigProperty(value = "evm.version", defaultValue = "v0.51") @NetworkProperty String evmVersion,
         @ConfigProperty(value = "evm.nativeLibVerification.halt.enabled", defaultValue = "false") @NetworkProperty
                 boolean nativeLibVerificationHaltEnabled,
-        @ConfigProperty(value = "evm.pectra.enabled", defaultValue = "false") @NetworkProperty boolean evmPectraEnabled,
+        @ConfigProperty(value = "evm.pectra.enabled", defaultValue = "true") @NetworkProperty boolean evmPectraEnabled,
         @ConfigProperty(value = "metrics.smartContract.primary.enabled", defaultValue = "true") @NetworkProperty
                 boolean metricsSmartContractPrimaryEnabled,
         @ConfigProperty(value = "metrics.smartContract.secondary.enabled", defaultValue = "true") @NetworkProperty


### PR DESCRIPTION
**Description**:
We are targeting Pectra with the v.70 version of the EVM module.  We still want to have a feature flag for Pectra (7702 transactions) but we want to set the default value to be on.

