### PR TITLE
fix: Schedule KV state purges are not user state changes for `BlockUnitSplit` purposes

### DIFF
--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/schemas/V0570ScheduleSchema.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/schemas/V0570ScheduleSchema.java
@@ -24,12 +24,6 @@ import java.util.Set;
  * General schema for the schedule service.
  */
 public final class V0570ScheduleSchema extends Schema<SemanticVersion> {
-
-    private static final long MAX_SCHEDULED_COUNTS = 50_000L;
-    private static final long MAX_SCHEDULED_ORDERS = 50_000L;
-    private static final long MAX_SCHEDULED_USAGES = 50_000L;
-    private static final long MAX_SCHEDULE_ID_BY_EQUALITY = 50_000L;
-
     private static final SemanticVersion VERSION =
             SemanticVersion.newBuilder().major(0).minor(57).patch(0).build();
 
@@ -73,9 +67,6 @@ public final class V0570ScheduleSchema extends Schema<SemanticVersion> {
 
     public static final int SCHEDULE_ID_BY_EQUALITY_STATE_ID =
             StateKey.KeyOneOfType.SCHEDULESERVICE_I_SCHEDULE_ID_BY_EQUALITY.protoOrdinal();
-
-    public static final String SCHEDULE_ID_BY_EQUALITY_STATE_LABEL =
-            computeLabel(ScheduleService.NAME, SCHEDULE_ID_BY_EQUALITY_KEY);
 
     /**
      * Instantiates a new V0570 (version 0.57.0) schedule schema.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/RoleFreeBlockUnitSplit.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/RoleFreeBlockUnitSplit.java
@@ -6,6 +6,11 @@ import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_HINTS
 import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_PREPROCESSING_VOTES;
 import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_PROOF_KEY_SETS;
 import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_PROOF_VOTES;
+import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_SCHEDULED_COUNTS;
+import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_SCHEDULED_ORDERS;
+import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_SCHEDULED_USAGES;
+import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_SCHEDULES_BY_ID;
+import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_SCHEDULE_ID_BY_EQUALITY;
 import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_TRANSACTION_RECEIPTS;
 import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_WRAPS_MESSAGE_HISTORIES;
 import static com.hedera.hapi.node.base.HederaFunctionality.ATOMIC_BATCH;
@@ -73,7 +78,12 @@ public class RoleFreeBlockUnitSplit {
             STATE_ID_CRS_PUBLICATIONS.protoOrdinal(),
             STATE_ID_PROOF_KEY_SETS.protoOrdinal(),
             STATE_ID_PROOF_VOTES.protoOrdinal(),
-            STATE_ID_WRAPS_MESSAGE_HISTORIES.protoOrdinal());
+            STATE_ID_WRAPS_MESSAGE_HISTORIES.protoOrdinal(),
+            STATE_ID_SCHEDULES_BY_ID.protoOrdinal(),
+            STATE_ID_SCHEDULED_COUNTS.protoOrdinal(),
+            STATE_ID_SCHEDULE_ID_BY_EQUALITY.protoOrdinal(),
+            STATE_ID_SCHEDULED_ORDERS.protoOrdinal(),
+            STATE_ID_SCHEDULED_USAGES.protoOrdinal());
 
     private static final Set<HederaFunctionality> TRIGGERING_OPS = EnumSet.of(SCHEDULE_CREATE, SCHEDULE_SIGN);
 


### PR DESCRIPTION
**Description**:
 - C.f. [this failure](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/21923917110/job/63311933063?pr=23545)