### PR TITLE
chore: HIP-1261: Charge unreadable transaction fee on pre-handle parse failures

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/basic_types.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/basic_types.proto
@@ -1873,6 +1873,12 @@ enum HederaFunctionality {
      * Delete a registered node
      */
     RegisteredNodeDelete = 115;
+
+    /**
+     * (Internal-only) Synthetic functionality used to charge due-diligence fees
+     * for a transaction whose bytes cannot be parsed.
+     */
+    UnparsableTransaction = 116;
 }
 
 /**

--- a/hedera-node/configuration/dev/api-permission.properties
+++ b/hedera-node/configuration/dev/api-permission.properties
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-
 # Crypto
 createAccount=0-*
 cryptoTransfer=0-*
@@ -68,6 +67,7 @@ systemDelete=2-59
 systemUndelete=2-60
 freeze=2-58
 uncheckedSubmit=2-50
+unparsableTransaction=0-0
 networkGetExecutionTime=2-50
 getAccountDetails=2-50
 # Batch

--- a/hedera-node/configuration/mainnet/upgrade/simpleFeesSchedules.json
+++ b/hedera-node/configuration/mainnet/upgrade/simpleFeesSchedules.json
@@ -14,7 +14,7 @@
     "multiplier": 9
   },
   "unreadable": {
-    "feeValue": 100
+    "fee": 100000000000
   },
 
   "extras": [

--- a/hedera-node/configuration/previewnet/upgrade/simpleFeesSchedules.json
+++ b/hedera-node/configuration/previewnet/upgrade/simpleFeesSchedules.json
@@ -14,7 +14,7 @@
     "multiplier": 9
   },
   "unreadable": {
-    "feeValue": 100
+    "fee": 100000000000
   },
 
   "extras": [

--- a/hedera-node/configuration/testnet/upgrade/simpleFeesSchedules.json
+++ b/hedera-node/configuration/testnet/upgrade/simpleFeesSchedules.json
@@ -14,7 +14,7 @@
     "multiplier": 9
   },
   "unreadable": {
-    "feeValue": 100
+    "fee": 100000000000
   },
 
   "extras": [

--- a/hedera-node/data/config/api-permission.properties
+++ b/hedera-node/data/config/api-permission.properties
@@ -67,4 +67,5 @@ systemDelete=2-59
 systemUndelete=2-60
 freeze=2-58
 uncheckedSubmit=2-50
+unparsableTransaction=0-0
 networkGetExecutionTime=2-50

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeManager.java
@@ -309,6 +309,19 @@ public final class FeeManager {
     }
 
     /**
+     * Returns the fixed network fee to charge for an unreadable transaction.
+     *
+     * @param consensusTime the consensus time used to resolve exchange rates
+     * @return the unreadable transaction fee in tinybars, or {@code 0} if unavailable
+     */
+    public long unreadableTransactionFee(@NonNull final Instant consensusTime) {
+        requireNonNull(consensusTime);
+        requireNonNull(simpleFeesSchedule.unreadable());
+        final var unreadableFeeTinycents = simpleFeesSchedule.unreadable().fee();
+        return exchangeRateManager.getTinybarsFromTinycents(unreadableFeeTinycents, consensusTime);
+    }
+
+    /**
      * Gets the current exchange rate manager.
      */
     @NonNull

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/ParentTxnFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/ParentTxnFactory.java
@@ -2,7 +2,9 @@
 package com.hedera.node.app.workflows.handle.steps;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.STATE_SIGNATURE_TRANSACTION;
+import static com.hedera.hapi.node.base.HederaFunctionality.UNPARSABLE_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
+import static com.hedera.hapi.util.HapiUtils.asTimestamp;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.NODE;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.SCHEDULED;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.USER;
@@ -20,8 +22,12 @@ import static org.hiero.hapi.fees.HighVolumePricingCalculator.HIGH_VOLUME_PRICIN
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.transaction.ExchangeRateSet;
+import com.hedera.hapi.node.transaction.SignedTransaction;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.node.transaction.UncheckedSubmitBody;
 import com.hedera.node.app.blocks.BlockStreamManager;
 import com.hedera.node.app.blocks.impl.BoundaryStateChangeListener;
 import com.hedera.node.app.blocks.impl.ImmediateStateChangeListener;
@@ -41,6 +47,7 @@ import com.hedera.node.app.signature.AppKeyVerifier;
 import com.hedera.node.app.signature.DefaultKeyVerifier;
 import com.hedera.node.app.spi.api.ServiceApiProvider;
 import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fees.NodeFeeAccumulator;
 import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.info.NodeInfo;
