### PR TITLE
chore: Disable event hash validators

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
@@ -31,8 +31,6 @@ import com.hedera.services.bdd.junit.support.validators.TokenReconciliationValid
 import com.hedera.services.bdd.junit.support.validators.TransactionBodyValidator;
 import com.hedera.services.bdd.junit.support.validators.block.BlockContentsValidator;
 import com.hedera.services.bdd.junit.support.validators.block.BlockNumberSequenceValidator;
-import com.hedera.services.bdd.junit.support.validators.block.EventHashBlockStreamValidator;
-import com.hedera.services.bdd.junit.support.validators.block.RedactingEventHashBlockStreamValidator;
 import com.hedera.services.bdd.junit.support.validators.block.StateChangesValidator;
 import com.hedera.services.bdd.junit.support.validators.block.TransactionRecordParityValidator;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -73,9 +71,11 @@ public class StreamValidationOp extends UtilOp implements LifecycleTest {
             TransactionRecordParityValidator.FACTORY,
             StateChangesValidator.FACTORY,
             BlockContentsValidator.FACTORY,
-            BlockNumberSequenceValidator.FACTORY,
-            EventHashBlockStreamValidator.FACTORY,
-            RedactingEventHashBlockStreamValidator.FACTORY);
+            BlockNumberSequenceValidator.FACTORY
+            // (FUTURE) Disabled until PCES events are integrated as the source of truth. See GH issue #22769.
+            //            EventHashBlockStreamValidator.FACTORY,
+            //            RedactingEventHashBlockStreamValidator.FACTORY
+            );
 
     private final int historyProofsToWaitFor;
 


### PR DESCRIPTION
Occasionally the `EventHashBlockStreamValidator` class [here](https://github.com/hiero-ledger/hiero-consensus-node/blob/cd0ff1db81c62608d75def5dbc4fd3dbc0933bf5/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/EventHashBlockStreamValidator.java#L28-L28) fails in CI test runs (see #22479). Our current working theory is that events created by the test nodes, but never included in consensus (and thus the block stream), are causing the failures. There's a solution in progress to fix this, but for the time being this PR disables these validators until the work for #22769 is complete. 