### PR TITLE
ci(fix-bug): remove yahcli step from node-zxc-build-release-artifact

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -584,22 +584,6 @@ jobs:
       jf-docker-registry: ${{ secrets.jf-docker-registry }}
       jf-access-token: ${{ secrets.jf-access-token }}
 
-  yahcli-image:
-    name: Publish Yahcli Image
-    uses: ./.github/workflows/zxc-publish-yahcli-image.yaml
-    needs:
-      - validate
-    with:
-      version: ${{ needs.validate.outputs.version }}
-      version-policy: ${{ inputs.version-policy }}
-      dry-run-enabled: ${{ inputs.dry-run-enabled }}
-      ref: ${{ needs.validate.outputs.commit-id }}
-      java-distribution: ${{ inputs.java-distribution }}
-      java-version: ${{ inputs.java-version }}
-      gradle-version: ${{ inputs.gradle-version }}
-    secrets:
-      access-token: ${{ secrets.access-token }}
-
   validate-production-image:
     name: Validate Production Image
     runs-on: hl-cn-default-lin-md


### PR DESCRIPTION
## Description

This pull request makes a change to the `.github/workflows/node-zxc-build-release-artifact.yaml` workflow configuration by removing the job responsible for publishing the Yahcli image. The workflow will no longer build and publish the Yahcli image as part of its release process. This job is intended to publish with each push of a tag in hiero-consensus-node (see #23558)

Workflow configuration update:

* Removed the `yahcli-image` job, which previously published the Yahcli image using the `.github/workflows/zxc-publish-yahcli-image.yaml` workflow. This includes eliminating all related inputs, dependencies, and secrets.

## Related Issue(s)

* Fixes #23860 
* Relates to #23558
