### PR TITLE
feat: Initialize Block producing benchmarks

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -58,10 +58,17 @@ jmhModuleInfo {
     requires("com.hedera.node.app.hapi.utils")
     requires("com.hedera.node.app.spi.test.fixtures")
     requires("com.hedera.node.app.test.fixtures")
+    requires("com.hedera.node.config")
     requires("com.hedera.node.hapi")
     requires("com.hedera.pbj.runtime")
+    requires("com.swirlds.config.api")
+    requires("com.swirlds.config.extensions")
+    requires("com.swirlds.metrics.api")
+    requires("com.swirlds.platform.core")
+    requires("com.swirlds.state.api")
     requires("jmh.core")
     requires("org.hiero.base.crypto")
+    requires("org.hiero.consensus.model")
 }
 
 // Add all the libs dependencies into the jar manifest!

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/BlockProductionBenchmark.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/BlockProductionBenchmark.java
@@ -1,0 +1,410 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks;
+
+import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_ACCOUNTS;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.SignedTxCustomizer.NOOP_SIGNED_TX_CUSTOMIZER;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.input.RoundHeader;
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.hapi.block.stream.output.MapChangeKey;
+import com.hedera.hapi.block.stream.output.MapChangeValue;
+import com.hedera.hapi.block.stream.output.MapUpdateChange;
+import com.hedera.hapi.block.stream.output.StateChange;
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TransferList;
+import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.transaction.ExchangeRate;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.blocks.impl.BlockStreamBuilder;
+import com.hedera.node.app.blocks.utils.BlockStreamManagerWrapper;
+import com.hedera.node.app.blocks.utils.NoOpDependencies;
+import com.hedera.node.app.blocks.utils.TransactionGeneratorUtil;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Block production benchmark using BlockStreamManagerImpl.
+ *
+ * This benchmark uses the actual production BlockStreamManagerImpl class with
+ * NoOpDependencies
+ * to provide all required dependencies. This provides the most realistic
+ * performance measurement
+ * as it uses the exact production code path.
+ *
+ * PRODUCTION COMPONENTS TESTED:
+ * - REAL BlockStreamManagerImpl (complete production implementation)
+ * - REAL task system (ParallelTask, SequentialTask)
+ * - REAL merkle tree operations (all 5 trees)
+ * - REAL block hash computation
+ * - REAL state management (via NoOpDependencies)
+ *
+ * DOES NOT TEST:
+ * - Transaction execution (happens before)
+ * - Network streaming (happens after)
+ * - Block signing (async, doesn't block pipeline)
+ * - Disk I/O (NoOpBlockItemWriter)
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 3, time = 2)
+@Fork(1)
+public class BlockProductionBenchmark {
+
+    @Param({"20"}) // Number of blocks to produce
+    private int blocksPerRun;
+
+    @Param({"2000"}) // Block time in milliseconds
+    private int blockTimeMs;
+
+    @Param({"100000"}) // Target TPS
+    private int targetTPS;
+
+    @Param({"6000"}) // Transaction size in bytes
+    private int transactionSizeBytes;
+
+    @Param({"false"}) // Enable rate limiting (false = max capacity stress test)
+    private boolean enableRateLimiting;
+
+    private int maxTransactionsPerBlock;
+    private long benchmarkStartTime;
+    private long benchmarkEndTime;
+    private int totalTransactionsProcessed;
+
+    // Transaction tracking
+    private int totalTransactionsGenerated = 0;
+    private int totalBlockItemsInBlocks = 0;
+    private long totalTimeSpentWaiting = 0;
+
+    // REAL production manager (wrapped for simpler API)
+    private BlockStreamManagerWrapper blockStreamManager;
+
+    // Template data
+    // BENCHMARK LIMITATION: Same transaction template is reused for all
+    // transactions.
+    // This improves benchmark performance but doesn't reflect production diversity.
+    // TODO: Add parameter to control transaction diversity (different types, sizes,
+    // accounts)
+    private SignedTransaction signedTxTemplate;
+    private Bytes serializedSignedTxTemplate;
+    private TransactionBody txBodyTemplate;
+    private ExchangeRateSet exchangeRates;
+    private TransferList sampleTransferList;
+
+    private Recording jfrRecording;
+
+    @Setup(Level.Trial)
+    public void setupTrial() {
+        maxTransactionsPerBlock = (blockTimeMs * targetTPS) / 1000;
+
+        try {
+            Bytes txBodyBytes = TransactionGeneratorUtil.generateTransaction(transactionSizeBytes);
+            txBodyTemplate = TransactionBody.PROTOBUF.parse(txBodyBytes);
+            signedTxTemplate =
+                    SignedTransaction.newBuilder().bodyBytes(txBodyBytes).build();
+            serializedSignedTxTemplate = SignedTransaction.PROTOBUF.toBytes(signedTxTemplate);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse template transaction", e);
+        }
+
+        exchangeRates = ExchangeRateSet.newBuilder()
+                .currentRate(
+                        ExchangeRate.newBuilder().centEquiv(12).hbarEquiv(1).build())
+                .nextRate(ExchangeRate.newBuilder().centEquiv(12).hbarEquiv(1).build())
+                .build();
+
+        sampleTransferList = TransferList.newBuilder()
+                .accountAmounts(
+                        AccountAmount.newBuilder()
+                                .accountID(AccountID.newBuilder().accountNum(2).build())
+                                .amount(-1000L)
+                                .build(),
+                        AccountAmount.newBuilder()
+                                .accountID(AccountID.newBuilder().accountNum(3).build())
+                                .amount(1000L)
+                                .build())
+                .build();
+
+        System.out.printf(
+                ">>> Config: Blocks/run=%d, Block time=%dms, Target TPS=%d, Tx size=%dB, Max tx/block=%d%n",
+                blocksPerRun, blockTimeMs, targetTPS, transactionSizeBytes, maxTransactionsPerBlock);
+        System.out.printf(
+                ">>> Mode: %s%n", enableRateLimiting ? "Rate-limited (target TPS)" : "MAX CAPACITY STRESS TEST");
+        System.out.printf(">>> Using REAL BlockStreamManagerImpl with NoOpDependencies%n");
+
+        // Start JFR recording
+        try {
+            String projectRoot = System.getProperty("user.dir");
+            String jfrPath = String.format(
+                    "%s/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/jfr/block-prod-tps%d-size%d.jfr",
+                    projectRoot, targetTPS, transactionSizeBytes);
+            jfrRecording = new Recording(Configuration.getConfiguration("profile"));
+            jfrRecording.setDestination(Paths.get(jfrPath));
+            jfrRecording.start();
+            System.out.println(">>> JFR recording started: " + jfrPath);
+        } catch (Exception e) {
+            System.err.println(">>> Failed to start JFR recording: " + e.getMessage());
+        }
+    }
+
+    @Setup(Level.Iteration)
+    public void setupIteration() {
+        benchmarkStartTime = 0;
+        benchmarkEndTime = 0;
+        totalTransactionsProcessed = 0;
+        totalTransactionsGenerated = 0;
+        totalBlockItemsInBlocks = 0;
+        totalTimeSpentWaiting = 0;
+
+        // Create REAL BlockStreamManagerImpl wrapper with NoOpDependencies
+        blockStreamManager = new BlockStreamManagerWrapper(NoOpDependencies.NoOpBlockItemWriter::new);
+    }
+
+    /**
+     * Main benchmark: Uses BlockStreamManagerImpl.
+     */
+    @Benchmark
+    public int produceBlocks(Blackhole bh) {
+        benchmarkStartTime = System.nanoTime();
+
+        for (int blockNum = 0; blockNum < blocksPerRun; blockNum++) {
+            produceOneBlock(blockNum);
+        }
+
+        benchmarkEndTime = System.nanoTime();
+
+        bh.consume(blockStreamManager.getTotalItemsWritten());
+        bh.consume(blockStreamManager.getLastComputedBlockHash());
+        return blocksPerRun;
+    }
+
+    /**
+     * Produces a single block using REAL BlockStreamManagerImpl.
+     */
+    private void produceOneBlock(long blockNumber) {
+        long blockStartTime = System.currentTimeMillis();
+        int txGeneratedThisBlock = 0;
+        long blockItemsBeforeBlock = blockStreamManager.getTotalItemsWritten();
+
+        // START BLOCK (production pattern via wrapper)
+        Instant timestamp = Instant.now();
+        BlockItem header = BlockItem.newBuilder()
+                .blockHeader(BlockHeader.newBuilder()
+                        .number(blockNumber)
+                        .blockTimestamp(Timestamp.newBuilder()
+                                .seconds(timestamp.getEpochSecond())
+                                .nanos(timestamp.getNano())
+                                .build())
+                        .softwareVersion(SemanticVersion.newBuilder()
+                                .major(0)
+                                .minor(56)
+                                .patch(0)
+                                .build())
+                        .build())
+                .build();
+
+        blockStreamManager.startBlock(blockNumber, header);
+
+        // Add round header
+        blockStreamManager.writeItem(BlockItem.newBuilder()
+                .roundHeader(RoundHeader.newBuilder().roundNumber(blockNumber).build())
+                .build());
+
+        Instant consensusNow = timestamp;
+        int txInBlock = 0;
+
+        // PROCESS TRANSACTIONS
+        while (txInBlock < maxTransactionsPerBlock) {
+
+            BlockStreamBuilder builder = new BlockStreamBuilder(REVERSIBLE, NOOP_SIGNED_TX_CUSTOMIZER, USER);
+
+            builder.functionality(HederaFunctionality.CRYPTO_TRANSFER)
+                    .signedTx(signedTxTemplate)
+                    .serializedSignedTx(serializedSignedTxTemplate)
+                    .transactionID(txBodyTemplate.transactionIDOrThrow())
+                    .memo(txBodyTemplate.memo())
+                    .consensusTimestamp(consensusNow)
+                    .exchangeRate(exchangeRates)
+                    .status(ResponseCodeEnum.SUCCESS)
+                    .transactionFee(1000L)
+                    .transferList(sampleTransferList);
+
+            // BENCHMARK LIMITATION: State changes are simplified for performance testing.
+            // In production, HandleWorkflow would provide actual state mutations from
+            // transaction execution.
+            // This benchmark focuses on block production performance, not transaction
+            // execution.
+            // The state changes below are minimal but structurally correct for benchmarking
+            // purposes.
+            List<StateChange> mockStateChanges = new ArrayList<>();
+            for (AccountAmount accountAmount : sampleTransferList.accountAmounts()) {
+                // Create minimal state change (no hardcoded balances - just structure)
+                Account mockAccount = Account.newBuilder()
+                        .accountId(accountAmount.accountIDOrThrow())
+                        .build();
+
+                StateChange stateChange = StateChange.newBuilder()
+                        .stateId(STATE_ID_ACCOUNTS.protoOrdinal())
+                        .mapUpdate(MapUpdateChange.newBuilder()
+                                .key(MapChangeKey.newBuilder()
+                                        .accountIdKey(accountAmount.accountIDOrThrow())
+                                        .build())
+                                .value(MapChangeValue.newBuilder()
+                                        .accountValue(mockAccount)
+                                        .build())
+                                .identical(false)
+                                .build())
+                        .build();
+                mockStateChanges.add(stateChange);
+            }
+            builder.stateChanges(mockStateChanges);
+
+            // BENCHMARK LIMITATION: groupStateChanges is null because this benchmark tests
+            // individual transactions only, not grouped transactions (atomic batch/hook
+            // dispatch).
+            // TODO: Add separate benchmark variant for grouped transaction scenarios.
+            BlockStreamBuilder.Output output = builder.build(false, null);
+
+            // WRITE ITEMS via REAL BlockStreamManagerImpl.writeItem()
+            for (BlockItem item : output.blockItems()) {
+                blockStreamManager.writeItem(item);
+            }
+
+            txInBlock++;
+            txGeneratedThisBlock++;
+            totalTransactionsProcessed++;
+
+            // Realistic timestamp spacing based on target TPS (not 1ns increments)
+            long nanosBetweenTx = TimeUnit.SECONDS.toNanos(1) / targetTPS;
+            consensusNow = consensusNow.plusNanos(nanosBetweenTx);
+
+            // Rate limiting
+            if (enableRateLimiting) {
+                long targetIntervalNanos = TimeUnit.SECONDS.toNanos(1) / targetTPS;
+                long now = System.nanoTime();
+                long nextTxTime = benchmarkStartTime + (totalTransactionsProcessed * targetIntervalNanos);
+                long sleepNanos = nextTxTime - now;
+
+                if (sleepNanos > 0 && sleepNanos < TimeUnit.MILLISECONDS.toNanos(blockTimeMs)) {
+                    try {
+                        long sleepStart = System.nanoTime();
+                        TimeUnit.NANOSECONDS.sleep(sleepNanos);
+                        totalTimeSpentWaiting += (System.nanoTime() - sleepStart);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            }
+        }
+
+        // SEAL BLOCK (production pattern via wrapper)
+        BlockItem proof = BlockItem.newBuilder()
+                .blockProof(com.hedera.hapi.block.stream.BlockProof.newBuilder()
+                        .block(blockNumber)
+                        .build())
+                .build();
+        blockStreamManager.sealBlock(proof);
+
+        // Track what actually made it into the block
+        long blockItemsAfterBlock = blockStreamManager.getTotalItemsWritten();
+        long itemsInThisBlock = blockItemsAfterBlock - blockItemsBeforeBlock;
+        totalTransactionsGenerated += txGeneratedThisBlock;
+        totalBlockItemsInBlocks += (int) itemsInThisBlock;
+
+        System.out.printf(
+                "[Block %d] Generated %d tx → %d BlockItems in block (%.1f items/tx)%n",
+                blockNumber, txGeneratedThisBlock, itemsInThisBlock, (double) itemsInThisBlock / txGeneratedThisBlock);
+    }
+
+    @TearDown(Level.Iteration)
+    public void teardownIteration() {
+        if (benchmarkStartTime > 0 && benchmarkEndTime > 0) {
+            double elapsedSeconds = (benchmarkEndTime - benchmarkStartTime) / 1_000_000_000.0;
+            double actualTPS = totalTransactionsProcessed / elapsedSeconds;
+            double avgTxPerBlock = (double) totalTransactionsProcessed / blocksPerRun;
+            double avgItemsPerTx = totalTransactionsProcessed > 0
+                    ? (double) totalBlockItemsInBlocks / totalTransactionsProcessed
+                    : 0.0;
+            double waitTimeSeconds = totalTimeSpentWaiting / 1_000_000_000.0;
+            double utilization = ((elapsedSeconds - waitTimeSeconds) / elapsedSeconds) * 100;
+
+            System.out.printf("%n>>> SUMMARY:%n");
+            System.out.printf(
+                    ">>> Mode: %s%n", enableRateLimiting ? "Rate-limited (target TPS)" : "MAX CAPACITY STRESS TEST");
+            System.out.printf(
+                    ">>> Target TPS: %d, Actual TPS: %.0f (%.1f%% of target)%n",
+                    targetTPS, actualTPS, (actualTPS / targetTPS) * 100);
+            System.out.printf(
+                    ">>> Transactions: Generated=%d, Processed=%d%n",
+                    totalTransactionsGenerated, totalTransactionsProcessed);
+            System.out.printf(
+                    ">>> BlockItems: In blocks=%d, From manager=%d%n",
+                    totalBlockItemsInBlocks, blockStreamManager.getTotalItemsWritten());
+            System.out.printf(
+                    ">>> Time: Total=%.3fs, Waiting=%.3fs (%.1f%% utilized)%n",
+                    elapsedSeconds, waitTimeSeconds, utilization);
+            System.out.printf(
+                    ">>> Blocks: %d blocks, %.0f tx/block, %.1f items/tx%n",
+                    blocksPerRun, avgTxPerBlock, avgItemsPerTx);
+
+            if (enableRateLimiting) {
+                if (actualTPS < targetTPS * 0.95) {
+                    System.out.printf(
+                            "%n⚠️  WARNING: System only achieved %.0f TPS (%.1f%% of target %d TPS)%n",
+                            actualTPS, (actualTPS / targetTPS) * 100, targetTPS);
+                } else {
+                    System.out.printf(
+                            "%n✅ System kept up with target TPS (%.1f%% achieved)%n", (actualTPS / targetTPS) * 100);
+                }
+            } else {
+                System.out.printf("%nMAX CAPACITY: System achieved %.0f TPS without rate limiting%n", actualTPS);
+                System.out.printf("This is %.1fx the target rate of %d TPS%n", actualTPS / targetTPS, targetTPS);
+                System.out.printf("Utilization: %.1f%% (%.3fs total time)%n", utilization, elapsedSeconds);
+            }
+        }
+
+        System.gc();
+    }
+
+    @TearDown(Level.Trial)
+    public void teardownTrial() {
+        // Stop JFR recording
+        if (jfrRecording != null) {
+            try {
+                jfrRecording.stop();
+                jfrRecording.close();
+                System.out.println(">>> JFR recording stopped and saved.");
+            } catch (Exception e) {
+                System.err.println(">>> Failed to stop JFR recording: " + e.getMessage());
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        // JFR profiling managed manually in setupTrial/teardownTrial
+        // Files saved to: hedera-app/src/jmh/java/com/hedera/node/app/blocks/jfr/
+        // Filename format: block-prod-tps<tps>-size<bytes>.jfr
+        // Same parameter combinations will overwrite previous runs
+        org.openjdk.jmh.Main.main(new String[] {"BlockProductionBenchmark", "-v", "EXTRA" /* , "-prof", "gc" */});
+    }
+}

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/BlockProductionMicrobenchmarks.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/BlockProductionMicrobenchmarks.java
@@ -1,0 +1,662 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks;
+
+import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBehavior.REVERSIBLE;
+import static com.hedera.node.app.spi.workflows.record.StreamBuilder.SignedTxCustomizer.NOOP_SIGNED_TX_CUSTOMIZER;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.output.StateChanges;
+import com.hedera.hapi.block.stream.output.TransactionResult;
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.base.TransferList;
+import com.hedera.hapi.node.transaction.ExchangeRate;
+import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.blocks.impl.BlockStreamBuilder;
+import com.hedera.node.app.blocks.impl.ConcurrentStreamingTreeHasher;
+import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
+import com.hedera.node.app.blocks.utils.TransactionGeneratorUtil;
+import com.hedera.node.app.hapi.utils.CommonUtils;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Component-level microbenchmarks for block production pipeline.
+ *
+ * Each benchmark tests a specific production component in isolation to identify
+ * bottlenecks.
+ * These benchmarks use production classes without mocking or simulation.
+ *
+ * COMPONENTS TESTED:
+ * 1. BlockItem serialization - How fast can we serialize BlockItems?
+ * 2. BlockItem hashing (SHA-384) - How fast can we hash serialized BlockItems?
+ * 3. ConcurrentStreamingTreeHasher - How fast are merkle tree operations?
+ * 4. IncrementalStreamingHasher - How fast is the previousBlockHashes tree?
+ * 5. BlockStreamBuilder - How fast can we translate execution results to
+ * BlockItems?
+ * 6. Block hash combining - How fast is the 10x SHA-384 combine operation?
+ * 7. Block serialization - How fast can we serialize final blocks?
+ * 8. Running hash (n-3) - How fast is the running hash computation?
+ *
+ * BENEFITS:
+ * - No mocking required (all components are self-contained)
+ * - No maintenance when production code changes (compile-time safety)
+ * - Pinpoint specific bottlenecks (which component is slow)
+ * - Test scaling behavior (how does performance change with size)
+ * - CI/CD friendly (catch regressions early)
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class BlockProductionMicrobenchmarks {
+
+    /**
+     * 1. BlockItem Serialization Benchmark
+     * Tests: BlockItem.PROTOBUF.toBytes()
+     * Measures: How many BlockItems can we serialize per second?
+     */
+    @Benchmark
+    public void blockItemSerialization_TransactionResult(SerializationState state, Blackhole bh) {
+        Bytes serialized = BlockItem.PROTOBUF.toBytes(state.transactionResultItem);
+        bh.consume(serialized.length());
+    }
+
+    @Benchmark
+    public void blockItemSerialization_SignedTransaction(SerializationState state, Blackhole bh) {
+        Bytes serialized = BlockItem.PROTOBUF.toBytes(state.signedTransactionItem);
+        bh.consume(serialized.length());
+    }
+
+    @Benchmark
+    public void blockItemSerialization_StateChanges(SerializationState state, Blackhole bh) {
+        Bytes serialized = BlockItem.PROTOBUF.toBytes(state.stateChangesItem);
+        bh.consume(serialized.length());
+    }
+
+    @State(Scope.Thread)
+    public static class SerializationState {
+        BlockItem transactionResultItem;
+        BlockItem signedTransactionItem;
+        BlockItem stateChangesItem;
+        Recording jfrRecording;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            // Start JFR recording
+            jfrRecording = startJfr("micro-serialize.jfr");
+
+            // Create realistic BlockItems
+            Instant now = Instant.now();
+
+            transactionResultItem = BlockItem.newBuilder()
+                    .transactionResult(TransactionResult.newBuilder()
+                            .consensusTimestamp(Timestamp.newBuilder()
+                                    .seconds(now.getEpochSecond())
+                                    .nanos(now.getNano())
+                                    .build())
+                            .status(ResponseCodeEnum.SUCCESS)
+                            .transactionFeeCharged(1000L)
+                            .build())
+                    .build();
+
+            signedTransactionItem = BlockItem.newBuilder()
+                    .signedTransaction(TransactionGeneratorUtil.generateTransaction(5000))
+                    .build();
+
+            stateChangesItem = BlockItem.newBuilder()
+                    .stateChanges(StateChanges.newBuilder()
+                            .consensusTimestamp(Timestamp.newBuilder()
+                                    .seconds(now.getEpochSecond())
+                                    .build())
+                            .build())
+                    .build();
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            stopJfr(jfrRecording);
+        }
+    }
+
+    /**
+     * 2. BlockItem Hashing Benchmark
+     * Tests: SHA-384 hashing of serialized BlockItems
+     * Measures: How many BlockItem hashes can we compute per second?
+     */
+    @Benchmark
+    public void blockItemHashing(HashingState state, Blackhole bh) {
+        try {
+            MessageDigest digest = sha384DigestOrThrow();
+            state.serializedItem.writeTo(digest);
+            byte[] hash = digest.digest();
+            bh.consume(hash.length);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class HashingState {
+        Bytes serializedItem;
+        Recording jfrRecording;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            // Start JFR recording
+            jfrRecording = startJfr("micro-hashing.jfr");
+
+            BlockItem item = BlockItem.newBuilder()
+                    .transactionResult(TransactionResult.newBuilder()
+                            .consensusTimestamp(Timestamp.newBuilder()
+                                    .seconds(Instant.now().getEpochSecond())
+                                    .build())
+                            .status(ResponseCodeEnum.SUCCESS)
+                            .transactionFeeCharged(1000L)
+                            .build())
+                    .build();
+            serializedItem = BlockItem.PROTOBUF.toBytes(item);
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            stopJfr(jfrRecording);
+        }
+    }
+
+    /**
+     * 3. ConcurrentStreamingTreeHasher Benchmark
+     * Tests: Real merkle tree operations with parallel hashing
+     * Measures: How many leaves can we process per second?
+     */
+    @Benchmark
+    public void merkleTreeHashing_Concurrent(MerkleTreeState state, Blackhole bh) {
+        ConcurrentStreamingTreeHasher hasher = new ConcurrentStreamingTreeHasher(state.executor);
+
+        // Add all leaves
+        for (ByteBuffer hash : state.precomputedHashes) {
+            hasher.addLeaf(hash.duplicate()); // duplicate to allow reuse
+        }
+
+        // Compute root hash (parallel computation)
+        Bytes rootHash = hasher.rootHash().join();
+        bh.consume(rootHash);
+    }
+
+    @State(Scope.Thread)
+    public static class MerkleTreeState {
+        @Param({"100", "1000", "10000", "100000"})
+        int numLeaves;
+
+        List<ByteBuffer> precomputedHashes;
+        ForkJoinPool executor;
+        Recording jfrRecording;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            // Start JFR recording
+            jfrRecording = startJfr(String.format("micro-merkle-%d.jfr", numLeaves));
+
+            executor = new ForkJoinPool(Runtime.getRuntime().availableProcessors());
+            precomputedHashes = new ArrayList<>();
+
+            try {
+                MessageDigest digest = sha384DigestOrThrow();
+                for (int i = 0; i < numLeaves; i++) {
+                    byte[] data = ("item" + i).getBytes();
+                    digest.reset();
+                    byte[] hash = digest.digest(data);
+                    precomputedHashes.add(ByteBuffer.wrap(hash));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            // Proper executor cleanup with timeout
+            executor.shutdownNow();
+            try {
+                if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    System.err.println("Executor did not terminate in time");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            stopJfr(jfrRecording);
+        }
+    }
+
+    /**
+     * 4. IncrementalStreamingHasher Benchmark
+     * Tests: Real previousBlockHashes tree operations
+     * Measures: How fast can we maintain the tree of previous block hashes?
+     */
+    @Benchmark
+    public void incrementalStreamingHasher_AddLeaf(IncrementalHasherState state, Blackhole bh) {
+        IncrementalStreamingHasher hasher =
+                new IncrementalStreamingHasher(CommonUtils.sha384DigestOrThrow(), List.of(), 0L);
+
+        // Add leaves and compute root (simulating block-by-block hashing)
+        for (byte[] blockHash : state.blockHashes) {
+            hasher.addLeaf(blockHash);
+        }
+
+        byte[] rootHash = hasher.computeRootHash();
+        bh.consume(rootHash.length);
+    }
+
+    @State(Scope.Thread)
+    public static class IncrementalHasherState {
+        @Param({"10", "100", "1000"})
+        int numBlocks;
+
+        List<byte[]> blockHashes;
+        Recording jfrRecording;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            // Start JFR recording
+            jfrRecording = startJfr(String.format("micro-incremental-%d.jfr", numBlocks));
+
+            blockHashes = new ArrayList<>();
+            try {
+                MessageDigest digest = sha384DigestOrThrow();
+                for (int i = 0; i < numBlocks; i++) {
+                    byte[] data = ("block" + i).getBytes();
+                    digest.reset();
+                    blockHashes.add(digest.digest(data));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            stopJfr(jfrRecording);
+        }
+    }
+
+    /**
+     * 5. BlockStreamBuilder Benchmark
+     * Tests: Real BlockStreamBuilder accumulation and translation
+     * Measures: How many transactions can BlockStreamBuilder process per second?
+     */
+    @Benchmark
+    public void blockStreamBuilder_Accumulation(BuilderState state, Blackhole bh) {
+        BlockStreamBuilder builder = new BlockStreamBuilder(REVERSIBLE, NOOP_SIGNED_TX_CUSTOMIZER, USER);
+
+        // Accumulate execution results (like HandleWorkflow does)
+        builder.functionality(HederaFunctionality.CRYPTO_TRANSFER)
+                .signedTx(state.signedTx)
+                .serializedSignedTx(state.serializedSignedTx)
+                .transactionID(state.txId)
+                .memo(state.memo)
+                .consensusTimestamp(state.consensusTime)
+                .exchangeRate(state.exchangeRates)
+                .status(ResponseCodeEnum.SUCCESS)
+                .transactionFee(1000L)
+                .transferList(state.transferList);
+
+        // Build BlockItems (translation)
+        BlockStreamBuilder.Output output = builder.build(false, null);
+        bh.consume(output.blockItems().size());
+    }
+
+    @State(Scope.Thread)
+    public static class BuilderState {
+        @Param({"1000", "5000", "10000"})
+        int transactionSizeBytes;
+
+        SignedTransaction signedTx;
+        Bytes serializedSignedTx;
+        Instant consensusTime;
+        ExchangeRateSet exchangeRates;
+        TransferList transferList;
+        TransactionID txId;
+        String memo;
+        Recording jfrRecording;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            // Start JFR recording
+            jfrRecording = startJfr(String.format("micro-builder-size%d.jfr", transactionSizeBytes));
+
+            try {
+                Bytes txBodyBytes = TransactionGeneratorUtil.generateTransaction(transactionSizeBytes);
+                TransactionBody txBody = TransactionBody.PROTOBUF.parse(txBodyBytes);
+
+                signedTx = SignedTransaction.newBuilder().bodyBytes(txBodyBytes).build();
+                serializedSignedTx = SignedTransaction.PROTOBUF.toBytes(signedTx);
+                txId = txBody.transactionIDOrThrow();
+                memo = txBody.memo();
+
+                consensusTime = Instant.now();
+
+                exchangeRates = ExchangeRateSet.newBuilder()
+                        .currentRate(ExchangeRate.newBuilder()
+                                .centEquiv(12)
+                                .hbarEquiv(1)
+                                .build())
+                        .nextRate(ExchangeRate.newBuilder()
+                                .centEquiv(12)
+                                .hbarEquiv(1)
+                                .build())
+                        .build();
+
+                transferList = TransferList.newBuilder()
+                        .accountAmounts(
+                                AccountAmount.newBuilder()
+                                        .accountID(AccountID.newBuilder()
+                                                .accountNum(2)
+                                                .build())
+                                        .amount(-1000L)
+                                        .build(),
+                                AccountAmount.newBuilder()
+                                        .accountID(AccountID.newBuilder()
+                                                .accountNum(3)
+                                                .build())
+                                        .amount(1000L)
+                                        .build())
+                        .build();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            stopJfr(jfrRecording);
+        }
+    }
+
+    /**
+     * 6. Block Hash Combining Benchmark
+     * Tests: Real 10x SHA-384 combine operations from combineTreeRoots()
+     * Measures: How many complete block hash computations per second?
+     */
+    @Benchmark
+    public void blockHashCombining(CombineState state, Blackhole bh) {
+        // Production logic: 10x SHA-384 combines
+
+        // Depth 4 combines (4 operations)
+        Bytes depth4Node1 = combineSha384(state.hash1, state.hash2);
+        Bytes depth4Node2 = combineSha384(state.hash3, state.hash4);
+        Bytes depth4Node3 = combineSha384(state.hash5, state.hash6);
+        Bytes depth4Node4 = combineSha384(state.hash7, state.hash8);
+
+        // Depth 3 combines (2 operations)
+        Bytes depth3Node1 = combineSha384(depth4Node1, depth4Node2);
+        Bytes depth3Node2 = combineSha384(depth4Node3, depth4Node4);
+
+        // Depth 2 combine (1 operation)
+        Bytes depth2Node1 = combineSha384(depth3Node1, depth3Node2);
+
+        // Depth 1 combines (2 operations)
+        Bytes depth2Node2Combined = combineSha384(
+                combineSha384(
+                        combineSha384(state.nullHash, state.nullHash), combineSha384(state.nullHash, state.nullHash)),
+                combineSha384(
+                        combineSha384(state.nullHash, state.nullHash), combineSha384(state.nullHash, state.nullHash)));
+        Bytes depth1Node1 = combineSha384(depth2Node1, depth2Node2Combined);
+
+        // Timestamp hash (1 operation)
+        Bytes depth1Node0 = sha384HashOf(state.timestampBytes);
+
+        // Final root hash (1 operation) - TOTAL: 10 SHA-384 operations
+        Bytes rootHash = combineSha384(depth1Node0, depth1Node1);
+
+        bh.consume(rootHash);
+    }
+
+    @State(Scope.Thread)
+    public static class CombineState {
+        Bytes hash1, hash2, hash3, hash4, hash5, hash6, hash7, hash8;
+        Bytes nullHash;
+        Bytes timestampBytes;
+        Recording jfrRecording;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            // Start JFR recording
+            jfrRecording = startJfr("micro-combine.jfr");
+
+            try {
+                MessageDigest digest = sha384DigestOrThrow();
+
+                // Generate 8 random hashes (representing the 8 merkle branches)
+                hash1 = Bytes.wrap(digest.digest("branch1".getBytes()));
+                digest.reset();
+                hash2 = Bytes.wrap(digest.digest("branch2".getBytes()));
+                digest.reset();
+                hash3 = Bytes.wrap(digest.digest("branch3".getBytes()));
+                digest.reset();
+                hash4 = Bytes.wrap(digest.digest("branch4".getBytes()));
+                digest.reset();
+                hash5 = Bytes.wrap(digest.digest("branch5".getBytes()));
+                digest.reset();
+                hash6 = Bytes.wrap(digest.digest("branch6".getBytes()));
+                digest.reset();
+                hash7 = Bytes.wrap(digest.digest("branch7".getBytes()));
+                digest.reset();
+                hash8 = Bytes.wrap(digest.digest("branch8".getBytes()));
+
+                nullHash = Bytes.wrap(new byte[48]); // SHA-384 null hash
+
+                Timestamp timestamp = Timestamp.newBuilder()
+                        .seconds(Instant.now().getEpochSecond())
+                        .build();
+                timestampBytes = Timestamp.PROTOBUF.toBytes(timestamp);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            stopJfr(jfrRecording);
+        }
+    }
+
+    /**
+     * 7. Block Serialization Benchmark
+     * Tests: Real Block.PROTOBUF.toBytes() with varying block sizes
+     * Measures: How fast can we serialize complete blocks?
+     */
+    @Benchmark
+    public void blockSerialization(BlockState state, Blackhole bh) {
+        Block block = new Block(state.blockItems);
+        Bytes serialized = Block.PROTOBUF.toBytes(block);
+        bh.consume(serialized.length());
+    }
+
+    @State(Scope.Thread)
+    public static class BlockState {
+        @Param({"100", "1000", "10000", "100000"})
+        int itemsPerBlock;
+
+        List<BlockItem> blockItems;
+        Recording jfrRecording;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            // Start JFR recording
+            jfrRecording = startJfr(String.format("micro-block-items%d.jfr", itemsPerBlock));
+
+            blockItems = new ArrayList<>();
+            Instant now = Instant.now();
+
+            // Create realistic BlockItems (alternating SIGNED_TRANSACTION and
+            // TRANSACTION_RESULT)
+            for (int i = 0; i < itemsPerBlock; i++) {
+                if (i % 2 == 0) {
+                    blockItems.add(BlockItem.newBuilder()
+                            .signedTransaction(TransactionGeneratorUtil.generateTransaction(1000))
+                            .build());
+                } else {
+                    blockItems.add(BlockItem.newBuilder()
+                            .transactionResult(TransactionResult.newBuilder()
+                                    .consensusTimestamp(Timestamp.newBuilder()
+                                            .seconds(now.getEpochSecond())
+                                            .nanos(i)
+                                            .build())
+                                    .status(ResponseCodeEnum.SUCCESS)
+                                    .transactionFeeCharged(1000L)
+                                    .build())
+                            .build());
+                }
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            stopJfr(jfrRecording);
+        }
+    }
+
+    /**
+     * 8. Running Hash (n-3) Benchmark
+     * Tests: Real RunningHashManager.nextResultHash() computation
+     * Measures: How many running hash updates per second?
+     */
+    @Benchmark
+    public void runningHashComputation(RunningHashState state, Blackhole bh) {
+        // Simulate n-3 running hash computation (production logic)
+        byte[] currentHash = state.initialHash.clone();
+
+        try {
+            MessageDigest digest = sha384DigestOrThrow();
+
+            for (ByteBuffer resultHash : state.resultHashes) {
+                // Running hash update logic
+                digest.reset();
+                digest.update(currentHash);
+                byte[] tempHash = new byte[48];
+                resultHash.get(tempHash);
+                resultHash.rewind();
+                digest.update(tempHash);
+                currentHash = digest.digest();
+            }
+
+            bh.consume(currentHash.length);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class RunningHashState {
+        @Param({"100", "1000", "10000", "100000"})
+        int numResults;
+
+        List<ByteBuffer> resultHashes;
+        byte[] initialHash;
+        Recording jfrRecording;
+
+        @Setup(Level.Trial)
+        public void setup() {
+            // Start JFR recording
+            jfrRecording = startJfr(String.format("micro-running-hash-%d.jfr", numResults));
+
+            try {
+                MessageDigest digest = sha384DigestOrThrow();
+                initialHash = new byte[48]; // Start with zeros
+
+                resultHashes = new ArrayList<>();
+                for (int i = 0; i < numResults; i++) {
+                    byte[] data = ("result" + i).getBytes();
+                    digest.reset();
+                    resultHashes.add(ByteBuffer.wrap(digest.digest(data)));
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @TearDown(Level.Trial)
+        public void tearDown() {
+            stopJfr(jfrRecording);
+        }
+    }
+
+    // ============================================================================
+    // HELPER METHODS (utility methods for block hash combining)
+    // ============================================================================
+
+    private static Recording startJfr(String filenameSuffix) {
+        try {
+            String projectRoot = System.getProperty("user.dir");
+            String jfrPath = String.format(
+                    "%s/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/jfr/%s",
+                    projectRoot, filenameSuffix);
+            Recording recording = new Recording(Configuration.getConfiguration("profile"));
+            recording.setDestination(Paths.get(jfrPath));
+            recording.start();
+            System.out.println(">>> JFR recording started: " + jfrPath);
+            return recording;
+        } catch (Exception e) {
+            System.err.println(">>> Failed to start JFR recording: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static void stopJfr(Recording recording) {
+        if (recording != null) {
+            try {
+                recording.stop();
+                recording.close();
+                System.out.println(">>> JFR recording stopped and saved.");
+            } catch (Exception e) {
+                System.err.println(">>> Failed to stop JFR recording: " + e.getMessage());
+            }
+        }
+    }
+
+    private static Bytes combineSha384(Bytes leftHash, Bytes rightHash) {
+        MessageDigest digest = sha384DigestOrThrow();
+        digest.update(leftHash.toByteArray());
+        digest.update(rightHash.toByteArray());
+        return Bytes.wrap(digest.digest());
+    }
+
+    private static Bytes sha384HashOf(Bytes data) {
+        MessageDigest digest = sha384DigestOrThrow();
+        digest.update(data.toByteArray());
+        return Bytes.wrap(digest.digest());
+    }
+
+    public static void main(String[] args) throws Exception {
+        org.openjdk.jmh.Main.main(new String[] {"BlockProductionMicrobenchmarks", "-v", "EXTRA" /* , "-prof", "gc" */});
+    }
+    // use
+    // jfr print --events
+    // "jdk.SocketRead,jdk.GarbageCollection,jdk.JavaMonitorEnter" --json
+    // **/profile.jfr >
+    // analysis.json
+    // at profile.jfr location to convert output to json
+}

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/docs/BENCHMARKS.md
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/docs/BENCHMARKS.md
@@ -1,0 +1,177 @@
+# Block Production Benchmarks
+
+## Overview
+
+Performance benchmarks for the block production pipeline using JMH (Java Microbenchmark Harness).
+
+---
+
+## Benchmark Classes
+
+### 1. `BlockProductionBenchmark.java`
+
+**End-to-end performance test**
+
+- **Purpose:** Measures complete block production pipeline throughput using REAL `BlockStreamManagerImpl`
+- **Tests:** Full flow from transaction → block production → serialization
+- **Components tested:**
+  - `BlockStreamManagerImpl`
+  - `BlockStreamBuilder` (translates execution results to BlockItems)
+  - BlockStreamManager task system (`ParallelTask`, `SequentialTask`)
+  - Merkle tree operations (all 5 trees via `ConcurrentStreamingTreeHasher`)
+  - Block hash computation (10× SHA-384 combines)
+  - State operations (API calls with simulated VirtualMap costs)
+  - Block serialization
+
+---
+
+### 2. `BlockProductionMicrobenchmarks.java`
+
+**Component-level performance tests**
+
+- **Purpose:** Measures individual components in isolation to find bottlenecks
+- **Tests:** 8 separate benchmarks for different components
+  - BlockItem serialization (3 types: TransactionResult, SignedTransaction, StateChanges)
+  - BlockItem hashing (SHA-384)
+  - Merkle tree operations (`ConcurrentStreamingTreeHasher` with varying leaf counts)
+  - Previous block hashes (`IncrementalStreamingHasher`)
+  - `BlockStreamBuilder` accumulation (translates execution results to BlockItems)
+  - Block hash combining (10× SHA-384 combine operations)
+  - Block serialization (varying block sizes)
+  - Running hash computation (n-3 pattern)
+
+**When to run:**
+- When end-to-end performance drops (find which component is slow)
+- To validate component optimizations
+- To understand scaling behavior at different loads
+
+---
+
+## Utility Classes
+
+### `BlockStreamManagerWrapper.java`
+
+**Wrapper for BlockStreamManagerImpl**
+
+- **Purpose:** Simplifies usage of `BlockStreamManagerImpl` in benchmarks by handling complex `Round` and `State` object creation
+- **Key Features:**
+  - Wraps production `BlockStreamManagerImpl` with a simpler API (`startBlock()`, `writeItem()`, `sealBlock()`)
+  - Provides minimal `BenchmarkRound` and `BenchmarkState` implementations
+  - Handles state hash future completion (simulates platform's `StateHashedNotification`)
+  - Tracks items written for metrics (`getTotalItemsWritten()`)
+  - Simulates VirtualMap operation costs:
+    - State read: 15× SHA-384 hashes (simulates `VirtualMap.get()` path traversal)
+    - State commit: 28× SHA-384 hashes (simulates `VirtualMap.put() + commit()` path rehashing)
+- **Why use real `BlockStreamManagerImpl`?**
+  - Actual production code path (most realistic)
+  - No code copying/maintenance burden
+  - Automatically stays in sync with production changes
+  - Uses `NoOpDependencies` for non-critical components
+
+---
+
+### `NoOpDependencies.java`
+
+**No-op implementations for benchmarking**
+
+- **Purpose:** Provides minimal implementations of dependencies required by `BlockStreamManagerImpl` to enable isolated performance testing
+- **Key Classes:**
+
+  **No-Op Implementations:**
+  - `NoOpBlockItemWriter` - No disk I/O (intentionally excluded)
+  - `NoOpPlatform` - No Swirlds platform operations
+  - `NoOpMetrics` - No metrics collection overhead
+  - `NoOpLifecycle` - No node reward hooks
+  - `NoOpStoreMetricsService` - No store metrics
+
+  **Realistic Implementations:**
+  - `RealisticBlockHashSigner` - Simulates block signing cost (SHA-384 hash, async)
+  - `createBenchmarkBoundaryStateChangeListener()` - Real `BoundaryStateChangeListener` with `NoOpStoreMetricsService`
+  - `createBenchmarkQuiescenceController()` - Real `QuiescenceController` (disabled via config)
+  - `createBenchmarkQuiescedHeartbeat()` - Real `QuiescedHeartbeat` with real `QuiescenceController`
+
+  **Configuration:**
+  - `createBenchmarkConfigProvider()` - Sets up complete configuration with all required config data types
+  - Configures TSS disabled, quiescence disabled, and other benchmark-appropriate settings
+
+- **Design Philosophy:**
+
+  - Use real implementations where they matter
+  - Use NoOp where they don't affect throughput (disk I/O, metrics, platform)
+  - Simulate CPU costs accurately (block signing, state operations)
+
+---
+
+### `TransactionGeneratorUtil.java`
+
+- **Purpose:** Creates CryptoTransfer transactions for testing
+- **Features:**
+  - Configurable transaction size (via memo padding)
+  - Object reuse pattern (caches default size transactions for performance)
+  - Bulk generation methods (`generateTransactions(count)`)
+  - Rate-limited transaction spamming (`spamTransactions()` with TPS control)
+  - Default transaction size support (`DEFAULT_TX_SIZE = 200` bytes)
+  - Size measurement (`getTransactionSize()`)
+
+---
+
+## Configuration
+
+- **Merkle tree batch size:** 32 (matches production `BlockStreamConfig.hashCombineBatchSize`)
+- **JMH warmup:** 2 iterations, 2 seconds (ensures proper JIT optimization)
+- **JMH measurement:** 3 iterations, 2 seconds
+- **Component testing:** Extended to 100K params (validates high-load scaling)
+- **Microbenchmarks warmup:** 3 iterations, 1 second
+- **Microbenchmarks measurement:** 5 iterations, 1 second
+
+---
+
+## Architecture
+
+```
+BlockProductionBenchmark (end-to-end)
+    ↓ uses
+BlockStreamManagerWrapper
+    ↓ wraps
+BlockStreamManagerImpl (production code)
+    ↓ uses
+NoOpDependencies (minimal implementations)
+    ↓ uses
+TransactionGeneratorUtil (test data)
+
+BlockProductionMicrobenchmarks (components)
+    ↓ uses
+Real production classes directly (no mocking)
+    ↓ uses
+TransactionGeneratorUtil (test data)
+```
+
+---
+
+## Design Decisions
+
+### Why Simulate Some Components?
+
+**State Operations (VirtualMap):**
+- Real VirtualMap infrastructure is complex and not needed for CPU-bound testing
+- CPU cost accurately simulated with equivalent SHA-384 work
+- State read: 15× SHA-384 (simulates cached path traversal)
+- State commit: 28× SHA-384 (simulates log N path rehashing)
+
+**Block Signing:**
+- Signing is async and doesn't block the pipeline
+- Simulated with SHA-384 hash (matches production when TSS disabled)
+- Includes realistic CPU cost without TSS infrastructure complexity
+
+### Why Use NoOp for Some Dependencies?
+
+**NoOp Components (Don't Affect Throughput):**
+- `NoOpBlockItemWriter` - Disk I/O excluded intentionally
+- `NoOpPlatform` - Platform operations not part of block production
+- `NoOpMetrics` - Metrics collection doesn't affect throughput
+- `NoOpLifecycle` - Lifecycle hooks don't affect block production
+
+**Real Components (Do Affect Behavior):**
+- `BoundaryStateChangeListener` - Real implementation (captures state changes)
+- `QuiescenceController` - Real implementation (disabled via config)
+- `QuiescedHeartbeat` - Real implementation (uses real `QuiescenceController`)

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/jfr/.gitignore
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/jfr/.gitignore
@@ -1,0 +1,6 @@
+# JFR (Java Flight Recorder) profiling output files
+*.jfr
+*.json
+
+# Keep this directory in git
+!.gitignore

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/BlockStreamManagerWrapper.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/BlockStreamManagerWrapper.java
@@ -1,0 +1,569 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.utils;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
+import com.hedera.hapi.node.state.common.EntityNumber;
+import com.hedera.hapi.node.state.entity.EntityCounts;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.platform.state.PlatformState;
+import com.hedera.node.app.blocks.BlockItemWriter;
+import com.hedera.node.app.blocks.BlockStreamManager;
+import com.hedera.node.app.blocks.impl.BlockStreamManagerImpl;
+import com.hedera.node.app.blocks.schemas.V0560BlockStreamSchema;
+import com.hedera.node.app.quiescence.QuiescenceController;
+import com.hedera.node.app.service.entityid.EntityIdService;
+import com.hedera.node.app.service.entityid.impl.schemas.V0490EntityIdSchema;
+import com.hedera.node.app.service.entityid.impl.schemas.V0590EntityIdSchema;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.internal.network.PendingProof;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.platform.system.state.notifications.StateHashedNotification;
+import com.swirlds.state.State;
+import com.swirlds.state.spi.CommittableWritableStates;
+import com.swirlds.state.spi.ReadableKVState;
+import com.swirlds.state.spi.ReadableQueueState;
+import com.swirlds.state.spi.ReadableSingletonState;
+import com.swirlds.state.spi.ReadableStates;
+import com.swirlds.state.spi.WritableKVState;
+import com.swirlds.state.spi.WritableQueueState;
+import com.swirlds.state.spi.WritableSingletonState;
+import com.swirlds.state.spi.WritableStates;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import org.hiero.base.crypto.Hash;
+import org.hiero.consensus.model.event.ConsensusEvent;
+import org.hiero.consensus.model.hashgraph.Round;
+
+/**
+ * Wrapper around BlockStreamManagerImpl that provides a simpler API for benchmarking.
+ * Handles creation of minimal Round and State objects internally.
+ */
+@SuppressWarnings("unchecked")
+public class BlockStreamManagerWrapper {
+    private final BlockStreamManagerImpl manager;
+    private long currentRoundNumber = 1;
+    private final BenchmarkState state;
+    private final AtomicReference<BlockStreamInfo> blockStreamInfoRef;
+    private final AtomicReference<Long> itemsWrittenRef;
+
+    public BlockStreamManagerWrapper(Supplier<BlockItemWriter> writerSupplier) {
+        this.itemsWrittenRef = new AtomicReference<>(0L);
+        this.blockStreamInfoRef = new AtomicReference<>(BlockStreamInfo.newBuilder()
+                .blockNumber(0)
+                .trailingBlockHashes(Bytes.EMPTY)
+                .intermediatePreviousBlockRootHashes(Collections.emptyList())
+                .intermediateBlockRootsLeafCount(0L)
+                .build());
+
+        this.state = new BenchmarkState(blockStreamInfoRef);
+
+        // Wrap writer to track items written
+        Supplier<BlockItemWriter> trackingWriterSupplier = () -> {
+            BlockItemWriter original = writerSupplier.get();
+            return new BlockItemWriter() {
+                @Override
+                public void openBlock(long blockNumber) {
+                    original.openBlock(blockNumber);
+                }
+
+                @Override
+                public void writePbjItemAndBytes(@NonNull BlockItem item, @NonNull Bytes bytes) {
+                    itemsWrittenRef.updateAndGet(v -> v + 1);
+                    original.writePbjItemAndBytes(item, bytes);
+                }
+
+                @Override
+                public void writePbjItem(@NonNull BlockItem item) {
+                    itemsWrittenRef.updateAndGet(v -> v + 1);
+                    original.writePbjItem(item);
+                }
+
+                @Override
+                public void closeCompleteBlock() {
+                    original.closeCompleteBlock();
+                }
+
+                @Override
+                public void flushPendingBlock(@NonNull PendingProof pendingProof) {
+                    original.flushPendingBlock(pendingProof);
+                }
+
+                @Override
+                public void jumpToBlockAfterFreeze(long blockNumber) {
+                    original.jumpToBlockAfterFreeze(blockNumber);
+                }
+            };
+        };
+
+        ConfigProvider configProvider = NoOpDependencies.createBenchmarkConfigProvider();
+        QuiescenceController quiescenceController =
+                NoOpDependencies.createBenchmarkQuiescenceController(configProvider);
+
+        this.manager = new BlockStreamManagerImpl(
+                new NoOpDependencies.RealisticBlockHashSigner(),
+                trackingWriterSupplier,
+                ForkJoinPool.commonPool(),
+                configProvider,
+                NoOpDependencies.createBenchmarkBoundaryStateChangeListener(configProvider),
+                new NoOpDependencies.NoOpPlatform(),
+                quiescenceController,
+                NoOpDependencies.createNoOpInitialStateHash(),
+                SemanticVersion.DEFAULT,
+                new NoOpDependencies.NoOpLifecycle(),
+                NoOpDependencies.createBenchmarkQuiescedHeartbeat(quiescenceController),
+                new NoOpDependencies.NoOpMetrics());
+
+        manager.init(state, BlockStreamManager.ZERO_BLOCK_HASH);
+    }
+
+    public void startBlock(long blockNumber, BlockItem header) {
+        state.updateBlockNumber(blockNumber);
+        BenchmarkRound round = new BenchmarkRound(currentRoundNumber++, Instant.now());
+        manager.startRound(round, state);
+        manager.writeItem(header);
+    }
+
+    public void writeItem(@NonNull BlockItem item) {
+        manager.writeItem(item);
+    }
+
+    public void sealBlock(BlockItem proof) {
+        manager.writeItem(proof);
+        long roundNum = currentRoundNumber - 1;
+
+        // Complete the state hash future for this round BEFORE endRound()
+        // (endRound() for the NEXT block will wait for this future)
+        // In production, this is done by the platform's state hashing notification system
+        // For benchmark, we simulate it with a dummy hash
+        Hash dummyStateHash = new Hash(new byte[48]); // 48 bytes = SHA-384 hash size
+        StateHashedNotification notification = new StateHashedNotification(roundNum, dummyStateHash);
+        manager.notify(notification);
+
+        // Now endRound() can proceed (it waits for the previous round's future, which we completed above)
+        manager.endRound(state, roundNum);
+    }
+
+    public long getTotalItemsWritten() {
+        return itemsWrittenRef.get();
+    }
+
+    public Bytes getLastComputedBlockHash() {
+        return manager.blockHashByBlockNumber(manager.blockNo() - 1);
+    }
+
+    // Minimal Round implementation
+    private static class BenchmarkRound implements Round {
+        private final long roundNum;
+        private final Instant consensusTimestamp;
+
+        BenchmarkRound(long roundNum, Instant consensusTimestamp) {
+            this.roundNum = roundNum;
+            this.consensusTimestamp = consensusTimestamp;
+        }
+
+        @Override
+        public @NonNull Iterator<ConsensusEvent> iterator() {
+            return Collections.emptyIterator();
+        }
+
+        @Override
+        public long getRoundNum() {
+            return roundNum;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return true;
+        }
+
+        @Override
+        public int getEventCount() {
+            return 0;
+        }
+
+        @Override
+        public @NonNull Roster getConsensusRoster() {
+            return Roster.DEFAULT;
+        }
+
+        @Override
+        public @NonNull Instant getConsensusTimestamp() {
+            return consensusTimestamp;
+        }
+    }
+
+    // Minimal State implementation
+    private static class BenchmarkState implements State {
+        private Hash hash;
+        private final AtomicReference<BlockStreamInfo> blockStreamInfoRef;
+        private long blockNumber = 0;
+
+        BenchmarkState(AtomicReference<BlockStreamInfo> blockStreamInfoRef) {
+            this.blockStreamInfoRef = blockStreamInfoRef;
+        }
+
+        @Override
+        public @NonNull State copy() {
+            return this; // No-op for benchmark
+        }
+
+        @Override
+        public void setHash(@NonNull Hash hash) {
+            this.hash = hash;
+        }
+
+        @Override
+        public @NonNull Hash getHash() {
+            return hash != null ? hash : new Hash(new byte[48]);
+        }
+
+        void updateBlockNumber(long blockNumber) {
+            this.blockNumber = blockNumber;
+            blockStreamInfoRef.set(BlockStreamInfo.newBuilder()
+                    .blockNumber(blockNumber)
+                    .trailingBlockHashes(Bytes.EMPTY)
+                    .intermediatePreviousBlockRootHashes(Collections.emptyList())
+                    .intermediateBlockRootsLeafCount(0L)
+                    .build());
+        }
+
+        @Override
+        public @NonNull ReadableStates getReadableStates(@NonNull String serviceName) {
+            return switch (serviceName) {
+                case "BlockStreamService" ->
+                    new ReadableStates() {
+                        @Override
+                        public @NonNull <T> ReadableSingletonState<T> getSingleton(int stateId) {
+                            return new ReadableSingletonState<>() {
+                                @Override
+                                public @NonNull T get() {
+                                    return (T) blockStreamInfoRef.get();
+                                }
+
+                                @Override
+                                public int getStateId() {
+                                    return stateId;
+                                }
+
+                                @Override
+                                public boolean isRead() {
+                                    return true;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public @NonNull <K, V> ReadableKVState<K, V> get(int stateId) {
+                            throw new UnsupportedOperationException("KV states not supported");
+                        }
+
+                        @Override
+                        public @NonNull <T> ReadableQueueState<T> getQueue(int stateId) {
+                            throw new UnsupportedOperationException("Queue states not supported");
+                        }
+
+                        @Override
+                        public boolean contains(int stateId) {
+                            return stateId == V0560BlockStreamSchema.BLOCK_STREAM_INFO_STATE_ID;
+                        }
+
+                        @Override
+                        public @NonNull Set<Integer> stateIds() {
+                            return Set.of(V0560BlockStreamSchema.BLOCK_STREAM_INFO_STATE_ID);
+                        }
+                    };
+                case "PlatformStateService" ->
+                    new ReadableStates() {
+                        @Override
+                        public @NonNull <T> ReadableSingletonState<T> getSingleton(int stateId) {
+                            return new ReadableSingletonState<>() {
+                                @Override
+                                public @NonNull T get() {
+                                    return (T) PlatformState.DEFAULT;
+                                }
+
+                                @Override
+                                public int getStateId() {
+                                    return stateId;
+                                }
+
+                                @Override
+                                public boolean isRead() {
+                                    return true;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public @NonNull <K, V> ReadableKVState<K, V> get(int stateId) {
+                            throw new UnsupportedOperationException("KV states not supported");
+                        }
+
+                        @Override
+                        public @NonNull <T> ReadableQueueState<T> getQueue(int stateId) {
+                            throw new UnsupportedOperationException("Queue states not supported");
+                        }
+
+                        @Override
+                        public boolean contains(int stateId) {
+                            return true;
+                        }
+
+                        @Override
+                        public @NonNull Set<Integer> stateIds() {
+                            return Set.of(
+                                    com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema
+                                            .PLATFORM_STATE_STATE_ID);
+                        }
+                    };
+                case EntityIdService.NAME ->
+                    new ReadableStates() {
+                        @Override
+                        @SuppressWarnings("deprecation")
+                        public @NonNull <T> ReadableSingletonState<T> getSingleton(int stateId) {
+                            return new ReadableSingletonState<T>() {
+                                @Override
+                                @SuppressWarnings("deprecation")
+                                public @NonNull T get() {
+                                    T result;
+                                    if (stateId == V0490EntityIdSchema.ENTITY_ID_STATE_ID) {
+                                        @SuppressWarnings("deprecation")
+                                        EntityNumber entityNumber = EntityNumber.DEFAULT;
+                                        result = (T) entityNumber;
+                                    } else if (stateId == V0590EntityIdSchema.ENTITY_COUNTS_STATE_ID) {
+                                        result = (T) EntityCounts.DEFAULT;
+                                    } else {
+                                        throw new UnsupportedOperationException(
+                                                "Unknown EntityIdService state ID: " + stateId);
+                                    }
+                                    return result;
+                                }
+
+                                @Override
+                                public int getStateId() {
+                                    return stateId;
+                                }
+
+                                @Override
+                                public boolean isRead() {
+                                    return true;
+                                }
+                            };
+                        }
+
+                        @Override
+                        public @NonNull <K, V> ReadableKVState<K, V> get(int stateId) {
+                            throw new UnsupportedOperationException("KV states not supported");
+                        }
+
+                        @Override
+                        public @NonNull <T> ReadableQueueState<T> getQueue(int stateId) {
+                            throw new UnsupportedOperationException("Queue states not supported");
+                        }
+
+                        @Override
+                        public boolean contains(int stateId) {
+                            return stateId == V0490EntityIdSchema.ENTITY_ID_STATE_ID
+                                    || stateId == V0590EntityIdSchema.ENTITY_COUNTS_STATE_ID;
+                        }
+
+                        @Override
+                        public @NonNull Set<Integer> stateIds() {
+                            return Set.of(
+                                    V0490EntityIdSchema.ENTITY_ID_STATE_ID, V0590EntityIdSchema.ENTITY_COUNTS_STATE_ID);
+                        }
+                    };
+                default ->
+                    // Empty ReadableStates for other services
+                    new ReadableStates() {
+                        @Override
+                        public @NonNull <T> ReadableSingletonState<T> getSingleton(int stateId) {
+                            throw new UnsupportedOperationException("Service not supported: " + serviceName);
+                        }
+
+                        @Override
+                        public @NonNull <K, V> ReadableKVState<K, V> get(int stateId) {
+                            throw new UnsupportedOperationException("KV states not supported");
+                        }
+
+                        @Override
+                        public @NonNull <T> ReadableQueueState<T> getQueue(int stateId) {
+                            throw new UnsupportedOperationException("Queue states not supported");
+                        }
+
+                        @Override
+                        public boolean contains(int stateId) {
+                            return false;
+                        }
+
+                        @Override
+                        public @NonNull Set<Integer> stateIds() {
+                            return Collections.emptySet();
+                        }
+                    };
+            };
+        }
+
+        @Override
+        public @NonNull WritableStates getWritableStates(@NonNull String serviceName) {
+            if ("BlockStreamService".equals(serviceName)) {
+                return new CommittableBlockStreamWritableStates(blockStreamInfoRef);
+            }
+            throw new UnsupportedOperationException("WritableStates not supported for: " + serviceName);
+        }
+    }
+
+    /** WritableStates implementation that also implements CommittableWritableStates */
+    private static class CommittableBlockStreamWritableStates implements WritableStates, CommittableWritableStates {
+        private final AtomicReference<BlockStreamInfo> blockStreamInfoRef;
+        private Bytes lastStateReadHash = Bytes.EMPTY; // Prevent Dead Code Elimination of state read simulation
+        private Bytes lastStateCommitHash = Bytes.EMPTY; // Prevent Dead Code Elimination of state commit simulation
+
+        CommittableBlockStreamWritableStates(AtomicReference<BlockStreamInfo> blockStreamInfoRef) {
+            this.blockStreamInfoRef = blockStreamInfoRef;
+        }
+
+        /**
+         * SIMULATED STATE READ: Mimics the cost of VirtualMap.get() to read BlockStreamInfo.
+         *
+         * In production, reading BlockStreamInfo from VirtualMap at startRound() involves
+         * VirtualMap.get() which traverses the merkle path from root to leaf. This involves
+         * ~log(N) hash verifications where N is the total number of leaves.
+         *
+         * For efficiency, we simulate a smaller read cost (~15 hashes) since reads are
+         * typically cached and don't require full path rehashing like writes do.
+         */
+        private void simulateStateRead() {
+            final int READ_HASH_COUNT = 15;
+            final byte[] NULL_HASH = new byte[48]; // SHA-384 = 48 bytes
+
+            try {
+                final var digest = java.security.MessageDigest.getInstance("SHA-384");
+                byte[] hash = blockStreamInfoRef.get() != null
+                        ? digest.digest(blockStreamInfoRef.get().toString().getBytes())
+                        : digest.digest(new byte[48]);
+
+                // Simulate read cost (path traversal with cached hashes)
+                for (int i = 0; i < READ_HASH_COUNT; i++) {
+                    digest.reset();
+                    digest.update(hash);
+                    digest.update(NULL_HASH);
+                    hash = digest.digest();
+                }
+
+                // Prevent Dead Code Elimination: Store result
+                lastStateReadHash = Bytes.wrap(hash);
+            } catch (Exception e) {
+                // Ignore - simulation failure shouldn't break benchmark
+            }
+        }
+
+        /**
+         * SIMULATED STATE COMMIT: Mimics the cost of VirtualMap.put() + commit().
+         *
+         * In production, committing BlockStreamInfo to VirtualMap triggers VirtualHasher
+         * to rehash the merkle path from the modified leaf to the root. This involves
+         * ~log(N) SHA-384 hash operations where N is the total number of leaves in the
+         * VirtualMap.
+         *
+         * For a typical VirtualMap with millions of entries, the tree depth is ~25-30,
+         * so we simulate 28 SHA-384 hashes (path from leaf to root).
+         *
+         * This mimics the REAL CPU cost without requiring actual VirtualMap infrastructure.
+         */
+        private void simulateStateCommit() {
+            final int VIRTUAL_MAP_TREE_DEPTH = 28; // Typical depth for large VirtualMap
+            final byte[] NULL_HASH = new byte[48]; // SHA-384 = 48 bytes
+
+            try {
+                final var digest = java.security.MessageDigest.getInstance("SHA-384");
+                BlockStreamInfo info = blockStreamInfoRef.get();
+                byte[] hash = info != null
+                        ? digest.digest(info.toString().getBytes()) // Leaf hash
+                        : digest.digest(new byte[48]);
+
+                // REAL: Rehash from leaf to root (log N hashes)
+                // This is what VirtualHasher does when we commit a write
+                for (int depth = 0; depth < VIRTUAL_MAP_TREE_DEPTH; depth++) {
+                    digest.reset();
+                    digest.update(hash);
+                    digest.update(NULL_HASH); // Sibling hash (simplified - we use null)
+                    hash = digest.digest();
+                }
+
+                // Prevent JIT from optimizing away the work
+                lastStateCommitHash = Bytes.wrap(hash);
+            } catch (Exception e) {
+                // Ignore - simulation failure shouldn't break benchmark
+            }
+        }
+
+        @Override
+        public @NonNull <T> WritableSingletonState<T> getSingleton(int stateId) {
+            return new WritableSingletonState<T>() {
+                @Override
+                public @NonNull T get() {
+                    // SIMULATE state read cost (VirtualMap.get() path traversal)
+                    simulateStateRead();
+                    return (T) blockStreamInfoRef.get();
+                }
+
+                @Override
+                public void put(T value) {
+                    BlockStreamInfo info = (BlockStreamInfo) value;
+                    blockStreamInfoRef.set(info);
+                    // Actual commit cost is simulated in commit() method
+                }
+
+                @Override
+                public int getStateId() {
+                    return stateId;
+                }
+
+                @Override
+                public boolean isRead() {
+                    return true;
+                }
+
+                @Override
+                public boolean isModified() {
+                    return false;
+                }
+            };
+        }
+
+        @Override
+        public @NonNull <K, V> WritableKVState<K, V> get(int stateId) {
+            throw new UnsupportedOperationException("KV states not supported");
+        }
+
+        @Override
+        public @NonNull <T> WritableQueueState<T> getQueue(int stateId) {
+            throw new UnsupportedOperationException("Queue states not supported");
+        }
+
+        @Override
+        public boolean contains(int stateId) {
+            return stateId == V0560BlockStreamSchema.BLOCK_STREAM_INFO_STATE_ID;
+        }
+
+        @Override
+        public @NonNull Set<Integer> stateIds() {
+            return Set.of(V0560BlockStreamSchema.BLOCK_STREAM_INFO_STATE_ID);
+        }
+
+        @Override
+        public void commit() {
+            // SIMULATE state commit cost (VirtualMap.put() + commit() path rehashing)
+            simulateStateCommit();
+        }
+    }
+}

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/NoOpDependencies.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/NoOpDependencies.java
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.utils;
+
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.node.app.blocks.BlockHashSigner;
+import com.hedera.node.app.blocks.BlockItemWriter;
+import com.hedera.node.app.blocks.BlockStreamManager;
+import com.hedera.node.app.blocks.InitialStateHash;
+import com.hedera.node.app.blocks.impl.BoundaryStateChangeListener;
+import com.hedera.node.app.quiescence.QuiescedHeartbeat;
+import com.hedera.node.app.quiescence.QuiescenceController;
+import com.hedera.node.app.spi.metrics.StoreMetricsService;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.node.config.VersionedConfigImpl;
+import com.hedera.node.config.converter.FunctionalitySetConverter;
+import com.hedera.node.config.converter.SemanticVersionConverter;
+import com.hedera.node.config.data.*;
+import com.hedera.node.config.types.HederaFunctionalitySet;
+import com.hedera.node.internal.network.PendingProof;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.notification.NotificationEngine;
+import com.swirlds.common.utility.AutoCloseableWrapper;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.extensions.sources.SimpleConfigSource;
+import com.swirlds.metrics.api.Counter;
+import com.swirlds.metrics.api.Metric;
+import com.swirlds.metrics.api.MetricConfig;
+import com.swirlds.metrics.api.MetricType;
+import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.system.Platform;
+import com.swirlds.state.State;
+import com.swirlds.state.spi.metrics.StoreMetrics;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import org.hiero.base.crypto.Signature;
+import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.quiescence.QuiescenceCommand;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * No-op implementations of dependencies for benchmarking BlockStreamManagerImpl.
+ */
+@SuppressWarnings("deprecation") // Uses deprecated APIs (MetricType, etc.) that are still used in production
+public final class NoOpDependencies {
+
+    private NoOpDependencies() {}
+
+    /**
+     * Realistic BlockHashSigner that simulates the CPU cost of signing.
+     *
+     * In production (without TSS), signing is just a SHA-384 hash of the block hash.
+     * This implementation simulates that cost by computing the hash asynchronously,
+     * matching the production behavior where signing doesn't block the pipeline.
+     *
+     * This is cleaner than using real TssBlockHashSigner with NoOp services because:
+     * - When TSS is disabled, TssBlockHashSigner sets services to null internally anyway
+     * - NoOp services would never be used, adding unnecessary complexity
+     * - This simulation matches production behavior exactly (SHA-384 hash path)
+     */
+    public static class RealisticBlockHashSigner implements BlockHashSigner {
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public Attempt sign(@NonNull Bytes blockHash) {
+            // Simulate production behavior: async SHA-384 hash computation
+            // This matches TssBlockHashSigner when TSS is disabled (no hintsService)
+            return new Attempt(
+                    null, // No verification key (TSS disabled)
+                    null, // No chain of trust proof (TSS disabled)
+                    CompletableFuture.supplyAsync(() -> {
+                        // Simulate the CPU cost: SHA-384 hash of block hash
+                        // This matches production: noThrowSha384HashOf(blockHash)
+                        try {
+                            final var digest = java.security.MessageDigest.getInstance("SHA-384");
+                            digest.update(blockHash.toByteArray());
+                            return Bytes.wrap(digest.digest());
+                        } catch (Exception e) {
+                            // Fallback: return zero hash if SHA-384 unavailable (shouldn't happen)
+                            return Bytes.wrap(new byte[48]); // SHA-384 = 48 bytes
+                        }
+                    }));
+        }
+    }
+
+    /** No-op BlockHashSigner (deprecated - use createRealTssBlockHashSigner() for production realism) */
+    @Deprecated
+    public static class NoOpBlockHashSigner implements BlockHashSigner {
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public Attempt sign(@NonNull Bytes blockHash) {
+            return new Attempt(null, null, CompletableFuture.completedFuture(Bytes.wrap(new byte[64])));
+        }
+    }
+
+    /** No-op BlockItemWriter */
+    public static class NoOpBlockItemWriter implements BlockItemWriter {
+        @Override
+        public void openBlock(long blockNumber) {}
+
+        @Override
+        public void writePbjItemAndBytes(@NonNull BlockItem item, @NonNull Bytes bytes) {}
+
+        @Override
+        public void writePbjItem(@NonNull BlockItem item) {}
+
+        @Override
+        public void closeCompleteBlock() {}
+
+        @Override
+        public void flushPendingBlock(@NonNull PendingProof pendingProof) {}
+
+        @Override
+        public void jumpToBlockAfterFreeze(long blockNumber) {}
+    }
+
+    /** No-op StoreMetricsService - can be used with real BoundaryStateChangeListener */
+    public static class NoOpStoreMetricsService implements StoreMetricsService {
+        @Override
+        public StoreMetrics get(@NonNull StoreType storeType, long capacity) {
+            return count -> {};
+        }
+    }
+
+    /** Minimal Platform implementation */
+    public static class NoOpPlatform implements Platform {
+        @Override
+        public @NonNull PlatformContext getContext() {
+            throw new UnsupportedOperationException("NoOpPlatform.getContext() not implemented");
+        }
+
+        @Override
+        public @NonNull NotificationEngine getNotificationEngine() {
+            throw new UnsupportedOperationException("NoOpPlatform.getNotificationEngine() not implemented");
+        }
+
+        @Override
+        public @NonNull Roster getRoster() {
+            throw new UnsupportedOperationException("NoOpPlatform.getRoster() not implemented");
+        }
+
+        @Override
+        public @NonNull NodeId getSelfId() {
+            throw new UnsupportedOperationException("NoOpPlatform.getSelfId() not implemented");
+        }
+
+        @Override
+        public @NonNull <T extends State> AutoCloseableWrapper<T> getLatestImmutableState(@NonNull String reason) {
+            throw new UnsupportedOperationException("NoOpPlatform.getLatestImmutableState() not implemented");
+        }
+
+        @Override
+        public @NonNull Signature sign(@NonNull byte[] data) {
+            throw new UnsupportedOperationException("NoOpPlatform.sign() not implemented");
+        }
+
+        @Override
+        public void quiescenceCommand(@NonNull QuiescenceCommand command) {}
+
+        @Override
+        public void start() {}
+
+        @Override
+        public void destroy() {}
+    }
+
+    /** Creates a real QuiescenceController with disabled quiescence for benchmarking */
+    public static QuiescenceController createBenchmarkQuiescenceController(@NonNull ConfigProvider configProvider) {
+        final var config = configProvider.getConfiguration().getConfigData(QuiescenceConfig.class);
+        return new QuiescenceController(config, java.time.Instant::now, () -> 0L);
+    }
+
+    /** Creates a no-op InitialStateHash */
+    public static InitialStateHash createNoOpInitialStateHash() {
+        return new InitialStateHash(CompletableFuture.completedFuture(Bytes.wrap(new byte[48])), 0L);
+    }
+
+    /** No-op Lifecycle */
+    public static class NoOpLifecycle implements BlockStreamManager.Lifecycle {
+        @Override
+        public void onOpenBlock(@NonNull State state) {}
+
+        @Override
+        public void onCloseBlock(@NonNull State state) {}
+    }
+
+    /** Creates a QuiescedHeartbeat using real QuiescenceController but NoOpPlatform */
+    public static QuiescedHeartbeat createBenchmarkQuiescedHeartbeat(
+            @NonNull QuiescenceController quiescenceController) {
+        return new QuiescedHeartbeat(quiescenceController, new NoOpPlatform());
+    }
+
+    /** Creates a real BoundaryStateChangeListener for benchmarking */
+    public static BoundaryStateChangeListener createBenchmarkBoundaryStateChangeListener(
+            @NonNull ConfigProvider configProvider) {
+        return new BoundaryStateChangeListener(new NoOpStoreMetricsService(), configProvider::getConfiguration);
+    }
+
+    /** No-op Counter */
+    public static class NoOpCounter implements Counter {
+        @Override
+        public long get() {
+            return 0;
+        }
+
+        @Override
+        public void add(final long value) {
+            // No-op
+        }
+
+        @Override
+        public void increment() {
+            // No-op
+        }
+
+        @Override
+        public @NonNull String getCategory() {
+            return "noop";
+        }
+
+        @Override
+        public @NonNull String getName() {
+            return "noop-counter";
+        }
+
+        @Override
+        public @NonNull String getDescription() {
+            return "No-op counter";
+        }
+
+        @Override
+        public @NonNull String getUnit() {
+            return "";
+        }
+
+        @Override
+        public @NonNull String getFormat() {
+            return "%d";
+        }
+
+        @Override
+        @SuppressWarnings("deprecation") // MetricType is deprecated but still required by Counter interface
+        public @NonNull MetricType getMetricType() {
+            return MetricType.COUNTER;
+        }
+
+        @Override
+        public @NonNull Long get(@NonNull final ValueType valueType) {
+            return 0L;
+        }
+
+        @Override
+        public void reset() {
+            // No-op
+        }
+    }
+
+    /** No-op Metrics */
+    public static class NoOpMetrics implements Metrics {
+        @Override
+        public Metric getMetric(@NonNull String category, @NonNull String name) {
+            return null;
+        }
+
+        @Override
+        public @NonNull Collection<Metric> findMetricsByCategory(@NonNull String category) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public @NonNull Collection<Metric> getAll() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T extends Metric> @NotNull T getOrCreate(final @NonNull MetricConfig<T, ?> config) {
+            // Check if this is a Counter config and return a NoOpCounter
+            if (config.getResultClass() == Counter.class) {
+                return (T) new NoOpCounter();
+            }
+            // For other metric types, throw exception (can be extended later if needed)
+            throw new UnsupportedOperationException("NoOpMetrics.getOrCreate() not implemented for "
+                    + config.getResultClass().getSimpleName());
+        }
+
+        @Override
+        public void remove(@NonNull MetricConfig<?, ?> config) {}
+
+        @Override
+        public void remove(@NonNull Metric metric) {}
+
+        @Override
+        public void remove(@NonNull String category, @NonNull String name) {}
+
+        @Override
+        public void addUpdater(@NonNull Runnable updater) {}
+
+        @Override
+        public void removeUpdater(@NonNull Runnable updater) {}
+
+        @Override
+        public void start() {}
+    }
+
+    /** Creates a minimal ConfigProvider */
+    public static ConfigProvider createBenchmarkConfigProvider() {
+        return new ConfigProvider() {
+            @Override
+            public @NonNull VersionedConfigImpl getConfiguration() {
+                return new VersionedConfigImpl(createBenchmarkConfiguration(), 1L);
+            }
+        };
+    }
+
+    /** Creates a minimal Configuration with hardcoded values */
+    private static Configuration createBenchmarkConfiguration() {
+        SimpleConfigSource source = new SimpleConfigSource()
+                .withValue("blockStream.streamMode", "BOTH")
+                .withValue("blockStream.writerMode", "FILE")
+                .withValue("blockStream.blockFileDir", "/tmp/benchmark-blocks")
+                .withValue("blockStream.hashCombineBatchSize", "32")
+                .withValue("blockStream.roundsPerBlock", "1")
+                .withValue("blockStream.blockPeriod", "2s")
+                .withValue("blockStream.receiptEntriesBatchSize", "8192")
+                .withValue("blockStream.workerLoopSleepDuration", "10ms")
+                .withValue("blockStream.maxConsecutiveScheduleSecondsToProbe", "100")
+                .withValue("blockStream.quiescedHeartbeatInterval", "1s")
+                .withValue("blockStream.maxReadDepth", "512")
+                .withValue("blockStream.maxReadBytesSize", "500000000")
+                .withValue("tss.hintsEnabled", "false")
+                .withValue("tss.historyEnabled", "false")
+                .withValue("quiescence.enabled", "false")
+                .withValue("quiescence.tctDuration", "5s")
+                .withValue("networkAdmin.diskNetworkExport", "NEVER")
+                .withValue("networkAdmin.diskNetworkExportFile", "/tmp/benchmark-network-export")
+                .withValue("version.hapiVersion", "0.56.0")
+                .withValue("staking.periodMins", "1440")
+                .withValue("blockRecordStream.numOfBlockHashesInState", "256");
+
+        return ConfigurationBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(TssConfig.class)
+                .withConfigDataType(QuiescenceConfig.class)
+                .withConfigDataType(NetworkAdminConfig.class)
+                .withConfigDataType(VersionConfig.class)
+                .withConfigDataType(StakingConfig.class)
+                .withConfigDataType(BlockRecordStreamConfig.class)
+                .withConverter(HederaFunctionalitySet.class, new FunctionalitySetConverter())
+                .withConverter(SemanticVersion.class, new SemanticVersionConverter())
+                .withSource(source)
+                .build();
+    }
+}

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/TransactionGeneratorUtil.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/TransactionGeneratorUtil.java
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.blocks.utils;
+
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.Duration;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.base.TransferList;
+import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Generates realistic transactions for benchmarking and testing.
+ * Uses CryptoTransfer with memo padding to achieve target size.
+ * Follows object reuse pattern for performance.
+ */
+public final class TransactionGeneratorUtil {
+
+    private static final int DEFAULT_TX_SIZE = 200; // Bytes for typical transfer
+
+    // Realistic test accounts
+    private static final AccountID PAYER =
+            AccountID.newBuilder().accountNum(1001).build();
+    private static final AccountID NODE = AccountID.newBuilder().accountNum(3).build();
+    private static final AccountID SENDER =
+            AccountID.newBuilder().accountNum(1001).build();
+    private static final AccountID RECEIVER =
+            AccountID.newBuilder().accountNum(1002).build();
+
+    // Cached reusable transaction for default size
+    private static volatile Bytes cachedTransaction_200B = null;
+
+    private TransactionGeneratorUtil() {
+        throw new UnsupportedOperationException("Utility class");
+    }
+
+    /**
+     * Generates a single transaction with default size.
+     *
+     * @return Serialized transaction as Bytes
+     */
+    public static Bytes generateTransaction() {
+        return generateTransaction(DEFAULT_TX_SIZE);
+    }
+
+    /**
+     * Generates a single transaction of approximately the specified size.
+     *
+     * @param targetSizeBytes Target size in bytes
+     * @return Serialized transaction as Bytes
+     */
+    public static Bytes generateTransaction(int targetSizeBytes) {
+        // Use cached transaction for default size
+        if (targetSizeBytes == DEFAULT_TX_SIZE) {
+            if (cachedTransaction_200B == null) {
+                synchronized (TransactionGeneratorUtil.class) {
+                    if (cachedTransaction_200B == null) {
+                        cachedTransaction_200B = createTransaction(targetSizeBytes);
+                    }
+                }
+            }
+            return cachedTransaction_200B;
+        }
+
+        return createTransaction(targetSizeBytes);
+    }
+
+    /**
+     * Generates a list of transactions with default size.
+     * Reuses same transaction instance for performance.
+     *
+     * @param count Number of transactions to generate
+     * @return List of transactions
+     */
+    public static List<Bytes> generateTransactions(int count) {
+        return generateTransactions(count, DEFAULT_TX_SIZE);
+    }
+
+    /**
+     * Generates a list of transactions, all the same size.
+     * Reuses same transaction instance for performance.
+     *
+     * @param count Number of transactions to generate
+     * @param sizeBytes Size per transaction in bytes
+     * @return List of transactions
+     */
+    public static List<Bytes> generateTransactions(int count, int sizeBytes) {
+        List<Bytes> transactions = new ArrayList<>(count);
+        Bytes template = generateTransaction(sizeBytes);
+
+        // Reuse same reference for performance gain
+        for (int i = 0; i < count; i++) {
+            transactions.add(template);
+        }
+
+        return transactions;
+    }
+
+    /**
+     * Spams transactions at a specified rate with default size.
+     * Executes consumer for each transaction, respecting the target TPS.
+     *
+     * @param consumer Handler for each generated transaction
+     * @param totalTransactions Total number of transactions to generate
+     * @param transactionsPerSecond Target rate (TPS)
+     */
+    public static void spamTransactions(Consumer<Bytes> consumer, int totalTransactions, int transactionsPerSecond) {
+        spamTransactions(consumer, totalTransactions, transactionsPerSecond, DEFAULT_TX_SIZE);
+    }
+
+    /**
+     * Spams transactions at a specified rate and size.
+     * Executes consumer for each transaction, respecting the target TPS.
+     *
+     * @param consumer Handler for each generated transaction
+     * @param totalTransactions Total number of transactions to generate
+     * @param transactionsPerSecond Target rate (TPS)
+     * @param transactionSizeBytes Size per transaction
+     */
+    public static void spamTransactions(
+            Consumer<Bytes> consumer, int totalTransactions, int transactionsPerSecond, int transactionSizeBytes) {
+
+        // Pre-generate transaction once (reuse pattern)
+        Bytes transaction = generateTransaction(transactionSizeBytes);
+
+        long intervalNanos = TimeUnit.SECONDS.toNanos(1) / transactionsPerSecond;
+        long startTime = System.nanoTime();
+
+        for (int i = 0; i < totalTransactions; i++) {
+            long targetTime = startTime + (i * intervalNanos);
+
+            // Send transaction
+            consumer.accept(transaction);
+
+            // Sleep until next transaction is due
+            long now = System.nanoTime();
+            long sleepNanos = targetTime - now;
+
+            if (sleepNanos > 0) {
+                try {
+                    TimeUnit.NANOSECONDS.sleep(sleepNanos);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a CryptoTransfer transaction with memo padding to achieve target size.
+     */
+    private static Bytes createTransaction(int targetSizeBytes) {
+        // Simple HBAR transfer (1000 tinybars from sender to receiver)
+        var cryptoTransfer = CryptoTransferTransactionBody.newBuilder()
+                .transfers(TransferList.newBuilder()
+                        .accountAmounts(
+                                AccountAmount.newBuilder()
+                                        .accountID(SENDER)
+                                        .amount(-1000)
+                                        .build(),
+                                AccountAmount.newBuilder()
+                                        .accountID(RECEIVER)
+                                        .amount(1000)
+                                        .build())
+                        .build())
+                .build();
+
+        // Build base transaction body without memo
+        var baseBody = TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder()
+                        .accountID(PAYER)
+                        .transactionValidStart(Timestamp.newBuilder()
+                                .seconds(System.currentTimeMillis() / 1000)
+                                .build())
+                        .build())
+                .nodeAccountID(NODE)
+                .transactionFee(100_000)
+                .transactionValidDuration(Duration.newBuilder().seconds(120).build())
+                .cryptoTransfer(cryptoTransfer)
+                .build();
+
+        long baseSize = TransactionBody.PROTOBUF.measureRecord(baseBody);
+
+        // Add memo padding to reach target size
+        int memoSize = Math.max(0, (int) (targetSizeBytes - baseSize));
+        String memo = generatePaddingMemo(memoSize);
+
+        var finalBody = baseBody.copyBuilder().memo(memo).build();
+
+        // Serialize transaction body
+        return TransactionBody.PROTOBUF.toBytes(finalBody);
+    }
+
+    /**
+     * Generates a memo string of the specified size for padding.
+     */
+    private static String generatePaddingMemo(int targetSize) {
+        if (targetSize <= 0) {
+            return "";
+        }
+
+        // Use repeating pattern for efficiency
+        StringBuilder memo = new StringBuilder(targetSize);
+        String pattern = "BENCH_PAD_"; // 10 chars
+
+        while (memo.length() < targetSize) {
+            memo.append(pattern);
+        }
+
+        return memo.substring(0, Math.min(targetSize, memo.length()));
+    }
+
+    /**
+     * Returns the actual size of a transaction in bytes.
+     *
+     * @param transaction Transaction to measure
+     * @return Size in bytes
+     */
+    public static long getTransactionSize(Bytes transaction) {
+        return transaction.length();
+    }
+}


### PR DESCRIPTION
**Description**:
Adds prerequisites for #22397, #22398, #22399 
Adds initial versions of:
- TransactionGeneratorUtil
- BenchmarkBlockStreamManager
- BlockProductionBenchmark

**Related issue(s)**:
Closes #22398
Closes #22399

**Notes for reviewer**:
Currently, implementation is neither final, nor completed. It is still a work in progress.
BenchmarkBlockStreamManager is supposed to mock BlockStreamManager but without the dependencies that are not subject of the tests. Some parts are identical to the original, some are simulated, other are entirely cut out.
