### PR TITLE
fix: cherry-pick HandleWorkflow RECORDS only change

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -369,9 +369,11 @@ public class HandleWorkflow {
                     stateSignatureTxnCallback.accept(scopedTxn);
                 }
 
-                final var txnItem =
-                        BlockItem.newBuilder().signedTransaction(bytes).build();
-                blockStreamManager.writeItem(txnItem);
+                if (streamMode != RECORDS) {
+                    final var txnItem =
+                            BlockItem.newBuilder().signedTransaction(bytes).build();
+                    blockStreamManager.writeItem(txnItem);
+                }
             };
 
             // log start of event to transaction state log

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusUpdateTopicHandlerTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusUpdateTopicHandlerTest.java
@@ -93,21 +93,6 @@ class ConsensusUpdateTopicHandlerTest extends ConsensusTestBase {
     }
 
     @Test
-    @DisplayName("No admin key to update memo fails")
-    void rejectsNonExpiryMutationOfImmutableTopic() {
-        givenValidTopic(AccountID.newBuilder().accountNum(0).build(), false, false);
-        refreshStoresWithCurrentTopicInBothReadableAndWritable();
-
-        final var txBody = TransactionBody.newBuilder()
-                .consensusUpdateTopic(OP_BUILDER.topicID(topicId).memo("Please mind the vase"))
-                .build();
-        given(handleContext.body()).willReturn(txBody);
-
-        // expect:
-        assertFailsWith(ResponseCodeEnum.UNAUTHORIZED, () -> subject.handle(handleContext));
-    }
-
-    @Test
     @DisplayName("Invalid new admin key update fails")
     void validatesNewAdminKey() {
         givenValidTopic(AccountID.newBuilder().accountNum(0).build(), false);


### PR DESCRIPTION
**Description**:
This PR cherry-picks the relevant fix in HandleWorkflow to fix a NullPointerException when streamMode is set to RECORDS only.

```
java.lang.NullPointerException: Cannot invoke "com.hedera.node.app.blocks.impl.BlockStreamManagerImpl$BlockStreamManagerTask.addItem(com.hedera.hapi.block.stream.BlockItem)" because "this.worker" is null
```

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
