### PR TITLE
docs: Remove deprecated block footer fields (BMT v69)

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/block_proof.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/block_proof.proto
@@ -110,108 +110,6 @@ message BlockProof {
     uint64 block = 1;
 
     /**
-     * A block root hash for the previous block.
-     * <p>
-     * This value MUST match the block merkle tree root hash of the previous
-     * block in the block stream.<br/>
-     * This value SHALL be empty for the genesis block, and SHALL NOT be empty
-     * for any other block.<br/>
-     * Client systems SHOULD optimistically reject any block with a
-     * `previous_block_proof_hash` that does not match the block hash of the
-     * previous block and MAY assume the block stream has encountered data
-     * loss, data corruption, or unauthorized modification.
-     * <p>
-     * The process for computing a block hash is somewhat complex, and involves
-     * creating a "virtual" merkle tree to obtain the root merkle hash of
-     * that virtual tree.<br/>
-     * The merkle tree SHALL have a 4 part structure with 2 internal nodes,
-     * structured in a strictly binary tree.
-     * <ul>
-     *   <li>The merkle tree root SHALL be the parent of both
-     *       internal nodes.
-     *     <ol>
-     *       <li>The first "internal" node SHALL be the parent of the
-     *           two "left-most" nodes.
-     *         <ol>
-     *           <li>The first leaf MUST be the previous block hash, and is a
-     *               single 48-byte value.</li>
-     *           <li>The second leaf MUST be the root of a, strictly binary,
-     *               merkle tree composed of all "input" block items in
-     *               the block.<br/>
-     *               Input items SHALL be transactions, system transactions,
-     *               and events.<br/>
-     *               Leaf nodes in this subtree SHALL be ordered in the
-     *               same order that the block items are encountered
-     *               in the stream.</li>
-     *         </ol>
-     *       </li>
-     *       <li>The second "internal" node SHALL be the parent of the
-     *           two "right-most" nodes.
-     *         <ol>
-     *           <li>The third leaf MUST be the root of a, strictly binary,
-     *               merkle tree composed of all "output" block items in
-     *               the block.<br/>
-     *               Output items SHALL be transaction result, transaction
-     *               output, and state changes.<br/>
-     *               Leaf nodes in this subtree SHALL be ordered in the
-     *               same order that the block items are encountered
-     *               in the stream.</li>
-     *           <li>The fourth leaf MUST be the merkle tree root hash for
-     *               network state at the start of the block, and is a single
-     *               48-byte value.</li>
-     *         </ol>
-     *       </li>
-     *     </ol>
-     *   </li>
-     *   <li>The block hash SHALL be the SHA-384 hash calculated for the root
-     *       of this merkle tree.</li>
-     * </ul>
-     */
-    bytes previous_block_root_hash = 2 [deprecated = true];
-
-    /**
-     * A merkle root hash of the network state.<br/>
-     * This is present to support validation of this block proof by clients
-     * that do not maintain a full copy of the network state.
-     * <p>
-     * This MUST contain a hash of the "state" merkle tree root at the start
-     * of the current block (which this block proof verifies).<br/>
-     * State processing clients SHOULD calculate the state root hash
-     * independently and SHOULD NOT rely on this value.<br/>
-     * State processing clients MUST validate the application of state changes
-     * for a block using the value present in the Block Proof of the
-     * _following_ block.
-     * Compliant consensus nodes MUST produce an "empty" block (containing
-     * only `BlockHeader` and `BlockProof` as the last block prior to a
-     * network "freeze" to ensure the final state hash is incorporated into
-     * the Block Stream correctly.
-     * Stateless (non-state-processing) clients MUST use this value to
-     * construct the block merkle tree.
-     */
-    bytes start_of_block_state_root_hash = 3 [deprecated = true];
-
-    /**
-     * A TSS signature for one block.<br/>
-     * This is a single signature representing the collection of partial
-     * signatures from nodes holding strictly greater than 2/3 of the
-     * current network "weight" in aggregate. The signature is produced by
-     * cryptographic "aggregation" of the partial signatures to produce a
-     * single signature that can be verified with the network public key,
-     * but could not be produced by fewer nodes than required to meet the
-     * threshold for network stake "weight".
-     * <p>
-     * This message MUST make use of a threshold signature scheme like `BLS`
-     * which provides the necessary cryptographic guarantees.<br/>
-     * This signature SHALL use a TSS signature to provide a single signature
-     * that represents the consensus signature of consensus nodes.<br/>
-     * The exact subset of nodes that signed SHALL neither be known nor
-     * tracked, but it SHALL be cryptographically verifiable that the
-     * threshold was met if the signature itself can be validated with
-     * the network public key (a.k.a `LedgerID`).
-     */
-    bytes block_signature = 4 [deprecated = true];
-
-    /**
      * A set of hash values along with ordering information.<br/>
      * This list of hash values form the set of sibling hash values needed to
      * correctly reconstruct the parent hash, and all hash values "above" that
@@ -238,19 +136,19 @@ message BlockProof {
      * "secondary" root hash MUST then be verified using the value of
      * `block_signature`.
      */
-    repeated MerkleSiblingHash sibling_hashes = 5;
+    repeated MerkleSiblingHash sibling_hashes = 2;
 
     /**
      * The hinTS key that this signature verifies under; a stream consumer should
      * only use this key after first checking the chain of trust proof.
      */
-    bytes verification_key = 6;
+    bytes verification_key = 3;
 
     /**
      * Proof the hinTS verification key is in the chain of trust extending
      * from the network's ledger id.
      */
-    ChainOfTrustProof verification_key_proof = 7;
+    ChainOfTrustProof verification_key_proof = 4;
 
     /**
      * The proof contents verifying the block's merkle root hash.<br/>
@@ -266,14 +164,16 @@ message BlockProof {
          * used when the current block is signed directly by the consensus
          * nodes with a TSS signature; otherwise it MUST be empty.
          */
-        TssSignedBlockProof signed_block_proof = 8;
+        TssSignedBlockProof signed_block_proof = 5;
+
         /**
          * A proof of the block merkle tree's contents. This proof SHALL
          * contain the information necessary to validate the previous block's
          * hash, along with any information necessary to validate the current
          * block's hash.
          */
-        StateProof block_state_proof = 9;
+        StateProof block_state_proof = 6;
+
         /**
          * A proof consisting of RSA signatures from consensus nodes.<br/>
          * This proof type exists for backward compatibility with blocks that
@@ -282,7 +182,7 @@ message BlockProof {
          * individual RSA signatures from consensus nodes; otherwise it MUST be
          * empty.
          */
-        SignedRecordFileProof signed_record_file_proof = 10;
+        SignedRecordFileProof signed_record_file_proof = 7;
     }
 }
 

