### PR TITLE
chore(ci): update BN regression workflow to hiero-ledger/proto package

### DIFF
--- a/.github/workflows/zxc-block-node-regression.yaml
+++ b/.github/workflows/zxc-block-node-regression.yaml
@@ -165,14 +165,14 @@ jobs:
           # Extract package versions from the parent package.json
           SDK_VERSION=$(node -e "console.log(require('../package.json').version)")
           LONG_VERSION=$(node -e "console.log(require('../package.json').dependencies.long)")
-          PROTO_VERSION=$(node -e "console.log(require('../package.json').dependencies['@hashgraph/proto'])")
+          PROTO_VERSION=$(node -e "console.log(require('../package.json').dependencies['@hiero-ledger/proto'])")
 
           echo "Using SDK version: ${SDK_VERSION}"
           echo "Using long version: ${LONG_VERSION}"
           echo "Using proto version: ${PROTO_VERSION}"
 
           # Install with the extracted versions
-          pnpm add @hashgraph/sdk@^${SDK_VERSION} long@${LONG_VERSION} @hashgraph/proto@${PROTO_VERSION}
+          pnpm add @hiero-ledger/sdk@^${SDK_VERSION} long@${LONG_VERSION} @hiero-ledger/proto@${PROTO_VERSION}
           pnpm install
           nohup pnpm start &
           server_pid=$!


### PR DESCRIPTION
**Description**:

Update the Block Node regression workflow to use the `hiero-ledger/proto` published package instead of `hashgraph/proto` namespace package.

**Related Issue(s)**:

Fixes #22338
