### PR TITLE
chore: 22109: VirtualMapConfig.flushInterval is no longer used and can be removed

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -78,9 +78,8 @@ class SerializationTest extends MerkleTestBase {
         setupConstructableRegistry();
 
         this.config = new TestConfigBuilder()
-                .withSource(new SimpleConfigSource()
-                        .withValue(VirtualMapConfig_.FLUSH_INTERVAL, 1 + "")
-                        .withValue(VirtualMapConfig_.COPY_FLUSH_CANDIDATE_THRESHOLD, 1 + ""))
+                .withSource(
+                        new SimpleConfigSource().withValue(VirtualMapConfig_.COPY_FLUSH_CANDIDATE_THRESHOLD, 1 + ""))
                 .withConfigDataType(VirtualMapConfig.class)
                 .withConfigDataType(HederaConfig.class)
                 .withConfigDataType(CryptoConfig.class)

--- a/platform-sdk/swirlds-benchmarks/settings.txt
+++ b/platform-sdk/swirlds-benchmarks/settings.txt
@@ -6,6 +6,5 @@ benchmark.printHistogram,                      false
 benchmark.csvOutputFolder,                     data
 benchmark.csvWriteFrequency,                   1000
 benchmark.csvAppend,                           true
-virtualMap.flushInterval,                      20
 virtualMap.familyThrottleThreshold,            10000000000
 merkleDb.hashesRamToDiskThreshold,             8388608

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -435,8 +435,6 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             dataSource = dataSourceBuilder.build(metadata.getLabel(), null, true, false);
         }
 
-        updateShouldBeFlushed();
-
         this.records = new RecordAccessor(this.metadata, cache, dataSource);
         if (statistics == null) {
             // Only create statistics instance if we don't yet have statistics. During a reconnect operation.
@@ -833,21 +831,20 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
     }
 
     /**
-     * Sets flush threshold for this virtual root. When a copy of this virtual root is created,
+     * Sets a flush threshold for this virtual root. When a copy of this virtual root is created,
      * it inherits the threshold value.
      *
-     * If this virtual root is explicitly marked to flush using {@link #enableFlush()}, changing
-     * flush threshold doesn't have any effect.
+     * <p>If this virtual root is explicitly marked to flush using {@link #enableFlush()}, changing
+     * the flush threshold doesn't have any effect.
      *
      * @param value The flush threshold, in bytes
      */
     public void setFlushCandidateThreshold(long value) {
         flushCandidateThreshold.set(value);
-        updateShouldBeFlushed();
     }
 
     /**
-     * Gets flush threshold for this virtual root.
+     * Gets the flush threshold for this virtual root.
      *
      * @return The flush threshold, in bytes
      */
