### PR TITLE
feat: Add full saturation for no block nodes case

### DIFF
--- a/hedera-node/docs/design/app/blocks/BlockBufferService.md
+++ b/hedera-node/docs/design/app/blocks/BlockBufferService.md
@@ -30,6 +30,8 @@ produced by a given consensus node in an ordered manner.
 - Maintains an internal buffer of blocks with timestamps for acknowledgment tracking.
 - Periodically prunes acknowledged blocks exceeding the TTL to maintain buffer size and resource efficiency.
 - Calculates buffer saturation as a percentage of ideal max buffer size derived from TTL and block period.
+- In `BLOCKS` stream mode with `GRPC` writer mode, treats saturation as `100%` when block-node configuration has
+  been evaluated but no usable block nodes are available.
 - Activates or deactivates backpressure based on saturation status, coordinating with blocking futures to manage flow control.
 
 ## Component Interaction
@@ -54,6 +56,20 @@ The system maintains a buffer of block states in `BlockBufferService` with the f
 - Entries remain in the buffer until acknowledged and expired, according to a configurable TTL (Time To Live).
 - A periodic pruning mechanism removes acknowledged and expired entries.
 - The buffer size is monitored to apply backpressure when needed.
+
+### Special Saturation Rule: `BLOCKS` + `GRPC`
+
+When running in `blockStream.streamMode=BLOCKS` and `blockStream.writerMode=GRPC`, the buffer service applies a
+special saturation rule tied to block-node configuration availability:
+
+- Before block-node configuration has been evaluated at least once, saturation is calculated normally.
+- After evaluation, if there are no usable block-node configurations (for example, `block-nodes.json` is empty or
+  unparsable), saturation is forced to `100%`.
+- If usable block-node configurations are present, saturation uses the normal calculation.
+
+This behavior ensures startup does not prematurely trigger full saturation before the connection manager has attempted
+to load block-node configurations, while still applying immediate backpressure semantics once configuration state is
+known.
 
 ### Buffer State
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
@@ -10,6 +10,7 @@ import com.hedera.node.app.metrics.BlockStreamMetrics;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockBufferConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.node.config.types.BlockStreamWriterMode;
 import com.hedera.node.config.types.StreamMode;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -122,6 +123,15 @@ public class BlockBufferService {
      * Flag indicating if the buffer service has been started.
      */
     private final AtomicBoolean isStarted = new AtomicBoolean(false);
+    /**
+     * Indicates whether block-node configuration has been evaluated at least once by the
+     * {@link BlockNodeConnectionManager}. Until this is true, saturation is calculated normally.
+     */
+    private final AtomicBoolean hasEvaluatedBlockNodeConfigs = new AtomicBoolean(false);
+    /**
+     * Indicates whether the last observed block-node configuration contained at least one usable block node.
+     */
+    private final AtomicBoolean hasUsableBlockNodeConfigs = new AtomicBoolean(true);
 
     /**
      * Creates a new BlockBufferService with the given configuration.
@@ -301,6 +311,17 @@ public class BlockBufferService {
     public void setBlockNodeConnectionManager(@NonNull final BlockNodeConnectionManager blockNodeConnectionManager) {
         this.blockNodeConnectionManager =
                 requireNonNull(blockNodeConnectionManager, "blockNodeConnectionManager must not be null");
+    }
+
+    /**
+     * Updates whether block-node configurations have been evaluated and whether there are any usable block nodes.
+     *
+     * @param hasEvaluated true if block-node config loading/parsing has been attempted at least once
+     * @param hasUsable true if at least one usable block node is available from the last evaluation
+     */
+    public void updateBlockNodeConfigAvailability(final boolean hasEvaluated, final boolean hasUsable) {
+        hasEvaluatedBlockNodeConfigs.set(hasEvaluated);
+        hasUsableBlockNodeConfigs.set(hasUsable);
     }
 
     /**
@@ -627,14 +648,30 @@ public class BlockBufferService {
         blockStreamMetrics.recordBufferOldestBlock(newEarliestBlock == Long.MIN_VALUE ? -1 : newEarliestBlock);
         blockStreamMetrics.recordBufferNewestBlock(newLatestBlock);
 
-        return new PruneResult(maxBufferSize, numChecked, numPendingAck, numPruned, newEarliestBlock, newLatestBlock);
+        return new PruneResult(
+                maxBufferSize,
+                numChecked,
+                numPendingAck,
+                numPruned,
+                newEarliestBlock,
+                newLatestBlock,
+                shouldForceSaturationDueToMissingBlockNodes());
+    }
+
+    private boolean shouldForceSaturationDueToMissingBlockNodes() {
+        final BlockStreamConfig blockStreamConfig =
+                configProvider.getConfiguration().getConfigData(BlockStreamConfig.class);
+        return blockStreamConfig.streamMode() == StreamMode.BLOCKS
+                && blockStreamConfig.writerMode() == BlockStreamWriterMode.GRPC
+                && hasEvaluatedBlockNodeConfigs.get()
+                && !hasUsableBlockNodeConfigs.get();
     }
 
     /**
      * Simple class that contains information related to the outcome of the buffer pruning.
      */
     static class PruneResult {
-        static final PruneResult NIL = new PruneResult(0, 0, 0, 0, 0, 0);
+        static final PruneResult NIL = new PruneResult(0, 0, 0, 0, 0, 0, false);
 
         final long idealMaxBufferSize;
         final int numBlocksChecked;
@@ -651,7 +688,8 @@ public class BlockBufferService {
                 final int numBlocksPendingAck,
                 final int numBlocksPruned,
                 final long oldestBlockNumber,
-                final long newestBlockNumber) {
+                final long newestBlockNumber,
+                final boolean forceSaturation) {
             this.idealMaxBufferSize = idealMaxBufferSize;
             this.numBlocksChecked = numBlocksChecked;
             this.numBlocksPendingAck = numBlocksPendingAck;
@@ -659,16 +697,21 @@ public class BlockBufferService {
             this.oldestBlockNumber = oldestBlockNumber;
             this.newestBlockNumber = newestBlockNumber;
 
-            isSaturated = idealMaxBufferSize != 0 && numBlocksPendingAck >= idealMaxBufferSize;
-
-            if (idealMaxBufferSize == 0) {
-                saturationPercent = 0D;
+            if (forceSaturation) {
+                isSaturated = true;
+                saturationPercent = 100.0D;
             } else {
-                final BigDecimal size = BigDecimal.valueOf(idealMaxBufferSize);
-                final BigDecimal pending = BigDecimal.valueOf(numBlocksPendingAck);
-                saturationPercent = pending.divide(size, 6, RoundingMode.HALF_EVEN)
-                        .multiply(BigDecimal.valueOf(100))
-                        .doubleValue();
+                isSaturated = idealMaxBufferSize != 0 && numBlocksPendingAck >= idealMaxBufferSize;
+
+                if (idealMaxBufferSize == 0) {
+                    saturationPercent = 0D;
+                } else {
+                    final BigDecimal size = BigDecimal.valueOf(idealMaxBufferSize);
+                    final BigDecimal pending = BigDecimal.valueOf(numBlocksPendingAck);
+                    saturationPercent = pending.divide(size, 6, RoundingMode.HALF_EVEN)
+                            .multiply(BigDecimal.valueOf(100))
+                            .doubleValue();
+                }
             }
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -862,6 +862,7 @@ public class BlockNodeConnectionManager {
     private void refreshAvailableBlockNodes() {
         final String configDir = blockNodeConfigDirectory.toString();
         final List<BlockNodeConfiguration> newConfigs = extractBlockNodesConfigurations(configDir);
+        blockBufferService.updateBlockNodeConfigAvailability(true, !newConfigs.isEmpty());
 
         // Compare new configs with existing ones to determine if a restart is needed
         synchronized (availableBlockNodes) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
@@ -818,6 +818,82 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
+    void testNoUsableBlockNodesForcesSaturationOnlyAfterConfigEvaluatedForGrpcInBlocksMode() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", BlockStreamWriterMode.GRPC)
+                .withValue("blockStream.streamMode", StreamMode.BLOCKS)
+                .withValue("blockStream.buffer.maxBlocks", 10)
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+        blockBufferService.openBlock(1L);
+        blockBufferService.closeBlock(1L);
+
+        reset(blockStreamMetrics, connectionManager);
+
+        checkBufferHandle.invoke(blockBufferService);
+        assertThat(lastPruningResult(blockBufferService).isSaturated).isFalse();
+        assertThat(lastPruningResult(blockBufferService).saturationPercent).isEqualTo(10.0D);
+        verify(blockStreamMetrics).recordBufferSaturation(10.0D);
+        verify(blockStreamMetrics).recordBackPressureDisabled();
+        verify(blockStreamMetrics).recordNumberOfBlocksPruned(0);
+        verify(blockStreamMetrics).recordBufferOldestBlock(1L);
+        verify(blockStreamMetrics).recordBufferNewestBlock(1L);
+        verifyNoMoreInteractions(connectionManager);
+        verifyNoMoreInteractions(blockStreamMetrics);
+
+        reset(blockStreamMetrics, connectionManager);
+        blockBufferService.updateBlockNodeConfigAvailability(true, false);
+
+        checkBufferHandle.invoke(blockBufferService);
+        assertThat(lastPruningResult(blockBufferService).isSaturated).isTrue();
+        assertThat(lastPruningResult(blockBufferService).saturationPercent).isEqualTo(100.0D);
+        verify(blockStreamMetrics).recordBufferSaturation(100.0D);
+        verify(blockStreamMetrics).recordBackPressureActive();
+        verify(blockStreamMetrics).recordNumberOfBlocksPruned(0);
+        verify(blockStreamMetrics).recordBufferOldestBlock(1L);
+        verify(blockStreamMetrics).recordBufferNewestBlock(1L);
+        verify(connectionManager).selectNewBlockNodeForStreaming(true);
+        verifyNoMoreInteractions(connectionManager);
+        verifyNoMoreInteractions(blockStreamMetrics);
+    }
+
+    @Test
+    void testNoUsableBlockNodesDoesNotForceSaturationForFileAndGrpcWriterMode() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", BlockStreamWriterMode.FILE_AND_GRPC)
+                .withValue("blockStream.streamMode", StreamMode.BLOCKS)
+                .withValue("blockStream.buffer.maxBlocks", 10)
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+        blockBufferService.openBlock(1L);
+        blockBufferService.closeBlock(1L);
+        blockBufferService.updateBlockNodeConfigAvailability(true, false);
+
+        reset(blockStreamMetrics, connectionManager);
+        checkBufferHandle.invoke(blockBufferService);
+
+        assertThat(lastPruningResult(blockBufferService).isSaturated).isFalse();
+        assertThat(lastPruningResult(blockBufferService).saturationPercent).isEqualTo(10.0D);
+        verify(blockStreamMetrics).recordBufferSaturation(10.0D);
+        verify(blockStreamMetrics).recordBackPressureDisabled();
+        verify(blockStreamMetrics).recordNumberOfBlocksPruned(0);
+        verify(blockStreamMetrics).recordBufferOldestBlock(1L);
+        verify(blockStreamMetrics).recordBufferNewestBlock(1L);
+        verifyNoMoreInteractions(connectionManager);
+        verifyNoMoreInteractions(blockStreamMetrics);
+    }
+
+    @Test
     void testOpenBlock_streamingDisabled() {
         when(configProvider.getConfiguration()).thenReturn(versionedConfiguration);
         when(blockBufferConfig.bufferDirectory()).thenReturn(testDir);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -1523,6 +1523,54 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
+    void testRefreshAvailableBlockNodesUpdatesBufferAvailabilityWhenConfigInvalid() throws Exception {
+        blockNodeConfigDirectoryHandle.set(connectionManager, tempDir);
+        final Path file = tempDir.resolve("block-nodes.json");
+        Files.writeString(file, "not-json", StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+
+        invoke_refreshAvailableBlockNodes();
+
+        verify(bufferService).updateBlockNodeConfigAvailability(true, false);
+    }
+
+    @Test
+    void testRefreshAvailableBlockNodesUpdatesBufferAvailabilityWhenConfigValid() throws Exception {
+        blockNodeConfigDirectoryHandle.set(connectionManager, tempDir);
+        final Path file = tempDir.resolve("block-nodes.json");
+        final List<BlockNodeConfig> configs = new ArrayList<>();
+        configs.add(BlockNodeConfig.newBuilder()
+                .address(PBJ_UNIT_TEST_HOST)
+                .streamingPort(8080)
+                .servicePort(8081)
+                .priority(0)
+                .build());
+        final BlockNodeConnectionInfo connectionInfo = new BlockNodeConnectionInfo(configs);
+        Files.writeString(
+                file,
+                BlockNodeConnectionInfo.JSON.toJSON(connectionInfo),
+                StandardCharsets.UTF_8,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING);
+
+        doReturn(100L).when(bufferService).getEarliestAvailableBlockNumber();
+        doReturn(200L).when(bufferService).getLastBlockNumberProduced();
+        doAnswer(invocation -> {
+                    final List<RetrieveBlockNodeStatusTask> tasks = invocation.getArgument(0);
+                    final List<CompletableFuture<BlockNodeStatus>> futures = new ArrayList<>();
+                    for (int i = 0; i < tasks.size(); ++i) {
+                        futures.add(completedFuture(reachable(10, 99)));
+                    }
+                    return futures;
+                })
+                .when(blockingIoExecutor)
+                .invokeAll(anyList(), anyLong(), any(TimeUnit.class));
+
+        invoke_refreshAvailableBlockNodes();
+
+        verify(bufferService).updateBlockNodeConfigAvailability(true, true);
+    }
+
+    @Test
     void testRefreshAvailableBlockNodes_shutsDownExecutorAndReloads_whenValid() throws Exception {
         // Point manager at real bootstrap config directory so reload finds valid JSON
         final var configPath = Objects.requireNonNull(


### PR DESCRIPTION
**Description**:
This pull request introduces a new rule for buffer saturation in the `BlockBufferService` when running in `BLOCKS` stream mode with the `GRPC` writer mode. Specifically, if block-node configuration has been evaluated and no usable block nodes are available, the buffer is considered fully saturated (100%), which triggers backpressure. The implementation includes updates to the service logic, integration with the connection manager, and new tests to verify this behavior.

**Buffer Saturation Logic Enhancements:**

* Added logic in `BlockBufferService` to track whether block-node configuration has been evaluated and if any usable block nodes are available, using new atomic flags. Saturation is now forced to 100% (full backpressure) in `BLOCKS` + `GRPC` mode after config evaluation if no block nodes are usable.
* Updated the documentation in `BlockBufferService.md` to describe the new saturation rule and its rationale, clarifying behavior during startup and after configuration evaluation.

**Integration with Block Node Connection Manager:**

* Modified `BlockNodeConnectionManager` to notify `BlockBufferService` whenever block-node configurations are (re)evaluated, passing whether any usable nodes are present.

**Testing and Validation:**

* Added new unit tests in `BlockBufferServiceTest` to confirm that saturation is only forced to 100% in the correct mode and only after configuration has been evaluated, and that other writer modes are unaffected.
* Added tests in `BlockNodeConnectionManagerTest` to verify that buffer availability is updated correctly for both valid and invalid block-node configurations.

**Related issue(s)**:

Fixes #23977 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
