### PR TITLE
fix: Block Node Comms fix notifyConnectionClosed

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -1080,6 +1080,6 @@ public class BlockNodeConnectionManager {
         activeConnectionRef.compareAndSet(connection, null);
 
         // Remove from connections map
-        connections.remove(connection.getNodeConfig());
+        connections.remove(connection.getBlockNodeConnectionConfig());
     }
 }


### PR DESCRIPTION
**Description**:
This pull request updates the way closed connections are removed from the connection map in `BlockNodeConnectionManager` and adds a unit test to verify this behavior. The main focus is ensuring that the correct key is used when removing a connection, and that closing a non-active connection does not trigger unintended side effects.

**Connection management improvements:**

* Updated `notifyConnectionClosed` in `BlockNodeConnectionManager` to remove connections from the map using `getBlockNodeConnectionConfig()` instead of `getNodeConfig()`, ensuring the correct key is used for removal.

**Testing enhancements:**

* Added a unit test `testNotifyConnectionClosed_removesNonActiveConnection` in `BlockNodeConnectionManagerTest` to verify that closing a non-active connection removes it from the map and does not cause side effects (no interactions with executor, buffer, or metrics services).

**Related issue(s)**:#21777

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
