### PR TITLE
chore: cherry-pick reject file append on files with empty key list (#23831)

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileAppendHandler.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/handlers/FileAppendHandler.java
@@ -9,7 +9,7 @@ import static com.hedera.node.app.service.file.impl.FileServiceImpl.THREE_MONTHS
 import static com.hedera.node.app.service.file.impl.utils.FileServiceUtils.preValidate;
 import static com.hedera.node.app.service.file.impl.utils.FileServiceUtils.validateAndAddRequiredKeys;
 import static com.hedera.node.app.service.file.impl.utils.FileServiceUtils.validateContent;
-import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
+import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -123,7 +123,7 @@ public class FileAppendHandler implements TransactionHandler {
         final var file = optionalFile.get();
 
         // First validate this file is mutable; and the pending mutations are allowed
-        validateFalse(file.keys() == null, UNAUTHORIZED);
+        validateTrue(file.hasKeys() && !file.keys().keys().isEmpty(), UNAUTHORIZED);
 
         if (file.deleted()) {
             throw new HandleException(FILE_DELETED);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileAppendSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileAppendSuite.java
@@ -13,10 +13,13 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sendModified;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedBodyIds;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedQueryIds;
+import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_FILE_SIZE_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.spec.keys.SigControl;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -76,6 +79,23 @@ public class FileAppendSuite {
                 fileCreate("file").contents(BYTES_3K_MINUS1),
                 fileAppend("file").content(BYTES_1),
                 fileAppend("file").content(BYTES_1).hasKnownStatus(MAX_FILE_SIZE_EXCEEDED));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> cannotAppendToImmutableFile() {
+        final String file1 = "FILE_1";
+        final String file2 = "FILE_2";
+        return hapiTest(
+                fileCreate(file1).contents("Hello World").unmodifiable(),
+                fileCreate(file2).contents("Hello World").waclShape(SigControl.emptyList()),
+                fileAppend(file1)
+                        .content("Goodbye World")
+                        .signedBy(DEFAULT_PAYER)
+                        .hasKnownStatus(UNAUTHORIZED),
+                fileAppend(file2)
+                        .content("Goodbye World")
+                        .signedBy(DEFAULT_PAYER)
+                        .hasKnownStatus(UNAUTHORIZED));
     }
 
     private final int BYTES_4K = 4 * (1 << 10);


### PR DESCRIPTION
(cherry picked from commit 1a7df341dc61b264a1a12839db9569d3cd4bf19b)

XTS - https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/22451507943