### PR TITLE
ci(workflow-bugfix): Fix issue with Deploy Production Release using incorrect reference.

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - "release/**"
-  workflow_dispatch:
 
 defaults:
   run:
@@ -80,8 +79,6 @@ jobs:
 
           echo "Using workflow reference: ${RESOLVED_REF}"
           echo "workflow-ref=${RESOLVED_REF}" >> "${GITHUB_OUTPUT}"
-
-          gh run cancel ${{ github.run_id }}
 
       - name: Trigger ZXF Deploy Production Release
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7


### PR DESCRIPTION
## Description

This pull request updates the deployment workflow in `.github/workflows/node-flow-build-application.yaml` to improve how the workflow reference is resolved before triggering the deploy step. The changes ensure that the correct workflow definition is used, defaulting to `main` if the current reference is not found.

Key workflow improvements:

* Added a new step to check out the code using `actions/checkout` with `fetch-depth: "0"` to ensure the full git history is available.
* Introduced a step to resolve the workflow reference dynamically: it checks if the current `github.ref_name` exists in the remote; if not, it falls back to `main` and sets the resolved reference as an output.
* Updated the deploy trigger to use the dynamically resolved workflow reference instead of always using `main`, ensuring the correct workflow version is used for deployments.

## Related Issue(s)

Fixes #24465 

## Testing

- [x] [testing complete](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/23504067668) ✅ - Invalid. Reference was never passed.
- [x] [testing in progress](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/23506194977) ✅  