### PR TITLE
fix: 24640: Reduce Hash object allocations in VirtualHasher

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualHashChunk.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualHashChunk.java
@@ -446,7 +446,22 @@ public class VirtualHashChunk {
     }
 
     // index must be 0 <= index < chunkSize
+    private void setHashBytesImpl(final int index, final byte[] hash) {
+        final int pos = index * Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+        assert pos < hashData.length;
+        final int len = Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+        // No synchronization for reading or writing hashes. Memory visibility has
+        // to be ensured by the caller, typically virtual hashing tasks
+        System.arraycopy(hash, 0, hashData, pos, len);
+    }
+
+    // index must be 0 <= index < chunkSize
     private Hash getHashImpl(final int index) {
+        return new Hash(getHashBytesImpl(index), Cryptography.DEFAULT_DIGEST_TYPE);
+    }
+
+    // index must be 0 <= index < chunkSize
+    private byte[] getHashBytesImpl(final int index) {
         final int pos = index * Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
         assert pos < hashData.length;
         final int len = Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
@@ -454,7 +469,7 @@ public class VirtualHashChunk {
         // No synchronization for reading or writing hashes. Memory visibility has
         // to be ensured by the caller, typically virtual hashing tasks
         System.arraycopy(hashData, pos, hashBytes, 0, len);
-        return new Hash(hashBytes, Cryptography.DEFAULT_DIGEST_TYPE);
+        return hashBytes;
     }
 
     /**
@@ -472,11 +487,26 @@ public class VirtualHashChunk {
         final int index = getPathIndexInChunk(path, this.path, height);
         setHashImpl(index, hash);
 
+        updateDataRank(path);
+    }
+
+    public void setHashBytesAtPath(final long path, final byte[] hash) {
+        final int index = getPathIndexInChunk(path, this.path, height);
+        setHashBytesImpl(index, hash);
+
+        updateDataRank(path);
+    }
+
+    /**
+     * Updates this chunk's data rank, given that a hash at the given path is stored
+     * in the chunk.
+     */
+    private void updateDataRank(final long hashPath) {
         final int chunkRank = Path.getRank(this.path);
-        final int pathRank = Path.getRank(path);
-        // No synchronization as setHashAtPath() should not be called in parallel for paths
-        // at different ranks. Field visibility is guaranteed by the caller, typically
-        // VirtualHasher fork-join tasks
+        final int pathRank = Path.getRank(hashPath);
+        // No synchronization as setHashAtPath() / setHashBytesAtPath() should not be called
+        // in parallel for paths at different ranks. Field visibility is guaranteed by the
+        // caller, typically VirtualHasher fork-join tasks
         dataRank = Math.max(dataRank, pathRank - chunkRank);
     }
 
@@ -496,6 +526,15 @@ public class VirtualHashChunk {
     public Hash getHashAtPath(final long path) {
         final int index = getPathIndexInChunk(path, this.path, height);
         return getHashImpl(index);
+    }
+
+    /**
+     * Returns hash bytes at the given path. This method is similar to {@link
+     * #getHashAtPath(long)}, except it returns hash bytes rather than a hash object.
+     */
+    public byte[] getHashBytesAtPath(final long path) {
+        final int index = getPathIndexInChunk(path, this.path, height);
+        return getHashBytesImpl(index);
     }
 
     /**
@@ -522,7 +561,7 @@ public class VirtualHashChunk {
      * even doesn't belong to the current chunk, it belongs to the parent chunk.
      */
     public Hash chunkRootHash(final long firstLeafPath, final long lastLeafPath) {
-        return calcHash(height, path, firstLeafPath, lastLeafPath);
+        return new Hash(calcHashBytes(path, firstLeafPath, lastLeafPath), Cryptography.DEFAULT_DIGEST_TYPE);
     }
 
     /**
@@ -534,26 +573,49 @@ public class VirtualHashChunk {
      * hashes are stored at different paths.
      */
     public Hash calcHash(final long path, final long firstLeafPath, final long lastLeafPath) {
+        return new Hash(calcHashBytes(path, firstLeafPath, lastLeafPath), Cryptography.DEFAULT_DIGEST_TYPE);
+    }
+
+    /**
+     * Calculates a hash at the given path and returns its bytes. This method is similar to
+     * {@link #calcHash(long, long, long)}, except it does not allocate a hash object, but
+     * returns raw hash bytes instead.
+     */
+    public byte[] calcHashBytes(final long path, final long firstLeafPath, final long lastLeafPath) {
         final int pathRank = Path.getRank(path);
         final int chunkRank = Path.getRank(this.path);
         assert pathRank >= chunkRank;
         assert pathRank <= chunkRank + height;
-        return calcHash(chunkRank + height - pathRank, path, firstLeafPath, lastLeafPath);
+        return calcHashBytes(chunkRank + height - pathRank, path, firstLeafPath, lastLeafPath);
     }
 
-    private Hash calcHash(final long h, final long path, final long firstLeafPath, final long lastLeafPath) {
+    private byte[] calcHashBytes(final long h, final long path, final long firstLeafPath, final long lastLeafPath) {
         if (path > lastLeafPath) {
             assert path == 2;
-            return VirtualHasher.NO_PATH2_HASH;
+            return null;
         }
         if ((h == 0) || ((path >= firstLeafPath))) {
-            return getHashAtPath(path);
+            return getHashBytesAtPath(path);
         }
         assert h > 0;
         final long leftPath = Path.getLeftChildPath(path);
-        final Hash leftHash = calcHash(h - 1, leftPath, firstLeafPath, lastLeafPath);
+        final byte[] leftHash = calcHashBytes(h - 1, leftPath, firstLeafPath, lastLeafPath);
         final long rightPath = Path.getRightChildPath(path);
-        final Hash rightHash = calcHash(h - 1, rightPath, firstLeafPath, lastLeafPath);
+        final byte[] rightHash = calcHashBytes(h - 1, rightPath, firstLeafPath, lastLeafPath);
         return VirtualHasher.hashInternal(leftHash, rightHash);
+    }
+
+    /**
+     * Utility method for testing purposes. Calculates a hash for an internal node from
+     * its left and right child node hashes. This method may be called with the null right
+     * hash to calculate the root hash for a tree with only one leaf node.
+     *
+     * @see VirtualHasher#hashInternal(byte[], byte[])
+     */
+    public static Hash hashInternal(final Hash left, final Hash right) {
+        final byte[] leftBytes = left.copyToByteArray();
+        final byte[] rightBytes = (right != null) ? right.copyToByteArray() : null;
+        final byte[] hashBytes = VirtualHasher.hashInternal(leftBytes, rightBytes);
+        return new Hash(hashBytes, Cryptography.DEFAULT_DIGEST_TYPE);
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/hash/VirtualHasher.java
@@ -40,12 +40,6 @@ import org.hiero.base.crypto.Hash;
  */
 public final class VirtualHasher {
 
-    // When virtual tree is of size 1 (only the root node and a single leaf), root hash should
-    // include the hash for path 1 (leaf), but not for path 2. This marker Hash object is used
-    // as path 2 input hash for the root hashing task. Null hash cannot be used here as it would
-    // trigger loading path 2 hash from disk
-    public static final Hash NO_PATH2_HASH = new Hash();
-
     /**
      * Use this for all logging, as controlled by the optional data/log4j2.xml file
      */
@@ -109,22 +103,29 @@ public final class VirtualHasher {
         hashingPool.shutdown();
     }
 
-    public static Hash hashInternal(final Hash left, final Hash right) {
+    /**
+     * Calculates a hash for an internal node from its left and right child hashes.
+     *
+     * <p>The left hash must always be provided. The right hash is typically provided, too.
+     * However, this method may also be called with a null right hash to calculate a root
+     * hash for a tree with only one leaf node.
+     */
+    public static byte[] hashInternal(@NonNull final byte[] left, @Nullable final byte[] right) {
         return hashInternal(left, right, MESSAGE_DIGEST_THREAD_LOCAL.get());
     }
 
-    private static Hash hashInternal(final Hash left, final Hash right, final WritableMessageDigest wmd) {
+    private static byte[] hashInternal(final byte[] left, final byte[] right, final WritableMessageDigest wmd) {
         // Unique value to make sure internal node hashes are different from leaf hashes. This
         // value indicates the number of child nodes. All internal virtual nodes have 2 children
         // except a root node in a tree with just one element / leaf. In this and only this case,
         // the right hash will be set to a marker NO_PATH2_HASH hash object
-        wmd.writeByte(right == NO_PATH2_HASH ? (byte) 0x01 : (byte) 0x02);
-        left.getBytes().writeTo(wmd);
-        if (right != NO_PATH2_HASH) { // use identity check rather than equals
-            right.getBytes().writeTo(wmd);
+        wmd.writeByte(right == null ? (byte) 0x01 : (byte) 0x02);
+        wmd.writeBytes(left);
+        if (right != null) {
+            wmd.writeBytes(right);
         }
         // Note that the digest is reset after the call to digest()
-        return new Hash(wmd.digest(), Cryptography.DEFAULT_DIGEST_TYPE);
+        return wmd.digest();
     }
 
     // A task that can supply hashes to other tasks. There are two hash producer task
@@ -165,7 +166,7 @@ public final class VirtualHasher {
         private final int height;
 
         // Hash inputs, at least two
-        private final Hash[] ins;
+        private final byte[][] ins;
 
         // Number of input dependencies set for this task, either other tasks, or
         // nulls, which indicate the hash will be loaded from disk. No synchronization,
@@ -181,7 +182,7 @@ public final class VirtualHasher {
             super(pool, 1 + (1 << height));
             this.path = path;
             this.height = height;
-            this.ins = new Hash[1 << height];
+            this.ins = new byte[1 << height][];
         }
 
         // Notifies this task that one of its input hashes will be provided by
@@ -216,7 +217,7 @@ public final class VirtualHasher {
             return inputsInitialized == (1 << height);
         }
 
-        void setHash(final long path, @NonNull final Hash hash) {
+        void setHash(final long path, @NonNull final byte[] hash) {
             assert Path.getRank(this.path) + height == Path.getRank(path)
                     : this.path + " " + Path.getRank(this.path) + " " + height + " " + path + " " + Path.getRank(path);
             assert hash != null;
@@ -229,7 +230,7 @@ public final class VirtualHasher {
 
         Hash getResult() {
             assert isDone();
-            return ins[0];
+            return new Hash(ins[0], Cryptography.DEFAULT_DIGEST_TYPE);
         }
 
         @Override
@@ -269,7 +270,7 @@ public final class VirtualHasher {
             final WritableMessageDigest wmd = MESSAGE_DIGEST_THREAD_LOCAL.get();
             while (len > 1) {
                 for (int i = 0; i < len / 2; i++) {
-                    Hash left = ins[i * 2];
+                    byte[] left = ins[i * 2];
                     final long leftPath = rankPath + i * 2;
                     assert (leftPath < lastLeafPath) || (lastLeafPath == 1);
                     final boolean leftIsLeaf = leftPath >= firstLeafPath;
@@ -277,39 +278,38 @@ public final class VirtualHasher {
                         assert currentRank == taskRank + height;
                         // Need to load the hash from hashChunk
                         if ((height == defaultChunkHeight) || leftIsLeaf) {
-                            left = hashChunk.getHashAtPath(leftPath);
+                            left = hashChunk.getHashBytesAtPath(leftPath);
                         } else {
                             // Get left's left and right child hashes and hashInternal() them
-                            left = hashChunk.calcHash(leftPath, firstLeafPath, lastLeafPath);
+                            left = hashChunk.calcHashBytes(leftPath, firstLeafPath, lastLeafPath);
                         }
                     } else {
                         // Hash is provided / computed, need to update it in hashChunk
                         if ((currentRank == chunkLastRank) || leftIsLeaf) {
-                            hashChunk.setHashAtPath(leftPath, left);
+                            hashChunk.setHashBytesAtPath(leftPath, left);
                         }
                     }
 
-                    Hash right = ins[i * 2 + 1];
+                    byte[] right = ins[i * 2 + 1];
                     final long rightPath = rankPath + i * 2 + 1;
                     assert (rightPath <= lastLeafPath) || (lastLeafPath == 1);
                     final boolean rightIsLeaf = rightPath >= firstLeafPath;
                     if (rightPath > lastLeafPath) {
                         assert rightPath == 2;
                         assert right == null;
-                        right = NO_PATH2_HASH;
                     } else if (right == null) {
                         assert currentRank == taskRank + height;
                         // Need to load the hash from hashChunk
                         if ((height == defaultChunkHeight) || rightIsLeaf) {
-                            right = hashChunk.getHashAtPath(rightPath);
+                            right = hashChunk.getHashBytesAtPath(rightPath);
                         } else {
                             // Get right's left and right child hashes and hashInternal() them
-                            right = hashChunk.calcHash(rightPath, firstLeafPath, lastLeafPath);
+                            right = hashChunk.calcHashBytes(rightPath, firstLeafPath, lastLeafPath);
                         }
                     } else {
                         // Hash is provided / computed, need to update it in hashChunk
                         if ((currentRank == chunkLastRank) || rightIsLeaf) {
-                            hashChunk.setHashAtPath(rightPath, right);
+                            hashChunk.setHashBytesAtPath(rightPath, right);
                         }
                     }
 
@@ -354,7 +354,7 @@ public final class VirtualHasher {
         protected boolean onExecute() {
             final WritableMessageDigest wmd = MESSAGE_DIGEST_THREAD_LOCAL.get();
             leaf.writeToForHashing(wmd);
-            final Hash hash = new Hash(wmd.digest(), Cryptography.DEFAULT_DIGEST_TYPE);
+            final byte[] hash = wmd.digest();
             listener.onLeafHashed(leaf);
             out.setHash(path, hash);
             return true;

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapRehashTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapRehashTest.java
@@ -14,7 +14,6 @@ import com.swirlds.virtualmap.config.VirtualMapConfig;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualHashChunk;
 import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
-import com.swirlds.virtualmap.internal.hash.VirtualHasher;
 import com.swirlds.virtualmap.internal.merkle.VirtualMapMetadata;
 import com.swirlds.virtualmap.test.fixtures.InMemoryBuilder;
 import com.swirlds.virtualmap.test.fixtures.TestValue;
@@ -110,7 +109,7 @@ class VirtualMapRehashTest extends VirtualTestBase {
 
         // Internal node (path 0) should also be hashed
         assertEquals(
-                VirtualHasher.hashInternal(correctHash, correctHash2),
+                VirtualHashChunk.hashInternal(correctHash, correctHash2),
                 vm.getRecords().rootHash(),
                 "Root hash should be computed");
 

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualHashChunkTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualHashChunkTest.java
@@ -17,7 +17,6 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.swirlds.virtualmap.internal.Path;
-import com.swirlds.virtualmap.internal.hash.VirtualHasher;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import org.hiero.base.crypto.Cryptography;
@@ -797,11 +796,11 @@ public class VirtualHashChunkTest {
         assertEquals(hash4, chunk.calcHash(4, 3, 6));
         assertEquals(hash5, chunk.calcHash(5, 3, 6));
         assertEquals(hash6, chunk.calcHash(6, 3, 6));
-        final Hash hash1 = VirtualHasher.hashInternal(hash3, hash4);
-        final Hash hash2 = VirtualHasher.hashInternal(hash5, hash6);
+        final Hash hash1 = VirtualHashChunk.hashInternal(hash3, hash4);
+        final Hash hash2 = VirtualHashChunk.hashInternal(hash5, hash6);
         assertEquals(hash1, chunk.calcHash(1, 3, 6));
         assertEquals(hash2, chunk.calcHash(2, 3, 6));
-        final Hash rootHash = VirtualHasher.hashInternal(hash1, hash2);
+        final Hash rootHash = VirtualHashChunk.hashInternal(hash1, hash2);
         assertEquals(rootHash, chunk.calcHash(0, 3, 6));
         assertEquals(rootHash, chunk.chunkRootHash(3, 6));
         assertEquals(rootHash, chunk.chunkRootHash(10, 20));
@@ -822,10 +821,10 @@ public class VirtualHashChunkTest {
         assertEquals(hash2, chunk.calcHash(2, 2, 4));
         assertEquals(hash3, chunk.calcHash(3, 2, 4));
         assertEquals(hash4, chunk.calcHash(4, 2, 4));
-        final Hash hash1 = VirtualHasher.hashInternal(hash3, hash4);
+        final Hash hash1 = VirtualHashChunk.hashInternal(hash3, hash4);
         assertEquals(hash1, chunk.calcHash(1, 2, 4));
         assertEquals(hash2, chunk.calcHash(2, 2, 4));
-        final Hash rootHash = VirtualHasher.hashInternal(hash1, hash2);
+        final Hash rootHash = VirtualHashChunk.hashInternal(hash1, hash2);
         assertEquals(rootHash, chunk.calcHash(0, 2, 4));
         assertEquals(rootHash, chunk.chunkRootHash(2, 4));
     }
@@ -845,7 +844,7 @@ public class VirtualHashChunkTest {
         final Hash calculatedRootHash = chunk.calcHash(0, 1, 1);
 
         // Expected: hash of (hash1, NO_PATH2_HASH)
-        final Hash expectedRootHash = VirtualHasher.hashInternal(hash1, VirtualHasher.NO_PATH2_HASH);
+        final Hash expectedRootHash = VirtualHashChunk.hashInternal(hash1, null);
         assertEquals(expectedRootHash, calculatedRootHash);
 
         // Also test via chunkRootHash
@@ -874,12 +873,12 @@ public class VirtualHashChunkTest {
 
         // Calculate hash at path 1 (internal rank)
         final Hash hash1Calculated = chunk.calcHash(1, 3, 6);
-        final Hash hash1Expected = VirtualHasher.hashInternal(hash3, hash4);
+        final Hash hash1Expected = VirtualHashChunk.hashInternal(hash3, hash4);
         assertEquals(hash1Expected, hash1Calculated);
 
         // Calculate hash at path 2 (internal rank)
         final Hash hash2Calculated = chunk.calcHash(2, 3, 6);
-        final Hash hash2Expected = VirtualHasher.hashInternal(hash5, hash6);
+        final Hash hash2Expected = VirtualHashChunk.hashInternal(hash5, hash6);
         assertEquals(hash2Expected, hash2Calculated);
     }
 
@@ -923,7 +922,7 @@ public class VirtualHashChunkTest {
         final Hash hash4 = chunk.calcHash(4, 7, 14); // Should calculate from paths 9-10
         assertNotNull(hash4);
 
-        final Hash expectedHash1 = VirtualHasher.hashInternal(hash3, hash4);
+        final Hash expectedHash1 = VirtualHashChunk.hashInternal(hash3, hash4);
         final Hash hash1 = chunk.calcHash(1, 7, 14);
         assertEquals(expectedHash1, hash1);
     }


### PR DESCRIPTION
Fix summary:

* `VirtualHasher.ChunkHashTask` is changed to work with byte arrays rather than `Hash` objects
* Some methods are added to / changed in `VirtualHashChunk` to ease working with hash bytes
* `VirtualHasher.NO_PATH2_HASH` is removed

Results:

* Total memory allocations are reduced ~25% in CryptoBench (local run)
* VirtualHasher memory allocations are reduced ~33% in CryptoBench (same local run)

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/24640
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
