### PR TITLE
chore(23105): otter new source-set

### DIFF
--- a/platform-sdk/consensus-otter-tests/build.gradle.kts
+++ b/platform-sdk/consensus-otter-tests/build.gradle.kts
@@ -33,6 +33,16 @@ testing {
     suites.register<JvmTestSuite>("testChaos") {
         targets.configureEach { testTask { dependsOn(":consensus-otter-docker-app:assemble") } }
     }
+
+    suites.register<JvmTestSuite>("testPerformance") {
+        // Runs performance benchmarks against the Turtle environment
+        targets.configureEach {
+            testTask {
+                systemProperty("otter.env", "turtle")
+                dependsOn(":consensus-otter-docker-app:assemble")
+            }
+        }
+    }
 }
 
 testModuleInfo {
@@ -61,6 +71,10 @@ extensions.getByName<GradleOnlyDirectives>("testOtterModuleInfo").apply {
 }
 
 extensions.getByName<GradleOnlyDirectives>("testChaosModuleInfo").apply {
+    runtimeOnly("io.grpc.netty.shaded")
+}
+
+extensions.getByName<GradleOnlyDirectives>("testPerformanceModuleInfo").apply {
     runtimeOnly("io.grpc.netty.shaded")
 }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/module-info.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/module-info.java
@@ -62,6 +62,7 @@ module org.hiero.otter.fixtures {
     exports org.hiero.otter.fixtures.specs;
     exports org.hiero.otter.fixtures.util;
     exports org.hiero.otter.fixtures.app to
+            org.hiero.otter.test.performance,
             com.swirlds.config.extensions,
             com.swirlds.config.impl,
             org.hiero.otter.test,
@@ -90,4 +91,7 @@ module org.hiero.otter.fixtures {
 
     opens org.hiero.otter.fixtures.container.network to
             com.fasterxml.jackson.databind;
+
+    exports org.hiero.otter.fixtures.app.state to
+            org.hiero.otter.test.performance;
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TransactionFactory.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TransactionFactory.java
@@ -11,7 +11,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
 import org.hiero.consensus.model.node.NodeId;
-import org.hiero.otter.fixtures.network.transactions.BenchmarkTransaction;
 import org.hiero.otter.fixtures.network.transactions.EmptyTransaction;
 import org.hiero.otter.fixtures.network.transactions.HashPartition;
 import org.hiero.otter.fixtures.network.transactions.OtterFreezeTransaction;
@@ -36,35 +35,6 @@ public class TransactionFactory {
         return OtterTransaction.newBuilder()
                 .setNonce(nonce)
                 .setEmptyTransaction(emptyTransaction)
-                .build();
-    }
-
-    /**
-     * Creates a new benchmark transaction with the current time as the submission timestamp.
-     *
-     * @param nonce the nonce for the benchmark transaction
-     * @return a benchmark transaction
-     */
-    @NonNull
-    public static OtterTransaction createBenchmarkTransaction(final long nonce) {
-        return createBenchmarkTransaction(nonce, System.currentTimeMillis());
-    }
-
-    /**
-     * Creates a new benchmark transaction with the specified submission timestamp.
-     *
-     * @param nonce the nonce for the benchmark transaction
-     * @param submissionTimeMillis the submission timestamp in epoch milliseconds
-     * @return a benchmark transaction
-     */
-    @NonNull
-    public static OtterTransaction createBenchmarkTransaction(final long nonce, final long submissionTimeMillis) {
-        final BenchmarkTransaction benchmarkTransaction = BenchmarkTransaction.newBuilder()
-                .setSubmissionTimeMillis(submissionTimeMillis)
-                .build();
-        return OtterTransaction.newBuilder()
-                .setNonce(nonce)
-                .setBenchmarkTransaction(benchmarkTransaction)
                 .build();
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/logging/internal/LogConfigHelper.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/logging/internal/LogConfigHelper.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures.logging.internal;
 
-import static com.swirlds.logging.legacy.LogMarker.BENCHMARK;
 import static com.swirlds.logging.legacy.LogMarker.DEMO_INFO;
 import static com.swirlds.logging.legacy.LogMarker.ERROR;
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
@@ -60,8 +59,7 @@ public final class LogConfigHelper {
             STATE_TO_DISK,
             DEMO_INFO,
             TESTING_EXCEPTIONS_ACCEPTABLE_RECONNECT,
-            MERKLE_DB,
-            BENCHMARK));
+            MERKLE_DB));
 
     private static final Set<LogMarker> IGNORED_CONSOLE_MARKERS = Set.of(STARTUP, MERKLE_DB, VIRTUAL_MERKLE_STATS);
 

--- a/platform-sdk/consensus-otter-tests/src/testPerformance/java/module-info.java
+++ b/platform-sdk/consensus-otter-tests/src/testPerformance/java/module-info.java
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+open module org.hiero.otter.test.performance {
+    requires org.hiero.consensus.model;
+    requires org.hiero.otter.fixtures;
+    requires static com.github.spotbugs.annotations;
+}

--- a/platform-sdk/consensus-otter-tests/src/testPerformance/java/org/hiero/otter/test/performance/benchmark/BenchmarkTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testPerformance/java/org/hiero/otter/test/performance/benchmark/BenchmarkTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package org.hiero.otter.test;
+package org.hiero.otter.test.performance.benchmark;
 
 import static org.hiero.consensus.model.status.PlatformStatus.ACTIVE;
 import static org.hiero.consensus.model.status.PlatformStatus.CHECKING;
@@ -19,22 +19,23 @@ import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.OtterTest;
 import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
-import org.hiero.otter.fixtures.TransactionFactory;
 import org.hiero.otter.fixtures.logging.StructuredLog;
+import org.hiero.otter.fixtures.network.transactions.BenchmarkTransaction;
 import org.hiero.otter.fixtures.network.transactions.OtterTransaction;
 
 /**
- * A simple benchmark test that submits benchmark transactions and logs latency.
- * @implNote the location is initially here to validate the approach.
- *   The final location will be a new source-set in this module dedicated to performance-testing
+ * Performance benchmark test that measures consensus layer latency.
  */
 public class BenchmarkTest {
 
     private static final AtomicLong NONCE_GENERATOR = new AtomicLong(0);
     private static final int TRANSACTION_COUNT = 10;
+
     /**
-     * Simple test that runs a network with 4 nodes and submits benchmark transactions.
+     * Benchmark test that runs a network with 4 nodes and submits benchmark transactions.
      * The BenchmarkService logs the latency for each transaction.
+     *
+     * uses {@link org.hiero.otter.test.performance.benchmark.fixtures.BenchmarkService}
      *
      * @param env the test environment for this test
      */
@@ -44,7 +45,8 @@ public class BenchmarkTest {
         final TimeManager timeManager = env.timeManager();
 
         // Enable the BenchmarkService
-        network.withConfigValue("event.services", "org.hiero.otter.fixtures.app.services.benchmark.BenchmarkService");
+        network.withConfigValue(
+                "event.services", "org.hiero.otter.test.performance.benchmark.fixtures.BenchmarkService");
 
         // Setup simulation with 4 nodes
         network.addNodes(4);
@@ -61,10 +63,9 @@ public class BenchmarkTest {
         timeManager.waitFor(Duration.ofSeconds(3L));
 
         // Submit benchmark transactions
-
         for (int i = 0; i < TRANSACTION_COUNT; i++) {
             final OtterTransaction tx =
-                    TransactionFactory.createBenchmarkTransaction(NONCE_GENERATOR.incrementAndGet());
+                    createBenchmarkTransaction(NONCE_GENERATOR.incrementAndGet(), System.currentTimeMillis());
             network.submitTransaction(tx);
 
             // Small delay between submissions
@@ -91,8 +92,25 @@ public class BenchmarkTest {
 
     private static long countBenchmarkLogs(@NonNull final List<StructuredLog> logs) {
         return logs.stream()
-                .filter(log ->
-                        log.marker() != null && "BENCHMARK".equals(log.marker().getName()))
+                .filter(log -> log.message().contains("BenchmarkService:"))
                 .count();
+    }
+
+    /**
+     * Creates a new benchmark transaction with the specified submission timestamp.
+     *
+     * @param nonce the nonce for the benchmark transaction
+     * @param submissionTimeMillis the submission timestamp in epoch milliseconds
+     * @return a benchmark transaction
+     */
+    @NonNull
+    public static OtterTransaction createBenchmarkTransaction(final long nonce, final long submissionTimeMillis) {
+        final BenchmarkTransaction benchmarkTransaction = BenchmarkTransaction.newBuilder()
+                .setSubmissionTimeMillis(submissionTimeMillis)
+                .build();
+        return OtterTransaction.newBuilder()
+                .setNonce(nonce)
+                .setBenchmarkTransaction(benchmarkTransaction)
+                .build();
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testPerformance/java/org/hiero/otter/test/performance/benchmark/fixtures/BenchmarkService.java
+++ b/platform-sdk/consensus-otter-tests/src/testPerformance/java/org/hiero/otter/test/performance/benchmark/fixtures/BenchmarkService.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-package org.hiero.otter.fixtures.app.services.benchmark;
+package org.hiero.otter.test.performance.benchmark.fixtures;
 
-import static com.swirlds.logging.legacy.LogMarker.BENCHMARK;
+import static com.swirlds.logging.legacy.LogMarker.DEMO_INFO;
 
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.swirlds.state.spi.WritableStates;
@@ -68,8 +68,8 @@ public class BenchmarkService implements OtterService {
             final long latencyMillis = consensusTimeMillis - submissionTimeMillis;
 
             log.info(
-                    BENCHMARK.getMarker(),
-                    "BENCHMARK: nonce={}, latency={}ms, submissionTime={}, consensusTime={}",
+                    DEMO_INFO.getMarker(),
+                    "BENCHMARK BenchmarkService: nonce={}, latency={}ms, submissionTime={}, consensusTime={}",
                     transaction.getNonce(),
                     latencyMillis,
                     submissionTimeMillis,

--- a/platform-sdk/consensus-otter-tests/src/testPerformance/java/org/hiero/otter/test/performance/benchmark/fixtures/BenchmarkStateSpecification.java
+++ b/platform-sdk/consensus-otter-tests/src/testPerformance/java/org/hiero/otter/test/performance/benchmark/fixtures/BenchmarkStateSpecification.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package org.hiero.otter.fixtures.app.services.benchmark;
+package org.hiero.otter.test.performance.benchmark.fixtures;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.swirlds.state.lifecycle.StateDefinition;

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LogMarker.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/LogMarker.java
@@ -166,12 +166,7 @@ public enum LogMarker {
     /**
      * logging related to metric system
      */
-    METRICS(LogMarkerType.INFO),
-
-    /**
-     * logs related to benchmark measurements (latency, throughput, etc.)
-     */
-    BENCHMARK(LogMarkerType.INFO);
+    METRICS(LogMarkerType.INFO);
 
     private final LogMarkerType type;
     private final Marker marker;


### PR DESCRIPTION
**Description**:
New source-set to contain benchmark related code, since we wont run "regular" test (most of them won't have asserts).
This aims to avoid confusions and being able to identify and isolate the run of these benchmarks when we have a provided environment

**Related issue(s)**:

Fixes #23105
