### PR TITLE
fix: Sloth script improvements

### DIFF
--- a/platform-sdk/consensus-sloth/src/testPerformance/scripts/deploy-benchmark.sh
+++ b/platform-sdk/consensus-sloth/src/testPerformance/scripts/deploy-benchmark.sh
@@ -120,7 +120,7 @@ echo ""
 # ── Step 2: Verify no Gradle tasks or active users ──────────────────────────
 echo -e "${BLUE}=== Step 2: Checking remote server is idle ===${NC}"
 
-REMOTE_CHECK=$(ssh -o BatchMode=yes "$SSH_DEST" bash <<'REMOTE_EOF'
+REMOTE_CHECK=$(ssh -o BatchMode=yes "$SSH_DEST" -t bash <<'REMOTE_EOF'
 ISSUES=""
 
 # Check for active Gradle builds (ignore idle daemons and worker processes)
@@ -169,7 +169,7 @@ echo ""
 # ── Step 3: Clone or update repo and checkout branch ─────────────────────────
 echo -e "${BLUE}=== Step 3: Preparing repository on remote (branch: $BRANCH) ===${NC}"
 
-ssh -o BatchMode=yes "$SSH_DEST" bash <<REMOTE_EOF
+ssh -o BatchMode=yes "$SSH_DEST" -t bash <<REMOTE_EOF
 set -eo pipefail
 
 if [[ ! -d "$REMOTE_REPO_DIR/.git" ]]; then
@@ -201,7 +201,7 @@ echo "Remote results will be stored at: $REMOTE_TMP_RESULTS"
 echo ""
 
 BENCHMARK_EXIT=0
-ssh -o BatchMode=yes "$SSH_DEST" bash <<REMOTE_EOF || BENCHMARK_EXIT=$?
+ssh -o BatchMode=yes "$SSH_DEST" -t bash <<REMOTE_EOF || BENCHMARK_EXIT=$?
 set -eo pipefail
 
 # Source profile to pick up JAVA_HOME and PATH in non-interactive SSH sessions
@@ -253,7 +253,7 @@ LOCAL_TAR="${LOCAL_TAR_DIR}/benchmark-${SERVER}-${BRANCH//\//-}-${TIMESTAMP}.tar
 
 # Create tar on remote (best-effort: archive whatever results exist)
 TRANSFER_EXIT=0
-ssh -o BatchMode=yes "$SSH_DEST" bash <<REMOTE_EOF || TRANSFER_EXIT=$?
+ssh -o BatchMode=yes "$SSH_DEST" -t bash <<REMOTE_EOF || TRANSFER_EXIT=$?
 set -eo pipefail
 if [[ ! -d "$REMOTE_TMP_RESULTS" ]] || [[ -z "\$(ls -A "$REMOTE_TMP_RESULTS")" ]]; then
     echo "WARNING: No results found at $REMOTE_TMP_RESULTS — nothing to archive."
@@ -278,7 +278,7 @@ fi
 echo "Cleaning up remote temporary files..."
 ssh -o BatchMode=yes "$SSH_DEST" "rm -rf '$REMOTE_TMP_RESULTS' '$REMOTE_TAR'" || true
 echo "Stopping Gradle daemons on remote..."
-ssh -o BatchMode=yes "$SSH_DEST" bash <<'STOP_EOF'
+ssh -o BatchMode=yes "$SSH_DEST" -t bash <<'STOP_EOF'
 for f in "$HOME/.profile" "$HOME/.bash_profile" "$HOME/.bashrc" "/etc/profile"; do
     [[ -f "$f" ]] && source "$f" 2>/dev/null || true
 done

--- a/platform-sdk/consensus-sloth/src/testPerformance/scripts/run-benchmark.sh
+++ b/platform-sdk/consensus-sloth/src/testPerformance/scripts/run-benchmark.sh
@@ -141,7 +141,8 @@ for EXPERIMENT in "${EXPERIMENTS_TO_RUN[@]}"; do
         # failed assertion).  The log is always written by tee regardless of the exit code.
         # shellcheck disable=SC2086
         GRADLE_EXIT=0
-        ./gradlew :consensus-sloth:testPerformance --tests "*${EXPERIMENT_CLASS}" --rerun-tasks ${SLOTH_JVM_PROPS:-} 2>&1 | tee "$LOG_FILE" || GRADLE_EXIT=$?
+        echo ./gradlew :consensus-sloth:testPerformance ${SLOTH_JVM_PROPS:-} --tests "*${EXPERIMENT_CLASS}" --rerun-tasks
+        ./gradlew :consensus-sloth:testPerformance ${SLOTH_JVM_PROPS:-} --tests "*${EXPERIMENT_CLASS}" --rerun-tasks  2>&1 | tee "$LOG_FILE" || GRADLE_EXIT=$?
         if [[ "$GRADLE_EXIT" -ne 0 ]]; then
             echo -e "${RED}ERROR: Test execution failed for ${EXPERIMENT_CLASS} (exit ${GRADLE_EXIT}) — collecting partial results${NC}"
         fi


### PR DESCRIPTION
**Description**:
Small improvements to sloth deployment script

Fixes #24345

**Notes for reviewer**:
 Echo command is not left by mistake, it helps with seeing what is happening at the cost of one extra line in output.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
