### PR TITLE
fix: 23646 - Fix logging formatted messages in hiero metrics

### DIFF
--- a/hiero-observability/hiero-metrics/src/main/java/org/hiero/metrics/core/Label.java
+++ b/hiero-observability/hiero-metrics/src/main/java/org/hiero/metrics/core/Label.java
@@ -22,6 +22,11 @@ public record Label(@NonNull String name, @NonNull String value) implements Comp
     }
 
     @Override
+    public String toString() {
+        return name + "=" + value;
+    }
+
+    @Override
     public int compareTo(Label other) {
         int nameCompare = name.compareTo(other.name);
         return nameCompare != 0 ? nameCompare : value.compareTo(other.value);

--- a/hiero-observability/hiero-metrics/src/main/java/org/hiero/metrics/core/MetricRegistry.java
+++ b/hiero-observability/hiero-metrics/src/main/java/org/hiero/metrics/core/MetricRegistry.java
@@ -55,14 +55,11 @@ public final class MetricRegistry implements Closeable {
             exporter.setSnapshotSupplier(snapshot::update);
             logger.log(
                     INFO,
-                    "Created metric registry with global labels {} and metrics exporter {}.",
+                    "Created metric registry. globalLabels={0}, exporter={1}",
                     this.globalLabels,
                     exporter.getClass());
         } else {
-            logger.log(
-                    INFO,
-                    "Created metric registry with global labels {} and without metrics exporter.",
-                    this.globalLabels);
+            logger.log(INFO, "Created metric registry. globalLabels={0}", this.globalLabels);
         }
     }
     /**
@@ -121,7 +118,7 @@ public final class MetricRegistry implements Closeable {
 
             M metric =
                     builder.addStaticLabels(globalLabels.toArray(Label[]::new)).build();
-            logger.log(DEBUG, "Registered metric: {}", metric.name());
+            logger.log(DEBUG, "Registered metric. name={0}", metric.name());
 
             snapshot.addMetricSnapshot(metric.snapshot());
 
@@ -174,7 +171,7 @@ public final class MetricRegistry implements Closeable {
     @Override
     public void close() throws IOException {
         if (exporter != null) {
-            logger.log(INFO, "Closing metrics exporter: {}", exporter.getClass());
+            logger.log(INFO, "Closing metrics exporter: {0}", exporter.getClass());
             exporter.close();
         }
     }
@@ -281,14 +278,14 @@ public final class MetricRegistry implements Closeable {
                 if (exporterDiscoveryDisabled != null && exporterDiscoveryDisabled) {
                     logger.log(
                             INFO,
-                            "Exporter discovery is disabled by configuration property: {}",
+                            "Exporter discovery is disabled by configuration property: {0}",
                             PROPERTY_EXPORT_DISCOVERY_DISABLED);
                 } else {
                     List<MetricsExporterFactory> factories = MetricUtils.load(MetricsExporterFactory.class);
                     if (factories.size() > 1) {
                         logger.log(
                                 WARNING,
-                                "Multiple metrics exporter factories found {}. "
+                                "Multiple metrics exporter factories found: {0}. "
                                         + "Expected at most one. Ignoring discovered exporter factories.",
                                 factories);
                     } else if (factories.size() == 1) {
@@ -299,7 +296,7 @@ public final class MetricRegistry implements Closeable {
                         if (exporter != null) {
                             this.metricsExporter = exporter;
                         } else {
-                            logger.log(INFO, "Exporter factory did not create an exporter: {}", factory.getClass());
+                            logger.log(INFO, "Exporter factory did not create an exporter: {0}", factory.getClass());
                         }
                     }
                 }
@@ -317,7 +314,7 @@ public final class MetricRegistry implements Closeable {
 
                 for (MetricsRegistrationProvider provider : providers) {
                     Objects.requireNonNull(provider, "metrics registration provider must not be null");
-                    logger.log(INFO, "Registering metrics from provider: {}", provider.getClass());
+                    logger.log(INFO, "Registering metrics from provider: {0}", provider.getClass());
 
                     Collection<Metric.Builder<?, ?>> metricsToRegister = provider.getMetricsToRegister();
                     Objects.requireNonNull(metricsToRegister, "metrics collection must not be null");

--- a/hiero-observability/hiero-metrics/src/test/java/org/hiero/metrics/core/MetricRegistryTest.java
+++ b/hiero-observability/hiero-metrics/src/test/java/org/hiero/metrics/core/MetricRegistryTest.java
@@ -93,7 +93,7 @@ public class MetricRegistryTest {
             assertThatThrownBy(() -> registry.register(
                             LongCounter.builder("test_counter").addStaticLabels(new Label("env", "production"))))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContainingAll("Label", "conflicts with existing", "env");
+                    .hasMessageContainingAll("conflicts with existing", "env");
         }
 
         @Test

--- a/hiero-observability/openmetrics-httpserver/src/main/java/org/hiero/metrics/openmetrics/OpenMetricsWriter.java
+++ b/hiero-observability/openmetrics-httpserver/src/main/java/org/hiero/metrics/openmetrics/OpenMetricsWriter.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.metrics.openmetrics;
 
+import static java.lang.System.Logger.Level.WARNING;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -24,6 +26,8 @@ import org.hiero.metrics.core.MetricType;
  * <p>See <a href="https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md">OpenMetrics</a> for details.
  */
 class OpenMetricsWriter {
+
+    private static final System.Logger logger = System.getLogger(OpenMetricsWriter.class.getName());
 
     private static final EnumMap<MetricType, byte[]> METRIC_TYPES = new EnumMap<>(MetricType.class);
     private static final byte[] UNKNOWN_TYPE = "unknown".getBytes(StandardCharsets.UTF_8);
@@ -80,11 +84,10 @@ class OpenMetricsWriter {
                 output.write(convertValue(doubleSnapshot.get()));
                 output.write(NEW_LINE);
             } else {
-                System.getLogger(getClass().getName())
-                        .log(
-                                System.Logger.Level.WARNING,
-                                "Skipping unsupported measurement snapshot type: "
-                                        + measurementSnapshot.getClass().getName());
+                logger.log(
+                        WARNING,
+                        "Skipping unsupported measurement snapshot type: {0}",
+                        measurementSnapshot.getClass().getName());
             }
         }
     }


### PR DESCRIPTION
`hiero-observability` modules use `System.Logger` to log messages, but formatting messages using `{}`.
Add argument indices (and optional formatting configurations where needed) to fix logging-formatted messages.

Fixes #23646 
