### PR TITLE
chore(ci): add skip release candidate notes generation flag

### DIFF
--- a/.github/workflows/flow-generate-release-notes.yaml
+++ b/.github/workflows/flow-generate-release-notes.yaml
@@ -64,7 +64,7 @@ jobs:
             echo "Skipping prerelease tag: $tag" | tee -a "${GITHUB_STEP_SUMMARY}"
             echo "skip-generate-release-notes=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "Not a prerelease tag: $tag" | tee -a "${GITHUB_STEP_SUMMARY}"
+            echo "Not a prerelease tag: ${tag}" | tee -a "${GITHUB_STEP_SUMMARY}"
             echo "skip-generate-release-notes=false" >> "${GITHUB_OUTPUT}"
           fi
 


### PR DESCRIPTION
**Description**:

Add a var to skip the release candidate notes generation and continue cleanly rather than exiting the workflow.

**Related Issue(s)**:

Implements #22241

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
	- [x] `v0.68.1` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/19510680548/job/55849262219)
	- [x] `v0.68.2-rc.1` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/19511127684)
