### PR TITLE
refactor(hints,wraps): lazy load native libraries 

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsLibraryImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsLibraryImpl.java
@@ -21,14 +21,12 @@ public class HintsLibraryImpl implements HintsLibrary {
     private static HintsLibraryBridge bridge;
 
     private static HintsLibraryBridge getBridge() {
-        if (bridge == null) {
-            synchronized (HintsLibraryImpl.class) {
-                if (bridge == null) {
-                    bridge = HintsLibraryBridge.getInstance();
-                }
+        synchronized (HintsLibraryImpl.class) {
+            if (bridge == null) {
+                bridge = HintsLibraryBridge.getInstance();
             }
+            return bridge;
         }
-        return bridge;
     }
 
     public static final int VK_LENGTH = 1096;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/HistoryLibraryImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/HistoryLibraryImpl.java
@@ -24,14 +24,12 @@ public class HistoryLibraryImpl implements HistoryLibrary {
     private static WRAPSLibraryBridge wraps;
 
     private static WRAPSLibraryBridge getWraps() {
-        if (wraps == null) {
-            synchronized (HistoryLibraryImpl.class) {
-                if (wraps == null) {
-                    wraps = WRAPSLibraryBridge.getInstance();
-                }
+        synchronized (HistoryLibraryImpl.class) {
+            if (wraps == null) {
+                wraps = WRAPSLibraryBridge.getInstance();
             }
+            return wraps;
         }
-        return wraps;
     }
 
     @Override


### PR DESCRIPTION
**Description**:
Replace eager static initialization of HintsLibraryBridge and WRAPSLibraryBridge with lazy loading.

Previously, both native libraries were initialized at class load time, causing them to be loaded even when the corresponding feature flags (tss.hintsEnabled, tss.wrapsEnabled) were disabled. This led to unnecessary memory usage and increased startup overhead.

This change introduces lazy initialization using thread-safe getter methods, ensuring that the native libraries are only loaded when actually needed.

Replace static final initialization with lazy-loaded fields
Add thread-safe double-checked locking for initialization
Update all usages to use getter methods instead of static fields

**Related issue(s)**:

Fixes #24693 

**Notes for reviewer**:
This change replaces eager initialization of native libraries with lazy loading. No functional behavior was modified, and the change is limited to initialization timing.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
