### PR TITLE
chore: Change Block Buffer persistence logic

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
@@ -517,7 +517,7 @@ public class BlockBufferService {
      * @see BlockBufferIO
      */
     public void persistBuffer() {
-        if (!isBackpressureEnabled() || !isStarted.get() || !isBufferPersistenceEnabled()) {
+        if (!isGrpcStreamingEnabled() || !isStarted.get() || !isBufferPersistenceEnabled()) {
             return;
         }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
@@ -1611,40 +1611,6 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testPersistBuffer_recordsMode() throws Throwable {
-        final Configuration config = HederaTestConfigBuilder.create()
-                .withConfigDataType(BlockStreamConfig.class)
-                .withConfigDataType(BlockBufferConfig.class)
-                .withValue("blockStream.writerMode", "GRPC")
-                .withValue("blockStream.streamMode", "RECORDS")
-                .withValue("blockStream.blockPeriod", Duration.ofSeconds(1))
-                .withValue("blockStream.buffer.isBufferPersistenceEnabled", true)
-                .withValue("blockStream.buffer.bufferDirectory", testDir)
-                .getOrCreateConfig();
-        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
-
-        Files.createDirectories(testDirFile.toPath());
-
-        blockBufferService = initBufferService(configProvider);
-
-        // create a block
-        final long BLOCK_1 = 1L;
-        blockBufferService.openBlock(BLOCK_1);
-        final List<BlockItem> block1Items = generateBlockItems(60, BLOCK_1, Set.of(10L, 11L));
-        block1Items.forEach(item -> blockBufferService.addItem(BLOCK_1, item));
-        blockBufferService.closeBlock(BLOCK_1);
-
-        blockBufferService.persistBuffer();
-
-        persistBufferHandle.invoke(blockBufferService);
-
-        // verify nothing on disk - should not persist when streamMode != BLOCKS
-        try (final Stream<Path> stream = Files.list(testDirFile.toPath())) {
-            assertThat(stream.count()).isZero();
-        }
-    }
-
-    @Test
     void testPersistBuffer_notStarted() throws Throwable {
         final Configuration config = HederaTestConfigBuilder.create()
                 .withConfigDataType(BlockStreamConfig.class)

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
@@ -37,5 +37,5 @@ public record BlockBufferConfig(
         @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty double actionStageThreshold,
         @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty Duration actionGracePeriod,
         @ConfigProperty(defaultValue = "85.0") @Min(0) @NetworkProperty double recoveryThreshold,
-        @ConfigProperty(defaultValue = "true") @NodeProperty boolean isBufferPersistenceEnabled,
+        @ConfigProperty(defaultValue = "false") @NodeProperty boolean isBufferPersistenceEnabled,
         @ConfigProperty(defaultValue = "/opt/hgcapp/blockStreams/buffer") @NodeProperty String bufferDirectory) {}


### PR DESCRIPTION
**Description**:
This pull request updates the buffer persistence logic in the block streaming service, focusing on when and how the buffer is persisted to disk. The changes refine the enabling conditions for buffer persistence, update configuration defaults, and remove an obsolete test case.

**Buffer Persistence Logic Updates:**

* Changed the guard in `persistBuffer()` (in `BlockBufferService`) to check `isGrpcStreamingEnabled()` instead of `isBackpressureEnabled()`, ensuring buffer persistence is only attempted when gRPC streaming is active.

**Configuration Changes:**

* Updated the default value of `isBufferPersistenceEnabled` in `BlockBufferConfig` from `true` to `false`

**Test Cleanup:**

* Removed the `testPersistBuffer_recordsMode` test, which verified that buffer persistence does not occur in `RECORDS` stream mode, because this scenario is now obsolete.

**Related issue(s)**:

Fixes #22281 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
