### PR TITLE
fix: Open the `ivy` package to `info.picocli`

### DIFF
--- a/hedera-node/yahcli/src/main/java/module-info.java
+++ b/hedera-node/yahcli/src/main/java/module-info.java
@@ -18,6 +18,8 @@ module com.hedera.node.yahcli {
             info.picocli;
     opens com.hedera.services.yahcli.commands.nodes to
             info.picocli;
+    opens com.hedera.services.yahcli.commands.ivy to
+            info.picocli;
 
     exports com.hedera.services.yahcli.config.domain;
     exports com.hedera.services.yahcli.config;


### PR DESCRIPTION
Fixes a yahcli `ivy` module error