### PR TITLE
fix: ConcurrentModificationException in HapiSpecRegistry

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -43,17 +43,17 @@ import com.hederahashgraph.api.proto.java.TransactionID;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Function;
 
 public class HapiSpecRegistry {
-    private final Map<String, Object> registry = new HashMap<>();
+    private final Map<String, Object> registry = new ConcurrentHashMap<>();
     private final HapiSpecSetup setup;
-    private final Map<Class, List<RegistryChangeListener>> listenersByType = new HashMap<>();
+    private final Map<Class, List<RegistryChangeListener>> listenersByType = new ConcurrentHashMap<>();
 
     private static final Integer ZERO = 0;
 
@@ -152,7 +152,9 @@ public class HapiSpecRegistry {
 
     public void register(RegistryChangeListener<?> listener) {
         Class<?> type = listener.forType();
-        listenersByType.computeIfAbsent(type, ignore -> new ArrayList<>()).add(listener);
+        listenersByType
+                .computeIfAbsent(type, ignore -> new CopyOnWriteArrayList<>())
+                .add(listener);
     }
 
     public void saveContractChoice(String name, SupportedContract choice) {


### PR DESCRIPTION
**Description**:
HapiSpecRegistry uses plain HashMap and ArrayList for its internal state, but multiple test specs run concurrently (parallel.mode.default = concurrent) and share the same @BeforeAll registry via include(). The include() method calls HashMap.putAll() without synchronization, and register() mutates listenersByType without synchronization, creating race conditions that surface as flaky ConcurrentModificationException failures (e.g. TokenAirdropTest$InvalidAirdrops.airdropInvalidDecimals).

Switched registry and listenersByType to ConcurrentHashMap and CopyOnWriteArrayList respectively.

Fixes #23734