### PR TITLE
fix: 24349: CompactionInterruptTest may cause JVM crush

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/CompactionInterruptTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/CompactionInterruptTest.java
@@ -164,9 +164,9 @@ class CompactionInterruptTest {
                     keyToPathCompactor,
                     pathToKeyValueCompactor);
         } finally {
-            dataSource.close();
             exec.shutdown();
             assertTrue(exec.awaitTermination(10, TimeUnit.SECONDS), "Should not timeout");
+            dataSource.close();
         }
         return true;
     }


### PR DESCRIPTION
**Description**:

Fixes #24349

In the test's `finally` block, `dataSource.close()` was called before the snapshot executor (`exec`) was shut down and awaited. The `MerkleDbDataSource.close()` method frees off-heap `DirectByteBuffer` memory backing the `LongListOffHeap` indices (via `Unsafe.invokeCleaner()`). However, the snapshot — running asynchronously on exec — may still be reading from these same off-heap buffers (e.g. during `LongListOffHeap.writeLongsData()` or index iteration). This creates a use-after-free condition: the snapshot thread accesses native memory that has already been deallocated, causing the JVM to segfault.

