### PR TITLE
fix: Replace flaky receiptUnknownBeforeConsensus with unit test

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
@@ -150,7 +150,7 @@ public class NetworkAdminHandlerTestBase {
     protected RecordCacheImpl cache;
 
     @Mock
-    private DeduplicationCache dedupeCache;
+    protected DeduplicationCache dedupeCache;
 
     @Mock
     protected SavepointStackImpl stack;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TxnRecordRegression.java
@@ -22,7 +22,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSA
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECEIPT_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECORD_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNKNOWN;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.RepeatableHapiTest;
@@ -94,13 +93,6 @@ public class TxnRecordRegression {
                 // Run a transaction that will reach consensus at T+180 to purge receipts
                 cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
                 getReceipt("success").hasAnswerOnlyPrecheck(RECEIPT_NOT_FOUND));
-    }
-
-    @HapiTest
-    final Stream<DynamicTest> receiptUnknownBeforeConsensus() {
-        return hapiTest(
-                cryptoCreate("misc").via("success").balance(1_000L).deferStatusResolution(),
-                getReceipt("success").hasPriorityStatus(UNKNOWN));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
The HapiSpec test TxnRecordRegression.receiptUnknownBeforeConsensus was inherently racy - it relied on querying a receipt before consensus, but consensus timing is non-deterministic in subprocess concurrent mode.
Added a handler-level unit test that deterministically verifies the same behavior: when a transaction is in the dedup cache but has no consensus records, NetworkTransactionGetReceiptHandler returns UNKNOWN status.

Fixes #23856