### PR TITLE
chore: switch hashgraph to hiero-ledger packages in tck regression workflow

### DIFF
--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -139,14 +139,14 @@ jobs:
           # Extract package versions from the parent package.json
           SDK_VERSION=$(node -e "console.log(require('../package.json').version)")
           LONG_VERSION=$(node -e "console.log(require('../package.json').dependencies.long)")
-          PROTO_VERSION=$(node -e "console.log(require('../package.json').dependencies['@hashgraph/proto'])")
+          PROTO_VERSION=$(node -e "console.log(require('../package.json').dependencies['@hiero-ledger/proto'])")
 
           echo "Using SDK version: ${SDK_VERSION}"
           echo "Using long version: ${LONG_VERSION}"
           echo "Using proto version: ${PROTO_VERSION}"
 
           # Install with the extracted versions
-          pnpm add @hashgraph/sdk@^${SDK_VERSION} long@${LONG_VERSION} @hashgraph/proto@${PROTO_VERSION}
+          pnpm add @hiero-ledger/sdk@^${SDK_VERSION} long@${LONG_VERSION} @hiero-ledger/proto@${PROTO_VERSION}
           pnpm install
           nohup pnpm start &
           server_pid=$!


### PR DESCRIPTION
**Description**:

Update the `hashgraph` packages to `hiero-ledger` proto packages in the TCK Regression workflow.

**Related Issue(s)**:

Fixes #22299

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
  - Dry Run in work [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/19634851501)
