### PR TITLE
test: Update ERC20ContractInteractions to fix insufficient payer balance

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC20ContractInteractions.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/openzeppelin/ERC20ContractInteractions.java
@@ -12,6 +12,7 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.evmAddressFromSecp256k1Key;
@@ -20,6 +21,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_CONTRACT_RECEIVER;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_CONTRACT_SENDER;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_RECEIVER_SOURCE_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
 import static com.hedera.services.bdd.suites.contract.Utils.asAddressInTopic;
@@ -31,6 +33,7 @@ import static org.hiero.base.utility.CommonUtils.unhex;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.stream.Stream;
@@ -74,6 +77,7 @@ public class ERC20ContractInteractions {
                 newKeyNamed(VALID_ALIAS).shape(SECP_256K1_SHAPE),
                 getAccountBalance(DEFAULT_CONTRACT_SENDER),
                 getAccountInfo(DEFAULT_CONTRACT_SENDER).savingSnapshot(DEFAULT_CONTRACT_SENDER),
+                cryptoTransfer(TokenMovement.movingHbar(10_000_000L).between(GENESIS, DEFAULT_CONTRACT_RECEIVER)),
                 getAccountInfo(DEFAULT_CONTRACT_RECEIVER).savingSnapshot(DEFAULT_CONTRACT_RECEIVER),
                 withOpContext((spec, log) -> {
                     final var ownerInfo = spec.registry().getAccountInfo(DEFAULT_CONTRACT_SENDER);


### PR DESCRIPTION
**Description**:
This pull request makes a small update to the ERC20 contract interaction tests by ensuring the `DEFAULT_CONTRACT_RECEIVER` account has sufficient HBAR balance before running contract-related operations. The change introduces a `cryptoTransfer` operation to fund the receiver account, improving the reliability of the test suite.

Most important change:

* Added a `cryptoTransfer` operation to transfer HBAR from the `GENESIS` account to `DEFAULT_CONTRACT_RECEIVER` at the start of the `callsERC20ContractInteractions` test, ensuring the receiver has funds for subsequent contract interactions.

**Related issue(s)**:

Fixes #22230 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
