### PR TITLE
chore: restore quiet CI logging for embedded/repeatable HAPI tasks

### DIFF
--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -355,32 +355,7 @@ jobs:
           LC_ALL: en.UTF-8
           LANG: en_US.UTF-8
         # Simple Fees uses same task for PR and MATS (no MATS suffix)
-        run: |
-          set -euo pipefail
-          LOG_DIR="ci-logs/hapi-simple-fees"
-          mkdir -p "${LOG_DIR}"
-          run_gradle_capture() {
-            local task_name="$1"
-            local log_file="${LOG_DIR}/${task_name}.log"
-            echo "Running ${task_name} (capturing output to ${log_file})"
-            if ! ${GRADLE_EXEC} "${task_name}" --no-daemon >"${log_file}" 2>&1; then
-              echo "Task ${task_name} failed. Last 200 log lines:"
-              tail -n 200 "${log_file}" || true
-              return 1
-            fi
-          }
-          run_gradle_capture "hapiTestSimpleFees"
-          run_gradle_capture "hapiEmbeddedSimpleFees"
-          run_gradle_capture "hapiTestSimpleFeesSerial"
-
-      - name: Upload HAPI Test (Simple Fees) Gradle Logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ always() && !cancelled() }}
-        with:
-          name: HAPI Test (Simple Fees) Gradle Logs
-          path: ci-logs/hapi-simple-fees/*.log
-          if-no-files-found: warn
-          retention-days: 7
+        run: ${GRADLE_EXEC} hapiTestSimpleFees --no-daemon && ${GRADLE_EXEC} hapiEmbeddedSimpleFees --no-daemon && ${GRADLE_EXEC} hapiTestSimpleFeesSerial --no-daemon
 
       - name: Publish HAPI Test (Simple Fees) Report
         uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
@@ -898,32 +873,7 @@ jobs:
         env:
           LC_ALL: en.UTF-8
           LANG: en_US.UTF-8
-        run: |
-          set -euo pipefail
-          LOG_DIR="ci-logs/hapi-atomic-batch"
-          mkdir -p "${LOG_DIR}"
-          run_gradle_capture() {
-            local task_name="$1"
-            local log_file="${LOG_DIR}/${task_name}.log"
-            echo "Running ${task_name} (capturing output to ${log_file})"
-            if ! ${GRADLE_EXEC} "${task_name}" --no-daemon >"${log_file}" 2>&1; then
-              echo "Task ${task_name} failed. Last 200 log lines:"
-              tail -n 200 "${log_file}" || true
-              return 1
-            fi
-          }
-          run_gradle_capture "hapiTestAtomicBatch"
-          run_gradle_capture "hapiTestAtomicBatchSerial"
-          run_gradle_capture "hapiTestAtomicBatchEmbedded"
-
-      - name: Upload HAPI Test (Atomic Batch) Gradle Logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ always() && !cancelled() }}
-        with:
-          name: HAPI Test (Atomic Batch) Gradle Logs
-          path: ci-logs/hapi-atomic-batch/*.log
-          if-no-files-found: warn
-          retention-days: 7
+        run: ${GRADLE_EXEC} hapiTestAtomicBatch --no-daemon && ${GRADLE_EXEC} hapiTestAtomicBatchSerial --no-daemon && ${GRADLE_EXEC} hapiTestAtomicBatchEmbedded --no-daemon
 
       - name: Publish HAPI Test (Atomic Batch) Report
         uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -37,7 +37,6 @@ tasks.jacocoTestReport {
 tasks.test {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    systemProperty("log4j.configurationFile", "log4j2-test-client.xml")
 
     // Unlike other tests, these intentionally corrupt embedded state to test FAIL_INVALID
     // code paths; hence we do not run LOG_VALIDATION after the test suite finishes
@@ -299,7 +298,6 @@ tasks {
 tasks.register<Test>("testSubprocess") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    systemProperty("log4j.configurationFile", "log4j2-test-client.xml")
 
     val ciTagExpression =
         gradle.startParameter.taskNames
@@ -416,14 +414,11 @@ tasks.register<Test>("testSubprocess") {
         "--add-reads=org.testcontainers=org.apache.commons.codec",
     )
     maxParallelForks = 1
-    // temporary fix for logging
-    modularity.inferModulePath.set(false)
 }
 
 tasks.register<Test>("testSubprocessConcurrent") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    systemProperty("log4j.configurationFile", "log4j2-test-client.xml")
 
     val ciTagExpression =
         gradle.startParameter.taskNames
@@ -536,14 +531,11 @@ tasks.register<Test>("testSubprocessConcurrent") {
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
     maxParallelForks = 1
-    // temporary fix for logging
-    modularity.inferModulePath.set(false)
 }
 
 tasks.register<Test>("testRemote") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    systemProperty("log4j.configurationFile", "log4j2-test-client.xml")
 
     systemProperty("hapi.spec.remote", "true")
     // Support overriding a single remote target network for all executing specs
@@ -650,7 +642,6 @@ tasks {
 tasks.register<Test>("testEmbedded") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    systemProperty("log4j.configurationFile", "log4j2-test-client.xml")
 
     val ciTagExpression =
         gradle.startParameter.taskNames
@@ -697,8 +688,6 @@ tasks.register<Test>("testEmbedded") {
     // Limit heap and number of processors
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
-    // temporary fix for logging
-    modularity.inferModulePath.set(false)
 }
 
 val repeatableBaseTags = mapOf("hapiTestMiscRepeatable" to "REPEATABLE&!CRYPTO")
@@ -726,7 +715,6 @@ tasks {
 tasks.register<Test>("testRepeatable") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    systemProperty("log4j.configurationFile", "log4j2-test-client.xml")
 
     val ciTagExpression =
         gradle.startParameter.taskNames
@@ -755,8 +743,6 @@ tasks.register<Test>("testRepeatable") {
     // Limit heap and number of processors
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
-    // temporary fix for logging
-    modularity.inferModulePath.set(false)
 }
 
 application.mainClass = "com.hedera.services.bdd.suites.SuiteRunner"


### PR DESCRIPTION
**Description**:
Fixes CI log spam in HAPI test checks by restoring the intended Log4j initialization behavior from #23813, without relying on modularity.inferModulePath.set(false)
