### PR TITLE
chore: Fix BN XTS Regression Panel

### DIFF
--- a/.github/workflows/zxc-block-node-regression.yaml
+++ b/.github/workflows/zxc-block-node-regression.yaml
@@ -68,7 +68,7 @@ jobs:
             echo "No stable v*.*.* tags found."; exit 1
           fi
           echo "Latest stable tag: ${LATEST_STABLE}"
-          echo "CN_LATEST_TAG=v0.72.0-alpha.3" >> "$GITHUB_ENV"
+          echo "CN_LATEST_TAG=${LATEST_STABLE}" >> "$GITHUB_ENV"
 
       #  Checkout the block-node repository
       - name: Checkout Block-Node Code


### PR DESCRIPTION
**Description**:
Multiple version updates across solo, CN and BN have rendered the logic broken.

- Replace git repo checkout with REST call to retrieve latest BN version
- Remove hardcode MN version and replace with retrieve latest version
- Update BN protobuf retrieval labels and tar logic
- Update Solo CN logs retrieval logic

**Related issue(s)**:

Fixes #23861 

**Notes for reviewer**:
2 successful runs
- https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/22425498616/job/64934437378
- https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/22427007418/job/64938600073

Version pulls using github url was inspired by @AlfredoG87 work on BN support for Solo. I prefer it over having to checkout a repo and do nothing with it just because you want the version

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
