### PR TITLE
chore: Remove HAPI dependency from base-utility

### DIFF
--- a/platform-sdk/base-utility/src/main/java/module-info.java
+++ b/platform-sdk/base-utility/src/main/java/module-info.java
@@ -9,7 +9,6 @@ module org.hiero.base.utility {
     exports org.hiero.base.iterator;
     exports org.hiero.base.utility;
 
-    requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.base;
     requires transitive com.swirlds.logging;

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/utility/CommonUtils.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/utility/CommonUtils.java
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.utility;
 
-import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
-import java.time.Instant;
 
 /**
  * Utility class for other operations
@@ -151,31 +149,6 @@ public class CommonUtils {
         }
 
         return out;
-    }
-
-    /**
-     * Converts an {@link Instant} to a {@link Timestamp}
-     *
-     * @param instant the {@code Instant} to convert
-     * @return the {@code Timestamp} equivalent of the {@code Instant}
-     */
-    @Nullable
-    public static Timestamp toPbjTimestamp(@Nullable final Instant instant) {
-        if (instant == null) {
-            return null;
-        }
-        return new Timestamp(instant.getEpochSecond(), instant.getNano());
-    }
-
-    /**
-     * Converts a {@link Timestamp} to an {@link Instant}
-     *
-     * @param timestamp the {@code Timestamp} to convert
-     * @return the {@code Instant} equivalent of the {@code Timestamp}
-     */
-    @Nullable
-    public static Instant fromPbjTimestamp(@Nullable final Timestamp timestamp) {
-        return timestamp == null ? null : Instant.ofEpochSecond(timestamp.seconds(), timestamp.nanos());
     }
 
     private static int toDigit(final char ch, final int index) throws IllegalArgumentException {

--- a/platform-sdk/consensus-model/src/main/java/module-info.java
+++ b/platform-sdk/consensus-model/src/main/java/module-info.java
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 module org.hiero.consensus.model {
+    exports org.hiero.consensus.model;
     exports org.hiero.consensus.model.event;
     exports org.hiero.consensus.model.hashgraph;
     exports org.hiero.consensus.model.node;

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/PbjConverters.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/PbjConverters.java
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.model;
+
+import com.hedera.hapi.node.base.Timestamp;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Instant;
+
+/**
+ * Utility class for converting between PBJ and Java types.
+ */
+public class PbjConverters {
+
+    private PbjConverters() {}
+
+    /**
+     * Converts an {@link Instant} to a {@link Timestamp}
+     *
+     * @param instant the {@code Instant} to convert
+     * @return the {@code Timestamp} equivalent of the {@code Instant}
+     */
+    @Nullable
+    public static Timestamp toPbjTimestamp(@Nullable final Instant instant) {
+        if (instant == null) {
+            return null;
+        }
+        return new Timestamp(instant.getEpochSecond(), instant.getNano());
+    }
+
+    /**
+     * Converts a {@link Timestamp} to an {@link Instant}
+     *
+     * @param timestamp the {@code Timestamp} to convert
+     * @return the {@code Instant} equivalent of the {@code Timestamp}
+     */
+    @Nullable
+    public static Instant fromPbjTimestamp(@Nullable final Timestamp timestamp) {
+        return timestamp == null ? null : Instant.ofEpochSecond(timestamp.seconds(), timestamp.nanos());
+    }
+}

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/hashgraph/ConsensusRound.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/hashgraph/ConsensusRound.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.model.hashgraph;
 
+import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
+
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.swirlds.base.utility.ToStringBuilder;
@@ -13,7 +15,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.hiero.base.iterator.TypedIterator;
-import org.hiero.base.utility.CommonUtils;
 import org.hiero.consensus.model.event.CesEvent;
 import org.hiero.consensus.model.event.ConsensusEvent;
 import org.hiero.consensus.model.event.PlatformEvent;
@@ -190,7 +191,7 @@ public class ConsensusRound implements Round {
      */
     @Override
     public @NonNull Instant getConsensusTimestamp() {
-        return Objects.requireNonNull(CommonUtils.fromPbjTimestamp(snapshot.consensusTimestamp()));
+        return Objects.requireNonNull(fromPbjTimestamp(snapshot.consensusTimestamp()));
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TransactionFactory.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TransactionFactory.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures;
 
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
+
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
@@ -8,7 +10,6 @@ import com.hederahashgraph.api.proto.java.Timestamp;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
-import org.hiero.base.utility.CommonUtils;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.otter.fixtures.network.transactions.EmptyTransaction;
 import org.hiero.otter.fixtures.network.transactions.HashPartition;
@@ -46,7 +47,7 @@ public class TransactionFactory {
      */
     @NonNull
     public static OtterTransaction createFreezeTransaction(final long nonce, @NonNull final Instant freezeTime) {
-        final Timestamp timestamp = CommonPbjConverters.fromPbj(CommonUtils.toPbjTimestamp(freezeTime));
+        final Timestamp timestamp = CommonPbjConverters.fromPbj(toPbjTimestamp(freezeTime));
         final OtterFreezeTransaction freezeTransaction =
                 OtterFreezeTransaction.newBuilder().setFreezeTime(timestamp).build();
         return OtterTransaction.newBuilder()

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/services/platform/PlatformStateService.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/services/platform/PlatformStateService.java
@@ -3,6 +3,7 @@ package org.hiero.otter.fixtures.app.services.platform;
 
 import static com.swirlds.logging.legacy.LogMarker.STARTUP;
 import static com.swirlds.platform.state.service.PlatformStateUtils.isInFreezePeriod;
+import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
 
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
@@ -18,7 +19,6 @@ import java.time.Instant;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.hiero.base.utility.CommonUtils;
 import org.hiero.consensus.model.event.ConsensusEvent;
 import org.hiero.consensus.model.event.Event;
 import org.hiero.consensus.model.hashgraph.Round;
@@ -100,7 +100,7 @@ public class PlatformStateService implements OtterService {
             @NonNull final WritableStates writableStates, @NonNull final OtterFreezeTransaction freezeTransaction) {
         final Timestamp freezeTime = CommonPbjConverters.toPbj(freezeTransaction.getFreezeTime());
         final WritablePlatformStateStore store = new WritablePlatformStateStore(writableStates);
-        store.setFreezeTime(CommonUtils.fromPbjTimestamp(freezeTime));
+        store.setFreezeTime(fromPbjTimestamp(freezeTime));
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
@@ -5,6 +5,8 @@ import static com.swirlds.logging.legacy.LogMarker.CONSENSUS_VOTING;
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.logging.legacy.LogMarker.STARTUP;
 import static java.util.stream.Collectors.toSet;
+import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
 import static org.hiero.consensus.model.hashgraph.ConsensusConstants.FIRST_CONSENSUS_NUMBER;
 
 import com.hedera.hapi.node.state.roster.Roster;
@@ -42,7 +44,6 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
-import org.hiero.base.utility.CommonUtils;
 import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
@@ -242,7 +243,7 @@ public class ConsensusImpl implements Consensus {
         initJudges = new InitJudges(snapshot.round(), judgeHashes);
         rounds.loadFromMinimumJudge(snapshot.minimumJudgeInfoList());
         numConsensus = snapshot.nextConsensusNumber();
-        lastConsensusTime = CommonUtils.fromPbjTimestamp(snapshot.consensusTimestamp());
+        lastConsensusTime = fromPbjTimestamp(snapshot.consensusTimestamp());
     }
 
     /** Reset this instance to a state of a newly created instance */
@@ -764,7 +765,7 @@ public class ConsensusImpl implements Consensus {
                         decidedRoundNumber,
                         rounds.getMinimumJudgeInfoList(),
                         numConsensus,
-                        CommonUtils.toPbjTimestamp(lastConsensusTime),
+                        toPbjTimestamp(lastConsensusTime),
                         judgeIds),
                 pcesMode,
                 time.now());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/SyntheticSnapshot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/SyntheticSnapshot.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.consensus;
 
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
+
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.hedera.hapi.platform.state.JudgeId;
 import com.hedera.hapi.platform.state.MinimumJudgeInfo;
@@ -8,7 +10,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
 import java.util.stream.LongStream;
-import org.hiero.base.utility.CommonUtils;
 import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
@@ -58,8 +59,7 @@ public final class SyntheticSnapshot {
                         .build()))
                 .minimumJudgeInfoList(minimumJudgeInfos)
                 .nextConsensusNumber(lastConsensusOrder + 1)
-                .consensusTimestamp(
-                        CommonUtils.toPbjTimestamp(ConsensusUtils.calcMinTimestampForNextEvent(roundTimestamp)))
+                .consensusTimestamp(toPbjTimestamp(ConsensusUtils.calcMinTimestampForNextEvent(roundTimestamp)))
                 .build();
     }
 
@@ -76,7 +76,7 @@ public final class SyntheticSnapshot {
                 .minimumJudgeInfoList(
                         List.of(new MinimumJudgeInfo(ConsensusConstants.ROUND_FIRST, ConsensusConstants.ROUND_FIRST)))
                 .nextConsensusNumber(ConsensusConstants.FIRST_CONSENSUS_NUMBER)
-                .consensusTimestamp(CommonUtils.toPbjTimestamp(Instant.EPOCH))
+                .consensusTimestamp(toPbjTimestamp(Instant.EPOCH))
                 .build();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PbjConverter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/PbjConverter.java
@@ -2,7 +2,7 @@
 package com.swirlds.platform.state.service;
 
 import static java.util.Objects.requireNonNull;
-import static org.hiero.base.utility.CommonUtils.toPbjTimestamp;
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
 
 import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.pbj.runtime.io.buffer.Bytes;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadablePlatformStateStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/ReadablePlatformStateStore.java
@@ -2,7 +2,7 @@
 package com.swirlds.platform.state.service;
 
 import static java.util.Objects.requireNonNull;
-import static org.hiero.base.utility.CommonUtils.fromPbjTimestamp;
+import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/SnapshotPlatformStateAccessor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/SnapshotPlatformStateAccessor.java
@@ -2,7 +2,7 @@
 package com.swirlds.platform.state.service;
 
 import static java.util.Objects.requireNonNull;
-import static org.hiero.base.utility.CommonUtils.fromPbjTimestamp;
+import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritablePlatformStateStore.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/service/WritablePlatformStateStore.java
@@ -3,7 +3,7 @@ package com.swirlds.platform.state.service;
 
 import static com.swirlds.platform.state.service.PbjConverter.toPbjPlatformState;
 import static java.util.Objects.requireNonNull;
-import static org.hiero.base.utility.CommonUtils.toPbjTimestamp;
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/DefaultTransactionHandlerTests.java
@@ -3,6 +3,7 @@ package com.swirlds.platform.eventhandling;
 
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertAllDatabasesClosed;
 import static com.swirlds.platform.test.fixtures.state.RandomSignedStateGenerator.releaseAllBuiltSignedStates;
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -20,7 +21,6 @@ import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
-import org.hiero.base.utility.CommonUtils;
 import org.hiero.consensus.model.event.ConsensusEvent;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
@@ -202,7 +202,7 @@ class DefaultTransactionHandlerTests {
                 .minimumJudgeInfoList(
                         List.of(new MinimumJudgeInfo(ConsensusConstants.ROUND_FIRST, ConsensusConstants.ROUND_FIRST)))
                 .nextConsensusNumber(ConsensusConstants.FIRST_CONSENSUS_NUMBER)
-                .consensusTimestamp(CommonUtils.toPbjTimestamp(consensusTimestamp))
+                .consensusTimestamp(toPbjTimestamp(consensusTimestamp))
                 .build();
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PbjConverterTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/PbjConverterTest.java
@@ -5,10 +5,10 @@ import static com.swirlds.platform.state.service.PbjConverter.toPbjPlatformState
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomHash;
-import static org.hiero.base.utility.CommonUtils.fromPbjTimestamp;
-import static org.hiero.base.utility.CommonUtils.toPbjTimestamp;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.nextInt;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.randomInstant;
+import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/WritablePlatformStateStoreTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/service/WritablePlatformStateStoreTest.java
@@ -7,6 +7,7 @@ import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchem
 import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.PLATFORM_STATE_STATE_LABEL;
 import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomHash;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.nextInt;
+import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +25,6 @@ import com.swirlds.state.spi.WritableStates;
 import com.swirlds.state.test.fixtures.merkle.VirtualMapUtils;
 import com.swirlds.virtualmap.VirtualMap;
 import java.time.Instant;
-import org.hiero.base.utility.CommonUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,9 +70,7 @@ class WritablePlatformStateStoreTest {
         assertEquals(platformState.getCreationSoftwareVersion(), store.getCreationSoftwareVersion());
         assertEquals(platformState.getSnapshot().round(), store.getRound());
         assertEquals(platformState.getLegacyRunningEventHash(), store.getLegacyRunningEventHash());
-        assertEquals(
-                CommonUtils.fromPbjTimestamp(platformState.getSnapshot().consensusTimestamp()),
-                store.getConsensusTimestamp());
+        assertEquals(fromPbjTimestamp(platformState.getSnapshot().consensusTimestamp()), store.getConsensusTimestamp());
         assertEquals(platformState.getRoundsNonAncient(), store.getRoundsNonAncient());
         assertEquals(platformState.getSnapshot(), store.getSnapshot());
         assertEquals(platformState.getFreezeTime(), store.getFreezeTime());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/uptime/UptimeTests.java
@@ -5,6 +5,7 @@ import static com.swirlds.platform.test.fixtures.addressbook.RosterTestUtils.add
 import static com.swirlds.platform.test.fixtures.addressbook.RosterTestUtils.dropRosterEntryFromRoster;
 import static com.swirlds.platform.uptime.UptimeData.NO_ROUND;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -27,7 +28,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
-import org.hiero.base.utility.CommonUtils;
 import org.hiero.consensus.model.event.ConsensusEvent;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
@@ -83,7 +83,7 @@ class UptimeTests {
         final ConsensusRound round =
                 new ConsensusRound(roster, events, mock(EventWindow.class), snapshot, false, Instant.now());
         final Instant consensusTimestamp = events.get(events.size() - 1).getConsensusTimestamp();
-        when(snapshot.consensusTimestamp()).thenReturn(CommonUtils.toPbjTimestamp(consensusTimestamp));
+        when(snapshot.consensusTimestamp()).thenReturn(toPbjTimestamp(consensusTimestamp));
         when(snapshot.round()).thenReturn(roundNum);
         when(round.getRoundNum()).thenReturn(roundNum);
         return round;

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/PlatformStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/PlatformStateUtils.java
@@ -9,6 +9,7 @@ import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomHash;
 import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomHashBytes;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.nextInt;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.randomInstant;
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
@@ -19,7 +20,6 @@ import com.swirlds.state.State;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
-import org.hiero.base.utility.CommonUtils;
 
 public final class PlatformStateUtils {
 
@@ -60,7 +60,7 @@ public final class PlatformStateUtils {
                         .judgeIds(judges)
                         .minimumJudgeInfoList(minimumJudgeInfo)
                         .nextConsensusNumber(random.nextLong())
-                        .consensusTimestamp(CommonUtils.toPbjTimestamp(randomInstant(random)))
+                        .consensusTimestamp(toPbjTimestamp(randomInstant(random)))
                         .build());
 
         return getWritablePlatformStateOf(state);

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
@@ -9,6 +9,7 @@ import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomHash;
 import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomHashBytes;
 import static org.hiero.base.crypto.test.fixtures.CryptoRandomUtils.randomSignature;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
+import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.roster.Roster;
@@ -47,7 +48,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.crypto.Signature;
-import org.hiero.base.utility.CommonUtils;
 import org.hiero.base.utility.test.fixtures.RandomUtils;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.roster.RosterUtils;
@@ -182,7 +182,7 @@ public class RandomSignedStateGenerator {
                             .mapToObj(i -> new MinimumJudgeInfo(roundInstance - i, 0L))
                             .toList())
                     .nextConsensusNumber(roundInstance)
-                    .consensusTimestamp(CommonUtils.toPbjTimestamp(consensusTimestampInstance))
+                    .consensusTimestamp(toPbjTimestamp(consensusTimestampInstance))
                     .build();
         } else {
             consensusSnapshotInstance = consensusSnapshot;


### PR DESCRIPTION
**Description**:

This PR moves the methods `toPbjTimestamp()` and `fromPbjTimestamp()` to `consensus-model`. This way, `base-utility` has no dependency on HAPI anymore

**Related issue(s)**:

Fixes #22587 