### PR TITLE
refactor: Last reviewer comments...

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/FrameRunner.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/FrameRunner.java
@@ -23,6 +23,7 @@ import com.hedera.node.app.service.contract.impl.bonneville.BonnevilleEVM;
 import com.hedera.node.app.service.contract.impl.exec.gas.CustomGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomContractCreationProcessor;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
+import com.hedera.node.app.service.contract.impl.hevm.HEVM;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransactionResult;
 import com.hedera.node.app.service.contract.impl.hevm.HevmPropagatedCallFailure;
 import com.hedera.node.app.service.entityid.EntityIdFactory;
@@ -68,27 +69,19 @@ public class FrameRunner {
      */
     public HederaEvmTransactionResult runToCompletion(
             final long gasLimit,
-            @NonNull final AccountID senderId,
-            @NonNull final MessageFrame frame,
-            @NonNull final ActionSidecarContentTracer tracer,
-            @NonNull final CustomMessageCallProcessor messageCall,
-            @NonNull final ContractCreationProcessor contractCreation) {
-        requireNonNull(frame);
-        requireNonNull(tracer);
-        requireNonNull(senderId);
-        requireNonNull(messageCall);
-        requireNonNull(contractCreation);
-
-        final var recipientAddress = frame.getRecipientAddress();
+            @NonNull AccountID senderId,
+            @NonNull MessageFrame frame,
+            @NonNull ActionSidecarContentTracer tracer,
+            @NonNull CustomMessageCallProcessor messageCall,
+            @NonNull ContractCreationProcessor contractCreation,
+            @NonNull HEVM hevm) {
+        var recipientAddress = frame.getRecipientAddress();
         // We compute the called contract's Hedera id up front because it could
         // self-destruct, preventing us from looking up its id after the fact
-        final var recipientMetadata = computeRecipientMetadata(frame, recipientAddress);
+        var recipientMetadata = computeRecipientMetadata(frame, recipientAddress);
         tracer.traceOriginAction(frame);
 
-        // <Soapbox> Pass these golden instances to Bonneville through this
-        // silly back door channel, because the endless wrappers & injectors
-        // stop me from doing it the obvious way - CNC. </soapbox>
-        if (messageCall._evm instanceof BonnevilleEVM bonneville) {
+        if (hevm instanceof BonnevilleEVM bonneville) {
             bonneville.setProcessors(messageCall, (CustomContractCreationProcessor) contractCreation);
             runToCompletion(frame, tracer, messageCall, contractCreation);
         } else {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionProcessor.java
@@ -22,6 +22,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.GasCharges;
 import com.hedera.node.app.service.contract.impl.exec.processors.CustomMessageCallProcessor;
 import com.hedera.node.app.service.contract.impl.exec.utils.FrameBuilder;
 import com.hedera.node.app.service.contract.impl.exec.utils.OpsDurationCounter;
+import com.hedera.node.app.service.contract.impl.hevm.HEVM;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmContext;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransaction;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmTransactionResult;
@@ -52,15 +53,17 @@ public class TransactionProcessor {
     private final ContractCreationProcessor contractCreation;
     private final FeatureFlags featureFlags;
     private final CodeFactory codeFactory;
+    private final HEVM hevm;
 
     public TransactionProcessor(
-            @NonNull final FrameBuilder frameBuilder,
-            @NonNull final FrameRunner frameRunner,
-            @NonNull final CustomGasCharging gasCharging,
-            @NonNull final CustomMessageCallProcessor messageCall,
-            @NonNull final ContractCreationProcessor contractCreation,
-            @NonNull final FeatureFlags featureFlags,
-            @NonNull final CodeFactory codeFactory) {
+            @NonNull FrameBuilder frameBuilder,
+            @NonNull FrameRunner frameRunner,
+            @NonNull CustomGasCharging gasCharging,
+            @NonNull CustomMessageCallProcessor messageCall,
+            @NonNull ContractCreationProcessor contractCreation,
+            @NonNull FeatureFlags featureFlags,
+            @NonNull CodeFactory codeFactory,
+            @NonNull HEVM hevm) {
         this.frameBuilder = requireNonNull(frameBuilder);
         this.frameRunner = requireNonNull(frameRunner);
         this.gasCharging = requireNonNull(gasCharging);
@@ -68,6 +71,7 @@ public class TransactionProcessor {
         this.contractCreation = requireNonNull(contractCreation);
         this.featureFlags = requireNonNull(featureFlags);
         this.codeFactory = codeFactory;
+        this.hevm = hevm;
     }
 
     /**
@@ -145,7 +149,7 @@ public class TransactionProcessor {
 
         // Compute the result of running the frame to completion
         final var result = frameRunner.runToCompletion(
-                transaction.gasLimit(), parties.senderId(), initialFrame, tracer, messageCall, contractCreation);
+                transaction.gasLimit(), parties.senderId(), initialFrame, tracer, messageCall, contractCreation, hevm);
 
         // Maybe refund some of the charged fees before committing if not a hook dispatch
         // Note that for hook dispatch, gas is charged during cryptoTransfer and will not be refunded once

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/CustomMessageCallProcessor.java
@@ -57,8 +57,6 @@ public class CustomMessageCallProcessor extends PublicMessageCallProcessor {
     private final Map<Address, HederaSystemContract> systemContracts;
     private final ContractMetrics contractMetrics;
 
-    public final HEVM _evm;
-
     private enum ForLazyCreation {
         YES,
         NO,
@@ -80,7 +78,6 @@ public class CustomMessageCallProcessor extends PublicMessageCallProcessor {
             @NonNull final Map<Address, HederaSystemContract> systemContracts,
             @NonNull final ContractMetrics contractMetrics) {
         super(evm, precompiles);
-        _evm = evm;
         this.featureFlags = Objects.requireNonNull(featureFlags);
         this.precompiles = Objects.requireNonNull(precompiles);
         this.addressChecks = Objects.requireNonNull(addressChecks);
@@ -368,9 +365,5 @@ public class CustomMessageCallProcessor extends PublicMessageCallProcessor {
                 ((ActionSidecarContentTracer) operationTracer).traceNotExecuting(frame);
             }
         }
-    }
-
-    public HederaSystemContract systemContractsRead(Address key) {
-        return systemContracts.get(key);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/FrameUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/FrameUtils.java
@@ -100,9 +100,7 @@ public class FrameUtils {
      *
      * @param frame a frame in the transaction of interest
      */
-    public static @NonNull HevmPropagatedCallFailure getAndClearPropagatedCallFailure(
-            @NonNull final MessageFrame frame) {
-        requireNonNull(frame);
+    public static HevmPropagatedCallFailure getAndClearPropagatedCallFailure(@NonNull final MessageFrame frame) {
         var ref = propagatedCallFailureReference(frame);
         return ref == null ? null : ref.getAndClear();
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/V030Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/V030Module.java
@@ -85,7 +85,8 @@ public interface V030Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                null);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/V034Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/V034Module.java
@@ -87,7 +87,8 @@ public interface V034Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                null);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/V038Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/V038Module.java
@@ -87,7 +87,8 @@ public interface V038Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                null);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v046/V046Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v046/V046Module.java
@@ -87,7 +87,8 @@ public interface V046Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                null);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v050/V050Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v050/V050Module.java
@@ -97,7 +97,8 @@ public interface V050Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                null);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v051/V051Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v051/V051Module.java
@@ -97,7 +97,8 @@ public interface V051Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                null);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v065/V065Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v065/V065Module.java
@@ -96,7 +96,8 @@ public interface V065Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                null);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v066/V066Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v066/V066Module.java
@@ -96,7 +96,8 @@ public interface V066Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                null);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v067/V067Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v067/V067Module.java
@@ -76,7 +76,8 @@ public interface V067Module {
             @ServicesV067 @NonNull final ContractCreationProcessor contractCreationProcessor,
             @NonNull final CustomGasCharging gasCharging,
             @ServicesV067 @NonNull final FeatureFlags featureFlags,
-            @NonNull final CodeFactory codeFactory) {
+            @NonNull final CodeFactory codeFactory,
+            @ServicesV067 @NonNull final HEVM evm) {
         return new TransactionProcessor(
                 frameBuilder,
                 frameRunner,
@@ -84,7 +85,8 @@ public interface V067Module {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                codeFactory);
+                codeFactory,
+                evm);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/FrameRunnerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/FrameRunnerTest.java
@@ -117,7 +117,7 @@ class FrameRunnerTest {
         given(frame.getGasRefund()).willReturn(nominalRefund);
 
         final var result = subject.runToCompletion(
-                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor);
+                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor, null);
 
         inOrder.verify(tracer).traceOriginAction(frame);
         inOrder.verify(contractCreationProcessor).process(frame, tracer);
@@ -145,7 +145,7 @@ class FrameRunnerTest {
         given(entityIdFactory.newContractId(numberOfLongZero(NON_SYSTEM_LONG_ZERO_ADDRESS)))
                 .willReturn(contractId);
         final var result = subject.runToCompletion(
-                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor);
+                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor, null);
 
         inOrder.verify(tracer).traceOriginAction(frame);
         assertEquals(EXPECTED_GAS_USED_NO_REFUNDS, result.gasUsed());
@@ -170,7 +170,7 @@ class FrameRunnerTest {
                 .willReturn(contractId);
 
         final var result = subject.runToCompletion(
-                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor);
+                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor, null);
 
         inOrder.verify(tracer).traceOriginAction(frame);
         inOrder.verify(contractCreationProcessor).process(frame, tracer);
@@ -195,7 +195,7 @@ class FrameRunnerTest {
                 .willReturn(contractId);
 
         final var result = subject.runToCompletion(
-                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor);
+                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor, null);
 
         inOrder.verify(tracer).traceOriginAction(frame);
         inOrder.verify(contractCreationProcessor).process(frame, tracer);
@@ -220,7 +220,7 @@ class FrameRunnerTest {
                 .willReturn(contractId);
 
         final var result = subject.runToCompletion(
-                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor);
+                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor, null);
 
         inOrder.verify(tracer).traceOriginAction(frame);
         inOrder.verify(contractCreationProcessor).process(frame, tracer);
@@ -247,7 +247,7 @@ class FrameRunnerTest {
                 .willReturn(contractId);
 
         final var result = subject.runToCompletion(
-                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor);
+                GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor, null);
 
         inOrder.verify(tracer).traceOriginAction(frame);
         inOrder.verify(contractCreationProcessor).process(frame, tracer);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionProcessorTest.java
@@ -158,7 +158,8 @@ class TransactionProcessorTest {
                 messageCallProcessor,
                 contractCreationProcessor,
                 featureFlags,
-                CODE_FACTORY);
+                CODE_FACTORY,
+                null);
         opsDurationCounter = OpsDurationCounter.disabled();
     }
 
