### PR TITLE
fix: Add gas charging to contract call local simple fee implementation

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/main/resources/genesis/simpleFeesSchedules.json
+++ b/hedera-node/hedera-file-service-impl/src/main/resources/genesis/simpleFeesSchedules.json
@@ -716,7 +716,11 @@
         {
           "name": "ContractCallLocal",
           "baseFee": 9000000,
-          "extras": []
+          "extras": [
+            {
+              "name": "GAS", "includedCount": 0
+            }
+          ]
         },
         {
           "name": "ContractGetBytecode",

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/calculator/ContractCallLocalFeeCalculator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/calculator/ContractCallLocalFeeCalculator.java
@@ -10,6 +10,7 @@ import com.hedera.node.app.spi.fees.QueryFeeCalculator;
 import com.hedera.node.app.spi.fees.SimpleFeeContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hiero.hapi.fees.FeeResult;
+import org.hiero.hapi.support.fees.Extra;
 import org.hiero.hapi.support.fees.FeeSchedule;
 
 public class ContractCallLocalFeeCalculator implements QueryFeeCalculator {
@@ -19,8 +20,10 @@ public class ContractCallLocalFeeCalculator implements QueryFeeCalculator {
             @NonNull SimpleFeeContext queryContext,
             @NonNull FeeResult feeResult,
             @NonNull FeeSchedule feeSchedule) {
+        final var op = query.contractCallLocalOrThrow();
         final var serviceDef = requireNonNull(lookupServiceFee(feeSchedule, HederaFunctionality.CONTRACT_CALL_LOCAL));
         feeResult.setServiceBaseFeeTinycents(serviceDef.baseFee());
+        addExtraFee(feeResult, serviceDef, Extra.GAS, feeSchedule, op.gas());
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/calculator/ContractServiceFeeCalculatorsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/calculator/ContractServiceFeeCalculatorsTest.java
@@ -243,6 +243,16 @@ public class ContractServiceFeeCalculatorsTest {
     }
 
     @Test
+    void testContractCallLocalWithGasExtra() {
+        final var query = Query.newBuilder()
+                .contractCallLocal(ContractCallLocalQuery.newBuilder().gas(12L))
+                .build();
+        final var result = feeCalculator.calculateQueryFee(query, new SimpleFeeContextImpl(null, queryContext));
+
+        assertThat(result.totalTinycents()).isEqualTo(570);
+    }
+
+    @Test
     void testContractGetBytecode() {
         final var contractId = ContractID.newBuilder().contractNum(12333).build();
         final var contractStoreMock = mock(ContractStateStore.class);
@@ -280,7 +290,8 @@ public class ContractServiceFeeCalculatorsTest {
                         makeExtraDef(Extra.SIGNATURES, 1000000),
                         makeExtraDef(Extra.KEYS, 10000000),
                         makeExtraDef(Extra.STATE_BYTES, 10),
-                        makeExtraDef(Extra.HOOK_UPDATES, 20000000))
+                        makeExtraDef(Extra.HOOK_UPDATES, 20000000),
+                        makeExtraDef(Extra.GAS, 3))
                 .services(makeService(
                         "ContractService",
                         makeServiceFee(
@@ -298,7 +309,7 @@ public class ContractServiceFeeCalculatorsTest {
                                 makeExtraIncluded(Extra.HOOK_UPDATES, 0)),
                         makeServiceFee(CONTRACT_DELETE, 69000000),
                         makeServiceFee(ETHEREUM_TRANSACTION, 0),
-                        makeServiceFee(HederaFunctionality.CONTRACT_CALL_LOCAL, 555),
+                        makeServiceFee(HederaFunctionality.CONTRACT_CALL_LOCAL, 555, makeExtraIncluded(Extra.GAS, 7)),
                         makeServiceFee(HederaFunctionality.CONTRACT_GET_BYTECODE, 666),
                         makeServiceFee(HederaFunctionality.CONTRACT_GET_INFO, 777)))
                 .build();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/ContractServiceQueriesSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/ContractServiceQueriesSimpleFeesTest.java
@@ -9,6 +9,10 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractBytecod
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdForQueries;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONTRACT_CALL_LOCAL_BASE_FEE;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONTRACT_GET_BYTECODE_BASE_FEE;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONTRACT_GET_INFO_BASE_FEE;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.GAS_FEE_USD;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
@@ -28,9 +32,6 @@ import org.junit.jupiter.api.Tag;
 @Tag(SIMPLE_FEES)
 @HapiTestLifecycle
 public class ContractServiceQueriesSimpleFeesTest {
-    private static final double CONTRACT_CALL_LOCAL_BASE_FEE = 0.001;
-    private static final double CONTRACT_GET_BYTECODE_BASE_FEE = 0.05;
-    private static final double CONTRACT_GET_INFO_BASE_FEE = 0.0001;
 
     @Contract(contract = "SmartContractsFees")
     static SpecContract contract;
@@ -51,13 +52,15 @@ public class ContractServiceQueriesSimpleFeesTest {
     @DisplayName("Call a local smart contract local and assure proper fee charged")
     final Stream<DynamicTest> contractLocalCallBaseUSDFee() {
         final var contractLocalCall = "contractLocalCall";
+        final var offeredGas = 21500;
         return hapiTest(
                 contractCallLocal(contract.name(), "contractLocalCallGet1Byte")
-                        .gas(21500)
+                        .gas(offeredGas)
                         .payingWith(civilian.name())
                         .signedBy(civilian.name())
                         .via(contractLocalCall),
-                validateChargedUsdForQueries(contractLocalCall, CONTRACT_CALL_LOCAL_BASE_FEE, 1));
+                validateChargedUsdForQueries(
+                        contractLocalCall, CONTRACT_CALL_LOCAL_BASE_FEE + offeredGas * GAS_FEE_USD, 1));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
@@ -205,4 +205,7 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final long CONTRACT_CREATE_INCLUDED_HOOK_UPDATES = 0L;
     public static final long CONTRACT_CREATE_INCLUDED_KEYS = 0L;
     public static final double CONTRACT_CREATE_BASE_FEE_USD = 0.9999;
+    public static final double CONTRACT_CALL_LOCAL_BASE_FEE = 0.001;
+    public static final double CONTRACT_GET_BYTECODE_BASE_FEE = 0.05;
+    public static final double CONTRACT_GET_INFO_BASE_FEE = 0.0001;
 }


### PR DESCRIPTION
**Description**:
The simple fees implementation for contract call local was not charging for gas, this PR addresses that.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
