### PR TITLE
fix: to compile with JDK25 (#22142), suppress javadoc warning-as-error 'dangling-doc-comments'

### DIFF
--- a/hapi/hapi/build.gradle.kts
+++ b/hapi/hapi/build.gradle.kts
@@ -11,9 +11,11 @@ description = "Hedera API"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Xlint:-exports,-deprecation,-removal" + compilerArgsExtra)
 }

--- a/hedera-node/hapi-utils/build.gradle.kts
+++ b/hedera-node/hapi-utils/build.gradle.kts
@@ -11,9 +11,9 @@ testModuleInfo {
     requires("org.mockito")
     requires("org.assertj.core")
 }
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-  tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add("-Xlint:-dangling-doc-comments")
-  }
-}
 
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    tasks.withType<JavaCompile>().configureEach {
+        options.compilerArgs.add("-Xlint:-dangling-doc-comments")
+    }
+}

--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -7,11 +7,12 @@ plugins {
 
 description = "Hedera Application - Implementation"
 
-if(JavaVersion.current() >= JavaVersion.VERSION_25) {
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
     tasks.withType<JavaCompile>().configureEach {
         options.compilerArgs.add("-Xlint:-dangling-doc-comments")
     }
 }
+
 mainModuleInfo {
     annotationProcessor("dagger.compiler")
     annotationProcessor("com.google.auto.service.processor")

--- a/hedera-node/hedera-smart-contract-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-smart-contract-service-impl/build.gradle.kts
@@ -6,10 +6,14 @@ description = "Default Hedera Smart Contract Service Implementation"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports" + compilerArgsExtra) }
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-exports" + compilerArgsExtra)
+}
 
 mainModuleInfo { annotationProcessor("dagger.compiler") }
 

--- a/hedera-node/hedera-smart-contract-service/build.gradle.kts
+++ b/hedera-node/hedera-smart-contract-service/build.gradle.kts
@@ -6,7 +6,11 @@ description = "Hedera Smart Contract Service API"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports" + compilerArgsExtra) }
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-exports" + compilerArgsExtra)
+}

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -16,10 +16,14 @@ mainModuleInfo {
 sourceSets { create("rcdiff") }
 
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports" + compilerArgsExtra) }
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-exports" + compilerArgsExtra)
+}
 
 tasks.register<JavaExec>("runTestClient") {
     group = "build"

--- a/hedera-node/yahcli/build.gradle.kts
+++ b/hedera-node/yahcli/build.gradle.kts
@@ -23,10 +23,14 @@ testModuleInfo {
 }
 
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-exports" + compilerArgsExtra) }
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-exports" + compilerArgsExtra)
+}
 
 tasks.compileJava { dependsOn(":test-clients:assemble") }
 

--- a/platform-sdk/platform-apps/demos/StatsDemo/build.gradle.kts
+++ b/platform-sdk/platform-apps/demos/StatsDemo/build.gradle.kts
@@ -3,8 +3,8 @@ plugins { id("org.hiero.gradle.module.application") }
 
 application.mainClass = "com.swirlds.demo.stats.StatsDemoMain"
 
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-  tasks.withType<JavaCompile>().configureEach {
-      options.compilerArgs.add("-Xlint:-dangling-doc-comments")
-  }
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    tasks.withType<JavaCompile>().configureEach {
+        options.compilerArgs.add("-Xlint:-dangling-doc-comments")
+    }
 }

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/build.gradle.kts
@@ -9,9 +9,11 @@ plugins {
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Xlint:-exports,-static,-cast" + compilerArgsExtra)
 }

--- a/platform-sdk/swirlds-base/build.gradle.kts
+++ b/platform-sdk/swirlds-base/build.gradle.kts
@@ -10,9 +10,11 @@ plugins {
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Xlint:-exports,-varargs,-static" + compilerArgsExtra)
 }

