### PR TITLE
ci(workflow-fix): update arg in slack message action

### DIFF
--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -292,7 +292,7 @@ jobs:
           webhook: ${{ secrets.SLACK_CITR_BUILD_PROMOTION_WEBHOOK }}
           webhook-type: incoming-webhook
           payload-templated: true
-          payload: slack_payload.json
+          payload-file-path: slack_payload.json
 
   report-no-promotion:
     name: Report No Build Promotion


### PR DESCRIPTION
**Description**:

Update the arg name in slack message action to `payload-file-path` instead of `payload` in the Promote Build Candidate successful section of the workflow.

**Related Issue(s)**:

Fixes #23706

