### PR TITLE
fix: make ClasspathFileConfigSource compatible with --module-path

### DIFF
--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/ClasspathFileConfigSource.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/sources/ClasspathFileConfigSource.java
@@ -42,7 +42,8 @@ public class ClasspathFileConfigSource extends AbstractFileConfigSource {
     @NonNull
     @Override
     protected BufferedReader getReader() {
-        final InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(filePath.toString());
+        final InputStream inputStream =
+                Thread.currentThread().getContextClassLoader().getResourceAsStream(filePath.toString());
         Objects.requireNonNull(inputStream, "Could not load properties from classpath resource " + filePath);
         return new BufferedReader(new InputStreamReader(inputStream));
     }


### PR DESCRIPTION
**Description**:

This change makes sure that the config file is treated as a resource that is **not** encapsulated in a Java Module but globally accessible, even if you run with `--module-path`. In the latest versions of IDEA, this will be the case if you run a `main` method from IDEA. For example, you hit this issue with `com.swirlds.platform.base.example.Application.main()`. 

This is the same change as in `V0490FileSchema.loadResourceInRoot` in https://github.com/hiero-ledger/hiero-consensus-node/pull/19088

**Related issue(s)**:

#19088
#11573
