### PR TITLE
fix: Remove round communication overhead from Sloth benchmark

### DIFF
--- a/platform-sdk/consensus-sloth/src/testFixtures/java/org/hiero/sloth/fixtures/container/docker/EventMessageFactory.java
+++ b/platform-sdk/consensus-sloth/src/testFixtures/java/org/hiero/sloth/fixtures/container/docker/EventMessageFactory.java
@@ -3,12 +3,10 @@ package org.hiero.sloth.fixtures.container.docker;
 
 import com.swirlds.platform.listeners.PlatformStatusChangeNotification;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.sloth.fixtures.container.proto.EventMessage;
 import org.hiero.sloth.fixtures.container.proto.LogEntry;
 import org.hiero.sloth.fixtures.container.proto.PlatformStatusChange;
-import org.hiero.sloth.fixtures.container.proto.ProtoConsensusRound;
 import org.hiero.sloth.fixtures.internal.ProtobufConverter;
 import org.hiero.sloth.fixtures.logging.StructuredLog;
 
@@ -36,19 +34,6 @@ public final class EventMessageFactory {
         return EventMessage.newBuilder()
                 .setPlatformStatusChange(protoStatusChange)
                 .build();
-    }
-
-    /**
-     * Creates an {@link EventMessage} carrying a consensus round.
-     *
-     * @param round the consensus round
-     * @return the corresponding {@link EventMessage}
-     */
-    @NonNull
-    public static EventMessage fromConsensusRound(@NonNull final ConsensusRound round) {
-        final ProtoConsensusRound protoRound = ProtobufConverter.fromPlatform(round);
-
-        return EventMessage.newBuilder().setConsensusRound(protoRound).build();
     }
 
     /**

--- a/platform-sdk/consensus-sloth/src/testFixtures/java/org/hiero/sloth/fixtures/container/docker/platform/ConsensusNodeManager.java
+++ b/platform-sdk/consensus-sloth/src/testFixtures/java/org/hiero/sloth/fixtures/container/docker/platform/ConsensusNodeManager.java
@@ -195,15 +195,6 @@ public class ConsensusNodeManager {
     }
 
     /**
-     * Registers a listener to receive notifications about new consensus rounds.
-     *
-     * @param listener the listener to register
-     */
-    public void registerConsensusRoundListener(@NonNull final ConsensusRoundListener listener) {
-        consensusRoundListeners.add(listener);
-    }
-
-    /**
      * Updates the synthetic bottleneck duration.
      *
      * @param millisToSleepPerRound the number of milliseconds to sleep per round

--- a/platform-sdk/consensus-sloth/src/testFixtures/java/org/hiero/sloth/fixtures/container/docker/platform/NodeCommunicationService.java
+++ b/platform-sdk/consensus-sloth/src/testFixtures/java/org/hiero/sloth/fixtures/container/docker/platform/NodeCommunicationService.java
@@ -137,9 +137,6 @@ public class NodeCommunicationService extends NodeCommunicationServiceImplBase {
     private void setupStreamingEventDispatcher() {
         consensusNodeManager.registerPlatformStatusChangeListener(
                 notification -> dispatcher.enqueue(EventMessageFactory.fromPlatformStatusChange(notification)));
-
-        consensusNodeManager.registerConsensusRoundListener(
-                round -> dispatcher.enqueue(EventMessageFactory.fromConsensusRound(round)));
     }
 
     private static boolean isInvalidRequest(

--- a/platform-sdk/consensus-sloth/src/testFixtures/java/org/hiero/sloth/fixtures/internal/ProtobufConverter.java
+++ b/platform-sdk/consensus-sloth/src/testFixtures/java/org/hiero/sloth/fixtures/internal/ProtobufConverter.java
@@ -7,7 +7,6 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.platform.event.legacy.EventConsensusData;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.time.Instant;
 import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.MarkerManager;
@@ -444,58 +443,6 @@ public class ProtobufConverter {
         return com.hedera.hapi.platform.state.legacy.JudgeId.newBuilder()
                 .setCreatorId(sourceJudgeId.creatorId())
                 .setJudgeHash(fromPbj(sourceJudgeId.judgeHash()))
-                .build();
-    }
-
-    /**
-     * Converts a ProtoConsensusRound to ConsensusRound.
-     *
-     * @param sourceRound the ProtoConsensusRound to convert
-     * @return the converted ConsensusRound
-     */
-    @NonNull
-    public static org.hiero.consensus.model.hashgraph.ConsensusRound toPlatform(
-            @NonNull final org.hiero.sloth.fixtures.container.proto.ProtoConsensusRound sourceRound) {
-        final com.hedera.hapi.node.state.roster.Roster consensusRoster = toPbj(sourceRound.getConsensusRoster());
-        final List<org.hiero.consensus.model.event.PlatformEvent> consensusEvents =
-                sourceRound.getConsensusEventsList().stream()
-                        .map(ProtobufConverter::toPlatform)
-                        .toList();
-        final org.hiero.consensus.model.hashgraph.EventWindow eventWindow = toPlatform(sourceRound.getEventWindow());
-        final com.hedera.hapi.platform.state.ConsensusSnapshot snapshot = toPbj(sourceRound.getSnapshot());
-        final Instant reachedConsTimestamp = Instant.ofEpochSecond(sourceRound.getReachedConsTimestamp());
-
-        return new org.hiero.consensus.model.hashgraph.ConsensusRound(
-                consensusRoster,
-                consensusEvents,
-                eventWindow,
-                snapshot,
-                sourceRound.getPcesRound(),
-                reachedConsTimestamp);
-    }
-
-    /**
-     * Converts a ConsensusRound to a ProtoConsensusRound.
-     *
-     * @param sourceRound the ConsensusRound to convert
-     * @return the converted ProtoConsensusRound
-     */
-    @NonNull
-    public static org.hiero.sloth.fixtures.container.proto.ProtoConsensusRound fromPlatform(
-            @NonNull final org.hiero.consensus.model.hashgraph.ConsensusRound sourceRound) {
-        final List<org.hiero.sloth.fixtures.container.proto.ProtoPlatformEvent> events =
-                sourceRound.getConsensusEvents().stream()
-                        .map(ProtobufConverter::fromPlatform)
-                        .toList();
-
-        return org.hiero.sloth.fixtures.container.proto.ProtoConsensusRound.newBuilder()
-                .addAllConsensusEvents(events)
-                .setEventWindow(fromPlatform(sourceRound.getEventWindow()))
-                .setNumAppTransactions(sourceRound.getNumAppTransactions())
-                .setSnapshot(fromPbj(sourceRound.getSnapshot()))
-                .setConsensusRoster(fromPbj(sourceRound.getConsensusRoster()))
-                .setPcesRound(sourceRound.isPcesRound())
-                .setReachedConsTimestamp(sourceRound.getReachedConsTimestamp().getEpochSecond())
                 .build();
     }
 

