### PR TITLE
fix: Avoid NPE in TipsetEventCreator in case we cannot create selfles…

### DIFF
--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreator.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreator.java
@@ -319,6 +319,9 @@ public class TipsetEventCreator implements EventCreator {
         if (beNiceChance > 0 && random.nextDouble() < beNiceChance) {
             // replace one of the best parents with the one chosen to reduce selfishness
             final PlatformEvent selflessParent = selectParentToReduceSelfishness();
+            if (selflessParent == null) {
+                return null;
+            }
             // if we already contain that event, everything is good
             if (!contains(chosenBestParents, selflessParent)) {
                 // otherwise, replace the least important parent with one we have chosen to reduce selfishness
@@ -363,7 +366,7 @@ public class TipsetEventCreator implements EventCreator {
      *
      * @return parent to reduce selfishness
      */
-    private @NonNull PlatformEvent selectParentToReduceSelfishness() {
+    private @Nullable PlatformEvent selectParentToReduceSelfishness() {
         final Collection<PlatformEvent> possibleOtherParents = childlessOtherEventTracker.getChildlessEvents();
         final List<PlatformEvent> ignoredNodes = new ArrayList<>(possibleOtherParents.size());
 


### PR DESCRIPTION
Description:
Due to change related to multiple other parents (MOP), null reference might have escaped from very rarely executed branch of code. This change makes sure it is not resulting in NPE, but rather skips event generation, as in pre-0.70 version.

**Related issue(s)**:

Fixes #24142

**Notes for reviewer**:
It is a cherrypick of https://github.com/hiero-ledger/hiero-consensus-node/pull/24146

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
