### PR TITLE
fix: Fix `refundFees` logic when feeCollectionAccount is enabled

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/NodeFeeAccumulator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/NodeFeeAccumulator.java
@@ -19,6 +19,8 @@ public interface NodeFeeAccumulator {
     /**
      * Accumulates node fees for each transaction processed. This will update an in-memory map of node fees
      * for each transaction, which is then written to state at block boundaries for efficiency.
+     * Implementations should accept negative values to reverse previously accumulated fees (for example,
+     * when a transaction is refunded) and clamp the accumulated balance at zero.
      *
      * @param nodeAccountId the node account id
      * @param fees the fees to accumulate

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/api/TokenServiceApiImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/api/TokenServiceApiImplTest.java
@@ -832,23 +832,29 @@ class TokenServiceApiImplTest {
                     .build());
 
             final var config = configBuilder.getOrCreateConfig();
-            subject = new TokenServiceApiImpl(config, writableStates, customFeeTest, entityCounters);
+            final var nodeFeeAccumulator = new TestNodeFeeAccumulator();
+            nodeFeeAccumulator.accumulate(NODE_ACCOUNT_ID, 10L);
+            subject =
+                    new TokenServiceApiImpl(config, writableStates, customFeeTest, entityCounters, nodeFeeAccumulator);
 
             // When we refund fees (with node fee)
             final var fees = new Fees(10, 20, 20); // 10 node, 40 network+service
             subject.refundFees(EOA_ACCOUNT_ID, NODE_ACCOUNT_ID, fees, rb, (amount) -> {});
 
-            // Then fee collection account balance is reduced by network+service fees
+            // Then fee collection account balance is reduced by total fees
             final var feeCollectionAccount = requireNonNull(accountState.get(FEE_COLLECTION_ACCOUNT_ID));
-            assertThat(feeCollectionAccount.tinybarBalance()).isEqualTo(60L); // 100 - 40
+            assertThat(feeCollectionAccount.tinybarBalance()).isEqualTo(50L); // 100 - 50
 
-            // And node account balance is reduced by node fee
+            // And node account balance is unchanged
             final var nodeAccount = requireNonNull(accountState.get(NODE_ACCOUNT_ID));
-            assertThat(nodeAccount.tinybarBalance()).isEqualTo(40L); // 50 - 10
+            assertThat(nodeAccount.tinybarBalance()).isEqualTo(50L);
 
             // And payer balance is increased by total refund
             final var payerAccount = requireNonNull(accountState.get(EOA_ACCOUNT_ID));
             assertThat(payerAccount.tinybarBalance()).isEqualTo(70L); // 20 + 50 (10 + 40)
+
+            // And accumulated node fees are reduced
+            assertThat(nodeFeeAccumulator.getAccumulatedFees(NODE_ACCOUNT_ID)).isZero();
         }
 
         private static class TestNodeFeeAccumulator implements NodeFeeAccumulator {
@@ -856,7 +862,13 @@ class TokenServiceApiImplTest {
 
             @Override
             public void accumulate(AccountID nodeAccountId, long amount) {
-                accumulatedFees.merge(nodeAccountId, amount, Long::sum);
+                if (amount == 0) {
+                    return;
+                }
+                final long updated = accumulatedFees.merge(nodeAccountId, amount, Long::sum);
+                if (updated <= 0) {
+                    accumulatedFees.remove(nodeAccountId);
+                }
             }
 
             public long getAccumulatedFees(AccountID nodeAccountId) {


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/22764

Fixed `refundFees()` in `TokenServiceApiImpl`. When `feeCollectionAccountEnabled=true`, retracted node fees from fee collection account instead of node account