### PR TITLE
build: remove unused platform-sdk "container" module

### DIFF
--- a/platform-sdk/build.gradle.kts
+++ b/platform-sdk/build.gradle.kts
@@ -1,5 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.module.application") }
-
-// Disable checkModuleDirectivesScope task if it exists
-afterEvaluate { tasks.findByName("checkModuleDirectivesScope")?.enabled = false }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,9 +5,6 @@ plugins {
 }
 
 javaModules {
-    // This "intermediate parent project" should be removed
-    module("platform-sdk") { artifact = "swirlds-platform" }
-
     // The Hedera API module
     directory("hapi") { group = "com.hedera.hashgraph" }
 


### PR DESCRIPTION
**Description**:

This was never a real module – in the sense of a Java Module that contains code and from which a Jar file is built.

This "module" was only used as a "container" for some copy/packaging tasks. Now, after #22720, this is no longer needed and we can remove this special case from the Gradle setup for good.

**Related issue(s)**:

Follow up to #22720

