### PR TITLE
chore: Backport 22211: Use the latest block when initializing which block to stream first

### DIFF
--- a/hedera-node/docs/design/app/blocks/BlockNodeConnection.md
+++ b/hedera-node/docs/design/app/blocks/BlockNodeConnection.md
@@ -64,10 +64,8 @@ sending requests to the block node. The worker operates in a loop, sleeping for 
 the configuration property `blockNode.connectionWorkerSleepDuration`. When not sleeping, the worker will first check if
 the current streaming block needs to be updated. If this is the first time the worker has performed this check, one of
 the following will happen:
-- If the connection with initialized with an explicit block to start with, then that block will be loaded from the block buffer.
-- If the connection wasn't initialized with an explicit block, then the earliest, unacknowledged block in the block buffer
-will be selected as the starting point.
-- If no blocks in the block buffer have been acknowledged, then the earliest block in the buffer will be selected.
+- If the connection was initialized with an explicit block to start with, then that block will be loaded from the block buffer.
+- If the connection wasn't initialized with an explicit block, then the most recent block produced is chosen as the block to start streaming.
 - If at any point during the lifespan of the connection a `SkipBlock` or `ResendBlock` response is received, then the
 worker will detect this and switch to that block.
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -1127,14 +1127,13 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
         private void switchBlockIfNeeded() {
             final long activeBlockNum = streamingBlockNumber.get();
             if (activeBlockNum == -1) {
-                final long highestAckedBlock = blockBufferService.getHighestAckedBlockNumber();
-                if (highestAckedBlock != -1) {
-                    // Set to the next block that isn't acked
-                    streamingBlockNumber.compareAndSet(activeBlockNum, highestAckedBlock + 1);
-                } else {
-                    // If no blocks are acked, start with the earliest block in the buffer
-                    final long earliestBlock = blockBufferService.getEarliestAvailableBlockNumber();
-                    streamingBlockNumber.compareAndSet(activeBlockNum, earliestBlock);
+                final long latestBlock = blockBufferService.getLastBlockNumberProduced();
+
+                if (streamingBlockNumber.compareAndSet(-1L, latestBlock)) {
+                    logger.info(
+                            "{} Connection was not initialized with a starting block; defaulting to latest block produced ({})",
+                            BlockNodeConnection.this,
+                            latestBlock);
                 }
             }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
@@ -1074,13 +1074,13 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testConnectionWorker_switchBlock_initializeToHighestAckedBlock() throws Exception {
+    void testConnectionWorker_switchBlock_initialValue() throws Exception {
         openConnectionAndResetMocks();
         final AtomicReference<Thread> workerThreadRef = workerThreadRef();
         workerThreadRef.set(null); // clear out the fake worker thread so a real one can be initialized
         final AtomicLong streamingBlockNumber = streamingBlockNumber();
 
-        doReturn(100L).when(bufferService).getHighestAckedBlockNumber();
+        doReturn(101L).when(bufferService).getLastBlockNumberProduced();
         doReturn(new BlockState(101)).when(bufferService).getBlockState(101);
 
         assertThat(streamingBlockNumber).hasValue(-1);
@@ -1091,36 +1091,8 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         assertThat(workerThreadRef).doesNotHaveNullValue();
         assertThat(streamingBlockNumber).hasValue(101);
 
-        verify(bufferService).getHighestAckedBlockNumber();
+        verify(bufferService).getLastBlockNumberProduced();
         verify(bufferService).getBlockState(101);
-        verifyNoMoreInteractions(bufferService);
-        verifyNoInteractions(connectionManager);
-        verifyNoInteractions(metrics);
-        verifyNoInteractions(requestPipeline);
-    }
-
-    @Test
-    void testConnectionWorker_switchBlock_initializeToEarliestBlock() throws Exception {
-        openConnectionAndResetMocks();
-        final AtomicReference<Thread> workerThreadRef = workerThreadRef();
-        workerThreadRef.set(null); // clear out the fake worker thread so a real one can be initialized
-        final AtomicLong streamingBlockNumber = streamingBlockNumber();
-
-        doReturn(-1L).when(bufferService).getHighestAckedBlockNumber();
-        doReturn(12L).when(bufferService).getEarliestAvailableBlockNumber();
-        doReturn(new BlockState(12)).when(bufferService).getBlockState(12);
-
-        assertThat(streamingBlockNumber).hasValue(-1);
-
-        connection.updateConnectionState(ConnectionState.ACTIVE);
-        sleep(50); // give some time for the worker loop to detect the changes
-
-        assertThat(workerThreadRef).doesNotHaveNullValue();
-        assertThat(streamingBlockNumber).hasValue(12);
-
-        verify(bufferService).getHighestAckedBlockNumber();
-        verify(bufferService).getEarliestAvailableBlockNumber();
-        verify(bufferService).getBlockState(12);
         verifyNoMoreInteractions(bufferService);
         verifyNoInteractions(connectionManager);
         verifyNoInteractions(metrics);
@@ -1134,8 +1106,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         workerThreadRef.set(null); // clear out the fake worker thread so a real one can be initialized
         final AtomicLong streamingBlockNumber = streamingBlockNumber();
 
-        doReturn(-1L).when(bufferService).getHighestAckedBlockNumber();
-        doReturn(-1L).when(bufferService).getEarliestAvailableBlockNumber();
+        doReturn(-1L).when(bufferService).getLastBlockNumberProduced();
 
         assertThat(streamingBlockNumber).hasValue(-1);
 
@@ -1145,8 +1116,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         assertThat(workerThreadRef).doesNotHaveNullValue();
         assertThat(streamingBlockNumber).hasValue(-1);
 
-        verify(bufferService, atLeastOnce()).getHighestAckedBlockNumber();
-        verify(bufferService, atLeastOnce()).getEarliestAvailableBlockNumber();
+        verify(bufferService, atLeastOnce()).getLastBlockNumberProduced();
         verifyNoMoreInteractions(bufferService);
         verifyNoInteractions(connectionManager);
         verifyNoInteractions(metrics);


### PR DESCRIPTION
**Description**:
Always use the most recent produced block as the initial block to start streaming with. This helps avoid an unrecoverable situation where back pressure is disabled and the earliest unacked block (what we would previously default to send first) has been pruned from the buffer and thus can't be sent.

backport of: https://github.com/hiero-ledger/hiero-consensus-node/pull/22212

**Related issue(s)**:

Fixes #22211 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
