### PR TITLE
ci(workflows-fix): Determinism checks failing python setup for debian (cp #23350)

### DIFF
--- a/.github/workflows/flow-artifact-determinism.yaml
+++ b/.github/workflows/flow-artifact-determinism.yaml
@@ -72,5 +72,6 @@ jobs:
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
       java-version: ${{ inputs.java-version || '21.0.6' }}
     secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
       gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}

--- a/.github/workflows/zxc-mats-tests.yaml
+++ b/.github/workflows/zxc-mats-tests.yaml
@@ -279,6 +279,7 @@ jobs:
       java-version: ${{ inputs.java-version || '21.0.6' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
     secrets:
+      github-token: ${{ secrets.access-token }}
       gradle-cache-username: ${{ secrets.gradle-cache-username }}
       gradle-cache-password: ${{ secrets.gradle-cache-password }}
 
@@ -294,6 +295,7 @@ jobs:
       java-version: ${{ inputs.java-version || '21.0.6' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
     secrets:
+      github-token: ${{ secrets.access-token }}
       gradle-cache-username: ${{ secrets.gradle-cache-username }}
       gradle-cache-password: ${{ secrets.gradle-cache-password }}
 

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -20,6 +20,9 @@ on:
         default: "21.0.6"
 
     secrets:
+      github-token:
+        description: "GitHub Token with permissions to checkout the repository."
+        required: true
       gradle-cache-username:
         description: "The username used to authenticate with the Gradle Build Cache Node."
         required: true
@@ -58,15 +61,18 @@ jobs:
       name: ${{ steps.baseline.outputs.name }}
 
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+      - name: Prepare Job
+        uses: pandaswhocode/initialize-github-job@a57cd6d8d768b2f3c95334bdd4fa8c21609fc651 # v1.0.5
         with:
-          egress-policy: audit
-
-      - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.ref }}
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-token: "${{ secrets.github-token }}"
+          checkout-fetch-depth: "1"
+          setup-java: "true"
+          java-distribution: "${{ inputs.java-distribution }}"
+          java-version: "${{ inputs.java-version }}"
+          setup-gradle: "true"
+          gradle-cache-read-only: "false"
 
       - name: Authenticate to Google Cloud
         id: google-auth
@@ -101,19 +107,6 @@ jobs:
           echo "path=${BASELINE_PATH}" >> "${GITHUB_OUTPUT}"
           echo "name=${BASELINE_NAME}" >> "${GITHUB_OUTPUT}"
           echo "file=${BASELINE_FILE}" >> "${GITHUB_OUTPUT}"
-
-      - name: Setup Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
-        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
-        with:
-          distribution: ${{ inputs.java-distribution }}
-          java-version: ${{ inputs.java-version }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
-        with:
-          cache-disabled: true
 
       - name: Install Skopeo and JQ
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
@@ -224,25 +217,35 @@ jobs:
           - hl-cn-docker-determinism-lin-u24-lg
           - hl-cn-docker-determinism-lin-d12-lg
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: audit
-
       - name: Standardize Git Line Endings
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Prepare Job
+        uses: pandaswhocode/initialize-github-job@a57cd6d8d768b2f3c95334bdd4fa8c21609fc651 # v1.0.5
         with:
-          ref: ${{ inputs.ref }}
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-token: "${{ secrets.github-token }}"
+          checkout-fetch-depth: "1"
+          setup-java: "true"
+          java-distribution: "${{ inputs.java-distribution }}"
+          java-version: "${{ inputs.java-version }}"
+          setup-gradle: "true"
+          gradle-cache-read-only: "false"
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      - name: Install Python (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends python3 python3-venv python3-pip
+
+      - name: Install Python
+        if: ${{ runner.os != 'Linux' }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - name: Install JQ (Linux)
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -20,6 +20,9 @@ on:
         default: "21.0.6"
 
     secrets:
+      github-token:
+        description: "GitHub Token with permissions to checkout the repository."
+        required: true
       gradle-cache-username:
         description: "The username used to authenticate with the Gradle Build Cache Node."
         required: true
@@ -52,26 +55,18 @@ jobs:
       file: ${{ steps.baseline.outputs.file }}
       name: ${{ steps.baseline.outputs.name }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+      - name: Prepare Job
+        uses: pandaswhocode/initialize-github-job@a57cd6d8d768b2f3c95334bdd4fa8c21609fc651 # v1.0.5
         with:
-          egress-policy: audit
-
-      - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ inputs.ref }}
-
-      - name: Setup Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
-        with:
-          distribution: ${{ inputs.java-distribution }}
-          java-version: ${{ inputs.java-version }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-        with:
-          cache-disabled: true
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-token: "${{ secrets.github-token }}"
+          checkout-fetch-depth: "1"
+          setup-java: "true"
+          java-distribution: "${{ inputs.java-distribution }}"
+          java-version: "${{ inputs.java-version }}"
+          setup-gradle: "true"
+          gradle-cache-read-only: "false"
 
       - name: Authenticate to Google Cloud
         id: google-auth
@@ -121,7 +116,7 @@ jobs:
         run: gsutil cp "${{ steps.manifest.outputs.file }}" "${{ steps.baseline.outputs.file }}"
 
   generate-matrix:
-    name: "Generate OS Matrix for Determinism Verification"
+    name: "Gradle: Generate OS Matrix"
     runs-on: hl-cn-gradle-determinism-lin-ss
     outputs:
       os-matrix: ${{ steps.set-matrix.outputs.os-matrix }}
@@ -182,36 +177,35 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.os-matrix) }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: audit
-
       - name: Standardize Git Line Endings
         run: |
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Prepare Job
+        uses: pandaswhocode/initialize-github-job@a57cd6d8d768b2f3c95334bdd4fa8c21609fc651 # v1.0.5
         with:
-          ref: ${{ inputs.ref }}
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-token: "${{ secrets.github-token }}"
+          checkout-fetch-depth: "1"
+          setup-java: "true"
+          java-distribution: "${{ inputs.java-distribution }}"
+          java-version: "${{ inputs.java-version }}"
+          setup-gradle: "true"
+          gradle-cache-read-only: "false"
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: 3.9
+      - name: Install Python (Linux)
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends python3 python3-venv python3-pip
 
-      - name: Setup Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+      - name: Install Python
+        if: ${{ runner.os != 'Linux' }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          distribution: ${{ inputs.java-distribution }}
-          java-version: ${{ inputs.java-version }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-        with:
-          cache-disabled: true
+          python-version: "3.12"
 
       - name: Setup CoreUtils (macOS)
         if: ${{ runner.os == 'macOS' }}


### PR DESCRIPTION
## Description

This pull request makes significant improvements to several GitHub Actions workflows by consolidating job setup steps, enhancing secrets management, and updating tool versions. The most notable change is the replacement of multiple manual setup steps with the reusable `pandaswhocode/initialize-github-job` action, which streamlines workflow configuration and reduces duplication. Additionally, secrets handling is improved for better security and flexibility, and Python setup is now OS-aware with updated versions.

**Workflow setup consolidation:**

* Replaced manual steps for code checkout, Java setup, and Gradle setup with the `pandaswhocode/initialize-github-job` action in both `zxc-verify-docker-build-determinism.yaml` and `zxc-verify-gradle-build-determinism.yaml`, simplifying job configuration and reducing duplication. [[1]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30L61-R75) [[2]](diffhunk://#diff-3f2b36b8f9b865d9ff7ceb4c00526eb0e783a4188038caabaca6fe377889e496L55-R69) [[3]](diffhunk://#diff-3f2b36b8f9b865d9ff7ceb4c00526eb0e783a4188038caabaca6fe377889e496L185-R208) [[4]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30L227-R248)

**Secrets management improvements:**

* Added a `github-token` secret to workflow inputs and job secrets for improved authentication and flexibility, replacing previous hardcoded usages and allowing for more secure repository access. [[1]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30R23-R25) [[2]](diffhunk://#diff-3f2b36b8f9b865d9ff7ceb4c00526eb0e783a4188038caabaca6fe377889e496R23-R25) [[3]](diffhunk://#diff-b1807573e6d897f28bb26228078cb9c90183cc56186bcf069fd2590c1e25e445R75) [[4]](diffhunk://#diff-6ead8440dd8e7b048efa5745d75500006f97146fd8f26c133fb6d8ec46f68584R282) [[5]](diffhunk://#diff-6ead8440dd8e7b048efa5745d75500006f97146fd8f26c133fb6d8ec46f68584R298)

**Tool setup and version updates:**

* Updated Python setup: now installs Python manually on Linux runners and uses the latest `actions/setup-python` version for non-Linux runners, ensuring consistent environments and upgrading to Python 3.12. [[1]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30L227-R248) [[2]](diffhunk://#diff-3f2b36b8f9b865d9ff7ceb4c00526eb0e783a4188038caabaca6fe377889e496L185-R208)
* Removed redundant and deprecated steps for runner hardening and tool setup, relying instead on centralized initialization and updated actions. [[1]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30L61-R75) [[2]](diffhunk://#diff-3f2b36b8f9b865d9ff7ceb4c00526eb0e783a4188038caabaca6fe377889e496L55-R69) [[3]](diffhunk://#diff-3f2b36b8f9b865d9ff7ceb4c00526eb0e783a4188038caabaca6fe377889e496L185-R208) [[4]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30L105-L117)

**Workflow naming and matrix generation:**

* Improved job naming and matrix generation for clarity in `zxc-verify-gradle-build-determinism.yaml`.

These changes collectively improve maintainability, security, and reliability of CI workflows.

## Related Issue(s)

#23350 