@@ -875,17 +872,6 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
     @Override
     public boolean isFlushed() {
         return flushed.get();
-    }
-
-    /**
-     * If flush threshold isn't set for this virtual root, marks the root to flush based on
-     * {@link VirtualMapConfig#flushInterval()} setting.
-     */
-    private void updateShouldBeFlushed() {
-        if (flushCandidateThreshold.get() <= 0) {
-            // If copy size flush threshold is not set, use flush interval
-            this.shouldBeFlushed.set(fastCopyVersion != 0 && fastCopyVersion % virtualMapConfig.flushInterval() == 0);
-        }
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
@@ -32,14 +32,9 @@ import com.swirlds.config.api.validation.annotation.Min;
  * @param numCleanerThreads
  * 		The number of threads to devote to cache cleaning. If not set, defaults to the number of threads implied by
  *      {@code virtualMap.percentCleanerThreads} and {@link Runtime#availableProcessors()}.
- * @param flushInterval
- * 		The interval between flushing of copies. This value defines the value of N where every Nth copy is flushed. The
- * 		value must be positive and will typically be a fairly small number, such as 20. The first copy is not flushed,
- * 		but every Nth copy thereafter is.
  * @param copyFlushCandidateThreshold
- *      Virtual map copy flush threshold. A copy can be flushed to disk only if it's size exceeds this
- *      threshold. If set to zero, size-based flushes aren't used, and copies are flushed based on {@link
- *      #flushInterval} instead.
+ *      Virtual map copy flush threshold. A copy can be flushed to disk only if its size exceeds this
+ *      threshold.
  * @param familyThrottleThreshold
  *      Virtual map family throttle threshold. When estimated size of all unreleased copies of the same virtual
  *      root exceeds this threshold, virtual pipeline starts applying backpressure on creating new root copies.
@@ -60,8 +55,7 @@ public record VirtualMapConfig(
         @Min(0) @ConfigProperty(defaultValue = "500000") int reconnectFlushInterval,
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "25.0") double percentCleanerThreads,
         @Min(-1) @ConfigProperty(defaultValue = "-1") int numCleanerThreads,
-        @Min(1) @ConfigProperty(defaultValue = "20") int flushInterval,
-        @Min(-1) @ConfigProperty(defaultValue = "1000000000") long copyFlushCandidateThreshold,
+        @Min(1) @ConfigProperty(defaultValue = "1000000000") long copyFlushCandidateThreshold,
         @Min(-1) @Max(100) @ConfigProperty(defaultValue = "10.0") double familyThrottlePercent,
         @Min(-1) @ConfigProperty(defaultValue = "-1") long familyThrottleThreshold) {
 

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -42,7 +42,6 @@ import com.swirlds.metrics.api.Metric;
 import com.swirlds.metrics.api.Metric.ValueType;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
-import com.swirlds.virtualmap.config.VirtualMapConfig_;
 import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
 import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import com.swirlds.virtualmap.internal.RecordAccessor;
@@ -1482,16 +1481,15 @@ class VirtualMapTests extends VirtualTestBase {
     }
 
     @Test
-    @DisplayName("Flush interval is inherited by copies")
-    void flushIntervalInheritedTest() {
+    @DisplayName("Flush threshold is inherited by copies")
+    void flushThresholdInheritedTest() {
         final long threshold = 12345678L;
         final VirtualMapConfig config =
                 new TestConfigBuilder().getOrCreateConfig().getConfigData(VirtualMapConfig.class);
 
-        final int flushInterval = config.flushInterval();
         VirtualMap root = createMap();
         root.setFlushCandidateThreshold(threshold);
-        for (int i = 0; i <= flushInterval; i++) {
+        for (int i = 0; i < 50; i++) {
             assertEquals(threshold, root.getFlushCandidateThreshold());
             VirtualMap copy = root.copy();
             copy.postInit();
@@ -1499,64 +1497,6 @@ class VirtualMapTests extends VirtualTestBase {
             root = copy;
         }
         root.release();
-    }
-
-    @Test
-    @DisplayName("Zero flush threshold enables round based flushes")
-    void zeroFlushThresholdTest() {
-        final VirtualMapConfig config =
-                new TestConfigBuilder().getOrCreateConfig().getConfigData(VirtualMapConfig.class);
-        final int flushInterval = config.flushInterval();
-        VirtualMap map = createMap();
-        map.setFlushCandidateThreshold(0);
-        assertFalse(map.shouldBeFlushed()); // the very first copy is never flushed
-        for (int i = 0; i < flushInterval; i++) {
-            VirtualMap copy = map.copy();
-            copy.postInit();
-            map.release();
-            map = copy;
-        }
-        assertTrue(map.shouldBeFlushed());
-        map.release();
-    }
-
-    @Test
-    @DisplayName("Default zero flush threshold")
-    void defaultZeroFlushThresholdTest() {
-        final Configuration configuration = new TestConfigBuilder()
-                .withValue(VirtualMapConfig_.COPY_FLUSH_CANDIDATE_THRESHOLD, "0")
-                .getOrCreateConfig();
-
-        final VirtualDataSourceBuilder builder = new InMemoryBuilder();
-        VirtualMap map = new VirtualMap(VM_LABEL, builder, configuration);
-
-        assertEquals(0, map.getFlushCandidateThreshold());
-        final int flushInterval =
-                configuration.getConfigData(VirtualMapConfig.class).flushInterval();
-        for (int i = 0; i < flushInterval; i++) {
-            VirtualMap copy = map.copy();
-            copy.postInit();
-            map.release();
-            map = copy;
-        }
-        final VirtualMap copyShouldBeFlushed = map;
-        map.setFlushCandidateThreshold(12345678L);
-        for (int i = 0; i < flushInterval; i++) {
-            VirtualMap copy = map.copy();
-            copy.postInit();
-            map.release();
-            map = copy;
-        }
-        final VirtualMap copyShouldNotBeFlushed = map;
-        // shouldBeFlushed() can only be called on released copies, so create one more copy to
-        // release copyShouldNotBeFlushed
-        final VirtualMap finalCopy = map.copy();
-        map.release();
-
-        assertTrue(copyShouldBeFlushed.shouldBeFlushed());
-        assertFalse(copyShouldNotBeFlushed.shouldBeFlushed()); // should still have a custom flush threshold
-
-        finalCopy.release();
     }
 
     @Test

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/config/VirtualMapConfigTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/config/VirtualMapConfigTest.java
@@ -76,10 +76,10 @@ class VirtualMapConfigTest {
     }
 
     @Test
-    void testFlushIntervalOutOfRangeMin() {
+    void testFlushThresholdOutOfRangeMin() {
         // given
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
-                .withSources(new SimpleConfigSource("virtualMap.flushInterval", 0L))
+                .withSources(new SimpleConfigSource("virtualMap.copyFlushCandidateThreshold", 0L))
                 .withConfigDataType(VirtualMapConfig.class);
 
         // then
@@ -87,6 +87,17 @@ class VirtualMapConfigTest {
                 ConfigViolationException.class, () -> configurationBuilder.build(), "init must end in a violation");
 
         Assertions.assertEquals(1, exception.getViolations().size(), "We must exactly have 1 violation");
+    }
+
+    @Test
+    void testFlushThresholdMinAllowed() {
+        // given
+        final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
+                .withSources(new SimpleConfigSource("virtualMap.copyFlushCandidateThreshold", 1L))
+                .withConfigDataType(VirtualMapConfig.class);
+
+        // then
+        Assertions.assertDoesNotThrow(() -> configurationBuilder.build(), "init must be successful");
     }
 
     @Test


### PR DESCRIPTION
Fix summary: `VirtualMapConfig.flushInterval` is removed. `copyFlushCandidateThreshold` config is now the only way to control copy flushes. It now can't be set to a zero or negative value.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/22109
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
