### PR TITLE
fix: Support zero-weight nodes in sync lag calculation

### DIFF
--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculator.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculator.java
@@ -25,7 +25,7 @@ public class SyncLagCalculator {
     /**
      * Total weight of all nodes except for current node
      */
-    private final long totalWeight;
+    private final long otherNodesTotalWeight;
 
     /**
      * Keep track of how much behind or ahead we are compared to peers based on the latestConsensusRound
@@ -45,7 +45,7 @@ public class SyncLagCalculator {
      */
     public SyncLagCalculator(final NodeId selfId, final Roster roster) {
         this.selfId = selfId;
-        totalWeight = roster.rosterEntries().stream()
+        otherNodesTotalWeight = roster.rosterEntries().stream()
                 .peek(entry -> weightMap.put(NodeId.of(entry.nodeId()), entry.weight()))
                 .peek(entry -> {
                     if (selfId.id() != entry.nodeId()) {
@@ -87,13 +87,13 @@ public class SyncLagCalculator {
     public double getSyncRoundLag() {
         final var lagArray = consensusLag.values().toArray(WeightAndLag[]::new);
         double medianLag;
-        if (totalWeight > 0) {
+        if (otherNodesTotalWeight > 0) {
             // shut up compiler about the loop exit
             medianLag = lagArray[0].lag();
             // we need to sort everything based on lags to look for median
             Arrays.sort(lagArray, Comparator.comparing(WeightAndLag::lag));
 
-            final long correctedTotalWeight = totalWeight;
+            final long correctedTotalWeight = otherNodesTotalWeight;
             long runningWeight = 0;
             for (int i = 0; i < lagArray.length; i++) {
                 runningWeight += lagArray[i].weight();

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculatorTests.java
@@ -3,10 +3,10 @@ package org.hiero.consensus.event.creator.impl.rules;
 
 import static com.swirlds.common.test.fixtures.WeightGenerators.BALANCED_1000_PER_NODE;
 import static com.swirlds.common.test.fixtures.WeightGenerators.GAUSSIAN;
+import static com.swirlds.common.test.fixtures.WeightGenerators.SINGLE_NODE_HAS_ALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 import org.hiero.base.utility.test.fixtures.RandomUtils;
 import org.hiero.base.utility.test.fixtures.ResettableRandom;
@@ -118,14 +118,7 @@ public class SyncLagCalculatorTests {
     public void singleNodeNetworkRealNode(final int zeroWeightNodeCount) {
 
         rosterBuilder.withSize(zeroWeightNodeCount + 1);
-        rosterBuilder.withWeightGenerator((seed, numberOfNodes) -> {
-            final Long[] weights = new Long[numberOfNodes];
-            weights[0] = Math.max(100, seed);
-            for (int i = 1; i < numberOfNodes; i++) {
-                weights[i] = random.nextLong(10000000);
-            }
-            return Arrays.asList(weights);
-        });
+        rosterBuilder.withWeightGenerator(SINGLE_NODE_HAS_ALL);
         final var roster = rosterBuilder.build();
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         assertEquals(0, slc.getSyncRoundLag());
@@ -136,14 +129,7 @@ public class SyncLagCalculatorTests {
     public void singleNodeNetworkUselessNode(final int zeroWeightNodeCount) {
 
         rosterBuilder.withSize(zeroWeightNodeCount + 1);
-        rosterBuilder.withWeightGenerator((seed, numberOfNodes) -> {
-            final Long[] weights = new Long[numberOfNodes];
-            weights[0] = Math.max(100, seed);
-            for (int i = 1; i < numberOfNodes; i++) {
-                weights[i] = 0L;
-            }
-            return Arrays.asList(weights);
-        });
+        rosterBuilder.withWeightGenerator(SINGLE_NODE_HAS_ALL);
         final var roster = rosterBuilder.build();
         final var selfNodeId = NodeId.of(roster.rosterEntries()
                 .get(1 + random.nextInt(zeroWeightNodeCount))
@@ -156,9 +142,9 @@ public class SyncLagCalculatorTests {
                 slc.reportSyncLag(nodeId, random.nextLong(10000000));
             }
         }
-        final long reportedWeight = 123456L;
-        slc.reportSyncLag(NodeId.FIRST_NODE_ID, reportedWeight);
+        final long reportedLag = 123456L;
+        slc.reportSyncLag(NodeId.FIRST_NODE_ID, reportedLag);
 
-        assertEquals(reportedWeight, slc.getSyncRoundLag());
+        assertEquals(reportedLag, slc.getSyncRoundLag());
     }
 }

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/WeightGenerators.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/WeightGenerators.java
@@ -29,6 +29,8 @@ public final class WeightGenerators {
     public static final WeightGenerator GAUSSIAN = GaussianWeightGenerator.withAverageNodeWeight(1000, 100);
     public static final WeightGenerator REAL_NETWORK_GAUSSIAN =
             GaussianWeightGenerator.withNetworkWeight(TOTAL_NETWORK_WEIGHT, 100_000);
+    public static final WeightGenerator SINGLE_NODE_HAS_ALL =
+            (long l, int i) -> WeightGenerators.singleNodeWithEntireWeight(i);
 
     private static final long MINIMUM_NON_ZERO_WEIGHT = 1L;
 
@@ -50,7 +52,7 @@ public final class WeightGenerators {
     /**
      * Generates balanced weight values for each node.
      *
-     * @param numberOfNodes the number of nodes to generate weight for
+     * @param numberOfNodes      the number of nodes to generate weight for
      * @param useRealTotalWeight true if the real amount of total weight should be evenly distributed amongst each node
      * @return a list of weight values
      */
@@ -67,8 +69,8 @@ public final class WeightGenerators {
      * will be distributed to maintain weight balance.
      *
      * @param numberOfNodes the number of nodes to generate weight for
-     * @param totalWeight the total amount of weight to distribute. Note that not all weight is assigned if not evenly
-     * divisible among the nodes.
+     * @param totalWeight   the total amount of weight to distribute. Note that not all weight is assigned if not evenly
+     *                      divisible among the nodes.
      * @return a list of weight values
      */
     public static List<Long> balancedNodeWeights(final int numberOfNodes, final long totalWeight) {
@@ -79,10 +81,10 @@ public final class WeightGenerators {
     /**
      * Generates random node weights.
      *
-     * @param weightSeed the seed to use for the random number generator
-     * @param numberOfNodes the number of nodes to generate weight for
+     * @param weightSeed         the seed to use for the random number generator
+     * @param numberOfNodes      the number of nodes to generate weight for
      * @param useRealTotalWeight if true, the real amount of total weight should be distributed. If false, a smaller,
-     * easier to read value will be used as the maximum for each node.
+     *                           easier to read value will be used as the maximum for each node.
      * @return a list of weight values
      */
     public static List<Long> randomNodeWeights(
@@ -97,9 +99,9 @@ public final class WeightGenerators {
      * Generates a list of node weights that are pseudo-random and sum to exactly {@code totalWeight}. No node is
      * assigned more than 1/2 of the total weight. Nodes may be assigned zero weight.
      *
-     * @param weightSeed the seed to use for the random number generator
+     * @param weightSeed    the seed to use for the random number generator
      * @param numberOfNodes the number of nodes to generate weight for
-     * @param totalWeight the total amount of weight to distribute
+     * @param totalWeight   the total amount of weight to distribute
      * @return a list of weight values
      */
     public static List<Long> randomNodeWeights(final long weightSeed, final int numberOfNodes, final long totalWeight) {
@@ -121,7 +123,7 @@ public final class WeightGenerators {
     /**
      * Generates random weight values for each node between 1 (inclusive) and 90 (exclusive).
      *
-     * @param weightSeed the seed to use for the random number generator
+     * @param weightSeed    the seed to use for the random number generator
      * @param numberOfNodes the number of nodes to generate weight for
      * @return a list of weight values
      */
@@ -178,6 +180,28 @@ public final class WeightGenerators {
                 weight = strongMinorityWeight;
             }
             nodeWeights.add(weight);
+        }
+        return nodeWeights;
+    }
+
+    /**
+     * Creates a list of node weights where a single node has entire weight, all other nodes have zero weight.
+     *
+     * @param numberOfNodes the number of nodes to generate weight for
+     * @return test arguments
+     */
+    public static List<Long> singleNodeWithEntireWeight(final int numberOfNodes) {
+
+        final List<Long> nodeWeights = new ArrayList<>(numberOfNodes);
+
+        for (int nodeId = 0; nodeId < numberOfNodes; nodeId++) {
+
+            if (nodeId == 0) {
+                // a single node has entire weight
+                nodeWeights.add(TOTAL_NETWORK_WEIGHT);
+            } else {
+                nodeWeights.add(0L);
+            }
         }
         return nodeWeights;
     }


### PR DESCRIPTION
**Description**:

Sync lag calculation had special support for single-node networks, where the roster had only a single entry. Unfortunately, it was failing in case there were multiple nodes, but only one of them had a non-zero weight. This PR fixes this special case.

**Related issue(s)**:

Fixes #22292 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
