### PR TITLE
feat: 23827: null metric snapshots when no exporter

### DIFF
--- a/hiero-observability/hiero-metrics/src/test/java/org/hiero/metrics/core/MetricRegistryTest.java
+++ b/hiero-observability/hiero-metrics/src/test/java/org/hiero/metrics/core/MetricRegistryTest.java
@@ -372,6 +372,20 @@ public class MetricRegistryTest {
     }
 
     @Test
+    void testNullSnapshotWhenNoExporter() {
+        MetricRegistry registry = MetricRegistry.builder().build();
+
+        LongCounter counter = registry.register(LongCounter.builder("test_counter"));
+        counter.getOrCreateNotLabeled().increment();
+
+        LongGauge gauge = registry.register(LongGauge.builder("test_gauge").addDynamicLabelNames("label"));
+        gauge.getOrCreateLabeled("label", "1").set(10);
+
+        MetricSnapshotVerifier.verifMetricHasNoSnapshot(counter);
+        MetricSnapshotVerifier.verifMetricHasNoSnapshot(gauge);
+    }
+
+    @Test
     void testConcurrentMetricsRegistrations() throws InterruptedException {
         MetricRegistry registry = MetricRegistry.builder().build();
 

--- a/hiero-observability/hiero-metrics/src/test/java/org/hiero/metrics/core/MetricSnapshotVerifier.java
+++ b/hiero-observability/hiero-metrics/src/test/java/org/hiero/metrics/core/MetricSnapshotVerifier.java
@@ -88,8 +88,16 @@ public class MetricSnapshotVerifier {
         }
     }
 
+    public static void verifMetricHasNoSnapshot(Metric metric) {
+        assertThat(metric.snapshot())
+                .as("Snapshot should be null for metric " + metric.name())
+                .isNull();
+    }
+
     public void verify() {
         MetricSnapshot snapshot = metric.snapshot();
+        assertThat(snapshot).isNotNull();
+
         snapshot.update();
 
         verify(snapshot);


### PR DESCRIPTION
Avoid creating and keeping reusable metric snapshot objects while no exporter is set for the metric registry.

Fixes #23827

