### PR TITLE
test: add hapi tests for crypto create and crypto update with delegation addresses

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/crypto_get_info.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/crypto_get_info.proto
@@ -269,6 +269,11 @@ message CryptoGetInfoResponse {
          * Staking information for this account.
          */
         StakingInfo staking_info = 22;
+
+        /**
+         * Delegation address if a EIP-7702 code delegation is set for the account.
+         */
+        bytes delegation_address = 23;
     }
 
     /**

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -212,7 +212,7 @@ public record EthTxData(
                                 Integers.toBytesUnsigned(value),
                                 callData,
                                 accessListAsRlp() != null ? accessListAsRlp() : new Object[0],
-                                List.of(authorizationList),
+                                authorizationListAsRlp() != null ? authorizationListAsRlp() : new Object[0],
                                 Integers.toBytes(recId),
                                 r,
                                 s));

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
@@ -163,6 +163,7 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
             info.ownedNfts(account.numberOwnedNfts());
             info.maxAutomaticTokenAssociations(account.maxAutoAssociations());
             info.ethereumNonce(account.ethereumNonce());
+            info.delegationAddress(account.delegationAddress());
             if (!AliasUtils.isOfEvmAddressSize(account.alias())) {
                 info.alias(account.alias());
             }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Assertions;
 public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo> {
 
     public static final String BAD_ALIAS = "Bad Alias!";
+    public static final String WRONG_DELEGATION_ADDRESS = "Wrong delegation address!";
 
     boolean hasTokenAssociationExpectations = false;
 
@@ -216,6 +217,12 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
                     (allowedPercentDiff / 100.0) * expectedTinyBarsToSubtract,
                     errorMsgIfOutsideTolerance);
         });
+        return this;
+    }
+
+    public AccountInfoAsserts delegationAddress(ByteString delegationAddress) {
+        registerProvider((spec, o) ->
+                assertEquals(delegationAddress, ((AccountInfo) o).getDelegationAddress(), WRONG_DELEGATION_ADDRESS));
         return this;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoCreate.java
@@ -90,6 +90,7 @@ public class HapiCryptoCreate extends HapiTxnOp<HapiCryptoCreate> {
     private boolean setEvmAddressAliasFromKey = false;
     private Optional<ShardID> shardId = Optional.empty();
     private Optional<RealmID> realmId = Optional.empty();
+    private Optional<ByteString> delegationAddress = Optional.empty();
 
     private List<Function<HapiSpec, HookCreationDetails>> hookFactories = List.of();
 
@@ -275,6 +276,11 @@ public class HapiCryptoCreate extends HapiTxnOp<HapiCryptoCreate> {
         return evmAddress(ByteString.copyFrom(explicitFromHeadlong(evmAddress)));
     }
 
+    public HapiCryptoCreate delegationAddress(final ByteString delegationAddress) {
+        this.delegationAddress = Optional.of(delegationAddress);
+        return this;
+    }
+
     @Override
     protected HapiCryptoCreate self() {
         return this;
@@ -337,6 +343,7 @@ public class HapiCryptoCreate extends HapiTxnOp<HapiCryptoCreate> {
                             maxAutomaticTokenAssociations.ifPresent(b::setMaxAutomaticTokenAssociations);
                             shardId.ifPresent(b::setShardID);
                             realmId.ifPresent(b::setRealmID);
+                            delegationAddress.ifPresent(b::setDelegationAddress);
                             if (stakedAccountId.isPresent()) {
                                 // Calculate and assign the effective staked account ID
                                 AccountID effectiveStakedAcctId = TxnUtils.asId(stakedAccountId.get(), spec);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -12,6 +12,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.MoreObjects;
 import com.google.protobuf.BoolValue;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.UInt64Value;
@@ -64,6 +65,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
     private Optional<String> newStakee = Optional.empty();
     private Optional<Long> newStakedNodeId = Optional.empty();
     private Optional<Boolean> isDeclinedReward = Optional.empty();
+    private Optional<ByteString> delegationAddress = Optional.empty();
 
     private List<Long> hookIdsToDelete = List.of();
     private List<Function<HapiSpec, HookCreationDetails>> hookFactories = List.of();
@@ -199,6 +201,11 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
         return this;
     }
 
+    public HapiCryptoUpdate delegationAddress(final ByteString delegationAddress) {
+        this.delegationAddress = Optional.of(delegationAddress);
+        return this;
+    }
+
     @Override
     public HederaFunctionality type() {
         return HederaFunctionality.CryptoUpdate;
@@ -270,6 +277,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
                                 builder.setStakedNodeId(newStakedNodeId.get());
                             }
                             isDeclinedReward.ifPresent(b -> builder.setDeclineReward(BoolValue.of(b)));
+                            delegationAddress.ifPresent(builder::setDelegationAddress);
                             hookIdsToDelete.forEach(builder::addHookIdsToDelete);
                             hookFactories.forEach(factory -> builder.addHookCreationDetails(pbjToProto(
                                     factory.apply(spec),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -55,6 +55,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_G
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALIAS_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_MAX_AUTO_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
@@ -1036,5 +1037,21 @@ public class CryptoCreateSuite {
                         .balance(1L)
                         .realmId(RealmID.newBuilder().setRealmNum(4).build())
                         .hasKnownStatus(INVALID_ACCOUNT_ID));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> createAccountWithDelegationAddress() {
+        final var longZeroAddress = ByteString.copyFrom(CommonUtils.unhex("0000000000000000000000000000000fffffffff"));
+        final var emptyAddress = ByteString.empty();
+        final var badAddress = ByteString.copyFrom(CommonUtils.unhex("0fffffffff"));
+        return hapiTest(
+                cryptoCreate("withDelegationAddress").balance(ONE_HUNDRED_HBARS).delegationAddress(longZeroAddress),
+                getAccountInfo("withDelegationAddress").has(accountWith().delegationAddress(longZeroAddress)),
+                cryptoCreate("withEmptyAddress").balance(ONE_HUNDRED_HBARS).delegationAddress(emptyAddress),
+                getAccountInfo("withEmptyAddress").has(accountWith().delegationAddress(emptyAddress)),
+                cryptoCreate("withBadDelegationAddress")
+                        .balance(ONE_HUNDRED_HBARS)
+                        .delegationAddress(badAddress)
+                        .hasPrecheck(INVALID_CONTRACT_ID));
     }
 }


### PR DESCRIPTION
**Description**:
Include tests that exercise the delegation_address field with the crypto create and crypto update calls.

**Related issue(s)**:

Fixes #22702 
