### PR TITLE
chore: Only use round timestamp for long-term schedules if *all* evts are empty

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -402,7 +402,9 @@ public class HandleWorkflow {
             final int receiptEntriesBatchSize,
             @NonNull final Consumer<ScopedSystemTransaction<StateSignatureTransaction>> stateSignatureTxnCallback) {
         boolean transactionsDispatched = false;
-        for (final var event : round) {
+        final var iter = round.iterator();
+        while (iter.hasNext()) {
+            final var event = iter.next();
             if (streamMode != RECORDS) {
                 writeEventHeader(event);
             }
@@ -437,9 +439,8 @@ public class HandleWorkflow {
                 // Clear tx metadata now that we won't use it again
                 platformTxn.setMetadata(null);
             }
-            if (!transactionsDispatched) {
-                // If there were no platform transactions to follow with scheduled transactions, then
-                // use the round consensus time as the execution start time for scheduled transactions
+            if (!transactionsDispatched && !iter.hasNext()) {
+                // If the entire round was empty, use the round consensus time as exec time for scheduled transactions
                 transactionsDispatched = executeScheduledTransactions(state, round.getConsensusTimestamp(), creator);
             }
             recordCache.maybeCommitReceiptsBatch(


### PR DESCRIPTION
**Description**:
 - Ensure using round timestamp for long-term scheduled txs doesn't "skip ahead" of later user txs.