### PR TITLE
fix: Assign free port for TlsFactoryTest to avoid random failures

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/connectivity/TlsFactoryTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/connectivity/TlsFactoryTest.java
@@ -67,7 +67,6 @@ class TlsFactoryTest extends ConnectivityTestBase {
         // test that B can talk to A - A(serverSocket) -> B(clientSocket1)
         serverSocket = socketFactoryA.createServerSocket(0);
         this.ephemeralPort = serverSocket.getLocalPort();
-        System.out.println(this.ephemeralPort);
         serverThread = createSocketThread(serverSocket, closeSeverConnection);
 
         clientSocketB = socketFactoryB.createClientSocket(STRING_IP, ephemeralPort);


### PR DESCRIPTION
**Description**:
Fix flakiness in TlsFactoryTest by using free ephemeral port, rather than hardcoded one (which can be used by some other test running in parallel on same runner)

**Related issue(s)**:

Fixes #23288

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
