### PR TITLE
fix: container startup failures in BN XTS

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/BlockNodeNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/BlockNodeNetwork.java
@@ -161,19 +161,16 @@ public class BlockNodeNetwork {
 
     private void startRealBlockNodeContainer(final long id) {
         final int port = findAvailablePort();
-        final BlockNodeContainer container = new BlockNodeContainer(id, port);
         try {
+            final BlockNodeContainer container = new BlockNodeContainer(id, port);
+
             container.start();
 
             blockNodeContainerById.put(id, container);
 
             logger.info("Started real block node container {} @ {}", id, container);
         } catch (final Exception e) {
-            final String logs = container.getCapturedLogs();
-            throw new RuntimeException(
-                    "Failed to start real block node container " + id + " on port " + port
-                            + "\n--- Container output ---\n" + (logs.isEmpty() ? "(no output captured)" : logs),
-                    e);
+            throw new RuntimeException("Failed to start real block node container " + id + " on port " + port, e);
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.output.ToStringConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
@@ -31,6 +30,7 @@ public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("ghcr.io/hiero-ledger/hiero-block-node:" + BLOCK_NODE_VERSION);
     private static final int GRPC_PORT = 40840;
+    private static final int HEALTH_PORT = 16007;
     private static final String MAVEN_CENTRAL_BASE_URL = "https://repo1.maven.org/maven2";
     private static final String HIER0_BLOCK_NODE_GROUP_PATH = "org/hiero/block-node";
     private static final Object PLUGINS_LOCK = new Object();
@@ -66,7 +66,6 @@ public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
             Map.entry(
                     "antlr4-runtime-4.13.2.jar",
                     MAVEN_CENTRAL_BASE_URL + "/org/antlr/antlr4-runtime/4.13.2/antlr4-runtime-4.13.2.jar"));
-    private final ToStringConsumer logConsumer = new ToStringConsumer();
     private String containerId;
 
     /**
@@ -91,19 +90,12 @@ public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
 
         // Expose the gRPC port for block node communication
         this.addFixedExposedPort(port, GRPC_PORT);
-        this.withLogConsumer(logConsumer);
+        // Also expose the health check port
+        this.addExposedPort(HEALTH_PORT);
         this.withNetworkAliases("block-node-" + blockNodeId)
                 .withEnv("VERSION", BLOCK_NODE_VERSION)
-                // Wait for the block node app to log its startup message
-                .waitingFor(Wait.forLogMessage(".*Started BlockNode Server.*", 1)
-                        .withStartupTimeout(Duration.ofMinutes(3)));
-    }
-
-    /**
-     * Returns all container output (stdout + stderr) captured so far.
-     */
-    public String getCapturedLogs() {
-        return logConsumer.toUtf8String();
+                // Use HTTP health check on the health port to verify the service is ready
+                .waitingFor(Wait.forHttp("/-/healthy").forPort(HEALTH_PORT).withStartupTimeout(Duration.ofMinutes(2)));
     }
 
     private static String pluginsDirInContainer() {


### PR DESCRIPTION
**Description**:
The BN Comms XTS tests were failing because the block node 0.29.0 verification plugin added a new JPMS dependency (requires com.hedera.cryptography.wraps) whose transitive JARs were not being downloaded into the plugins/ directory. Without them on the module path, the JVM failed at module resolution and the app crashed on startup.

Changes:

- Added 4 missing transitive dependency JARs to `REQUIRED_EXTRA_JARS`: `hedera-cryptography-wraps`, `hedera-cryptography-hints`, `hedera-common-nativesupport`, and `antlr4-runtime`
- Fixed a bug in `BlockNodeNetwork` where `findAvailablePort() `was called twice, causing the error message to report a different port than the one actually used by the container
- Removed dead `waitForHealthy()` method and its call — `waitingFor()` only sets the wait strategy, it doesn’t re-execute it after the container is already running

**Related issue(s)**:

Fixes #24365 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