--- a/platform-sdk/consensus-sloth/src/testFixtures/proto/node_communication.proto
+++ b/platform-sdk/consensus-sloth/src/testFixtures/proto/node_communication.proto
@@ -137,23 +137,6 @@ message ProtoPlatformEvent {
   com.hedera.hapi.platform.event.EventConsensusData consensus_data = 2;
 }
 
-// Represents a single consensus round.
-message ProtoConsensusRound {
-  // Events that reached consensus in this round.
-  repeated ProtoPlatformEvent consensus_events = 1;
-  // Window of events for this round.
-  EventWindow event_window = 2;
-  // Number of application transactions in this round.
-  int32 num_app_transactions = 3;
-  // Snapshot of the consensus state.
-  com.hedera.hapi.platform.state.ConsensusSnapshot snapshot = 4;
-  // Roster of nodes participating in consensus.
-  com.hedera.hapi.node.state.roster.Roster consensus_roster = 5;
-  // Indicates if this is a PCES round.
-  bool pces_round = 6;
-  // Timestamp when consensus was reached.
-  uint64 reached_cons_timestamp = 7;
-}
 
 // Wrapper for different types of event messages.
 message EventMessage {
@@ -163,8 +146,6 @@ message EventMessage {
     PlatformStatusChange platform_status_change = 1;
     // Log entry event.
     LogEntry log_entry = 2;
-    // Consensus rounds event.
-    ProtoConsensusRound consensus_round = 3;
   }
 }
 


### PR DESCRIPTION
**Description**:
We are already not transferring events and rounds to controller for assertions in Sloth, but they are still gathered, causing OOM to happen with longer runs.

**Related issue(s)**:

Fixes #24241 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
