### PR TITLE
ci(workflows): move determinism and snyk checks to MQ

### DIFF
--- a/.github/workflows/210-flow-merge-queue-controller.yaml
+++ b/.github/workflows/210-flow-merge-queue-controller.yaml
@@ -22,7 +22,6 @@ jobs:
     uses: ./.github/workflows/zxc-mats-tests.yaml
     with:
       ref: ${{ github.ref }}
-      enable-unit-tests: "true" # for Codacy and Codecov
       enable-snyk-scan: "true" # for Snyk
       enable-gradle-determinism: "true"
       enable-docker-determinism: "true"

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -38,9 +38,7 @@ merge:
     - "MQ MATS / Docker Determinism / Docker: Verify Artifacts (ubuntu-24.04)"
     - "MQ MATS / Docker Determinism / Docker: Verify Artifacts (hl-cn-docker-determinism-lin-lg)"
 
-    # MATS Codecov, Codacy, and Snyk
-    - "MQ MATS / Unit Test / Publish To Codecov"
-    - "MQ MATS / Unit Test / Publish to Codacy"
+    # MATS Snyk
     - "MQ MATS / Snyk Scan / Snyk Checks"
 
     # XTS Required Checks


### PR DESCRIPTION
**Description**:

Add the gradle determinism, docker determinism, snyk, and codacy checks to Merge Queues.

**Related Issue(s)**:

Implements #24192
Implements #24258
