### PR TITLE
fix: rework HapiTestLifecycle doAdhoc method to be thread-safe 24228

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/TestLifecycle.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/TestLifecycle.java
@@ -13,12 +13,25 @@ import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.SpecStateObserver;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
+/**
+ * Concurrency notes for nested test classes using injected {@link TestLifecycle}:
+ * <ul>
+ *     <li>{@link #doAdhoc(SpecOperation...)} is safe to call from nested {@code @BeforeAll} methods in concurrently
+ *     executing nested classes.</li>
+ *     <li>{@link #overrideInClass(Map)} is class-scoped and not safe when called from nested {@code @BeforeAll}
+ *     methods in concurrently executing nested classes. Such root test classes should be annotated with
+ *     {@code @OrderedInIsolation} and run serially.</li>
+ *     <li>If a root class has a root {@code @BeforeAll} plus nested {@code @BeforeAll} methods, concurrent execution
+ *     is supported only when nested {@code @BeforeAll} methods do not call {@link #overrideInClass(Map)}. The root
+ *     {@code @BeforeAll} may call {@link #overrideInClass(Map)}.</li>
+ * </ul>
+ */
 public class TestLifecycle {
     private static final String SPEC_NAME = "<MANAGED>";
 
@@ -26,7 +39,7 @@ public class TestLifecycle {
 
     private final Deque<Memories> deque = new ArrayDeque<>();
 
-    private final List<SpecStateObserver.SpecState> sharedStates = new ArrayList<>();
+    private final List<SpecStateObserver.SpecState> sharedStates = new CopyOnWriteArrayList<>();
 
     private final HederaNetwork targetNetwork;
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -1374,6 +1374,7 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
         }
         Optional.ofNullable(TEST_LIFECYCLE.get())
                 .map(TestLifecycle::getSharedStates)
+                .map(List::copyOf)
                 .ifPresent(spec::setSharedStates);
         spec.throttleResource = THROTTLES_OVERRIDE.get();
         spec.feeResource = FEES_OVERRIDE.get();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/TopicCustomFeeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/TopicCustomFeeCreateTest.java
@@ -62,6 +62,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 
+/**
+ * Runs safely in concurrent misc execution because nested {@code @BeforeAll} methods only call
+ * {@link TestLifecycle#doAdhoc(com.hedera.services.bdd.spec.SpecOperation...)} and do not call
+ * {@link TestLifecycle#overrideInClass(java.util.Map)}.
+ */
 @HapiTestLifecycle
 @DisplayName("Topic custom fees")
 public class TopicCustomFeeCreateTest extends TopicCustomFeeBase {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/TopicCustomFeeSubmitMessageTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/TopicCustomFeeSubmitMessageTest.java
@@ -91,6 +91,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 
+/**
+ * Runs safely in concurrent misc execution because nested {@code @BeforeAll} methods only call
+ * {@link TestLifecycle#doAdhoc(com.hedera.services.bdd.spec.SpecOperation...)} and do not call
+ * {@link TestLifecycle#overrideInClass(java.util.Map)}.
+ */
 @HapiTestLifecycle
 @DisplayName("Submit message")
 public class TopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {


### PR DESCRIPTION
## Description

This PR makes `TestLifecycle.doAdhoc()` safe for concurrent execution because some test classes use `@HapiTestLifecycle` with nested classes and nested `@BeforeAll` methods.
In concurrent runs, multiple nested @BeforeAll blocks can call `doAdhoc()` at the same time, while other tests are building specs from lifecycle shared state; this created a read/write race on shared lifecycle state and led to intermittent `java.util.ConcurrentModificationException` (observed in CI in testSubprocessConcurrent for `TopicCustomFeeSubmitMessageTest`).

The change makes the `doAdhoc` shared-state path safe under concurrent access (snapshot + thread-safe shared state usage), which removes that CME failure mode.

I intentionally do not rework `overrideInClass()` to be thread-safe in this PR.
`overrideInClass()` is class-scoped and depends on shared class-ordering semantics (currentTestClass/restore stack), so making it truly thread-safe requires a larger behavioral redesign. For now, classes that use `overrideInClass()` in nested `@BeforeAll` should run in isolation (`@OrderedInIsolation` / serial mode).

## Follow-up classes to comment (future)

These classes use @HapiTestLifecycle + nested classes + nested @BeforeAll, and should carry explicit concurrency guidance:

`SelfDestructSuite` - smart contract
`TokenExpiryInfoSuite` - smart contract
`NumericValidationTest` - smart contract
`TransferTokenTest` - smart contract
`UpdateTokenMetadataTest` - smart contract
`UpdateTokenPrecompileTest` - smart contract
`EvmValidationTest` - smart contract
`AtomicEvmValidationTest` - smart contract
`AtomicTopicCustomFeeCreateTest` - atomic batch
`AtomicTopicCustomFeeSubmitMessageTest` - atomic batch
`TopicCustomFeeCreateTest` - misc
`TopicCustomFeeSubmitMessageTest` - misc

Note: on main, currently only the last two (`TopicCustomFeeCreateTest`, `TopicCustomFeeSubmitMessageTest`) are running concurrently; comments were added there.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/24228

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
