### PR TITLE
chore: Xts records and retrieves operation duration test improve

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/SystemContractOpsDurationMetricTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/SystemContractOpsDurationMetricTest.java
@@ -71,9 +71,9 @@ class SystemContractOpsDurationMetricTest {
         final double total =
                 subject.getSystemContractOpsDuration(SC1, ADDR1).accumulator().get();
         // Then
-        assertThat(average).isCloseTo(avg, within(5.0)); // (100 + 200) / 2
-        assertThat(count).isEqualTo(cycles * 2); // Two durations recorded
-        assertThat(total).isEqualTo(cycles * 2 * avg); // 100 + 200
+        assertThat(average).isCloseTo(avg, within(5.0));
+        assertThat(count).isEqualTo(cycles * 2);
+        assertThat(total).isEqualTo(cycles * 2 * avg);
     }
 
     @Test
@@ -94,9 +94,9 @@ class SystemContractOpsDurationMetricTest {
         // When
         generateMetric(subject, SC1, ADDR1, cycles1, avg1);
         generateMetric(subject, SC2, ADDR2, cycles2, avg2);
-        // Then
         final var metric1 = subject.getSystemContractOpsDuration(SC1, ADDR1);
         final var metric2 = subject.getSystemContractOpsDuration(SC2, ADDR2);
+        // Then
         assertThat(metric1.average().get()).isCloseTo(avg1, within(5.0));
         assertThat(metric1.counter().get()).isEqualTo(cycles1 * 2);
         assertThat(metric1.accumulator().get()).isEqualTo(cycles1 * 2 * avg1);


### PR DESCRIPTION
**Description**:
Random test flake in smart contracts was [reported](https://scans.gradle.com/s/llezog467h6wa/tests/task/:app-service-contract-impl:test/details/com.hedera.node.app.service.contract.impl.test.exec.metrics.SystemContractOpsDurationMetricTest/recordsAndRetrievesOperationDuration()?expanded-stacktrace=WyIwIl0&top-execution=1).

This branch tries to fix possible flakiness of the test.

**Notes for reviewer**:
1. `SystemContractOpsDurationMetric` -> uses `RunningAverageMetric` ->  uses `StatsRunningAverage` -> uses `StatsSpeedometer values / StatsSpeedometer times` to calculate average. [StatsSpeedometer](https://github.com/hiero-ledger/hiero-consensus-node/blob/15dae911a3136d680cbb1757930921f8d739ef75/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/statistics/StatsSpeedometer.java#L18) is a time based counter that counts `times per second`. So in theory, because of some `time.nanoTime()` "glitch" metric can be inaccurate. 
The idea of the fix is to use more samples to reduce metric inaccuracy.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
