### PR TITLE
chore: disable test while the bug on the BN side is fixed

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/NodeDeathReconnectBlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/NodeDeathReconnectBlockNodeSuite.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.hiero.consensus.model.status.PlatformStatus;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -99,6 +100,7 @@ public class NodeDeathReconnectBlockNodeSuite implements LifecycleTest {
     }
 
     // FUTURE: This scenario should be updated after the behavior changes on the BN side
+    @Disabled
     @HapiTest
     @HapiBlockNode(
             networkSize = 2,


### PR DESCRIPTION
**Description**:
Disable the `nodeDeathReconnectAllNodes()` until the bug is fixed on the BN side so that we have a deterministic behaviour that we can test properly

**Related issue(s)**:

Fixes #23522 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
