### PR TITLE
fix(bug): Codacy returns errcode 413 when publishing unit test aggregation results

### DIFF
--- a/.github/workflows/zxc-execute-unit-tests.yaml
+++ b/.github/workflows/zxc-execute-unit-tests.yaml
@@ -113,11 +113,12 @@ jobs:
           token: ${{ secrets.codecov-token }}
           files: gradle/aggregation/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
 
+      # Disable step while investigating Codacy upload failures (see #23737)
       - name: Publish to Codacy
         id: publish-codacy
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.codacy-project-token }}
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        if: ${{ false && !github.event.pull_request.head.repo.fork }}
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Java -r gradle/aggregation/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
 
       - name: Upload Test Reports


### PR DESCRIPTION
## Description

This pull request makes a small but important change to the CI workflow configuration. The step responsible for publishing test coverage reports to Codacy has been temporarily disabled while the team investigates upload failures.

* CI/CD workflow update:
  * [`.github/workflows/zxc-execute-unit-tests.yaml`](diffhunk://#diff-ab3f6d2febf24a642d640f391d2013ec737d9edc0027b4709423ee3b20f3d46cR116-R121): Disabled the "Publish to Codacy" step by setting its condition to always evaluate as false, referencing issue #23737.

## Related issue(s)

Relates to #23737 
