### PR TITLE
fix: stabilize AtomicExchangeRateControlSuite

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicExchangeRateControlSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicExchangeRateControlSuite.java
@@ -22,7 +22,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACT
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.spec.transactions.file.HapiFileUpdate;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Tag;
 // This test cases are direct copies of ExchangeRateControlSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @Tag(ATOMIC_BATCH)
-@HapiTestLifecycle
+@OrderedInIsolation
 class AtomicExchangeRateControlSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";


### PR DESCRIPTION
**Description**:
The flake is due to a race condition caused by shared static state in FeesAndRatesProvider. The same test class in bdd/suites/file/batch is annotated OrderedInIsolation to avoid parallel running of the tests and the flake respectively.  Fixed by applying the same annotation on the class in question.

Fixes #23145

**Notes for reviewer**:
Contents of com/hedera/services/bdd/suites/file/batch/AtomicExchangeRateControlSuite.java and com/hedera/services/bdd/suites/hip551/AtomicExchangeRateControlSuite.java are identical. We should consider further refactoring in a follow-up issue if necessary.