### PR TITLE
build: create and upload XML coverage reports in chunks

### DIFF
--- a/.github/workflows/zxc-execute-unit-tests.yaml
+++ b/.github/workflows/zxc-execute-unit-tests.yaml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Unit Testing
         id: gradle-test
-        run: ${GRADLE_EXEC} :aggregation:testCodeCoverageReport
+        run: ${GRADLE_EXEC} :aggregation:testCodeCoverageReportPartitioned
 
       - name: Publish Unit Test Report
         id: publish-unit-test-report
@@ -111,15 +111,14 @@ jobs:
         uses: codecov/codecov-action@5c47607acb93fed5485fdbf7232e8a31425f672a # v5.0.2
         with:
           token: ${{ secrets.codecov-token }}
-          files: gradle/aggregation/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+          directory: ./gradle/aggregation/build/reports/jacoco-xml
 
-      # Disable step while investigating Codacy upload failures (see #23737)
       - name: Publish to Codacy
         id: publish-codacy
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.codacy-project-token }}
-        if: ${{ false && !github.event.pull_request.head.repo.fork }}
-        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Java -r gradle/aggregation/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Java $(find gradle/aggregation/build/reports/jacoco-xml/*.xml -printf '-r %p ')
 
       - name: Upload Test Reports
         id: upload-test-reports

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -16,26 +16,79 @@ dependencies {
     implementation(project(":consensus-otter-tests"))
 }
 
+// HTML code coverage report containing complete repository coverage
 tasks.testCodeCoverageReport {
-    // Redo the setup done in 'JacocoReportAggregationPlugin', but gather the class files in the
-    // file tree and filter out selected classes by path.
-    val filteredClassFiles =
-        configurations.aggregateCodeCoverageReportResults
-            .get()
-            .incoming
-            .artifactView {
-                componentFilter { id -> id is ProjectComponentIdentifier }
-                attributes.attribute(
-                    LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-                    objects.named(LibraryElements.CLASSES),
+    reports {
+        html.required = true
+        xml.required = false
+    }
+    classDirectories.setFrom(filteredClassFiles())
+}
+
+// XML code coverage report split into multiple files for codacy and codecov upload
+val testCodeCoverageReportPartitioned = tasks.register("testCodeCoverageReportPartitioned")
+
+javaModuleDependencies.allLocalModules().forEach { module ->
+    val testCodeCoverageReportForModule =
+        tasks.register<JacocoReport>("testCodeCoverageReport_" + module.moduleName) {
+            reports {
+                html.required = false
+                xml.required = true
+                // use a naming pattern expected by codecov: jacoco*.xml
+                xml.outputLocation.set(
+                    layout.buildDirectory.file("reports/jacoco-xml/jacoco_${module.moduleName}.xml")
                 )
             }
-            .files
-            .asFileTree
-            .filter { file ->
-                listOf("test-clients", "testFixtures", "example-apps").none {
-                    file.path.contains(it)
-                }
-            }
-    classDirectories.setFrom(filteredClassFiles)
+            executionData.from(aggregatedExecutionData())
+            classDirectories.from(filteredClassFiles(module.projectPath))
+        }
+
+    testCodeCoverageReportPartitioned { dependsOn(testCodeCoverageReportForModule) }
 }
+
+// Redo the setup done in 'JacocoReportAggregationPlugin', but gather the class files in the
+// file tree and filter out selected classes by path.
+fun filteredClassFiles(projectPath: String? = null) =
+    configurations.aggregateCodeCoverageReportResults
+        .get()
+        .incoming
+        .artifactView {
+            componentFilter { id ->
+                id is ProjectComponentIdentifier &&
+                    (projectPath == null || projectPath == id.projectPath)
+            }
+            attributes.attribute(
+                LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+                objects.named(LibraryElements.CLASSES),
+            )
+        }
+        .files
+        .asFileTree
+        .filter { file ->
+            listOf("test-clients", "testFixtures", "example-apps").none { file.path.contains(it) }
+        }
+
+// execution data setup copied from
+// https://github.com/gradle/gradle/blob/afb1ef26efebbb52509e70d20bc89b8964f5daa0/platforms/jvm/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoReportAggregationPlugin.java#L109-L120
+@Suppress("UnstableApiUsage")
+fun aggregatedExecutionData() =
+    configurations.aggregateCodeCoverageReportResults
+        .get()
+        .incoming
+        .artifactView {
+            withVariantReselection()
+            componentFilter { id -> id is ProjectComponentIdentifier }
+            attributes {
+                attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.VERIFICATION))
+                attribute(TestSuiteName.TEST_SUITE_NAME_ATTRIBUTE, objects.named("test"))
+                attribute(
+                    VerificationType.VERIFICATION_TYPE_ATTRIBUTE,
+                    objects.named(VerificationType.JACOCO_RESULTS),
+                )
+                attribute(
+                    ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE,
+                    ArtifactTypeDefinition.BINARY_DATA_TYPE,
+                )
+            }
+        }
+        .files


### PR DESCRIPTION
**Description**:

Attempt to fix #23737 by letting Gradle produce one report XML per Java module. 

**Related issue(s)**:

Fixes #23737
