### PR TITLE
fix: change block per-item byte overhead from 2 bytes to 5 bytes for requests

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -1100,7 +1100,7 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
                             "{} Starting to process items for block {}", BlockNodeConnection.this, block.blockNumber());
                 }
 
-                final int itemSize = item.protobufSize() + 2; // each item has 2 bytes of overhead
+                final int itemSize = item.protobufSize() + 5; // add an extra 5 bytes to account for potential overhead
                 final long newRequestBytes = pendingRequestBytes + itemSize;
 
                 if (newRequestBytes > MAX_BYTES_PER_REQUEST) {


### PR DESCRIPTION
**Description**:
This updates the number of bytes we add for each block item for potential overhead from 2 bytes to 5 bytes.

During recent performance testing, there were several cases where requests would be created with a serialized size larger than we expected. As we build a "pending request" we make an effort to estimate what the size of the request would be by taking a baseline of 100 bytes and then adding for each item, the `BlockItem#protobufSize` with 2 extra bytes. However, these two bytes seem to small, so we will update it to 5 bytes each which should cover most, if not all, cases. While each item may not have 5 bytes of overhead in reality, by adding this to each item we hopefully avoid cases where we aren't assigning enough overhead.

**Related issue(s)**:

This PR is a followup to a previous [PR](https://github.com/hiero-ledger/hiero-consensus-node/pull/21924) that tried to address ticket #21923

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
