### PR TITLE
chore: Update which checks run on PRs coming from forks

### DIFF
--- a/.github/workflows/zxc-mats-tests.yaml
+++ b/.github/workflows/zxc-mats-tests.yaml
@@ -223,7 +223,7 @@ jobs:
 
   mats-snyk-scan:
     name: Snyk Scan
-    if: ${{ inputs.enable-snyk-scan == 'true' }}
+    if: ${{ inputs.enable-snyk-scan == 'true' && !github.event.workflow_call.repository.fork }}
     needs:
       - build
     uses: ./.github/workflows/zxc-snyk-scan.yaml
@@ -239,7 +239,7 @@ jobs:
 
   mats-gradle-determinism:
     name: Gradle Determinism
-    if: ${{ inputs.enable-gradle-determinism == 'true' }}
+    if: ${{ inputs.enable-gradle-determinism == 'true' && !github.event.workflow_call.repository.fork }}
     needs:
       - build
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -253,7 +253,7 @@ jobs:
 
   mats-docker-determinism:
     name: Docker Determinism
-    if: ${{ inputs.enable-docker-determinism == 'true' }}
+    if: ${{ inputs.enable-docker-determinism == 'true' && !github.event.workflow_call.repository.fork }}
     needs:
       - build
     uses: ./.github/workflows/zxc-verify-docker-build-determinism.yaml


### PR DESCRIPTION
## Description

This pull request updates the workflow conditions in `.github/workflows/zxc-mats-tests.yaml` to prevent certain jobs from running on forked repositories. This helps improve security and avoids running sensitive or unnecessary jobs in forked environments.

Workflow condition updates:

* Updated the `if` conditions for the following jobs to ensure they only run when not triggered from a forked repository:
  - `mats-snyk-scan` job now checks that the workflow is not running from a fork before executing.
  - `mats-gradle-determinism` job now checks that the workflow is not running from a fork before executing.
  - `mats-docker-determinism` job now checks that the workflow is not running from a fork before executing.

## Related Issue(s)

Closes #22723