### PR TITLE
chore: Fix warnings in build

### DIFF
--- a/platform-sdk/swirlds-state-impl/src/test/java/com/swirlds/state/merkle/VirtualMapStateTest.java
+++ b/platform-sdk/swirlds-state-impl/src/test/java/com/swirlds/state/merkle/VirtualMapStateTest.java
@@ -1196,7 +1196,7 @@ public class VirtualMapStateTest extends MerkleTestBase {
     @DisplayName("getKv returns value for existing key and null for missing key")
     void testGetKv() {
         setupFruitVirtualMap();
-        final VirtualMap vm = (VirtualMap) virtualMapState.getRoot();
+        final VirtualMap vm = virtualMapState.getRoot();
 
         addKvState(vm, fruitMetadata, A_KEY, APPLE);
 
@@ -1214,7 +1214,7 @@ public class VirtualMapStateTest extends MerkleTestBase {
     @DisplayName("singleton returns bytes for valid singleton and null for invalid IDs")
     void testSingletonAccessor() {
         setupSingletonCountry();
-        final VirtualMap vm = (VirtualMap) virtualMapState.getRoot();
+        final VirtualMap vm = virtualMapState.getRoot();
         addSingletonState(vm, countryMetadata, GHANA);
 
         virtualMapState.initializeState(countryMetadata);


### PR DESCRIPTION
While doing `./gradlew assemble` the build fails with warnings as below.
```
/Users/neeharikasompalli/Documents/Hedera/Repos/repo3/hiero-consensus-node/platform-sdk/swirlds-state-impl/src/test/java/com/swirlds/state/merkle/VirtualMapStateTest.java:1199: warning: [cast] redundant cast to VirtualMap
        final VirtualMap vm = (VirtualMap) virtualMapState.getRoot();
                              ^
/Users/neeharikasompalli/Documents/Hedera/Repos/repo3/hiero-consensus-node/platform-sdk/swirlds-state-impl/src/test/java/com/swirlds/state/merkle/VirtualMapStateTest.java:1217: warning: [cast] redundant cast to VirtualMap
        final VirtualMap vm = (VirtualMap) virtualMapState.getRoot();
                              ^
error: warnings found and -Werror specified
1 error
2 warnings
```
Fixed these errors in the test