### PR TITLE
chore:  Cherry-pick extend Schedule Delete admin key check to also keep track of delegatable contract ids (#22834)

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/deleteschedule/DeleteScheduleTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/deleteschedule/DeleteScheduleTranslator.java
@@ -149,7 +149,8 @@ public class DeleteScheduleTranslator extends AbstractCallTranslator<HssCallAtte
                 && attempt.isRedirect()
                 && attempt.redirectScheduleTxn() != null
                 && attempt.redirectScheduleTxn().adminKey() != null
-                && !attempt.redirectScheduleTxn().adminKey().hasContractID();
+                && !attempt.redirectScheduleTxn().adminKey().hasContractID()
+                && !attempt.redirectScheduleTxn().adminKey().hasDelegatableContractId();
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/deleteschedule/DeleteScheduleTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/deleteschedule/DeleteScheduleTranslatorTest.java
@@ -195,6 +195,36 @@ class DeleteScheduleTranslatorTest extends CallAttemptTestBase {
 
     @Test
     void testScheduleDeleteProxyWithNonContractAdminKey() {
+        prepProxyCall();
+        given(schedule.adminKeyOrElse(Key.DEFAULT)).willReturn(adminKey);
+        given(schedule.adminKey()).willReturn(adminKey);
+        given(adminKey.hasContractID()).willReturn(false);
+        given(adminKey.hasDelegatableContractId()).willReturn(false);
+        given(adminKey.hasEcdsaSecp256k1()).willReturn(true);
+        // when:
+        callAndAssert();
+    }
+
+    @Test
+    void testScheduleDeleteProxyWithContractAdminKey() {
+        prepProxyCall();
+        given(schedule.adminKey()).willReturn(adminKey);
+        given(adminKey.hasContractID()).willReturn(true);
+        // when:
+        callAndAssert();
+    }
+
+    @Test
+    void testScheduleDeleteProxyWithDelegatableContractAdminKey() {
+        prepProxyCall();
+        given(schedule.adminKey()).willReturn(adminKey);
+        given(adminKey.hasContractID()).willReturn(false);
+        given(adminKey.hasDelegatableContractId()).willReturn(true);
+        // when:
+        callAndAssert();
+    }
+
+    private void prepProxyCall() {
         given(nativeOperations.getAccount(payerId)).willReturn(B_CONTRACT);
         given(addressIdConverter.convertSender(OWNER_BESU_ADDRESS)).willReturn(payerId);
         given(verificationStrategies.activatingOnlyContractKeysFor(OWNER_BESU_ADDRESS, false, nativeOperations))
@@ -202,11 +232,9 @@ class DeleteScheduleTranslatorTest extends CallAttemptTestBase {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         given(nativeOperations.getSchedule(any(ScheduleID.class))).willReturn(schedule);
-        given(schedule.adminKeyOrElse(Key.DEFAULT)).willReturn(adminKey);
-        given(schedule.adminKey()).willReturn(adminKey);
-        given(adminKey.hasContractID()).willReturn(false);
-        given(adminKey.hasEcdsaSecp256k1()).willReturn(true);
-        // when:
+    }
+
+    private void callAndAssert() {
         var input = bytesForRedirectScheduleTxn(
                 DeleteScheduleTranslator.DELETE_SCHEDULE_PROXY.selector(), NON_SYSTEM_LONG_ZERO_ADDRESS);
         attempt = createHssCallAttempt(input, false, configuration, List.of(subject));


### PR DESCRIPTION
**Description**:

Cherry picking https://github.com/hiero-ledger/hiero-consensus-node/pull/22834

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
