### PR TITLE
chore: remove abbreviated panel again

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -252,7 +252,6 @@ jobs:
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
       custom-job-label: "XTS (main):"
       enable-extended-test-suite: "true"
-      enable-abbreviated-panel: "true"
       enable-hedera-node-jrs-panel: "true"
       enable-sdk-tck-regression-panel: "true"
     secrets:


### PR DESCRIPTION
The JRS tests were previously removed from XTS, but were added back on 11/17. This PR removes them again.