### PR TITLE
build: update besu beyond 25.2.2

### DIFF
--- a/gradle/besu-native-patch/build.gradle.kts
+++ b/gradle/besu-native-patch/build.gradle.kts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+plugins { `kotlin-dsl` }
+
+repositories { gradlePluginPortal() }
+
+dependencies {
+    // Only needed for Gradle to compile the build configuration and the patched code.
+    // The versions defined here are not actually used in a running build.
+    compileOnly("org.gradlex:extra-java-module-info:1.13.1")
+    compileOnly("net.java.dev.jna:jna:5.18.1")
+}

--- a/gradle/besu-native-patch/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
+++ b/gradle/besu-native-patch/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.nativelib.common;
+
+import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class BesuNativeLibraryLoader {
+
+  /**
+   * Wraps JNA with a prescriptive path, removing any platform naming inconsistencies
+   *  that might exist.  E.g. linux-gnu-x86-64 vs linux-x86_64.
+   *
+   *  Note that this method expects the directory space to be "partitioned" only by the arch, and
+   *  relies on the different operating systems to have different shared library object
+   *  filenames.  E.g. .dylib vs .so vs .dll.
+   */
+  public static void registerJNA(Class jnaClass, String libraryName) {
+
+    try {
+      String moduleContextClassName = Thread.currentThread().getStackTrace()[2].getClassName();
+      Class<?> moduleContextClass = Class.forName(moduleContextClassName);
+
+      final Optional<Path> libPath = extract(moduleContextClass, libraryName);
+
+      if (libPath.isPresent()) {
+        NativeLibrary lib = NativeLibrary.getInstance(libPath.get().toString());
+        Native.register(jnaClass, lib);
+      } else {
+        // fallback: try loading from library name via JNA
+        Native.register(jnaClass, libraryName);
+      }
+    } catch (UnsatisfiedLinkError __) {
+        String exceptionMessage =
+            String.format(
+                "Couldn't load native library (%s). It wasn't available at %s or the library path.",
+                libraryName, asLibraryResourcePath(libraryName));
+        throw new RuntimeException(exceptionMessage);
+    } catch (ClassNotFoundException e) {
+        throw new RuntimeException(e);
+    }
+  }
+
+  public static void loadJNI(Class jniClass, String libraryName) {
+
+    try {
+      final Optional<Path> libPath = extract(jniClass, libraryName);
+
+      if (libPath.isPresent()) {
+        System.load(libPath.get().toString());
+      } else {
+        System.loadLibrary(libraryName);
+      }
+    } catch (UnsatisfiedLinkError __) {
+      String exceptionMessage =
+          String.format(
+              "Couldn't load native library (%s). It wasn't available at %s or the library path.",
+              libraryName, asLibraryResourcePath(libraryName));
+      throw new RuntimeException(exceptionMessage);
+    }
+  }
+
+
+  private static Optional<Path> extract(Class classResource, String libraryName) {
+    final String platformNativeLibraryName = System.mapLibraryName(libraryName);
+
+    // load from lib/arch.  replace underscore with dash to avoid platform arch naming oddities
+    final String libraryResourcePath = asLibraryResourcePath(libraryName);
+
+    InputStream libraryResource = classResource.getResourceAsStream(libraryResourcePath);
+
+    if (libraryResource == null) {
+      // try absolute classpath reference for filesystem resources in case we are running tests:
+      libraryResource = classResource.getResourceAsStream("/" + libraryResourcePath);
+    }
+
+    if (libraryResource != null) {
+      try {
+        Path tempDir = Files.createTempDirectory(libraryName + "@");
+        tempDir.toFile().deleteOnExit();
+        Path tempDll = tempDir.resolve(platformNativeLibraryName);
+        tempDll.toFile().deleteOnExit();
+        Files.copy(libraryResource, tempDll, StandardCopyOption.REPLACE_EXISTING);
+        libraryResource.close();
+        return Optional.of(tempDll);
+      } catch (IOException ex) {
+        throw new UncheckedIOException(ex);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static String asLibraryResourcePath(String libraryName) {
+
+    final String platformNativeLibraryName = System.mapLibraryName(libraryName);
+    return safeArchLib(platformNativeLibraryName);
+
+  }
+
+  // deal with the variants that might be reported for x86-64
+  static String[] X86_VARIANTS = {"amd64", "x86_64", "x64", "ia32e", "EMT64T"};
+  private static String safeArchLib(String platformNativeLibraryName) {
+    String arch = System.getProperty("os.arch");
+
+    if (Arrays.asList(X86_VARIANTS).contains(arch)) {
+      arch = "x86-64";
+    }
+    // It is important that the folder 'lib-native' contains a '-' such that it is only
+    // folder and not a 'java package' to wich visibility rules may be applied by JPMS.
+    return String.format("lib-native/%s/%s", arch, platformNativeLibraryName );
+  }
+}

--- a/gradle/besu-native-patch/src/main/kotlin/org.hiero.gradle.feature.besu-native-patch.settings.gradle.kts
+++ b/gradle/besu-native-patch/src/main/kotlin/org.hiero.gradle.feature.besu-native-patch.settings.gradle.kts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE
+import org.gradlex.javamodule.moduleinfo.ExtraJavaModuleInfoPluginExtension
+import org.hiero.gradle.transforms.BesuNativePatchTransform
+
+@Suppress("UnstableApiUsage")
+gradle.lifecycle.beforeProject {
+    plugins.withId("org.hiero.gradle.base.jpms-modules") {
+        configure<ExtraJavaModuleInfoPluginExtension> {
+            // with the upgrade, besu requires the consensys' fork of the tuweni libraries
+            module("io.consensys.tuweni:tuweni-units", "tuweni.units")
+            module("io.consensys.tuweni:tuweni-bytes", "tuweni.bytes")
+            module("io.vertx:vertx-core", "io.vertx.core")
+        }
+
+        val javaModule = Attribute.of("javaModule", Boolean::class.javaObjectType)
+        val javaModulePatched = Attribute.of("javaModulePatched", Boolean::class.javaObjectType)
+
+        dependencies.artifactTypes["jar"].attributes.attribute(javaModulePatched, false)
+
+        dependencies.registerTransform(BesuNativePatchTransform::class) {
+            from.attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar")
+                .attribute(javaModule, true)
+                .attribute(javaModulePatched, false)
+            to.attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar")
+                .attribute(javaModule, true)
+                .attribute(javaModulePatched, true)
+        }
+
+        the<SourceSetContainer>()
+            .named { it != "jmh" }
+            .configureEach {
+                configurations[runtimeClasspathConfigurationName]
+                    .attributes
+                    .attribute(javaModulePatched, true)
+                configurations[compileClasspathConfigurationName]
+                    .attributes
+                    .attribute(javaModulePatched, true)
+                configurations[annotationProcessorConfigurationName]
+                    .attributes
+                    .attribute(javaModulePatched, true)
+            }
+    }
+}

--- a/gradle/besu-native-patch/src/main/kotlin/org/hiero/gradle/transforms/BesuNativePatchTransform.kt
+++ b/gradle/besu-native-patch/src/main/kotlin/org/hiero/gradle/transforms/BesuNativePatchTransform.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.gradle.transforms
+
+import java.io.BufferedOutputStream
+import java.io.File
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarInputStream
+import java.util.jar.JarOutputStream
+import org.gradle.api.artifacts.transform.*
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Classpath
+
+@CacheableTransform
+abstract class BesuNativePatchTransform : TransformAction<TransformParameters.None> {
+    companion object {
+        // Modified loader, see: https://github.com/hyperledger/besu-native/pull/290
+        const val BESU_NATIVE_LIBRARY_LOADER_CLASS =
+            "org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.class"
+        // See modules in: https://github.com/hyperledger/besu-native
+        val BESU_NATIVE_JARS =
+            listOf(
+                "besu-native-common",
+                "arithmetic",
+                "blake2bf",
+                "boringssl",
+                "constantine",
+                "gnark",
+                "ipa-multipoint",
+                "secp256k1",
+                "secp256r1",
+            )
+    }
+
+    @get:InputArtifact
+    @get:Classpath
+    protected abstract val inputArtifact: Provider<FileSystemLocation>
+
+    override fun transform(outputs: TransformOutputs) {
+        val originalJar = inputArtifact.get().asFile
+        if (BESU_NATIVE_JARS.any { originalJar.name.startsWith("$it-") }) {
+            val patchedJar = outputs.file("${originalJar.nameWithoutExtension}-besu.jar")
+            patch(originalJar, patchedJar)
+        } else {
+            outputs.file(originalJar)
+        }
+    }
+
+    fun patch(besuJar: File, patchedJar: File) {
+        patchedJar.createNewFile()
+        JarOutputStream(patchedJar.outputStream()).use { outJar ->
+            JarInputStream(besuJar.inputStream()).use { inJar ->
+                val inManifest = inJar.manifest
+                if (inManifest != null) {
+                    val outManifest = newReproducibleEntry(JarFile.MANIFEST_NAME)
+                    outJar.putNextEntry(outManifest)
+                    inManifest.write(BufferedOutputStream(outJar))
+                    outJar.closeEntry()
+                }
+
+                var jarEntry = inJar.nextJarEntry
+                while (jarEntry != null) {
+                    val name = jarEntry.name
+                    var content = inJar.readBytes()
+
+                    if (name.startsWith("lib/")) {
+                        // All native lib files are moved from 'lib' to 'lib-native'
+                        jarEntry = newReproducibleEntry(name.replaceFirst("lib/", "lib-native/"))
+                    }
+                    if (name.equals(BESU_NATIVE_LIBRARY_LOADER_CLASS)) {
+                        // The library loader is replaced with our own version
+                        content =
+                            BesuNativePatchTransform::class
+                                .java
+                                .getResourceAsStream("/$BESU_NATIVE_LIBRARY_LOADER_CLASS")!!
+                                .readBytes()
+                    }
+
+                    jarEntry.setCompressedSize(-1)
+                    outJar.putNextEntry(jarEntry)
+                    outJar.write(content)
+                    outJar.closeEntry()
+
+                    jarEntry = inJar.nextJarEntry
+                }
+            }
+        }
+    }
+
+    private fun newReproducibleEntry(name: String) =
+        JarEntry(name).also {
+            it.time = GregorianCalendar(1980, Calendar.FEBRUARY, 1, 0, 0, 0).getTimeInMillis()
+        }
+}

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -9,11 +9,11 @@ dependencies {
 }
 
 val autoService = "1.1.1"
-val besu = "25.2.2"
+val besu = "25.6.0"
 val bouncycastle = "1.81"
 val dagger = "2.56.2"
 val eclipseCollections = "13.0.0"
-val grpc = "1.72.0"
+val grpc = "1.73.0"
 val hederaCryptography = "3.0.0"
 val helidon = "4.3.2"
 val jackson = "2.19.0"
@@ -24,7 +24,7 @@ val pbj = pluginVersions.version("com.hedera.pbj.pbj-compiler")
 val protobuf = "4.31.1"
 val blockNodeProtobufSources = "0.21.2"
 val testContainers = "2.0.2"
-val tuweni = "2.4.2"
+val tuweni = "2.7.2"
 val webcompare = "2.1.8"
 
 dependencies.constraints {
@@ -44,7 +44,7 @@ dependencies.constraints {
         because("com.fasterxml.jackson.dataformat.yaml")
     }
     api("com.github.ben-manes.caffeine:caffeine:3.2.0") { because("com.github.benmanes.caffeine") }
-    api("com.github.docker-java:docker-java-api:3.5.3") { because("com.github.dockerjava.api") }
+    api("com.github.docker-java:docker-java-api:3.7.0") { because("com.github.dockerjava.api") }
     api("com.github.spotbugs:spotbugs-annotations:4.9.3") {
         because("com.github.spotbugs.annotations")
     }
@@ -65,7 +65,7 @@ dependencies.constraints {
     api("com.hedera.pbj:pbj-grpc-helidon:${pbj}") { because("com.hedera.pbj.grpc.helidon") }
     api("com.hedera.pbj:pbj-runtime:$pbj") { because("com.hedera.pbj.runtime") }
     api("com.squareup:javapoet:1.13.0") { because("com.squareup.javapoet") }
-    api("net.java.dev.jna:jna:5.17.0") { because("com.sun.jna") }
+    api("net.java.dev.jna:jna:5.18.1") { because("com.sun.jna") }
     api("com.google.dagger:dagger:$dagger") { because("dagger") }
     api("com.google.dagger:dagger-compiler:$dagger") { because("dagger.compiler") }
     api("io.grpc:grpc-netty:$grpc") { because("io.grpc.netty") }
@@ -83,10 +83,10 @@ dependencies.constraints {
     api("com.goterl:lazysodium-java:5.2.0") { because("com.goterl.lazysodium") }
     api("net.i2p.crypto:eddsa:0.3.0") { because("net.i2p.crypto.eddsa") }
     api("org.antlr:antlr4-runtime:4.13.2") { because("org.antlr.antlr4.runtime") }
-    api("commons-codec:commons-codec:1.18.0") { because("org.apache.commons.codec") }
-    api("commons-io:commons-io:2.19.0") { because("org.apache.commons.io") }
+    api("commons-codec:commons-codec:1.19.0") { because("org.apache.commons.codec") }
+    api("commons-io:commons-io:2.20.0") { because("org.apache.commons.io") }
     api("org.apache.commons:commons-lang3:3.18.0") { because("org.apache.commons.lang3") }
-    api("org.apache.commons:commons-compress:1.27.1") { because("org.apache.commons.compress") }
+    api("org.apache.commons:commons-compress:1.28.0") { because("org.apache.commons.compress") }
     api("org.apache.logging.log4j:log4j-api:$log4j") { because("org.apache.logging.log4j") }
     api("org.apache.logging.log4j:log4j-core:$log4j") { because("org.apache.logging.log4j.core") }
     api("org.apache.logging.log4j:log4j-slf4j2-impl:$log4j") {
@@ -116,8 +116,8 @@ dependencies.constraints {
     api("org.opentest4j:opentest4j:1.3.0") { because("org.opentest4j") }
     api("org.testcontainers:testcontainers:$testContainers") { because("org.testcontainers") }
     api("org.yaml:snakeyaml:2.4") { because("org.yaml.snakeyaml") }
-    api("io.tmio:tuweni-bytes:$tuweni") { because("tuweni.bytes") }
-    api("io.tmio:tuweni-units:$tuweni") { because("tuweni.units") }
+    api("io.consensys.tuweni:tuweni-bytes:$tuweni") { because("tuweni.bytes") }
+    api("io.consensys.tuweni:tuweni-units:$tuweni") { because("tuweni.units") }
     api("uk.org.webcompere:system-stubs-core:$webcompare") {
         because("uk.org.webcompere.systemstubs.core")
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+pluginManagement { includeBuild("gradle/besu-native-patch") }
+
 plugins {
     id("org.hiero.gradle.build") version "0.6.2"
+    id("org.hiero.gradle.feature.besu-native-patch")
     id("com.hedera.pbj.pbj-compiler") version "0.12.10" apply false
 }
 


### PR DESCRIPTION

**Description**:

Updates BESU to `5.6.0` and transitive dependencies to the versions BESU pulls in.

This requires additional patching of the besu-native Jars, to integrate the fixes in https://github.com/hyperledger/besu-native/pull/290 until they are released upstream.