--- a/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/output/block_footer.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/output/block_footer.proto
@@ -23,8 +23,16 @@ option java_multiple_files = true;
 
 message BlockFooter {
 
-    /** The root hash of the block, for the previous block to the one this
-     *  footer belongs to.
+    /**
+     * The root hash of the block, for the previous block to the one this
+     * footer belongs to. This value MUST match the block merkle tree root
+     * hash of the previous block in the block stream.<br/>
+     * This value SHALL be empty for the genesis block, and SHALL NOT be empty
+     * for any other block.<br/>
+     * Client systems SHOULD optimistically reject any block with a
+     * `previous_block_proof_hash` that does not match the block hash of the
+     * previous block and MAY assume the block stream has encountered data
+     * loss, data corruption, or unauthorized modification.
      */
     bytes previous_block_root_hash = 1;
 
@@ -34,8 +42,20 @@ message BlockFooter {
      */
     bytes root_hash_of_all_block_hashes_tree = 2;
 
-    /** The root hash of the state merkle tree for the version of state at
-     *  the beginning of the current block.
+    /**
+     * A merkle root hash of the network state.<br/>
+     * This is present to support validation of this block proof by clients
+     * that do not maintain a full copy of the network state.
+     * <p>
+     * This MUST contain a hash of the "state" merkle tree root at the start
+     * of the current block.<br/>
+     * State processing clients SHOULD calculate the state root hash
+     * independently and SHOULD NOT rely on this value.<br/>
+     * State processing clients MUST validate the application of state changes
+     * for a block using the value present in the Block Footer of the
+     * _following_ block.
+     * Stateless (non-state-processing) clients MUST use this value to
+     * construct the block merkle tree.
      */
     bytes start_of_block_state_root_hash = 3;
 }


### PR DESCRIPTION
A few of the properties inside of the `BlockFooter` protobuf message are now deprecated and should be removed. Documentation for the corresponding new properties in the `BlockFooter` have been ported over as appropriate. 

Note that the fields in `BlockFooter` _have_ been re-numbered. 

Part of #22077