### PR TITLE
chore: remove empty upload artifact step in XTS workflow

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -157,6 +157,14 @@ jobs:
             /repos/hiero-ledger/hiero-consensus-node/actions/jobs/$job_id/logs >> run.log
           done
 
+      - name: Upload log as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        continue-on-error: true
+        with:
+          retention-days: 7
+          path: |
+            run.log
+
       - name: Get Commit Information
         id: fetch-commit-info
         run: |


### PR DESCRIPTION
**Description**:

Remove the empty upload artifact step in the XTS workflow

**Related Issue(s)**:

Fixes #22605
