### PR TITLE
refactor(clpr): add LedgerIdentityChangeListener and fix state proof bug

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/LedgerIdentityChangeListener.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/LedgerIdentityChangeListener.java
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.spi;
+
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.state.State;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Instant;
+
+/**
+ * A listener notified whenever the ledger's identity changes (roster adoption or ledger ID change),
+ * but only when both the active roster and ledger ID are available.
+ *
+ * <p>Any {@link RpcService} implementing this interface is automatically discovered and called
+ * by the framework when the ledger identity changes.
+ */
+public interface LedgerIdentityChangeListener {
+    /**
+     * Called when the ledger identity changes and both the active roster and ledger ID are available.
+     *
+     * @param activeRoster the current active roster
+     * @param ledgerId the current ledger ID
+     * @param consensusTime the consensus time of the change
+     * @param state the current state for direct writes
+     */
+    void onLedgerIdentityChanged(
+            @NonNull Roster activeRoster, @NonNull Bytes ledgerId, @NonNull Instant consensusTime, @NonNull State state);
+}

--- a/hedera-node/hiero-clpr-interledger-service-impl/src/main/java/org/hiero/interledger/clpr/impl/ClprStateProofManager.java
+++ b/hedera-node/hiero-clpr-interledger-service-impl/src/main/java/org/hiero/interledger/clpr/impl/ClprStateProofManager.java
@@ -248,10 +248,28 @@ public class ClprStateProofManager {
             throw new IllegalStateException("Unable to build Merkle proofs from a non-VirtualMap state");
         }
 
+        final var tssSigBytes = snapshot.tssSignature();
+        if (tssSigBytes == null || Objects.equals(tssSigBytes, Bytes.EMPTY)) {
+            throw new IllegalStateException("TSS signature is missing or invalid");
+        }
+
+        final var blockTimestamp = snapshot.blockTimestamp();
+        if (blockTimestamp == null || Objects.equals(blockTimestamp, Timestamp.DEFAULT)) {
+            throw new IllegalStateException("Block timestamp is missing or invalid");
+        }
+
+        final var path = snapshot.path();
+        if (path == null || Objects.equals(path, MerklePath.DEFAULT) || !path.hasHash()) {
+            throw new IllegalStateException("Merkle path is missing or invalid");
+        }
+
         return buildMerkleStateProof(
                 virtualMapState,
                 V0700ClprSchema.CLPR_MESSAGE_QUEUE_METADATA_STATE_ID,
-                ClprLedgerId.PROTOBUF.toBytes(ledgerId));
+                ClprLedgerId.PROTOBUF.toBytes(ledgerId),
+                tssSigBytes,
+                blockTimestamp,
+                path);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Add `LedgerIdentityChangeListener` SPI interface for decoupling ledger identity change notifications from specific service implementations
- Fix compilation error in `ClprStateProofManager.getMessageQueueMetadata` where `buildMerkleStateProof` was called with 3 arguments instead of the required 6

## Context
The original refinement commits from the previous base branch (23653) were largely superseded by upstream changes on `20111-clpr-prototype` (state proofs, message queues, middleware integration). The rename from "Set" to "AdoptRemote" and other refactorings no longer apply cleanly to the evolved codebase.

## Test plan
- [x] `./gradlew assemble` compiles successfully
- [ ] Existing CLPR unit tests pass
- [ ] No regressions in CLPR integration tests (`ClprSuite`)