### PR TITLE
ci(workflow-sizing): Update HAPI Tests (bn-comms) runner

### DIFF
--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -788,7 +788,7 @@ jobs:
   hapi-tests-bn-comms:
     name: "HAPI Tests (BN Comms)"
     if: ${{ inputs.enable-hapi-tests-bn-communication == 'true' }}
-    runs-on: hl-cn-hapi-lin-xl
+    runs-on: hl-cn-hapi-bn-lin-xl
     steps:
       - name: Prepare Runner
         uses: pandaswhocode/initialize-github-job@bfe0b1633012cee3033c757c7095d49c360e23a6 # v1.0.1


### PR DESCRIPTION
## Description

This pull request makes a minor update to the GitHub Actions workflow for HAPI tests. The change updates the runner label for the "HAPI Tests (BN Comms)" job to use the correct runner.

- Updated the `runs-on` label for the `hapi-tests-bn-comms` job in `.github/workflows/zxc-execute-hapi-tests.yaml` to use `hl-cn-hapi-bn-lin-xl` instead of `hl-cn-hapi-lin-xl`.

## Related Issue(s)

- Closes: #24605 