### PR TITLE
ci(bug): Fix broken workflow -- make non-required arguments not required

### DIFF
--- a/.github/workflows/zxc-xts-tests.yaml
+++ b/.github/workflows/zxc-xts-tests.yaml
@@ -71,10 +71,10 @@ on:
         required: false
       gradle-cache-username:
         description: "Gradle Cache Username"
-        required: true
+        required: false
       gradle-cache-password:
         description: "Gradle Cache Password"
-        required: true
+        required: false
       grafana-agent-username:
         description: "Grafana Agent Username"
         required: false


### PR DESCRIPTION
## Description

This pull request makes a small change to the GitHub Actions workflow configuration by making the `gradle-cache-username` and `gradle-cache-password` inputs optional instead of required. This allows the workflow to run without these credentials if they are not provided.

Fixes [this workflow error](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/19439647682/workflow)

## Related Issue(s)

Fixes #22200 