### PR TITLE
chore: Remove FlickeringIsolationExperiment from default chaos test

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/chaosbot/ChaosBotConfiguration.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/chaosbot/ChaosBotConfiguration.java
@@ -32,8 +32,7 @@ public record ChaosBotConfiguration(
                     new HighLatencyNodeExperiment(),
                     new LowBandwidthNodeExperiment(),
                     new NetworkPartitionExperiment(),
-                    new NodeFailureExperiment(),
-                    new FlickeringIsolationExperiment()));
+                    new NodeFailureExperiment()));
 
     /**
      * Create a new configuration.


### PR DESCRIPTION
**Description**:

This PR removes `FlickeringIsolationExperiment` from the default chaos test. Something causes the chaos test to fail since it was added. I will add it back once I have determined the root cause.

**Related issue(s)**:

Fixes #22358 