### PR TITLE
build: remove redundant shadow plugin configuration

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -514,19 +514,15 @@ tasks.register<Test>("testRepeatable") {
 
 application.mainClass = "com.hedera.services.bdd.suites.SuiteRunner"
 
-// allow shadow Jar files to have more than 64k entries
-tasks.withType<ShadowJar>().configureEach { isZip64 = true }
-
 tasks.shadowJar { archiveFileName.set("SuiteRunner.jar") }
 
 val rcdiffJar =
     tasks.register<ShadowJar>("rcdiffJar") {
-        exclude(listOf("META-INF/*.DSA", "META-INF/*.RSA", "META-INF/*.SF", "META-INF/INDEX.LIST"))
         from(sourceSets["main"].output)
         from(sourceSets["rcdiff"].output)
-        destinationDirectory.set(project.file("rcdiff"))
-        archiveFileName.set("rcdiff.jar")
-        configurations = listOf(project.configurations.getByName("rcdiffRuntimeClasspath"))
+        destinationDirectory = layout.projectDirectory.dir("rcdiff")
+        archiveFileName = "rcdiff.jar"
+        configurations = listOf(project.configurations["rcdiffRuntimeClasspath"])
 
         manifest { attributes("Main-Class" to "com.hedera.services.rcdiff.RcDiffCmdWrapper") }
     }

--- a/hedera-node/yahcli/build.gradle.kts
+++ b/hedera-node/yahcli/build.gradle.kts
@@ -29,22 +29,13 @@ tasks.compileJava { dependsOn(":test-clients:assemble") }
 
 val yahCliJar =
     tasks.register<ShadowJar>("yahCliJar") {
-        archiveClassifier.set("shadow")
-        configurations = listOf(project.configurations.getByName("runtimeClasspath"))
+        archiveClassifier = "shadow"
+        configurations = listOf(project.configurations["runtimeClasspath"])
 
         manifest { attributes("Main-Class" to "com.hedera.services.yahcli.Yahcli") }
 
         // Include all classes and resources from the main source set
         from(sourceSets["main"].output)
-
-        // Also include all service files (except signature-related) in META-INF
-        mergeServiceFiles()
-        exclude(listOf("META-INF/*.DSA", "META-INF/*.RSA", "META-INF/*.SF", "META-INF/INDEX.LIST"))
-
-        // Allow shadow Jar files to have more than 64k entries
-        isZip64 = true
-
-        dependsOn(tasks.compileJava, tasks.classes, tasks.processResources)
     }
 
 tasks.register<Copy>("copyYahCli") {

--- a/hedera-state-validator/build.gradle.kts
+++ b/hedera-state-validator/build.gradle.kts
@@ -7,12 +7,3 @@ plugins {
 mainModuleInfo { runtimeOnly("org.junit.jupiter.engine") }
 
 application.mainClass = "com.hedera.statevalidation.StateOperatorCommand"
-
-tasks.shadowJar {
-    isZip64 = true
-
-    // Prevent duplicate log4j2.xml files from dependencies (which disable logging) from overwriting
-    // this module's configuration.
-    mergeServiceFiles()
-    filesNotMatching("META-INF/services/**") { duplicatesStrategy = DuplicatesStrategy.EXCLUDE }
-}


### PR DESCRIPTION
The standard setup for the Gradle Shadow plugin has been streamlined with the last Gradle conventions update:

- #22939 
- https://github.com/hiero-ledger/hiero-gradle-conventions/pull/383

Our current default setup is now this: [org.hiero.gradle.feature.shadow.gradle.kts](https://github.com/hiero-ledger/hiero-gradle-conventions/blob/v0.7.0/src/main/kotlin/org.hiero.gradle.feature.shadow.gradle.kts#L15-L51)

This PR removes all custom configuration from this repository that is now a noop.