### PR TITLE
chore: Cherry-pick #22359 Remove FlickeringIsolationExperiment from default chaos test

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/chaosbot/ChaosBotConfiguration.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/chaosbot/ChaosBotConfiguration.java
@@ -32,8 +32,7 @@ public record ChaosBotConfiguration(
                     new HighLatencyNodeExperiment(),
                     new LowBandwidthNodeExperiment(),
                     new NetworkPartitionExperiment(),
-                    new NodeFailureExperiment(),
-                    new FlickeringIsolationExperiment()));
+                    new NodeFailureExperiment()));
 
     /**
      * Create a new configuration.


### PR DESCRIPTION
**Description**:

Cherry picking #22359 
to disable flaky experiment in default chaos bot configuration.

**Related issue(s)**:

Fixes #22358 