### PR TITLE
fix: use full prefix for deterministic fee calculation

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeCreateTest.java
@@ -491,6 +491,7 @@ class AtomicNodeCreateTest {
                                 .adminKey(ED_25519_KEY)
                                 .payingWith("payer")
                                 .signedBy("payer")
+                                .sigMapPrefixes(uniqueWithFullPrefixesFor("payer"))
                                 .gossipCaCertificate(
                                         gossipCertificates.getFirst().getEncoded())
                                 .hasKnownStatus(UNAUTHORIZED)


### PR DESCRIPTION
**Description**:
Always use full prefix public key to be deterministic when validating the fee

**Related issue(s)**:

Fixes #22867 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
