### PR TITLE
chore: Bump PBJ to v0.12.8

### DIFF
--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/key/KeyUtilsTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/key/KeyUtilsTest.java
@@ -27,7 +27,7 @@ public class KeyUtilsTest {
         assertTrue(KeyUtils.isEmpty(Key.DEFAULT));
         assertTrue(KeyUtils.isEmpty(Key.newBuilder().keyList(KeyList.DEFAULT).build()));
         assertTrue(KeyUtils.isEmpty(
-                Key.newBuilder().keyList(KeyList.newBuilder().keys().build()).build()));
+                Key.newBuilder().keyList(KeyList.newBuilder().build()).build()));
         assertTrue(KeyUtils.isEmpty(
                 Key.newBuilder().thresholdKey(ThresholdKey.DEFAULT).build()));
         assertTrue(KeyUtils.isEmpty(Key.newBuilder()
@@ -36,7 +36,7 @@ public class KeyUtilsTest {
                 .build()));
         assertTrue(KeyUtils.isEmpty(Key.newBuilder()
                 .thresholdKey(ThresholdKey.newBuilder().threshold(1))
-                .keyList(KeyList.newBuilder().keys().build())
+                .keyList(KeyList.newBuilder().build())
                 .build()));
         assertTrue(KeyUtils.isEmpty(Key.newBuilder().ed25519(Bytes.EMPTY).build()));
         assertTrue(KeyUtils.isEmpty(Key.newBuilder().ecdsaSecp256k1(Bytes.EMPTY).build()));
@@ -55,7 +55,7 @@ public class KeyUtilsTest {
         assertFalse(KeyUtils.isValid(Key.DEFAULT));
         assertFalse(KeyUtils.isValid(Key.newBuilder().keyList(KeyList.DEFAULT).build()));
         assertFalse(KeyUtils.isValid(
-                Key.newBuilder().keyList(KeyList.newBuilder().keys().build()).build()));
+                Key.newBuilder().keyList(KeyList.newBuilder().build()).build()));
         assertFalse(KeyUtils.isValid(
                 Key.newBuilder().thresholdKey(ThresholdKey.DEFAULT).build()));
         assertFalse(KeyUtils.isValid(Key.newBuilder()
@@ -64,7 +64,7 @@ public class KeyUtilsTest {
                 .build()));
         assertFalse(KeyUtils.isValid(Key.newBuilder()
                 .thresholdKey(ThresholdKey.newBuilder().threshold(1))
-                .keyList(KeyList.newBuilder().keys().build())
+                .keyList(KeyList.newBuilder().build())
                 .build()));
         assertFalse(KeyUtils.isValid(Key.newBuilder().ed25519(Bytes.EMPTY).build()));
         assertFalse(

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerPureChecksTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerPureChecksTest.java
@@ -323,8 +323,6 @@ class CryptoTransferHandlerPureChecksTest extends CryptoTransferHandlerTestBase 
         final var txn = newCryptoTransfer(TokenTransferList.newBuilder()
                 .token(TOKEN_2468)
                 // transfers and nftTransfers are intentionally empty (will result in a count of zero transfers)
-                .transfers()
-                .nftTransfers()
                 .build());
         given(pureChecksContext.body()).willReturn(txn);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
@@ -279,8 +279,6 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
         final var txn = newTokenAirdrop(TokenTransferList.newBuilder()
                 .token(TOKEN_2468)
                 // transfers and nftTransfers are intentionally empty (will result in a count of zero transfers)
-                .transfers()
-                .nftTransfers()
                 .build());
         given(pureChecksContext.body()).willReturn(txn);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AdjustHbarChangesStepTest.java
@@ -180,7 +180,6 @@ class AdjustHbarChangesStepTest extends StepsBase {
                 .transfers(TransferList.newBuilder()
                         .accountAmounts(aaWithAllowance(ownerId, -1_0000), aaWith(unknownAliasedId, +1_000))
                         .build())
-                .tokenTransfers()
                 .build();
         givenTxn(body, spenderId);
         ensureAliasesStep = new EnsureAliasesStep(body);
@@ -212,7 +211,6 @@ class AdjustHbarChangesStepTest extends StepsBase {
                 .transfers(TransferList.newBuilder()
                         .accountAmounts(aaWith(ownerId, -1_0001), aaWith(unknownAliasedId, +1_000))
                         .build())
-                .tokenTransfers()
                 .build();
         givenTxn(body, spenderId);
         ensureAliasesStep = new EnsureAliasesStep(body);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
@@ -282,7 +282,6 @@ class EnsureAliasesStepTest extends StepsBase {
                                 aaWith(ownerId, -1_000),
                                 aaWith(unknownAliasedId, +1_000))
                         .build())
-                .tokenTransfers()
                 .build();
         txn = asTxn(body, payerId);
         given(handleContext.body()).willReturn(txn);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/ReplaceAliasesWithIDsInOpTest.java
@@ -274,7 +274,6 @@ class ReplaceAliasesWithIDsInOpTest extends StepsBase {
                                 AccountAmountUtils.aaWith(ownerId, -1_000),
                                 AccountAmountUtils.aaWith(unknownAliasedId, +1_000))
                         .build())
-                .tokenTransfers()
                 .build();
         txn = asTxn(body, payerId);
         given(handleContext.body()).willReturn(txn);

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.hiero.gradle.build") version "0.6.2"
-    id("com.hedera.pbj.pbj-compiler") version "0.12.2" apply false
+    id("com.hedera.pbj.pbj-compiler") version "0.12.8" apply false
 }
 
 javaModules {


### PR DESCRIPTION
**Description**:
This pull request upgrades the PBJ compiler plugin version. The changes remove unnecessary explicit empty field initializations in test cases, relying on default object construction, and update the build configuration for improved compatibility.

Test code simplification:

* Removed explicit `.keys()` and empty `.transfers()`/`.nftTransfers()` calls when constructing empty `KeyList` and `TokenTransferList` objects in various test cases, simplifying object creation and relying on default values.

Build configuration update:

* Upgraded the `com.hedera.pbj.pbj-compiler` Gradle plugin version from `0.12.2` to `0.12.8` in `settings.gradle.kts` for improved build tooling support.

**Related issue(s)**:

Fixes #22288 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
