### PR TITLE
fix(typo): Fix typo in parameter name parameterSupplier

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
@@ -610,10 +610,10 @@ public class TxnVerbs {
     }
 
     public static HapiContractCall contractCall(
-            String contract, String functionName, Supplier<Object> parmeterSupplier) {
+            String contract, String functionName, Supplier<Object> parameterSupplier) {
         final var abi = getABIFor(FUNCTION, functionName, contract);
         return new HapiContractCall(
-                abi, contract, spec -> List.of(parmeterSupplier.get()).toArray());
+                abi, contract, spec -> List.of(parameterSupplier.get()).toArray());
     }
 
     public static HapiContractCall contractCallWithTuple(String contract, String abi, Function<HapiSpec, Tuple> fn) {


### PR DESCRIPTION
## Description

This pull request makes a minor fix to the `contractCall` method in `TxnVerbs.java`, correcting a typo in a parameter name. The change improves code readability and consistency.

* Renamed the parameter `parmeterSupplier` to `parameterSupplier` in the `contractCall` method signature and its usage.

## Related issue(s)

Fixes #24135 
