### PR TITLE
chore: Update codeownership on gradle files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,7 +117,7 @@ gradlew                                             @hiero-ledger/github-maintai
 gradlew.bat                                         @hiero-ledger/github-maintainers
 **/build-logic/                                     @hiero-ledger/github-maintainers
 **/gradle.*                                         @hiero-ledger/github-maintainers
-**/*.gradle.*                                       @hiero-ledger/github-maintainers
+**/*.gradle.*                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-foundation-codeowners @hiero-ledger/hiero-consensus-node-consensus-codeowners
 
 # Codacy Tool Configurations
 /config/                                            @hiero-ledger/github-maintainers


### PR DESCRIPTION
## Description

This pull request makes a small update to the `.github/CODEOWNERS` file. The change adds additional code owner teams for files matching the `**/*.gradle.*` pattern, ensuring that the relevant consensus node teams are also assigned ownership for the build.gradle.kts files and other relevant changes.

## Related Issue(s)

Closes #22847 