@@ -241,7 +242,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor))
+                        contractCreationProcessor,
+                        null))
                 .willReturn(SUCCESS_RESULT);
 
         final var result =
@@ -296,7 +298,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor))
+                        contractCreationProcessor,
+                        null))
                 .willReturn(SUCCESS_RESULT);
         given(featureFlags.isAllowCallsToNonContractAccountsEnabled(any(), any()))
                 .willReturn(true);
@@ -353,7 +356,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor))
+                        contractCreationProcessor,
+                        null))
                 .willReturn(SUCCESS_RESULT);
         given(featureFlags.isAllowCallsToNonContractAccountsEnabled(any(), any()))
                 .willReturn(true);
@@ -467,7 +471,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor))
+                        contractCreationProcessor,
+                        null))
                 .willReturn(SUCCESS_RESULT);
         final var parsedAccount =
                 Account.newBuilder().accountId(senderAccount.hederaId()).build();
@@ -499,7 +504,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor);
+                        contractCreationProcessor,
+                        null);
         inOrder.verify(gasCharging)
                 .maybeRefundGiven(
                         GAS_LIMIT - SUCCESS_RESULT.gasUsed(),
@@ -547,7 +553,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor))
+                        contractCreationProcessor,
+                        null))
                 .willReturn(SUCCESS_RESULT);
         given(initialFrame.getSelfDestructs()).willReturn(Set.of(NON_SYSTEM_LONG_ZERO_ADDRESS));
 
