### PR TITLE
fix: Stabilize transplant updates in presence of empty consensus rounds

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/migrate/StartupNetworks.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/migrate/StartupNetworks.java
@@ -30,6 +30,14 @@ public interface StartupNetworks {
     Optional<Network> overrideNetworkFor(long roundNumber, Configuration platformConfig);
 
     /**
+     * Returns the last override network sourced and confirmed used via {@link #setOverrideRound(long)} by the roster
+     * transplant schema; only called in non-prod environments.
+     * @param platformConfig the current node's configuration
+     * @return the last-used override network
+     */
+    Optional<Network> lastUsedOverrideNetwork(Configuration platformConfig);
+
+    /**
      * Called by a node after applying override network details to the state from a given round.
      *
      * @param roundNumber the round number for which the override was applied

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
@@ -18,6 +18,7 @@ import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,6 +48,9 @@ public class DiskStartupNetworks implements StartupNetworks {
     private final ConfigProvider configProvider;
 
     private boolean isArchived = false;
+
+    @Nullable
+    private Long lastOverrideRoundNumber = null;
 
     /**
      * The types of network information that could be exported to disk.
@@ -96,6 +100,11 @@ public class DiskStartupNetworks implements StartupNetworks {
     }
 
     @Override
+    public Optional<Network> lastUsedOverrideNetwork(Configuration platformConfig) {
+        return Optional.ofNullable(lastOverrideRoundNumber).flatMap(n -> overrideNetworkFor(n, platformConfig));
+    }
+
+    @Override
     public void setOverrideRound(final long roundNumber) {
         final var config = configProvider.getConfiguration();
         final var path = networksPath(config, OVERRIDE_NETWORK_JSON);
@@ -106,6 +115,7 @@ public class DiskStartupNetworks implements StartupNetworks {
                 Files.createDirectories(roundDir);
                 Files.move(path, scopedPath);
                 log.info("Moved override network file to {}", scopedPath);
+                lastOverrideRoundNumber = roundNumber;
             } catch (IOException e) {
                 log.warn("Failed to move override network file", e);
             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -644,7 +644,7 @@ public class SystemTransactions {
         final var nodeStore = readableStoreFactory.readableStore(ReadableNodeStore.class);
         final var systemContext = newSystemContext(
                 now, state, dispatch -> {}, UseReservedConsensusTimes.YES, TriggerStakePeriodSideEffects.YES);
-        final var network = startupNetworks.overrideNetworkFor(currentRoundNum - 1, configProvider.getConfiguration());
+        final var network = startupNetworks.lastUsedOverrideNetwork(configProvider.getConfiguration());
         if (rosterStore.isTransplantInProgress() && network.isPresent()) {
             log.info("Roster transplant in progress, dispatching node updates for round {}", currentRoundNum - 1);
             final var overrideNodes = network.get().nodeMetadata().stream()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/DiskStartupNetworksTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/DiskStartupNetworksTest.java
@@ -142,6 +142,13 @@ class DiskStartupNetworksTest {
     }
 
     @Test
+    void hasNoLastUsedOverrideNetworkBeforeOverrideRoundIsSet() {
+        final var object = subject.lastUsedOverrideNetwork(DEFAULT_CONFIG);
+
+        assertThat(object).isEmpty();
+    }
+
+    @Test
     void archivesGenesisNetworks() throws IOException {
         givenConfig();
         putJsonAt(GENESIS_NETWORK_JSON);
@@ -212,6 +219,19 @@ class DiskStartupNetworksTest {
 
         final var maybeOverrideNetworkAfterRound = subject.overrideNetworkFor(ROUND_NO + 1, DEFAULT_CONFIG);
         assertThat(maybeOverrideNetworkAfterRound).isEmpty();
+    }
+
+    @Test
+    void findsLastUsedOverrideNetworkAfterOverrideRoundIsSet() throws IOException {
+        givenConfig();
+        putJsonAt(OVERRIDE_NETWORK_JSON);
+
+        subject.setOverrideRound(ROUND_NO);
+
+        final var lastUsedOverrideNetwork = subject.lastUsedOverrideNetwork(DEFAULT_CONFIG);
+
+        assertThat(lastUsedOverrideNetwork).isPresent();
+        assertThat(lastUsedOverrideNetwork.orElseThrow()).isEqualTo(NETWORK);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeStartupNetworks.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/com/hedera/node/app/fixtures/state/FakeStartupNetworks.java
@@ -22,7 +22,12 @@ public class FakeStartupNetworks implements StartupNetworks {
     }
 
     @Override
-    public Optional<Network> overrideNetworkFor(long roundNumber, Configuration platformConfig) {
+    public Optional<Network> overrideNetworkFor(long roundNumber, @NonNull final Configuration platformConfig) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Network> lastUsedOverrideNetwork(@NonNull final Configuration platformConfig) {
         return Optional.empty();
     }
 


### PR DESCRIPTION
**Description**:
 - Closes #24373 
 - In non-prod envs using _override-network.json_, the pattern is:
    1. `RosterTransplantSchema` applies the overrides for round `N` to roster state and moves the JSON to a _data/config/<round-number>/_ directory so that later reconnects from a round `M > N` won't ISS by reapplying the overrides.
    2. Next, `SystemTransactions.doUpgradeSetup()` dispatches synthetic txs to externalize the override details.
 - But on `main`, step (2) assumes that the the post-upgrade round will be exactly `N+1`.
   - ⚠️ When the first consensus round post-upgrade is empty, this assumption breaks.
   - We fix in this PR by having `DiskStartupNetworks` remember its last-applied override network round number and always using that one.