### PR TITLE
fix: Precreate dynamic metrics

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossipModular.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossipModular.java
@@ -138,7 +138,7 @@ public class SyncGossipModular implements Gossip {
         final ProtocolConfig protocolConfig = platformContext.getConfiguration().getConfigData(ProtocolConfig.class);
 
         final int rosterSize = peers.size() + 1;
-        final SyncMetrics syncMetrics = new SyncMetrics(platformContext.getMetrics(), platformContext.getTime());
+        final SyncMetrics syncMetrics = new SyncMetrics(platformContext.getMetrics(), platformContext.getTime(), peers);
 
         if (protocolConfig.rpcGossip()) {
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/SyncMetrics.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/metrics/SyncMetrics.java
@@ -22,6 +22,7 @@ import com.swirlds.platform.gossip.shadowgraph.SyncPhase;
 import com.swirlds.platform.gossip.shadowgraph.SyncResult;
 import com.swirlds.platform.gossip.shadowgraph.SyncTiming;
 import com.swirlds.platform.network.Connection;
+import com.swirlds.platform.network.PeerInfo;
 import com.swirlds.platform.stats.AverageAndMax;
 import com.swirlds.platform.stats.AverageAndMaxTimeStat;
 import com.swirlds.platform.stats.AverageStat;
@@ -31,6 +32,7 @@ import com.swirlds.platform.system.PlatformStatNames;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.hiero.consensus.model.hashgraph.EventWindow;
@@ -199,9 +201,10 @@ public class SyncMetrics {
      *
      * @param metrics a reference to the metrics-system
      * @param time    time source for the system
+     * @param peers   list of all peers to pre-create dynamic metrics
      * @throws IllegalArgumentException if {@code metrics} is {@code null}
      */
-    public SyncMetrics(final Metrics metrics, final Time time) {
+    public SyncMetrics(final Metrics metrics, final Time time, final List<PeerInfo> peers) {
         this.metrics = Objects.requireNonNull(metrics);
         this.time = Objects.requireNonNull(time);
         avgBytesPerSecSync = metrics.getOrCreate(AVG_BYTES_PER_SEC_SYNC_CONFIG);
@@ -315,6 +318,21 @@ public class SyncMetrics {
                 "rpc_output_queue_poll_time",
                 "amount of us spent sleeping waiting for poll to happen or timeout on rpc output queue",
                 FORMAT_10_0);
+
+        precreateDynamicMetrics(peers);
+    }
+
+    /**
+     * Out metric csv report needs all the metrics upfront to not get confused
+     * @param peers list of all peers to pre-create dynamic metrics
+     */
+    private void precreateDynamicMetrics(final List<PeerInfo> peers) {
+        for (final PeerInfo peer : peers) {
+            final NodeId nodeId = peer.nodeId();
+            rpcInputQueueSize(nodeId, 0);
+            rpcOutputQueueSize(nodeId, 0);
+            reportSyncPhase(nodeId, SyncPhase.OUTSIDE_OF_RPC);
+        }
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerCommunication.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/PeerCommunication.java
@@ -82,7 +82,7 @@ public class PeerCommunication implements ConnectionTracker {
         this.selfPeer = Objects.requireNonNull(selfPeer);
         this.selfId = selfPeer.nodeId();
 
-        this.networkMetrics = new NetworkMetrics(platformContext.getMetrics(), selfPeer.nodeId());
+        this.networkMetrics = new NetworkMetrics(platformContext.getMetrics(), selfPeer.nodeId(), peers);
         platformContext.getMetrics().addUpdater(networkMetrics::update);
 
         this.topology = new StaticTopology(peers, selfPeer.nodeId());


### PR DESCRIPTION
**Description**:
Precreate metrics for ones which are dynamically created. Dynamic creation of metrics is a future functionality, for when we will get a full DAB support, csv reports will have to be fully redone then anyway, so for now, we should just precreate ones from static startup roster.

**Related issue(s)**:

Fixes #21754 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
