### PR TITLE
fix: flaky test `classifiableTakesPriorityOverUnclassifiable`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
@@ -38,6 +38,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import java.util.concurrent.atomic.AtomicLong;
@@ -201,7 +202,7 @@ public class DuplicateManagementTest {
                                 .transfers(includingDeduction("node payment", TO))));
     }
 
-    @HapiTest
+    @EmbeddedHapiTest(MUST_SKIP_INGEST)
     final Stream<DynamicTest> classifiableTakesPriorityOverUnclassifiable() {
         return hapiTest(
                 cryptoCreate(CIVILIAN).balance(100 * 100_000_000L),


### PR DESCRIPTION
**Description**:
Fix flakiness in `DuplicateManagementTest.classifiableTakesPriorityOverUnclassifiable()`

**Related issue(s)**:

Fixes #24140 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
