### PR TITLE
fix(bug): Incorrect token name

### DIFF
--- a/.github/workflows/platform-zxcron-release-jrs-regression.yaml
+++ b/.github/workflows/platform-zxcron-release-jrs-regression.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install Github CLI
         env:
-          GITHUB_TOKEN: ${{ secrets.PLATFORM_access-token }}
+          GITHUB_TOKEN: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
         run: |
           curl -O -L -s https://github.com/cli/cli/releases/download/v2.12.1/gh_2.12.1_linux_amd64.deb
           sudo apt install -y ./gh_2.12.1_linux_amd64.deb


### PR DESCRIPTION
## Description

This pull request makes a small update to the GitHub Actions workflow configuration. The change updates the environment variable used for GitHub authentication to use the correct secret.

* Updated the `GITHUB_TOKEN` environment variable in `.github/workflows/platform-zxcron-release-jrs-regression.yaml` from `PLATFORM_access-token` to `PLATFORM_GH_ACCESS_TOKEN` to ensure the workflow uses the correct secret for authentication.

## Related Issue(s)

Fixes #22449