### PR TITLE
fix: Remove log error in CustomFeeAssessmentStep

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CustomFeeAssessmentStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CustomFeeAssessmentStep.java
@@ -209,7 +209,6 @@ public class CustomFeeAssessmentStep {
         } while (!tokenTransfers.isEmpty() && levelNum <= MAX_PLAUSIBLE_LEVEL_NUM);
 
         if (levelNum > MAX_PLAUSIBLE_LEVEL_NUM) {
-            log.error("Recursive charging exceeded maximum plausible depth for transaction {}", op);
             throw new HandleException(CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH);
         }
 


### PR DESCRIPTION
**Description**:
This pull request makes a small change to the error handling logic in the custom fee assessment process. The main update is the removal of an error log message when the recursive charging exceeds the maximum plausible depth.

* Removed the `log.error` statement from the `assessFees` method in `CustomFeeAssessmentStep.java`, so exceeding the recursion depth now only throws an exception without logging an error message.

**Related issue(s)**:

Fixes #23769 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
