### PR TITLE
chore: Bump Block Node container version to v0.23.1

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
@@ -12,7 +12,7 @@ import org.testcontainers.utility.DockerImageName;
  * A test container for running a block node server instance.
  */
 public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
-    private static final String BLOCK_NODE_VERSION = "0.21.1";
+    private static final String BLOCK_NODE_VERSION = "0.23.1";
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("ghcr.io/hiero-ledger/hiero-block-node:" + BLOCK_NODE_VERSION);
     private static final int GRPC_PORT = 40840;


### PR DESCRIPTION
**Description**:
This pull request updates the `BlockNodeContainer` to use a newer version of the block node server. The only change is updating the `BLOCK_NODE_VERSION` constant from `0.21.1` to `0.23.1`, which will ensure that tests run against the latest compatible block node image.

**Related issue(s)**:

Fixes #22282 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
