### PR TITLE
fix: Add missing CIVILIAN_PAYER setup in Hip1313DisabledTest

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/hip1313/Hip1313DisabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/hip1313/Hip1313DisabledTest.java
@@ -9,6 +9,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThrottles;
 import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
@@ -32,6 +33,7 @@ public class Hip1313DisabledTest {
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         testLifecycle.overrideInClass(
                 Map.of("fees.simpleFeesEnabled", "false", "networkAdmin.highVolumeThrottlesEnabled", "false"));
+        testLifecycle.doAdhoc(cryptoCreate(CIVILIAN_PAYER).balance(ONE_MILLION_HBARS));
     }
 
     @HapiTest


### PR DESCRIPTION
Closes #23619

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
## Summary
- add `CIVILIAN_PAYER` setup in `Hip1313DisabledTest.beforeAll`
- align disabled HIP-1313 test setup with existing enabled test pattern

## Validation
- `./gradlew :test-clients:testSubprocess --tests 'com.hedera.services.bdd.suites.throttling.hip1313.Hip1313DisabledTest'`
- `./gradlew hapiTestSimpleFees hapiEmbeddedSimpleFees`

Closes #23619

**Related issue(s)**:

Fixes #23619

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
