### PR TITLE
chore: Cherry-Pick (0.71): Use incremental streaming hashers for all subroots

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/state/blockstream/block_stream_info.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/state/blockstream/block_stream_info.proto
@@ -100,7 +100,7 @@ message BlockStreamInfo {
      * This SHALL count the number of output block items that _precede_
      * the state change that updates this singleton.
      */
-    uint32 num_preceding_state_changes_items = 7;
+    uint64 num_preceding_state_changes_items = 7;
 
     /**
      * A concatenation of SHA2-384 hash values.<br/>

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -10,7 +10,6 @@ import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.NONE;
 import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.POST_UPGRADE_WORK;
 import static com.hedera.node.app.blocks.impl.BlockImplUtils.appendHash;
 import static com.hedera.node.app.blocks.impl.BlockImplUtils.hashLeaf;
-import static com.hedera.node.app.blocks.impl.ConcurrentStreamingTreeHasher.rootHashFrom;
 import static com.hedera.node.app.blocks.impl.streaming.FileBlockItemWriter.blockDirFor;
 import static com.hedera.node.app.blocks.impl.streaming.FileBlockItemWriter.cleanUpPendingBlock;
 import static com.hedera.node.app.blocks.impl.streaming.FileBlockItemWriter.loadContiguousPendingBlocks;
@@ -31,7 +30,6 @@ import com.hedera.hapi.block.stream.ChainOfTrustProof;
 import com.hedera.hapi.block.stream.MerklePath;
 import com.hedera.hapi.block.stream.MerkleSiblingHash;
 import com.hedera.hapi.block.stream.StateProof;
-import com.hedera.hapi.block.stream.SubMerkleTree;
 import com.hedera.hapi.block.stream.TssSignedBlockProof;
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.hapi.block.stream.output.SingletonUpdateChange;
@@ -156,11 +154,11 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
 
     // Block merkle subtrees and leaves
     private IncrementalStreamingHasher previousBlockHashes;
-    private StreamingTreeHasher consensusHeaderHasher;
-    private StreamingTreeHasher inputTreeHasher;
-    private StreamingTreeHasher outputTreeHasher;
-    private StreamingTreeHasher stateChangesHasher;
-    private StreamingTreeHasher traceDataHasher;
+    private IncrementalStreamingHasher consensusHeaderHasher;
+    private IncrementalStreamingHasher inputTreeHasher;
+    private IncrementalStreamingHasher outputTreeHasher;
+    private IncrementalStreamingHasher stateChangesHasher;
+    private IncrementalStreamingHasher traceDataHasher;
 
     private BlockStreamManagerTask worker;
     private final boolean hintsEnabled;
@@ -277,9 +275,12 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         // We have to calculate the final hash of the previous block's state changes subtree because only the
         // penultimate state hash is in the block stream info object (constructed from numPrecedingStateChangesItems and
         // rightmostPrecedingStateChangesTreeHashes)
-        final var penultimateStateChangesTreeStatus = new StreamingTreeHasher.Status(
-                blockStreamInfo.numPrecedingStateChangesItems(),
-                blockStreamInfo.rightmostPrecedingStateChangesTreeHashes());
+        final var initialStateChangesHasher = new IncrementalStreamingHasher(
+                sha384DigestOrThrow(),
+                blockStreamInfo.rightmostPrecedingStateChangesTreeHashes().stream()
+                        .map(Bytes::toByteArray)
+                        .toList(),
+                blockStreamInfo.numPrecedingStateChangesItems());
 
         // Reconstruct the final state change block item that would have been emitted by the previous block
         final var lastBlockFinalStateChange = StateChange.newBuilder()
@@ -293,12 +294,12 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                 // state change time
                 .stateChanges(new StateChanges(blockStreamInfo.blockEndTime(), List.of(lastBlockFinalStateChange)))
                 .build();
-        // Hash the reconstructed (final) state changes block item
-        final var lastLeafHash = BlockImplUtils.hashLeaf(BlockItem.PROTOBUF.toBytes(lastStateChanges));
+        final var lastStateChangesBytes =
+                BlockItem.PROTOBUF.toBytes(lastStateChanges).toByteArray();
 
-        // Combine the penultimate tree status and the hash of the reconstructed state change item to produce the
-        // previous block's final state changes hash
-        final var lastBlockFinalStateChangesHash = rootHashFrom(penultimateStateChangesTreeStatus, lastLeafHash);
+        // Add the final state change item's hash to the reconstructed state changes tree, and compute the final hash
+        initialStateChangesHasher.addLeaf(lastStateChangesBytes);
+        final var lastBlockFinalStateChangesHash = Bytes.wrap(initialStateChangesHasher.computeRootHash());
 
         final var calculatedLastBlockHash = Optional.ofNullable(lastBlockHash)
                 .orElseGet(() -> BlockStreamManagerImpl.combine(
@@ -314,7 +315,12 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                         .blockRootHash());
         requireNonNull(calculatedLastBlockHash);
         this.lastBlockHash = calculatedLastBlockHash;
-        previousBlockHashes.addLeaf(calculatedLastBlockHash.toByteArray());
+        log.info("Initialized block stream from state with last block hash {}", calculatedLastBlockHash.toHex());
+
+        // Only add the last hash if it's not the marker zero block hash
+        if (!Objects.equals(calculatedLastBlockHash, ZERO_BLOCK_HASH)) {
+            previousBlockHashes.addLeaf(calculatedLastBlockHash.toByteArray());
+        }
     }
 
     @Override
@@ -501,37 +507,20 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             lastRoundOfPrevBlock = roundNum;
 
             // Branch 1: lastBlockHash
-            // Branch 2
+            // Branch 2: previous block hashes root hash
             // Branch 3: blockStartStateHash
-            // Calculate hashes for branches 4-8
-            final Map<SubMerkleTree, Bytes> computedHashes = new ConcurrentHashMap<>();
-            final var future = CompletableFuture.allOf(
-                    // Branch 4
-                    consensusHeaderHasher
-                            .rootHash()
-                            .thenAccept(b -> computedHashes.put(SubMerkleTree.CONSENSUS_HEADER_ITEMS, b)),
-                    // Branch 5
-                    inputTreeHasher.rootHash().thenAccept(b -> computedHashes.put(SubMerkleTree.INPUT_ITEMS_TREE, b)),
-                    // Branch 6
-                    outputTreeHasher.rootHash().thenAccept(b -> computedHashes.put(SubMerkleTree.OUTPUT_ITEMS_TREE, b)),
-                    // Branch 7 will be computed below after adding the final state change item
-                    // Branch 8
-                    traceDataHasher
-                            .rootHash()
-                            .thenAccept(b -> computedHashes.put(SubMerkleTree.TRACE_DATA_ITEMS_TREE, b)));
-            future.join();
-
             // Branch 4 final hash:
-            final var consensusHeaderHash = computedHashes.get(SubMerkleTree.CONSENSUS_HEADER_ITEMS);
+            final var consensusHeaderHash = Bytes.wrap(consensusHeaderHasher.computeRootHash());
             // Branch 5 final hash:
-            final var inputsHash = computedHashes.get(SubMerkleTree.INPUT_ITEMS_TREE);
+            final var inputsHash = Bytes.wrap(inputTreeHasher.computeRootHash());
             // Branch 6 final hash:
-            final var outputsHash = computedHashes.get(SubMerkleTree.OUTPUT_ITEMS_TREE);
+            final var outputsHash = Bytes.wrap(outputTreeHasher.computeRootHash());
             // Branch 7 (penultimate status only because there will be one more state change when the block stream info
             // object is stored)
-            final var penultimateStateChangesTreeStatus = stateChangesHasher.status();
+            final var interimStateChanges = stateChangesHasher.intermediateHashingState();
+            final var interimStateChangeLeaves = stateChangesHasher.leafCount();
             // Branch 8 final hash:
-            final var traceDataHash = computedHashes.get(SubMerkleTree.TRACE_DATA_ITEMS_TREE);
+            final var traceDataHash = Bytes.wrap(traceDataHasher.computeRootHash());
 
             // Put this block hash context in state via the block stream info
             final var writableState = state.getWritableStates(BlockStreamService.NAME);
@@ -543,8 +532,8 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                     blockHashManager.blockHashes(),
                     inputsHash,
                     blockStartStateHash,
-                    penultimateStateChangesTreeStatus.numLeaves(),
-                    penultimateStateChangesTreeStatus.rightmostHashes(),
+                    interimStateChangeLeaves,
+                    interimStateChanges,
                     lastUsedTime,
                     pendingWork != POST_UPGRADE_WORK,
                     version,
@@ -562,7 +551,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             worker.addItem(flushChangesFromListener(boundaryStateChangeListener));
             worker.sync();
 
-            final var stateChangesHash = stateChangesHasher.rootHash().join();
+            final var stateChangesHash = Bytes.wrap(stateChangesHasher.computeRootHash());
 
             final var prevBlockRootsHash = Bytes.wrap(previousBlockHashes.computeRootHash());
             final var rootAndSiblingHashes = combine(
@@ -794,14 +783,14 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                     final var stateProof = BlockStateProofGenerator.generateStateProof(
                             currentPendingBlock,
                             blockNumber,
-                            blockSignature,
+                            effectiveSignature,
                             signedBlock.blockTimestamp(),
                             // Pass the remaining pending blocks, but don't remove them from the queue
                             pendingBlocks.stream());
                     proof = currentPendingBlock.proofBuilder().blockStateProof(stateProof);
 
                     if (log.isDebugEnabled()) {
-                        logStateProof(blockSignature, currentPendingBlock, blockNumber, stateProof);
+                        logStateProof(effectiveSignature, currentPendingBlock, blockNumber, stateProof);
                     }
                 } else {
                     // (FUTURE) Once state proofs are enabled, this placeholder proof can be removed
@@ -949,23 +938,8 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         @Override
         protected boolean onExecute() {
             try {
-                Bytes bytes = BlockItem.PROTOBUF.toBytes(item);
-                final var kind = item.item().kind();
-                ByteBuffer hash = null;
-                switch (kind) {
-                    case EVENT_HEADER,
-                            SIGNED_TRANSACTION,
-                            TRANSACTION_RESULT,
-                            TRANSACTION_OUTPUT,
-                            STATE_CHANGES,
-                            ROUND_HEADER,
-                            BLOCK_HEADER,
-                            TRACE_DATA -> {
-                        final var hashedLeaf = BlockImplUtils.hashLeaf(bytes);
-                        hash = ByteBuffer.wrap(hashedLeaf.toByteArray());
-                    }
-                }
-                out.send(item, hash, bytes);
+                final byte[] bytes = BlockItem.PROTOBUF.toBytes(item).toByteArray();
+                out.send(item, bytes);
                 return true;
             } catch (Exception e) {
                 log.error("{} - error hashing item {}", ALERT_MESSAGE, item, e);
@@ -978,8 +952,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
 
         SequentialTask next;
         BlockItem item;
-        Bytes serialized;
-        ByteBuffer hash;
+        byte[] serialized;
 
         SequentialTask() {
             super(executor, 3);
@@ -989,16 +962,18 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         protected boolean onExecute() {
             final var kind = item.item().kind();
             switch (kind) {
-                case ROUND_HEADER, EVENT_HEADER -> consensusHeaderHasher.addLeaf(hash);
-                case SIGNED_TRANSACTION -> inputTreeHasher.addLeaf(hash);
+                case ROUND_HEADER, EVENT_HEADER -> consensusHeaderHasher.addLeaf(serialized);
+                case SIGNED_TRANSACTION -> inputTreeHasher.addLeaf(serialized);
                 case TRANSACTION_RESULT -> {
-                    runningHashManager.nextResultHash(hash);
-                    hash.rewind();
-                    outputTreeHasher.addLeaf(hash);
+                    outputTreeHasher.addLeaf(serialized);
+
+                    // Also update running hashes
+                    final var hashedLeaf = BlockImplUtils.hashLeaf(serialized);
+                    runningHashManager.nextResultHash(ByteBuffer.wrap(hashedLeaf));
                 }
-                case TRANSACTION_OUTPUT, BLOCK_HEADER -> outputTreeHasher.addLeaf(hash);
-                case STATE_CHANGES -> stateChangesHasher.addLeaf(hash);
-                case TRACE_DATA -> traceDataHasher.addLeaf(hash);
+                case TRANSACTION_OUTPUT, BLOCK_HEADER -> outputTreeHasher.addLeaf(serialized);
+                case STATE_CHANGES -> stateChangesHasher.addLeaf(serialized);
+                case TRACE_DATA -> traceDataHasher.addLeaf(serialized);
                 case BLOCK_FOOTER, BLOCK_PROOF -> {
                     // BlockFooter and BlockProof are not included in any merkle tree
                     // They are metadata about the block, not part of the hashed content
@@ -1009,7 +984,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             if (header != null) {
                 writer.openBlock(header.number());
             }
-            writer.writePbjItemAndBytes(item, serialized);
+            writer.writePbjItemAndBytes(item, Bytes.wrap(serialized));
 
             next.send();
             return true;
@@ -1025,9 +1000,8 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             send();
         }
 
-        void send(BlockItem item, ByteBuffer hash, Bytes serialized) {
+        void send(BlockItem item, byte[] serialized) {
             this.item = item;
-            this.hash = hash;
             this.serialized = serialized;
             send();
         }
@@ -1183,15 +1157,15 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
      */
     private void resetSubtrees() {
         // Branch 4
-        consensusHeaderHasher = new ConcurrentStreamingTreeHasher(executor, hashCombineBatchSize);
+        consensusHeaderHasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
         // Branch 5
-        inputTreeHasher = new ConcurrentStreamingTreeHasher(executor, hashCombineBatchSize);
+        inputTreeHasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
         // Branch 6
-        outputTreeHasher = new ConcurrentStreamingTreeHasher(executor, hashCombineBatchSize);
+        outputTreeHasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
         // Branch 7
-        stateChangesHasher = new ConcurrentStreamingTreeHasher(executor, hashCombineBatchSize);
+        stateChangesHasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
         // Branch 8
-        traceDataHasher = new ConcurrentStreamingTreeHasher(executor, hashCombineBatchSize);
+        traceDataHasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
     }
 
     private record RootAndSiblingHashes(Bytes blockRootHash, MerkleSiblingHash[] siblingHashes) {}
@@ -1205,6 +1179,10 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
      * as a leaf node (prefixed with {@link StreamingTreeHasher#LEAF_PREFIX}) or as an internal node (prefixed
      * with {@link StreamingTreeHasher#INTERNAL_NODE_PREFIX}). Therefore, they should <b>not</b> be hashed
      * again until combined with another hash.
+     * <p>
+     * While {@code prevBlockHash} could programmatically be null, in practice it never should be. Even
+     * in the case of the genesis block, this value should be {@link BlockStreamManager#ZERO_BLOCK_HASH}. For
+     * all other blocks, it should be the actual previous block's root hash.
      * @return the block root hash and all possibly-required sibling hashes, ordered from bottom (the
      * leaf level, depth six) to top (the root, depth one)
      */
@@ -1218,6 +1196,8 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             @NonNull final Bytes stateChangesHash,
             @NonNull final Bytes traceDataHash,
             @NonNull final Timestamp firstConsensusTimeOfCurrentBlock) {
+        requireNonNull(prevBlockHash);
+
         // Compute depth five hashes
         final var depth5Node1 = BlockImplUtils.hashInternalNode(prevBlockHash, prevBlockRootsHash);
         final var depth5Node2 = BlockImplUtils.hashInternalNode(startingStateHash, consensusHeaderHash);

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -130,23 +130,33 @@ val prCheckStartPorts =
     }
 val prCheckPropOverrides =
     buildMap<String, String> {
-        put("hapiTestAdhoc", "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=true")
+        put(
+            "hapiTestAdhoc",
+            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+        )
         put(
             "hapiTestCrypto",
-            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=false,blockStream.blockPeriod=1s",
+            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=false,blockStream.blockPeriod=1s,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
         )
         put("hapiTestSmartContract", "tss.historyEnabled=false")
         put(
             "hapiTestRestart",
-            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.initialCrsParties=16,blockStream.blockPeriod=1s,quiescence.enabled=true",
+            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.initialCrsParties=16,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
         )
-        put("hapiTestMisc", "nodes.nodeRewardsEnabled=false,quiescence.enabled=true")
+        put(
+            "hapiTestMisc",
+            "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+        )
         put("hapiTestTimeConsuming", "nodes.nodeRewardsEnabled=false,quiescence.enabled=true")
         put(
             "hapiTestMiscRecords",
-            "blockStream.streamMode=RECORDS,nodes.nodeRewardsEnabled=false,quiescence.enabled=true",
+            "blockStream.streamMode=RECORDS,nodes.nodeRewardsEnabled=false,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
         )
         put("hapiTestSimpleFees", "fees.simpleFeesEnabled=true")
+        put(
+            "hapiTestNDReconnect",
+            "blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+        )
 
         // Copy vals to the MATS variants
         val originalEntries = toMap() // Create a snapshot of current entries

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/IndirectProofSequenceValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/IndirectProofSequenceValidator.java
@@ -189,6 +189,7 @@ class IndirectProofSequenceValidator {
      * block proofs. Triggers construction of all expected indirect proofs based on the partial proofs already
      * collected.
      *
+     * @param signedTimestamp the designated consensus timestamp of the signed block
      * @param signedProof the TSS-signed block proof that ends the indirect proof sequence
      */
     private void endOfSequence(@NonNull final Timestamp signedTimestamp, @NonNull final BlockProof signedProof) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
@@ -61,7 +61,6 @@ import com.hedera.node.app.ServicesMain;
 import com.hedera.node.app.blocks.BlockStreamManager;
 import com.hedera.node.app.blocks.StreamingTreeHasher;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
-import com.hedera.node.app.blocks.impl.NaiveStreamingTreeHasher;
 import com.hedera.node.app.config.BootstrapConfigProviderImpl;
 import com.hedera.node.app.hapi.utils.CommonUtils;
 import com.hedera.node.app.hapi.utils.blocks.BlockStreamAccess;
@@ -90,7 +89,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -390,7 +388,6 @@ public class StateChangesValidator implements BlockStreamValidator {
                         c.constructionId(), c.hintsSchemeOrThrow().preprocessedKeysOrThrow()));
         final IncrementalStreamingHasher incrementalBlockHashes =
                 new IncrementalStreamingHasher(CommonUtils.sha384DigestOrThrow(), List.of(), 0);
-        incrementalBlockHashes.addLeaf(BlockStreamManager.ZERO_BLOCK_HASH.toByteArray());
         for (int i = 0; i < n; i++) {
             final var block = blocks.get(i);
             final var shouldVerifyProof = i == 0
@@ -402,11 +399,16 @@ public class StateChangesValidator implements BlockStreamValidator {
                 this.state = stateToBeCopied.copy();
                 startOfStateHash = stateToBeCopied.getRoot().getHash().getBytes();
             }
-            final StreamingTreeHasher inputTreeHasher = new NaiveStreamingTreeHasher();
-            final StreamingTreeHasher outputTreeHasher = new NaiveStreamingTreeHasher();
-            final StreamingTreeHasher consensusHeaderHasher = new NaiveStreamingTreeHasher();
-            final StreamingTreeHasher stateChangesHasher = new NaiveStreamingTreeHasher();
-            final StreamingTreeHasher traceDataHasher = new NaiveStreamingTreeHasher();
+            final IncrementalStreamingHasher inputTreeHasher =
+                    new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
+            final IncrementalStreamingHasher outputTreeHasher =
+                    new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
+            final IncrementalStreamingHasher consensusHeaderHasher =
+                    new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
+            final IncrementalStreamingHasher stateChangesHasher =
+                    new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
+            final IncrementalStreamingHasher traceDataHasher =
+                    new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
 
             long firstBlockRound = -1;
             long eventNodeId = -1;
@@ -500,8 +502,7 @@ public class StateChangesValidator implements BlockStreamValidator {
                                     + " does not match final block BlockStreamInfo update type");
 
                     // The state changes hasher already incorporated the last state change, so compute its root hash
-                    final var finalStateChangesHash =
-                            stateChangesHasher.rootHash().join();
+                    final var finalStateChangesHash = Bytes.wrap(stateChangesHasher.computeRootHash());
 
                     final var expectedRootAndSiblings = computeBlockHash(
                             firstConsensusTimestamp,
@@ -630,21 +631,19 @@ public class StateChangesValidator implements BlockStreamValidator {
 
     private void hashSubTrees(
             final BlockItem item,
-            final StreamingTreeHasher inputTreeHasher,
-            final StreamingTreeHasher outputTreeHasher,
-            final StreamingTreeHasher consensusHeaderHasher,
-            final StreamingTreeHasher stateChangesHasher,
-            final StreamingTreeHasher traceDataHasher) {
-        final var itemSerialized = BlockItem.PROTOBUF.toBytes(item);
-        final var itemAsLeaf = hashLeaf(itemSerialized);
+            final IncrementalStreamingHasher inputTreeHasher,
+            final IncrementalStreamingHasher outputTreeHasher,
+            final IncrementalStreamingHasher consensusHeaderHasher,
+            final IncrementalStreamingHasher stateChangesHasher,
+            final IncrementalStreamingHasher traceDataHasher) {
+        final var serialized = BlockItem.PROTOBUF.toBytes(item).toByteArray();
 
         switch (item.item().kind()) {
-            case EVENT_HEADER, ROUND_HEADER -> consensusHeaderHasher.addLeaf(ByteBuffer.wrap(itemAsLeaf.toByteArray()));
-            case SIGNED_TRANSACTION -> inputTreeHasher.addLeaf(ByteBuffer.wrap(itemAsLeaf.toByteArray()));
-            case TRANSACTION_RESULT, TRANSACTION_OUTPUT, BLOCK_HEADER ->
-                outputTreeHasher.addLeaf(ByteBuffer.wrap(itemAsLeaf.toByteArray()));
-            case STATE_CHANGES -> stateChangesHasher.addLeaf(ByteBuffer.wrap(itemAsLeaf.toByteArray()));
-            case TRACE_DATA -> traceDataHasher.addLeaf(ByteBuffer.wrap(itemAsLeaf.toByteArray()));
+            case EVENT_HEADER, ROUND_HEADER -> consensusHeaderHasher.addLeaf(serialized);
+            case SIGNED_TRANSACTION -> inputTreeHasher.addLeaf(serialized);
+            case TRANSACTION_RESULT, TRANSACTION_OUTPUT, BLOCK_HEADER -> outputTreeHasher.addLeaf(serialized);
+            case STATE_CHANGES -> stateChangesHasher.addLeaf(serialized);
+            case TRACE_DATA -> traceDataHasher.addLeaf(serialized);
             default -> {
                 // Other items are not part of the input/output trees
             }
@@ -680,16 +679,16 @@ public class StateChangesValidator implements BlockStreamValidator {
             final Bytes previousBlockHash,
             final IncrementalStreamingHasher prevBlockRootsHasher,
             final Bytes startOfBlockStateHash,
-            final StreamingTreeHasher inputTreeHasher,
-            final StreamingTreeHasher outputTreeHasher,
-            final StreamingTreeHasher consensusHeaderHasher,
+            final IncrementalStreamingHasher inputTreeHasher,
+            final IncrementalStreamingHasher outputTreeHasher,
+            final IncrementalStreamingHasher consensusHeaderHasher,
             final Bytes finalStateChangesHash,
-            final StreamingTreeHasher traceDataHasher) {
+            final IncrementalStreamingHasher traceDataHasher) {
         final var prevBlocksRootHash = Bytes.wrap(prevBlockRootsHasher.computeRootHash());
-        final var consensusHeaderHash = consensusHeaderHasher.rootHash().join();
-        final var inputTreeHash = inputTreeHasher.rootHash().join();
-        final var outputTreeHash = outputTreeHasher.rootHash().join();
-        final var traceDataHash = traceDataHasher.rootHash().join();
+        final var consensusHeaderHash = Bytes.wrap(consensusHeaderHasher.computeRootHash());
+        final var inputTreeHash = Bytes.wrap(inputTreeHasher.computeRootHash());
+        final var outputTreeHash = Bytes.wrap(outputTreeHasher.computeRootHash());
+        final var traceDataHash = Bytes.wrap(traceDataHasher.computeRootHash());
 
         // Compute depth five hashes
         final var depth5Node1 = hashInternalNode(previousBlockHash, prevBlocksRootHash);


### PR DESCRIPTION
This PR cherry-picks the incremental hashers work for merkle mountaintop from #22995, needed by downstream consumers/verifiers of the block stream