### PR TITLE
fix: benchmark scripts

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testPerformance/scripts/deploy-benchmark.sh
+++ b/platform-sdk/consensus-otter-tests/src/testPerformance/scripts/deploy-benchmark.sh
@@ -160,7 +160,8 @@ echo -e "${BLUE}=== Step 4: Running benchmark on remote server ===${NC}"
 echo "Remote results will be stored at: $REMOTE_TMP_RESULTS"
 echo ""
 
-ssh -o BatchMode=yes "$SSH_DEST" bash <<REMOTE_EOF
+BENCHMARK_EXIT=0
+ssh -o BatchMode=yes "$SSH_DEST" bash <<REMOTE_EOF || BENCHMARK_EXIT=$?
 set -eo pipefail
 
 # Source profile to pick up JAVA_HOME and PATH in non-interactive SSH sessions
@@ -193,7 +194,11 @@ bash "\$SCRIPT_PATH" "$EXPERIMENT" "$NUM_RUNS"
 REMOTE_EOF
 
 echo ""
-echo -e "${GREEN}Remote benchmark completed.${NC}"
+if [[ "$BENCHMARK_EXIT" -ne 0 ]]; then
+    echo -e "${YELLOW}⚠️  Benchmark exited with code $BENCHMARK_EXIT — results (if any) will still be downloaded.${NC}"
+else
+    echo -e "${GREEN}Remote benchmark completed.${NC}"
+fi
 echo ""
 
 # ── Step 5: Tar results and transfer to local machine ────────────────────────
@@ -204,25 +209,32 @@ LOCAL_TAR_DIR="$LOCAL_RESULTS_DIR"
 mkdir -p "$LOCAL_TAR_DIR"
 LOCAL_TAR="${LOCAL_TAR_DIR}/benchmark-${SERVER}-${BRANCH//\//-}-${TIMESTAMP}.tar.gz"
 
-# Create tar on remote
-ssh -o BatchMode=yes "$SSH_DEST" bash <<REMOTE_EOF
+# Create tar on remote (best-effort: archive whatever results exist)
+TRANSFER_EXIT=0
+ssh -o BatchMode=yes "$SSH_DEST" bash <<REMOTE_EOF || TRANSFER_EXIT=$?
 set -eo pipefail
 if [[ ! -d "$REMOTE_TMP_RESULTS" ]] || [[ -z "\$(ls -A "$REMOTE_TMP_RESULTS")" ]]; then
-    echo "ERROR: No results found at $REMOTE_TMP_RESULTS"
-    exit 1
+    echo "WARNING: No results found at $REMOTE_TMP_RESULTS — nothing to archive."
+    exit 2
 fi
 echo "Compressing results..."
 tar -czf "$REMOTE_TAR" -C "$REMOTE_TMP_RESULTS" .
 echo "Archive size: \$(du -h "$REMOTE_TAR" | cut -f1)"
 REMOTE_EOF
 
-# Transfer to local
-echo "Downloading results to $LOCAL_TAR ..."
-scp -o BatchMode=yes "$SSH_DEST:$REMOTE_TAR" "$LOCAL_TAR"
+# Transfer to local (skip if there was nothing to archive)
+if [[ "$TRANSFER_EXIT" -eq 2 ]]; then
+    echo -e "${YELLOW}⚠️  No results were produced — skipping download.${NC}"
+elif [[ "$TRANSFER_EXIT" -ne 0 ]]; then
+    echo -e "${RED}ERROR: Failed to create remote archive (exit $TRANSFER_EXIT) — skipping download.${NC}"
+else
+    echo "Downloading results to $LOCAL_TAR ..."
+    scp -o BatchMode=yes "$SSH_DEST:$REMOTE_TAR" "$LOCAL_TAR"
+fi
 
-# Clean up remote temp files and stop Gradle daemons
+# Clean up remote temp files and stop Gradle daemons (always)
 echo "Cleaning up remote temporary files..."
-ssh -o BatchMode=yes "$SSH_DEST" "rm -rf '$REMOTE_TMP_RESULTS' '$REMOTE_TAR'"
+ssh -o BatchMode=yes "$SSH_DEST" "rm -rf '$REMOTE_TMP_RESULTS' '$REMOTE_TAR'" || true
 echo "Stopping Gradle daemons on remote..."
 ssh -o BatchMode=yes "$SSH_DEST" bash <<'STOP_EOF'
 for f in "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.bashrc" "/etc/profile"; do
@@ -232,17 +244,30 @@ cd hedera-services && ./gradlew --stop 2>/dev/null || true
 STOP_EOF
 
 echo ""
