### PR TITLE
chore: Create empty Hashgraph Implementation module

### DIFF
--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/module-info.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/module-info.java
@@ -1,8 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-import org.hiero.consensus.hashgraph.HashgraphModule;
-import org.hiero.consensus.hashgraph.impl.DefaultHashgraphModule;
-
-// SPDX-License-Identifier: Apache-2.0
 module org.hiero.consensus.hashgraph.impl {
     requires transitive com.hedera.node.hapi;
     requires transitive com.swirlds.base;
@@ -13,6 +9,6 @@ module org.hiero.consensus.hashgraph.impl {
     requires transitive org.hiero.consensus.model;
     requires static com.github.spotbugs.annotations;
 
-    provides HashgraphModule with
-            DefaultHashgraphModule;
+    provides org.hiero.consensus.hashgraph.HashgraphModule with
+            org.hiero.consensus.hashgraph.impl.DefaultHashgraphModule;
 }

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/DefaultHashgraphModule.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/DefaultHashgraphModule.java
@@ -4,6 +4,7 @@ package org.hiero.consensus.hashgraph.impl;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.swirlds.base.time.Time;
+import com.swirlds.component.framework.model.WiringModel;
 import com.swirlds.component.framework.wires.input.InputWire;
 import com.swirlds.component.framework.wires.output.OutputWire;
 import com.swirlds.config.api.Configuration;
@@ -16,6 +17,9 @@ import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.status.PlatformStatus;
 
+/**
+ * The default implementation of the {@link HashgraphModule}
+ */
 public class DefaultHashgraphModule implements HashgraphModule {
 
     /**
@@ -23,6 +27,7 @@ public class DefaultHashgraphModule implements HashgraphModule {
      */
     @Override
     public void initialize(
+            @NonNull final WiringModel model,
             @NonNull final Configuration configuration,
             @NonNull final Metrics metrics,
             @NonNull final Time time,
@@ -35,6 +40,7 @@ public class DefaultHashgraphModule implements HashgraphModule {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public InputWire<PlatformEvent> eventInputWire() {
         return null;
@@ -43,6 +49,7 @@ public class DefaultHashgraphModule implements HashgraphModule {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public OutputWire<ConsensusRound> consensusRoundOutputWire() {
         throw new UnsupportedOperationException("Not yet implemented.");
@@ -51,6 +58,7 @@ public class DefaultHashgraphModule implements HashgraphModule {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public OutputWire<PlatformEvent> preconsensusEventOutputWire() {
         throw new UnsupportedOperationException("Not yet implemented.");
@@ -59,6 +67,7 @@ public class DefaultHashgraphModule implements HashgraphModule {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public OutputWire<PlatformEvent> staleEventOutputWire() {
         throw new UnsupportedOperationException("Not yet implemented.");
@@ -67,6 +76,7 @@ public class DefaultHashgraphModule implements HashgraphModule {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public InputWire<PlatformStatus> platformStatusInputWire() {
         throw new UnsupportedOperationException("Not yet implemented.");
@@ -75,6 +85,7 @@ public class DefaultHashgraphModule implements HashgraphModule {
     /**
      * {@inheritDoc}
      */
+    @NonNull
     @Override
     public InputWire<ConsensusSnapshot> consensusSnapshotInputWire() {
         throw new UnsupportedOperationException("Not yet implemented.");

--- a/platform-sdk/consensus-hashgraph/src/main/java/org/hiero/consensus/hashgraph/HashgraphModule.java
+++ b/platform-sdk/consensus-hashgraph/src/main/java/org/hiero/consensus/hashgraph/HashgraphModule.java
@@ -4,6 +4,7 @@ package org.hiero.consensus.hashgraph;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.swirlds.base.time.Time;
+import com.swirlds.component.framework.model.WiringModel;
 import com.swirlds.component.framework.wires.input.InputWire;
 import com.swirlds.component.framework.wires.output.OutputWire;
 import com.swirlds.config.api.Configuration;
@@ -24,6 +25,7 @@ public interface HashgraphModule {
     /**
      * Initialize the Hashgraph module.
      *
+     * @param model the wiring model
      * @param configuration the configuration
      * @param metrics the metrics registry
      * @param time the time source
@@ -32,6 +34,7 @@ public interface HashgraphModule {
      * @param freezeChecker the freeze checker used to determine when a freeze is in progress
      */
     void initialize(
+            @NonNull WiringModel model,
             @NonNull Configuration configuration,
             @NonNull Metrics metrics,
             @NonNull Time time,
@@ -49,6 +52,7 @@ public interface HashgraphModule {
      * @see #preconsensusEventOutputWire()
      * @see #staleEventOutputWire()
      */
+    @NonNull
     InputWire<PlatformEvent> eventInputWire();
 
     /**
@@ -57,6 +61,7 @@ public interface HashgraphModule {
      * @return the consensus engine output wire
      * @see #eventInputWire()
      */
+    @NonNull
     OutputWire<ConsensusRound> consensusRoundOutputWire();
 
     /**
@@ -64,6 +69,7 @@ public interface HashgraphModule {
      *
      * @return the pre-consensus events output wire
      */
+    @NonNull
     OutputWire<PlatformEvent> preconsensusEventOutputWire();
 
     /**
@@ -71,6 +77,7 @@ public interface HashgraphModule {
      *
      * @return the stale events output wire
      */
+    @NonNull
     OutputWire<PlatformEvent> staleEventOutputWire();
 
     /**
@@ -78,6 +85,7 @@ public interface HashgraphModule {
      *
      * @return the platform status input wire
      */
+    @NonNull
     InputWire<PlatformStatus> platformStatusInputWire();
 
     /**
@@ -86,5 +94,6 @@ public interface HashgraphModule {
      *
      * @return the consensus snapshot input wire
      */
+    @NonNull
     InputWire<ConsensusSnapshot> consensusSnapshotInputWire();
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,5 +58,3 @@ javaModules {
     // Platform demo applications
     directory("platform-sdk/platform-apps/demos") { group = "com.hedera.hashgraph" }
 }
-
-include("platform-sdk:consensus-hashgraph-impl")


### PR DESCRIPTION
**Description**:
This PR creates an empty hashgraph implementation module with only a default implementation class that has no implementation yet. It also:

1. Adds a single parameter to the intialize method that I realized will be necessary
2. Changes the Hashgraph module output wires to return a single object instead of lists of objects for the consensus rounds, preconsensus events, and stale events. The wiring was splitting them into separate objects anyways, and now the detail that multiple are known at once can be hidden inside the module.

**Related issue(s)**:

Fixes #22563
