### PR TITLE
refactor: 15946 Removed static fields from `VirtualHasher` and `VirtualNodeCache`

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -355,9 +355,9 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         this.configuration = requireNonNull(configuration);
 
         this.fastCopyVersion = 0;
-        // Hasher is required during reconnects
-        this.hasher = new VirtualHasher();
         this.virtualMapConfig = requireNonNull(configuration.getConfigData(VirtualMapConfig.class));
+        // Hasher is required during reconnects
+        this.hasher = new VirtualHasher(virtualMapConfig);
         this.flushCandidateThreshold.set(virtualMapConfig.copyFlushCandidateThreshold());
     }
 
@@ -373,8 +373,8 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         this.configuration = requireNonNull(configuration);
 
         this.fastCopyVersion = 0;
-        this.hasher = new VirtualHasher();
         this.virtualMapConfig = requireNonNull(configuration.getConfigData(VirtualMapConfig.class));
+        this.hasher = new VirtualHasher(virtualMapConfig);
         this.flushCandidateThreshold.set(virtualMapConfig.copyFlushCandidateThreshold());
         this.dataSourceBuilder = requireNonNull(dataSourceBuilder);
         dataSource = dataSourceBuilder.build(LABEL, null, true, false);
@@ -396,8 +396,8 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
 
         this.fastCopyVersion = 0L;
         this.configuration = requireNonNull(configuration);
-        this.hasher = new VirtualHasher();
         this.virtualMapConfig = requireNonNull(configuration.getConfigData(VirtualMapConfig.class));
+        this.hasher = new VirtualHasher(virtualMapConfig);
         this.flushCandidateThreshold.set(virtualMapConfig.copyFlushCandidateThreshold());
         this.dataSourceBuilder = requireNonNull(dataSourceBuilder);
         this.dataSource = dataSourceBuilder.build(LABEL, snapshotPath, true, false);
@@ -547,8 +547,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
                         rehashIterator,
                         firstLeafPath,
                         lastLeafPath,
-                        hashListener,
-                        virtualMapConfig))
+                        hashListener))
                 .exceptionally((exception) -> {
                     // Shut down the iterator.
                     rehashIterator.close();
@@ -869,6 +868,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
             // is not immediate, the hasher will eventually stop once it finishes all of its work.
             hasher.shutdown();
         }
+        cache.shutdown();
         closeDataSource();
     }
 
@@ -1192,8 +1192,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
                         .iterator(),
                 metadata.getFirstLeafPath(),
                 metadata.getLastLeafPath(),
