### PR TITLE
chore: remove teams from CODEOWNERS for gradle

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
 *                                               @hiero-ledger/github-maintainers
+**/*.gradle.*                                   @hiero-ledger/github-maintainers
+
 #########################
 ##### Example apps ######
 #########################
@@ -14,6 +16,7 @@
 ##### State Validator ######
 ############################
 /hedera-state-validator                         @hiero-ledger/hiero-consensus-node-foundation-codeowners
+/hedera-state-validator/**/*.gradle             @hiero-ledger/hiero-consensus-node-foundation-codeowners
 
 #########################
 ##### Hedera Node  ######
@@ -21,6 +24,7 @@
 
 # Hedera Node Root Protections
 /hedera-node/                                   @hiero-ledger/hiero-consensus-node-execution-codeowners
+/hedera-node/**/*.gradle                        @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
 
 # Hedera Node Deployments - Configuration & Grafana Dashboards
 /hedera-node/configuration/**                   @rbair23 @dalvizu @Nana-EC @SimiHunjan @steven-sheehy @nathanklick @rbarker-dev @Ferparishuertas @beeradb
@@ -53,6 +57,7 @@
 ###############################
 # add @rsinha as an explicit codeowner once hiero-invite has been added
 /hedera-cryptography/                               @hiero-ledger/hiero-consensus-node-foundation-codeowners
+/hedera-cryptography/**/*.gradle                    @hiero-ledger/hiero-consensus-node-foundation-codeowners
 
 #########################
 ##### Platform SDK ######
@@ -60,6 +65,7 @@
 
 # Platform SDK Root Protections
 /platform-sdk/                                      @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-foundation-codeowners
+/platform-sdk/**/*.gradle                           @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-foundation-codeowners
 /platform-sdk/README.md                             @hiero-ledger/hiero-consensus-node-consensus-codeowners
 
 # Platform SDK Modules
@@ -82,12 +88,14 @@
 /platform-sdk/swirlds-virtualmap/                   @hiero-ledger/hiero-consensus-node-foundation-codeowners
 
 /hiero-observability                                @hiero-ledger/hiero-consensus-node-foundation-codeowners
+/hiero-observability/**/*.gradle                    @hiero-ledger/hiero-consensus-node-foundation-codeowners
 
 ####################
 #####   HAPI  ######
 ####################
 
 /hapi/                                              @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
+/hapi/**/*.gradle                                   @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
 
 # Protobuf
 /hapi/hedera-protobuf-java-api/src/main/proto/services/ @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners @jsync-swirlds @hiero-ledger/hiero-mirror-node-maintainers
@@ -119,7 +127,6 @@ gradlew                                             @hiero-ledger/github-maintai
 gradlew.bat                                         @hiero-ledger/github-maintainers
 **/build-logic/                                     @hiero-ledger/github-maintainers
 **/gradle.*                                         @hiero-ledger/github-maintainers
-**/*.gradle.*                                       @hiero-ledger/github-maintainers
 
 # Codacy Tool Configurations
 /config/                                            @hiero-ledger/github-maintainers


### PR DESCRIPTION
**Description**:
A recent change made anyone and everyone own any and all Gradle files. This creates a lot of noise for PR review requests that are unrelated to the teams. Gradle files ownership should be made team-specific based on the parts of the repository that those teams own.

As the first step, I'm removing all teams from owning all Gradle files and making the github-maintainers own them, just as before. The CI team may consider removing this line altogether if they want to rely on existing codeownership rules setup in the repository so that teams own their own Gradle files.

**Related issue(s)**:

Fixes #23052

**Notes for reviewer**:
Everything should work.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
