### PR TITLE
fix: increase query/txn op transient platform error sleep

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -232,7 +232,7 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
                 log.trace("{}retry count: {}", spec.logPrefix(), retryCount);
                 try {
                     // Use longer sleep for platform errors to allow recovery
-                    sleep(isTransientPlatformError ? 100 : 10);
+                    sleep(isTransientPlatformError ? 1000 : 10);
                 } catch (InterruptedException e) {
                     log.error("Interrupted while sleeping before retry");
                     throw new RuntimeException(e);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -298,7 +298,7 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
                 retryCount++;
                 try {
                     // Use longer sleep for platform errors to allow recovery
-                    sleep(isTransientPlatformError ? 100 : 10);
+                    sleep(isTransientPlatformError ? 1000 : 10);
                 } catch (InterruptedException e) {
                     log.error("Interrupted while sleeping before retry");
                     throw new RuntimeException(e);


### PR DESCRIPTION
**Description**:
Increases the transient platform error sleep in HAPI query and txn ops from 100ms to 1s. This doesn't introduce any sensible delays and stabilizes the tests further.

Fixes #23591