### PR TITLE
chore: 23407 Use `computeHash` instead of `getHash`

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -126,7 +126,7 @@ public class BlockStreamRecoveryWorkflow {
 
         // To make sure that VirtualMapMetadata is persisted after all changes from the block stream were applied
         state.copy();
-        state.getHash();
+        state.computeHash();
         final var rootHash = requireNonNull(state.getHash()).getBytes();
 
         if (!expectedRootHash.isEmpty() && !expectedRootHash.equals(rootHash.toString())) {

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/MerkleBenchmarkUtils.java
@@ -46,12 +46,10 @@ public class MerkleBenchmarkUtils {
         System.out.println("desired: " + desiredTree);
 
         if (startingTree != null) {
-            // calculate hash
-            startingTree.getHash();
+            startingTree.computeHash();
         }
         if (desiredTree != null) {
-            // calculate hash
-            desiredTree.getHash();
+            desiredTree.computeHash();
         }
         return testSynchronization(
                 startingTree,

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/GenesisPlatformStateCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/GenesisPlatformStateCommand.java
@@ -84,7 +84,7 @@ public class GenesisPlatformStateCommand extends AbstractCommand {
                 ((CommittableWritableStates) writableStates).commit();
             }
             System.out.printf("Hashing state %n");
-            reservedSignedState.get().getState().getHash(); // calculate hash
+            reservedSignedState.get().getState().computeHash();
             System.out.printf("Writing modified state to %s %n", outputDir.toAbsolutePath());
             writeSignedStateFilesToDirectory(
                     platformContext, NO_NODE_ID, outputDir, reservedSignedState.get(), stateLifecycleManager);

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/recovery/EventRecoveryWorkflow.java
@@ -280,7 +280,7 @@ public final class EventRecoveryWorkflow {
         }
 
         logger.info(STARTUP.getMarker(), "Hashing resulting signed state");
-        signedState.get().getState().getHash();
+        signedState.get().getState().computeHash();
         logger.info(STARTUP.getMarker(), "Hashing complete");
 
         // Let the application know about the recovered state

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
@@ -64,9 +64,7 @@ public final class StateInitializer {
                 signedState.getState(), platform, trigger, previousSoftwareVersion);
 
         // calculate hash
-        abortAndThrowIfInterrupted(
-                initialState::getHash, // calculate hash
-                "interrupted while attempting to hash the state");
+        abortAndThrowIfInterrupted(initialState::computeHash, "interrupted while attempting to hash the state");
 
         // If our hash changes as a result of the new address book then our old signatures may become invalid.
         if (trigger != GENESIS) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectController.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectController.java
@@ -145,7 +145,7 @@ public class ReconnectController implements Runnable {
                 platformCoordinator.clear();
                 logger.info(RECONNECT.getMarker(), "Queues have been cleared");
 
-                final State currentState = stateLifecycleManager.getMutableState();
+                final State currentState = stateLifecycleManager.getLatestImmutableState();
                 currentState.computeHash();
                 int failedReconnectsInARow = 0;
                 do {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectController.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectController.java
@@ -146,7 +146,7 @@ public class ReconnectController implements Runnable {
                 logger.info(RECONNECT.getMarker(), "Queues have been cleared");
 
                 final State currentState = stateLifecycleManager.getMutableState();
-                currentState.getHash(); // hash the state
+                currentState.computeHash();
                 int failedReconnectsInARow = 0;
                 do {
                     final AttemptReconnectResult result = attemptReconnect(currentState);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hasher/DefaultStateHasher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hasher/DefaultStateHasher.java
@@ -35,7 +35,7 @@ public class DefaultStateHasher implements StateHasher {
     public ReservedSignedState hashState(@NonNull final StateWithHashComplexity stateWithHashComplexity) {
         final ReservedSignedState reservedSignedState = stateWithHashComplexity.reservedSignedState();
         final Instant start = Instant.now();
-        reservedSignedState.get().getState().getHash();
+        reservedSignedState.get().getState().computeHash();
         metrics.reportHashingTime(Duration.between(start, Instant.now()));
 
         return reservedSignedState;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectControllerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectControllerTest.java
@@ -147,8 +147,9 @@ class ReconnectControllerTest {
                 .forEach(rosterEntry -> sigSet.addSignature(NodeId.of(rosterEntry.nodeId()), randomSignature(random)));
 
         testSignedState.setSigSet(sigSet);
-
-        testWorkingState = testSignedState.getState().copy();
+        // making the state immutable
+        testSignedState.getState().copy().release();
+        testWorkingState = testSignedState.getState();
         testReservedSignedState = testSignedState.reserve("test");
 
         // Mock Platform
@@ -170,7 +171,7 @@ class ReconnectControllerTest {
 
         // Mock SwirldStateManager
         stateLifecycleManager = mock(StateLifecycleManager.class);
-        when(stateLifecycleManager.getMutableState()).thenReturn(testWorkingState);
+        when(stateLifecycleManager.getLatestImmutableState()).thenReturn(testWorkingState);
 
         // Mock SavedStateController
         savedStateController = mock(SavedStateController.class);


### PR DESCRIPTION
**Description**:

This PR replaces usages of `getHash` with `copmuteHash` where it's appropriate

**Related issue(s)**:

Fixes #23407 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
