### PR TITLE
ci(workflow): update merge queue workflow permissions

### DIFF
--- a/.github/workflows/210-flow-merge-queue-controller.yaml
+++ b/.github/workflows/210-flow-merge-queue-controller.yaml
@@ -6,9 +6,12 @@ on:
       - trunk-merge/**
 
 permissions:
-  contents: read
   id-token: write
+  actions: write
   pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
 
 jobs:
   # Trigger the MQ XTS Tests


### PR DESCRIPTION
**Description**:

Update the merge queue controller permissions to match XTS Tests permissions.

**Related Issue(s)**:

Implements #23814
