### PR TITLE
refactor: Move `IntReference` to `base-utility`

### DIFF
--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/IntReference.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/IntReference.java
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.common.utility;
+package org.hiero.base;
 
 import com.swirlds.base.utility.ToStringBuilder;
 import java.util.Objects;
-import org.hiero.base.ValueReference;
 
 /**
  * An object wrapper for an int that allows it to mutate, unlike {@link Integer}. Similar to {@link ValueReference} but

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/CandidateWitness.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/CandidateWitness.java
@@ -3,12 +3,12 @@ package com.swirlds.platform.consensus;
 
 import static com.swirlds.logging.legacy.LogMarker.CONSENSUS_VOTING;
 
-import com.swirlds.common.utility.IntReference;
 import com.swirlds.platform.internal.EventImpl;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hiero.base.IntReference;
 
 /** A wrapper for a witness which holds additional metadata while an election to decide its fame is ongoing */
 public final class CandidateWitness {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/RoundElections.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/consensus/RoundElections.java
@@ -4,7 +4,6 @@ package com.swirlds.platform.consensus;
 import static com.swirlds.logging.legacy.LogMarker.CONSENSUS_VOTING;
 
 import com.hedera.hapi.platform.state.MinimumJudgeInfo;
-import com.swirlds.common.utility.IntReference;
 import com.swirlds.platform.internal.EventImpl;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -16,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hiero.base.IntReference;
 import org.hiero.base.utility.ArrayUtils;
 import org.hiero.consensus.model.event.EventConstants;
 import org.hiero.consensus.model.event.NonDeterministicGeneration;


### PR DESCRIPTION
Fixes #22696