### PR TITLE
fix: use method-scoped token in cancel airdrop negative test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/airdrops/TokenCancelAirdropSystemContractTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/airdrops/TokenCancelAirdropSystemContractTest.java
@@ -232,9 +232,10 @@ public class TokenCancelAirdropSystemContractTest {
 
     @HapiTest
     @DisplayName("Fails to cancel airdrop without having any pending airdrops")
-    public Stream<DynamicTest> failToCancelAirdropWhenThereAreNoPending() {
+    public Stream<DynamicTest> failToCancelAirdropWhenThereAreNoPending(
+            @FungibleToken final SpecFungibleToken neverAirdropped) {
         return hapiTest(cancelAirdrop
-                .call("cancelAirdrop", sender, receiver, token)
+                .call("cancelAirdrop", sender, receiver, neverAirdropped)
                 .payingWith(sender)
                 .via("cancelAirdrop")
                 .andAssert(txn -> txn.hasKnownStatuses(CONTRACT_REVERT_EXECUTED, INVALID_PENDING_AIRDROP_ID)));


### PR DESCRIPTION
**Description**:
The `failToCancelAirdropWhenThereAreNoPending` test shared the static `(sender, receiver, token)` triple with `cancelAirdrop`, causing a race condition when running concurrently: 

the negative test could cancel the pending airdrop created by the positive test, flaking both.

Give the negative test its own method-scoped `@FungibleToken` so the two tests no longer interfere with each other.

Fixes #24677 #24678 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
