### PR TITLE
chore: Simplify consensus constructor

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
+++ b/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/ConsensusBenchmark.java
@@ -12,7 +12,6 @@ import com.swirlds.platform.test.fixtures.event.emitter.EventEmitterBuilder;
 import com.swirlds.platform.test.fixtures.event.emitter.StandardEventEmitter;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.hiero.consensus.hashgraph.ConsensusConfig;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -56,7 +55,7 @@ public class ConsensusBenchmark {
         events = emitter.emitEvents(numEvents);
 
         consensus = new ConsensusImpl(
-                platformContext.getConfiguration().getConfigData(ConsensusConfig.class),
+                platformContext.getConfiguration(),
                 platformContext.getTime(),
                 new NoOpConsensusMetrics(),
                 emitter.getGraphGenerator().getRoster());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ConsensusImpl.java
@@ -4,6 +4,7 @@ package com.swirlds.platform;
 import static com.swirlds.logging.legacy.LogMarker.CONSENSUS_VOTING;
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.logging.legacy.LogMarker.STARTUP;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
 import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
@@ -17,6 +18,7 @@ import com.hedera.hapi.util.HapiUtils;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.utility.Threshold;
 import com.swirlds.common.utility.throttle.RateLimitedLogger;
+import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.LogMarker;
 import com.swirlds.platform.consensus.AncestorSearch;
 import com.swirlds.platform.consensus.CandidateWitness;
@@ -203,17 +205,17 @@ public class ConsensusImpl implements Consensus {
     /**
      * Constructs an empty object (no events) to keep track of elections and calculate consensus.
      *
-     * @param consensusConfig the consensus configuration
+     * @param configuration the configuration
      * @param time the time source
      * @param consensusMetrics metrics related to consensus
      * @param roster the global address book, which never changes
      */
     public ConsensusImpl(
-            @NonNull final ConsensusConfig consensusConfig,
+            @NonNull final Configuration configuration,
             @NonNull final Time time,
             @NonNull final ConsensusMetrics consensusMetrics,
             @NonNull final Roster roster) {
-        this.config = consensusConfig;
+        this.config = requireNonNull(configuration).getConfigData(ConsensusConfig.class);
         this.time = time;
         this.consensusMetrics = consensusMetrics;
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/consensus/DefaultConsensusEngine.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/consensus/DefaultConsensusEngine.java
@@ -70,9 +70,8 @@ public class DefaultConsensusEngine implements ConsensusEngine {
             @NonNull final FreezeCheckHolder freezeChecker) {
 
         final ConsensusMetrics consensusMetrics = new ConsensusMetricsImpl(selfId, platformContext.getMetrics());
-        final ConsensusConfig consensusConfig =
-                platformContext.getConfiguration().getConfigData(ConsensusConfig.class);
-        consensus = new ConsensusImpl(consensusConfig, platformContext.getTime(), consensusMetrics, roster);
+        consensus = new ConsensusImpl(
+                platformContext.getConfiguration(), platformContext.getTime(), consensusMetrics, roster);
 
         linker = new ConsensusLinker(
                 new DefaultLinkerLogsAndMetrics(platformContext.getMetrics(), platformContext.getTime()));

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiEventStorage.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiEventStorage.java
@@ -52,10 +52,8 @@ public class GuiEventStorage {
         this.configuration = Objects.requireNonNull(configuration);
         final PlatformContext platformContext = PlatformContext.create(configuration);
 
-        final ConsensusConfig consensusConfig =
-                platformContext.getConfiguration().getConfigData(ConsensusConfig.class);
-        this.consensus =
-                new ConsensusImpl(consensusConfig, platformContext.getTime(), new NoOpConsensusMetrics(), roster);
+        this.consensus = new ConsensusImpl(
+                platformContext.getConfiguration(), platformContext.getTime(), new NoOpConsensusMetrics(), roster);
         this.linker = new ConsensusLinker(NoOpLinkerLogsAndMetrics.getInstance());
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/DefaultIssDetector.java
@@ -13,7 +13,6 @@ import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.utility.Mnemonics;
 import com.swirlds.common.utility.throttle.RateLimiter;
 import com.swirlds.logging.legacy.payload.IssPayload;
-import com.swirlds.platform.config.PathsConfig;
 import com.swirlds.platform.config.StateConfig;
 import com.swirlds.platform.metrics.IssMetrics;
 import com.swirlds.platform.state.iss.internal.ConsensusHashFinder;
@@ -118,7 +117,6 @@ public class DefaultIssDetector implements IssDetector {
             final long ignoredRound,
             final long latestFreezeRound) {
         Objects.requireNonNull(platformContext);
-        final PathsConfig pathsConfig = platformContext.getConfiguration().getConfigData(PathsConfig.class);
 
         final ConsensusConfig consensusConfig =
                 platformContext.getConfiguration().getConfigData(ConsensusConfig.class);

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/event/generator/StandardGraphGenerator.java
@@ -200,10 +200,10 @@ public class StandardGraphGenerator implements GraphGenerator {
      * Note: once an event source has been passed to this constructor it should not be modified by the outer context.
      *
      * @param platformContext The platform context
-     * @param seed            The random seed used to generate events.
+     * @param seed The random seed used to generate events.
      * @param maxOtherParents The maximum number of other-parents for each event.
-     * @param eventSources    One or more event sources.
-     * @param roster          The roster to use.
+     * @param eventSources One or more event sources.
+     * @param roster The roster to use.
      */
     public StandardGraphGenerator(
             @NonNull final PlatformContext platformContext,
@@ -252,9 +252,8 @@ public class StandardGraphGenerator implements GraphGenerator {
     }
 
     private void initializeInternalConsensus() {
-        final ConsensusConfig consensusConfig =
-                platformContext.getConfiguration().getConfigData(ConsensusConfig.class);
-        consensus = new ConsensusImpl(consensusConfig, platformContext.getTime(), new NoOpConsensusMetrics(), roster);
+        consensus = new ConsensusImpl(
+                platformContext.getConfiguration(), platformContext.getTime(), new NoOpConsensusMetrics(), roster);
         linker = new ConsensusLinker(NoOpLinkerLogsAndMetrics.getInstance());
         orphanBuffer = new DefaultOrphanBuffer(platformContext.getMetrics(), mock(IntakeEventCounter.class));
     }
@@ -264,7 +263,7 @@ public class StandardGraphGenerator implements GraphGenerator {
      * the event sources from the addresses.
      *
      * @param eventSources the event sources to initialize.
-     * @param roster       the roster to use.
+     * @param roster the roster to use.
      */
     private void setAddressBookInitializeEventSources(
             @NonNull final List<EventSource> eventSources, @NonNull final Roster roster) {
@@ -281,9 +280,8 @@ public class StandardGraphGenerator implements GraphGenerator {
      * Set the affinity of each node for choosing the parents of its events.
      *
      * @param affinityMatrix An n by n matrix where n is the number of event sources. Each row defines the preference of
-     *                       a particular node when choosing other parents. Node 0 is described by the first row, node 1
-     *                       by the next, etc. Each entry should be a weight. Weights of self (i.e. the weights on the
-     *                       diagonal) should be 0.
+     * a particular node when choosing other parents. Node 0 is described by the first row, node 1 by the next, etc.
+     * Each entry should be a weight. Weights of self (i.e. the weights on the diagonal) should be 0.
      */
     public void setOtherParentAffinity(final List<List<Double>> affinityMatrix) {
         setOtherParentAffinity(staticDynamicValue(affinityMatrix));
@@ -293,7 +291,7 @@ public class StandardGraphGenerator implements GraphGenerator {
      * Set the affinity of each node for choosing the parents of its events.
      *
      * @param affinityMatrix A dynamic n by n matrix where n is the number of event sources. Each entry should be a
-     *                       weight. Weights of self (i.e. the weights on the diagonal) should be 0.
+     * weight. Weights of self (i.e. the weights on the diagonal) should be 0.
      */
     public void setOtherParentAffinity(final DynamicValue<List<List<Double>>> affinityMatrix) {
         this.affinityMatrix = new DynamicValueGenerator<>(affinityMatrix);
@@ -303,7 +301,7 @@ public class StandardGraphGenerator implements GraphGenerator {
      * Get the affinity vector for a particular node.
      *
      * @param eventIndex the current event index
-     * @param nodeId     the node ID that is being requested
+     * @param nodeId the node ID that is being requested
      */
     private List<Double> getOtherParentAffinityVector(final long eventIndex, final int nodeId) {
         return affinityMatrix.get(getRandom(), eventIndex).get(nodeId);


### PR DESCRIPTION
**Description**:
This PR addresses two comments from a previous PR:

- Remove the unused `PathsConfig` from `DefaultIssDetector`
- Change the `ConsensusImpl` constructor to accept the `Configuration` object instead of it's specific configuration type to reduce duplicated code when instantiating it

**Related issue(s)**:

Fixes #22610