### PR TITLE
feat: Option for enabled TPC_QUICKACK for sync process

### DIFF
--- a/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/SocketConfig.java
+++ b/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/SocketConfig.java
@@ -39,4 +39,4 @@ public record SocketConfig(
         @ConfigProperty(defaultValue = "false") boolean gzipCompression,
         @ConfigProperty(defaultValue = "10") int waitBetweenConnectionRetries,
         @ConfigProperty(defaultValue = "30") int maxSocketAcceptThreads,
-        @ConfigProperty(defaultValue = "false") boolean quickAck) {}
+        @ConfigProperty(defaultValue = "true") boolean quickAck) {}

--- a/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/SocketConfig.java
+++ b/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/SocketConfig.java
@@ -25,6 +25,7 @@ import com.swirlds.config.api.ConfigProperty;
  * @param maxSocketAcceptThreads     maximum amount of threads which will be spawned to handle incoming SSL socket
  *                                   accepts, needed because of length SSL handshake; at same time, we don't want it to
  *                                   be unlimited, to not run out of threads on some kind of DOS
+ * @param quickAck                   use TCP_QUICKACK on sync sockets after each read
  */
 @ConfigData("socket")
 public record SocketConfig(
@@ -37,4 +38,5 @@ public record SocketConfig(
         @ConfigProperty(defaultValue = "true") boolean tcpNoDelay,
         @ConfigProperty(defaultValue = "false") boolean gzipCompression,
         @ConfigProperty(defaultValue = "10") int waitBetweenConnectionRetries,
-        @ConfigProperty(defaultValue = "30") int maxSocketAcceptThreads) {}
+        @ConfigProperty(defaultValue = "30") int maxSocketAcceptThreads,
+        @ConfigProperty(defaultValue = "false") boolean quickAck) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/Connection.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/Connection.java
@@ -47,7 +47,7 @@ public interface Connection {
 
     /**
      * Is there currently a valid connection from me to the member at the given index in the address book?
-     *
+     * <p>
      * If this method returns {@code true}, the underlying socket is guaranteed to be non-null.
      *
      * @return true is connected, false otherwise.
@@ -58,26 +58,23 @@ public interface Connection {
      * Returns the current timeout value of this connection.
      *
      * @return the current timeout value in milliseconds
-     * @throws SocketException
-     * 		if there is an error in the underlying protocol, such as a TCP error.
+     * @throws SocketException if there is an error in the underlying protocol, such as a TCP error.
      */
     int getTimeout() throws SocketException;
 
     /**
      * Sets the timeout of this connection.
      *
-     * @param timeoutMillis
-     * 		The timeout value to set in milliseconds. A value of zero is treated as an infinite timeout.
-     * @throws SocketException
-     * 		if there is an error in the underlying protocol, such as a TCP error.
+     * @param timeoutMillis The timeout value to set in milliseconds. A value of zero is treated as an infinite
+     *                      timeout.
+     * @throws SocketException if there is an error in the underlying protocol, such as a TCP error.
      */
     void setTimeout(final long timeoutMillis) throws SocketException;
 
     /**
      * Initialize {@code this} instance for a gossip session.
      *
-     * @throws IOException
-     * 		if the connection is broken
+     * @throws IOException if the connection is broken
      */
     void initForSync() throws IOException;
 
@@ -103,4 +100,10 @@ public interface Connection {
     default String generateDescription() {
         return String.format("%s %s %s", getSelfId(), isOutbound() ? "->" : "<-", getOtherId());
     }
+
+    /**
+     * Optional call by client to indicate that read operation has finished. Some implementations of Connection might
+     * use it to optimize network communication (by sending quick ack for example)
+     */
+    default void afterRead() {}
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/SocketConnection.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/SocketConnection.java
@@ -12,6 +12,7 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import jdk.net.ExtendedSocketOptions;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.io.exceptions.BadIOException;
@@ -36,6 +37,7 @@ public class SocketConnection implements Connection {
     private final boolean outbound;
     private final String description;
     private final Configuration configuration;
+    private final boolean quickAck;
 
     /**
      * @param connectionTracker tracks open connections
@@ -71,6 +73,7 @@ public class SocketConnection implements Connection {
         this.dis = dis;
         this.dos = dos;
         this.configuration = configuration;
+        this.quickAck = configuration.getConfigData(SocketConfig.class).quickAck();
     }
 
     /**
@@ -196,5 +199,21 @@ public class SocketConnection implements Connection {
     @Override
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void afterRead() {
+        try {
+            if (quickAck) {
+                // quick ack has to be set after each read - it just sends instant acknowledgement
+                // it is NOT implemented on Mac as of 2025, but shouldn't hurt, except for some wasted cpu cycles
+                getSocket().setOption(ExtendedSocketOptions.TCP_QUICKACK, true);
+            }
+        } catch (final IOException e) {
+            // we can silently ignore it, as it is optional
+        }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/rpc/RpcPeerProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/rpc/RpcPeerProtocol.java
@@ -466,6 +466,8 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
                             pingHandler.handleIncomingPingReply(pingReply);
                             break;
                     }
+
+                    connection.afterRead();
                 }
             }
         } finally {


### PR DESCRIPTION
**Description**:
Possibility for enabling TCP_QUICKACK for sync.

Please read https://catonmat.net/tcp-quickack for context.

This PR has it disabled by default, as it is hard to test and does NOT work on Mac (it shouldn't break anything, just won't give any benefits).

Hope is that it can reduce the latency of sync slightly in some environments. If it has no visible benefits after enabling on linux, it is probably not worth to include it.

**Related issue(s)**:

Fixes #22189 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
