### PR TITLE
fix: fix message in the BN communication test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -440,8 +440,7 @@ public class BlockNodeSuite {
                                 "/localhost:%s/ACTIVE] Connection will be closed at the next block boundary",
                                 portNumbers.get(3)),
                         String.format(
-                                "/localhost:%s/ACTIVE] Block boundary reached; closing connection (finished sending block)",
-                                portNumbers.get(3)),
+                                "/localhost:%s/ACTIVE] Block boundary reached; closing connection", portNumbers.get(3)),
                         String.format("/localhost:%s/CLOSING] Closing connection.", portNumbers.get(3)),
                         String.format(
                                 "/localhost:%s/CLOSING] Connection state transitioned from ACTIVE to CLOSING",


### PR DESCRIPTION
**Description**:
Change the log message we check in `BlockNodeSuite.node0StreamingBlockNodeConnectionDropsTrickle` test.
We want to verify that the connection will be closed at the next block boundary, but there might be no block available and in this case, the log message is a bit different at the end

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
