### PR TITLE
chore: Update network node base dockerfile for wrapped record hashes file

### DIFF
--- a/hedera-node/infrastructure/docker/containers/production/network-node-base/Dockerfile
+++ b/hedera-node/infrastructure/docker/containers/production/network-node-base/Dockerfile
@@ -92,6 +92,7 @@ RUN mkdir -p "/opt/hgcapp" && \
     mkdir -p "/opt/hgcapp/eventsStreams" && \
     mkdir -p "/opt/hgcapp/recordStreams" && \
     mkdir -p "/opt/hgcapp/blockStreams" && \
+    mkdir -p "/opt/hgcapp/wrappedRecordHashes" && \
     mkdir -p "/opt/hgcapp/services-hedera" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data" && \
@@ -122,6 +123,7 @@ VOLUME "/opt/hgcapp/accountBalances"
 VOLUME "/opt/hgcapp/eventsStreams"
 VOLUME "/opt/hgcapp/recordStreams"
 VOLUME "/opt/hgcapp/blockStreams"
+VOLUME "/opt/hgcapp/wrappedRecordHashes"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/config"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/diskFs"
 VOLUME "/opt/hgcapp/services-hedera/HapiApp2.0/data/keys"


### PR DESCRIPTION
**Description**:
This pull request makes a small update to the Docker setup for the network node base image. It adds support for a new directory and volume to handle wrapped record hashes.

* Dockerfile updates:
  * Added creation of the `/opt/hgcapp/wrappedRecordHashes` directory to the image build process (`hedera-node/infrastructure/docker/containers/production/network-node-base/Dockerfile`).
  * Declared `/opt/hgcapp/wrappedRecordHashes` as a Docker volume for persistent storage.

**Related issue(s)**:

Fixes #23940

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
