### PR TITLE
chore: cherry-pick PR #22019 (changing block item overhead to 5 bytes)

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -1005,7 +1005,7 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
                             "{} Starting to process items for block {}", BlockNodeConnection.this, block.blockNumber());
                 }
 
-                final int itemSize = item.protobufSize() + 2; // each item has 2 bytes of overhead
+                final int itemSize = item.protobufSize() + 5; // add an extra 5 bytes to account for potential overhead
                 final long newRequestBytes = pendingRequestBytes + itemSize;
 
                 if (newRequestBytes > MAX_BYTES_PER_REQUEST) {


### PR DESCRIPTION
…requests (#22019)

**Description**:
Cherry-pick of https://github.com/hiero-ledger/hiero-consensus-node/pull/22019

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
