### PR TITLE
refactor: Move `EventWindowUtils` and `RoundCalculationUtils` to `consensus-utility`

### DIFF
--- a/platform-sdk/consensus-utility/src/main/java/module-info.java
+++ b/platform-sdk/consensus-utility/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module org.hiero.consensus.utility {
     exports org.hiero.consensus.exceptions;
     exports org.hiero.consensus.roster;
     exports org.hiero.consensus.transaction;
+    exports org.hiero.consensus.round;
 
     requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/round/EventWindowUtils.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/round/EventWindowUtils.java
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.consensus;
+package org.hiero.consensus.round;
 
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
-import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 
 /**
@@ -16,16 +14,6 @@ public final class EventWindowUtils {
      * Private constructor to prevent instantiation.
      */
     private EventWindowUtils() {}
-
-    /**
-     * Same as {@link #createEventWindow(ConsensusSnapshot, int)} but uses the configuration to get the
-     *  {@code roundsNonAncient}.
-     */
-    public static @NonNull EventWindow createEventWindow(
-            @NonNull final ConsensusSnapshot snapshot, @NonNull final Configuration configuration) {
-        return createEventWindow(
-                snapshot, configuration.getConfigData(ConsensusConfig.class).roundsNonAncient());
-    }
 
     /**
      * Creates a new instance of {@link EventWindow} with the specified parameters.

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/round/RoundCalculationUtils.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/round/RoundCalculationUtils.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.consensus;
+package org.hiero.consensus.round;
 
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.hedera.hapi.platform.state.MinimumJudgeInfo;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -32,7 +32,6 @@ import com.swirlds.platform.components.DefaultSavedStateController;
 import com.swirlds.platform.components.EventWindowManager;
 import com.swirlds.platform.components.SavedStateController;
 import com.swirlds.platform.config.StateConfig;
-import com.swirlds.platform.consensus.EventWindowUtils;
 import com.swirlds.platform.event.EventCounter;
 import com.swirlds.platform.event.preconsensus.InlinePcesWriter;
 import com.swirlds.platform.event.preconsensus.PcesConfig;
@@ -72,11 +71,13 @@ import org.hiero.base.crypto.Cryptography;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.crypto.Signature;
 import org.hiero.consensus.crypto.PlatformSigner;
+import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.quiescence.QuiescenceCommand;
+import org.hiero.consensus.round.EventWindowUtils;
 
 /**
  * The swirlds consensus node platform. Responsible for the creation, gossip, and consensus of events. Also manages the
@@ -153,7 +154,7 @@ public class SwirldsPlatform implements Platform {
      * Constructor.
      *
      * @param builder this object is responsible for building platform components and other things needed by the
-     *                platform
+     * platform
      */
     public SwirldsPlatform(@NonNull final PlatformComponentBuilder builder) {
         final PlatformBuildingBlocks blocks = builder.getBuildingBlocks();
@@ -307,8 +308,12 @@ public class SwirldsPlatform implements Platform {
             // We only load non-ancient events during start up, so the initial expired threshold will be
             // equal to the ancient threshold when the system first starts. Over time as we get more events,
             // the expired threshold will continue to expand until it reaches its full size.
+            final int roundsNonAncient = platformContext
+                    .getConfiguration()
+                    .getConfigData(ConsensusConfig.class)
+                    .roundsNonAncient();
             platformCoordinator.updateEventWindow(
-                    EventWindowUtils.createEventWindow(consensusSnapshot, platformContext.getConfiguration()));
+                    EventWindowUtils.createEventWindow(consensusSnapshot, roundsNonAncient));
             platformCoordinator.overrideIssDetectorState(initialState.reserve("initialize issDetector"));
         }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/consensus/DefaultConsensusEngine.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/consensus/DefaultConsensusEngine.java
@@ -8,7 +8,6 @@ import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.Consensus;
 import com.swirlds.platform.ConsensusImpl;
-import com.swirlds.platform.consensus.EventWindowUtils;
 import com.swirlds.platform.event.linking.ConsensusLinker;
 import com.swirlds.platform.event.linking.DefaultLinkerLogsAndMetrics;
 import com.swirlds.platform.internal.EventImpl;
@@ -30,6 +29,7 @@ import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.status.PlatformStatus;
+import org.hiero.consensus.round.EventWindowUtils;
 
 /**
  * The default implementation of the {@link ConsensusEngine} interface

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusRounds.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/ConsensusRounds.java
@@ -18,6 +18,7 @@ import org.hiero.consensus.model.event.EventConstants;
 import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
 import org.hiero.consensus.roster.RosterUtils;
+import org.hiero.consensus.round.RoundCalculationUtils;
 
 /**
  * Stores all hashgraph round information in a single place.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/SyntheticSnapshot.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/SyntheticSnapshot.java
@@ -12,6 +12,7 @@ import org.hiero.base.utility.CommonUtils;
 import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
+import org.hiero.consensus.round.RoundCalculationUtils;
 
 /**
  * Utility class for generating "synthetic" snapshots

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiEventStorage.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiEventStorage.java
@@ -10,7 +10,6 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.Consensus;
 import com.swirlds.platform.ConsensusImpl;
-import com.swirlds.platform.consensus.EventWindowUtils;
 import com.swirlds.platform.event.linking.ConsensusLinker;
 import com.swirlds.platform.event.linking.NoOpLinkerLogsAndMetrics;
 import com.swirlds.platform.internal.EventImpl;
@@ -24,6 +23,7 @@ import java.util.Objects;
 import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
+import org.hiero.consensus.round.EventWindowUtils;
 
 /**
  * This class is responsible for storing events utilized by the GUI.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -12,7 +12,6 @@ import com.swirlds.platform.builder.ApplicationCallbacks;
 import com.swirlds.platform.components.AppNotifier;
 import com.swirlds.platform.components.EventWindowManager;
 import com.swirlds.platform.components.consensus.ConsensusEngine;
-import com.swirlds.platform.consensus.EventWindowUtils;
 import com.swirlds.platform.event.branching.BranchDetector;
 import com.swirlds.platform.event.branching.BranchReporter;
 import com.swirlds.platform.event.deduplication.EventDeduplicator;
@@ -36,11 +35,13 @@ import com.swirlds.state.MerkleNodeState;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
 import org.hiero.consensus.event.creator.EventCreatorModule;
+import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.quiescence.QuiescenceCommand;
 import org.hiero.consensus.roster.RosterHistory;
 import org.hiero.consensus.roster.RosterUtils;
+import org.hiero.consensus.round.EventWindowUtils;
 
 /**
  * Responsible for coordinating activities through the component's wire for the platform.
@@ -397,7 +398,9 @@ public record PlatformCoordinator(@NonNull PlatformComponents components, @NonNu
         final RosterHistory rosterHistory = RosterUtils.createRosterHistory(state);
         this.injectRosterHistory(rosterHistory);
 
-        this.updateEventWindow(EventWindowUtils.createEventWindow(consensusSnapshot, configuration));
+        final int roundsNonAncient =
+                configuration.getConfigData(ConsensusConfig.class).roundsNonAncient();
+        this.updateEventWindow(EventWindowUtils.createEventWindow(consensusSnapshot, roundsNonAncient));
 
         final RunningEventHashOverride runningEventHashOverride =
                 new RunningEventHashOverride(legacyRunningEventHashOf(state), true);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/RoundCalculationUtilsTest.java
@@ -2,6 +2,7 @@
 package com.swirlds.platform.consensus;
 
 import org.hiero.consensus.model.event.EventConstants;
+import org.hiero.consensus.round.RoundCalculationUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/TestIntake.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/TestIntake.java
@@ -19,7 +19,6 @@ import com.swirlds.platform.components.EventWindowManager;
 import com.swirlds.platform.components.consensus.ConsensusEngine;
 import com.swirlds.platform.components.consensus.ConsensusEngineOutput;
 import com.swirlds.platform.components.consensus.DefaultConsensusEngine;
-import com.swirlds.platform.consensus.EventWindowUtils;
 import com.swirlds.platform.consensus.SyntheticSnapshot;
 import com.swirlds.platform.event.orphan.DefaultOrphanBuffer;
 import com.swirlds.platform.event.orphan.OrphanBuffer;
@@ -41,6 +40,7 @@ import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.round.EventWindowUtils;
 
 /**
  * Event intake with consensus and shadowgraph, used for testing

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/OutputNoEventsLostValidation.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/OutputNoEventsLostValidation.java
@@ -4,7 +4,6 @@ package com.swirlds.platform.test.fixtures.consensus.framework.validation;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import com.swirlds.platform.consensus.RoundCalculationUtils;
 import com.swirlds.platform.test.fixtures.consensus.framework.ConsensusOutput;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
@@ -13,6 +12,7 @@ import org.hiero.base.crypto.Hash;
 import org.hiero.base.crypto.Hashable;
 import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.hiero.consensus.model.event.PlatformEvent;
+import org.hiero.consensus.round.RoundCalculationUtils;
 
 @SuppressWarnings("unused") // issue tracked #6998
 /**

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
@@ -11,7 +11,6 @@ import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.ConsensusImpl;
-import com.swirlds.platform.consensus.EventWindowUtils;
 import com.swirlds.platform.event.linking.ConsensusLinker;
 import com.swirlds.platform.event.linking.NoOpLinkerLogsAndMetrics;
 import com.swirlds.platform.event.orphan.DefaultOrphanBuffer;
@@ -45,6 +44,7 @@ import org.hiero.consensus.model.hashgraph.ConsensusConstants;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.roster.RosterUtils;
+import org.hiero.consensus.round.EventWindowUtils;
 
 /**
  * A utility class for generating a graph of events.


### PR DESCRIPTION
**Description**:
This PR moves two classes used by both the reconnect state loading logic and the hashgraph logic to the `consensus-utility` class. There, it can safely be used by both when the hashgraph module is extracted.

The only non-move change that was made was to eliminate the dependency on `Configuration` in the utility classes. Instead of passing in the configuration and having the utility class read the required configuration, the raw configuration value must now be supplied.

Fixes #22599 
