### PR TITLE
chore(ci): declare storage class for mirror node regression

### DIFF
--- a/.github/workflows/zxc-mirror-node-regression.yaml
+++ b/.github/workflows/zxc-mirror-node-regression.yaml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
+        with:
+          version: "3.19.2"
 
       - name: Setup NodeJS Environment
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0


### PR DESCRIPTION
**Description**:

We need to declare the storage class for mirror node regression rather than leaving the storage class as a null value.

**Related Issue(s)**:

Fixes #22351
