### PR TITLE
chore: fix CODEOWNERS for gradle files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
 *                                               @hiero-ledger/github-maintainers
+**/*.gradle.*                                   @hiero-ledger/github-maintainers
+
 #########################
 ##### Example apps ######
 #########################
@@ -44,6 +46,7 @@
 /hedera-node/hedera-staking*/                   @hiero-ledger/hiero-consensus-node-execution-codeowners
 /hedera-node/test-clients/                      @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
 /hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/  @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
+/hedera-node/**/*.gradle                        @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
 
 # Documentation
 /hedera-node/docs/design/services/smart-contract-service    @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
@@ -80,14 +83,17 @@
 /platform-sdk/swirlds-state-*/                      @hiero-ledger/hiero-consensus-node-foundation-codeowners
 /platform-sdk/swirlds-unit-tests/structures/        @hiero-ledger/hiero-consensus-node-foundation-codeowners
 /platform-sdk/swirlds-virtualmap/                   @hiero-ledger/hiero-consensus-node-foundation-codeowners
+/platform-sdk/**/*.gradle                           @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-foundation-codeowners
 
 /hiero-observability                                @hiero-ledger/hiero-consensus-node-foundation-codeowners
+/hiero-observability/**/*.gradle                    @hiero-ledger/hiero-consensus-node-foundation-codeowners
 
 ####################
 #####   HAPI  ######
 ####################
 
 /hapi/                                              @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
+/hapi/**/*.gradle                                   @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
 
 # Protobuf
 /hapi/hedera-protobuf-java-api/src/main/proto/services/ @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners @jsync-swirlds @hiero-ledger/hiero-mirror-node-maintainers
@@ -119,7 +125,6 @@ gradlew                                             @hiero-ledger/github-maintai
 gradlew.bat                                         @hiero-ledger/github-maintainers
 **/build-logic/                                     @hiero-ledger/github-maintainers
 **/gradle.*                                         @hiero-ledger/github-maintainers
-**/*.gradle.*                                       @hiero-ledger/github-maintainers @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-foundation-codeowners @hiero-ledger/hiero-consensus-node-consensus-codeowners
 
 # Codacy Tool Configurations
 /config/                                            @hiero-ledger/github-maintainers


### PR DESCRIPTION
## Description

This pull request updates the `.github/CODEOWNERS` file to provide more precise ownership for Gradle-related files across different parts of the repository. The main changes clarify which teams are responsible for specific Gradle files in various modules, improving code review workflows and accountability.

**Ownership rule updates for Gradle files:**

* Added a general rule to assign all `**/*.gradle.*` files to `@hiero-ledger/github-maintainers`, ensuring a default owner for Gradle files not covered by more specific rules.
* Introduced targeted ownership for `/hedera-node/**/*.gradle` files, assigning them to `@hiero-ledger/hiero-consensus-node-smart-contract-codeowners`.
* Assigned `/platform-sdk/**/*.gradle` files to both `@hiero-ledger/hiero-consensus-node-consensus-codeowners` and `@hiero-ledger/hiero-consensus-node-foundation-codeowners`.
* Assigned `/hiero-observability/**/*.gradle` files to `@hiero-ledger/hiero-consensus-node-foundation-codeowners`.
* Assigned `/hapi/**/*.gradle` files to `@hiero-ledger/hiero-consensus-node-consensus-codeowners`, `@hiero-ledger/hiero-consensus-node-execution-codeowners`, and `@hiero-ledger/hiero-consensus-node-smart-contract-codeowners`.
* Removed a previous broad rule that assigned all `**/*.gradle.*` files to multiple teams, replacing it with the more granular rules above.

## Related Issue(s)

Fixes #22959