### PR TITLE
feat: extend tests for HIP-1300 and support them in an `AtomicBatch`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -102,6 +102,7 @@ import com.hedera.node.app.workflows.query.QueryWorkflow;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.Utils;
 import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.node.config.data.GovernanceTransactionsConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.NetworkAdminConfig;
 import com.hedera.node.config.data.QuiescenceConfig;
@@ -506,10 +507,14 @@ public final class Hedera implements SwirldMain<MerkleNodeState>, AppContext.Gos
         boundaryStateChangeListener = new BoundaryStateChangeListener(storeMetricsService, configSupplier);
         hintsService = hintsServiceFactory.apply(appContext, bootstrapConfig);
         historyService = historyServiceFactory.apply(appContext, bootstrapConfig);
+        final GovernanceTransactionsConfig governanceConfig =
+                bootstrapConfig.getConfigData(GovernanceTransactionsConfig.class);
+        final int maxTransactionBytes = governanceConfig.isEnabled()
+                ? governanceConfig.maxTxnSize()
+                : bootstrapConfig.getConfigData(HederaConfig.class).transactionMaxBytes();
         utilServiceImpl = new UtilServiceImpl(appContext, (txnBytes, config) -> daggerApp
                 .transactionChecker()
-                .parseSignedAndCheck(
-                        txnBytes, config.getConfigData(HederaConfig.class).transactionMaxBytes())
+                .parseSignedAndCheck(txnBytes, maxTransactionBytes)
                 .txBody());
         tokenServiceImpl = new TokenServiceImpl(appContext);
         consensusServiceImpl = new ConsensusServiceImpl();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/BootstrapConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/BootstrapConfigProviderImpl.java
@@ -8,6 +8,7 @@ import com.hedera.node.config.converter.BytesConverter;
 import com.hedera.node.config.converter.CongestionMultipliersConverter;
 import com.hedera.node.config.converter.EntityScaleFactorsConverter;
 import com.hedera.node.config.converter.LongPairConverter;
+import com.hedera.node.config.converter.PermissionedAccountsRangeConverter;
 import com.hedera.node.config.converter.SemanticVersionConverter;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.BlockNodeConnectionConfig;
@@ -16,6 +17,7 @@ import com.hedera.node.config.data.BootstrapConfig;
 import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.FeesConfig;
 import com.hedera.node.config.data.FilesConfig;
+import com.hedera.node.config.data.GovernanceTransactionsConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.JumboTransactionsConfig;
 import com.hedera.node.config.data.LedgerConfig;
@@ -27,6 +29,7 @@ import com.hedera.node.config.sources.PropertyConfigSource;
 import com.hedera.node.config.types.CongestionMultipliers;
 import com.hedera.node.config.types.EntityScaleFactors;
 import com.hedera.node.config.types.LongPair;