-                hashListener,
-                virtualMapConfig);
+                hashListener);
 
         if (virtualHash == null) {
             final Hash rootHash = (metadata.getSize() == 0) ? null : records.rootHash();
@@ -1460,8 +1459,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
                         reconnectIterator,
                         firstLeafPath,
                         lastLeafPath,
-                        hashListener,
-                        virtualMapConfig)))
+                        hashListener)))
                 .setExceptionHandler((thread, exception) -> {
                     // Shut down the iterator. This will cause reconnect to terminate.
                     reconnectIterator.close();

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -107,38 +108,10 @@ public final class VirtualNodeCache implements FastCopyable {
      */
     public static final VirtualLeafBytes<?> DELETED_LEAF_RECORD = new VirtualLeafBytes<>(-1, Bytes.EMPTY, null, null);
 
-    private static Executor cleaningPool = null;
-
     /**
-     * This method is invoked from a non-static method and uses the provided configuration.
-     * Consequently, the cleaning pool will be initialized using the configuration provided
-     * by the first instance of VirtualNodeCache class that calls the relevant non-static methods.
-     * Subsequent calls will reuse the same pool, regardless of any new configurations provided.
+     * Thread pool used to asynchronously clean up the indexes on cache release.
      */
-    private static synchronized Executor getCleaningPool(@NonNull final VirtualMapConfig virtualMapConfig) {
-        requireNonNull(virtualMapConfig);
-
-        if (cleaningPool == null) {
-            cleaningPool = Boolean.getBoolean("syncCleaningPool")
-                    ? Runnable::run
-                    : new ThreadPoolExecutor(
-                            virtualMapConfig.getNumCleanerThreads(),
-                            virtualMapConfig.getNumCleanerThreads(),
-                            60L,
-                            TimeUnit.SECONDS,
-                            new LinkedBlockingQueue<>(),
-                            new ThreadConfiguration(getStaticThreadManager())
-                                    .setThreadGroup(new ThreadGroup("virtual-cache-cleaners"))
-                                    .setComponent("virtual-map")
-                                    .setThreadName("cache-cleaner")
-                                    .setExceptionHandler((t, ex) -> logger.error(
-                                            EXCEPTION.getMarker(),
-                                            "Failed to purge unneeded key/mutationList pairs",
-                                            ex))
-                                    .buildFactory());
-        }
-        return cleaningPool;
-    }
+    private final Executor cleaningPool;
 
     /**
      * The fast-copyable version of the cache. This version number is auto-incrementing and set
@@ -321,7 +294,7 @@ public final class VirtualNodeCache implements FastCopyable {
      * @param virtualMapConfig platform configuration for VirtualMap
      * @param hashChunkHeight virtual hash chunk height
      * @param hashChunkLoader virtual hash chunk loader, must not be null
-     * @param fastCopyVersion copy version
+     * @param fastCopyVersion  the version of this cache
      */
     public VirtualNodeCache(
             final @NonNull VirtualMapConfig virtualMapConfig,
@@ -337,6 +310,22 @@ public final class VirtualNodeCache implements FastCopyable {
         this.lastReleased = new AtomicLong(-1L);
         this.fastCopyVersion.set(fastCopyVersion);
         this.virtualMapConfig = requireNonNull(virtualMapConfig);
+
+        cleaningPool = Boolean.getBoolean("syncCleaningPool")
+                ? Runnable::run
+                : new ThreadPoolExecutor(
+                        virtualMapConfig.getNumCleanerThreads(),
+                        virtualMapConfig.getNumCleanerThreads(),
+                        60L,
+                        TimeUnit.SECONDS,
+                        new LinkedBlockingQueue<>(),
+                        new ThreadConfiguration(getStaticThreadManager())
+                                .setThreadGroup(new ThreadGroup("virtual-cache-cleaners"))
+                                .setComponent("virtual-map")
+                                .setThreadName("cache-cleaner")
+                                .setExceptionHandler((t, ex) -> logger.error(
+                                        EXCEPTION.getMarker(), "Failed to purge unneeded key/mutationList pairs", ex))
+                                .buildFactory());
     }
 
     /**
@@ -363,6 +352,7 @@ public final class VirtualNodeCache implements FastCopyable {
         this.releaseLock = source.releaseLock;
         this.lastReleased = source.lastReleased;
         this.virtualMapConfig = source.virtualMapConfig;
+        this.cleaningPool = source.cleaningPool;
 
         // The source now has immutable leaves and mutable internals
         source.prepareForHashing();
@@ -449,9 +439,9 @@ public final class VirtualNodeCache implements FastCopyable {
 
         // Fire off the cleaning threads to go and clear out data in the indexes that doesn't need
         // to be there anymore.
-        purge(dirtyLeaves, keyToDirtyLeafIndex, virtualMapConfig);
-        purge(dirtyLeafPaths, pathToDirtyKeyIndex, virtualMapConfig);
-        purge(dirtyHashChunks, idToDirtyHashChunkIndex, virtualMapConfig);
+        purge(dirtyLeaves, keyToDirtyLeafIndex);
+        purge(dirtyLeafPaths, pathToDirtyKeyIndex);
+        purge(dirtyHashChunks, idToDirtyHashChunkIndex);
 
         estimatedLeavesSizeInBytes.set(0);
         estimatedHashesSizeInBytes.set(0);
@@ -470,6 +460,15 @@ public final class VirtualNodeCache implements FastCopyable {
     @Override
     public boolean isDestroyed() {
         return this.released.get();
+    }
+
+    /**
+     * Shutdown the cleaning pool.
+     */
+    public void shutdown() {
+        if (cleaningPool instanceof ExecutorService service) {
+            service.shutdown();
+        }
     }
 
     /**
@@ -793,7 +792,7 @@ public final class VirtualNodeCache implements FastCopyable {
         }
         if (dedupe) {
             // Mark obsolete mutations to filter later
-            filterMutations(dirtyLeaves, virtualMapConfig);
+            filterMutations(dirtyLeaves);
         }
         return dirtyLeaves.stream()
                 .filter(mutation -> {
@@ -823,16 +822,15 @@ public final class VirtualNodeCache implements FastCopyable {
         }
 
         final Map<Bytes, VirtualLeafBytes> leaves = new ConcurrentHashMap<>();
-        final StandardFuture<Void> result =
-                dirtyLeaves.parallelTraverse(getCleaningPool(virtualMapConfig), (i, element) -> {
-                    if (element.isDeleted()) {
-                        final Bytes key = element.key;
-                        final Mutation<Bytes, VirtualLeafBytes> mutation = lookup(keyToDirtyLeafIndex.get(key));
-                        if (mutation != null && mutation.isDeleted()) {
-                            leaves.putIfAbsent(key, element.value);
-                        }
-                    }
-                });
+        final StandardFuture<Void> result = dirtyLeaves.parallelTraverse(cleaningPool, (i, element) -> {
+            if (element.isDeleted()) {
+                final Bytes key = element.key;
+                final Mutation<Bytes, VirtualLeafBytes> mutation = lookup(keyToDirtyLeafIndex.get(key));
+                if (mutation != null && mutation.isDeleted()) {
+                    leaves.putIfAbsent(key, element.value);
+                }
+            }
+        });
         try {
             result.getAndRethrow();
         } catch (final InterruptedException ex) {
@@ -911,7 +909,7 @@ public final class VirtualNodeCache implements FastCopyable {
             throw new MutabilityException("Cannot get the dirty internal records for a non-sealed cache.");
         }
         // Mark obsolete mutations to filter later
-        filterMutations(dirtyHashChunks, virtualMapConfig);
+        filterMutations(dirtyHashChunks);
         return dirtyHashChunks.stream()
                 .filter(mutation -> {
                     final long hashChunkPath = mutation.value.path();
@@ -1185,11 +1183,8 @@ public final class VirtualNodeCache implements FastCopyable {
      * @param <V>
      * 		The value type referenced by the mutation list
      */
-    private static <K, V> void purge(
-            final ConcurrentArray<Mutation<K, V>> array,
-            final Map<K, Mutation<K, V>> index,
-            @NonNull final VirtualMapConfig virtualMapConfig) {
-        array.parallelTraverse(getCleaningPool(virtualMapConfig), (i, element) -> {
+    private <K, V> void purge(final ConcurrentArray<Mutation<K, V>> array, final Map<K, Mutation<K, V>> index) {
+        array.parallelTraverse(cleaningPool, (i, element) -> {
             // If a cache copy is released after flush, some mutations may be already marked as
             // filtered in dirtyLeavesForFlush() and dirtyHashesForFlush(). When a mutation is
             // filtered, it means there is a newer mutation for the same key in the same cache
@@ -1231,8 +1226,7 @@ public final class VirtualNodeCache implements FastCopyable {
      * @param <V>
      * 		The value type referenced by the mutation list
      */
-    private static <K, V> void filterMutations(
-            final ConcurrentArray<Mutation<K, V>> array, @NonNull final VirtualMapConfig virtualMapConfig) {
+    private <K, V> void filterMutations(final ConcurrentArray<Mutation<K, V>> array) {
         final BiConsumer<Integer, Mutation<K, V>> action = (i, mutation) -> {
             // local variable is required because mutation.next can be changed by another thread to null
             // see https://github.com/hashgraph/hedera-services/issues/7046 for the context
@@ -1242,7 +1236,7 @@ public final class VirtualNodeCache implements FastCopyable {
             }
         };
         try {
-            array.parallelTraverse(getCleaningPool(virtualMapConfig), action).getAndRethrow();
+            array.parallelTraverse(cleaningPool, action).getAndRethrow();
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
@@ -51,35 +51,7 @@ public final class VirtualHasher {
      */
     private static final Logger logger = LogManager.getLogger(VirtualHasher.class);
 
-    private static volatile ForkJoinPool hashingPool = null;
-
-    /**
-     * This method is invoked from a non-static method, passing the provided configuration.
-     * Consequently, the hashing pool will be initialized using the configuration provided
-     * with the first call of the hash method. Subsequent calls will reuse the same pool.
-     */
-    private static ForkJoinPool getHashingPool(final @NonNull VirtualMapConfig virtualMapConfig) {
-        requireNonNull(virtualMapConfig);
-
-        ForkJoinPool pool = hashingPool;
-        if (pool == null) {
-            synchronized (VirtualHasher.class) {
-                pool = hashingPool;
-                if (pool == null) {
-                    pool = new ForkJoinPool(
-                            virtualMapConfig.getNumHashThreads(),
-                            ForkJoinPool.defaultForkJoinWorkerThreadFactory,
-                            (t, e) -> logger.error(
-                                    EXCEPTION.getMarker(),
-                                    "Virtual hasher thread terminated with exception: {}",
-                                    StackTrace.getStackTrace(e)),
-                            true);
-                    hashingPool = pool;
-                }
-            }
-        }
-        return pool;
-    }
+    private final ForkJoinPool hashingPool;
 
     /**
      * This thread-local gets a message digest that can be used for hashing on a per-thread basis.
@@ -110,13 +82,31 @@ public final class VirtualHasher {
      */
     private final AtomicBoolean shutdown = new AtomicBoolean(false);
 
+    private final VirtualMapConfig virtualMapConfig;
+
     /**
-     * Indicate to the virtual hasher that it has been shut down. This method does not interrupt threads, but
-     * it indicates to threads that an interrupt may happen, and that the interrupt should not be treated as
-     * an error.
+     * @param virtualMapConfig platform configuration for VirtualMap
+     */
+    public VirtualHasher(final @NonNull VirtualMapConfig virtualMapConfig) {
+        requireNonNull(virtualMapConfig);
+        this.virtualMapConfig = virtualMapConfig;
+        hashingPool = new ForkJoinPool(
+                virtualMapConfig.getNumHashThreads(),
+                ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+                (t, e) -> logger.error(
+                        EXCEPTION.getMarker(),
+                        "Virtual hasher thread terminated with exception: {}",
+                        StackTrace.getStackTrace(e)),
+                true);
+    }
+
+    /**
+     * Indicate to the virtual hasher that it has been shut down. This method shuts down the
+     * hashing pool.
      */
     public void shutdown() {
         shutdown.set(true);
+        hashingPool.shutdown();
     }
 
     public static Hash hashInternal(final Hash left, final Hash right) {
@@ -441,8 +431,6 @@ public final class VirtualHasher {
      * 		No leaf in {@code sortedDirtyLeaves} may have a path greater than {@code lastLeafPath}.
      * @param listener
      *      Hash listener. May be {@code null}
-     * @param virtualMapConfig
-     *      Platform configuration for VirtualMap
      * @return
      *      The hash of the root of the tree, or {@code null} if the list of dirty leaves is empty
      */
@@ -453,8 +441,7 @@ public final class VirtualHasher {
             final @NonNull Iterator<VirtualLeafBytes> sortedDirtyLeaves,
             final long firstLeafPath,
             final long lastLeafPath,
-            final @Nullable VirtualHashListener listener,
-            final @NonNull VirtualMapConfig virtualMapConfig) {
+            final @Nullable VirtualHashListener listener) {
         requireNonNull(hashChunkPreloader);
         requireNonNull(virtualMapConfig);
 
@@ -469,9 +456,8 @@ public final class VirtualHasher {
         // Let the listener know we have started hashing.
         this.listener.onHashingStarted(firstLeafPath, lastLeafPath);
 
-        final ForkJoinPool pool = Thread.currentThread() instanceof ForkJoinWorkerThread thread
-                ? thread.getPool()
-                : getHashingPool(virtualMapConfig);
+        final ForkJoinPool pool =
+                Thread.currentThread() instanceof ForkJoinWorkerThread thread ? thread.getPool() : hashingPool;
 
         final ChunkHashTask rootTask = pool.invoke(ForkJoinTask.adapt(
                 () -> hashImpl(hashChunkPreloader, sortedDirtyLeaves, firstLeafPath, lastLeafPath, pool)));

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherHugeTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherHugeTest.java
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.virtualmap.internal.hash;
 
-import static com.swirlds.virtualmap.test.fixtures.VirtualMapTestUtils.CONFIGURATION;
+import static com.swirlds.virtualmap.test.fixtures.VirtualMapTestUtils.VIRTUAL_MAP_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.swirlds.virtualmap.config.VirtualMapConfig;
 import com.swirlds.virtualmap.datasource.VirtualHashChunk;
 import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import com.swirlds.virtualmap.test.fixtures.TestKey;
@@ -45,7 +44,7 @@ class VirtualHasherHugeTest extends VirtualHasherTestBase {
         // Go ahead and hash. I'm just going to check that the root hash produces *something*. I'm not worried
         // in this test as to the validity of this root hash since correctness is validated heavily in other
         // tests. In this test, I just want to be sure that we complete, and that we don't run out of memory.
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
         final Hash rootHash = hasher.hash(
                 CHUNK_HEIGHT,
                 chunkPath -> new VirtualHashChunk(chunkPath, CHUNK_HEIGHT),
@@ -54,8 +53,7 @@ class VirtualHasherHugeTest extends VirtualHasherTestBase {
                         .iterator(),
                 firstLeafPath,
                 lastLeafPath,
-                null,
-                CONFIGURATION.getConfigData(VirtualMapConfig.class));
+                null);
         System.err.println("Root hash: " + rootHash);
         assertNotNull(rootHash, "No hash produced");
     }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTest.java
@@ -55,11 +55,11 @@ class VirtualHasherTest extends VirtualHasherTestBase {
     @Tag(TestComponentTags.VMAP)
     @DisplayName("Null preloader produces NPE")
     void nullPreloaderProducesNPE() {
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
         final List<VirtualLeafBytes> leaves = new ArrayList<>();
         assertThrows(
                 NullPointerException.class,
-                () -> hasher.hash(CHUNK_HEIGHT, null, leaves.iterator(), 1, 2, null, VIRTUAL_MAP_CONFIG),
+                () -> hasher.hash(CHUNK_HEIGHT, null, leaves.iterator(), 1, 2, null),
                 "Call should have produced an NPE");
     }
 
@@ -71,10 +71,10 @@ class VirtualHasherTest extends VirtualHasherTestBase {
     @DisplayName("Null stream produces NPE")
     void nullStreamProducesNPE() {
         final TestDataSource ds = new TestDataSource(1, 2, CHUNK_HEIGHT);
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
         assertThrows(
                 NullPointerException.class,
-                () -> hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, null, 1, 2, null, VIRTUAL_MAP_CONFIG),
+                () -> hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, null, 1, 2, null),
                 "Call should have produced an NPE");
     }
 
@@ -87,10 +87,10 @@ class VirtualHasherTest extends VirtualHasherTestBase {
     @SuppressWarnings({"MismatchedQueryAndUpdateOfCollection", "RedundantOperationOnEmptyContainer"})
     void emptyStreamProducesNull() {
         final TestDataSource ds = new TestDataSource(1, 2, CHUNK_HEIGHT);
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
         final List<VirtualLeafBytes> leaves = new ArrayList<>();
         assertNull(
-                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, leaves.iterator(), 1, 2, null, VIRTUAL_MAP_CONFIG),
+                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, leaves.iterator(), 1, 2, null),
                 "Call should have returned a null hash");
     }
 
@@ -102,7 +102,7 @@ class VirtualHasherTest extends VirtualHasherTestBase {
     @DisplayName("Invalid leaf paths")
     void invalidLeafPaths() {
         final TestDataSource ds = new TestDataSource(Path.INVALID_PATH, Path.INVALID_PATH, CHUNK_HEIGHT);
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
         final List<VirtualLeafBytes> emptyLeaves = new ArrayList<>();
         // Empty dirty leaves stream -> null hash
         assertNull(
@@ -112,34 +112,19 @@ class VirtualHasherTest extends VirtualHasherTestBase {
                         emptyLeaves.iterator(),
                         Path.INVALID_PATH,
                         Path.INVALID_PATH,
-                        null,
-                        VIRTUAL_MAP_CONFIG),
+                        null),
                 "Call should have produced null");
         assertNull(
-                hasher.hash(
-                        CHUNK_HEIGHT,
-                        ds::loadHashChunk,
-                        emptyLeaves.iterator(),
-                        Path.INVALID_PATH,
-                        2,
-                        null,
-                        VIRTUAL_MAP_CONFIG),
+                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, emptyLeaves.iterator(), Path.INVALID_PATH, 2, null),
                 "Call should have produced null");
         assertNull(
-                hasher.hash(
-                        CHUNK_HEIGHT,
-                        ds::loadHashChunk,
-                        emptyLeaves.iterator(),
-                        1,
-                        Path.INVALID_PATH,
-                        null,
-                        VIRTUAL_MAP_CONFIG),
+                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, emptyLeaves.iterator(), 1, Path.INVALID_PATH, null),
                 "Call should have produced null");
         assertNull(
-                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, emptyLeaves.iterator(), 0, 2, null, VIRTUAL_MAP_CONFIG),
+                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, emptyLeaves.iterator(), 0, 2, null),
                 "Call should have produced null");
         assertNull(
-                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, emptyLeaves.iterator(), 1, 0, null, VIRTUAL_MAP_CONFIG),
+                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, emptyLeaves.iterator(), 1, 0, null),
                 "Call should have produced null");
         // Non-empty dirty leaves stream + empty leaf path range -> IllegalStateException
         final List<VirtualLeafBytes> nonEmptyLeaves = new ArrayList<>();
@@ -152,18 +137,15 @@ class VirtualHasherTest extends VirtualHasherTestBase {
                         nonEmptyLeaves.iterator(),
                         Path.INVALID_PATH,
                         Path.INVALID_PATH,
-                        null,
-                        VIRTUAL_MAP_CONFIG),
+                        null),
                 "Non-null leaves iterator + invalid paths should throw an exception");
         assertThrows(
                 IllegalArgumentException.class,
-                () -> hasher.hash(
-                        CHUNK_HEIGHT, ds::loadHashChunk, nonEmptyLeaves.iterator(), 0, 2, null, VIRTUAL_MAP_CONFIG),
+                () -> hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, nonEmptyLeaves.iterator(), 0, 2, null),
                 "Non-null leaves iterator + invalid paths should throw an exception");
         assertThrows(
                 IllegalArgumentException.class,
-                () -> hasher.hash(
-                        CHUNK_HEIGHT, ds::loadHashChunk, nonEmptyLeaves.iterator(), 1, 0, null, VIRTUAL_MAP_CONFIG),
+                () -> hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, nonEmptyLeaves.iterator(), 1, 0, null),
                 "Non-null leaves iterator + invalid paths should throw an exception");
     }
 
@@ -186,17 +168,11 @@ class VirtualHasherTest extends VirtualHasherTestBase {
             throws Exception {
         final TestDataSource ds = new TestDataSource(firstLeafPath, lastLeafPath, CHUNK_HEIGHT);
         final HashingListener listener = new HashingListener();
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
         final Hash expected = hashTree(ds);
         final List<VirtualLeafBytes> leaves = invalidateNodes(ds, dirtyPaths.stream());
-        final Hash rootHash = hasher.hash(
-                CHUNK_HEIGHT,
-                ds::loadHashChunk,
-                leaves.iterator(),
-                firstLeafPath,
-                lastLeafPath,
-                listener,
-                VIRTUAL_MAP_CONFIG);
+        final Hash rootHash =
+                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, leaves.iterator(), firstLeafPath, lastLeafPath, listener);
         assertEquals(expected, rootHash, "Hash value does not match expected");
 
         // Make sure the saver saw each dirty node exactly once.
@@ -220,14 +196,8 @@ class VirtualHasherTest extends VirtualHasherTestBase {
         assertEquals(savedChunks.size(), seenChunks.size(), "Expected equals");
         assertCallsAreBalanced(listener);
 
-        final Hash hashItAgain = hasher.hash(
-                CHUNK_HEIGHT,
-                ds::loadHashChunk,
-                leaves.iterator(),
-                firstLeafPath,
-                lastLeafPath,
-                listener,
-                VIRTUAL_MAP_CONFIG);
+        final Hash hashItAgain =
+                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, leaves.iterator(), firstLeafPath, lastLeafPath, listener);
         assertEquals(expected, hashItAgain, "Hash value does not match expected");
 
         for (int i = 0; i < leaves.size(); i++) {
@@ -239,14 +209,8 @@ class VirtualHasherTest extends VirtualHasherTestBase {
             }
         }
         leaves.sort(Comparator.comparing(VirtualLeafBytes::path));
-        final Hash hashItOnceMore = hasher.hash(
-                CHUNK_HEIGHT,
-                ds::loadHashChunk,
-                leaves.iterator(),
-                firstLeafPath,
-                lastLeafPath,
-                listener,
-                VIRTUAL_MAP_CONFIG);
+        final Hash hashItOnceMore =
+                hasher.hash(CHUNK_HEIGHT, ds::loadHashChunk, leaves.iterator(), firstLeafPath, lastLeafPath, listener);
         assertEquals(expected, hashItOnceMore, "Hash value does not match expected");
     }
 
@@ -378,7 +342,7 @@ class VirtualHasherTest extends VirtualHasherTestBase {
         final long firstLeafPath = 52L;
         final long lastLeafPath = firstLeafPath * 2;
         final TestDataSource ds = new TestDataSource(firstLeafPath, lastLeafPath, chunkHeight);
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
         final Hash expected = hashTree(ds);
         final List<Long> dirtyLeafPaths = List.of(
                 53L, 56L, 59L, 63L, 66L, 72L, 76L, 77L, 80L, 81L, 82L, 83L, 85L, 87L, 88L, 94L, 96L, 100L, 104L);
@@ -387,14 +351,8 @@ class VirtualHasherTest extends VirtualHasherTestBase {
         // this will *likely* find it.
         for (int i = 0; i < 500; i++) {
             final List<VirtualLeafBytes> leaves = invalidateNodes(ds, dirtyLeafPaths.stream());
-            final Hash rootHash = hasher.hash(
-                    chunkHeight,
-                    ds::loadHashChunk,
-                    leaves.iterator(),
-                    firstLeafPath,
-                    lastLeafPath,
-                    null,
-                    VIRTUAL_MAP_CONFIG);
+            final Hash rootHash =
+                    hasher.hash(chunkHeight, ds::loadHashChunk, leaves.iterator(), firstLeafPath, lastLeafPath, null);
             assertEquals(expected, rootHash, "Expected equals");
         }
 
@@ -408,13 +366,7 @@ class VirtualHasherTest extends VirtualHasherTestBase {
         for (int i = 0; i < 500; i++) {
             final List<VirtualLeafBytes> leaves = invalidateNodes(ds, dirtyLeafPaths.stream());
             final Hash rootHash = hasher.hash(
-                    chunkHeight,
-                    ds::loadHashChunk,
-                    leaves.iterator(),
-                    firstLeafPath,
-                    lastLeafPath,
-                    listener,
-                    VIRTUAL_MAP_CONFIG);
+                    chunkHeight, ds::loadHashChunk, leaves.iterator(), firstLeafPath, lastLeafPath, listener);
             assertEquals(expected, rootHash, "Expected equals");
         }
     }
@@ -425,7 +377,7 @@ class VirtualHasherTest extends VirtualHasherTestBase {
         final long firstLeafPath = 801;
         final long lastLeafPath = firstLeafPath * 2;
         final TestDataSource ds = new TestDataSource(firstLeafPath, lastLeafPath, chunkHeight);
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
         final Hash expected = hashTree(ds);
         final List<Long> dirtyLeafPaths =
                 LongStream.range(firstLeafPath, lastLeafPath + 1).boxed().toList();
@@ -437,25 +389,13 @@ class VirtualHasherTest extends VirtualHasherTestBase {
             }
         };
         final List<VirtualLeafBytes> leaves = invalidateNodes(ds, dirtyLeafPaths.stream());
-        final Hash rootHash = hasher.hash(
-                chunkHeight,
-                ds::loadHashChunk,
-                leaves.iterator(),
-                firstLeafPath,
-                lastLeafPath,
-                listener,
-                VIRTUAL_MAP_CONFIG);
+        final Hash rootHash =
+                hasher.hash(chunkHeight, ds::loadHashChunk, leaves.iterator(), firstLeafPath, lastLeafPath, listener);
         assertEquals(expected, rootHash, "Expected equals");
 
         final List<VirtualLeafBytes> oneDirtyLeaf = List.of(ds.getLeaf((firstLeafPath + lastLeafPath) / 2));
-        final Hash hashItAgain = hasher.hash(
-                chunkHeight,
-                ds::loadHashChunk,
-                oneDirtyLeaf.iterator(),
-                firstLeafPath,
-                lastLeafPath,
-                null,
-                VIRTUAL_MAP_CONFIG);
+        final Hash hashItAgain =
+                hasher.hash(chunkHeight, ds::loadHashChunk, oneDirtyLeaf.iterator(), firstLeafPath, lastLeafPath, null);
         assertEquals(expected, hashItAgain, "Expected equals");
     }
 
@@ -480,20 +420,13 @@ class VirtualHasherTest extends VirtualHasherTestBase {
         final long lastLeafPath = firstLeafPath * 2;
         final TestDataSource ds = new TestDataSource(firstLeafPath, lastLeafPath, hashChunkHeight);
         final HashingListener listener = new HashingListener();
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(virtualMapConfig);
         hashTree(ds);
         final List<Long> dirtyLeafPaths = List.of(
                 53L, 56L, 59L, 63L, 66L, 72L, 76L, 77L, 80L, 81L, 82L, 83L, 85L, 87L, 88L, 94L, 96L, 100L, 104L);
 
         final List<VirtualLeafBytes> leaves = invalidateNodes(ds, dirtyLeafPaths.stream());
-        hasher.hash(
-                hashChunkHeight,
-                ds::loadHashChunk,
-                leaves.iterator(),
-                firstLeafPath,
-                lastLeafPath,
-                listener,
-                virtualMapConfig);
+        hasher.hash(hashChunkHeight, ds::loadHashChunk, leaves.iterator(), firstLeafPath, lastLeafPath, listener);
 
         // Check the different callbacks were called the correct number of times
         assertEquals(1, listener.onHashingStartedCallCount, "Unexpected count");
@@ -518,7 +451,7 @@ class VirtualHasherTest extends VirtualHasherTestBase {
     @DisplayName("Verify the hasher does not ask for internal records it will recreate")
     void hasherDoesNotAskForInternalsItWillRecreate() {
         final HashingListener listener = new HashingListener();
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(VIRTUAL_MAP_CONFIG);
 
         // We will simulate growing the tree from 53 leaves to 106 leaves (doubling the size) and providing
         // all new leaves. This will guarantee that some internal nodes live at the paths that leaves used
@@ -536,14 +469,7 @@ class VirtualHasherTest extends VirtualHasherTestBase {
 
         assertDoesNotThrow(
                 () -> {
-                    hasher.hash(
-                            CHUNK_HEIGHT,
-                            hashChunkReader,
-                            dirtyLeaves,
-                            firstLeafPath,
-                            lastLeafPath,
-                            listener,
-                            VIRTUAL_MAP_CONFIG);
+                    hasher.hash(CHUNK_HEIGHT, hashChunkReader, dirtyLeaves, firstLeafPath, lastLeafPath, listener);
                 },
                 "Hashing should not throw an exception");
     }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
@@ -81,7 +81,7 @@ class ReconnectHashListenerTest {
         final int first = size - 1;
         final int last = 2 * size - 2;
         final ReconnectHashListener listener = new ReconnectHashListener(flusher);
-        final VirtualHasher hasher = new VirtualHasher();
+        final VirtualHasher hasher = new VirtualHasher(CONFIGURATION.getConfigData(VirtualMapConfig.class));
         final LongFunction<VirtualHashChunk> chunkPreloader = path -> {
             final long chunkId = VirtualHashChunk.chunkPathToChunkId(path, hashChunkHeight);
             final long chunkPath = VirtualHashChunk.chunkIdToChunkPath(chunkId, hashChunkHeight);
@@ -93,8 +93,7 @@ class ReconnectHashListenerTest {
                 LongStream.range(first, last + 1).mapToObj(this::leaf).iterator(),
                 first,
                 last,
-                listener,
-                CONFIGURATION.getConfigData(VirtualMapConfig.class));
+                listener);
 
         // Now validate that everything showed up the data source in ordered chunks
         final TreeSet<VirtualHashChunk> allFlushedChunks =


### PR DESCRIPTION
**Description**:

This PR replaced `VirtualNodeCache.cleaningPool` and `VirtualHasher.hashingPool` with object-level fields. 


**Related issue(s)**:

Fixes #15946 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
