### PR TITLE
chore(23104): Initial BenchmarkService implementation

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TransactionFactory.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TransactionFactory.java
@@ -11,6 +11,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.otter.fixtures.network.transactions.BenchmarkTransaction;
 import org.hiero.otter.fixtures.network.transactions.EmptyTransaction;
 import org.hiero.otter.fixtures.network.transactions.HashPartition;
 import org.hiero.otter.fixtures.network.transactions.OtterFreezeTransaction;
@@ -35,6 +36,35 @@ public class TransactionFactory {
         return OtterTransaction.newBuilder()
                 .setNonce(nonce)
                 .setEmptyTransaction(emptyTransaction)
+                .build();
+    }
+
+    /**
+     * Creates a new benchmark transaction with the current time as the submission timestamp.
+     *
+     * @param nonce the nonce for the benchmark transaction
+     * @return a benchmark transaction
+     */
+    @NonNull
+    public static OtterTransaction createBenchmarkTransaction(final long nonce) {
+        return createBenchmarkTransaction(nonce, System.currentTimeMillis());
+    }
+
+    /**
+     * Creates a new benchmark transaction with the specified submission timestamp.
+     *
+     * @param nonce the nonce for the benchmark transaction
+     * @param submissionTimeMillis the submission timestamp in epoch milliseconds
+     * @return a benchmark transaction
+     */
+    @NonNull
+    public static OtterTransaction createBenchmarkTransaction(final long nonce, final long submissionTimeMillis) {
+        final BenchmarkTransaction benchmarkTransaction = BenchmarkTransaction.newBuilder()
+                .setSubmissionTimeMillis(submissionTimeMillis)
+                .build();
+        return OtterTransaction.newBuilder()
+                .setNonce(nonce)
+                .setBenchmarkTransaction(benchmarkTransaction)
                 .build();
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/services/benchmark/BenchmarkService.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/services/benchmark/BenchmarkService.java
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.app.services.benchmark;
+
+import static com.swirlds.logging.legacy.LogMarker.BENCHMARK;
+
+import com.hedera.hapi.platform.event.StateSignatureTransaction;
+import com.swirlds.state.spi.WritableStates;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Instant;
+import java.util.function.Consumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hiero.consensus.model.event.ConsensusEvent;
+import org.hiero.consensus.model.transaction.ScopedSystemTransaction;
+import org.hiero.otter.fixtures.app.OtterService;
+import org.hiero.otter.fixtures.app.state.OtterServiceStateSpecification;
+import org.hiero.otter.fixtures.network.transactions.BenchmarkTransaction;
+import org.hiero.otter.fixtures.network.transactions.OtterTransaction;
+
+/**
+ * A service that logs latency for benchmark transactions.
+ *
+ * <p>This service listens for {@link BenchmarkTransaction}s and logs the latency
+ * between when the transaction was submitted (timestamp embedded in the transaction)
+ * and when it reached consensus (the consensus timestamp provided by the platform).
+ */
+public class BenchmarkService implements OtterService {
+
+    private static final Logger log = LogManager.getLogger(BenchmarkService.class);
+
+    private static final String NAME = "BenchmarkService";
+
+    private static final BenchmarkStateSpecification STATE_SPECIFICATION = new BenchmarkStateSpecification();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public String name() {
+        return NAME;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public OtterServiceStateSpecification stateSpecification() {
+        return STATE_SPECIFICATION;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleTransaction(
+            @NonNull final WritableStates writableStates,
+            @NonNull final ConsensusEvent event,
+            @NonNull final OtterTransaction transaction,
+            @NonNull final Instant transactionTimestamp,
+            @NonNull final Consumer<ScopedSystemTransaction<StateSignatureTransaction>> callback) {
+
+        if (transaction.hasBenchmarkTransaction()) {
+            final BenchmarkTransaction benchmarkTx = transaction.getBenchmarkTransaction();
+            final long submissionTimeMillis = benchmarkTx.getSubmissionTimeMillis();
+            final long consensusTimeMillis = transactionTimestamp.toEpochMilli();
+            final long latencyMillis = consensusTimeMillis - submissionTimeMillis;
+
+            log.info(
+                    BENCHMARK.getMarker(),
+                    "BENCHMARK: nonce={}, latency={}ms, submissionTime={}, consensusTime={}",
+                    transaction.getNonce(),
+                    latencyMillis,
+                    submissionTimeMillis,
+                    consensusTimeMillis);
+        }
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/services/benchmark/BenchmarkStateSpecification.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/services/benchmark/BenchmarkStateSpecification.java
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.app.services.benchmark;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.swirlds.state.lifecycle.StateDefinition;
+import com.swirlds.state.spi.WritableStates;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+import org.hiero.otter.fixtures.app.state.OtterServiceStateSpecification;
+
+/**
+ * State specification for the benchmark service.
+ *
+ * <p>The benchmark service does not require any persistent state. All tracking is done
+ * in memory and is not intended to survive restarts.
+ */
+public class BenchmarkStateSpecification implements OtterServiceStateSpecification {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public Set<StateDefinition<?, ?>> statesToCreate() {
+        return Set.of();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setDefaultValues(@NonNull final WritableStates states, @NonNull final SemanticVersion version) {
+        // No state to initialize
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/logging/internal/LogConfigHelper.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/logging/internal/LogConfigHelper.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures.logging.internal;
 
+import static com.swirlds.logging.legacy.LogMarker.BENCHMARK;
 import static com.swirlds.logging.legacy.LogMarker.DEMO_INFO;
 import static com.swirlds.logging.legacy.LogMarker.ERROR;
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
@@ -59,7 +60,8 @@ public final class LogConfigHelper {
             STATE_TO_DISK,
             DEMO_INFO,
             TESTING_EXCEPTIONS_ACCEPTABLE_RECONNECT,
-            MERKLE_DB));
+            MERKLE_DB,
+            BENCHMARK));
 
     private static final Set<LogMarker> IGNORED_CONSOLE_MARKERS = Set.of(STARTUP, MERKLE_DB, VIRTUAL_MERKLE_STATS);
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/proto/otter_transaction.proto
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/proto/otter_transaction.proto
@@ -17,6 +17,7 @@ message OtterTransaction {
     OtterFreezeTransaction freezeTransaction = 101;
     com.hedera.hapi.platform.event.StateSignatureTransaction stateSignatureTransaction = 102;
     OtterIssTransaction issTransaction = 103;
+    BenchmarkTransaction benchmarkTransaction = 104;
 
     CreateAccountTransaction createAccountTransaction = 201;
     DeleteAccountTransaction deleteAccountTransaction = 202;
@@ -44,5 +45,12 @@ message DeleteAccountTransaction {
 
 message HashPartition {
   repeated uint64 node_id = 1;
+}
+
+// A transaction used for benchmark measurements.
+// Contains a submission timestamp to calculate latency when the transaction reaches consensus.
+message BenchmarkTransaction {
+  // The timestamp (in epoch milliseconds) when this transaction was submitted.
+  uint64 submission_time_millis = 1;
 }
 

--- a/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/BenchmarkTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/BenchmarkTest.java
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.test;
+
+import static org.hiero.consensus.model.status.PlatformStatus.ACTIVE;
+import static org.hiero.consensus.model.status.PlatformStatus.CHECKING;
+import static org.hiero.consensus.model.status.PlatformStatus.OBSERVING;
+import static org.hiero.consensus.model.status.PlatformStatus.REPLAYING_EVENTS;
+import static org.hiero.otter.fixtures.OtterAssertions.assertContinuouslyThat;
+import static org.hiero.otter.fixtures.OtterAssertions.assertThat;
+import static org.hiero.otter.fixtures.assertions.StatusProgressionStep.target;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.hiero.otter.fixtures.Network;
+import org.hiero.otter.fixtures.Node;
+import org.hiero.otter.fixtures.OtterTest;
+import org.hiero.otter.fixtures.TestEnvironment;
+import org.hiero.otter.fixtures.TimeManager;
+import org.hiero.otter.fixtures.TransactionFactory;
+import org.hiero.otter.fixtures.logging.StructuredLog;
+import org.hiero.otter.fixtures.network.transactions.OtterTransaction;
+
+/**
+ * A simple benchmark test that submits benchmark transactions and logs latency.
+ * @implNote the location is initially here to validate the approach.
+ *   The final location will be a new source-set in this module dedicated to performance-testing
+ */
+public class BenchmarkTest {
+
+    private static final AtomicLong NONCE_GENERATOR = new AtomicLong(0);
+    private static final int TRANSACTION_COUNT = 10;
+    /**
+     * Simple test that runs a network with 4 nodes and submits benchmark transactions.
+     * The BenchmarkService logs the latency for each transaction.
+     *
+     * @param env the test environment for this test
+     */
+    @OtterTest
+    void testBenchmarkLatency(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        // Enable the BenchmarkService
+        network.withConfigValue("event.services", "org.hiero.otter.fixtures.app.services.benchmark.BenchmarkService");
+
+        // Setup simulation with 4 nodes
+        network.addNodes(4);
+
+        // Setup continuous assertions
+        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+        assertContinuouslyThat(network.newConsensusResults())
+                .haveEqualCommonRounds()
+                .haveConsistentRounds();
+
+        network.start();
+
+        // Wait for network to stabilize
+        timeManager.waitFor(Duration.ofSeconds(3L));
+
+        // Submit benchmark transactions
+
+        for (int i = 0; i < TRANSACTION_COUNT; i++) {
+            final OtterTransaction tx =
+                    TransactionFactory.createBenchmarkTransaction(NONCE_GENERATOR.incrementAndGet());
+            network.submitTransaction(tx);
+
+            // Small delay between submissions
+            timeManager.waitFor(Duration.ofMillis(100));
+        }
+
+        // Wait for all transactions to be processed
+        timeManager.waitFor(Duration.ofSeconds(5L));
+
+        // Verify that benchmark log messages were printed
+        for (final Node node : network.nodes()) {
+            final List<StructuredLog> logs = node.newLogResult().logs();
+            final long benchmarkLogCount = countBenchmarkLogs(logs);
+            assertTrue(
+                    benchmarkLogCount >= TRANSACTION_COUNT,
+                    "Expected at least " + TRANSACTION_COUNT + " BENCHMARK logs on node " + node.selfId()
+                            + ", but found " + benchmarkLogCount);
+        }
+
+        // Validations
+        assertThat(network.newPlatformStatusResults())
+                .haveSteps(target(ACTIVE).requiringInterim(REPLAYING_EVENTS, OBSERVING, CHECKING));
+    }
+
+    private static long countBenchmarkLogs(@NonNull final List<StructuredLog> logs) {
+        return logs.stream()
+                .filter(log ->
+                        log.marker() != null && "BENCHMARK".equals(log.marker().getName()))
+                .count();
+    }
+}

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LogMarker.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LogMarker.java
@@ -166,7 +166,12 @@ public enum LogMarker {
     /**
      * logging related to metric system
      */
-    METRICS(LogMarkerType.INFO);
+    METRICS(LogMarkerType.INFO),
+
+    /**
+     * logs related to benchmark measurements (latency, throughput, etc.)
+     */
+    BENCHMARK(LogMarkerType.INFO);
 
     private final LogMarkerType type;
     private final Marker marker;


### PR DESCRIPTION
**Description**:
Dummy otter service that will be used to track performance.
The idea is to move it from source set, but in the meantime is validated using an otterTest

**Related issue(s)**:

Fixes #23104
