### PR TITLE
fix: 23600 `VirtualPipelineTests.mergeReleaseRace` test fix

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
@@ -734,10 +734,8 @@ class VirtualPipelineTests {
             copies.get(i).release();
         }
 
-        // Wait for a moment and let the pipeline catch up with all work
-        MILLISECONDS.sleep(20);
-
-        assertTrue(copies.get(3).isMerged(), "copy should be merged by now");
+        // Wait for the pipeline to catch up with all work
+        assertEventuallyTrue(() -> copies.get(3).isMerged(), Duration.ofSeconds(1), "copy should be merged by now");
         assertFalse(copies.get(4).isMerged(), "copy should not be merged");
 
         // The next time isMerged() is called on copy 4, it will release itself.


### PR DESCRIPTION
**Description**:

This PR improves the flaky test by replacing `sleep(20)` with a dynamic wait (`assertEventuallyTrue`).


**Related issue(s)**:

Fixes #23600 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
