### PR TITLE
ci(fix): Set mirror node version for MN regression w env var

### DIFF
--- a/.github/workflows/zxc-mirror-node-regression.yaml
+++ b/.github/workflows/zxc-mirror-node-regression.yaml
@@ -4,27 +4,31 @@ on:
   workflow_call:
     inputs:
       ref:
-        description: "The branch, tag, or SHA to checkout:"
+        description: "The branch, tag, or SHA to checkout"
         required: false
         type: string
       custom-job-name:
-        description: "The custom job name to use for the job:"
+        description: "The custom job name to use for the job"
         required: false
         type: string
       solo-version:
-        description: "The version of solo to install (if not specified, latest will be used):"
+        description: "The version of solo to install (if not specified, latest will be used)"
         required: false
         type: string
       helm-release-name:
         description: "The Helm release name to use for the mirror node deployment"
         required: false
         type: string
+      mirror-node-version:
+        description: "The version of the mirror node to deploy (if not specified, '0.142.2' will be used)"
+        required: false
+        type: string
     secrets:
       access-token:
-        description: "GitHub Access Token with write permissions to the repository."
+        description: "GitHub Access Token with write permissions to the repository"
         required: true
       slack-detailed-report-webhook:
-        description: "Slack Webhook URL for TCK Monitoring."
+        description: "Slack Webhook URL for TCK Monitoring"
         required: true
 
 defaults:
@@ -96,7 +100,7 @@ jobs:
       - name: Configure and run solo
         id: run-solo
         env:
-          MIRROR_NODE_VERSION: "0.142.2"
+          MIRROR_NODE_VERSION: ${{ inputs.mirror-node-version || '0.142.2' }}
         run: |
           set -ex
           cat <<EOF > mirror.yml
@@ -117,6 +121,7 @@ jobs:
           version=$(solo --version | grep Version | awk '{print $3}')
           solo_ge_0440=$([[ "$(printf '%s\n' "${version}" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]] && echo "true" || echo "false")
           echo "::debug::solo_ge_0440=${solo_ge_0440}"
+          echo "::debug::MIRROR_NODE_VERSION=${MIRROR_NODE_VERSION}"
           if [[ "${solo_ge_0440}" == "true" ]]; then
             echo "::debug::Solo version ($version) is >= 0.44.0"
             solo cluster-ref config connect --cluster-ref "kind-${SOLO_CLUSTER_NAME}" --context "kind-${SOLO_CLUSTER_NAME}"

--- a/.github/workflows/zxc-xts-tests.yaml
+++ b/.github/workflows/zxc-xts-tests.yaml
@@ -41,6 +41,10 @@ on:
         type: string
         description: "The solo version to use for the regression panels"
         default: "latest"
+      mirror-node-version:
+        type: string
+        description: "The mirror node version to deploy for the mirror node regression panel (if not specified, '0.142.2' will be used)"
+        default: "latest"
       helm-release-name:
         type: string
         description: "The helm release name to use for the mirror node regression panel"
@@ -271,6 +275,7 @@ jobs:
       custom-job-name: "${{ inputs.custom-job-label }} Mirror Node Regression"
       solo-version: ${{ inputs.solo-version }}
       helm-release-name: ${{ inputs.helm-release-name }}
+      mirror-node-version: ${{ inputs.mirror-node-version || '0.142.2' }}
     secrets:
       access-token: ${{ secrets.regression-access-token }}
       slack-detailed-report-webhook: ${{ secrets.slack-citr-details-token }}

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -284,6 +284,7 @@ jobs:
       solo-version: ${{ needs.parameters.outputs.solo-version }}
       solo-ge-0440: ${{ needs.parameters.outputs.solo-ge-0440 }}
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
+      mirror-node-version: ${{ vars.CITR_MIRROR_NODE_VERSION }}
       custom-job-label: "XTS (Optional):"
       enable-mirror-node-regression-panel: "true"
       enable-rpc-relay-regression-panel: "true"

--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -104,6 +104,7 @@ jobs:
       branch_name: ${{ inputs.branch_name }}
       solo-version: ${{ needs.parameters.outputs.solo-version }}
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
+      mirror-node-version: ${{ vars.CITR_MIRROR_NODE_VERSION }}
       solo-ge-0440: ${{ needs.parameters.outputs.solo-ge-0440 }}
       enable-extended-test-suite: ${{ inputs.enable-extended-test-suite }}
       enable-abbreviated-panel: ${{ inputs.enable-abbreviated-panel }}


### PR DESCRIPTION
## Description

This pull request introduces a minor update to the workflow configuration by setting a specific environment variable for the mirror node version.

- Workflow configuration:
  * [`.github/workflows/zxc-mirror-node-regression.yaml`](diffhunk://#diff-8a3e8db58b6930d2ea8e049a0495209a5c38eac063d56b77779b926610819a09R98-R99): Added the `MIRROR_NODE_VERSION` environment variable with the value `"0.142.2"` to the `run-solo` step.

## Related Issue(s)

Fixes #22205