### PR TITLE
feat: 24072: implement data validation for ReconnectBench

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/ReconnectBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/ReconnectBench.java
@@ -82,6 +82,8 @@ public class ReconnectBench extends VirtualMapBaseBench {
 
     private VirtualMap reconnectedMap;
 
+    private long[] teacherData;
+
     String benchmarkName() {
         return "ReconnectBench";
     }
@@ -159,6 +161,13 @@ public class ReconnectBench extends VirtualMapBaseBench {
         BenchmarkMetrics.register(learnerMap::registerMetrics);
 
         teacherMapCopy = teacherMap.copy();
+
+        // Build the verification array from the teacher map before the benchmark runs
+        if (verify) {
+            // StateBuilder uses key indices from 1 to (2 * size - 1), where size = numRecords * numFiles.
+            teacherData = new long[numRecords * numFiles * 2];
+            copyMapToArray(teacherMap, teacherData);
+        }
     }
 
     @TearDown(Level.Invocation)
@@ -193,6 +202,7 @@ public class ReconnectBench extends VirtualMapBaseBench {
 
         teacherMap = null;
         learnerMap = null;
+        teacherData = null;
     }
 
     @Benchmark
@@ -207,6 +217,8 @@ public class ReconnectBench extends VirtualMapBaseBench {
                 delayNetworkFuzzRangePercent,
                 new NodeId(),
                 configuration);
+
+        verifyMap(teacherData, reconnectedMap);
     }
 
     public static void main(String[] args) throws Exception {

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBaseBench.java
@@ -80,21 +80,8 @@ public abstract class VirtualMapBaseBench extends BaseBench {
         VirtualMap virtualMap = restoreMap();
         if (virtualMap != null) {
             if (verify && map != null) {
-                final int parallelism = ForkJoinPool.getCommonPoolParallelism();
-                final AtomicLong numKeys = new AtomicLong();
-                final VirtualMap srcMap = virtualMap;
-                IntStream.range(0, parallelism).parallel().forEach(idx -> {
-                    long count = 0L;
-                    for (int i = idx; i < map.length; i += parallelism) {
-                        final BenchmarkValue value = srcMap.get(longToKey(i), BenchmarkValueCodec.INSTANCE);
-                        if (value != null) {
-                            map[i] = value.toLong();
-                            ++count;
-                        }
-                    }
-                    numKeys.addAndGet(count);
-                });
-                logger.info("Loaded {} keys in {} ms", numKeys, System.currentTimeMillis() - start);
+                copyMapToArray(virtualMap, map);
+                logger.info("Loaded {} keys in {} ms", map.length, System.currentTimeMillis() - start);
             } else {
                 logger.info("Loaded map in {} ms", System.currentTimeMillis() - start);
             }
@@ -103,6 +90,31 @@ public abstract class VirtualMapBaseBench extends BaseBench {
         }
         BenchmarkMetrics.register(virtualMap::registerMetrics);
         return virtualMap;
+    }
+
+    /**
+     * Copies values from the given {@link VirtualMap} into a {@code long[]} array,
+     * where each index {@code i} maps to the key {@code longToKey(i)}.
+     * This is used to build a verification reference for later comparison with {@link #verifyMap(long[], VirtualMap)}.
+     *
+     * @param srcMap the source virtual map to read from
+     * @param map    the destination array; must be pre-allocated to the desired key range size
+     */
+    protected void copyMapToArray(final VirtualMap srcMap, final long[] map) {
+        final int parallelism = ForkJoinPool.getCommonPoolParallelism();
+        final AtomicLong numKeys = new AtomicLong();
+        IntStream.range(0, parallelism).parallel().forEach(idx -> {
+            long count = 0L;
+            for (int i = idx; i < map.length; i += parallelism) {
+                final BenchmarkValue value = srcMap.get(longToKey(i), BenchmarkValueCodec.INSTANCE);
+                if (value != null) {
+                    map[i] = value.toLong();
+                    ++count;
+                }
+            }
+            numKeys.addAndGet(count);
+        });
+        logger.info("Copied {} keys to verification array", numKeys.get());
     }
 
     private int snapshotIndex = 0;


### PR DESCRIPTION
**Description**:
This PR makes it possible for `ReconnectBench` to reuse the `verifyResult` mechanism as used in the `CryptoBench` to allow `ReconnectBench` to check that learner's map is identical to teacher's after synchronization is complete.

**Related issue(s)**:
Fixes #24072 
