### PR TITLE
fix: shadowJar duplicate class handling in swirlds-platform-core

### DIFF
--- a/platform-sdk/swirlds-platform-core/build.gradle.kts
+++ b/platform-sdk/swirlds-platform-core/build.gradle.kts
@@ -71,3 +71,9 @@ timingSensitiveModuleInfo {
     requires("org.hiero.consensus.metrics")
     requires("org.junit.jupiter.api")
 }
+
+tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
+    // runtimeClasspath currently re-introduces this module via a transitive cycle
+    // (through consensus-reconnect-impl), which can duplicate classes already in main output.
+    duplicatesStrategy = org.gradle.api.file.DuplicatesStrategy.EXCLUDE
+}


### PR DESCRIPTION
## Summary
- Set `:swirlds-platform-core:shadowJar` duplicates strategy to `EXCLUDE`.
- Prevent duplicate `CommandLineArgs.class` copy during shading.

## Root Cause
`shadowJar` consumed both:
- module output classes from `swirlds-platform-core`
- the module's own jar reintroduced on runtime classpath via `consensus-reconnect-impl`

This created duplicate entries and failed the release publish flow.

## Validation
- `./gradlew :swirlds-platform-core:shadowJar --no-configuration-cache`

## Impact
Unblocks the `releaseDevelopCommit` path that invokes `:swirlds-platform-core:shadowJar`.