### PR TITLE
chore(ci): add additional log publishing from workflow runs

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -512,6 +512,7 @@ jobs:
         with:
           retention-days: 7
           path: |
+            run.log
             hedera-node/test-clients/build/*.log
             hedera-node/test-clients/build/*.blk.gz
             hedera-node/test-clients/build/*.rcd.gz


### PR DESCRIPTION
**Description**:

Add blocks, records, and log publishing from the build application workflow to enable more debugging when examining failed runs.

**Related Issue(s)**:

Fixes #22011
