### PR TITLE
ci: Use mirrornode v0.142.2 in release/0.68

### DIFF
--- a/.github/workflows/zxc-mirror-node-regression.yaml
+++ b/.github/workflows/zxc-mirror-node-regression.yaml
@@ -15,6 +15,10 @@ on:
         description: "The version of solo to install (if not specified, latest will be used):"
         required: false
         type: string
+      mirror-node-version:
+        description: "The version of the mirror node to deploy (if not specified, '0.142.2' will be used)"
+        required: false
+        type: string
       helm-release-name:
         description: "The Helm release name to use for the mirror node deployment"
         required: false
@@ -95,6 +99,8 @@ jobs:
 
       - name: Configure and run solo
         id: run-solo
+        env:
+          MIRROR_NODE_VERSION: ${{ inputs.mirror-node-version || '0.142.2' }}
         run: |
           set -ex
           cat <<EOF > mirror.yml

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -401,6 +401,7 @@ jobs:
       custom-job-name: "Mirror Node Regression"
       solo-version: ${{ vars.CITR_SOLO_VERSION }}
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
+      mirror-node-version: ${{ vars.CITR_MIRROR_NODE_VERSION }}
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}

--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -254,6 +254,7 @@ jobs:
       custom-job-name: "Mirror Node Regression"
       solo-version: ${{ needs.parameters.outputs.solo-version || vars.CITR_SOLO_VERSION }}
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
+      mirror-node-version: ${{ vars.CITR_MIRROR_NODE_VERSION }}
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}


### PR DESCRIPTION
## Description

This pull request adds support for specifying the mirror node version in several GitHub Actions workflows, improving flexibility and consistency in deployment and testing. The main changes introduce a new input parameter for the mirror node version, set a default value when not provided, and ensure this version is passed through relevant jobs.

**Workflow enhancements:**

* Added a new input parameter `mirror-node-version` to the `.github/workflows/zxc-mirror-node-regression.yaml` workflow, allowing the mirror node version to be specified (defaults to `0.142.2` if not set).
* Updated the `Configure and run solo` step in `.github/workflows/zxc-mirror-node-regression.yaml` to set the `MIRROR_NODE_VERSION` environment variable using the new input or the default value.

**Propagation of mirror node version:**

* Modified `.github/workflows/zxcron-extended-test-suite.yaml` to pass the `mirror-node-version` parameter from workflow variables to the regression job.
* Modified `.github/workflows/zxf-dry-run-extended-test-suite.yaml` to pass the `mirror-node-version` parameter from workflow variables to the regression job.

## Related Issues

Relates to #22205 

## Testing

- [XTS Dry Run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/19445127145)