### PR TITLE
fix: 21612: Export and SortedExport commands must be resilient to the corrupted state

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/JsonExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/JsonExporter.java
@@ -150,7 +150,16 @@ public class JsonExporter {
         boolean emptyFile = true;
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
             for (long path = start; path <= end; path++) {
-                VirtualLeafBytes leafRecord = vm.getRecords().findLeafRecord(path);
+                VirtualLeafBytes leafRecord = null;
+                try {
+                    leafRecord = vm.getRecords().findLeafRecord(path);
+                } catch (final Exception e) {
+                    log.error("Unexpected error while finding leaf record by path", e);
+                }
+                if (leafRecord == null) {
+                    log.error("No leaf record for path {}", path);
+                    continue;
+                }
                 final Bytes keyBytes = leafRecord.keyBytes();
                 final Bytes valueBytes = leafRecord.valueBytes();
                 final StateKey stateKey;

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedJsonExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedJsonExporter.java
@@ -176,7 +176,16 @@ public class SortedJsonExporter {
         }
 
         LongStream.range(firstLeafPath, lastLeafPath + 1).parallel().forEach(path -> {
-            final VirtualLeafBytes leafRecord = vm.getRecords().findLeafRecord(path);
+            VirtualLeafBytes leafRecord = null;
+            try {
+                leafRecord = vm.getRecords().findLeafRecord(path);
+            } catch (final Exception e) {
+                log.error("Unexpected error while finding leaf record by path", e);
+            }
+            if (leafRecord == null) {
+                log.error("No leaf record for path {}", path);
+                return;
+            }
             final Bytes keyBytes = leafRecord.keyBytes();
             final ReadableSequentialData keyData = keyBytes.toReadableSequentialData();
             final int tag = keyData.readVarInt(false);


### PR DESCRIPTION
Fixes #21612

Tested with manually corrupted states.
