### PR TITLE
ci(bug-fix): Fix invalid secret name in zxcron-extended-test-suite.yaml

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -291,7 +291,7 @@ jobs:
       enable-block-node-regression-panel: "true"
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
-      slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+      slack-citr-details-token: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
   tag-for-promotion:
     name: Tag as XTS-Passing


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `.github/workflows/zxcron-extended-test-suite.yaml` workflow file, renaming a secret to improve naming consistency.

- Renamed the secret `slack-detailed-report-webhook` to `slack-citr-details-token` in the workflow job configuration for clarity and consistency.

## Related Issue(s)

Fixes #22200

## Testing

[Workflow is shown to be valid](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/19470747258)