### PR TITLE
fix: update BlockNodeSuite#node0SupportsDynamicBlockNodeConnectionInfo

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -144,10 +144,7 @@ public class BlockNodeSuite {
                         "Detected ENTRY_MODIFY event for block-nodes.json",
                         String.format(
                                 "/localhost:%s/CLOSED] Connection state transitioned from CLOSING to CLOSED",
-                                portNumbers.getFirst()),
-                        // New invalid config is loaded
-                        // Connection client created but exception occurs with invalid address
-                        "Created BlockStreamPublishServiceClient for 26dsfg2364:1234")),
+                                portNumbers.getFirst()))),
                 doingContextual((spec) -> timeRef.set(Instant.now())),
                 waitUntilNextBlocks(5).withBackgroundTraffic(true),
                 // Delete block-nodes.json
@@ -231,8 +228,6 @@ public class BlockNodeSuite {
                         // Valid config is loaded
                         "Found available node in priority group 0",
                         // Connection is re-established
-                        String.format(
-                                "Created BlockStreamPublishServiceClient for localhost:%s", portNumbers.getFirst()),
                         String.format(
                                 "/localhost:%s/UNINITIALIZED] Scheduling reconnection for node in 0 ms",
                                 portNumbers.getFirst()),


### PR DESCRIPTION
**Description**:
update BlockNodeSuite#node0SupportsDynamicBlockNodeConnectionInfo to stop checking for log that doesn't exist anymore

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
