### PR TITLE
feat: 24063 Made `virtualMap.fullRehashTimeoutMs` configurable for State Operator

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ConfigUtils.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ConfigUtils.java
@@ -119,7 +119,8 @@ public final class ConfigUtils {
                 .withSource(new SimpleConfigSource().withValue("merkleDb.minNumberOfFilesInCompaction", 2))
                 .withSource(new SimpleConfigSource().withValue("merkleDb.maxFileChannelsPerFileReader", FILE_CHANNELS))
                 .withSource(new SimpleConfigSource().withValue("merkleDb.maxThreadsPerFileChannel", 1))
-                .withSource(new SimpleConfigSource().withValue("virtualMap.fullRehashTimeoutMs", FULL_REHASH_TIMEOUT_MS))
+                .withSource(
+                        new SimpleConfigSource().withValue("virtualMap.fullRehashTimeoutMs", FULL_REHASH_TIMEOUT_MS))
                 .withConverter(CongestionMultipliers.class, new CongestionMultipliersConverter())
                 .withConverter(EntityScaleFactors.class, new EntityScaleFactorsConverter())
                 .withConverter(KnownBlockValues.class, new KnownBlockValuesConverter())


### PR DESCRIPTION
**Description**:

This PR makes `virtualMap.fullRehashTimeoutMs` property configurable via command line as follows: `-DvirtualMap.fullRehashTimeoutMs=900000`

**Related issue(s)**:

Fixes #24063 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
