### PR TITLE
ci(workflows): add new merge queue workflows to trigger various tests

### DIFF
--- a/.github/workflows/210-flow-merge-queue-controller.yaml
+++ b/.github/workflows/210-flow-merge-queue-controller.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 name: "210: [FLOW] Merge Queue Controller"
 on:
   push:
@@ -10,7 +11,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  trigger-xts-tests:
+  # Trigger the MQ XTS Tests
+  trigger-merge-queue-xts-tests:
     name: Merge Queue XTS Required Tests
     uses: ./.github/workflows/zxc-xts-tests.yaml
     with:
@@ -41,3 +43,8 @@ jobs:
       slack-api-token: ${{ secrets.PLATFORM_SLACK_API_TOKEN }}
       slack-citr-details-token: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
       slack-tck-report-webhook: ${{ secrets.SLACK_TCK_MONITOR_WEBHOOK }}
+
+  # Trigger the MQ Performance/Longevity Tests
+#  trigger-merge-queue-performance-longevity-tests:
+#    name: Merge Queue Performance/Longevity Tests
+#    uses: ./.github/workflows/zxc-performance-tests.yaml

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -36,5 +36,20 @@ merge:
     - "MATS / Docker Determinism / Docker: Verify Artifacts (hl-cn-docker-determinism-lin-lg)"
 
     # XTS Required Checks
+    - "Merge Queue XTS Required Tests / XTS Timing Sensitive Tests / Timing Sensitive Tests"
+    - "Merge Queue XTS Required Tests / XTS Hammer Tests / Hammer Tests"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (Time Consuming)"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (Misc)"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (Misc Records)"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (Crypto)"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (Simple Fees)"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (Token)"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (Smart Contracts)"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (BN Comms)"
+    - "Merge Queue XTS Required Tests / XTS HAPI Tests / HAPI Tests (Atomic Batch)"
+    - "Merge Queue XTS Required Tests / XTS Otter Tests / Full Otter Tests"
+    - "Merge Queue XTS Required Tests / XTS Chaos Otter Tests / Chaos Otter Tests"
+    - "Merge Queue XTS Required Tests / Hedera Node JRS Panel / Merge Queue XTS: Abbrev Update Test"
+    - "Merge Queue XTS Required Tests / SDK TCK Regression Panel / Merge Queue XTS: SDK TCK Regression"
 
     # Merge Queue Checks


### PR DESCRIPTION
**Description**:

Add a new Merge Queue workflow to trigger various tests in the merge queue before `main`.

**Related Issue(s)**:

Fixes #23542
