### PR TITLE
fix(ci): point to explicit proto pkg version

### DIFF
--- a/.github/workflows/zxc-block-node-regression.yaml
+++ b/.github/workflows/zxc-block-node-regression.yaml
@@ -165,7 +165,7 @@ jobs:
           # Extract package versions from the parent package.json
           SDK_VERSION=$(node -e "console.log(require('../package.json').version)")
           LONG_VERSION=$(node -e "console.log(require('../package.json').dependencies.long)")
-          PROTO_VERSION=$(node -e "console.log(require('../package.json').dependencies['@hiero-ledger/proto'])")
+          PROTO_VERSION=$(node -e "console.log(require('../packages/proto/package.json').version)")
 
           echo "Using SDK version: ${SDK_VERSION}"
           echo "Using long version: ${LONG_VERSION}"

--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -139,7 +139,7 @@ jobs:
           # Extract package versions from the parent package.json
           SDK_VERSION=$(node -e "console.log(require('../package.json').version)")
           LONG_VERSION=$(node -e "console.log(require('../package.json').dependencies.long)")
-          PROTO_VERSION=$(node -e "console.log(require('../package.json').dependencies['@hiero-ledger/proto'])")
+          PROTO_VERSION=$(node -e "console.log(require('../packages/proto/package.json').version)")
 
           echo "Using SDK version: ${SDK_VERSION}"
           echo "Using long version: ${LONG_VERSION}"


### PR DESCRIPTION
## Summary

Update the TCK workflow to correctly resolve `@hiero-ledger/proto` when
the JS SDK uses `workspace:*` dependencies.

## What changed

-   Detect `workspace:*` (or any `workspace:` spec) instead of treating
    it as a publishable version.\
-   Read the concrete version from `packages/proto/package.json`.\
-   Use that resolved version when running
    `pnpm add @hiero-ledger/proto@<version>` in the TCK workflow.\
-   Avoid relying on parsing the raw dependency string from
    `package.json`.

## Why

The JS SDK now uses `workspace:*` for internal package linking as part
of adopting pnpm workspaces. This is not a real, installable version, so
the previous workflow logic (`pnpm add @hiero-ledger/proto@workspace:*`)
fails and causes the TCK client to crash with:

    Cannot find module '@hiero-ledger/proto'

Resolving the version from the proto package itself makes the workflow
robust to workspace-based dependencies.

## References

-   Root cause / SDK rationale:
    https://github.com/hiero-ledger/hiero-sdk-js/issues/3534
