### PR TITLE
Attempt at  Fix BlockProof protobuf for backwards compatibility

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/block_proof.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/block_proof.proto
@@ -241,16 +241,39 @@ message BlockProof {
     repeated MerkleSiblingHash sibling_hashes = 5;
 
     /**
+     * Legacy hinTS verification reference fields retained for backward
+     * compatibility with block proofs produced before direct verification keys
+     * were embedded in the block proof itself. New proofs SHOULD use
+     * `hints_verification_key` instead.
+     */
+    oneof verification_reference {
+        /**
+         * The id of the hinTS scheme this signature verifies under.
+         * (Legacy field retained for backward compatibility.)
+         */
+        uint64 scheme_id = 6 [deprecated = true];
+
+        /**
+         * The explicit hinTS key this signature verifies under; useful when
+         * the verifier can easily check whether a chain-of-trust proof
+         * exists for a key, but does does not have any context of the
+         * latest hinTS schemes published in the block stream.
+         * (Legacy field retained for backward compatibility.)
+         */
+        bytes verification_key = 7 [deprecated = true];
+    }
+
+    /**
      * The hinTS key that this signature verifies under; a stream consumer should
      * only use this key after first checking the chain of trust proof.
      */
-    bytes verification_key = 6;
+    bytes hints_verification_key = 11;
 
     /**
      * Proof the hinTS verification key is in the chain of trust extending
      * from the network's ledger id.
      */
-    ChainOfTrustProof verification_key_proof = 7;
+    ChainOfTrustProof verification_key_proof = 12;
 
     /**
      * The proof contents verifying the block's merkle root hash.<br/>


### PR DESCRIPTION
**Description**:
v0.68.0 of the Blockstream is not backwards compatible with previous HAPI versions. Including latest 0.66.0 and 0.67.0 versions.

This is due to a chage in `block_proof.proto` --> `BlockProof Message, where fields id 6 and 7 were replaced from:

old:
uint64 scheme_id = 6 
bytes verification_key = 7

new:
bytes verification_key = 6;
ChainOfTrustProof verification_key_proof = 7;

This breaks backwards compatibility when attempting to parse old blockstreams with new Protobuf definition.
This was discovered as part of the Verification Regresion test suites on BN when attempting to do a new BlockVerification Session that works for the latest HAPI version (v0.68.0).


**We either keep full compatibility or we (take advantage that the BlockStream is in Beta) and do NOT support backwards compatibility. In that case it does not make sense to have other deprecated fields and BlockStream could be further simplified by just removing those [deprecated] fields and re-using respective field Ids.**