### PR TITLE
chore: reorder XTS state validator build step

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -63,16 +63,6 @@ jobs:
           echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
           echo "solo-version=${{ vars.CITR_SOLO_VERSION }}" >> "${GITHUB_OUTPUT}"
 
-  state-validator-uberjar:
-    name: Build & Publish Hedera State Validator Uber JAR
-    runs-on: hiero-citr-linux-medium
-    needs:
-      - fetch-xts-candidate
-    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
-    uses: ./.github/workflows/zxc-build-publish-state-validator.yaml
-    with:
-      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
-
   fetch-xts-candidate:
     name: Fetch XTS Candidate Tag
     runs-on: hiero-citr-linux-medium
@@ -246,6 +236,16 @@ jobs:
             gh run cancel "${{ github.run_id }}"
           fi
           echo "::endgroup::" # Set Outputs
+
+  state-validator-uberjar:
+    name: Build & Publish Hedera State Validator Uber JAR
+    runs-on: hiero-citr-linux-medium
+    needs:
+      - fetch-xts-candidate
+    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
+    uses: ./.github/workflows/zxc-build-publish-state-validator.yaml
+    with:
+      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
 
   xts-execution:
     name: Execute XTS


### PR DESCRIPTION
**Description**:

Reorder the XTS workflow so the state validator build step is after fetching the XTS candidate SHA.

**Related issue(s)**:

Fixes #22567 
