### PR TITLE
chore: Remove log statement from BlockRecordManagerImpl

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -926,12 +926,6 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
         final var blockInfo = state.getReadableStates(BlockRecordService.NAME)
                 .<BlockInfo>getSingleton(BLOCKS_STATE_ID)
                 .get();
-        logger.info(
-                "votingState {} votingComplete {} currentBlockNumber {} votingCompletionDeadlineBlockNumber {}",
-                blockInfo,
-                blockInfo != null ? blockInfo.votingComplete() : null,
-                currentBlockNumber,
-                blockInfo != null ? blockInfo.votingCompletionDeadlineBlockNumber() : null);
         if (blockInfo == null) {
             return false;
         }


### PR DESCRIPTION
**Description**:
This pull request makes a minor change to the logging behavior in `BlockRecordManagerImpl`. Specifically, it removes a detailed info-level log statement related to voting state and block information, likely to reduce log noise or improve performance.

Logging changes:

* Removed an info-level log statement that outputted the voting state, voting completion status, current block number, and voting completion deadline block number from the `migrationRootHashVotingQueueingEnabled` method in `BlockRecordManagerImpl.java`.

**Related issue(s)**:

Fixes #24583 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
