### PR TITLE
fix: Additional Code Delegation HAPI tests

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/delegation/CodeDelegationProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/delegation/CodeDelegationProcessor.java
@@ -42,7 +42,7 @@ public record CodeDelegationProcessor(long chainId) {
     private static final BigInteger HALF_CURVE_ORDER =
             new BigInteger("7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0", 16);
 
-    private static final int MAX_Y_PARITY = 2 ^ 8;
+    private static final int MAX_Y_PARITY = 256;
 
     /** The size of the delegated code */
     public static final int DELEGATED_CODE_SIZE = CODE_DELEGATION_PREFIX.size() + Address.SIZE;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/delegation/CodeDelegationProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/delegation/CodeDelegationProcessorTest.java
@@ -159,7 +159,7 @@ class CodeDelegationProcessorTest {
         when(del.getChainId()).thenReturn(CHAIN_ID);
         when(del.nonce()).thenReturn(0L);
         when(del.getS()).thenReturn(HALF_ORDER.subtract(BigInteger.ONE));
-        when(del.getYParity()).thenReturn(2 ^ 8);
+        when(del.getYParity()).thenReturn(256);
         when(world.updater()).thenReturn(proxyWorldUpdater);
 
         final var p = new CodeDelegationProcessor(CHAIN_ID);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationChainingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationChainingTest.java
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.hips.hip1340;
+
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.esaulpaugh.headlong.abi.Function;
+import com.esaulpaugh.headlong.abi.Tuple;
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
+import com.hederahashgraph.api.proto.java.ContractFunctionResult;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@Tag(SMART_CONTRACT)
+@DisplayName("Code Delegation Chaining Tests")
+public class CodeDelegationChainingTest extends CodeDelegationTestBase {
+
+    @HapiTest
+    @DisplayName("Delegation chain through two EOAs fails with banned opcode")
+    final Stream<DynamicTest> testDelegationChainThroughTwoEoasResultsInFailure() {
+        return hapiTest(withOpContext((spec, opLog) -> {
+            final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+
+            final var contract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
+
+            // EOA_B delegates to the contract
+            final var eoaB = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            nativeSetCodeDelegation(spec, eoaB, contract);
+
+            // EOA_A delegates to EOA_B, creating a chain: A -> B -> Contract
+            final var eoaA = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            nativeSetCodeDelegation(spec, eoaA, ByteString.fromHex(eoaB.evmAddressHex()));
+
+            // Calling EOA_A resolves to EOA_B whose code is a delegation indicator (0xef0100...).
+            // The indicator is interpreted literally -> 0xef is a banned opcode -> execution fails.
+            allRunFor(
+                    spec,
+                    HapiEthereumCall.explicitlyTo(eoaA.evmAddressBytes(), 0)
+                            .withExplicitParams(() -> "cafebabe")
+                            .payingWith(payer.name())
+                            .signingWith(caller.keyName())
+                            .gasLimit(200_000L)
+                            .hasKnownStatus(ResponseCodeEnum.CONTRACT_EXECUTION_EXCEPTION));
+        }));
+    }
+
+    @HapiTest
+    @DisplayName("Delegation loop between two EOAs fails with banned opcode")
+    final Stream<DynamicTest> testDelegationLoopResultsInFailure() {
+        return hapiTest(withOpContext((spec, opLog) -> {
+            final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+
+            final var eoaA = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            final var eoaB = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+
+            // Circular delegation: A -> B, B -> A
+            nativeSetCodeDelegation(spec, eoaA, ByteString.fromHex(eoaB.evmAddressHex()));
+            nativeSetCodeDelegation(spec, eoaB, ByteString.fromHex(eoaA.evmAddressHex()));
+
+            // Calling EOA_A: resolves to EOA_B, whose code is 0xef0100||A_address -> banned opcode
+            allRunFor(
+                    spec,
+                    HapiEthereumCall.explicitlyTo(eoaA.evmAddressBytes(), 0)
+                            .withExplicitParams(() -> "cafebabe")
+                            .payingWith(payer.name())
+                            .signingWith(caller.keyName())
+                            .gasLimit(200_000L)
+                            .hasKnownStatus(ResponseCodeEnum.CONTRACT_EXECUTION_EXCEPTION));
+
+            // Symmetrically, calling EOA_B should also fail
+            allRunFor(
+                    spec,
+                    HapiEthereumCall.explicitlyTo(eoaB.evmAddressBytes(), 0)
+                            .withExplicitParams(() -> "cafebabe")
+                            .payingWith(payer.name())
+                            .signingWith(caller.keyName())
+                            .gasLimit(200_000L)
+                            .hasKnownStatus(ResponseCodeEnum.CONTRACT_EXECUTION_EXCEPTION));
+        }));
+    }
+
+    @HapiTest
+    @DisplayName("Self-delegation fails with banned opcode")
+    final Stream<DynamicTest> testSelfDelegationResultsInFailure() {
+        return hapiTest(withOpContext((spec, opLog) -> {
+            final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+
+            final var eoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+
+            // Self-delegation: EOA -> itself
+            nativeSetCodeDelegation(spec, eoa, ByteString.fromHex(eoa.evmAddressHex()));
+
+            // Calling the EOA resolves to itself, code is 0xef0100||own_address -> banned opcode
+            allRunFor(
+                    spec,
+                    HapiEthereumCall.explicitlyTo(eoa.evmAddressBytes(), 0)
+                            .withExplicitParams(() -> "cafebabe")
+                            .payingWith(payer.name())
+                            .signingWith(caller.keyName())
+                            .gasLimit(200_000L)
+                            .hasKnownStatus(ResponseCodeEnum.CONTRACT_EXECUTION_EXCEPTION));
+        }));
+    }
+
+    @HapiTest
+    @DisplayName("Delegation to non-existent address is a no-op with value transfer")
+    final Stream<DynamicTest> testDelegationToNonExistentAddressIsNoOp() {
+        return hapiTest(withOpContext((spec, opLog) -> {
+            final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+
+            final var eoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+
+            // Delegate to a non-existent address
+            final var nonExistentAddress = ByteString.fromHex("abcdef0123456789abcdef0123456789abcdef01");
+            nativeSetCodeDelegation(spec, eoa, nonExistentAddress);
+
+            final var tinyBarsAmount = 40_500_000L;
+            final AtomicReference<Long> eoaBalanceBefore = new AtomicReference<>();
+            final AtomicReference<Long> eoaBalanceAfter = new AtomicReference<>();
+            final AtomicReference<ContractFunctionResult> callResult = new AtomicReference<>();
+
+            allRunFor(
+                    spec,
+                    getAccountBalance(eoa.name()).exposingBalanceTo(eoaBalanceBefore::set),
+                    HapiEthereumCall.explicitlyTo(eoa.evmAddressBytes(), 0)
+                            .withExplicitParams(() -> "cafebabe")
+                            .sending(tinyBarsAmount)
+                            .payingWith(payer.name())
+                            .signingWith(caller.keyName())
+                            .gasLimit(200_000L)
+                            .exposingRawResultTo(callResult::set)
+                            .hasKnownStatus(ResponseCodeEnum.SUCCESS)
+                            .via(""),
+                    getAccountBalance(eoa.name()).exposingBalanceTo(eoaBalanceAfter::set));
+
+            // No code executed -> empty output
+            assertEquals(0, callResult.get().getContractCallResult().size());
+            // Value transfer should have succeeded
+            assertEquals(eoaBalanceBefore.get() + tinyBarsAmount, eoaBalanceAfter.get());
+        }));
+    }
+
+    @HapiTest
+    @DisplayName("Delegation chain reached via inner CALL reverts the inner call")
+    final Stream<DynamicTest> testDelegationChainViaInnerCallReverts() {
+        return hapiTest(withOpContext((spec, opLog) -> {
+            final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+
+            final var contract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
+
+            // EOA_B delegates to the contract
+            final var eoaB = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            nativeSetCodeDelegation(spec, eoaB, contract);
+
+            // EOA_A delegates to EOA_B, creating a chain: A -> B -> Contract
+            final var eoaA = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
+            nativeSetCodeDelegation(spec, eoaA, ByteString.fromHex(eoaB.evmAddressHex()));
+
+            // Use the contract's executeCall to make an inner call to EOA_A.
+            // The inner call fails due to the delegation chain (banned opcode),
+            // and executeCall propagates the revert.
+            final var innerCallData = new Function("executeCall(address,uint256,bytes)")
+                    .encodeCall(Tuple.of(eoaA.evmAddress(), BigInteger.ZERO, Hex.decode("cafebabe")))
+                    .array();
+
+            allRunFor(
+                    spec,
+                    HapiEthereumCall.explicitlyTo(contract.evmAddressBytes(), 0)
+                            .withExplicitParams(() -> Hex.toHexString(innerCallData))
+                            .payingWith(payer.name())
+                            .signingWith(caller.keyName())
+                            .gasLimit(200_000L)
+                            .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED));
+        }));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTestBase.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTestBase.java
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.hips.hip1340;
+
+import static com.esaulpaugh.headlong.abi.Address.toChecksumAddress;
+import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.useAddressOfKey;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+
+import com.esaulpaugh.headlong.abi.Address;
+import com.esaulpaugh.headlong.abi.Function;
+import com.esaulpaugh.headlong.abi.Tuple;
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
+import com.hederahashgraph.api.proto.java.AccountID;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.base.utility.CommonUtils;
+
+public abstract class CodeDelegationTestBase {
+    protected static final Address HTS_HOOKS_CONTRACT_ADDRESS =
+            Address.wrap("0x000000000000000000000000000000000000016D");
+    protected static final String DELEGATING_ACCOUNT = "delegating_account";
+    protected static final String DELEGATING_ACCOUNT_1 = DELEGATING_ACCOUNT + "_1";
+    protected static final String DELEGATING_ACCOUNT_2 = DELEGATING_ACCOUNT + "_2";
+    protected static final String DELEGATING_ACCOUNT_3 = DELEGATING_ACCOUNT + "_3";
+    protected static final String DELEGATING_ACCOUNT_ID = "delegating_account_id";
+    protected static final String DELEGATING_ACCOUNT_ID_1 = DELEGATING_ACCOUNT_ID + "_1";
+    protected static final String DELEGATING_ACCOUNT_ID_2 = DELEGATING_ACCOUNT_ID + "_2";
+    protected static final String DELEGATING_ACCOUNT_ID_3 = DELEGATING_ACCOUNT_ID + "_3";
+    protected static final String CONTRACT = "CreateTrivial";
+    protected static final String REVERTING_CONTRACT = "InternalCallee";
+    protected static final String CREATION = "creation";
+    protected static final String DELEGATION_SET = "delegation_set";
+    protected static final String DELEGATION_CALL = "delegation_call";
+    protected static final String DELEGATION_RESET = "delegation_reset";
+    protected static final String PAYER_KEY = "PayerAccountKey";
+    protected static final String PAYER = "PayerAccount";
+    protected static final String CODE_DELEGATION_CONTRACT = "CodeDelegationContract";
+
+    private final AtomicInteger accountIdCounter = new AtomicInteger(0);
+
+    protected record EvmAccount(
+            String keyName, String name, AccountID accountId, Address evmAddress, Address longZeroEvmAddress) {
+        String evmAddressHex() {
+            return toChecksumAddress(evmAddress.value()).replace("0x", "");
+        }
+
+        byte[] evmAddressBytes() {
+            return CommonUtils.unhex(evmAddressHex());
+        }
+    }
+
+    protected record EvmContract(String name, Address address) {
+        String evmAddressHex() {
+            return toChecksumAddress(address.value()).replace("0x", "");
+        }
+
+        ByteString evmAddressPbjBytes() {
+            return ByteString.fromHex(evmAddressHex());
+        }
+
+        byte[] evmAddressBytes() {
+            return CommonUtils.unhex(evmAddressHex());
+        }
+    }
+
+    protected EvmAccount createEvmAccountWithKey(HapiSpec spec) {
+        final var id = accountIdCounter.getAndIncrement();
+        final var name = "ACCOUNT_" + id;
+        final var keyName = "ACCOUNT_KEY_" + id;
+        final AtomicReference<Address> keyAliasEvmAddress = new AtomicReference<>();
+        final AtomicReference<AccountID> accountId = new AtomicReference<>();
+        final AtomicReference<Address> longZeroEvmAddress = new AtomicReference<>();
+        allRunFor(spec, newKeyNamed(keyName).shape(SECP_256K1_SHAPE));
+        final var key = spec.registry().getKey(keyName);
+        final var keyEvmAddress = ByteString.copyFrom(
+                recoverAddressFromPubKey(key.getECDSASecp256K1().toByteArray()));
+        allRunFor(
+                spec,
+                cryptoCreate(name)
+                        .key(keyName)
+                        .alias(keyEvmAddress)
+                        .exposingCreatedIdTo(accountId::set)
+                        .exposingEvmAddressTo(longZeroEvmAddress::set),
+                useAddressOfKey(keyName, keyAliasEvmAddress::set));
+        return new EvmAccount(keyName, name, accountId.get(), keyAliasEvmAddress.get(), longZeroEvmAddress.get());
+    }
+
+    protected EvmAccount createFundedEvmAccountWithKey(HapiSpec spec, long hbarAmount) {
+        final var account = createEvmAccountWithKey(spec);
+        allRunFor(spec, cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, account.name, hbarAmount)));
+        return account;
+    }
+
+    protected EvmContract deployEvmContract(HapiSpec spec, String name) {
+        final AtomicReference<Address> evmAddress = new AtomicReference<>();
+        allRunFor(
+                spec,
+                uploadInitCode(name),
+                contractCreate(name).exposingAddressTo(evmAddress::set).gas(2_000_000L));
+        return new EvmContract(name, evmAddress.get());
+    }
+
+    protected void nativeSetCodeDelegation(HapiSpec spec, EvmAccount account, EvmContract target) {
+        nativeSetCodeDelegation(spec, account, target.evmAddressPbjBytes());
+    }
+
+    protected void nativeSetCodeDelegation(HapiSpec spec, EvmAccount account, ByteString targetAddress) {
+        allRunFor(
+                spec,
+                cryptoUpdate(account.name()).delegationAddress(targetAddress),
+                getAccountInfo(account.name()).has(accountWith().delegationAddress(targetAddress)));
+    }
+
+    protected static void createSecp256k1Keys(HapiSpec spec, String... names) {
+        allRunFor(
+                spec,
+                Arrays.stream(names)
+                        .map(name -> (HapiSpecOperation) newKeyNamed(name).shape(SECP_256K1_SHAPE))
+                        .toArray(HapiSpecOperation[]::new));
+    }
+
+    protected static void verifyDelegationSet(HapiSpec spec, Address target, String... accountNames) {
+        allRunFor(
+                spec,
+                Arrays.stream(accountNames)
+                        .map(name -> (HapiSpecOperation)
+                                getAliasedAccountInfo(name).isNotHollow().hasDelegationAddress(target))
+                        .toArray(HapiSpecOperation[]::new));
+    }
+
+    protected static void verifyDelegationCleared(HapiSpec spec, String... accountNames) {
+        allRunFor(
+                spec,
+                Arrays.stream(accountNames)
+                        .map(name ->
+                                (HapiSpecOperation) getAliasedAccountInfo(name).hasNoDelegation())
+                        .toArray(HapiSpecOperation[]::new));
+    }
+
+    protected static void createPayerAccountWithAlias(HapiSpec spec) {
+        allRunFor(
+                spec,
+                newKeyNamed(PAYER_KEY).shape(SECP_256K1_SHAPE).exposingKeyTo(key -> {
+                    final var evmAddress = ByteString.copyFrom(
+                            recoverAddressFromPubKey(key.getECDSASecp256K1().toByteArray()));
+                    spec.registry()
+                            .saveAccountAlias(
+                                    PAYER_KEY,
+                                    AccountID.newBuilder().setAlias(evmAddress).build());
+                }),
+                cryptoTransfer(TokenMovement.movingHbar(ONE_HUNDRED_HBARS).between(GENESIS, PAYER_KEY))
+                        .via(CREATION),
+                getTxnRecord(CREATION).exposingCreationsTo(creations -> {
+                    final var createdId = HapiPropertySource.asAccount(creations.getFirst());
+                    spec.registry().saveAccountId(PAYER, createdId);
+                }));
+    }
+
+    protected static byte[] encodeHtsTransfer(Address receiver, BigInteger amount) {
+        return new Function("transfer(address,uint256)")
+                .encodeCall(Tuple.of(receiver, amount))
+                .array();
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTests.java
@@ -2,35 +2,26 @@
 package com.hedera.services.bdd.suites.contract.hips.hip1340;
 
 import static com.esaulpaugh.headlong.abi.Address.toChecksumAddress;
-import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.node.app.service.contract.impl.utils.ConstantUtils.ZERO_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.utils.ConstantUtils.ZERO_ADDRESS_BYTE_ARRAY;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
-import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
-import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.useAddressOfKey;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
-import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
 import static com.hedera.services.bdd.suites.contract.Utils.aaWith;
 import static com.hedera.services.bdd.suites.contract.Utils.aaWithPreHook;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -50,9 +41,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
-import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
-import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractLoginfo;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -62,11 +51,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
-import org.hiero.base.utility.CommonUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -75,12 +62,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @DisplayName("Code Delegation Tests")
 @HapiTestLifecycle
-public class CodeDelegationTests {
-    public static final Address HTS_HOOKS_CONTRACT_ADDRESS = Address.wrap("0x000000000000000000000000000000000000016D");
-
-    private static final String CODE_DELEGATION_CONTRACT = "CodeDelegationContract";
-
-    private final AtomicInteger accountIdCounter = new AtomicInteger(0);
+public class CodeDelegationTests extends CodeDelegationTestBase {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
@@ -94,7 +76,7 @@ public class CodeDelegationTests {
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
             /* Create a delegation target contract and an EOA delegating to it. */
-            final var delegationTargetContract = createEvmContract(spec, CODE_DELEGATION_CONTRACT);
+            final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             nativeSetCodeDelegation(spec, delegatingEoa, delegationTargetContract);
 
@@ -141,7 +123,7 @@ public class CodeDelegationTests {
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
             /* Create a delegation target contract and an EOA delegating to it. */
-            final var delegationTargetContract = createEvmContract(spec, CODE_DELEGATION_CONTRACT);
+            final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             nativeSetCodeDelegation(spec, delegatingEoa, delegationTargetContract);
 
@@ -162,7 +144,7 @@ public class CodeDelegationTests {
 
             // Verify that the event originates from the EOA
             assertEquals(
-                    delegatingEoa.accountId.getAccountNum(),
+                    delegatingEoa.accountId().getAccountNum(),
                     logInfo.get().getContractID().getContractNum());
 
             // And verify the remaining fields of the event
@@ -206,7 +188,7 @@ public class CodeDelegationTests {
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
             /* Create a delegation target contract and an EOA delegating to it. */
-            final var delegationTargetContract = createEvmContract(spec, CODE_DELEGATION_CONTRACT);
+            final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             nativeSetCodeDelegation(spec, delegatingEoa, delegationTargetContract);
 
@@ -222,7 +204,7 @@ public class CodeDelegationTests {
                             .exposingAddressTo(tokenAddress::set));
 
             final var tokenReceiver = createEvmAccountWithKey(spec);
-            allRunFor(spec, cryptoUpdate(tokenReceiver.name).maxAutomaticAssociations(100));
+            allRunFor(spec, cryptoUpdate(tokenReceiver.name()).maxAutomaticAssociations(100));
 
             final var innerTransferCallData = encodeHtsTransfer(tokenReceiver.evmAddress(), BigInteger.valueOf(200L));
 
@@ -266,7 +248,7 @@ public class CodeDelegationTests {
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
             /* Create a delegation target contract and an EOA delegating to it. */
-            final var delegationTargetContract = createEvmContract(spec, CODE_DELEGATION_CONTRACT);
+            final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             nativeSetCodeDelegation(spec, delegatingEoa, delegationTargetContract);
 
@@ -314,9 +296,9 @@ public class CodeDelegationTests {
     }
 
     @HapiTest
-    /// This scenario is equivalent to chaining delegations (since token account delegates to the HTS
-    /// System Contract), so we expect the second delegation code to be treated literally and fail
-    /// due to trying to execute an invalid op code.
+    /* This scenario is equivalent to chaining delegations (since token account delegates to the HTS
+    System Contract), so we expect the second delegation code to be treated literally and fail
+    due to trying to execute an invalid op code. */
     final Stream<DynamicTest> testDelegationToHtsTokenReverts() {
         return hapiTest(withOpContext((spec, opLog) -> {
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
@@ -343,7 +325,7 @@ public class CodeDelegationTests {
 
             // Let's encode a valid HTS call (token transfer) and verify that it doesn't trigger any action.
             final var wouldBeTokenReceiver = createEvmAccountWithKey(spec);
-            allRunFor(spec, cryptoUpdate(wouldBeTokenReceiver.name).maxAutomaticAssociations(100));
+            allRunFor(spec, cryptoUpdate(wouldBeTokenReceiver.name()).maxAutomaticAssociations(100));
 
             final var callData = encodeHtsTransfer(wouldBeTokenReceiver.evmAddress(), BigInteger.valueOf(200L));
 
@@ -462,7 +444,7 @@ public class CodeDelegationTests {
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
-            final var delegationTargetContract = createEvmContract(spec, CODE_DELEGATION_CONTRACT);
+            final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             nativeSetCodeDelegation(spec, delegatingEoa, delegationTargetContract);
 
@@ -478,7 +460,7 @@ public class CodeDelegationTests {
                     cryptoTransfer((unused, builder) -> {
                                 final var registry = spec.registry();
                                 final var hookData = TupleType.parse("(address,bytes)")
-                                        .encode(Tuple.of(delegatingEoa.evmAddress, Hex.decode("cafebabe")));
+                                        .encode(Tuple.of(delegatingEoa.evmAddress(), Hex.decode("cafebabe")));
                                 final var hookCall = HookCall.newBuilder()
                                         .hookId(hookId)
                                         .evmHookCall(EvmHookCall.newBuilder()
@@ -556,7 +538,7 @@ public class CodeDelegationTests {
             final var owner = createFundedEvmAccountWithKey(spec, ONE_HBAR);
             final var receiver = createFundedEvmAccountWithKey(spec, ONE_HBAR);
 
-            createEvmContract(spec, CODE_DELEGATION_CONTRACT);
+            deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
 
             allRunFor(
                     spec,
@@ -565,7 +547,7 @@ public class CodeDelegationTests {
                     cryptoTransfer((unused, builder) -> {
                                 final var registry = spec.registry();
                                 final var hookData = TupleType.parse("(address,bytes)")
-                                        .encode(Tuple.of(delegatingEoa.evmAddress, Hex.decode("cafebabe")));
+                                        .encode(Tuple.of(delegatingEoa.evmAddress(), Hex.decode("cafebabe")));
                                 final var hookCall = HookCall.newBuilder()
                                         .hookId(hookId)
                                         .evmHookCall(EvmHookCall.newBuilder()
@@ -612,7 +594,7 @@ public class CodeDelegationTests {
     final Stream<DynamicTest> testCrossAPIDelegationNativeToType4() {
         return hapiTest(withOpContext((spec, opLog) -> {
             // Create delegation target and account
-            final var delegationTargetContract = createEvmContract(spec, CODE_DELEGATION_CONTRACT);
+            final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
             nativeSetCodeDelegation(spec, delegatingEoa, delegationTargetContract);
@@ -624,7 +606,7 @@ public class CodeDelegationTests {
 
                     // Now proceed to clear delegation with type 4 eth transaction
                     sourcing(() -> ethereumCryptoTransfer(RELAYER, 1L)
-                            .signingWith(delegatingEoa.keyName)
+                            .signingWith(delegatingEoa.keyName())
                             .payingWith(RELAYER)
                             .type(EthTransactionType.EIP7702)
                             .gasLimit(50_000L)
@@ -638,7 +620,7 @@ public class CodeDelegationTests {
     final Stream<DynamicTest> testCrossAPIDelegationType4ToNative() {
         return hapiTest(withOpContext(((spec, assertLog) -> {
             // Create delegation target and account
-            final var delegationTargetContract = createEvmContract(spec, CODE_DELEGATION_CONTRACT);
+            final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
             final AtomicReference<Long> preEthereumNonce = new AtomicReference<>();
@@ -671,86 +653,5 @@ public class CodeDelegationTests {
                     // Verify that the delegation was cleared from the account
                     getAccountInfo(delegatingEoa.name()).hasNoDelegation());
         })));
-    }
-
-    private record EvmAccount(
-            String keyName, String name, AccountID accountId, Address evmAddress, Address longZeroEvmAddress) {
-        String evmAddressHex() {
-            return toChecksumAddress(evmAddress.value()).replace("0x", "");
-        }
-
-        byte[] evmAddressBytes() {
-            return CommonUtils.unhex(evmAddressHex());
-        }
-    }
-
-    private record EvmContract(String name, Address address) {
-        String evmAddressHex() {
-            return toChecksumAddress(address.value()).replace("0x", "");
-        }
-
-        ByteString evmAddressPbjBytes() {
-            return ByteString.fromHex(evmAddressHex());
-        }
-
-        byte[] evmAddressBytes() {
-            return CommonUtils.unhex(evmAddressHex());
-        }
-    }
-
-    private EvmAccount createEvmAccountWithKey(HapiSpec spec) {
-        final var id = accountIdCounter.getAndIncrement();
-        final var name = "ACCOUNT_" + id;
-        final var keyName = "ACCOUNT_KEY_" + id;
-        final AtomicReference<Address> keyAliasEvmAddress = new AtomicReference<>();
-        final AtomicReference<AccountID> accountId = new AtomicReference<>();
-        final AtomicReference<Address> longZeroEvmAddress = new AtomicReference<>();
-        allRunFor(spec, newKeyNamed(keyName).shape(SECP_256K1_SHAPE));
-        final var key = spec.registry().getKey(keyName);
-        final var keyEvmAddress = ByteString.copyFrom(
-                recoverAddressFromPubKey(key.getECDSASecp256K1().toByteArray()));
-        allRunFor(
-                spec,
-                cryptoCreate(name)
-                        .key(keyName)
-                        .alias(keyEvmAddress)
-                        .exposingCreatedIdTo(accountId::set)
-                        .exposingEvmAddressTo(longZeroEvmAddress::set),
-                useAddressOfKey(keyName, keyAliasEvmAddress::set));
-        return new EvmAccount(keyName, name, accountId.get(), keyAliasEvmAddress.get(), longZeroEvmAddress.get());
-    }
-
-    private EvmAccount createFundedEvmAccountWithKey(HapiSpec spec, long hbarAmount) {
-        final var account = createEvmAccountWithKey(spec);
-        allRunFor(spec, cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, account.name, hbarAmount)));
-        return account;
-    }
-
-    private EvmContract createEvmContract(HapiSpec spec, String name) {
-        final AtomicReference<Address> evmAddress = new AtomicReference<>();
-        allRunFor(
-                spec,
-                uploadInitCode(CODE_DELEGATION_CONTRACT),
-                contractCreate(CODE_DELEGATION_CONTRACT)
-                        .exposingAddressTo(evmAddress::set)
-                        .gas(2_000_000L));
-        return new EvmContract(name, evmAddress.get());
-    }
-
-    private void nativeSetCodeDelegation(HapiSpec spec, EvmAccount account, EvmContract target) {
-        nativeSetCodeDelegation(spec, account, target.evmAddressPbjBytes());
-    }
-
-    private void nativeSetCodeDelegation(HapiSpec spec, EvmAccount account, ByteString targetAddress) {
-        allRunFor(
-                spec,
-                cryptoUpdate(account.name()).delegationAddress(targetAddress),
-                getAccountInfo(account.name()).has(accountWith().delegationAddress(targetAddress)));
-    }
-
-    private static byte[] encodeHtsTransfer(Address receiver, BigInteger amount) {
-        return new Function("transfer(address,uint256)")
-                .encodeCall(Tuple.of(receiver, amount))
-                .array();
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationType4TransactionTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationType4TransactionTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.suites.contract.hips.hip1340;
 
-import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.node.app.service.contract.impl.utils.ConstantUtils.ZERO_ADDRESS;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
@@ -15,34 +14,27 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
-import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
-import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiPropertySource;
-import com.hedera.services.bdd.spec.HapiSpec;
-import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
-import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
@@ -54,31 +46,15 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @DisplayName("Code Delegation Via Ethereum Type 4 Transaction Tests")
 @HapiTestLifecycle
-public class CodeDelegationType4TransactionTest {
+public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
 
     private static final AtomicReference<Address> DELEGATION_TARGET = new AtomicReference<>();
-    private static final String DELEGATING_ACCOUNT = "delegating_account";
-    private static final String DELEGATING_ACCOUNT_1 = DELEGATING_ACCOUNT + "_1";
-    private static final String DELEGATING_ACCOUNT_2 = DELEGATING_ACCOUNT + "_2";
-    private static final String DELEGATING_ACCOUNT_3 = DELEGATING_ACCOUNT + "_3";
-    private static final String DELEGATING_ACCOUNT_ID = "delegating_account_id";
-    private static final String DELEGATING_ACCOUNT_ID_1 = DELEGATING_ACCOUNT_ID + "_1";
-    private static final String DELEGATING_ACCOUNT_ID_2 = DELEGATING_ACCOUNT_ID + "_2";
-    private static final String DELEGATING_ACCOUNT_ID_3 = DELEGATING_ACCOUNT_ID + "_3";
-    private static final String CONTRACT = "CreateTrivial";
-    private static final String REVERTING_CONTRACT = "InternalCallee";
-    private static final String CREATION = "creation";
-    private static final String DELEGATION_SET = "delegation_set";
-    private static final String DELEGATION_CALL = "delegation_call";
-    private static final String DELEGATION_RESET = "delegation_reset";
-    private static final String PAYER_KEY = "PayerAccountKey";
-    private static final String PAYER = "PayerAccount";
 
     @BeforeAll
     public static void setup(@NonNull TestLifecycle lifecycle) {
         lifecycle.doAdhoc(
-                uploadInitCode("CodeDelegationContract"),
-                contractCreate("CodeDelegationContract").exposingAddressTo(DELEGATION_TARGET::set),
+                uploadInitCode(CODE_DELEGATION_CONTRACT),
+                contractCreate(CODE_DELEGATION_CONTRACT).exposingAddressTo(DELEGATION_TARGET::set),
                 cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS));
     }
 
@@ -89,7 +65,7 @@ public class CodeDelegationType4TransactionTest {
                 new Function("getValue()").encodeCall(Tuple.EMPTY).array());
 
         return hapiTest(withOpContext((spec, opLog) -> {
-            deployContract(spec, CONTRACT);
+            deployEvmContract(spec, CONTRACT);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
             allRunFor(
                     spec,
@@ -142,7 +118,7 @@ public class CodeDelegationType4TransactionTest {
     final Stream<DynamicTest> testMultipleCodeDelegationsSetViaEthCall() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         return hapiTest(withOpContext((spec, opLog) -> {
-            deployContract(spec, CONTRACT);
+            deployEvmContract(spec, CONTRACT);
             createSecp256k1Keys(
                     spec, DELEGATING_ACCOUNT, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
             allRunFor(
@@ -193,7 +169,7 @@ public class CodeDelegationType4TransactionTest {
     @HapiTest
     final Stream<DynamicTest> testDelegatingToKey() {
         return hapiTest(withOpContext((spec, opLog) -> {
-            deployContract(spec, CONTRACT);
+            deployEvmContract(spec, CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
             allRunFor(
@@ -235,7 +211,7 @@ public class CodeDelegationType4TransactionTest {
     @HapiTest
     final Stream<DynamicTest> testDelegationSetToHollowAccountWithRevertingCall() {
         return hapiTest(withOpContext((spec, opLog) -> {
-            deployContract(spec, REVERTING_CONTRACT);
+            deployEvmContract(spec, REVERTING_CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
             allRunFor(spec, sourcing(() -> ethereumCall(REVERTING_CONTRACT, "revertWithRevertReason")
@@ -277,7 +253,7 @@ public class CodeDelegationType4TransactionTest {
     @HapiTest
     final Stream<DynamicTest> testDelegationSetToMultipleHollowAccountsWithRevertingCall() {
         return hapiTest(withOpContext((spec, opLog) -> {
-            deployContract(spec, REVERTING_CONTRACT);
+            deployEvmContract(spec, REVERTING_CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
             allRunFor(spec, sourcing(() -> ethereumCall(REVERTING_CONTRACT, "revertWithRevertReason")
@@ -333,7 +309,7 @@ public class CodeDelegationType4TransactionTest {
     @HapiTest
     final Stream<DynamicTest> testDelegationWithMultipleAccountsAndNotEnoughGasForLazyCreation() {
         return hapiTest(withOpContext((spec, opLog) -> {
-            deployContract(spec, CONTRACT);
+            deployEvmContract(spec, CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
             allRunFor(spec, sourcing(() -> ethereumCall(CONTRACT, "create")
@@ -383,55 +359,5 @@ public class CodeDelegationType4TransactionTest {
                                             .status(ResponseCodeEnum.SUCCESS))
                             .logged());
         }));
-    }
-
-    private static void deployContract(HapiSpec spec, String contractName) {
-        allRunFor(
-                spec, uploadInitCode(contractName), contractCreate(contractName).gas(4_000_000L));
-    }
-
-    private static void createPayerAccountWithAlias(HapiSpec spec) {
-        allRunFor(
-                spec,
-                newKeyNamed(PAYER_KEY).shape(SECP_256K1_SHAPE).exposingKeyTo(key -> {
-                    final var evmAddress = ByteString.copyFrom(
-                            recoverAddressFromPubKey(key.getECDSASecp256K1().toByteArray()));
-                    spec.registry()
-                            .saveAccountAlias(
-                                    PAYER_KEY,
-                                    AccountID.newBuilder().setAlias(evmAddress).build());
-                }),
-                cryptoTransfer(TokenMovement.movingHbar(ONE_HUNDRED_HBARS).between(GENESIS, PAYER_KEY))
-                        .via(CREATION),
-                getTxnRecord(CREATION).exposingCreationsTo(creations -> {
-                    final var createdId = HapiPropertySource.asAccount(creations.getFirst());
-                    spec.registry().saveAccountId(PAYER, createdId);
-                }));
-    }
-
-    private static void createSecp256k1Keys(HapiSpec spec, String... names) {
-        allRunFor(
-                spec,
-                Arrays.stream(names)
-                        .map(name -> (HapiSpecOperation) newKeyNamed(name).shape(SECP_256K1_SHAPE))
-                        .toArray(HapiSpecOperation[]::new));
-    }
-
-    private static void verifyDelegationSet(HapiSpec spec, Address target, String... accountNames) {
-        allRunFor(
-                spec,
-                Arrays.stream(accountNames)
-                        .map(name -> (HapiSpecOperation)
-                                getAliasedAccountInfo(name).isNotHollow().hasDelegationAddress(target))
-                        .toArray(HapiSpecOperation[]::new));
-    }
-
-    private static void verifyDelegationCleared(HapiSpec spec, String... accountNames) {
-        allRunFor(
-                spec,
-                Arrays.stream(accountNames)
-                        .map(name ->
-                                (HapiSpecOperation) getAliasedAccountInfo(name).hasNoDelegation())
-                        .toArray(HapiSpecOperation[]::new));
     }
 }


### PR DESCRIPTION
**Description**:
Additional HAPI tests for 7702 code delegation - cases with chaining. 
Extracted helper methods in a base test class. 
Also fixes a constant for Y parity 

**Related issue(s)**:
#23659 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
