### PR TITLE
chore: Capture PCES files in failure artifacts

### DIFF
--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -880,6 +880,3 @@ jobs:
           fi
 
           echo "failure-mode=${failure_mode}" >> "${GITHUB_OUTPUT}"
-
-hedera-node/test-clients/build/**/*:
-  pces:


### PR DESCRIPTION
In addition to `blk.gz` and `rcd.gz` files, we also want to capture `.pces` files when failure artifacts for the hapi tests are created. This PR adds `*.pces` files to those artifacts. 