### PR TITLE
fix: disable CONCURRENT_SUBPROCESS_VALIDATION for testSubprocess

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -237,6 +237,7 @@ tasks.register<Test>("testSubprocess") {
                 "(${ciTagExpression})&!(EMBEDDED|REPEATABLE)"
             else "(${ciTagExpression}|STREAM_VALIDATION|LOG_VALIDATION)&!(EMBEDDED|REPEATABLE|ISS)"
         )
+        excludeTags("CONCURRENT_SUBPROCESS_VALIDATION")
     }
 
     // Choose a different initial port for each test task if running as PR check


### PR DESCRIPTION
**Description**:
Disabled CONCURRENT_SUBPROCESS_VALIDATION for testSubprocess.

Fixes #23582 #23578 #23579 

XTS: https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/21990460676