### PR TITLE
fix: Always update override round number to set up _override-network.json_ transplants

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
@@ -115,11 +115,17 @@ public class DiskStartupNetworks implements StartupNetworks {
                 Files.createDirectories(roundDir);
                 Files.move(path, scopedPath);
                 log.info("Moved override network file to {}", scopedPath);
-                lastOverrideRoundNumber = roundNumber;
             } catch (IOException e) {
                 log.warn("Failed to move override network file", e);
             }
         }
+        // Even if above code didn't move a data/config/override-network.json to a
+        // data/config/<roundNumber>/override-network.json file, we still need to
+        // track the round number we are applying this override roster in; if not,
+        // when reconnecting from a <roundNumber> state after *already restarting*
+        // from that state we will fail to repeat the post-upgrade transplant
+        // dispatches and hit an ISS immediately after restart
+        lastOverrideRoundNumber = roundNumber;
     }
 
     @Override


### PR DESCRIPTION
**Description**:
 - Fixes mistake in https://github.com/hiero-ledger/hiero-consensus-node/pull/24376---we should repeat transplant dispatches in `SystemTransactions.doPostUpgradSetup()` **every time** a node restarts from the state whose round number has an associated _override-network.json_.
     * ⚠️ But I accidentally changed behavior to skip transplant dispatches when **re**-restarting with a _data/config/<round_number>/override-network.json_ that was moved from _data/config/override-network.json_.