### PR TITLE
fix: (CI) Update to RoleFreeBlockUnitSplit for system purged kv states edge case

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/RoleFreeBlockUnitSplit.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/RoleFreeBlockUnitSplit.java
@@ -335,14 +335,22 @@ public class RoleFreeBlockUnitSplit {
 
     private static boolean hasUserStateChanges(@NonNull final StateChanges stateChanges) {
         final var changes = stateChanges.stateChanges();
-        return changes.isEmpty()
-                || changes.stream()
-                        .anyMatch(change -> change.hasMapUpdate()
-                                || (change.hasMapDelete() && !SYSTEM_PURGED_KV_STATES.contains(change.stateId()))
-                                || (change.hasQueuePush()
-                                        && change.stateId() != STATE_ID_TRANSACTION_RECEIPTS.protoOrdinal())
-                                || (change.hasQueuePop()
-                                        && change.stateId() != STATE_ID_TRANSACTION_RECEIPTS.protoOrdinal()));
+        if (changes.isEmpty()) {
+            return true;
+        }
+        // Usually we ignore deletes in certain system-purged KV states so they do not affect unit splitting.
+        // However, some transactions can legitimately have *only* deletes in these
+        // states; if we ignore those deletes, we may fail to identify the top-level transaction.
+        final boolean onlyPurgedDeletes = changes.stream()
+                .allMatch(change -> change.hasMapDelete() && SYSTEM_PURGED_KV_STATES.contains(change.stateId()));
+        if (onlyPurgedDeletes) {
+            return true;
+        }
+        return changes.stream()
+                .anyMatch(change -> change.hasMapUpdate()
+                        || (change.hasMapDelete() && !SYSTEM_PURGED_KV_STATES.contains(change.stateId()))
+                        || (change.hasQueuePush() && change.stateId() != STATE_ID_TRANSACTION_RECEIPTS.protoOrdinal())
+                        || (change.hasQueuePop() && change.stateId() != STATE_ID_TRANSACTION_RECEIPTS.protoOrdinal()));
     }
 
     /**


### PR DESCRIPTION
**Description**:
This pull request updates the logic for detecting user state changes in the `RoleFreeBlockUnitSplit` class. The main change is to ensure that transactions containing only deletes in certain system-purged key-value states are properly recognized, which helps accurately identify top-level transactions.

Logic improvements for state change detection:

* Updated the `hasUserStateChanges` method to explicitly check for cases where all state changes are deletes in `SYSTEM_PURGED_KV_STATES`, treating these as user state changes rather than ignoring them. This ensures legitimate transactions with only such deletes are not missed.
* Refactored the method for clarity by splitting the logic into distinct checks for empty changes, only-purged deletes, and other types of state changes.

**Related issue(s)**:

Fixes #23448 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
