### PR TITLE
chore: Use wrapper instead of pure repeatable for HIP-1137 (#23908)

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/node_update.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/node_update.proto
@@ -174,12 +174,29 @@ message NodeUpdateTransactionBody {
      * HIP-1137) that are operated by the same entity that operates this
      * consensus node.
      * <p>
-     * This field is OPTIONAL and MAY be empty.<br/>
+     * This field is OPTIONAL.<br/>
+     * If this field is not set, the current list SHALL NOT change.<br/>
+     * If this field is set, but contains an empty list, any existing
+     * associated registered nodes SHALL be removed.<br/>
      * This field MUST NOT contain more than twenty(20) entries.<br/>
      * Every entry in this list MUST be a valid `registered_node_id` for a
      * current registered node.
-     * <p>
-     * If set, the new list SHALL replace the existing list.
      */
-    repeated uint64 associated_registered_node = 11;
+    AssociatedRegisteredNodeList associated_registered_node_list = 11;
+}
+
+/**
+ * A wrapper around a list of associated registered node identifiers.<br/>
+ * This wrapper exists to enable an update transaction to differentiate
+ * between a field that is not set and an empty list of values.
+ * <p>
+ * An _unset_ field of this type SHALL NOT modify existing values.<br/>
+ * A _set_ field of this type with an empty list SHALL remove any
+ * existing values.
+ */
+message AssociatedRegisteredNodeList {
+    /**
+     * A list of registered node identifiers.
+     */
+    repeated uint64 associated_registered_node = 1;
 }


### PR DESCRIPTION
**Description**:
This PR cherry-picks protobuf changes for HIP-1137

This pull request refines the way associated registered nodes are managed in the `NodeUpdateTransactionBody` message by introducing a wrapper message type. The main goal is to clarify the semantics of updating, removing, or leaving unchanged the list of associated registered nodes.

**Improvements to protocol semantics:**

* Added a new `AssociatedRegisteredNodeList` message type to wrap the list of associated registered node identifiers, enabling clear differentiation between an unset field (no change) and a set field with an empty list (removal of all existing associated nodes).
* Updated the comments and logic in `NodeUpdateTransactionBody` to specify that if the `associated_registered_node_list` field is not set, the current list remains unchanged; if set but empty, all existing associated registered nodes are removed.
* Changed the field number for `repeated uint64 associated_registered_node` from 11 to 1 in the new wrapper message for consistency and clarity.

**Related issue(s)**:

Fixes #23463

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
