### PR TITLE
ci(workflows): publish promote build candidate report to release team channel

### DIFF
--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -294,14 +294,6 @@ jobs:
           payload-templated: true
           payload: slack_payload.json
 
-      - name: Report Promoted Build (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload: slack_payload.json
-
   report-no-promotion:
     name: Report No Build Promotion
     runs-on: hl-cn-default-lin-sm


### PR DESCRIPTION
**Description**:

Publish the `promote build candidate` report slack message to the release team channel.

**Related Issue(s)**:

Implements #23641
