### PR TITLE
fix: 24435 Fix `cache-cleaner` thread leak in `VirtualNodeCache`

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -1635,6 +1635,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
             // And finally snapshot the copy to the target dir
             dataSourceBuilder.snapshot(outputDirectory, dataSourceCopy);
         } finally {
+            cacheSnapshot.getValue().shutdown();
             // Delete the snapshot directory
             FileUtils.deleteDirectory(snapshotPath);
             // And delete the data source copy directory

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/RecordAccessor.java
@@ -224,6 +224,7 @@ public final class RecordAccessor {
      * @throws IOException If an I/O error occurs
      */
     public void close() throws IOException {
+        cache.shutdown();
         dataSource.close();
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -311,21 +311,25 @@ public final class VirtualNodeCache implements FastCopyable {
         this.fastCopyVersion.set(fastCopyVersion);
         this.virtualMapConfig = requireNonNull(virtualMapConfig);
 
-        cleaningPool = Boolean.getBoolean("syncCleaningPool")
-                ? Runnable::run
-                : new ThreadPoolExecutor(
-                        virtualMapConfig.getNumCleanerThreads(),
-                        virtualMapConfig.getNumCleanerThreads(),
-                        60L,
-                        TimeUnit.SECONDS,
-                        new LinkedBlockingQueue<>(),
-                        new ThreadConfiguration(getStaticThreadManager())
-                                .setThreadGroup(new ThreadGroup("virtual-cache-cleaners"))
-                                .setComponent("virtual-map")
-                                .setThreadName("cache-cleaner")
-                                .setExceptionHandler((t, ex) -> logger.error(
-                                        EXCEPTION.getMarker(), "Failed to purge unneeded key/mutationList pairs", ex))
-                                .buildFactory());
+        if (Boolean.getBoolean("syncCleaningPool")) {
+            cleaningPool = Runnable::run;
+        } else {
+            final ThreadPoolExecutor pool = new ThreadPoolExecutor(
+                    virtualMapConfig.getNumCleanerThreads(),
+                    virtualMapConfig.getNumCleanerThreads(),
+                    60L,
+                    TimeUnit.SECONDS,
+                    new LinkedBlockingQueue<>(),
+                    new ThreadConfiguration(getStaticThreadManager())
+                            .setThreadGroup(new ThreadGroup("virtual-cache-cleaners"))
+                            .setComponent("virtual-map")
+                            .setThreadName("cache-cleaner")
+                            .setExceptionHandler((t, ex) -> logger.error(
+                                    EXCEPTION.getMarker(), "Failed to purge unneeded key/mutationList pairs", ex))
+                            .buildFactory());
+            pool.allowCoreThreadTimeOut(true);
+            cleaningPool = pool;
+        }
     }
 
     /**
@@ -360,6 +364,35 @@ public final class VirtualNodeCache implements FastCopyable {
         // Wire up the next & prev references
         this.next.set(source);
         source.prev.set(this);
+    }
+
+    /**
+     * Create a new VirtualNodeCache with a provided executor for cleaning.
+     * This is used by {@link #snapshot()} to create lightweight cache instances
+     * that don't need their own thread pool.
+     *
+     * @param virtualMapConfig platform configuration for VirtualMap
+     * @param hashChunkHeight virtual hash chunk height
+     * @param hashChunkLoader virtual hash chunk loader, must not be null
+     * @param fastCopyVersion the version of this cache
+     * @param cleaningPool the executor to use for cleaning operations
+     */
+    private VirtualNodeCache(
+            final @NonNull VirtualMapConfig virtualMapConfig,
+            final int hashChunkHeight,
+            final @NonNull CheckedFunction<Long, VirtualHashChunk, IOException> hashChunkLoader,
+            final long fastCopyVersion,
+            final @NonNull Executor cleaningPool) {
+        this.hashChunkHeight = hashChunkHeight;
+        this.hashChunkLoader = requireNonNull(hashChunkLoader);
+        this.keyToDirtyLeafIndex = new ConcurrentHashMap<>();
+        this.pathToDirtyKeyIndex = new ConcurrentHashMap<>();
+        this.idToDirtyHashChunkIndex = new ConcurrentHashMap<>();
+        this.releaseLock = new ReentrantLock();
+        this.lastReleased = new AtomicLong(-1L);
+        this.fastCopyVersion.set(fastCopyVersion);
+        this.virtualMapConfig = requireNonNull(virtualMapConfig);
+        this.cleaningPool = requireNonNull(cleaningPool);
     }
 
     /**
@@ -939,8 +972,8 @@ public final class VirtualNodeCache implements FastCopyable {
      */
     public VirtualNodeCache snapshot() {
         synchronized (lastReleased) {
-            final VirtualNodeCache newSnapshot =
-                    new VirtualNodeCache(virtualMapConfig, hashChunkHeight, hashChunkLoader, fastCopyVersion.get());
+            final VirtualNodeCache newSnapshot = new VirtualNodeCache(
+                    virtualMapConfig, hashChunkHeight, hashChunkLoader, fastCopyVersion.get(), Runnable::run);
             setMapSnapshotAndArray(
                     this.idToDirtyHashChunkIndex, newSnapshot.idToDirtyHashChunkIndex, newSnapshot.dirtyHashChunks);
             setMapSnapshotAndArray(
@@ -1464,5 +1497,14 @@ public final class VirtualNodeCache implements FastCopyable {
         }
 
         return builder.toString();
+    }
+
+    /**
+     * Returns the cleaning pool executor. Package-private, intended for testing only.
+     *
+     * @return the cleaning pool executor
+     */
+    Executor getCleaningPool() {
+        return cleaningPool;
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCacheTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCacheTest.java
@@ -9,8 +9,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -40,6 +43,9 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -2800,9 +2806,229 @@ class VirtualNodeCacheTest extends VirtualTestBase {
                 cache1.getEstimatedSize());
     }
 
+    @Test
+    @DisplayName("Snapshot cache uses a synchronous executor, not a thread pool")
+    void snapshotCacheDoesNotCreateThreadPool() {
+        cache.putLeaf(appleLeaf(1));
+        cache.putLeaf(bananaLeaf(2));
+        cache.copy();
+
+        final VirtualNodeCache snapshot = cache.snapshot();
+
+        // The snapshot's cleaning pool should NOT be an ExecutorService (thread pool).
+        // It should be a simple synchronous executor (Runnable::run).
+        assertFalse(
+                snapshot.getCleaningPool() instanceof ExecutorService,
+                "Snapshot cache should use a synchronous executor, not a thread pool");
+    }
+
+    @Test
+    @DisplayName("Chained snapshots do not create thread pools")
+    void chainedSnapshotsDoNotCreateThreadPools() {
+        cache.putLeaf(appleLeaf(1));
+        cache.copy();
+
+        final VirtualNodeCache snapshot1 = cache.snapshot();
+        final VirtualNodeCache snapshot2 = snapshot1.snapshot();
+        final VirtualNodeCache snapshot3 = snapshot2.snapshot();
+
+        assertFalse(snapshot1.getCleaningPool() instanceof ExecutorService, "Snapshot should not have a thread pool");
+        assertFalse(
+                snapshot2.getCleaningPool() instanceof ExecutorService,
+                "Snapshot of snapshot should not have a thread pool");
+        assertFalse(
+                snapshot3.getCleaningPool() instanceof ExecutorService,
+                "Snapshot of snapshot of snapshot should not have a thread pool");
+    }
+
+    @Test
+    @DisplayName("Calling shutdown on a snapshot cache does not throw")
+    void shutdownOnSnapshotIsSafe() {
+        cache.putLeaf(appleLeaf(1));
+        cache.copy();
+
+        final VirtualNodeCache snapshot = cache.snapshot();
+        // Should be a no-op since the snapshot uses Runnable::run
+        assertDoesNotThrow(snapshot::shutdown, "shutdown() on a snapshot should not throw");
+        // Calling it twice should also be fine
+        assertDoesNotThrow(snapshot::shutdown, "shutdown() on a snapshot should be idempotent");
+    }
+
+    @Test
+    @DisplayName("Snapshot's deletedLeaves works correctly with synchronous executor")
+    void snapshotDeletedLeavesWorksWithSynchronousExecutor() {
+        // Set up a cache with some leaves, then delete one
+        cache.putLeaf(appleLeaf(1));
+        cache.putLeaf(bananaLeaf(2));
+        cache.putLeaf(cherryLeaf(3));
+
+        final VirtualNodeCache cache1 = cache.copy();
+        cache1.deleteLeaf(appleLeaf(1));
+
+        final VirtualNodeCache cache2 = cache1.copy();
+
+        cache.prepareForHashing();
+        cache.seal();
+        cache1.prepareForHashing();
+        cache1.seal();
+
+        cache.merge();
+
+        // Take a snapshot of cache1 (which has the deletion)
+        final VirtualNodeCache snapshot = cache1.snapshot();
+
+        // deletedLeaves() uses parallelTraverse(cleaningPool, ...) internally.
+        // With a synchronous executor, this should still work correctly.
+        final List<VirtualLeafBytes> deleted = snapshot.deletedLeaves().toList();
+        assertEquals(1, deleted.size(), "Snapshot should report exactly one deleted leaf");
+        assertEquals(A_KEY, deleted.get(0).keyBytes(), "The deleted leaf should be apple");
+    }
+
+    @Test
+    @DisplayName("Snapshot's dirtyLeavesForFlush works correctly with synchronous executor")
+    void snapshotDirtyLeavesForFlushWorksWithSynchronousExecutor() {
+        cache.putLeaf(appleLeaf(1));
+        cache.putLeaf(bananaLeaf(2));
+
+        final VirtualNodeCache cache1 = cache.copy();
+        cache1.putLeaf(cherryLeaf(3));
+
+        cache.prepareForHashing();
+        cache.seal();
+        cache1.prepareForHashing();
+        cache1.seal();
+        cache.merge();
+
+        cache1.copy();
+
+        final VirtualNodeCache snapshot = cache1.snapshot();
+
+        // dirtyLeavesForFlush should work with the synchronous executor
+        final List<VirtualLeafBytes> dirtyLeaves =
+                snapshot.dirtyLeavesForFlush(1, 3).toList();
+        assertFalse(dirtyLeaves.isEmpty(), "Snapshot should have dirty leaves for flush");
+    }
+
+    /**
+     * This test creates a VirtualNodeCache WITHOUT the syncCleaningPool=true
+     * system property, so a real ThreadPoolExecutor is created. We verify
+     * that allowCoreThreadTimeOut is enabled on it.
+     */
+    @Test
+    @DisplayName("Primary constructor's thread pool has allowCoreThreadTimeOut enabled")
+    void primaryConstructorPoolAllowsCoreThreadTimeout() {
+        // Save and clear the system property so a real pool is created
+        final String original = System.getProperty("syncCleaningPool");
+        try {
+            System.clearProperty("syncCleaningPool");
+
+            final VirtualMapConfig config = CONFIGURATION.getConfigData(VirtualMapConfig.class);
+            final VirtualNodeCache realPoolCache = new VirtualNodeCache(config, HASH_CHUNK_HEIGHT, chunkLoader);
+
+            try {
+                final Executor pool = realPoolCache.getCleaningPool();
+                assertInstanceOf(
+                        ThreadPoolExecutor.class,
+                        pool,
+                        "Without syncCleaningPool, a real ThreadPoolExecutor should be created");
+
+                final ThreadPoolExecutor threadPool = (ThreadPoolExecutor) pool;
+                assertTrue(
+                        threadPool.allowsCoreThreadTimeOut(),
+                        "Core thread timeout should be enabled so idle threads are reclaimed");
+            } finally {
+                realPoolCache.shutdown();
+            }
+        } finally {
+            // Restore the property
+            if (original != null) {
+                System.setProperty("syncCleaningPool", original);
+            } else {
+                System.clearProperty("syncCleaningPool");
+            }
+        }
+    }
+
+    /**
+     * No thread leak from snapshots of real-pool caches
+     */
+    @Test
+    @DisplayName("Snapshots of a real-pool cache do not spawn additional cache-cleaner threads")
+    void snapshotsDoNotSpawnCleanerThreads() {
+        final String original = System.getProperty("syncCleaningPool");
+        try {
+            System.clearProperty("syncCleaningPool");
+
+            final VirtualMapConfig config = CONFIGURATION.getConfigData(VirtualMapConfig.class);
+            final VirtualNodeCache realPoolCache = new VirtualNodeCache(config, HASH_CHUNK_HEIGHT, chunkLoader);
+
+            try {
+                realPoolCache.putLeaf(appleLeaf(1));
+                realPoolCache.putLeaf(bananaLeaf(2));
+                realPoolCache.copy();
+
+                final long cleanerThreadsBefore = countCacheCleanerThreads();
+
+                // Create many snapshots — none should spawn threads
+                for (int i = 0; i < 3; i++) {
+                    final VirtualNodeCache snapshot = realPoolCache.snapshot();
+                    assertFalse(
+                            snapshot.getCleaningPool() instanceof ExecutorService,
+                            "Snapshot #" + i + " should not have a thread pool");
+                }
+
+                final long cleanerThreadsAfter = countCacheCleanerThreads();
+                assertEquals(
+                        cleanerThreadsBefore,
+                        cleanerThreadsAfter,
+                        "No additional cache-cleaner threads should be created by snapshots");
+            } finally {
+                realPoolCache.shutdown();
+            }
+        } finally {
+            if (original != null) {
+                System.setProperty("syncCleaningPool", original);
+            } else {
+                System.clearProperty("syncCleaningPool");
+            }
+        }
+    }
+
+    /**
+     * Copy shares the pool, snapshot does not
+     */
+    @Test
+    @DisplayName("copy() shares the cleaning pool, snapshot() does not")
+    void copySharesPoolSnapshotDoesNot() {
+        cache.putLeaf(appleLeaf(1));
+
+        final VirtualNodeCache copy = cache.copy();
+        final VirtualNodeCache snapshot = cache.snapshot();
+
+        // copy() should share the same pool reference as the original
+        assertSame(
+                cache.getCleaningPool(),
+                copy.getCleaningPool(),
+                "copy() should share the cleaning pool with its source");
+
+        // snapshot() should NOT share the pool — it uses its own synchronous executor
+        assertNotSame(
+                cache.getCleaningPool(),
+                snapshot.getCleaningPool(),
+                "snapshot() should have its own executor, not the source's pool");
+        assertFalse(
+                snapshot.getCleaningPool() instanceof ExecutorService, "snapshot()'s executor should be synchronous");
+    }
+
     // ----------------------------------------------------------------------
     // Test Utility methods
     // ----------------------------------------------------------------------
+
+    private long countCacheCleanerThreads() {
+        return Thread.getAllStackTraces().keySet().stream()
+                .filter(t -> t.getName().contains("cache-cleaner"))
+                .count();
+    }
 
     @SuppressWarnings("unchecked")
     private TestValue lookupValue(final VirtualNodeCache cache, final Bytes key) {

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorTest.java
@@ -5,10 +5,13 @@ import static com.swirlds.virtualmap.internal.Path.INVALID_PATH;
 import static com.swirlds.virtualmap.test.fixtures.VirtualMapTestUtils.VIRTUAL_MAP_CONFIG;
 import static com.swirlds.virtualmap.test.fixtures.VirtualMapTestUtils.createHashChunkStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.metrics.api.Metrics;
@@ -26,8 +29,12 @@ import com.swirlds.virtualmap.test.fixtures.TestValueCodec;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Stream;
 import org.hiero.base.crypto.Cryptography;
 import org.hiero.base.crypto.CryptographyProvider;
@@ -242,6 +249,57 @@ public class RecordAccessorTest {
         final long path = records.findPath(key);
         final VirtualLeafBytes<?> record = records.findLeafRecord(path);
         assertEquals(key, record.keyBytes());
+    }
+
+    @Test
+    @DisplayName("close() shuts down the cache's cleaning pool")
+    void closeShutsCacheCleaningPool() throws IOException, NoSuchFieldException, IllegalAccessException {
+        // Save and clear the system property so a real thread pool is created
+        final String original = System.getProperty("syncCleaningPool");
+        try {
+            System.clearProperty("syncCleaningPool");
+
+            final VirtualMapMetadata state = new VirtualMapMetadata();
+            state.setLastLeafPath(2);
+            state.setFirstLeafPath(1);
+
+            final InMemoryDataSource ds = new InMemoryDataSource("closeShutsCacheCleaningPool");
+            final int hashChunkHeight = ds.getHashChunkHeight();
+
+            // Create a cache with a real thread pool (not syncCleaningPool).
+            // We intentionally use the primary constructor here, NOT a snapshot,
+            // to get a cache backed by a real ThreadPoolExecutor. This simulates
+            // a scenario where RecordAccessor receives a cache with a real pool.
+            final VirtualNodeCache realPoolCache =
+                    new VirtualNodeCache(VIRTUAL_MAP_CONFIG, hashChunkHeight, ds::loadHashChunk);
+
+            // VirtualNodeCache.cleaningPool is private and the class is final,
+            // so we use reflection to verify the pool state.
+            final Field cleaningPoolField = VirtualNodeCache.class.getDeclaredField("cleaningPool");
+            cleaningPoolField.setAccessible(true);
+            final Executor pool = (Executor) cleaningPoolField.get(realPoolCache);
+            assertInstanceOf(
+                    ThreadPoolExecutor.class, pool, "Without syncCleaningPool, should have a real ThreadPoolExecutor");
+            final ExecutorService executorService = (ExecutorService) pool;
+
+            assertFalse(executorService.isShutdown(), "Pool should not be shut down yet");
+
+            // Wrap it in a RecordAccessor and close
+            final RecordAccessor accessor = new RecordAccessor(state, hashChunkHeight, realPoolCache, ds);
+            accessor.close();
+
+            // After close(), both the data source and the cache's pool should be shut down
+            assertTrue(ds.isClosed(), "Data source should be closed after RecordAccessor.close()");
+            assertTrue(
+                    executorService.isShutdown(),
+                    "Cache's cleaning pool should be shut down after RecordAccessor.close()");
+        } finally {
+            if (original != null) {
+                System.setProperty("syncCleaningPool", original);
+            } else {
+                System.clearProperty("syncCleaningPool");
+            }
+        }
     }
 
     private static final class BreakableDataSource implements VirtualDataSource {


### PR DESCRIPTION
**Description**:

Moving `cleaningPool` from static to instance level (see https://github.com/hiero-ledger/hiero-consensus-node/pull/24061) introduced a thread leak. `VirtualNodeCache.snapshot()` calls the primary constructor, which creates a new `ThreadPoolExecutor` each time. These pools are never shut down in:

- **`VirtualMap.createSnapshot()`** — snapshot cache is flushed and dropped, pool is never shut down
- **`VirtualMap.detach()`** — snapshot cache is wrapped in `RecordAccessor`, whose `close()` only closes the data source
- **`VirtualNodeCacheTest`** — `@BeforeEach` creates a new cache/pool with no corresponding teardown

Core threads persist indefinitely (`allowCoreThreadTimeOut` defaults to `false`), so every snapshot leaks one pool worth of threads.

### Fix

**Snapshot caches don't need a thread pool.** They are standalone, sealed immediately, and never released/merged — so `purge()` is never called on them. The only pool usage is `deletedLeaves()` via `parallelTraverse`, which works fine synchronously.

Changes:

1. **`VirtualNodeCache`** — `snapshot()` now creates caches with `Runnable::run` instead of a `ThreadPoolExecutor` (via a new private constructor). The primary constructor's pool now enables `allowCoreThreadTimeOut(true)` as a safety net.
2. **`VirtualMap.createSnapshot()`** — calls `cacheSnapshot.shutdown()` in `finally` block.
3. **`RecordAccessor.close()`** — calls `cache.shutdown()` before closing the data source.
4. **`VirtualNodeCacheTest`** — adds `@AfterEach` calling `cache.shutdown()`.

### Tests

- Snapshot caches use synchronous executor, not a `ThreadPoolExecutor`
- Chained snapshots don't create pools
- 20 snapshots from a real-pool cache produce zero new `cache-cleaner` threads
- `copy()` shares pool; `snapshot()` does not
- `deletedLeaves()` / `dirtyLeavesForFlush()` work correctly with synchronous execution
- `allowCoreThreadTimeOut` is enabled on the real pool
- `RecordAccessor.close()` shuts down the cache pool

**Related issue(s)**:

Fixes #24435 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
