### PR TITLE
chore: reorder XTS state validator build step

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -239,7 +239,6 @@ jobs:
 
   state-validator-uberjar:
     name: Build & Publish Hedera State Validator Uber JAR
-    runs-on: hiero-citr-linux-medium
     needs:
       - fetch-xts-candidate
     if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}


### PR DESCRIPTION
**Description**:

Remove the `runs-on` stanza.

**Related issue(s)**:

Fixes #22567 
