### PR TITLE
ci(build-deps): Update dependencies for besu in release/0.71

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,3 +60,11 @@ javaModules {
 
     module("hedera-state-validator") { group = "com.hedera.hashgraph" }
 }
+
+dependencyResolutionManagement {
+    repositories {
+        maven("https://artifacts.hashgraph.io/artifactory/hyperledger-besu-maven-external/") {
+            content { includeGroupByRegex("org\\.hyperledger\\..*") }
+        }
+    }
+}


### PR DESCRIPTION
## Description

This pull request adds a new Maven repository to the project's dependency resolution management in `settings.gradle.kts`. This repository is specifically configured to include dependencies from groups matching `org.hyperledger.*`.

Dependency management improvements:

* Added a Maven repository (`https://artifacts.hashgraph.io/artifactory/hyperledger-besu-maven-external/`) to `dependencyResolutionManagement` in `settings.gradle.kts`, restricting included dependencies to those from groups matching `org.hyperledger.*`.

## Related Issue(s)

- Closes #24286
- Relates to #24284 