### PR TITLE
fix: 23930 `apply-block` shouldn't fail fast on hash mismatch

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -136,11 +136,6 @@ public class BlockStreamRecoveryWorkflow {
         state.getHash();
         final var rootHash = requireNonNull(state.getHash()).getBytes();
 
-        if (!expectedRootHash.isEmpty() && !expectedRootHash.equals(rootHash.toString())) {
-            throw new RuntimeException("Excepted and actual hashes do not match. \n Expected: %s \n Actual: %s "
-                    .formatted(expectedRootHash, rootHash));
-        }
-
         final SignedState signedState = new SignedState(
                 platformContext.getConfiguration(),
                 ConsensusCryptoUtils::verifySignature,
@@ -158,6 +153,11 @@ public class BlockStreamRecoveryWorkflow {
                     platformContext, selfId, outputPath, signedState, stateLifecycleManager);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+
+        if (!expectedRootHash.isEmpty() && !expectedRootHash.equals(rootHash.toString())) {
+            throw new RuntimeException("Excepted and actual hashes do not match. \n Expected: %s \n Actual: %s "
+                    .formatted(expectedRootHash, rootHash));
         }
     }
 


### PR DESCRIPTION
**Description**:

Once this PR is merged, `apply-block` will save a resulting state and only then fail on hash mismatch

**Related issue(s)**:

Fixes #23930 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