@@ -70,6 +77,7 @@ import com.hedera.node.app.workflows.prehandle.PreHandleResult;
 import com.hedera.node.app.workflows.prehandle.PreHandleWorkflow;
 import com.hedera.node.app.workflows.prehandle.PreHandleWorkflow.ShortCircuitCallback;
 import com.hedera.node.app.workflows.purechecks.PureChecksContextImpl;
+import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.ConsensusConfig;
@@ -168,7 +176,10 @@ public class ParentTxnFactory {
      */
     public static HandleContext.TransactionCategory getTxnCategory(@NonNull final PreHandleResult preHandleResult) {
         requireNonNull(preHandleResult);
-        return preHandleResult.txnInfoOrThrow().signatureMap().sigPair().isEmpty() ? NODE : USER;
+        return preHandleResult.txInfo() == null
+                        || preHandleResult.txnInfoOrThrow().signatureMap().sigPair().isEmpty()
+                ? NODE
+                : USER;
     }
 
     /**
@@ -204,14 +215,17 @@ public class ParentTxnFactory {
             platformTxn.setMetadata(preHandleResult);
         }
         final var txnInfo = preHandleResult.txInfo();
-        if (txnInfo == null) {
+        final var effectiveTxnInfo = txnInfo != null
+                ? txnInfo
+                : syntheticUnreadableTxnInfo(preHandleResult, creatorInfo, consensusNow, platformTxn);
+        if (effectiveTxnInfo == null) {
             log.error(
                     "Node {} submitted an unparseable transaction {}",
                     creatorInfo != null ? creatorInfo.nodeId() : null,
                     platformTxn);
             return null;
         }
-        if (creatorInfo == null || txnInfo.functionality() == STATE_SIGNATURE_TRANSACTION) {
+        if (creatorInfo == null || effectiveTxnInfo.functionality() == STATE_SIGNATURE_TRANSACTION) {
             return null;
         }
         final var tokenContext = new TokenContextImpl(
@@ -220,10 +234,10 @@ public class ParentTxnFactory {
                 consensusNow,
                 new WritableEntityIdStoreImpl(stack.getWritableStates(EntityIdService.NAME)));
         return new ParentTxn(
-                txnInfo.functionality(),
+                effectiveTxnInfo.functionality(),
                 consensusNow,
                 state,
-                txnInfo,
+                effectiveTxnInfo,
                 tokenContext,
                 stack,
                 preHandleResult,
@@ -377,7 +391,9 @@ public class ParentTxnFactory {
                 preHandleResult.innerResults(),
                 preHandleWorkflow,
                 transactionCategory);
-        final var fees = dispatcher.dispatchComputeFees(dispatchHandleContext);
+        final var fees = isUnreadableTxnCharge(preHandleResult)
+                ? new Fees(0, feeManager.unreadableTransactionFee(consensusNow), 0)
+                : dispatcher.dispatchComputeFees(dispatchHandleContext);
         final boolean isHighVolumePriced =
                 txnInfo.txBody().highVolume() && HIGH_VOLUME_PRICING_FUNCTIONS.contains(txnInfo.functionality());
         // High-volume pricing and congestion multipliers are mutually exclusive; only record the
@@ -435,6 +451,46 @@ public class ParentTxnFactory {
                 boundaryStateChangeListener,
                 immediateStateChangeListener,
                 blockStreamConfig.streamMode());
+    }
+
+    /**
+     * Returns a synthetic transaction info for an unreadable transaction fee charge if the pre-handle result
+     * represents an unreadable due diligence failure; otherwise returns {@code null}.
+     */
+    private @Nullable TransactionInfo syntheticUnreadableTxnInfo(
+            @NonNull final PreHandleResult preHandleResult,
+            @Nullable final NodeInfo creatorInfo,
+            @NonNull final Instant consensusNow,
+            @NonNull final ConsensusTransaction platformTxn) {
+        if (!isUnreadableTxnCharge(preHandleResult) || creatorInfo == null) {
+            return null;
+        }
+        final var syntheticBody = TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder()
+                        .accountID(creatorInfo.accountId())
+                        .transactionValidStart(asTimestamp(consensusNow))
+                        .build())
+                .nodeAccountID(creatorInfo.accountId())
+                // Keep the synthetic tx body classifiable in stream validation.
+                .uncheckedSubmit(UncheckedSubmitBody.newBuilder()
+                        .transactionBytes(platformTxn.getApplicationTransaction())
+                        .build())
+                .build();
+        final var syntheticSignedTx = SignedTransaction.newBuilder()
+                .bodyBytes(TransactionBody.PROTOBUF.toBytes(syntheticBody))
+                .build();
+        final var serializedSyntheticSignedTx = SignedTransaction.PROTOBUF.toBytes(syntheticSignedTx);
+        return new TransactionInfo(
+                syntheticSignedTx,
+                syntheticBody,
+                SignatureMap.DEFAULT,
+                platformTxn.getApplicationTransaction(),
+                UNPARSABLE_TRANSACTION,
+                serializedSyntheticSignedTx);
+    }
+
+    private static boolean isUnreadableTxnCharge(@NonNull final PreHandleResult preHandleResult) {
+        return preHandleResult.isUnreadableTransactionFailure();
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/ParentTxnFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/ParentTxnFactory.java
@@ -63,6 +63,7 @@ import com.hedera.node.app.store.WritableStoreFactory;
 import com.hedera.node.app.throttle.AppThrottleAdviser;
 import com.hedera.node.app.throttle.NetworkUtilizationManager;
 import com.hedera.node.app.workflows.TransactionChecker;
+import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.handle.Dispatch;
 import com.hedera.node.app.workflows.handle.DispatchHandleContext;
@@ -77,7 +78,6 @@ import com.hedera.node.app.workflows.prehandle.PreHandleResult;
 import com.hedera.node.app.workflows.prehandle.PreHandleWorkflow;
 import com.hedera.node.app.workflows.prehandle.PreHandleWorkflow.ShortCircuitCallback;
 import com.hedera.node.app.workflows.purechecks.PureChecksContextImpl;
-import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.ConsensusConfig;
@@ -177,7 +177,11 @@ public class ParentTxnFactory {
     public static HandleContext.TransactionCategory getTxnCategory(@NonNull final PreHandleResult preHandleResult) {
         requireNonNull(preHandleResult);
         return preHandleResult.txInfo() == null
-                        || preHandleResult.txnInfoOrThrow().signatureMap().sigPair().isEmpty()
+                        || preHandleResult
+                                .txnInfoOrThrow()
+                                .signatureMap()
+                                .sigPair()
+                                .isEmpty()
                 ? NODE
                 : USER;
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.workflows.prehandle;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNKNOWN;
 import static com.hedera.node.app.hapi.utils.keys.KeyUtils.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.NODE_DUE_DILIGENCE_FAILURE;
@@ -82,6 +84,15 @@ public record PreHandleResult(
         return status == NODE_DUE_DILIGENCE_FAILURE
                 ? HederaRecordCache.DueDiligenceFailure.YES
                 : HederaRecordCache.DueDiligenceFailure.NO;
+    }
+
+    /**
+     * Returns whether this result represents a node due diligence failure caused by unreadable transaction bytes.
+     */
+    public boolean isUnreadableTransactionFailure() {
+        return status == NODE_DUE_DILIGENCE_FAILURE
+                && txInfo == null
+                && (responseCode == INVALID_TRANSACTION || responseCode == INVALID_TRANSACTION_BODY);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -215,6 +215,8 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
                     e.txInfo(),
                     configProvider.getConfiguration().getVersion());
         } catch (PreCheckException e) {
+            // If parsing failed, this will be INVALID_TRANSACTION or INVALID_TRANSACTION_BODY; in handle,
+            // that due-diligence failure is charged the fixed unreadable transaction fee.
             return nodeDueDiligenceFailure(
                     creatorInfo.accountId(),
                     e.responseCode(),

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/ParentTxnTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/ParentTxnTest.java
@@ -3,6 +3,7 @@ package com.hedera.node.app.workflows.handle.steps;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONSENSUS_CREATE_TOPIC;
 import static com.hedera.hapi.node.base.HederaFunctionality.STATE_SIGNATURE_TRANSACTION;
+import static com.hedera.hapi.node.base.HederaFunctionality.UNPARSABLE_TRANSACTION;
 import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
 import static com.hedera.node.app.service.token.impl.api.TokenServiceApiProvider.TOKEN_SERVICE_API_PROVIDER;
 import static java.util.Collections.emptyMap;
@@ -15,6 +16,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.node.base.AccountID;
@@ -262,6 +265,35 @@ class ParentTxnTest {
                         .map(BlockItem::transactionResultOrThrow)
                         .orElseThrow();
         assertEquals(0L, result.congestionPricingMultiplier());
+    }
+
+    @Test
+    void createsDispatchForUnreadablePreHandleFailureWithFixedUnreadableFee() {
+        given(preHandleWorkflow.getCurrentPreHandleResult(
+                        any(NodeInfo.class),
+                        eq(PLATFORM_TXN),
+                        any(ReadableStoreFactory.class),
+                        eq(shortCircuitTxnCallback)))
+                .willReturn(preHandleResult);
+        given(preHandleResult.txInfo()).willReturn(null);
+        given(preHandleResult.isUnreadableTransactionFailure()).willReturn(true);
+        given(creatorInfo.accountId()).willReturn(PAYER_ID);
+        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(BLOCKS_CONFIG, 1));
+        given(feeManager.unreadableTransactionFee(CONSENSUS_NOW)).willReturn(123L);
+        given(preHandleResult.getVerificationResults()).willReturn(emptyMap());
+        given(serviceScopeLookup.getServiceName(any())).willReturn(ConsensusServiceImpl.NAME);
+
+        final var factory = createUserTxnFactory();
+        final var subject =
+                factory.createTopLevelTxn(state, creatorInfo, PLATFORM_TXN, CONSENSUS_NOW, shortCircuitTxnCallback);
+        assertNotNull(subject);
+        assertEquals(UNPARSABLE_TRANSACTION, subject.functionality());
+
+        final var dispatch = factory.createDispatch(subject, ExchangeRateSet.DEFAULT);
+        assertEquals(123L, dispatch.fees().networkFee());
+        assertEquals(0L, dispatch.fees().nodeFee());
+        assertEquals(0L, dispatch.fees().serviceFee());
+        verify(dispatcher, never()).dispatchComputeFees(any());
     }
 
     private ParentTxnFactory createUserTxnFactory() {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleResultTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleResultTest.java
@@ -2,6 +2,8 @@
 package com.hedera.node.app.workflows.prehandle;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNKNOWN;
 import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.NODE_DUE_DILIGENCE_FAILURE;
@@ -89,6 +91,27 @@ final class PreHandleResultTest implements Scenarios {
         given(context.optionalNonPayerKeys()).willReturn(Set.of(CAROL.account().keyOrThrow()));
         given(context.requiredHollowAccounts()).willReturn(Set.of(ERIN.account()));
         assertThat(DEFAULT_RESULT.hasReusableVerificationResultsFor(context)).isTrue();
+    }
+
+    @Test
+    void unreadableFailureIsDetectedFromParseFailureCode() {
+        final var result =
+                PreHandleResult.nodeDueDiligenceFailure(NODE_1.nodeAccountID(), INVALID_TRANSACTION, null, 1L);
+        assertThat(result.isUnreadableTransactionFailure()).isTrue();
+    }
+
+    @Test
+    void unreadableFailureIsDetectedFromInvalidBodyCode() {
+        final var result =
+                PreHandleResult.nodeDueDiligenceFailure(NODE_1.nodeAccountID(), INVALID_TRANSACTION_BODY, null, 1L);
+        assertThat(result.isUnreadableTransactionFailure()).isTrue();
+    }
+
+    @Test
+    void unreadableFailureRequiresNullTransactionInfo() {
+        final var result = PreHandleResult.nodeDueDiligenceFailure(
+                NODE_1.nodeAccountID(), INVALID_TRANSACTION, new TransactionScenarioBuilder().txInfo(), 1L);
+        assertThat(result.isUnreadableTransactionFailure()).isFalse();
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/resources/api-permission.properties
+++ b/hedera-node/hedera-app/src/test/resources/api-permission.properties
@@ -61,11 +61,12 @@ tokenFeeScheduleUpdate=0-*
 tokenPause=0-*
 tokenUnpause=0-*
 tokenGetNftInfos=0-*
-# Network 
+# Network
 getVersionInfo=0-*
 systemDelete=2-59
 systemUndelete=2-60
 freeze=2-58
 uncheckedSubmit=2-50
+unparsableTransaction=0-0
 networkGetExecutionTime=2-50
 getAccountDetails=2-50

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ApiPermissionConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ApiPermissionConfig.java
@@ -87,6 +87,7 @@ import static com.hedera.hapi.node.base.HederaFunctionality.TOKEN_UPDATE_NFTS;
 import static com.hedera.hapi.node.base.HederaFunctionality.TRANSACTION_GET_FAST_RECORD;
 import static com.hedera.hapi.node.base.HederaFunctionality.TRANSACTION_GET_RECEIPT;
 import static com.hedera.hapi.node.base.HederaFunctionality.TRANSACTION_GET_RECORD;
+import static com.hedera.hapi.node.base.HederaFunctionality.UNPARSABLE_TRANSACTION;
 import static com.hedera.hapi.node.base.HederaFunctionality.UTIL_PRNG;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -294,6 +295,7 @@ public record ApiPermissionConfig(
         @ConfigProperty(defaultValue = "0-0") PermissionedAccountsRange hookDispatch,
         @ConfigProperty(defaultValue = "0-0") PermissionedAccountsRange nodeStakeUpdate,
         @ConfigProperty(defaultValue = "0-0") PermissionedAccountsRange ledgerIdPublication,
+        @ConfigProperty(defaultValue = "0-0") PermissionedAccountsRange unparsableTransaction,
         @ConfigProperty(defaultValue = "0-0") PermissionedAccountsRange createRegisteredNode,
         @ConfigProperty(defaultValue = "0-0") PermissionedAccountsRange updateRegisteredNode,
         @ConfigProperty(defaultValue = "0-0") PermissionedAccountsRange deleteRegisteredNode) {
@@ -388,6 +390,7 @@ public record ApiPermissionConfig(
         permissionKeys.put(CRS_PUBLICATION, c -> c.crsPublication);
         permissionKeys.put(NODE_STAKE_UPDATE, c -> c.nodeStakeUpdate);
         permissionKeys.put(LEDGER_ID_PUBLICATION, c -> c.ledgerIdPublication);
+        permissionKeys.put(UNPARSABLE_TRANSACTION, c -> c.unparsableTransaction);
         permissionKeys.put(REGISTERED_NODE_CREATE, c -> c.createRegisteredNode);
         permissionKeys.put(REGISTERED_NODE_UPDATE, c -> c.updateRegisteredNode);
         permissionKeys.put(REGISTERED_NODE_DELETE, c -> c.deleteRegisteredNode);

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/ApiPermissionConfigTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/ApiPermissionConfigTest.java
@@ -29,6 +29,7 @@ final class ApiPermissionConfigTest {
                 "HOOK_DISPATCH",
                 "NODE_STAKE_UPDATE",
                 "LEDGER_ID_PUBLICATION",
+                "UNPARSABLE_TRANSACTION",
             })
     void internalDispatchTypesAreExplicitlyProhibited(@NonNull final HederaFunctionality function) {
         final var config = HederaTestConfigBuilder.create()
@@ -57,7 +58,8 @@ final class ApiPermissionConfigTest {
                 "CRYPTO_ACCOUNT_AUTO_RENEW",
                 "CONTRACT_AUTO_RENEW",
                 "UNCHECKED_SUBMIT",
-                "NODE_STAKE_UPDATE"
+                "NODE_STAKE_UPDATE",
+                "UNPARSABLE_TRANSACTION"
             })
     void testHederaFunctionalityUsage(final HederaFunctionality hederaFunctionality) {
         // given

--- a/hedera-node/hedera-file-service-impl/src/main/resources/genesis/simpleFeesSchedules.json
+++ b/hedera-node/hedera-file-service-impl/src/main/resources/genesis/simpleFeesSchedules.json
@@ -14,7 +14,7 @@
     "multiplier": 9
   },
   "unreadable": {
-    "feeValue": 100
+    "fee": 100000000000
   },
 
   "extras": [

--- a/hedera-node/hedera-file-service-impl/src/test/resources/api-permission.properties
+++ b/hedera-node/hedera-file-service-impl/src/test/resources/api-permission.properties
@@ -61,11 +61,12 @@ tokenFeeScheduleUpdate=0-*
 tokenPause=0-*
 tokenUnpause=0-*
 tokenGetNftInfos=0-*
-# Network 
+# Network
 getVersionInfo=0-*
 systemDelete=2-59
 systemUndelete=2-60
 freeze=2-58
 uncheckedSubmit=2-50
+unparsableTransaction=0-0
 networkGetExecutionTime=2-50
 getAccountDetails=2-50

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -638,6 +638,8 @@ tasks.register<Test>("testEmbedded") {
     ) {
         systemProperty("fees.createSimpleFeeSchedule", "true")
         systemProperty("fees.simpleFeesEnabled", "true")
+        // Prevent node fee/reward distribution during this task
+        systemProperty("staking.periodMins", "10000")
     }
 
     // Limit heap and number of processors

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
@@ -102,6 +102,8 @@ public class HgcaaLogValidator {
                 List.of("BlockNodeConnectionManager", "Block stream worker interrupted"),
                 List.of("BlockNodeConnectionManager", "No active connections available for streaming"),
                 List.of("No block nodes available to connect to"),
+                // Expected when exercising unreadable/unparsable transaction charging paths.
+                List.of("TransactionChecker - ParseException while parsing protobuf"),
                 // Not present on OS X
                 List.of("Native library besu blake2bf is not present"));
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/UnreadableTransactionSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/UnreadableTransactionSimpleFeesTest.java
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.hip1261;
+
+import static com.hedera.services.bdd.junit.EmbeddedReason.MUST_SKIP_INGEST;
+import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.approxChangeFromSnapshot;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.unchangedFromSnapshot;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.TINY_PARTS_PER_WHOLE;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.UNREADABLE_FEE_USD;
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hederahashgraph.api.proto.java.Transaction;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@Tag(SIMPLE_FEES)
+@HapiTestLifecycle
+public class UnreadableTransactionSimpleFeesTest {
+    private static final String PAYER = "payer";
+    private static final String NODE = "4";
+    private static final String PAYER_BALANCE_SNAPSHOT = "payerBalanceBeforeUnreadable";
+    private static final String NODE_BALANCE_SNAPSHOT = "nodeBalanceBeforeUnreadable";
+    private static final long UNREADABLE_FEE_EPSILON_TINYBARS = 1L;
+
+    @BeforeAll
+    static void beforeAll(final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of(
+                "fees.simpleFeesEnabled", "true",
+                "nodes.nodeRewardsEnabled", "false",
+                "nodes.feeCollectionAccountEnabled", "false"));
+    }
+
+    @LeakyEmbeddedHapiTest(reason = MUST_SKIP_INGEST)
+    @DisplayName("Unreadable transaction charges node and not payer")
+    final Stream<DynamicTest> unreadableTransactionChargesNode() {
+        return hapiTest(
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, NODE, ONE_HUNDRED_HBARS)),
+                balanceSnapshot(PAYER_BALANCE_SNAPSHOT, PAYER),
+                balanceSnapshot(NODE_BALANCE_SNAPSHOT, NODE),
+                cryptoTransfer(tinyBarsFromTo(PAYER, FUNDING, 1))
+                        .payingWith(PAYER)
+                        .setNode("4")
+                        .withTxnTransform(UnreadableTransactionSimpleFeesTest::withUnreadableSignedTransactionBytes)
+                        .fireAndForget(),
+                sleepFor(2_000L),
+                getAccountBalance(PAYER).hasTinyBars(unchangedFromSnapshot(PAYER_BALANCE_SNAPSHOT)),
+                getAccountBalance(NODE)
+                        .hasTinyBars(approxChangeFromSnapshot(
+                                NODE_BALANCE_SNAPSHOT,
+                                spec -> -spec.ratesProvider()
+                                        .toTbWithActiveRates((long) (UNREADABLE_FEE_USD * 100 * TINY_PARTS_PER_WHOLE)),
+                                UNREADABLE_FEE_EPSILON_TINYBARS)));
+    }
+
+    private static Transaction withUnreadableSignedTransactionBytes(final Transaction txn) {
+        try {
+            return txn.toBuilder()
+                    .setSignedTransactionBytes(ByteString.copyFromUtf8("not a protobuf signed transaction"))
+                    .build();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not mutate signed transaction bytes", e);
+        }
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
@@ -16,7 +16,7 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final int NETWORK_MULTIPLIER = 9;
     public static final double NETWORK_BASE_FEE = NODE_BASE_FEE_USD * NETWORK_MULTIPLIER;
     public static final double NODE_AND_NETWORK_BASE_FEE = NODE_BASE_FEE_USD + NETWORK_BASE_FEE;
-    public static final double UNREADABLE_FEE_USD = 0.00000001;
+    public static final double UNREADABLE_FEE_USD = 10.0;
 
     /* ---------- Global extras price table ("extras") ---------- */
 


### PR DESCRIPTION
**Description**:

Implements unreadable transaction fee support for simple fees by charging UNPARSABLE_TRANSACTION when transaction parsing fails in PreHandleWorkflowImpl. 
Updates simpleFeesSchedules.json to the HIP-defined value, adds embedded HAPI coverage that verifies the node is charged (with payer unchanged) using balance snapshots.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
