### PR TITLE
chore: remove unncessary assertions

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -384,8 +384,6 @@ public class BlockNodeSuite {
                         byNodeId(0),
                         "Closing and rescheduling connection for reconnect attempt",
                         Duration.ofSeconds(0)),
-                assertBlockNodeCommsLogDoesNotContainText(
-                        byNodeId(0), "No available block nodes found for streaming", Duration.ofSeconds(0)),
 
                 // EndOfStream error assertions
                 assertBlockNodeCommsLogDoesNotContainText(
@@ -407,7 +405,7 @@ public class BlockNodeSuite {
                 assertBlockNodeCommsLogDoesNotContainText(
                         byNodeId(0), "Received EndOfStream response", Duration.ofSeconds(0)),
                 assertBlockNodeCommsLogDoesNotContainText(
-                        byNodeId(0), "Sending EndStream (code=", Duration.ofSeconds(0)),
+                        byNodeId(0), "Attempting to send EndStream (code=", Duration.ofSeconds(0)),
 
                 // Connection state transition error assertions
                 assertBlockNodeCommsLogDoesNotContainText(byNodeId(0), "Handling failed stream", Duration.ofSeconds(0)),


### PR DESCRIPTION
**Description**:
During startup, `BlockNodeConnectionManager` cascades through all configured block nodes when initial connection attempts fail — each failure keeps the node in the connections map via `reschedule() `and immediately calls `selectNewBlockNodeForStreaming` to try the next one. After all 4 nodes are added to the map, the final selection call finds no candidates and logs `No available block nodes found for streaming`

- Removed the overly strict assertion for `No available block nodes found for streaming`
- Fixed a stale `EndStream` assertion: the log message changed from `Sending EndStream (code="`to `Attempting to send EndStream (code=`, making the old assertion a no-op.

**Related issue(s)**:

Fixes #24331 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
