### PR TITLE
test: Fix flaky BlockNodeStreamingConnectionComponentTest unit test

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
@@ -428,14 +428,14 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
 
         block.addItem(item);
 
-        // Set up latch to wait for connection closure after error
+        // Wait for the final close-side metric in the close() path; this avoids racing the async worker thread.
         final CountDownLatch connectionClosedLatch = new CountDownLatch(1);
         doAnswer(invocation -> {
                     connectionClosedLatch.countDown();
                     return null;
                 })
                 .when(metrics)
-                .recordConnectionClosed();
+                .recordActiveConnectionIp(-1L);
 
         connection.updateConnectionState(ConnectionState.ACTIVE);
 


### PR DESCRIPTION
**Description**:
This pull request updates the test logic in `BlockNodeStreamingConnectionComponentTest.java` to improve reliability when waiting for connection closure events. The main change is in how the test waits for the final close-side metric, switching from monitoring the `recordConnectionClosed()` method to `recordActiveConnectionIp(-1L)`.

Test reliability improvements:

* In `BlockNodeStreamingConnectionComponentTest.java`, replaced the latch trigger from `metrics.recordConnectionClosed()` to `metrics.recordActiveConnectionIp(-1L)` to ensure the test waits for the correct metric and avoids race conditions with the async worker thread.

**Related issue(s)**:

Fixes #24000 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
