### PR TITLE
fix: 23393 Fix of `DataFileCollectionCompactionTest#testDoubleMerge` intermittent failure

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -171,7 +172,8 @@ class DataFileCollectionCompactionTest {
         }
     }
 
-    @Test
+    // using RepeatedTest to increase a chance of discovering a thread race, as this test is timing-sensitive
+    @RepeatedTest(10)
     @DisplayName("Re-merge files without deletion")
     void testDoubleMerge() throws Exception {
         final int MAXKEYS = 100;


### PR DESCRIPTION
**Description**:

 Updated `DataFileCollectionCompactionTest.testDoubleMerge` to correctly use `store2` for the second compaction.  This ensures that the compactor uses a DataFileCollection that is not being closed by another thread.

Modified `DataFileReader.setFileCompleted()` to safely handle cases where `fileChannels.get(0)` might be null. This prevents the NPE even if a race condition occurs.

Fixes #23393 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
