### PR TITLE
ci(workflow-alerts): Remove release-team webhook calls for slack reports

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -323,11 +323,3 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -489,11 +489,3 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -767,11 +767,3 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json

--- a/.github/workflows/zxf-merge-queue-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-merge-queue-performance-test-controller-adhoc.yaml
@@ -462,11 +462,3 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json

--- a/.github/workflows/zxf-merge-queue-performance-test-controller.yaml
+++ b/.github/workflows/zxf-merge-queue-performance-test-controller.yaml
@@ -406,11 +406,3 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -544,11 +544,3 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -544,11 +544,3 @@ jobs:
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json


### PR DESCRIPTION
## Description

This pull request removes the step that reports failures to the release team Slack channel from several GitHub Actions workflow files. The Slack notification for failures directed at the release team is no longer sent in any of the affected workflows.

Removed Slack failure notifications from workflows:

* Node application workflows:
  - Removed the "Report failure (slack release-team)" step from `.github/workflows/node-flow-build-application.yaml`
  - Removed the "Report failure (slack release-team)" step from `.github/workflows/node-flow-deploy-release-artifact.yaml`

* Test and performance workflows:
  - Removed the "Report failure (slack release-team)" step from `.github/workflows/zxcron-extended-test-suite.yaml`
  - Removed the "Report failure (slack release-team)" step from `.github/workflows/zxf-merge-queue-performance-test-controller.yaml`
  - Removed the "Report failure (slack release-team)" step from `.github/workflows/zxf-merge-queue-performance-test-controller-adhoc.yaml`
  - Removed the "Report failure (slack release-team)" step from `.github/workflows/zxf-single-day-longevity-test-controller.yaml`
  - Removed the "Report failure (slack release-team)" step from `.github/workflows/zxf-single-day-performance-test-controller.yaml`

## Related Issue(s)

Closes #24058 