### PR TITLE
fix: Add missing test-clients logs in subprocess network

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SharedNetworkLauncherSessionListener.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SharedNetworkLauncherSessionListener.java
@@ -14,6 +14,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.services.bdd.HapiBlockNode;
 import com.hedera.services.bdd.junit.hedera.BlockNodeMode;
 import com.hedera.services.bdd.junit.hedera.BlockNodeNetwork;
+import com.hedera.services.bdd.junit.hedera.ExternalPath;
 import com.hedera.services.bdd.junit.hedera.HederaNetwork;
 import com.hedera.services.bdd.junit.hedera.embedded.EmbeddedMode;
 import com.hedera.services.bdd.junit.hedera.embedded.EmbeddedNetwork;
@@ -36,6 +37,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.LauncherSession;
@@ -52,6 +54,8 @@ import org.junit.platform.launcher.TestPlan;
 public class SharedNetworkLauncherSessionListener implements LauncherSessionListener {
     private static final Logger log = LogManager.getLogger(SharedNetworkLauncherSessionListener.class);
     private static final List<Consumer<HederaNetwork>> onSubProcessReady = new ArrayList<>();
+    private static final String TEST_CLIENT_LOG_FILE = "hapi.test.clients.log.file";
+    private static final String TEST_CLIENT_LOG_FILE_PATTERN = "hapi.test.clients.log.filePattern";
 
     public static final int CLASSIC_HAPI_TEST_NETWORK_SIZE = 4;
 
@@ -143,6 +147,7 @@ public class SharedNetworkLauncherSessionListener implements LauncherSessionList
                 network.start();
                 SHARED_NETWORK.set(network);
                 if (network instanceof SubProcessNetwork subProcessNetwork) {
+                    reconfigureSharedSubProcessLogging(subProcessNetwork);
                     onSubProcessReady.forEach(subProcessNetwork::onReady);
                     onSubProcessReady.clear();
                 }
@@ -248,6 +253,23 @@ public class SharedNetworkLauncherSessionListener implements LauncherSessionList
         private static void startSharedEmbedded(@NonNull final EmbeddedMode mode) {
             SHARED_NETWORK.set(EmbeddedNetwork.newSharedNetwork(mode));
             SHARED_NETWORK.get().start();
+        }
+
+        private static void reconfigureSharedSubProcessLogging(@NonNull final SubProcessNetwork network) {
+            final var outputDir = network.nodes()
+                    .getFirst()
+                    .getExternalPath(ExternalPath.APPLICATION_LOG)
+                    .getParent()
+                    .toAbsolutePath()
+                    .normalize();
+            System.setProperty(
+                    TEST_CLIENT_LOG_FILE, outputDir.resolve("test-clients.log").toString());
+            System.setProperty(
+                    TEST_CLIENT_LOG_FILE_PATTERN,
+                    outputDir.resolve("test-clients-%d{yyyy-MM-dd}-%i.log").toString());
+            // Reconfigure in place using log4j2-test-client.xml with subprocess-specific output paths.
+            Configurator.reconfigure();
+            log.info("Configured shared subprocess test-client logging under {}", outputDir);
         }
 
         /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/FeesChargingUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/FeesChargingUtils.java
@@ -126,29 +126,6 @@ public class FeesChargingUtils {
 
     // ------ Fees calculation utils ------//
 
-    /** tinycents -> USD */
-    public static double tinycentsToUsd(long tinycents) {
-        return tinycents / 100_000_000.0 / 100.0;
-    }
-
-    /**
-     * SimpleFees formula for node fees only:
-     * node = NODE_BASE + SIGNATURE_FEE * max(0, sigs - includedSigsNode)
-     */
-    private static double expectedNodeFeeUsd(long sigs, int txnSize) {
-        final long sigExtrasNode = Math.max(0L, sigs - NODE_INCLUDED_SIGNATURES);
-        final double nodeExtrasFee = sigExtrasNode * SIGNATURE_FEE_USD;
-        return NODE_BASE_FEE_USD + nodeExtrasFee + nodeFeeFromBytesUsd(txnSize);
-    }
-
-    /**
-     * SimpleFees formula for network fees only:
-     * network = node * NETWORK_MULTIPLIER
-     */
-    private static double expectedNetworkFeeUsd(long sigs, int txnSize) {
-        return expectedNodeFeeUsd(sigs, txnSize) * NETWORK_MULTIPLIER;
-    }
-
     /**
      * SimpleFees formula for node + network fees:
      * node    = NODE_BASE + SIGNATURE_FEE * max(0, sigs - includedSigsNode)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
@@ -23,19 +23,13 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final double SIGNATURE_FEE_USD = 0.00001;
     public static final double STATE_BYTES_FEE_USD = 0.0001;
     public static final double PROCESSING_BYTES_FEE_USD = 0.000001;
-    public static final long STATE_BYTES_INCLUDED = 1000L;
-    public static final long PROCESSING_BYTES_INCLUDED = 1024L;
     public static final double KEYS_FEE_USD = 0.01;
-    public static final double NFT_SERIALS_FEE_USD = 0.00089;
     public static final double ACCOUNTS_FEE_USD = 0.0001;
     public static final double SIGNATURE_FEE_AFTER_MULTIPLIER = (NETWORK_MULTIPLIER + 1) * SIGNATURE_FEE_USD;
 
     public static final double TOKEN_TYPES_FEE = 0.0001;
-
     public static final double GAS_FEE_USD = 0.0000000852;
-    public static final double ALLOWANCES_FEE_USD = 0.05;
 
-    public static final double TOKEN_CREATE_WITH_CUSTOM_FEES_FEE_USD = 1.0;
     public static final double TOKEN_MINT_FT_BASE_FEE = 0.001;
     public static final double TOKEN_MINT_NFT_FEE_USD = 0.02;
     public static final double TOKEN_UPDATE_NFT_FEE = 0.001;
@@ -57,10 +51,8 @@ public class SimpleFeesScheduleConstantsInUsd {
 
     public static final double CONS_SUBMIT_MESSAGE_BASE_FEE_USD = 0.0007;
     public static final long CONS_SUBMIT_MESSAGE_INCLUDED_BYTES = 1024L;
-    public static final long CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_INCLUDED_COUNT = 0L;
     public static final double CONS_CREATE_TOPIC_WITH_CUSTOM_FEE_USD = 1.99;
     public static final double CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_USD = 0.0492;
-    public static final double SCHEDULE_CREATE_CONTRACT_CALL_BASE_FEE_USD = 0.0499;
 
     /* ---------- Crypto service ---------- */
 
@@ -96,7 +88,6 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final double TOPIC_CREATE_WITH_CUSTOM_FEE = TOPIC_CREATE_FEE + CONS_CREATE_TOPIC_WITH_CUSTOM_FEE_USD;
     public static final double CONS_CREATE_TOPIC_BASE_FEE_USD = 0.0099;
     public static final long CONS_CREATE_TOPIC_INCLUDED_KEYS = 0L;
-    public static final long CONS_CREATE_TOPIC_WITH_CUSTOM_FEES = 0L;
 
     public static final double CONS_UPDATE_TOPIC_BASE_FEE_USD = 0.00012;
     public static final long CONS_UPDATE_TOPIC_INCLUDED_KEYS = 1L;
@@ -106,10 +97,7 @@ public class SimpleFeesScheduleConstantsInUsd {
 
     public static final double CONS_DELETE_TOPIC_BASE_FEE_USD = 0.0049;
 
-    public static final double CONS_GET_TOPIC_INFO_BASE_FEE_USD = 0.0;
-
     /* ---------- File service ---------- */
-
     public static final double FILE_CREATE_BASE_FEE_USD = 0.0499;
     public static final long FILE_CREATE_INCLUDED_KEYS = 1L;
     public static final long FILE_CREATE_INCLUDED_BYTES = 1000L;
@@ -122,10 +110,7 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final long FILE_APPEND_INCLUDED_BYTES = 1000L;
 
     public static final double FILE_DELETE_BASE_FEE_USD = 0.0069;
-    public static final long FILE_DELETE_INCLUDED_KEYS = 1L;
 
-    public static final double FILE_GET_CONTENTS_BASE_FEE_USD = 0.000000001;
-    public static final long FILE_GET_CONTENTS_INCLUDED_KEYS = 1L;
     public static final long FILE_GET_CONTENTS_INCLUDED_PROCESSING_BYTES = 1000L;
     public static final double FILE_CREATE_BASE_FEE = 0.05;
     public static final double FILE_UPDATE_BASE_FEE = 0.05;
@@ -143,7 +128,6 @@ public class SimpleFeesScheduleConstantsInUsd {
 
     public static final double TOKEN_UPDATE_BASE_FEE_USD = 0.0009;
     public static final long TOKEN_UPDATE_INCLUDED_KEYS = 1L;
-    public static final long TOKEN_UPDATE_INCLUDED_NFTS = 1L;
 
     public static final double TOKEN_DELETE_BASE_FEE_USD = 0.0009;
 
@@ -184,16 +168,12 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final long TOKEN_AIRDROPS_INCLUDED_COUNT = 0L;
 
     /* ---------- Schedule service ---------- */
-
-    public static final double SCHEDULE_CREATE_BASE_FEE_USD = 0.0099;
-    public static final long SCHEDULE_CREATE_INCLUDED_KEYS = 1L;
     public static final double SCHEDULE_SIGN_FEE = 0.001;
-    public static final double SCHEDULE_DELETE_BASE_FEE_USD = 0.0009;
 
     /* ---------- Util service ---------- */
-
     public static final double ATOMIC_BATCH_BASE_FEE_USD = 0.0009;
     public static final double UTIL_PRNG_BASE_FEE_USD = 0.0009;
+
     /* ---------- Atomic Batch service ------------ */
     public static final double BATCH_BASE_FEE = 0.001;
 

--- a/hedera-node/test-clients/src/main/resources/log4j2-test-client.xml
+++ b/hedera-node/test-clients/src/main/resources/log4j2-test-client.xml
@@ -5,8 +5,9 @@
             <!-- 'hc' -> 'HapiClients' -->
 			<PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} &lt;hc&gt; %-5p  %-4L %c{1} - %m%n"/>
 		</Console>
-		<RollingFile name="RollingFile" fileName="output/hapi-client.log"
-					 filePattern="output/hapi-client.log-%d{yyyy-MM-dd}-%i.log" >
+		<RollingFile name="RollingFile"
+					 fileName="${sys:hapi.test.clients.log.file:-output/hapi-client.log}"
+					 filePattern="${sys:hapi.test.clients.log.filePattern:-output/hapi-client.log-%d{yyyy-MM-dd}-%i.log}" >
 			<PatternLayout>
 				<!-- 'tc' -> 'test-clients' -->
 				<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} &lt;tc&gt; %-5p %-4L %c{1} - %m%n</pattern>


### PR DESCRIPTION
**Description**:

`testSubprocess` runs were not writing `com.hedera.services.bdd` logs to `hedera-node/test-clients/build/hapi-test/node0/output/test-clients.log` (file stayed empty), while embedded runs did.

This change fixes subprocess logging without swapping the entire Log4j config to node0’s log4j2.xml.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