--- a/platform-sdk/swirlds-benchmarks/build.gradle.kts
+++ b/platform-sdk/swirlds-benchmarks/build.gradle.kts
@@ -9,10 +9,14 @@ plugins {
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
-tasks.withType<JavaCompile>().configureEach { options.compilerArgs.add("-Xlint:-static" + compilerArgsExtra) }
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Xlint:-static" + compilerArgsExtra)
+}
 
 jmhModuleInfo {
     requires("com.hedera.pbj.runtime")

--- a/platform-sdk/swirlds-common/build.gradle.kts
+++ b/platform-sdk/swirlds-common/build.gradle.kts
@@ -9,12 +9,15 @@ plugins {
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add(
-        "-Xlint:-exports,-lossy-conversions,-overloads,-dep-ann,-text-blocks,-varargs" + compilerArgsExtra
+        "-Xlint:-exports,-lossy-conversions,-overloads,-dep-ann,-text-blocks,-varargs" +
+            compilerArgsExtra
     )
 }
 

--- a/platform-sdk/swirlds-component-framework/build.gradle.kts
+++ b/platform-sdk/swirlds-component-framework/build.gradle.kts
@@ -9,12 +9,15 @@ description = "Component Framework"
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add(
-        "-Xlint:-exports,-lossy-conversions,-overloads,-dep-ann,-text-blocks,-varargs" + compilerArgsExtra
+        "-Xlint:-exports,-lossy-conversions,-overloads,-dep-ann,-text-blocks,-varargs" +
+            compilerArgsExtra
     )
 }
 

--- a/platform-sdk/swirlds-fcqueue/build.gradle.kts
+++ b/platform-sdk/swirlds-fcqueue/build.gradle.kts
@@ -15,7 +15,8 @@ testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
 }
-if(JavaVersion.current() >= JavaVersion.VERSION_25) {
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
     tasks.withType<JavaCompile>().configureEach {
         options.compilerArgs.add("-Xlint:-dangling-doc-comments")
     }

--- a/platform-sdk/swirlds-logging/build.gradle.kts
+++ b/platform-sdk/swirlds-logging/build.gradle.kts
@@ -11,9 +11,11 @@ plugins {
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Xlint:-deprecation,-exports,-removal,-varargs" + compilerArgsExtra)
 }

--- a/platform-sdk/swirlds-merkledb/build.gradle.kts
+++ b/platform-sdk/swirlds-merkledb/build.gradle.kts
@@ -11,9 +11,11 @@ plugins {
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.add("-Xlint:-exports,-lossy-conversions" + compilerArgsExtra)
 }

--- a/platform-sdk/swirlds-platform-core/build.gradle.kts
+++ b/platform-sdk/swirlds-platform-core/build.gradle.kts
@@ -10,11 +10,15 @@ plugins {
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add("-Xlint:-exports,-overloads,-text-blocks,-dep-ann,-varargs" + compilerArgsExtra)
+    options.compilerArgs.add(
+        "-Xlint:-exports,-overloads,-text-blocks,-dep-ann,-varargs" + compilerArgsExtra
+    )
 }
 
 mainModuleInfo {

--- a/platform-sdk/swirlds-state-impl/build.gradle.kts
+++ b/platform-sdk/swirlds-state-impl/build.gradle.kts
@@ -19,8 +19,8 @@ testModuleInfo {
     requires("org.mockito.junit.jupiter")
 }
 
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-  tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add("-Xlint:-dangling-doc-comments")
-  }
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    tasks.withType<JavaCompile>().configureEach {
+        options.compilerArgs.add("-Xlint:-dangling-doc-comments")
+    }
 }

--- a/platform-sdk/swirlds-virtualmap/build.gradle.kts
+++ b/platform-sdk/swirlds-virtualmap/build.gradle.kts
@@ -13,11 +13,15 @@ plugins {
 // Remove the following line to enable all 'javac' lint checks that we have turned on by default
 // and then fix the reported issues.
 var compilerArgsExtra = ""
-if(JavaVersion.current() >= JavaVersion.VERSION_25){
-    compilerArgsExtra+=",-dangling-doc-comments"
+
+if (JavaVersion.current() >= JavaVersion.VERSION_25) {
+    compilerArgsExtra += ",-dangling-doc-comments"
 }
+
 tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add("-Xlint:-exports,-lossy-conversions,-synchronization" + compilerArgsExtra)
+    options.compilerArgs.add(
+        "-Xlint:-exports,-lossy-conversions,-synchronization" + compilerArgsExtra
+    )
 }
 
 mainModuleInfo { annotationProcessor("com.swirlds.config.processor") }


### PR DESCRIPTION
**Description**:
Since JDK23, new javadoc warning introduced that fails current CN gradle build with JDK25 compiler.
The fix is to explicitly tell compiler to ignore cases of 'dangling-doc-comments'.

As a reference, there were "uncountable" number of old-style javadoc comments that failed gradle: see
them in diff: https://github.com/hiero-ledger/hiero-consensus-node/compare/main...alexk/JDK25_sources
The suppressing/fixing all individual cases of such comments is less practical.
 
**Related issue(s)**:

Fixes #22142

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
