### PR TITLE
fix: stabilize flaky test in `BlockNodeConnectionManagerTest`

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -46,7 +46,6 @@ import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1387,13 +1386,10 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         Files.writeString(
                 file, valid, StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
         awaitCondition(() -> !availableNodes().isEmpty(), 5_000);
-
-        // Give the watcher some time to fully process the creation of the configuration file
-        Thread.sleep(1000);
-        final Map<BlockNodeConfiguration, BlockNodeConnection> before = new HashMap<>(connections());
+        final List<BlockNodeConfiguration> before = availableNodes();
         invoke_refreshAvailableBlockNodes();
-        final Map<BlockNodeConfiguration, BlockNodeConnection> after = new HashMap<>(connections());
-        assertThat(after.keySet()).isEqualTo(before.keySet());
+        final List<BlockNodeConfiguration> after = availableNodes();
+        assertThat(after).isEqualTo(before);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Fix `testStartConfigWatcher_reactsToCreateModifyDelete()` flaky unit test in `BlockNodeConnectionManager` by giving the watcher some time to fully process the creation of the configuration file

**Related issue(s)**:

Fixes #22289 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
