### PR TITLE
ci(bug): Mitigate issue with deploy release artifact not publishing GCP artifacts.

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -843,6 +843,7 @@ jobs:
           echo "::group::Sign Release Archives"
             cd "${SDK_ARCHIVE_DIR}" || exit "${?}"
             if [[ -f "${LIB_ARCHIVE_FILE}" ]]; then
+              echo "Signing the library archive: ${LIB_ARCHIVE_FILE}"
               sha256sum "${LIB_ARCHIVE_FILE}" >"${LIB_ARCHIVE_FILE}.sha256"
               gpg --output "${LIB_ARCHIVE_FILE}.asc" --detach-sig "${LIB_ARCHIVE_FILE}"
               gpg --output "${LIB_ARCHIVE_FILE}.sha256.asc" --detach-sig "${LIB_ARCHIVE_FILE}.sha256"
@@ -851,6 +852,7 @@ jobs:
             fi
 
             if [[ -f "${APPS_ARCHIVE_FILE}" ]]; then
+              echo "Signing the application archive: ${APPS_ARCHIVE_FILE}"
               sha256sum "${APPS_ARCHIVE_FILE}" >"${APPS_ARCHIVE_FILE}.sha256"
               gpg --output "${APPS_ARCHIVE_FILE}.asc" --detach-sig "${APPS_ARCHIVE_FILE}"
               gpg --output "${APPS_ARCHIVE_FILE}.sha256.asc" --detach-sig "${APPS_ARCHIVE_FILE}.sha256"
@@ -859,6 +861,7 @@ jobs:
             fi
 
             if [[ -f "${PUBLIC_ARCHIVE_FILE}" ]]; then
+              echo "Signing the public archive: ${PUBLIC_ARCHIVE_FILE}"
               sha256sum "${PUBLIC_ARCHIVE_FILE}" >"${PUBLIC_ARCHIVE_FILE}.sha256"
               gpg --output "${PUBLIC_ARCHIVE_FILE}.asc" --detach-sig "${PUBLIC_ARCHIVE_FILE}"
               gpg --output "${PUBLIC_ARCHIVE_FILE}.sha256.asc" --detach-sig "${PUBLIC_ARCHIVE_FILE}.sha256"


### PR DESCRIPTION
## Description

We have had failures in deploy release artifact since last week (Friday - 12/19/2025). This should mitigate the issue (`data/apps` not present) while we root cause the change to publishing.

This pull request improves the robustness and clarity of the release artifact build and signing process in the GitHub Actions workflow. The main changes add checks to ensure required files and directories exist before attempting to archive, sign, or upload them, and provide clear warnings or errors when expected artifacts are missing.

**Enhancements to build, signing, and upload steps:**

* **Build step improvements:**
  - Added checks to confirm that `data/lib`, `data/apps`, and `data` directories exist and are not empty before creating their respective archives. If any are missing or empty, a GitHub Actions warning is issued instead of failing silently.

* **Signing step improvements:**
  - Updated the signing process to verify that each archive file exists before attempting to sign or hash it. If an archive is missing, a warning is logged and signing for that archive is skipped, preventing errors.

* **Upload step improvements:**
  - Added a check to ensure the `sdk-archives` directory exists and is not empty before uploading to the GCP bucket. If the directory is missing, an error is logged and the workflow exits with a failure, making issues more visible.

## Related Issue(s)

Fixes #22709 

## Testing

[Publish to GCP without data/apps](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/20435902567/job/58717137553) ✅ 