### PR TITLE
fix: FAIL_INVALID in CustomFeeAssesmentStep recursion fall back

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CustomFeeAssessmentStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CustomFeeAssessmentStep.java
@@ -33,6 +33,7 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.customfees.Custo
 import com.hedera.node.app.service.token.impl.handlers.transfer.customfees.CustomRoyaltyFeeAssessor;
 import com.hedera.node.app.service.token.impl.handlers.transfer.customfees.ItemizedAssessedFee;
 import com.hedera.node.app.spi.fees.FeeContext;
+import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.TokensConfig;
 import com.swirlds.base.utility.Pair;
@@ -209,7 +210,7 @@ public class CustomFeeAssessmentStep {
 
         if (levelNum > MAX_PLAUSIBLE_LEVEL_NUM) {
             log.error("Recursive charging exceeded maximum plausible depth for transaction {}", op);
-            throw new IllegalStateException("Custom fee charging exceeded max recursion depth");
+            throw new HandleException(CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH);
         }
 
         // If the last charging level assessed fees, we should include them for further steps of CryptoTransfer

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CustomFeeRecursionFallbackTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CustomFeeRecursionFallbackTest.java
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.crypto;
+
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
+import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
+
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.spec.SpecOperation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+
+@HapiTestLifecycle
+public class CustomFeeRecursionFallbackTest {
+    private static final String TREASURY = "treasury";
+    private static final String SENDER = "sender";
+    private static final String RECEIVER = "receiver";
+    private static final String COLLECTOR = "collector";
+
+    @LeakyHapiTest(overrides = {"tokens.maxCustomFeeDepth"})
+    @DisplayName("Fallback max plausible custom-fee recursion depth returns correct status")
+    final Stream<DynamicTest> fallbackMaxPlausibleCustomFeeDepthReturnsCorrectStatus() {
+        // We need maxCustomFeeDepth > MAX_PLAUSIBLE_LEVEL_NUM (=10) so the earlier guard doesn't fire first.
+        // Then we create a chain of 12 tokens where token[i] charges a fixed HTS fee in token[i+1].
+        final List<String> tokens =
+                IntStream.range(0, 12).mapToObj(i -> "FEE_CHAIN_TOKEN_" + i).toList();
+
+        final List<SpecOperation> ops = new ArrayList<>();
+        ops.add(overriding("tokens.maxCustomFeeDepth", "50"));
+
+        ops.add(cryptoCreate(TREASURY).balance(ONE_MILLION_HBARS));
+        ops.add(cryptoCreate(SENDER).balance(ONE_MILLION_HBARS));
+        ops.add(cryptoCreate(RECEIVER).balance(ONE_HUNDRED_HBARS));
+        ops.add(cryptoCreate(COLLECTOR).balance(0L));
+
+        // Create token[11] first (no fee), then token[10] charges in token[11], ..., token[0] charges in token[1]
+        ops.add(tokenCreate(tokens.get(11))
+                .treasury(TREASURY)
+                .tokenType(FUNGIBLE_COMMON)
+                .initialSupply(1_000_000L));
+        // The fee collector must be associated with any denominating token used in custom fees at token creation time
+        ops.add(tokenAssociate(COLLECTOR, tokens.get(11)));
+        for (int i = 10; i >= 0; i--) {
+            ops.add(tokenCreate(tokens.get(i))
+                    .treasury(TREASURY)
+                    .tokenType(FUNGIBLE_COMMON)
+                    .initialSupply(1_000_000L)
+                    .withCustom(fixedHtsFee(1, tokens.get(i + 1), COLLECTOR)));
+            // Ensure collector is associated with token[i] before it becomes the denom token for token[i-1]
+            ops.add(tokenAssociate(COLLECTOR, tokens.get(i)));
+        }
+
+        // Ensure the sender can pay fees at every level
+        ops.add(tokenAssociate(SENDER, tokens.toArray(String[]::new)));
+        ops.add(tokenAssociate(RECEIVER, tokens.get(0)));
+
+        // Fund the sender with balances for the base transfer and each fee denomination token
+        for (final var token : tokens) {
+            ops.add(cryptoTransfer(moving(100L, token).between(TREASURY, SENDER)));
+        }
+
+        // This transfer should recurse beyond MAX_PLAUSIBLE_LEVEL_NUM; the expected behavior is the dedicated status,
+        // not FAIL_INVALID via an unchecked exception.
+        ops.add(cryptoTransfer(moving(1L, tokens.get(0)).between(SENDER, RECEIVER))
+                .payingWith(SENDER)
+                .hasKnownStatus(CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH));
+
+        return hapiTest(flattened(ops));
+    }
+}


### PR DESCRIPTION
**Description**:
This pull request improves error handling for custom fee assessment recursion and adds a new test to ensure correct status reporting when the maximum plausible recursion depth is exceeded. The main changes are grouped into error handling improvements and new test coverage.

**Error handling improvements:**

* Changed the exception thrown when custom fee charging exceeds the maximum plausible recursion depth from `IllegalStateException` to a domain-specific `HandleException` with the appropriate status code `CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH` in `CustomFeeAssessmentStep.java`.
* Added the import for `HandleException` in `CustomFeeAssessmentStep.java` to support the new exception handling.

**Test coverage:**

* Added a new test suite `CustomFeeRecursionFallbackTest.java` that creates a chain of tokens with custom fees to deliberately trigger recursion beyond the maximum plausible level, verifying that the system returns the correct status code (`CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH`) instead of failing with an unchecked exception.

**Related issue(s)**:

Fixes #23769 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