@@ -575,7 +582,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor);
+                        contractCreationProcessor,
+                        null);
         inOrder.verify(gasCharging)
                 .maybeRefundGiven(GAS_LIMIT - SUCCESS_RESULT.gasUsed(), 0, senderAccount, null, context, worldUpdater);
         inOrder.verify(worldUpdater).deleteAccount(NON_SYSTEM_LONG_ZERO_ADDRESS);
@@ -621,7 +629,8 @@ class TransactionProcessorTest {
                         eq(initialFrame),
                         eq(tracer),
                         any(),
-                        eq(contractCreationProcessor)))
+                        eq(contractCreationProcessor),
+                        any()))
                 .willReturn(SUCCESS_RESULT);
         given(initialFrame.getSelfDestructs()).willReturn(Set.of(NON_SYSTEM_LONG_ZERO_ADDRESS));
 
@@ -648,7 +657,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor);
+                        contractCreationProcessor,
+                        null);
         inOrder.verify(gasCharging)
                 .maybeRefundGiven(
                         GAS_LIMIT - SUCCESS_RESULT.gasUsed(),
@@ -699,7 +709,8 @@ class TransactionProcessorTest {
                         eq(initialFrame),
                         eq(tracer),
                         any(),
-                        eq(contractCreationProcessor)))
+                        eq(contractCreationProcessor),
+                        any()))
                 .willReturn(SUCCESS_RESULT);
         given(initialFrame.getSelfDestructs()).willReturn(Set.of(NON_SYSTEM_LONG_ZERO_ADDRESS));
         given(featureFlags.isAllowCallsToNonContractAccountsEnabled(any(), any()))
