### PR TITLE
ci(workflowS): Update step-security/publish-unit-test-result-action (v2.22.0)

### DIFF
--- a/.github/workflows/zxc-execute-hammer-tests.yaml
+++ b/.github/workflows/zxc-execute-hammer-tests.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Publish Hammer Test Report
         id: publish-test-report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: Hammer Test Results"
           json_thousands_separator: ","

--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -156,7 +156,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestMisc${{ inputs.mats-suffix }} --no-daemon && ${GRADLE_EXEC} hapiEmbeddedMisc${{ inputs.mats-suffix }} --no-daemon && ${GRADLE_EXEC} hapiRepeatableMisc${{ inputs.mats-suffix }} --no-daemon
 
       - name: Publish HAPI Test (Misc) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Misc) Results"
           json_thousands_separator: ","
@@ -221,7 +221,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestMiscRecords${{ inputs.mats-suffix }}
 
       - name: Publish HAPI Test (Misc Records) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Misc Records) Results"
           json_thousands_separator: ","
@@ -287,7 +287,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestCrypto --no-daemon && ${GRADLE_EXEC} hapiTestCryptoEmbedded --no-daemon && ${GRADLE_EXEC} hapiTestCryptoSerial --no-daemon
 
       - name: Publish HAPI Test (Crypto) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Crypto) Results"
           json_thousands_separator: ","
@@ -352,7 +352,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestSimpleFees${{ inputs.mats-suffix || '' }} && ${GRADLE_EXEC} hapiEmbeddedSimpleFees${{ inputs.mats-suffix }}
 
       - name: Publish HAPI Test (Simple Fees) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Simple Fees) Results"
           json_thousands_separator: ","
@@ -417,7 +417,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestToken${{ inputs.mats-suffix || '' }} --no-daemon
 
       - name: Publish HAPI Test (Token) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Token) Results"
           json_thousands_separator: ","
@@ -482,7 +482,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestSmartContract${{ inputs.mats-suffix || '' }}
 
       - name: Publish HAPI Test (Smart Contract) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Smart Contract) Results"
           json_thousands_separator: ","
@@ -547,7 +547,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestTimeConsuming
 
       - name: Publish HAPI Test (Time Consuming) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Time Consuming) Results"
           json_thousands_separator: ","
@@ -612,7 +612,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestRestart
 
       - name: Publish HAPI Test (Restart) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Restart) Results"
           json_thousands_separator: ","
@@ -677,7 +677,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestNDReconnect
 
       - name: Publish HAPI Test (Node Death Reconnect) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Node Death Reconnect) Results"
           json_thousands_separator: ","
@@ -742,7 +742,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestIss
 
       - name: Publish HAPI Test (ISS) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (ISS) Results"
           json_thousands_separator: ","
@@ -807,7 +807,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestBlockNodeCommunication
 
       - name: Publish HAPI Test (Block Node Communication) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Block Node Communication) Results"
           json_thousands_separator: ","
@@ -870,7 +870,7 @@ jobs:
         run: ${GRADLE_EXEC} hapiTestAtomicBatch${{ inputs.mats-suffix || '' }}
 
       - name: Publish HAPI Test (Atomic Batch) Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Atomic Batch) Results"
           json_thousands_separator: ","

--- a/.github/workflows/zxc-execute-integration-tests.yaml
+++ b/.github/workflows/zxc-execute-integration-tests.yaml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Publish Integration Test Report
         id: publish-test-report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: Integration Test Results"
           json_thousands_separator: ","

--- a/.github/workflows/zxc-execute-otter-tests.yaml
+++ b/.github/workflows/zxc-execute-otter-tests.yaml
@@ -105,7 +105,7 @@ jobs:
         run: ${GRADLE_EXEC} :consensus-otter-tests:testContainer
 
       - name: Publish Full Otter Testing Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         if: ${{ inputs.enable-full-otter-tests && !cancelled() }}
         with:
           check_name: "Node: Otter Tests Results"
@@ -158,7 +158,7 @@ jobs:
         run: ${GRADLE_EXEC} :consensus-otter-tests:testOtter
 
       - name: Publish Fast Otter Testing Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         if: ${{ inputs.enable-fast-otter-tests && !cancelled() }}
         with:
           check_name: "Node: Otter Tests Results"
@@ -219,7 +219,7 @@ jobs:
         run: ${GRADLE_EXEC} :consensus-otter-tests:testChaos
 
       - name: Publish Chaos Otter Testing Report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         if: ${{ inputs.enable-chaos-otter-tests && !cancelled() }}
         with:
           check_name: "Node: Chaos Otter Tests Result"

--- a/.github/workflows/zxc-execute-timing-sensitive-tests.yaml
+++ b/.github/workflows/zxc-execute-timing-sensitive-tests.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Publish Unit Test (Timing Sensitive) Report
         id: publish-test-report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: Timing Sensitive Unit Test Results"
           json_thousands_separator: ","

--- a/.github/workflows/zxc-execute-unit-tests.yaml
+++ b/.github/workflows/zxc-execute-unit-tests.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Publish Unit Test Report
         id: publish-unit-test-report
-        uses: step-security/publish-unit-test-result-action@5d195d4dec0b9fa7b51a3dbc4298362a021247c7 # v2.20.4
+        uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: Unit Test Results"
           json_thousands_separator: ","


### PR DESCRIPTION
## Description

This pull request updates the version of the `step-security/publish-unit-test-result-action` GitHub Action used to publish test reports across multiple workflow files. The action is upgraded from version `v2.20.4` to `v2.22.0` to ensure the latest features and bug fixes are included in the CI pipelines.

**CI workflow updates:**

* Upgraded `step-security/publish-unit-test-result-action` from `v2.20.4` to `v2.22.0` in the following workflows:
  - `.github/workflows/zxc-execute-hapi-tests.yaml` for all HAPI test report publishing steps [[1]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL159-R159) [[2]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL224-R224) [[3]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL290-R290) [[4]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL355-R355) [[5]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL420-R420) [[6]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL485-R485) [[7]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL550-R550) [[8]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL615-R615) [[9]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL680-R680) [[10]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL745-R745) [[11]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL810-R810) [[12]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL873-R873).
  - `.github/workflows/zxc-execute-otter-tests.yaml` for all Otter test report publishing steps [[1]](diffhunk://#diff-e83359651b7a0f9fedfafe8de2b1d59b6b29c2fb0a463ef504c1d384364c3c5cL108-R108) [[2]](diffhunk://#diff-e83359651b7a0f9fedfafe8de2b1d59b6b29c2fb0a463ef504c1d384364c3c5cL161-R161) [[3]](diffhunk://#diff-e83359651b7a0f9fedfafe8de2b1d59b6b29c2fb0a463ef504c1d384364c3c5cL222-R222).
  - `.github/workflows/zxc-execute-hammer-tests.yaml` for Hammer test report publishing.
  - `.github/workflows/zxc-execute-integration-tests.yaml` for Integration test report publishing.
  - `.github/workflows/zxc-execute-timing-sensitive-tests.yaml` for Timing Sensitive Unit test report publishing.
  - `.github/workflows/zxc-execute-unit-tests.yaml` for Unit test report publishing.

## Related Issue(s)

- Closes #23632 