### PR TITLE
build: update org.hiero.gradle.build to 0.7.5

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
-    id("org.hiero.gradle.build") version "0.7.4"
+    id("org.hiero.gradle.build") version "0.7.5"
     id("com.hedera.pbj.pbj-compiler") version "0.14.0" apply false
 }
 


### PR DESCRIPTION
**Description**:

- Adds `artifacts.hashgraph.io/artifactory/hyperledger-besu-maven-external/` as the primary repository for resolving `org.hyperledger.*` Besu dependencies
- Retains `hyperledger.jfrog.io/artifactory/besu-maven` as a fallback repository
- Gradle resolves repositories in declaration order, so the Hiero proxy is tried first


Full Release Notes: https://github.com/hiero-ledger/hiero-gradle-conventions/releases/tag/v0.7.5

**Related issue(s)**:

https://github.com/hiero-ledger/hiero-gradle-conventions/pull/431
