### PR TITLE
fix: Stabilize flaky simple fee tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenWipeSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenWipeSimpleFeesTest.java
@@ -11,7 +11,6 @@ import static com.hedera.services.bdd.spec.keys.KeyShape.sigs;
 import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
 import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
@@ -21,14 +20,18 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.wipeTokenAccoun
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedAccount;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTokenWipeFungibleFullFeeUsd;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTokenWipeNetworkFeeOnlyUsd;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateChargedFeeToUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.NETWORK_BASE_FEE;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.NETWORK_MULTIPLIER;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SIGNATURE_FEE_AFTER_MULTIPLIER;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SIGNATURE_FEE_USD;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.TOKEN_WIPE_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PAYER_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
@@ -37,8 +40,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECORD_NOT_FOU
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_WIPE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
@@ -48,7 +49,6 @@ import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -65,7 +65,6 @@ import org.junit.jupiter.api.Tag;
 @Tag(SIMPLE_FEES)
 @HapiTestLifecycle
 public class TokenWipeSimpleFeesTest {
-
     private static final String PAYER = "payer";
     private static final String TREASURY = "treasury";
     private static final String ACCOUNT = "account";
@@ -235,9 +234,6 @@ public class TokenWipeSimpleFeesTest {
             @HapiTest
             @DisplayName("TokenWipe - missing wipe key signature fails")
             final Stream<DynamicTest> tokenWipeMissingWipeKeySignatureFailsAtHandle() {
-                final AtomicLong initialBalance = new AtomicLong();
-                final AtomicLong afterBalance = new AtomicLong();
-
                 return hapiTest(
                         cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(TREASURY).balance(ONE_HUNDRED_HBARS),
@@ -256,31 +252,19 @@ public class TokenWipeSimpleFeesTest {
                         cryptoTransfer(moving(100L, TOKEN).between(TREASURY, ACCOUNT))
                                 .payingWith(TREASURY)
                                 .fee(ONE_HUNDRED_HBARS),
-                        getAccountBalance(PAYER).exposingBalanceTo(initialBalance::set),
                         wipeTokenAccount(TOKEN, ACCOUNT, 50L)
                                 .payingWith(PAYER)
                                 .signedBy(PAYER) // Missing wipe key signature
                                 .fee(ONE_HUNDRED_HBARS)
                                 .via("wipeTxn")
                                 .hasKnownStatus(INVALID_SIGNATURE),
-                        getAccountBalance(PAYER).exposingBalanceTo(afterBalance::set),
-                        withOpContext((spec, log) -> {
-                            assertTrue(initialBalance.get() > afterBalance.get());
-                        }),
-                        validateChargedFeeToUsd(
-                                "wipeTxn",
-                                initialBalance,
-                                afterBalance,
-                                expectedTokenWipeFungibleFullFeeUsd(1L),
-                                0.001));
+                        validateChargedUsd("wipeTxn", TOKEN_WIPE_FEE),
+                        validateChargedAccount("wipeTxn", PAYER));
             }
 
             @HapiTest
             @DisplayName("TokenWipe - insufficient tx fee fails on ingest - no fee charged")
             final Stream<DynamicTest> tokenWipeInsufficientTxFeeFailsOnIngest() {
-                final AtomicLong initialBalance = new AtomicLong();
-                final AtomicLong afterBalance = new AtomicLong();
-
                 return hapiTest(
                         cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(TREASURY).balance(ONE_HUNDRED_HBARS),
@@ -299,26 +283,18 @@ public class TokenWipeSimpleFeesTest {
                         cryptoTransfer(moving(100L, TOKEN).between(TREASURY, ACCOUNT))
                                 .payingWith(TREASURY)
                                 .fee(ONE_HUNDRED_HBARS),
-                        getAccountBalance(PAYER).exposingBalanceTo(initialBalance::set),
                         wipeTokenAccount(TOKEN, ACCOUNT, 50L)
                                 .payingWith(PAYER)
                                 .signedBy(PAYER, WIPE_KEY)
                                 .fee(1L) // Fee too low
                                 .via("wipeTxn")
                                 .hasPrecheck(INSUFFICIENT_TX_FEE),
-                        getTxnRecord("wipeTxn").hasAnswerOnlyPrecheckFrom(RECORD_NOT_FOUND),
-                        getAccountBalance(PAYER).exposingBalanceTo(afterBalance::set),
-                        withOpContext((spec, log) -> {
-                            assertEquals(initialBalance.get(), afterBalance.get());
-                        }));
+                        getTxnRecord("wipeTxn").hasAnswerOnlyPrecheckFrom(RECORD_NOT_FOUND));
             }
 
             @HapiTest
             @DisplayName("TokenWipe - no wipe key fails")
             final Stream<DynamicTest> tokenWipeNoWipeKeyFails() {
-                final AtomicLong initialBalance = new AtomicLong();
-                final AtomicLong afterBalance = new AtomicLong();
-
                 return hapiTest(
                         cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(TREASURY).balance(ONE_HUNDRED_HBARS),
@@ -336,31 +312,19 @@ public class TokenWipeSimpleFeesTest {
                         cryptoTransfer(moving(100L, TOKEN).between(TREASURY, ACCOUNT))
                                 .payingWith(TREASURY)
                                 .fee(ONE_HUNDRED_HBARS),
-                        getAccountBalance(PAYER).exposingBalanceTo(initialBalance::set),
                         wipeTokenAccount(TOKEN, ACCOUNT, 50L)
                                 .payingWith(PAYER)
                                 .signedBy(PAYER)
                                 .fee(ONE_HUNDRED_HBARS)
                                 .via("wipeTxn")
                                 .hasKnownStatus(TOKEN_HAS_NO_WIPE_KEY),
-                        getAccountBalance(PAYER).exposingBalanceTo(afterBalance::set),
-                        withOpContext((spec, log) -> {
-                            assertTrue(initialBalance.get() > afterBalance.get());
-                        }),
-                        validateChargedFeeToUsd(
-                                "wipeTxn",
-                                initialBalance,
-                                afterBalance,
-                                expectedTokenWipeFungibleFullFeeUsd(1L),
-                                0.001));
+                        validateChargedUsd("wipeTxn", TOKEN_WIPE_FEE),
+                        validateChargedAccount("wipeTxn", PAYER));
             }
 
             @HapiTest
             @DisplayName("TokenWipe - token not associated fails")
             final Stream<DynamicTest> tokenWipeNotAssociatedFails() {
-                final AtomicLong initialBalance = new AtomicLong();
-                final AtomicLong afterBalance = new AtomicLong();
-
                 return hapiTest(
                         cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(TREASURY).balance(ONE_HUNDRED_HBARS),
@@ -376,31 +340,19 @@ public class TokenWipeSimpleFeesTest {
                                 .payingWith(PAYER)
                                 .fee(ONE_HUNDRED_HBARS),
                         // Not associating the token
-                        getAccountBalance(PAYER).exposingBalanceTo(initialBalance::set),
                         wipeTokenAccount(TOKEN, ACCOUNT, 50L)
                                 .payingWith(PAYER)
                                 .signedBy(PAYER, WIPE_KEY)
                                 .fee(ONE_HUNDRED_HBARS)
                                 .via("wipeTxn")
                                 .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        getAccountBalance(PAYER).exposingBalanceTo(afterBalance::set),
-                        withOpContext((spec, log) -> {
-                            assertTrue(initialBalance.get() > afterBalance.get());
-                        }),
-                        validateChargedFeeToUsd(
-                                "wipeTxn",
-                                initialBalance,
-                                afterBalance,
-                                expectedTokenWipeFungibleFullFeeUsd(2L),
-                                0.001));
+                        validateChargedUsd("wipeTxn", TOKEN_WIPE_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER),
+                        validateChargedAccount("wipeTxn", PAYER));
             }
 
             @HapiTest
             @DisplayName("TokenWipe - invalid wiping amount fails")
             final Stream<DynamicTest> tokenWipeInvalidAmountFails() {
-                final AtomicLong initialBalance = new AtomicLong();
-                final AtomicLong afterBalance = new AtomicLong();
-
                 return hapiTest(
                         cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                         cryptoCreate(TREASURY).balance(ONE_HUNDRED_HBARS),
@@ -419,23 +371,14 @@ public class TokenWipeSimpleFeesTest {
                         cryptoTransfer(moving(100L, TOKEN).between(TREASURY, ACCOUNT))
                                 .payingWith(TREASURY)
                                 .fee(ONE_HUNDRED_HBARS),
-                        getAccountBalance(PAYER).exposingBalanceTo(initialBalance::set),
                         wipeTokenAccount(TOKEN, ACCOUNT, 200L) // More than account has
                                 .payingWith(PAYER)
                                 .signedBy(PAYER, WIPE_KEY)
                                 .fee(ONE_HUNDRED_HBARS)
                                 .via("wipeTxn")
                                 .hasKnownStatus(INVALID_WIPING_AMOUNT),
-                        getAccountBalance(PAYER).exposingBalanceTo(afterBalance::set),
-                        withOpContext((spec, log) -> {
-                            assertTrue(initialBalance.get() > afterBalance.get());
-                        }),
-                        validateChargedFeeToUsd(
-                                "wipeTxn",
-                                initialBalance,
-                                afterBalance,
-                                expectedTokenWipeFungibleFullFeeUsd(2L),
-                                0.001));
+                        validateChargedUsd("wipeTxn", TOKEN_WIPE_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER),
+                        validateChargedAccount("wipeTxn", PAYER));
             }
         }
 
@@ -446,13 +389,6 @@ public class TokenWipeSimpleFeesTest {
             @LeakyEmbeddedHapiTest(reason = MUST_SKIP_INGEST)
             @DisplayName("TokenWipe - invalid payer signature fails on pre-handle - network fee only")
             final Stream<DynamicTest> tokenWipeInvalidPayerSigFailsOnPreHandle() {
-                final AtomicLong initialBalance = new AtomicLong();
-                final AtomicLong afterBalance = new AtomicLong();
-                final AtomicLong initialNodeBalance = new AtomicLong();
-                final AtomicLong afterNodeBalance = new AtomicLong();
-
-                final String INNER_ID = "wipe-txn-inner-id";
-
                 KeyShape keyShape = threshOf(2, SIMPLE, SIMPLE);
                 SigControl invalidSig = keyShape.signedWith(sigs(ON, OFF));
 
@@ -474,31 +410,20 @@ public class TokenWipeSimpleFeesTest {
                         cryptoTransfer(moving(100L, TOKEN).between(TREASURY, ACCOUNT))
                                 .payingWith(TREASURY)
                                 .fee(ONE_HUNDRED_HBARS),
-                        getAccountBalance(PAYER).exposingBalanceTo(initialBalance::set),
                         cryptoTransfer(movingHbar(ONE_HBAR).between(DEFAULT_PAYER, "0.0.4"))
                                 .fee(ONE_HUNDRED_HBARS),
-                        getAccountBalance("0.0.4").exposingBalanceTo(initialNodeBalance::set),
                         wipeTokenAccount(TOKEN, ACCOUNT, 50L)
                                 .payingWith(PAYER)
                                 .sigControl(forKey(PAYER_KEY, invalidSig))
                                 .signedBy(PAYER, WIPE_KEY)
                                 .fee(ONE_HUNDRED_HBARS)
                                 .setNode("0.0.4")
-                                .via(INNER_ID)
+                                .via("wipeTxn")
                                 .hasKnownStatus(INVALID_PAYER_SIGNATURE),
-                        getTxnRecord(INNER_ID).assertingNothingAboutHashes().logged(),
-                        getAccountBalance(PAYER).exposingBalanceTo(afterBalance::set),
-                        getAccountBalance("0.0.4").exposingBalanceTo(afterNodeBalance::set),
-                        withOpContext((spec, log) -> {
-                            assertEquals(initialBalance.get(), afterBalance.get());
-                            assertTrue(initialNodeBalance.get() > afterNodeBalance.get());
-                        }),
-                        validateChargedFeeToUsd(
-                                INNER_ID,
-                                initialNodeBalance,
-                                afterNodeBalance,
-                                expectedTokenWipeNetworkFeeOnlyUsd(2L),
-                                0.001));
+                        // we should charge just the network fee for due-diligence failure
+                        validateChargedUsd("wipeTxn", NETWORK_BASE_FEE + SIGNATURE_FEE_USD * NETWORK_MULTIPLIER),
+                        // assert that the node is charged for due-diligence failure
+                        validateChargedAccount("wipeTxn", "0.0.4"));
             }
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
@@ -14,7 +14,8 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final long NODE_INCLUDED_BYTES = 1024L;
 
     public static final int NETWORK_MULTIPLIER = 9;
-
+    public static final double NETWORK_BASE_FEE = NODE_BASE_FEE_USD * NETWORK_MULTIPLIER;
+    public static final double NODE_AND_NETWORK_BASE_FEE = NODE_BASE_FEE_USD + NETWORK_BASE_FEE;
     public static final double UNREADABLE_FEE_USD = 0.00000001;
 
     /* ---------- Global extras price table ("extras") ---------- */
@@ -136,14 +137,16 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final double TOKEN_REVOKE_KYC_BASE_FEE_USD = 0.0009;
 
     public static final double TOKEN_FREEZE_BASE_FEE_USD = 0.0009;
-
     public static final double TOKEN_UNFREEZE_BASE_FEE_USD = 0.0009;
+    public static final double TOKEN_FREEZE_FEE = 0.001;
+    public static final double TOKEN_UNFREEZE_FEE = 0.001;
 
     public static final double TOKEN_PAUSE_BASE_FEE_USD = 0.0009;
 
     public static final double TOKEN_UNPAUSE_BASE_FEE_USD = 0.0009;
 
     public static final double TOKEN_WIPE_BASE_FEE_USD = 0.0009;
+    public static final double TOKEN_WIPE_FEE = 0.001;
 
     /* ---------- Schedule service ---------- */
 


### PR DESCRIPTION
**Description**:

Stabilize flaky simple fee tests, by getting the amount charged and the payer account from the transaction record instead of relying on snapshots. 

Fixes #
https://github.com/hiero-ledger/hiero-consensus-node/issues/23251
https://github.com/hiero-ledger/hiero-consensus-node/issues/23244