+import com.hedera.node.config.types.PermissionedAccountsRange;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
@@ -69,10 +72,12 @@ public class BootstrapConfigProviderImpl extends ConfigProviderBase {
                 .withConfigDataType(OpsDurationConfig.class)
                 .withConfigDataType(JumboTransactionsConfig.class)
                 .withConfigDataType(FeesConfig.class)
+                .withConfigDataType(GovernanceTransactionsConfig.class)
                 .withConverter(Bytes.class, new BytesConverter())
                 .withConverter(SemanticVersion.class, new SemanticVersionConverter())
                 .withConverter(CongestionMultipliers.class, new CongestionMultipliersConverter())
                 .withConverter(EntityScaleFactors.class, new EntityScaleFactorsConverter())
+                .withConverter(PermissionedAccountsRange.class, new PermissionedAccountsRangeConverter())
                 .withConverter(LongPair.class, new LongPairConverter());
 
         try {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
@@ -564,10 +564,14 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
         public Stream<DynamicTest> canNotPutJumboInsideOfBatch() {
             final var payloadSize = 127 * 1024;
             final var payload = new byte[payloadSize];
-            return hapiTest(atomicBatch(jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload))
-                    .hasPrecheck(TRANSACTION_OVERSIZE)
-                    // If we use subprocess network, the transaction should fail at gRPC level
-                    .orUnavailableStatus());
+            return hapiTest(
+                    cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                    atomicBatch(jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                                    .batchKey(PAYER))
+                            .payingWith(PAYER)
+                            .hasPrecheck(TRANSACTION_OVERSIZE)
+                            // If we use subprocess network, the transaction should fail at gRPC level
+                            .orUnavailableStatus());
         }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1300/GovernanceTransactionsTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1300/GovernanceTransactionsTests.java
@@ -4,12 +4,13 @@ package com.hedera.services.bdd.suites.hip1300;
 import static com.hedera.services.bdd.junit.TestTags.MATS;
 import static com.hedera.services.bdd.junit.TestTags.ONLY_SUBPROCESS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
@@ -22,6 +23,8 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.transactions.consensus.HapiTopicCreate;
 import com.hedera.services.bdd.suites.regression.system.LifecycleTest;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
@@ -42,16 +45,20 @@ import org.junit.jupiter.api.Tag;
 @OrderedInIsolation
 @DisplayName("Governance Transactions Tests")
 public class GovernanceTransactionsTests implements LifecycleTest {
-    private static final int OVERSIZED_TXN_SIZE = 130 * 1024; // ~130KB
-    private static final int LARGE_TXN_SIZE = 90 * 1024; // ~90KB
-    private static final String largeSizeMemo = StringUtils.repeat("a", LARGE_TXN_SIZE);
-
     private static final String PAYER = "payer";
+    private static final String PAYER2 = "payer2";
+    private static final String PAYER_KEY = "payer_key";
+    private static final String PAYER_KEY2 = "payer_key2";
     private static final String RECEIVER = "receiver";
     private static final String TOPIC = "topic";
     private static final String TOPIC2 = "topic2";
     private static final String SUBMIT_KEY = "submit_key";
     private static final String SUBMIT_KEY2 = "submit_key2";
+
+    private static final int OVERSIZED_TXN_SIZE = 130 * 1024; // ~130KB
+    private static final int LARGE_TXN_SIZE = 90 * 1024; // ~90KB
+    private static final String LARGE_SIZE_MEMO = StringUtils.repeat("a", LARGE_TXN_SIZE);
+    private static final KeyShape LARGE_SIZE_KEY = listOf(50);
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
@@ -59,143 +66,264 @@ public class GovernanceTransactionsTests implements LifecycleTest {
                 Map.of("hedera.transaction.maxMemoUtf8Bytes", OVERSIZED_TXN_SIZE + "")); // to avoid memo size limit
     }
 
-    // --- Tests to examine the behavior when the feature flag is turned on ---
+    // --- Tests to examine the behavior when the feature flag is on ---
 
     @HapiTest
     @Order(0)
-    @DisplayName("Normal account still cannot submit more than 6KB transactions when the feature is enabled")
-    public Stream<DynamicTest> nonGovernanceAccountCannotSubmitLargeSizeTransactionsIfEnabled() {
+    @DisplayName("Normal account cannot submit more than 6KB transactions, signed by a larger key")
+    public Stream<DynamicTest> nonGovernanceAccountCannotSubmitLargerSizeWithLargeKeyIfEnabled() {
         return hapiTest(
-                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
-                cryptoCreate(RECEIVER).balance(0L),
+                newKeyNamed(PAYER_KEY).shape(LARGE_SIZE_KEY),
+                newKeyNamed(PAYER_KEY2).shape(LARGE_SIZE_KEY),
                 newKeyNamed(SUBMIT_KEY),
+                cryptoCreate(PAYER).key(PAYER_KEY).balance(ONE_HUNDRED_HBARS).hasKnownStatus(SUCCESS),
+                cryptoCreate(PAYER2).key(PAYER_KEY2).balance(ONE_HUNDRED_HBARS).hasKnownStatus(SUCCESS),
                 createTopic(TOPIC)
                         .submitKeyName(SUBMIT_KEY)
                         .payingWith(PAYER)
-                        .memo(largeSizeMemo)
-                        .hasPrecheck(TRANSACTION_OVERSIZE)
-                        // the submitted transaction exceeds 6144 bytes and will have its
-                        // gRPC request terminated immediately
-                        .orUnavailableStatus());
+                        .signedBy(PAYER, PAYER2)
+                        .hasPrecheck(TRANSACTION_OVERSIZE));
     }
 
     @HapiTest
     @Order(1)
-    @DisplayName("Treasury and system admin accounts can submit more than 6KB transactions when the feature is enabled")
-    public Stream<DynamicTest> governanceAccountCanSubmitLargeSizeTransactions() {
+    @DisplayName("Governance account can submit more than 6KB transactions, signed by a larger key")
+    public Stream<DynamicTest> governanceAccountCanSubmitLargerSizeWithLargeKeyIfEnabled() {
         return hapiTest(
-                cryptoCreate(RECEIVER).balance(0L),
+                newKeyNamed(PAYER_KEY).shape(LARGE_SIZE_KEY),
+                newKeyNamed(PAYER_KEY2).shape(LARGE_SIZE_KEY),
                 newKeyNamed(SUBMIT_KEY),
-                newKeyNamed(SUBMIT_KEY2),
+                cryptoCreate(PAYER).key(PAYER_KEY).balance(ONE_HUNDRED_HBARS).hasKnownStatus(SUCCESS),
+                cryptoCreate(PAYER2).key(PAYER_KEY2).balance(ONE_HUNDRED_HBARS).hasKnownStatus(SUCCESS),
                 createTopic(TOPIC)
                         .submitKeyName(SUBMIT_KEY)
-                        .payingWith(GENESIS)
-                        .memo(largeSizeMemo)
-                        .hasKnownStatus(SUCCESS),
-                createTopic(TOPIC2)
-                        .submitKeyName(SUBMIT_KEY2)
                         .payingWith(SYSTEM_ADMIN)
-                        .memo(largeSizeMemo)
+                        .signedBy(SYSTEM_ADMIN, PAYER, PAYER2)
                         .hasKnownStatus(SUCCESS));
     }
 
     @HapiTest
     @Order(2)
-    @DisplayName("Non-governance account cannot submit transfers larger than 6KB even when the feature is enabled")
-    public Stream<DynamicTest> nonGovernanceAccountTransactionLargerThan6kb() {
+    @DisplayName("Normal account still cannot submit more than 6KB transactions when the feature is enabled")
+    public Stream<DynamicTest> nonGovernanceAccountCannotSubmitLargeSizeTransactionsIfEnabled() {
         return hapiTest(
-                cryptoCreate(PAYER).balance(ONE_MILLION_HBARS),
-                cryptoCreate("receiver"),
-                cryptoTransfer(tinyBarsFromTo(PAYER, "receiver", ONE_HUNDRED_HBARS))
-                        .memo(largeSizeMemo)
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(SUBMIT_KEY),
+                createTopic(TOPIC)
+                        .submitKeyName(SUBMIT_KEY)
                         .payingWith(PAYER)
-                        .hasPrecheck(TRANSACTION_OVERSIZE)
-                        .orUnavailableStatus());
+                        .memo(LARGE_SIZE_MEMO)
+                        .hasPrecheck(TRANSACTION_OVERSIZE));
     }
 
     @HapiTest
     @Order(3)
-    @DisplayName(
-            "Treasury and system admin accounts cannot submit more than 6KB transactions when the feature is disabled at runtime")
-    public Stream<DynamicTest> governanceAccountCannotSubmitLargeSizeTransactionsWhenDisabledDynamically() {
-        return hapiTest(
-                cryptoCreate(RECEIVER).balance(0L),
-                newKeyNamed(SUBMIT_KEY),
-                newKeyNamed(SUBMIT_KEY2),
-                overriding("governanceTransactions.isEnabled", "false"),
-                createTopic(TOPIC)
-                        .submitKeyName(SUBMIT_KEY)
-                        .payingWith(GENESIS)
-                        .memo(largeSizeMemo)
-                        .hasPrecheck(TRANSACTION_OVERSIZE)
-                        // the submitted transaction exceeds 6144 bytes and will have its
-                        // gRPC request terminated immediately
-                        .orUnavailableStatus(),
-                createTopic(TOPIC2)
-                        .submitKeyName(SUBMIT_KEY2)
-                        .payingWith(SYSTEM_ADMIN)
-                        .memo(largeSizeMemo)
-                        .hasPrecheck(TRANSACTION_OVERSIZE)
-                        // the submitted transaction exceeds 6144 bytes and will have its
-                        // gRPC request terminated immediately
-                        .orUnavailableStatus());
-    }
+    @DisplayName("Governance account cannot submit more than 6KB batch transactions when only the atomic batch is paid")
+    public Stream<DynamicTest> governanceAccountCannotSubmitWhenPaidOnlyBatchIfEnabled() {
+        final HapiTopicCreate innerTxn = createTopic(TOPIC)
+                .submitKeyName(SUBMIT_KEY)
+                .payingWith(PAYER)
+                .memo(LARGE_SIZE_MEMO)
+                .batchKey(GENESIS);
 
-    // --- Disable the governance transactions feature and test nothing has changed in the previous behavior ---
+        return hapiTest(
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(SUBMIT_KEY),
+                atomicBatch(innerTxn).payingWith(GENESIS).hasPrecheck(TRANSACTION_OVERSIZE));
+    }
 
     @HapiTest
     @Order(4)
-    @DisplayName("Update the governance config to disable governance transactions")
-    public Stream<DynamicTest> updateTheConfig() {
+    @DisplayName(
+            "Governance account cannot submit more than 6KB batch transactions when only the inner transaction is paid")
+    public Stream<DynamicTest> governanceAccountCannotSubmitWhenPaidOnlyInnerIfEnabled() {
+        final HapiTopicCreate innerTxn = createTopic(TOPIC)
+                .submitKeyName(SUBMIT_KEY)
+                .payingWith(GENESIS)
+                .memo(LARGE_SIZE_MEMO)
+                .batchKey(PAYER);
+
         return hapiTest(
-                // The feature flag is only used once at startup (when building gRPC ServiceDefinitions),
-                // so we can't toggle it via overriding(). Instead, we need to upgrade to the config version.
-                prepareFakeUpgrade(),
-                upgradeToNextConfigVersion(Map.of("governanceTransactions.isEnabled", "false"), noOp()));
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(SUBMIT_KEY),
+                atomicBatch(innerTxn).payingWith(PAYER).hasPrecheck(TRANSACTION_OVERSIZE));
     }
 
     @HapiTest
     @Order(5)
-    @DisplayName("Normal account cannot submit more than 6KB transactions when the feature is disabled")
-    public Stream<DynamicTest> nonGovernanceAccountCannotSubmitLargeSizeTransactions() {
+    @DisplayName(
+            "Governance account can submit more than 6KB batch transactions when both the batch and the inner transactions are paid")
+    public Stream<DynamicTest> governanceAccountCanSubmitWhenBothArePaidIfEnabled() {
+        final HapiTopicCreate innerTxn = createTopic(TOPIC)
+                .submitKeyName(SUBMIT_KEY)
+                .payingWith(GENESIS)
+                .memo(LARGE_SIZE_MEMO)
+                .batchKey(GENESIS);
+
         return hapiTest(
-                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
-                cryptoCreate(RECEIVER).balance(0L),
                 newKeyNamed(SUBMIT_KEY),
-                createTopic(TOPIC)
-                        .submitKeyName(SUBMIT_KEY)
-                        .payingWith(PAYER)
-                        .memo(largeSizeMemo)
-                        .hasPrecheck(TRANSACTION_OVERSIZE)
-                        // the submitted transaction exceeds 6144 bytes and will have its
-                        // gRPC request terminated immediately
-                        .orUnavailableStatus());
+                atomicBatch(innerTxn).payingWith(GENESIS).hasKnownStatus(SUCCESS));
     }
 
     @HapiTest
     @Order(6)
-    @DisplayName(
-            "Treasury and system admin accounts cannot submit more than 6KB transactions when the feature is disabled")
-    public Stream<DynamicTest> governanceAccountsCannotSubmitLargeSizeTransactions() {
+    @DisplayName("Treasury and system admin accounts can submit more than 6KB transactions when the feature is enabled")
+    public Stream<DynamicTest> governanceAccountCanSubmitLargeSizeTransactions() {
         return hapiTest(
-                cryptoCreate(RECEIVER).balance(0L),
                 newKeyNamed(SUBMIT_KEY),
                 newKeyNamed(SUBMIT_KEY2),
                 createTopic(TOPIC)
                         .submitKeyName(SUBMIT_KEY)
                         .payingWith(GENESIS)
-                        .memo(largeSizeMemo)
-                        .hasPrecheck(TRANSACTION_OVERSIZE)
-                        // the submitted transaction exceeds 6144 bytes and will have its
-                        // gRPC request terminated immediately
-                        .orUnavailableStatus(),
+                        .memo(LARGE_SIZE_MEMO)
+                        .hasKnownStatus(SUCCESS),
                 createTopic(TOPIC2)
                         .submitKeyName(SUBMIT_KEY2)
                         .payingWith(SYSTEM_ADMIN)
-                        .memo(largeSizeMemo)
-                        .hasPrecheck(TRANSACTION_OVERSIZE)
-                        // the submitted transaction exceeds 6144 bytes and will have its
-                        // gRPC request terminated immediately
-                        .orUnavailableStatus());
+                        .memo(LARGE_SIZE_MEMO)
+                        .hasKnownStatus(SUCCESS));
+    }
+
+    @HapiTest
+    @Order(7)
+    @DisplayName("Non-governance account cannot submit transfers larger than 6KB even when the feature is enabled")
+    public Stream<DynamicTest> nonGovernanceAccountTransactionLargerThan6kb() {
+        return hapiTest(
+                cryptoCreate(PAYER).balance(ONE_MILLION_HBARS),
+                cryptoCreate(RECEIVER),
+                cryptoTransfer(tinyBarsFromTo(PAYER, RECEIVER, ONE_HUNDRED_HBARS))
+                        .memo(LARGE_SIZE_MEMO)
+                        .payingWith(PAYER)
+                        .hasPrecheck(TRANSACTION_OVERSIZE));
+    }
+
+    // --- Test the behavior if the feature is disabled and verify nothing has changed ---
+
+    @HapiTest
+    @Order(8)
+    @DisplayName(
+            "Treasury and system admin accounts cannot submit more than 6KB transactions when the feature is disabled at runtime")
+    public Stream<DynamicTest> governanceAccountCannotSubmitLargeSizeTransactionsWhenDisabledDynamically() {
+        return hapiTest(
+                overriding("governanceTransactions.isEnabled", "false"),
+                newKeyNamed(SUBMIT_KEY),
+                newKeyNamed(SUBMIT_KEY2),
+                createTopic(TOPIC)
+                        .submitKeyName(SUBMIT_KEY)
+                        .payingWith(GENESIS)
+                        .memo(LARGE_SIZE_MEMO)
+                        .hasPrecheck(TRANSACTION_OVERSIZE),
+                createTopic(TOPIC2)
+                        .submitKeyName(SUBMIT_KEY2)
+                        .payingWith(SYSTEM_ADMIN)
+                        .memo(LARGE_SIZE_MEMO)
+                        .hasPrecheck(TRANSACTION_OVERSIZE));
+    }
+
+    @HapiTest
+    @Order(9)
+    @DisplayName("Governance account cannot submit more than 6KB transactions, signed by a larger key, if disabled")
+    public Stream<DynamicTest> governanceAccountCannotSubmitLargerSizeWithLargeKeyIfDisabled() {
+        return hapiTest(
+                overriding("governanceTransactions.isEnabled", "false"),
+                newKeyNamed(PAYER_KEY).shape(LARGE_SIZE_KEY),
+                newKeyNamed(PAYER_KEY2).shape(LARGE_SIZE_KEY),
+                newKeyNamed(SUBMIT_KEY),
+                cryptoCreate(PAYER).key(PAYER_KEY).balance(ONE_HUNDRED_HBARS).hasKnownStatus(SUCCESS),
+                cryptoCreate(PAYER2).key(PAYER_KEY2).balance(ONE_HUNDRED_HBARS).hasKnownStatus(SUCCESS),
+                createTopic(TOPIC)
+                        .submitKeyName(SUBMIT_KEY)
+                        .payingWith(SYSTEM_ADMIN)
+                        .signedBy(SYSTEM_ADMIN, PAYER, PAYER2)
+                        .hasPrecheck(TRANSACTION_OVERSIZE));
+    }
+
+    @HapiTest
+    @Order(10)
+    @DisplayName("Normal account cannot submit more than 6KB transactions when the feature is disabled")
+    public Stream<DynamicTest> nonGovernanceAccountCannotSubmitLargeSizeTransactions() {
+        return hapiTest(
+                overriding("governanceTransactions.isEnabled", "false"),
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(SUBMIT_KEY),
+                createTopic(TOPIC)
+                        .submitKeyName(SUBMIT_KEY)
+                        .payingWith(PAYER)
+                        .memo(LARGE_SIZE_MEMO)
+                        .hasPrecheck(TRANSACTION_OVERSIZE));
+    }
+
+    @HapiTest
+    @Order(11)
+    @DisplayName(
+            "Governance account cannot submit more than 6KB batch transactions when only the batch transaction is paid and feature disabled")
+    public Stream<DynamicTest> governanceAccountCannotSubmitWhenPaidOnlyBatchIfDisabled() {
+        final HapiTopicCreate innerTxn = createTopic(TOPIC)
+                .submitKeyName(SUBMIT_KEY)
+                .payingWith(PAYER)
+                .memo(LARGE_SIZE_MEMO)
+                .batchKey(GENESIS);
+
+        return hapiTest(
+                overriding("governanceTransactions.isEnabled", "false"),
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(SUBMIT_KEY),
+                atomicBatch(innerTxn).payingWith(GENESIS).hasPrecheck(TRANSACTION_OVERSIZE));
+    }
+
+    @HapiTest
+    @Order(12)
+    @DisplayName(
+            "Governance account cannot submit more than 6KB batch transactions when only the inner transaction is paid and feature disabled")
+    public Stream<DynamicTest> governanceAccountCannotSubmitWhenPaidOnlyInnerIfDisabled() {
+        final HapiTopicCreate innerTxn = createTopic(TOPIC)
+                .submitKeyName(SUBMIT_KEY)
+                .payingWith(GENESIS)
+                .memo(LARGE_SIZE_MEMO)
+                .batchKey(PAYER);
+
+        return hapiTest(
+                overriding("governanceTransactions.isEnabled", "false"),
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(SUBMIT_KEY),
+                atomicBatch(innerTxn).payingWith(PAYER).hasPrecheck(TRANSACTION_OVERSIZE));
+    }
+
+    @HapiTest
+    @Order(13)
+    @DisplayName(
+            "Governance account cannot submit more than 6KB batch transactions when both the batch and the inner transactions are paid")
+    public Stream<DynamicTest> governanceAccountCannotSubmitWhenBothArePaidIfDisabled() {
+        final HapiTopicCreate innerTxn = createTopic(TOPIC)
+                .submitKeyName(SUBMIT_KEY)
+                .payingWith(SYSTEM_ADMIN)
+                .memo(LARGE_SIZE_MEMO)
+                .batchKey(SYSTEM_ADMIN);
+
+        return hapiTest(
+                overriding("governanceTransactions.isEnabled", "false"),
+                newKeyNamed(SUBMIT_KEY),
+                atomicBatch(innerTxn).payingWith(SYSTEM_ADMIN).hasPrecheck(TRANSACTION_OVERSIZE));
+    }
+
+    @HapiTest
+    @Order(14)
+    @DisplayName(
+            "Treasury and system admin accounts cannot submit more than 6KB transactions when the feature is disabled")
+    public Stream<DynamicTest> governanceAccountsCannotSubmitLargeSizeTransactions() {
+        return hapiTest(
+                overriding("governanceTransactions.isEnabled", "false"),
+                newKeyNamed(SUBMIT_KEY),
+                newKeyNamed(SUBMIT_KEY2),
+                createTopic(TOPIC)
+                        .submitKeyName(SUBMIT_KEY)
+                        .payingWith(GENESIS)
+                        .memo(LARGE_SIZE_MEMO)
+                        .hasPrecheck(TRANSACTION_OVERSIZE),
+                createTopic(TOPIC2)
+                        .submitKeyName(SUBMIT_KEY2)
+                        .payingWith(SYSTEM_ADMIN)
+                        .memo(LARGE_SIZE_MEMO)
+                        .hasPrecheck(TRANSACTION_OVERSIZE));
     }
 }


### PR DESCRIPTION
**Description**:
Cherry-pick of [#22367](https://github.com/hiero-ledger/hiero-consensus-node/pull/22367) for `release/0.69`

This PR adds a support for governance transactions in an AtomicBatch. Meaning that inner transactions in a batch can be higher than 6KBs but limited to 130KBs, if they are payed by a governance account. The governance account must also pay for the AtomicBatch in order for a successful execution. The AtomicBatch itself is also restricted to the upper limit of 130KBs

**Related issue(s)**:

Fixes #22407 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