@@ -729,7 +740,8 @@ class TransactionProcessorTest {
                         initialFrame,
                         tracer,
                         messageCallProcessor,
-                        contractCreationProcessor);
+                        contractCreationProcessor,
+                        null);
         inOrder.verify(gasCharging)
                 .maybeRefundGiven(
                         GAS_LIMIT - SUCCESS_RESULT.gasUsed(),
@@ -777,7 +789,8 @@ class TransactionProcessorTest {
                         eq(initialFrame),
                         eq(tracer),
                         any(),
-                        eq(contractCreationProcessor)))
+                        eq(contractCreationProcessor),
+                        any()))
                 .willReturn(SUCCESS_RESULT);
         given(initialFrame.getSelfDestructs()).willReturn(Set.of(NON_SYSTEM_LONG_ZERO_ADDRESS));
 

--- a/hedera-node/log4j2-prod.xml
+++ b/hedera-node/log4j2-prod.xml
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- monitorInterval="600" , if any change to log level will be effective after 10 minute -->
+
+<Configuration status="WARN" monitorInterval="600">
+
+  <Filters>
+    <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
+    <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
+
+    <!-- Exceptions -->
+    <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="ACCEPT"     onMismatch="NEUTRAL"/>
+    <!-- Errors -->
+    <MarkerFilter marker="INVALID_EVENT_ERROR"    onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <!-- Other -->
+    <MarkerFilter marker="SYNC_START"             onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="SYNC_DONE"              onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="SYNC_ERROR"             onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="SYNC"                   onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="CREATE_EVENT"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="INTAKE_EVENT"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="WATCH_EVENTS_SEND_REC"  onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="QUEUES"                 onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="HEARTBEAT"              onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="EVENT_SIG"              onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="CERTIFICATES"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="FCM_COPY"               onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="FCM_COPY_FROM"          onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="FCM_COPY_TO"            onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="FCM_DEMO"               onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="FCM_COPY_FROM_DIFF"     onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="FCM_COPY_TO_DIFF"       onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="FC_SERIALIZATION"       onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="MERKLE_HASH"            onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="LOCKS"                  onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="TIME_MEASURE"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="STARTUP"                onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="STATE_SIG_DIST"         onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="EVENT_STREAM"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="EVENT_RESTART"          onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="DEMO_INFO"              onMatch="ACCEPT"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="DEMO_STAT"              onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="DEMO_MAP"               onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="FREEZE"                 onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="STALE_EVENTS"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+    <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+  </Filters>
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n"/>
+    </Console>
+
+    <RollingFile name="RollingFile" fileName="output/hgcaa.log"
+                 filePattern="output/hgcaa.log-%d{yyyy-MM-dd}-%i.log" >
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="100 MB" />
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
+    <RollingFile name="fileLog" fileName="output/swirlds.log"
+                 filePattern="output/swirlds.log-%d{yyyy-MM-dd}-%i.log" >
+      <PatternLayout>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-8sn %-5p %-16marker &lt;%t&gt; %c{1}: %msg{nolookups}%n</pattern>
+      </PatternLayout>
+      <Policies>
+        <SizeBasedTriggeringPolicy size="50 MB" />
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <Filters>
+        <!-- In the following, enable a marker with onMatch="ACCEPT" and disable with onMatch="DENY". -->
+        <!-- More markers can be added, but ensure that every onMismatch="NEUTRAL", except the last is "DENY". -->
+
+        <!-- Exceptions -->
+        <MarkerFilter marker="EXCEPTION"              onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TESTING_EXCEPTIONS"     onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SOCKET_EXCEPTIONS"      onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TCP_CONNECT_EXCEPTIONS" onMatch="ACCEPT"     onMismatch="NEUTRAL"/>
+        <!-- Errors -->
+        <MarkerFilter marker="INVALID_EVENT_ERROR"    onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <!-- Other -->
+        <MarkerFilter marker="SYNC_START"             onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC_DONE"              onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC_ERROR"             onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SYNC"                   onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="CREATE_EVENT"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="INTAKE_EVENT"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="WATCH_EVENTS_SEND_REC"  onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="QUEUES"                 onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="HEARTBEAT"              onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_SIG"              onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="CERTIFICATES"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY"               onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_FROM"          onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_TO"            onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_DEMO"               onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_FROM_DIFF"     onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FCM_COPY_TO_DIFF"       onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FC_SERIALIZATION"       onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_FORCE_FLUSH"     onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_HASH"            onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_GENERATION"      onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="MERKLE_LOCKS"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="LOCKS"                  onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="TIME_MEASURE"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STARTUP"                onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_SIG_DIST"         onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="OPENCL_INIT_EXCEPTIONS" onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_STREAM"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="EVENT_RESTART"          onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="DEMO_INFO"              onMatch="ACCEPT"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="DEMO_STAT"              onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="DEMO_MAP"               onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="FREEZE"                 onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STALE_EVENTS"           onMatch="DENY"     onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="SNAPSHOT_MANAGER"       onMatch="ACCEPT"   onMismatch="NEUTRAL"/>
+        <MarkerFilter marker="STATE_TO_DISK"          onMatch="ACCEPT"   onMismatch="DENY"/>
+      </Filters>
+      <!-- <AppenderRef ref="Console"/> -->
+      <AppenderRef ref="fileLog"/>
+    </Root>
+
+    <Logger name="com.hedera.services.legacy" level="warn" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="com.hedera.services.legacy.service" level="warn" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="com.hedera.services.legacy.handler" level="warn" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="com.hedera.services.legacy.utils" level="warn" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="com.hedera.services.legacy.hgcca.core" level="warn" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="com.hedera.services.legacy.evm" level="warn" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="com.hedera.services.legacy.initialization" level="warn" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+
+
+    <Logger name="org.springframework" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="state" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="trie" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="net" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="execute" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="VM" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="pending" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="sync" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="wire" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="db" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="general" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="TCK-Test" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="repository" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="blockchain" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="mine" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="blockqueue" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="rlp" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="java.nio" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="io.netty" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="io.grpc" level="ERROR" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+    <Logger name="discover" level="WARN" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="RollingFile"/>
+    </Logger>
+
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
...didn't make it in under the wire, so Yet Another PR. 
Pass the HEVM through TransactionProcessor instead of CustomMessageCallProcessor. 
Explicitly signal getAndClearPropagatedCallFailrue could always return a null. 
Restore lost log4j-prod.xml
