### PR TITLE
fix: 22295: VirtualNodeCache should consider ConcurrentArray memory overhead

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/ConcurrentArray.java
@@ -302,6 +302,29 @@ final class ConcurrentArray<T> {
     }
 
     /**
+     * Gets (estimated) memory overhead of this concurrent array. The overhead is from Java arrays
+     * used by SubArray objects to store elements of this array. Even when this array is empty, a
+     * single SubArray is allocated, which results in Long.BYTES * capacity bytes allocated.
+     *
+     * <p>Using Long.BYTES to estimate Java array size is conservative. On some systems (compressed
+     * ops enabled) each array element may use fewer bytes than Long.BYTES. In this case, estimated
+     * memory overhead will be more than real overhead, which will result in slightly more frequent
+     * flushes to disk. This is acceptable.
+     *
+     * @return Estimated memory overhead of this concurrent array, in bytes
+     */
+    long estimatedStorageMemoryOverhead() {
+        long subArrayCount;
+        if (size() == 0) {
+            // Even an empty concurrent array has one sub-array
+            subArrayCount = 1;
+        } else {
+            subArrayCount = (size() + subarrayCapacity - 1) / subarrayCapacity;
+        }
+        return subArrayCount * subarrayCapacity * Long.BYTES;
+    }
+
+    /**
      * Get a stream of all elements in this concurrent array.
      *
      * <p>This method can only be called on immutable instances. It may be called concurrently.

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -507,6 +507,7 @@ public final class VirtualNodeCache implements FastCopyable, SelfSerializable {
             p.dirtyLeaves.merge(dirtyLeaves);
             p.dirtyLeafPaths.merge(dirtyLeafPaths);
             p.dirtyHashes.merge(dirtyHashes);
+            // Estimated sizes include both mutations and concurrent array overheads
             p.estimatedLeavesSizeInBytes.addAndGet(estimatedLeavesSizeInBytes.get());
             p.estimatedLeafPathsSizeInBytes.addAndGet(estimatedLeafPathsSizeInBytes.get());
             p.estimatedHashesSizeInBytes.addAndGet(estimatedHashesSizeInBytes.get());
@@ -539,6 +540,11 @@ public final class VirtualNodeCache implements FastCopyable, SelfSerializable {
         dirtyLeaves.seal();
         dirtyHashes.seal();
         dirtyLeafPaths.seal();
+
+        // Update estimated size to include concurrent arrays storage overhead
+        estimatedHashesSizeInBytes.addAndGet(dirtyHashes.estimatedStorageMemoryOverhead());
+        estimatedLeavesSizeInBytes.addAndGet(dirtyLeaves.estimatedStorageMemoryOverhead());
+        estimatedLeafPathsSizeInBytes.addAndGet(dirtyLeafPaths.estimatedStorageMemoryOverhead());
     }
 
     // --------------------------------------------------------------------------------------------

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/ConcurrentArrayTest.java
@@ -315,6 +315,23 @@ class ConcurrentArrayTest {
         assertEquals("Element 6", sorted.get(5), "Wrong value");
     }
 
+    @Test
+    void estimatedMemoryOverheadTest() {
+        final int CAPACITY = 10;
+        final ConcurrentArray<String> arr = new ConcurrentArray<>(CAPACITY);
+        assertEquals(CAPACITY * Long.BYTES, arr.estimatedStorageMemoryOverhead());
+        arr.add("Element");
+        assertEquals(CAPACITY * Long.BYTES, arr.estimatedStorageMemoryOverhead());
+        for (int i = 0; i < CAPACITY; i++) {
+            arr.add("Element " + i);
+        }
+        assertEquals(CAPACITY * 2 * Long.BYTES, arr.estimatedStorageMemoryOverhead());
+        for (int i = 0; i < CAPACITY; i++) {
+            arr.add("Element " + (CAPACITY + i));
+        }
+        assertEquals(CAPACITY * 3 * Long.BYTES, arr.estimatedStorageMemoryOverhead());
+    }
+
     /**
      * Other tests indirectly validate this claim, but I thought it worth testing this explicitly.
      */


### PR DESCRIPTION
Fix summary:

* `ConcurrentArray.estimatedStorageMemoryOverhead()` method is introduced
* Estimated overhead is the number of sub-arrays times Long.BYTES (assuming each array element is 8 bytes)
* New concurrent array unit test is added
* New node cache test is added to check estimated sizes when caches are merged

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/22295
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
