### PR TITLE
build: add (empty) module-info to benchmarks project

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-benchmarks/src/main/java/module-info.java
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0
+module com.swirlds.benchmarks {}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,10 +9,7 @@ javaModules {
     directory("hapi") { group = "com.hedera.hashgraph" }
 
     // The Hedera platform modules
-    directory("platform-sdk") {
-        group = "com.hedera.hashgraph"
-        module("swirlds-benchmarks") // not actually a Module as it has no module-info.java
-    }
+    directory("platform-sdk") { group = "com.hedera.hashgraph" }
 
     // The Hedera services modules
     directory("hedera-node") {


### PR DESCRIPTION
**Description**:

Let's add this to have the Gradle build automatically discover the benchmarks module, which allows us to remove the special case from `settings.gradle.kts`.