### PR TITLE
test: Disable kitchen sink suite

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/KitchenSinkFeeComparisonSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/KitchenSinkFeeComparisonSuite.java
@@ -141,6 +141,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -160,6 +161,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(ADHOC)
 @Tag(ONLY_EMBEDDED)
 @HapiTestLifecycle
+@Disabled
 public class KitchenSinkFeeComparisonSuite {
     private static final Logger LOG = LogManager.getLogger(KitchenSinkFeeComparisonSuite.class);
 


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/23278


Kitchen sink suite is only used to gather needed data for simple fees testing. This need not run in CI. Disabled it in CI.