### PR TITLE
chore: Add converters to all new configuration extensions

### DIFF
--- a/platform-sdk/consensus-event-creator/src/main/java/org/hiero/consensus/event/creator/config/EventCreatorConfigurationExtension.java
+++ b/platform-sdk/consensus-event-creator/src/main/java/org/hiero/consensus/event/creator/config/EventCreatorConfigurationExtension.java
@@ -22,8 +22,8 @@ public class EventCreatorConfigurationExtension implements ConfigurationExtensio
     /**
      * {@inheritDoc}
      */
-    @NonNull
     @Override
+    @NonNull
     public Set<ConverterPair<?>> getConverters() {
         return Set.of(new ConverterPair<>(TaskSchedulerConfiguration.class, TaskSchedulerConfiguration::parse));
     }

--- a/platform-sdk/consensus-event-intake/src/main/java/org/hiero/consensus/event/intake/config/EventIntakeConfigurationExtension.java
+++ b/platform-sdk/consensus-event-intake/src/main/java/org/hiero/consensus/event/intake/config/EventIntakeConfigurationExtension.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.intake.config;
 
+import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.config.api.ConfigurationExtension;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
@@ -16,5 +17,14 @@ public class EventIntakeConfigurationExtension implements ConfigurationExtension
     @NonNull
     public Set<Class<? extends Record>> getConfigDataTypes() {
         return Set.of(EventIntakeWiringConfig.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public Set<ConverterPair<?>> getConverters() {
+        return Set.of(new ConverterPair<>(TaskSchedulerConfiguration.class, TaskSchedulerConfiguration::parse));
     }
 }

--- a/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/GossipConfigurationExtension.java
+++ b/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/GossipConfigurationExtension.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.gossip.config;
 
+import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.config.api.ConfigurationExtension;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
@@ -30,6 +31,8 @@ public class GossipConfigurationExtension implements ConfigurationExtension {
     @Override
     @NonNull
     public Set<ConverterPair<?>> getConverters() {
-        return Set.of(new ConverterPair<>(NetworkEndpoint.class, new NetworkEndpointConverter()));
+        return Set.of(
+                new ConverterPair<>(NetworkEndpoint.class, new NetworkEndpointConverter()),
+                new ConverterPair<>(TaskSchedulerConfiguration.class, TaskSchedulerConfiguration::parse));
     }
 }

--- a/platform-sdk/consensus-hashgraph/src/main/java/org/hiero/consensus/hashgraph/config/HashgraphConfigurationExtension.java
+++ b/platform-sdk/consensus-hashgraph/src/main/java/org/hiero/consensus/hashgraph/config/HashgraphConfigurationExtension.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.config;
 
+import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.config.api.ConfigurationExtension;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
@@ -16,5 +17,14 @@ public class HashgraphConfigurationExtension implements ConfigurationExtension {
     @NonNull
     public Set<Class<? extends Record>> getConfigDataTypes() {
         return Set.of(HashgraphWiringConfig.class, ConsensusConfig.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public Set<ConverterPair<?>> getConverters() {
+        return Set.of(new ConverterPair<>(TaskSchedulerConfiguration.class, TaskSchedulerConfiguration::parse));
     }
 }

--- a/platform-sdk/consensus-pces/src/main/java/org/hiero/consensus/pces/config/PcesConfigurationExtension.java
+++ b/platform-sdk/consensus-pces/src/main/java/org/hiero/consensus/pces/config/PcesConfigurationExtension.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.pces.config;
 
+import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.config.api.ConfigurationExtension;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
@@ -16,5 +17,14 @@ public class PcesConfigurationExtension implements ConfigurationExtension {
     @NonNull
     public Set<Class<? extends Record>> getConfigDataTypes() {
         return Set.of(PcesConfig.class, PcesWiringConfig.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public Set<ConverterPair<?>> getConverters() {
+        return Set.of(new ConverterPair<>(TaskSchedulerConfiguration.class, TaskSchedulerConfiguration::parse));
     }
 }


### PR DESCRIPTION
**Description**:

This PR adds converters for the `TaskSchedulerConfiguration` class in each module definition, enabling modules to be used in isolation.

**Related issue(s)**:

Fixes #23340 