### PR TITLE
ci(workflow): add check to skip flaky test processing on draft PRs

### DIFF
--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -116,7 +116,7 @@ jobs:
       - detect-change-type
       - mats-pr-checks
     # Skip flaky test processing when the PR is a draft
-    if: ${{ !cancelled() && always() && !github.event.pull_request.draft }}
+    if: ${{  !github.event.pull_request.draft && !cancelled() && always() }}
     uses: ./.github/workflows/800-call-report-flaky-test.yaml
     with:
       workflow-context: pr-checks


### PR DESCRIPTION
**Description**:

Add a new check to skip the flaky test processing when running on draft PRs.

**Related Issue(s)**:

Implements #24712
