### PR TITLE
chore: Fix flaky HIP-1313 test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/hip1313/Hip1313EnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/hip1313/Hip1313EnabledTest.java
@@ -249,6 +249,9 @@ public class Hip1313EnabledTest {
         return highVolumeTxns.get().stream()
                 .filter(e -> e.body().getHighVolume())
                 .filter(additionalFilter)
+                // Expected multipliers are derived from utilization progression; process
+                // records in consensus order to avoid nondeterministic flakiness.
+                .sorted()
                 .toList();
     }
 


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/23653

Fixes flaky HIp-1313 test since the record stream entries are not sorted to compute throttle