### PR TITLE
fix: Block merkle tree optimizations

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/IncrementalStreamingHasher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/IncrementalStreamingHasher.java
@@ -3,7 +3,6 @@ package com.hedera.node.app.blocks.impl;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.security.MessageDigest;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -81,9 +80,7 @@ public class IncrementalStreamingHasher {
      * @return the intermediate hashing state
      */
     public List<Bytes> intermediateHashingState() {
-        return hashList.stream()
-                .map(b -> Bytes.wrap(Arrays.copyOf(b, b.length)))
-                .toList();
+        return hashList.stream().map(Bytes::wrap).toList();
     }
 
     /**


### PR DESCRIPTION
**Description**:

There has been a substantial drop in network throughput, which could be reasonably attributed to the recent block merkle tree changes (see PR #21401). This PR makes further tweaks those changes by removing unnecessary null hashing and returning the byte arrays directly from the incremental streaming hasher. 