### PR TITLE
feat: Implement a support for the new BN response `BehindPublisher`

### DIFF
--- a/hapi/hapi/build.gradle.kts
+++ b/hapi/hapi/build.gradle.kts
@@ -20,7 +20,7 @@ tasks.withType<JavaCompile>().configureEach {
 // block would not be needed.
 dependencies {
     protobuf(platform(project(":hiero-dependency-versions")))
-    protobuf("org.hiero.block:block-node-protobuf-sources")
+    protobuf("org.hiero.block-node:protobuf-sources")
 }
 
 sourceSets {

--- a/hedera-node/docs/design/app/blocks/BlockNodeStreamingMetrics.md
+++ b/hedera-node/docs/design/app/blocks/BlockNodeStreamingMetrics.md
@@ -50,23 +50,24 @@ with "conn" for identification.
 
 These metrics relate to responses received from a block node. They are identified using the "connRecv" prefix.
 
-|                    Metric Name                     |     Type     |                         Description                         |
-|----------------------------------------------------|--------------|-------------------------------------------------------------|
-| `blockStream_connRecv_unknown`                     | Counter      | Number of responses received that are of unknown types      |
-| `blockStream_connRecv_acknowledgement`             | Counter      | Number of Acknowledgement responses received                |
-| `blockStream_connRecv_skipBlock`                   | Counter      | Number of SkipBlock responses received                      |
-| `blockStream_connRecv_resendBlock`                 | Counter      | Number of ResendBlock responses received                    |
-| `blockStream_connRecv_latestBlockEndOfStream`      | Gauge (long) | The latest block number received in an EndOfStream response |
-| `blockStream_connRecv_latestBlockSkipBlock`        | Gauge (long) | The latest block number received in a SkipBlock response    |
-| `blockStream_connRecv_latestBlockResendBlock`      | Gauge (long) | The latest block number received in a ResendBlock response  |
-| `blockStream_connRecv_endStream_success`           | Counter      | Number of EndStream.Success responses received              |
-| `blockStream_connRecv_endStream_invalidRequest`    | Counter      | Number of EndStream.InvalidRequest responses received       |
-| `blockStream_connRecv_endStream_error`             | Counter      | Number of EndStream.Error responses received                |
-| `blockStream_connRecv_endStream_timeout`           | Counter      | Number of EndStream.Timeout responses received              |
-| `blockStream_connRecv_endStream_duplicateBlock`    | Counter      | Number of EndStream.DuplicateBlock responses received       |
-| `blockStream_connRecv_endStream_badBlockProof`     | Counter      | Number of EndStream.BadBlockProof responses received        |
-| `blockStream_connRecv_endStream_behind`            | Counter      | Number of EndStream.Behind responses received               |
-| `blockStream_connRecv_endStream_persistenceFailed` | Counter      | Number of EndStream.PersistenceFailed responses received    |
+|                    Metric Name                     |     Type     |                          Description                           |
+|----------------------------------------------------|--------------|----------------------------------------------------------------|
+| `blockStream_connRecv_unknown`                     | Counter      | Number of responses received that are of unknown types         |
+| `blockStream_connRecv_acknowledgement`             | Counter      | Number of Acknowledgement responses received                   |
+| `blockStream_connRecv_skipBlock`                   | Counter      | Number of SkipBlock responses received                         |
+| `blockStream_connRecv_resendBlock`                 | Counter      | Number of ResendBlock responses received                       |
+| `blockStream_connRecv_nodeBehindPublisher`         | Counter      | Number of BehindPublisher responses received                   |
+| `blockStream_connRecv_latestBlockEndOfStream`      | Gauge (long) | The latest block number received in an EndOfStream response    |
+| `blockStream_connRecv_latestBlockSkipBlock`        | Gauge (long) | The latest block number received in a SkipBlock response       |
+| `blockStream_connRecv_latestBlockResendBlock`      | Gauge (long) | The latest block number received in a ResendBlock response     |
+| `blockStream_connRecv_latestBlockBehindPublisher`  | Gauge (long) | The latest block number received in a BehindPublisher response |
+| `blockStream_connRecv_endStream_success`           | Counter      | Number of EndStream.Success responses received                 |
+| `blockStream_connRecv_endStream_invalidRequest`    | Counter      | Number of EndStream.InvalidRequest responses received          |
+| `blockStream_connRecv_endStream_error`             | Counter      | Number of EndStream.Error responses received                   |
+| `blockStream_connRecv_endStream_timeout`           | Counter      | Number of EndStream.Timeout responses received                 |
+| `blockStream_connRecv_endStream_duplicateBlock`    | Counter      | Number of EndStream.DuplicateBlock responses received          |
+| `blockStream_connRecv_endStream_badBlockProof`     | Counter      | Number of EndStream.BadBlockProof responses received           |
+| `blockStream_connRecv_endStream_persistenceFailed` | Counter      | Number of EndStream.PersistenceFailed responses received       |
 
 ## Connection Send Metrics
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/metrics/BlockStreamMetrics.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/metrics/BlockStreamMetrics.java
@@ -58,6 +58,7 @@ public class BlockStreamMetrics {
     private LongGauge connRecv_latestBlockEndOfStreamGauge;
     private LongGauge connRecv_latestBlockSkipBlockGauge;
     private LongGauge connRecv_latestBlockResendBlockGauge;
+    private LongGauge connRecv_latestBlockBehindPublisherGauge;
 
     // connectivity metrics
     private Counter conn_onCompleteCounter;
@@ -496,6 +497,10 @@ public class BlockStreamMetrics {
         final LongGauge.Config latestBlockResendCfg = newLongGauge(GROUP_CONN_RECV, "latestBlockResendBlock")
                 .withDescription("The latest block number received in a ResendBlock response");
         this.connRecv_latestBlockResendBlockGauge = metrics.getOrCreate(latestBlockResendCfg);
+
+        final LongGauge.Config latestBlockBehindCfg = newLongGauge(GROUP_CONN_RECV, "latestBlockBehindPublisher")
+                .withDescription("The latest block number received in a BehindPublisher response");
+        this.connRecv_latestBlockBehindPublisherGauge = metrics.getOrCreate(latestBlockBehindCfg);
     }
 
     /**
@@ -557,6 +562,14 @@ public class BlockStreamMetrics {
      */
     public void recordLatestBlockResendBlock(final long blockNumber) {
         connRecv_latestBlockResendBlockGauge.set(blockNumber);
+    }
+
+    /**
+     * Record the latest block number received in a BehindPublisher response.
+     * @param blockNumber the block number from the response
+     */
+    public void recordLatestBlockBehindPublisher(final long blockNumber) {
+        connRecv_latestBlockBehindPublisherGauge.set(blockNumber);
     }
 
     // Connection SEND metrics -----------------------------------------------------------------------------------------

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeCommunicationTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeCommunicationTestBase.java
@@ -30,6 +30,7 @@ import org.hiero.block.api.BlockItemSet;
 import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamRequest.EndStream;
 import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.api.PublishStreamResponse.BehindPublisher;
 import org.hiero.block.api.PublishStreamResponse.BlockAcknowledgement;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream;
 import org.hiero.block.api.PublishStreamResponse.ResendBlock;
@@ -64,6 +65,15 @@ public abstract class BlockNodeCommunicationTestBase {
                 .status(responseCode)
                 .build();
         return PublishStreamResponse.newBuilder().endStream(eos).build();
+    }
+
+    @NonNull
+    protected static PublishStreamResponse createBlockNodeBehindResponse(final long lastVerifiedBlock) {
+        final BehindPublisher nodeBehind =
+                BehindPublisher.newBuilder().blockNumber(lastVerifiedBlock).build();
+        return PublishStreamResponse.newBuilder()
+                .nodeBehindPublisher(nodeBehind)
+                .build();
     }
 
     @NonNull

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
@@ -629,38 +629,33 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testOnNext_endOfStream_blockNodeBehind_blockExists() {
+    void testOnNext_blockNodeBehind_blockExists() {
         openConnectionAndResetMocks();
-        final PublishStreamResponse response = createEndOfStreamResponse(Code.BEHIND, 10L);
-        when(bufferService.getHighestAckedBlockNumber()).thenReturn(10L);
+        final PublishStreamResponse response = createBlockNodeBehindResponse(10L);
         when(bufferService.getBlockState(11L)).thenReturn(new BlockState(11L));
         connection.updateConnectionState(ConnectionState.ACTIVE);
 
         connection.onNext(response);
 
-        verify(metrics).recordLatestBlockEndOfStream(10L);
-        verify(metrics).recordResponseEndOfStreamReceived(Code.BEHIND);
-        verify(metrics).recordConnectionClosed();
-        verify(metrics).recordActiveConnectionIp(-1L);
-        verify(requestPipeline).onComplete();
-        verify(connectionManager).rescheduleConnection(connection, null, 11L, false);
+        verify(metrics).recordLatestBlockBehindPublisher(10L);
+        verify(metrics).recordResponseReceived(ResponseOneOfType.NODE_BEHIND_PUBLISHER);
         verify(bufferService).getBlockState(11L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
     }
 
     @Test
-    void testOnNext_endOfStream_blockNodeBehind_blockDoesNotExist() {
+    void testOnNext_blockNodeBehind_blockDoesNotExist_TooFarBehind() {
         openConnectionAndResetMocks();
-        final PublishStreamResponse response = createEndOfStreamResponse(Code.BEHIND, 10L);
-        when(bufferService.getHighestAckedBlockNumber()).thenReturn(10L);
+        final PublishStreamResponse response = createBlockNodeBehindResponse(10L);
         when(bufferService.getBlockState(11L)).thenReturn(null);
+        when(bufferService.getEarliestAvailableBlockNumber()).thenReturn(12L);
 
         connection.updateConnectionState(ConnectionState.ACTIVE);
         connection.onNext(response);
 
-        verify(metrics).recordLatestBlockEndOfStream(10L);
-        verify(metrics).recordResponseEndOfStreamReceived(Code.BEHIND);
+        verify(metrics).recordLatestBlockBehindPublisher(10L);
+        verify(metrics).recordResponseReceived(ResponseOneOfType.NODE_BEHIND_PUBLISHER);
         verify(metrics).recordConnectionClosed();
         verify(metrics).recordActiveConnectionIp(-1L);
         verify(metrics).recordRequestEndStreamSent(EndStream.Code.TOO_FAR_BEHIND);
@@ -672,6 +667,38 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
                 .onNext(PublishStreamRequest.newBuilder()
                         .endStream(EndStream.newBuilder()
                                 .endCode(EndStream.Code.TOO_FAR_BEHIND)
+                                .earliestBlockNumber(12L)
+                                .build())
+                        .build());
+        verify(requestPipeline).onComplete();
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
+        verifyNoMoreInteractions(metrics);
+        verifyNoMoreInteractions(requestPipeline);
+    }
+
+    @Test
+    void testOnNext_endOfStream_blockNodeBehind_blockDoesNotExist_Error() {
+        openConnectionAndResetMocks();
+        final PublishStreamResponse response = createBlockNodeBehindResponse(10L);
+        when(bufferService.getHighestAckedBlockNumber()).thenReturn(10L);
+        when(bufferService.getBlockState(11L)).thenReturn(null);
+
+        connection.updateConnectionState(ConnectionState.ACTIVE);
+        connection.onNext(response);
+
+        verify(metrics).recordLatestBlockBehindPublisher(10L);
+        verify(metrics).recordResponseReceived(ResponseOneOfType.NODE_BEHIND_PUBLISHER);
+        verify(metrics).recordConnectionClosed();
+        verify(metrics).recordActiveConnectionIp(-1L);
+        verify(metrics).recordRequestEndStreamSent(EndStream.Code.ERROR);
+        verify(metrics).recordRequestLatency(anyLong());
+        verify(bufferService, atLeastOnce()).getEarliestAvailableBlockNumber();
+        verify(bufferService, atLeastOnce()).getHighestAckedBlockNumber();
+        verify(bufferService).getBlockState(11L);
+        verify(requestPipeline)
+                .onNext(PublishStreamRequest.newBuilder()
+                        .endStream(EndStream.newBuilder()
+                                .endCode(EndStream.Code.ERROR)
                                 .latestBlockNumber(10L)
                                 .build())
                         .build());
@@ -1615,26 +1642,23 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         assertThat(connection.currentState()).isEqualTo(ConnectionState.CLOSED);
     }
 
-    // Tests EndOfStream BEHIND code with Long.MAX_VALUE edge case (should restart at block 0)
+    // Tests BehindPublisher code with Long.MAX_VALUE edge case (should restart at block 0)
     @Test
-    void testOnNext_endOfStream_blockNodeBehind_maxValueBlockNumber() {
+    void testOnNext_blockNodeBehind_maxValueBlockNumber() {
         openConnectionAndResetMocks();
-        final PublishStreamResponse response = createEndOfStreamResponse(Code.BEHIND, Long.MAX_VALUE);
+        final PublishStreamResponse response = createBlockNodeBehindResponse(Long.MAX_VALUE);
         when(bufferService.getBlockState(0L)).thenReturn(new BlockState(0L));
         connection.updateConnectionState(ConnectionState.ACTIVE);
 
         connection.onNext(response);
 
-        verify(metrics).recordLatestBlockEndOfStream(Long.MAX_VALUE);
-        verify(metrics).recordResponseEndOfStreamReceived(Code.BEHIND);
-        verify(requestPipeline).onComplete();
-        verify(connectionManager)
-                .rescheduleConnection(connection, null, 0L, false); // Should restart at 0 for MAX_VALUE
+        verify(metrics).recordLatestBlockBehindPublisher(Long.MAX_VALUE);
+        verify(metrics).recordResponseReceived(ResponseOneOfType.NODE_BEHIND_PUBLISHER);
         verify(bufferService).getBlockState(0L);
-        verify(metrics).recordConnectionClosed();
-        verify(metrics).recordActiveConnectionIp(-1L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
+        verifyNoMoreInteractions(connectionManager);
+        verifyNoMoreInteractions(bufferService);
     }
 
     // Tests stream failure handling without calling onComplete on the pipeline

--- a/hedera-node/infrastructure/grafana/dashboards/production/hedera-node/block-stream.json
+++ b/hedera-node/infrastructure/grafana/dashboards/production/hedera-node/block-stream.json
@@ -6738,110 +6738,6 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 158
-      },
-      "id": 37,
-      "options": {
-        "legend": {
-          "calcs": [
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.4.0-19576184216",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "disableTextWrap": false,
-          "editorMode": "builder",
-          "expr": "max by(node) (delta(blockStream_connRecv_endStream_behind_total{node=~\"$NodeId\", environment=\"$environment\"}[1m]))",
-          "fullMetaSearch": false,
-          "includeNullMetadata": true,
-          "legendFormat": "node {{node}}",
-          "range": true,
-          "refId": "A",
-          "useBackend": false
-        }
-      ],
-      "title": "EndStream:Behind Responses Received (1m delta)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
         "x": 0,
         "y": 166
       },
@@ -7180,6 +7076,120 @@
         }
       ],
       "title": "Latest Block received in EndOfStream",
+      "transformations": [
+        {
+          "id": "joinByLabels",
+          "options": {
+            "value": "node"
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "includeTimeField": false,
+            "labelsToFields": false,
+            "mode": "seriesToRows",
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "includeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Field": "Node",
+              "Last *": "Block"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Node"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": []
+            },
+            "inspect": false,
+            "wrapText": false
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 6,
+        "x": 12,
+        "y": 174
+      },
+      "id": 61,
+      "options": {
+        "cellHeight": "sm",
+        "frameIndex": 0,
+        "showHeader": true
+      },
+      "pluginVersion": "12.2.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "max by(node) (blockStream_connRecv_latestBlockBehindPublisher{node=~\"$NodeId\", environment=\"$environment\"})",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "{{node}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Latest Block received in NodeBehindPublisher",
       "transformations": [
         {
           "id": "joinByLabels",

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
@@ -12,7 +12,7 @@ import org.testcontainers.utility.DockerImageName;
  * A test container for running a block node server instance.
  */
 public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
-    private static final String BLOCK_NODE_VERSION = "0.23.1";
+    private static final String BLOCK_NODE_VERSION = "0.25.0";
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("ghcr.io/hiero-ledger/hiero-block-node:" + BLOCK_NODE_VERSION);
     private static final int GRPC_PORT = 40840;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/simulator/BlockNodeController.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/simulator/BlockNodeController.java
@@ -190,6 +190,36 @@ public class BlockNodeController {
     }
 
     /**
+     * Send a NodeBehindPublisher response immediately to all active streams on all simulated block nodes.
+     * This indicates that the block node is behind the publisher and needs to catch up.
+     *
+     * @param blockNumber the last verified block number
+     */
+    public void sendNodeBehindPublisherImmediately(final long blockNumber) {
+        for (final SimulatedBlockNodeServer server : simulatedBlockNodes.values()) {
+            server.sendNodeBehindPublisherImmediately(blockNumber);
+        }
+        log.info("Sent immediate NodeBehindPublisher response for block {} on all simulators", blockNumber);
+    }
+
+    /**
+     * Send a NodeBehindPublisher response immediately to all active streams on a specific simulated block node.
+     * This indicates that the block node is behind the publisher and needs to catch up.
+     *
+     * @param index the index of the simulated block node (0-based)
+     * @param blockNumber the last verified block number
+     */
+    public void sendNodeBehindPublisherImmediately(final long index, final long blockNumber) {
+        if (index >= 0 && index < simulatedBlockNodes.size()) {
+            final SimulatedBlockNodeServer server = simulatedBlockNodes.get(index);
+            server.sendNodeBehindPublisherImmediately(blockNumber);
+            log.info("Sent immediate NodeBehindPublisher response for block {} on simulator {}", blockNumber, index);
+        } else {
+            log.error("Invalid simulator index: {}, valid range is 0-{}", index, simulatedBlockNodes.size() - 1);
+        }
+    }
+
+    /**
      * Reset all configured responses on all simulated block nodes to default behavior.
      */
     public void resetAllResponses() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/simulator/SimulatedBlockNodeServer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/simulator/SimulatedBlockNodeServer.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.Logger;
 import org.hiero.block.api.BlockStreamPublishServiceInterface;
 import org.hiero.block.api.PublishStreamRequest;
 import org.hiero.block.api.PublishStreamResponse;
+import org.hiero.block.api.PublishStreamResponse.BehindPublisher;
 import org.hiero.block.api.PublishStreamResponse.BlockAcknowledgement;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream;
 import org.hiero.block.api.PublishStreamResponse.ResendBlock;
@@ -232,6 +233,17 @@ public class SimulatedBlockNodeServer {
     }
 
     /**
+     * Send a NodeBehindPublisher response immediately to all active streams.
+     * This indicates that the block node is behind the publisher and needs to catch up.
+     *
+     * @param blockNumber the last verified block number to include in the response
+     */
+    public void sendNodeBehindPublisherImmediately(final long blockNumber) {
+        serviceImpl.sendNodeBehindPublisherToAllStreams(blockNumber);
+        log.info("Sent immediate NodeBehindPublisher response for block {} on port {}", blockNumber, port);
+    }
+
+    /**
      * Gets the last verified block number.
      *
      * @return the last verified block number, initially -1 if no blocks have been verified
@@ -370,7 +382,7 @@ public class SimulatedBlockNodeServer {
 
                                     final long lastVerifiedBlockNum = lastVerifiedBlockNumber.get();
                                     if (blockNumber - lastVerifiedBlockNum > 1) {
-                                        handleBehindResponse(replies, blockNumber, lastVerifiedBlockNum);
+                                        handleBehindPublisherResponse(replies, blockNumber, lastVerifiedBlockNum);
                                         return;
                                     }
 
@@ -624,6 +636,37 @@ public class SimulatedBlockNodeServer {
             }
         }
 
+        /**
+         * Sends a NodeBehindPublisher response to all active streams.
+         * This indicates that the block node is behind the publisher and needs to catch up.
+         *
+         * @param blockNumber the last verified block number
+         */
+        public void sendNodeBehindPublisherToAllStreams(final long blockNumber) {
+            log.info(
+                    "Sending NodeBehindPublisher for block {} to {} active streams on port {}",
+                    blockNumber,
+                    activeStreams.size(),
+                    port);
+            // Use lock for consistent locking strategy with other methods
+            blockTrackingLock.readLock().lock(); // Read lock is sufficient for iteration
+            try {
+                for (final Pipeline<? super PublishStreamResponse> pipeline : activeStreams) {
+                    try {
+                        sendNodeBehindPublisher(pipeline, blockNumber);
+                    } catch (final Exception e) {
+                        log.error(
+                                "Failed to send NodeBehindPublisher to stream {} on port {}",
+                                pipeline.hashCode(),
+                                port,
+                                e);
+                    }
+                }
+            } finally {
+                blockTrackingLock.readLock().unlock();
+            }
+        }
+
         // Helper methods for sending specific responses
 
         /**
@@ -661,7 +704,7 @@ public class SimulatedBlockNodeServer {
          *
          * @param pipeline the pipeline to send the response to, must not be null
          * @param blockNumber the block number to skip
-         * @throws NullPointerException if pipeline is null
+         * @throws NullPointerException if the pipeline is null
          */
         private void sendSkipBlock(
                 @NonNull final Pipeline<? super PublishStreamResponse> pipeline, final long blockNumber) {
@@ -679,7 +722,7 @@ public class SimulatedBlockNodeServer {
          *
          * @param pipeline the pipeline to send the response to, must not be null
          * @param blockNumber the block number to resend
-         * @throws NullPointerException if pipeline is null
+         * @throws NullPointerException if the pipeline is null
          */
         private void sendResendBlock(
                 @NonNull final Pipeline<? super PublishStreamResponse> pipeline, final long blockNumber) {
@@ -693,38 +736,61 @@ public class SimulatedBlockNodeServer {
         }
 
         /**
-         * Handles sending a BEHIND response to a client when the block number is more than 1 ahead of the last verified block.
+         * Sends a NodeBehindPublisher response to a specific pipeline.
+         *
+         * @param pipeline the pipeline to send the response to, must not be null
+         * @param blockNumber the last verified block number
+         * @throws NullPointerException if the pipeline is null
+         */
+        private void sendNodeBehindPublisher(
+                @NonNull final Pipeline<? super PublishStreamResponse> pipeline, final long blockNumber) {
+            requireNonNull(pipeline, "pipeline cannot be null");
+            final BehindPublisher behindPublisher =
+                    BehindPublisher.newBuilder().blockNumber(blockNumber).build();
+            final PublishStreamResponse response = PublishStreamResponse.newBuilder()
+                    .nodeBehindPublisher(behindPublisher)
+                    .build();
+            pipeline.onNext(response);
+            log.debug(
+                    "Sent NodeBehindPublisher for block {} to stream {} on port {}",
+                    blockNumber,
+                    pipeline.hashCode(),
+                    port);
+        }
+
+        /**
+         * Handles sending a BehindPublisher response to a client when the block number is more than 1 ahead of the last verified block.
          * This indicates that the client is ahead of the server and should restart streaming from an earlier block.
          *
          * @param pipeline The pipeline to send the response to, must not be null
          * @param blockNumber The block number that was requested
          * @param lastVerifiedBlockNum The last verified block number
-         * @throws NullPointerException if pipeline is null
+         * @throws NullPointerException if the pipeline is null
          */
-        private void handleBehindResponse(
+        private void handleBehindPublisherResponse(
                 @NonNull final Pipeline<? super PublishStreamResponse> pipeline,
                 final long blockNumber,
                 final long lastVerifiedBlockNum) {
             requireNonNull(pipeline, "pipeline cannot be null");
 
-            final EndOfStream eos = EndOfStream.newBuilder()
+            final BehindPublisher behindPublisher = BehindPublisher.newBuilder()
                     .blockNumber(lastVerifiedBlockNum)
-                    .status(EndOfStream.Code.BEHIND)
                     .build();
-            final PublishStreamResponse response =
-                    PublishStreamResponse.newBuilder().endStream(eos).build();
+            final PublishStreamResponse response = PublishStreamResponse.newBuilder()
+                    .nodeBehindPublisher(behindPublisher)
+                    .build();
 
             try {
                 pipeline.onNext(response);
                 log.debug(
-                        "Sent EndOfStream BEHIND for block {} to stream {} on port {}. Last verified: {}",
+                        "Sent BehindPublisher for block {} to stream {} on port {}. Last verified: {}",
                         blockNumber,
                         pipeline.hashCode(),
                         port,
                         lastVerifiedBlockNum);
             } catch (final Exception e) {
                 log.error(
-                        "Failed to send EndOfStream BEHIND for block {} to stream {} on port {}. Removing stream.",
+                        "Failed to send BehindPublisher for block {} to stream {} on port {}. Removing stream.",
                         blockNumber,
                         pipeline.hashCode(),
                         port,
@@ -739,7 +805,7 @@ public class SimulatedBlockNodeServer {
          * Acquires the necessary write lock to ensure thread safety.
          *
          * @param pipeline The pipeline to remove.
-         * @throws NullPointerException if pipeline is null
+         * @throws NullPointerException if the pipeline is null
          */
         private void removeStreamFromTracking(@NonNull final Pipeline<? super PublishStreamResponse> pipeline) {
             requireNonNull(pipeline, "pipeline cannot be null");
@@ -756,7 +822,7 @@ public class SimulatedBlockNodeServer {
          * This method removes the pipeline from active streams and cleans up any blocks that were being streamed.
          *
          * @param pipeline The pipeline to remove, must not be null
-         * @throws NullPointerException if pipeline is null
+         * @throws NullPointerException if the pipeline is null
          */
         private void removeStreamFromTrackingInternal(@NonNull final Pipeline<? super PublishStreamResponse> pipeline) {
             requireNonNull(pipeline, "pipeline cannot be null");
@@ -894,7 +960,7 @@ public class SimulatedBlockNodeServer {
      * @param blockNumber The block number being acknowledged
      * @param pipeline The pipeline to send the acknowledgment to, must not be null
      *
-     * @throws NullPointerException if pipeline is null
+     * @throws NullPointerException if the pipeline is null
      */
     private void buildAndSendBlockAcknowledgement(
             final long blockNumber, @NonNull final Pipeline<? super PublishStreamResponse> pipeline) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
@@ -98,7 +98,7 @@ public class HgcaaLogValidator {
                 List.of("HintsSubmissions", "Failed to submit"),
                 List.of("Ignoring invalid partial signature"),
                 List.of("Action stack prematurely empty"),
-                List.of("Block node", "reported it is behind. Will restart stream at block"),
+                List.of("Block node", "reported it is behind. Will start streaming block"),
                 List.of("BlockNodeConnectionManager", "Block stream worker interrupted"),
                 List.of("BlockNodeConnectionManager", "No active connections available for streaming"),
                 List.of("No block nodes available to connect to"),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/BlockNodeVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/BlockNodeVerbs.java
@@ -80,6 +80,17 @@ public class BlockNodeVerbs {
         }
 
         /**
+         * Sends an immediate NodeBehindPublisher response to the block node simulator.
+         *
+         * @param blockNumber the last verified block number
+         * @return the operation
+         */
+        public BlockNodeOp sendNodeBehindPublisherImmediately(long blockNumber) {
+            return BlockNodeOp.sendNodeBehindPublisherImmediately(nodeIndex, blockNumber)
+                    .build();
+        }
+
+        /**
          * Shuts down the block node simulator immediately.
          *
          * @return the operation

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -337,17 +337,17 @@ public class BlockNodeSuite {
                 doingContextual(
                         spec -> LockSupport.parkNanos(Duration.ofSeconds(10).toNanos())),
                 doingContextual(spec -> time.set(Instant.now())),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(Long.MAX_VALUE),
+                blockNode(0).sendNodeBehindPublisherImmediately(Long.MAX_VALUE),
                 sourcingContextual(spec -> assertBlockNodeCommsLogContainsTimeframe(
                         byNodeId(0),
                         time::get,
                         Duration.ofSeconds(30),
                         Duration.ofSeconds(45),
                         String.format(
-                                "/localhost:%s/ACTIVE] Block node reported it is behind. Will restart stream at block 0.",
+                                "/localhost:%s/ACTIVE] Received BehindPublisher response for block 9223372036854775807.",
                                 portNumbers.getFirst()),
                         String.format(
-                                "/localhost:%s/ACTIVE] Received EndOfStream response (block=9223372036854775807, responseCode=BEHIND).",
+                                "/localhost:%s/ACTIVE] Block node reported it is behind. Will start streaming block 0.",
                                 portNumbers.getFirst()))),
                 doingContextual(
                         spec -> LockSupport.parkNanos(Duration.ofSeconds(10).toNanos())));
@@ -769,10 +769,11 @@ public class BlockNodeSuite {
                     portNumbers.add(spec.getBlockNodePortById(0));
                     portNumbers.add(spec.getBlockNodePortById(1));
                 }),
-                waitUntilNextBlocks(5).withBackgroundTraffic(true),
+                waitUntilNextBlocks(1).withBackgroundTraffic(true),
                 doingContextual(spec -> time.set(Instant.now())),
-                blockNode(0).sendEndOfStreamImmediately(Code.TIMEOUT).withBlockNumber(9L),
-                blockNode(0).sendEndOfStreamImmediately(Code.TIMEOUT).withBlockNumber(10L),
+                blockNode(0).sendEndOfStreamImmediately(Code.TIMEOUT).withBlockNumber(1L),
+                waitUntilNextBlocks(1).withBackgroundTraffic(true),
+                blockNode(0).sendEndOfStreamImmediately(Code.TIMEOUT).withBlockNumber(2L),
                 sourcingContextual(spec -> assertBlockNodeCommsLogContainsTimeframe(
                         byNodeId(0),
                         time::get,
@@ -813,13 +814,13 @@ public class BlockNodeSuite {
         return hapiTest(
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
                 doingContextual(spec -> time.set(Instant.now())),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(1L),
+                blockNode(0).sendEndOfStreamImmediately(Code.TIMEOUT).withBlockNumber(1L),
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(2L),
+                blockNode(0).sendEndOfStreamImmediately(Code.DUPLICATE_BLOCK).withBlockNumber(2L),
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(3L),
+                blockNode(0).sendEndOfStreamImmediately(Code.BAD_BLOCK_PROOF).withBlockNumber(3L),
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(4L),
+                blockNode(0).sendEndOfStreamImmediately(Code.INVALID_REQUEST).withBlockNumber(4L),
                 sourcingContextual(spec -> assertBlockNodeCommsLogContainsTimeframe(
                         byNodeId(0),
                         time::get,
@@ -904,17 +905,17 @@ public class BlockNodeSuite {
                         String.format(
                                 "/localhost:%s/ACTIVE] BlockAcknowledgement received for block",
                                 portNumbers.getFirst()))),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(Long.MAX_VALUE),
+                blockNode(0).sendNodeBehindPublisherImmediately(Long.MAX_VALUE),
                 sourcingContextual(spec -> assertBlockNodeCommsLogContainsTimeframe(
                         byNodeId(0),
                         time::get,
                         Duration.ofSeconds(20),
                         Duration.ofSeconds(20),
                         String.format(
-                                "/localhost:%s/ACTIVE] Received EndOfStream response (block=9223372036854775807, responseCode=BEHIND)",
+                                "/localhost:%s/ACTIVE] Received BehindPublisher response for block 9223372036854775807.",
                                 portNumbers.getFirst()),
                         String.format(
-                                "/localhost:%s/ACTIVE] Block node reported it is behind. Will restart stream at block 0.",
+                                "/localhost:%s/ACTIVE] Block node reported it is behind. Will start streaming block 0.",
                                 portNumbers.getFirst()))),
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
                 blockNode(0).sendSkipBlockImmediately(Long.MAX_VALUE),

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -22,7 +22,7 @@ val log4j = "2.25.0"
 val mockito = "5.18.0"
 val pbj = pluginVersions.version("com.hedera.pbj.pbj-compiler")
 val protobuf = "4.31.1"
-val blockNodeProtobufSources = "0.21.2"
+val blockNodeProtobufSources = "0.25.0"
 val testContainers = "2.0.2"
 val tuweni = "2.4.2"
 val webcompare = "2.1.8"
@@ -137,12 +137,12 @@ dependencies.constraints {
     // Versions of additional tools that are not part of the product or test module paths
     api("com.google.protobuf:protoc:${protobuf}")
     api("io.grpc:protoc-gen-grpc-java:${grpc}")
-    api("org.hiero.block:block-node-protobuf-sources:$blockNodeProtobufSources") {
+    api("org.hiero.block-node:protobuf-sources:$blockNodeProtobufSources") {
         because("External block node protobuf sources")
     }
     tasks.checkVersionConsistency {
         excludes.add("com.google.protobuf:protoc")
         excludes.add("io.grpc:protoc-gen-grpc-java")
-        excludes.add("org.hiero.block:block-node-protobuf-sources")
+        excludes.add("org.hiero.block-node:protobuf-sources")
     }
 }


### PR DESCRIPTION
**Description**:
Cherry-pick of [#22540](https://github.com/hiero-ledger/hiero-consensus-node/pull/22540) for `release/0.70`

This PR adds support for the new Block Node response `BehindPublisher`.

- It includes changes to the implementation in `BlockNodeConnection#onNext()` method to handle the new response
- Added a new metric for tracking the block number of the latest `BehindPublisher` received
- Adjusted the `block-stream.json` dashboard file accordingly
- Unit test fixes
- Additions and changes to the test-client in order to support testing the new response

**Related issue(s)**:

Fixes #22745 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