-echo -e "${GREEN}######################################################################${NC}"
-echo -e "${GREEN}=== Remote benchmark complete ===${NC}"
-echo -e "${GREEN}######################################################################${NC}"
-echo ""
-echo "Results archive: $LOCAL_TAR"
+if [[ "$BENCHMARK_EXIT" -ne 0 ]]; then
+    echo -e "${YELLOW}######################################################################${NC}"
+    echo -e "${YELLOW}=== Remote benchmark FAILED (exit code: $BENCHMARK_EXIT) ===${NC}"
+    echo -e "${YELLOW}######################################################################${NC}"
+else
+    echo -e "${GREEN}######################################################################${NC}"
+    echo -e "${GREEN}=== Remote benchmark complete ===${NC}"
+    echo -e "${GREEN}######################################################################${NC}"
+fi
 echo ""
 
-# Show contents summary
-echo -e "${BLUE}Archive contents:${NC}"
-tar -tzf "$LOCAL_TAR" | head -30
-RESULT_COUNT=$(tar -tzf "$LOCAL_TAR" | grep -c '/$' || true)
-echo "  ($RESULT_COUNT directories)"
-echo ""
-echo "To extract:  tar -xzf $LOCAL_TAR -C <destination>"
+# Show results summary only if we have a local archive
+if [[ -f "$LOCAL_TAR" ]]; then
+    echo "Results archive: $LOCAL_TAR"
+    echo ""
+    echo -e "${BLUE}Archive contents:${NC}"
+    tar -tzf "$LOCAL_TAR" | head -30
+    RESULT_COUNT=$(tar -tzf "$LOCAL_TAR" | grep -c '/$' || true)
+    echo "  ($RESULT_COUNT directories)"
+    echo ""
+    echo "To extract:  tar -xzf $LOCAL_TAR -C <destination>"
+fi
+
+# Propagate benchmark failure to the caller
+if [[ "$BENCHMARK_EXIT" -ne 0 ]]; then
+    exit "$BENCHMARK_EXIT"
+fi

--- a/platform-sdk/consensus-otter-tests/src/testPerformance/scripts/find-metrics.sh
+++ b/platform-sdk/consensus-otter-tests/src/testPerformance/scripts/find-metrics.sh
@@ -1,59 +1,139 @@
 #!/bin/bash
-# Find benchmark metric runs in build/container and interactively select which
-# ones to import into VictoriaMetrics via import-metrics.sh.
+# Find benchmark metric runs in build/container and ~/home/benchmark-results,
+# and interactively select which ones to import into VictoriaMetrics via import-metrics.sh.
 #
-# Usage: find-metrics.sh [--build-dir DIR]
+# Usage: find-metrics.sh [--build-dir DIR] [--benchmark-dir DIR]
 #
 # Defaults:
-#   --build-dir  <scripts directory>/../../../build/container
+#   --build-dir      <scripts directory>/../../../build/container
+#   --benchmark-dir  ~/benchmark-results
 
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="$SCRIPT_DIR/../../../build/container"
+BENCHMARK_DIR="$HOME/benchmark-results/remote"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --build-dir) BUILD_DIR="$2"; shift 2 ;;
+    --build-dir)      BUILD_DIR="$2";      shift 2 ;;
+    --benchmark-dir)  BENCHMARK_DIR="$2";  shift 2 ;;
     *) echo "Unknown argument: $1"; exit 1 ;;
   esac
 done
 
-if [ ! -d "$BUILD_DIR" ]; then
-  echo "⚠️  Build directory not found: $BUILD_DIR"
-  exit 1
-fi
-
-# Discover runs: directories that contain at least one metrics*.txt file.
+# Discover metric run directories under a given root.
 # A "run" is the grandparent of the node-* directories
-# (build/container/<test>/<run>/node-*/data/stats/metrics.txt -> <run>).
-RUN_DIRS=()
-while IFS= read -r dir; do
-  RUN_DIRS+=("$dir")
-done < <(
-  find "$BUILD_DIR" -name "metrics*.txt" -print0 \
+# (root/<test>/<run>/node-*/data/stats/metrics.txt -> 4 levels up = <run>).
+discover_build_runs() {
+  local root="$1"
+  if [ ! -d "$root" ]; then
+    return
+  fi
+  find "$root" -name "metrics*.txt" -print0 \
     | xargs -0 -I{} dirname {} \
     | xargs -I{} dirname {} \
     | xargs -I{} dirname {} \
     | xargs -I{} dirname {} \
     | sort -u
-)
+}
 
