### PR TITLE
fix: avoid converting PBJ object to bytes/byte array when writing to …

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockItemWriter.java
@@ -3,7 +3,6 @@ package com.hedera.node.app.blocks;
 
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.node.internal.network.PendingProof;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -16,14 +15,6 @@ public interface BlockItemWriter {
      * @param blockNumber the number of the block to open
      */
     void openBlock(final long blockNumber);
-
-    /**
-     * Writes an item and/or its serialized bytes to the destination stream.
-     *
-     * @param item the item to write
-     * @param bytes the serialized item to write
-     */
-    void writePbjItemAndBytes(@NonNull final BlockItem item, @NonNull final Bytes bytes);
 
     /**
      * Writes a PBJ item to the destination stream.
@@ -42,10 +33,4 @@ public interface BlockItemWriter {
      */
     void flushPendingBlock(@NonNull PendingProof pendingProof);
 
-    /**
-     * Jumps to a specific block number after a freeze event.
-     *
-     * @param blockNumber the block number to jump to after freeze
-     */
-    void jumpToBlockAfterFreeze(final long blockNumber);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileAndGrpcBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileAndGrpcBlockItemWriter.java
@@ -9,7 +9,6 @@ import com.hedera.node.app.spi.info.NodeInfo;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.internal.network.PendingProof;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.FileSystem;
 
@@ -56,16 +55,6 @@ public class FileAndGrpcBlockItemWriter implements BlockItemWriter {
     }
 
     @Override
-    public void writePbjItemAndBytes(@NonNull final BlockItem item, @NonNull final Bytes bytes) {
-        requireNonNull(item, "item cannot be null");
-        requireNonNull(bytes, "bytes cannot be null");
-        this.fileBlockItemWriter.writeItem(bytes.toByteArray());
-        if (isStreamingEnabled()) {
-            this.grpcBlockItemWriter.writePbjItem(item);
-        }
-    }
-
-    @Override
     public void closeCompleteBlock() {
         this.fileBlockItemWriter.closeCompleteBlock();
         if (isStreamingEnabled()) {
@@ -84,19 +73,10 @@ public class FileAndGrpcBlockItemWriter implements BlockItemWriter {
 
     @Override
     public void writePbjItem(@NonNull final BlockItem item) {
-        throw new UnsupportedOperationException("writePbjItem is not supported in this implementation");
-    }
-
-    /**
-     * Jumps to a specific block number after a freeze event.
-     * This method only affects the gRPC writer, not the file writer.
-     *
-     * @param blockNumber the block number to jump to after freeze
-     */
-    @Override
-    public void jumpToBlockAfterFreeze(final long blockNumber) {
+        this.fileBlockItemWriter.writePbjItem(item);
         if (isStreamingEnabled()) {
-            this.grpcBlockItemWriter.jumpToBlockAfterFreeze(blockNumber);
+            this.grpcBlockItemWriter.writePbjItem(item);
         }
     }
+
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/GrpcBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/GrpcBlockItemWriter.java
@@ -6,7 +6,6 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.node.app.blocks.BlockItemWriter;
 import com.hedera.node.internal.network.PendingProof;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,31 +62,12 @@ public class GrpcBlockItemWriter implements BlockItemWriter {
     }
 
     /**
-     * Writes a protocol buffer formatted block item and its serialized bytes to the current block's state.
-     * Only the block item is used, the serialized bytes are ignored.
-     *
-     * @param item the block item to write
-     * @param bytes the serialized item to write (ignored in this implementation)
-     */
-    @Override
-    public void writePbjItemAndBytes(@NonNull final BlockItem item, @NonNull final Bytes bytes) {
-        requireNonNull(item, "item must not be null");
-        requireNonNull(bytes, "bytes must not be null");
-        writePbjItem(item);
-    }
-
-    /**
      * Closes the current block and marks it as complete in the state manager.
      */
     @Override
     public void closeCompleteBlock() {
         blockBufferService.closeBlock(blockNumber);
         logger.debug("Closed block in GrpcBlockItemWriter {}", blockNumber);
-    }
-
-    @Override
-    public void jumpToBlockAfterFreeze(final long blockNumber) {
-        // no-op
     }
 
     /**


### PR DESCRIPTION
…disk and to message digest (WIP)

**Description**:
Avoid using `Codec#toBytes` and `Bytes#toByteArray` when processing blocks to help reduce allocation of byte arrays and thus reduce memory usage. Note: this PR does NOT fix tests. Just a quick changeset to get the work started.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
