### PR TITLE
build: publish the swirlds-cli Jar because other modules depend on it

### DIFF
--- a/platform-sdk/swirlds-cli/build.gradle.kts
+++ b/platform-sdk/swirlds-cli/build.gradle.kts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.module.application") }
+plugins {
+    id("org.hiero.gradle.module.application")
+    id("org.hiero.gradle.feature.publish-maven-repository")
+    id("org.hiero.gradle.feature.publish-maven-central")
+}
 
 tasks.jar {
     // Gradle fails to track 'configurations.runtimeClasspath' as an input to the task if it is


### PR DESCRIPTION
**Description**:

Normally, modules of type `org.hiero.gradle.module.application` are not published to Maven Central. In this case it is needed due to the changes in #22720.
 
**Related issue(s)**:

Follow up to #22720