-if [ ${#RUN_DIRS[@]} -eq 0 ]; then
-  echo "⚠️  No metrics files found under $BUILD_DIR"
+# Discover runs from the benchmark-results directory.
+# Each immediate subdirectory of root is treated as one run
+# (root/<run>/node-*/data/stats/metrics.txt -> 3 levels up = <run>).
+# Only subdirectories that contain at least one metrics file are included.
+discover_benchmark_runs() {
+  local root="$1"
+  if [ ! -d "$root" ]; then
+    return
+  fi
+  for dir in "$root"/*/; do
+    [ -d "$dir" ] || continue
+    if find "$dir" -name "metrics*.txt" -print -quit 2>/dev/null | grep -q .; then
+      echo "${dir%/}"
+    fi
+  done | sort -u
+}
+
+BUILD_RUN_DIRS=()
+while IFS= read -r dir; do
+  BUILD_RUN_DIRS+=("$dir")
+done < <(discover_build_runs "$BUILD_DIR")
+
+BENCHMARK_RUN_DIRS=()
+while IFS= read -r dir; do
+  BENCHMARK_RUN_DIRS+=("$dir")
+done < <(discover_benchmark_runs "$BENCHMARK_DIR")
+
+if [ ${#BUILD_RUN_DIRS[@]} -eq 0 ] && [ ${#BENCHMARK_RUN_DIRS[@]} -eq 0 ]; then
+  echo "⚠️  No metrics files found under:"
+  echo "     $BUILD_DIR"
+  echo "     $BENCHMARK_DIR"
   exit 1
 fi
 
+# Combined list for unified numbering; entries are parallel arrays.
+RUN_DIRS=()
+RUN_ROOTS=()
+
+print_category() {
+  local label="$1"
+  local root="$2"
+  local array_name="$3"  # name of the source array (eval-based, bash 3.2 compatible)
+  local start_idx="$4"   # current global index offset
+
+  local count
+  eval "count=\${#${array_name}[@]}"
+
+  if [ "$count" -eq 0 ]; then
+    echo "$label  ($root)"
+    echo "  (none found)"
+    echo ""
+    return
+  fi
+
+  echo "$label  ($root)"
+  local i=0
+  while [ "$i" -lt "$count" ]; do
+    local run
+    eval "run=\${${array_name}[$i]}"
+    local rel="${run#$root/}"
+    local file_count
+    file_count=$(find "$run" -name "metrics*.txt" | wc -l | tr -d ' ')
+    local global_num=$(( start_idx + i + 1 ))
+    printf "  [%2d] %s  (%s file%s)\n" \
+      "$global_num" "$rel" "$file_count" "$( [ "$file_count" -eq 1 ] && echo "" || echo "s" )"
+    RUN_DIRS+=("$run")
+    RUN_ROOTS+=("$root")
+    i=$(( i + 1 ))
+  done
+  echo ""
+}
+
 echo "Available benchmark runs:"
 echo ""
-for i in "${!RUN_DIRS[@]}"; do
-  run="${RUN_DIRS[$i]}"
-  rel="${run#$BUILD_DIR/}"
-  file_count=$(find "$run" -name "metrics*.txt" | wc -l | tr -d ' ')
-  printf "  [%2d] %s  (%s file%s)\n" "$((i+1))" "$rel" "$file_count" "$( [ "$file_count" -eq 1 ] && echo "" || echo "s" )"
-done
 
-echo ""
+if [ ! -d "$BUILD_DIR" ]; then
+  echo "Build directory  ($BUILD_DIR)"
+  echo "  ⚠️  Directory not found"
+  echo ""
+else
+  print_category "Build directory" "$BUILD_DIR" BUILD_RUN_DIRS 0
+fi
+
+if [ ! -d "$BENCHMARK_DIR" ]; then
+  echo "Benchmark results  ($BENCHMARK_DIR)"
+  echo "  ⚠️  Directory not found"
+  echo ""
+else
+  print_category "Benchmark results" "$BENCHMARK_DIR" BENCHMARK_RUN_DIRS "${#BUILD_RUN_DIRS[@]}"
+fi
+
+if [ ${#RUN_DIRS[@]} -eq 0 ]; then
+  echo "No runs available to select."
+  exit 1
+fi
+
 echo "Enter run numbers to import (e.g. 1  or  1 3  or  all):"
 read -r selection
 


### PR DESCRIPTION
- allows the find metrics script to look for metrics in the directory where remote tests are downloaded to
- the deploy script downloads the results even if the test fails