### PR TITLE
build: add a publishing step for modules in the 'org.hiero' namespace

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -874,12 +874,19 @@ jobs:
         if: ${{ inputs.version-policy != 'specified' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
         run: ./gradlew release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --no-configuration-cache
 
-      - name: Gradle Publish to Maven Central
+      - name: Gradle Publish to Maven Central (com.hedera)
         if: ${{ inputs.version-policy == 'specified' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
         env:
           NEXUS_USERNAME: ${{ secrets.central-publishing-username }}
           NEXUS_PASSWORD: ${{ secrets.central-publishing-password }}
-        run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true
+        run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true -PpublishingPackageGroup=com.hedera
+
+      - name: Gradle Publish to Maven Central (org.hiero)
+        if: ${{ inputs.version-policy == 'specified' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
+        env:
+          NEXUS_USERNAME: ${{ secrets.central-publishing-username }}
+          NEXUS_PASSWORD: ${{ secrets.central-publishing-password }}
+        run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true -PpublishingPackageGroup=org.hiero
 
       - name: Upload SDK Release Archives
         if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -12,6 +12,16 @@ dependencies {
     implementation(project(":consensus-otter-tests"))
 }
 
+// Allow filtering of the publication package via -PpublishingPackageGroup=<namespace>
+tasks.nmcpZipAggregation {
+    includeEmptyDirs = false
+    val publishingPackageGroup = providers.gradleProperty("publishingPackageGroup")
+    if (publishingPackageGroup.isPresent) {
+        val includeFolder = publishingPackageGroup.get().replace(".", "/")
+        include("$includeFolder/**")
+    }
+}
+
 tasks.testCodeCoverageReport {
     // Redo the setup done in 'JacocoReportAggregationPlugin', but gather the class files in the
     // file tree and filter out selected classes by path.


### PR DESCRIPTION
⚠️ **This may be used if we need the publishing for both namespaces in parallel – `com.hedera` and `org.hiero` – at some point / if we do a complete switchover of everything to `org.hiero` this may be discarded**  ⚠️

**Description**:

There are two Gradle tasks in the end of the process that we can use to control what is actually publish. The build process is like this:

1. Build everything first and make it ready to potentially publish
2. Zip the bundle <-- **here we can filter**
3. Upload the Zip

Via the `-PpublishingPackageGroup` parameter, the filter can be controlled from the CI pipeline.


