### PR TITLE
fix: prevent VisibleItemsAssertion from dropping items

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/VisibleItemsAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/VisibleItemsAssertion.java
@@ -27,6 +27,7 @@ public class VisibleItemsAssertion implements RecordStreamAssertion {
     private static final Logger log = LogManager.getLogger(VisibleItemsAssertion.class);
 
     private final HapiSpec spec;
+    private final Set<String> allIds;
     private final Set<String> unseenIds;
     private final VisibleItemsValidator validator;
     private final Map<String, VisibleItems> items = new ConcurrentHashMap<>();
@@ -56,6 +57,7 @@ public class VisibleItemsAssertion implements RecordStreamAssertion {
                 addAll(List.of(specTxnIds));
             }
         };
+        allIds = Set.copyOf(unseenIds);
         viewAll = unseenIds.contains(ALL_TX_IDS);
     }
 
@@ -75,7 +77,7 @@ public class VisibleItemsAssertion implements RecordStreamAssertion {
                         .add(entry);
             }
         } else {
-            new ArrayList<>(unseenIds)
+            new ArrayList<>(allIds)
                     .stream()
                             .filter(id -> spec.registry()
                                     .getMaybeTxnId(id)


### PR DESCRIPTION
**Description**:
Flake: VisibleItemsAssertion used one set (unseenIds) for both matching items and tracking completion. Background traffic between a ScheduleCreate and its triggered CryptoTransfer caused the ID to be removed from that set, silently dropping the second item.

Fix: Added an immutable allIds set for matching. unseenIds now only tracks completion. Items are never missed regardless of interleaving.

Fixes #24204
Fixes #24206
Fixes #24207