### PR TITLE
test: Harden additional HIP-1064 tests with explicit max rounds value

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/AdditionalHip1064Tests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/AdditionalHip1064Tests.java
@@ -174,26 +174,24 @@ public class AdditionalHip1064Tests {
                 EmbeddedVerbs.handleAnyRepeatableQueryPayment(),
 
                 // Set all eligible nodes to miss ALL rounds (100% inactive)
-                // Based on working tests, this is what makes nodes inactive
-                mutateSingleton(TokenService.NAME, NODE_REWARDS_STATE_ID, (NodeRewards nodeRewards) -> {
-                    final int totalRounds = (int) nodeRewards.numRoundsInStakingPeriod();
-                    return nodeRewards
-                            .copyBuilder()
-                            .nodeActivities(
-                                    NodeActivity.newBuilder()
-                                            .nodeId(1)
-                                            .numMissedJudgeRounds(totalRounds)
-                                            .build(), // 0% active
-                                    NodeActivity.newBuilder()
-                                            .nodeId(2)
-                                            .numMissedJudgeRounds(totalRounds)
-                                            .build(), // 0% active
-                                    NodeActivity.newBuilder()
-                                            .nodeId(3)
-                                            .numMissedJudgeRounds(totalRounds)
-                                            .build()) // 0% active
-                            .build();
-                }),
+                // Use Integer.MAX_VALUE to guarantee inactivity regardless of numRoundsInStakingPeriod
+                // (if numRoundsInStakingPeriod is 0, using totalRounds would make nodes appear active)
+                mutateSingleton(TokenService.NAME, NODE_REWARDS_STATE_ID, (NodeRewards nodeRewards) -> nodeRewards
+                        .copyBuilder()
+                        .nodeActivities(
+                                NodeActivity.newBuilder()
+                                        .nodeId(1)
+                                        .numMissedJudgeRounds(Integer.MAX_VALUE)
+                                        .build(), // 0% active
+                                NodeActivity.newBuilder()
+                                        .nodeId(2)
+                                        .numMissedJudgeRounds(Integer.MAX_VALUE)
+                                        .build(), // 0% active
+                                NodeActivity.newBuilder()
+                                        .nodeId(3)
+                                        .numMissedJudgeRounds(Integer.MAX_VALUE)
+                                        .build()) // 0% active
+                        .build()),
                 waitUntilStartOfNextStakingPeriod(1),
 
                 // Expect no rewards since nodes are completely inactive
@@ -230,25 +228,23 @@ public class AdditionalHip1064Tests {
                 EmbeddedVerbs.handleAnyRepeatableQueryPayment(),
 
                 // Set all nodes to be inactive (miss all rounds)
-                mutateSingleton(TokenService.NAME, NODE_REWARDS_STATE_ID, (NodeRewards nodeRewards) -> {
-                    final int totalRounds = (int) nodeRewards.numRoundsInStakingPeriod();
-                    return nodeRewards
-                            .copyBuilder()
-                            .nodeActivities(
-                                    NodeActivity.newBuilder()
-                                            .nodeId(1)
-                                            .numMissedJudgeRounds(totalRounds)
-                                            .build(), // 0% active
-                                    NodeActivity.newBuilder()
-                                            .nodeId(2)
-                                            .numMissedJudgeRounds(totalRounds)
-                                            .build(), // 0% active
-                                    NodeActivity.newBuilder()
-                                            .nodeId(3)
-                                            .numMissedJudgeRounds(totalRounds)
-                                            .build()) // 0% active
-                            .build();
-                }),
+                // Use Integer.MAX_VALUE to guarantee inactivity regardless of numRoundsInStakingPeriod
+                mutateSingleton(TokenService.NAME, NODE_REWARDS_STATE_ID, (NodeRewards nodeRewards) -> nodeRewards
+                        .copyBuilder()
+                        .nodeActivities(
+                                NodeActivity.newBuilder()
+                                        .nodeId(1)
+                                        .numMissedJudgeRounds(Integer.MAX_VALUE)
+                                        .build(), // 0% active
+                                NodeActivity.newBuilder()
+                                        .nodeId(2)
+                                        .numMissedJudgeRounds(Integer.MAX_VALUE)
+                                        .build(), // 0% active
+                                NodeActivity.newBuilder()
+                                        .nodeId(3)
+                                        .numMissedJudgeRounds(Integer.MAX_VALUE)
+                                        .build()) // 0% active
+                        .build()),
                 waitUntilStartOfNextStakingPeriod(1),
                 cryptoCreate("nobody").payingWith(GENESIS),
                 // Verify system handles all-inactive scenario gracefully
@@ -671,25 +667,23 @@ public class AdditionalHip1064Tests {
                 EmbeddedVerbs.handleAnyRepeatableQueryPayment(),
 
                 // Only node 2 is active, others are inactive
-                mutateSingleton(TokenService.NAME, NODE_REWARDS_STATE_ID, (NodeRewards nodeRewards) -> {
-                    int totalRounds = (int) nodeRewards.numRoundsInStakingPeriod();
-                    return nodeRewards
-                            .copyBuilder()
-                            .nodeActivities(
-                                    NodeActivity.newBuilder()
-                                            .nodeId(1)
-                                            .numMissedJudgeRounds(totalRounds)
-                                            .build(), // 0% active
-                                    NodeActivity.newBuilder()
-                                            .nodeId(2)
-                                            .numMissedJudgeRounds(0)
-                                            .build(), // 100% active
-                                    NodeActivity.newBuilder()
-                                            .nodeId(3)
-                                            .numMissedJudgeRounds(totalRounds)
-                                            .build()) // 0% active
-                            .build();
-                }),
+                // Use Integer.MAX_VALUE to guarantee inactivity regardless of numRoundsInStakingPeriod
+                mutateSingleton(TokenService.NAME, NODE_REWARDS_STATE_ID, (NodeRewards nodeRewards) -> nodeRewards
+                        .copyBuilder()
+                        .nodeActivities(
+                                NodeActivity.newBuilder()
+                                        .nodeId(1)
+                                        .numMissedJudgeRounds(Integer.MAX_VALUE)
+                                        .build(), // 0% active
+                                NodeActivity.newBuilder()
+                                        .nodeId(2)
+                                        .numMissedJudgeRounds(0)
+                                        .build(), // 100% active
+                                NodeActivity.newBuilder()
+                                        .nodeId(3)
+                                        .numMissedJudgeRounds(Integer.MAX_VALUE)
+                                        .build()) // 0% active
+                        .build()),
                 waitUntilStartOfNextStakingPeriod(1),
                 cryptoCreate("nobody").payingWith(GENESIS),
                 getAccountBalance(NODE_REWARD)


### PR DESCRIPTION
A few tests in `AdditionalHip1064Tests` can encounter a timing issue that leads to the code considering a subset of the nodes active, when most or all should be inactive. This PR fixes the timing issue by specifying `MAX_VALUE` for rounds missed. 

Closes #23329 