### PR TITLE
fix: guard `getTxnRecord` calls against missing txn IDs

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/IssueRegressionTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/IssueRegressionTests.java
@@ -264,8 +264,14 @@ public class IssueRegressionTests {
                                 .payingWith(payer)
                                 .via("txnB")
                                 .hasAnyKnownStatus()),
-                getTxnRecord("txnA").logged(),
-                getTxnRecord("txnB").logged());
+                withOpContext((spec, ctxLog) -> {
+                    if (spec.registry().getMaybeTxnId("txnA").isPresent()) {
+                        allRunFor(spec, getTxnRecord("txnA").logged());
+                    }
+                    if (spec.registry().getMaybeTxnId("txnB").isPresent()) {
+                        allRunFor(spec, getTxnRecord("txnB").logged());
+                    }
+                }));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
When parallel crypto transfers race and one fails at precheck with `INSUFFICIENT_PAYER_BALANCE`, the transaction ID is never registered because the exception bypasses `maybeRegisterTxnSubmitted()`. Use `getMaybeTxnId()` to conditionally retrieve records only for transactions whose IDs were successfully registered.

**Related issue(s)**:

Fixes #24736 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
