### PR TITLE
ci(fix): add not cancelled check to failure artifact publishing

### DIFF
--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -167,7 +167,7 @@ jobs:
 
       - name: Upload HAPI Test (Misc) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-misc.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-misc.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Misc) Network Logs
           path: |
@@ -230,7 +230,7 @@ jobs:
 
       - name: Upload HAPI Test (Misc Records) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-misc-records.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-misc-records.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Misc Records) Network Logs
           path: |
@@ -293,7 +293,7 @@ jobs:
 
       - name: Upload HAPI Test (Crypto) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-crypto.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-crypto.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Crypto) Network Logs
           path: |
@@ -356,7 +356,7 @@ jobs:
 
       - name: Upload HAPI Test (Simple Fees) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-simplefees.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-simplefees.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Simple Fees) Network Logs
           path: |
@@ -419,7 +419,7 @@ jobs:
 
       - name: Upload HAPI Test (Token) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-token.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-token.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Token) Network Logs
           path: |
@@ -482,7 +482,7 @@ jobs:
 
       - name: Upload HAPI Test (Smart Contract) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-smart-contract.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-smart-contract.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Smart Contract) Network Logs
           path: |
@@ -545,7 +545,7 @@ jobs:
 
       - name: Upload HAPI Test (Time Consuming) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-time-consuming.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-time-consuming.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Time Consuming) Network Logs
           path: |
@@ -608,7 +608,7 @@ jobs:
 
       - name: Upload HAPI Test (Restart) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-restart.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-restart.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Restart) Network Logs
           path: |
@@ -671,7 +671,7 @@ jobs:
 
       - name: Upload HAPI Test (Node Death Reconnect) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-nd-reconnect.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-nd-reconnect.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Node Death Reconnect) Network Logs
           path: |
@@ -734,7 +734,7 @@ jobs:
 
       - name: Upload HAPI Test (ISS) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-iss.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-iss.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (ISS) Network Logs
           path: |
@@ -797,7 +797,7 @@ jobs:
 
       - name: Upload HAPI Test (Block Node Communication) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-bn-communication.conclusion  == 'failure' && !cancelled() }}
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-hapi-bn-communication.conclusion == 'failure' && !cancelled() }}
         with:
           name: HAPI Test (Block Node Communication) Network Logs
           path: |


### PR DESCRIPTION
**Description**:

Add a `!cancelled()` check to publishing artifacts step on failure to ensure all artifacts are published as expected.

**Related Issue(s)**:

Fixes #22760

**Testing**:

- XTS Dry Run (showing publishing when a step fails) [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/20734879594) 🏃 

