### PR TITLE
fix: Always clear state when exiting RPC sync protocol (#22081)

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
@@ -214,8 +214,6 @@ public class RpcPeerHandler implements GossipRpcReceiver {
     public void cleanup() {
         clearInternalState();
         state.peerStillSendingEvents = false;
-        sharedShadowgraphSynchronizer.deregisterPeerHandler(this);
-        this.syncMetrics.reportSyncPhase(peerId, SyncPhase.OUTSIDE_OF_RPC);
     }
 
     // HANDLE INCOMING MESSAGES - all done on dispatch thread

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcShadowgraphSynchronizer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcShadowgraphSynchronizer.java
@@ -102,13 +102,4 @@ public class RpcShadowgraphSynchronizer extends AbstractShadowgraphSynchronizer 
                 fallenBehindMonitor);
         return rpcPeerHandler;
     }
-
-    /**
-     * Called when given handler is being destroyed due to connection collapsing or other similar event.
-     *
-     * @param rpcPeerHandler handler which should be removed from internal structures
-     */
-    public void deregisterPeerHandler(final RpcPeerHandler rpcPeerHandler) {
-        // no-op for now
-    }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiationProtocols.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/NegotiationProtocols.java
@@ -107,13 +107,4 @@ public class NegotiationProtocols {
             throw new IllegalStateException("no protocol initiated");
         }
     }
-
-    /**
-     * Perform optional cleanup on all peer protocols
-     */
-    public void cleanup() {
-        for (final PeerProtocol peerProtocol : allPeerProtocols) {
-            peerProtocol.cleanup();
-        }
-    }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/ProtocolNegotiatorThread.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/communication/ProtocolNegotiatorThread.java
@@ -31,16 +31,11 @@ public class ProtocolNegotiatorThread implements InterruptableRunnable {
     private final RateLimiter socketExceptionRateLimiter;
 
     /**
-     * @param connectionManager
-     * 		supplies network connections
-     * @param sleepMillis
-     *         the number of milliseconds to sleep if a negotiation fails
-     * @param handshakeProtocols
-     * 		the list of protocols to execute when a new connection is established
-     * @param protocols
-     * 		the protocols to negotiate and run
-     * @param time
-     *      the Time object
+     * @param connectionManager  supplies network connections
+     * @param sleepMillis        the number of milliseconds to sleep if a negotiation fails
+     * @param handshakeProtocols the list of protocols to execute when a new connection is established
+     * @param protocols          the protocols to negotiate and run
+     * @param time               the Time object
      */
     public ProtocolNegotiatorThread(
             final ConnectionManager connectionManager,
@@ -71,8 +66,6 @@ public class ProtocolNegotiatorThread implements InterruptableRunnable {
             }
         } catch (final RuntimeException | IOException | NetworkProtocolException | NegotiationException e) {
             NetworkUtils.handleNetworkException(e, currentConn, socketExceptionRateLimiter);
-        } finally {
-            protocols.cleanup();
         }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/PeerProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/PeerProtocol.java
@@ -64,12 +64,6 @@ public interface PeerProtocol extends ProtocolRunnable {
      */
     boolean acceptOnSimultaneousInitiate();
 
-    /**
-     * Will be called after connection is broken, to clean up possible internal resources if needed. Default
-     * implementation is no-op
-     */
-    default void cleanup() {}
-
     /** @return a string name representing this protocol */
     default String getProtocolName() {
         return this.getClass().getSimpleName();


### PR DESCRIPTION
(cherry picked from commit e7c53f6ee52a48fbfc875980daa0473a843d777a)

**Description**:
Given another issue with state sometimes getting corrupted in RPC sync during protocol changes, this change is simplifying entire interaction. Given that we are going to get rid of other protocols in future and only one which is important atm is reconnect (which anyway completely invalidates all sync in-progress), when RPC sync protocol is preempted it clears all of its state and starts anew on next negatiation.

It should have minimal impact in real life (except avoiding possible race conditions) and makes logic easier to follow. In unlikely case we would like to introduce other, non-reconnect protocols OUTSIDE of rpc in future, this would need to be revisited.


**Related issue(s)**:

Fixes #22080 

**Notes for reviewer**:
Backport of #22081


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
