### PR TITLE
refactor: cleanup relationship between BaseExecutorFactory and Metrics

### DIFF
--- a/platform-sdk/consensus-metrics/src/main/java/org/hiero/consensus/metrics/extensions/BaseExecutorFactoryMetrics.java
+++ b/platform-sdk/consensus-metrics/src/main/java/org/hiero/consensus/metrics/extensions/BaseExecutorFactoryMetrics.java
@@ -3,9 +3,9 @@ package org.hiero.consensus.metrics.extensions;
 
 import static com.swirlds.base.units.UnitConstants.MILLISECOND_UNIT;
 
-import com.swirlds.base.internal.BaseExecutorFactory;
-import com.swirlds.base.internal.observe.BaseExecutorObserver;
-import com.swirlds.base.internal.observe.BaseTaskDefinition;
+import com.swirlds.base.metrics.BaseExecutorMetricsRegistrar;
+import com.swirlds.base.metrics.BaseExecutorMetricsRegistrar.Observer;
+import com.swirlds.base.metrics.BaseExecutorMetricsRegistrar.TaskInfo;
 import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.DoubleGauge;
 import com.swirlds.metrics.api.LongGauge;
@@ -17,7 +17,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * This class installs metrics for the {@link BaseExecutorFactory}.
+ * This class installs metrics for the base executor (see the swirlds base executor factory).
  */
 public class BaseExecutorFactoryMetrics {
 
@@ -41,7 +41,7 @@ public class BaseExecutorFactoryMetrics {
     private final Counter tasksFailedCountAccumulator;
 
     /**
-     * Creates a new instance and installs metrics for the {@link BaseExecutorFactory}.
+     * Creates a new instance and installs metrics for the base executor.
      *
      * @param metrics the metrics system
      */
@@ -74,33 +74,33 @@ public class BaseExecutorFactoryMetrics {
 
         taskFailExecutionTimeMetric = new TaskExecutionTimeMetric(BASE_EXECUTOR, "task_failed_execution", metrics);
 
-        final BaseExecutorObserver observer = new BaseExecutorObserver() {
+        final Observer observer = new Observer() {
 
             @Override
-            public void onTaskSubmitted(@NonNull BaseTaskDefinition taskDefinition) {
+            public void onTaskSubmitted(@NonNull final TaskInfo taskInfo) {
                 taskCountAccumulator.increment();
             }
 
             @Override
-            public void onTaskStarted(@NonNull BaseTaskDefinition taskDefinition) {
+            public void onTaskStarted(@NonNull final TaskInfo taskInfo) {
                 taskExecutionCountAccumulator.increment();
             }
 
             @Override
-            public void onTaskDone(@NonNull BaseTaskDefinition taskDefinition, @NonNull Duration duration) {
+            public void onTaskDone(@NonNull final TaskInfo taskInfo, @NonNull final Duration duration) {
                 tasksDoneCountAccumulator.increment();
                 taskExecutionTimeMetric.update(duration);
                 taskDoneExecutionTimeMetric.update(duration);
             }
 
             @Override
-            public void onTaskFailed(@NonNull BaseTaskDefinition taskDefinition, @NonNull Duration duration) {
+            public void onTaskFailed(@NonNull final TaskInfo taskInfo, @NonNull final Duration duration) {
                 tasksFailedCountAccumulator.increment();
                 taskExecutionTimeMetric.update(duration);
                 taskFailExecutionTimeMetric.update(duration);
             }
         };
-        BaseExecutorFactory.addObserver(observer);
+        BaseExecutorMetricsRegistrar.addObserver(observer);
     }
 
     /**

--- a/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/metrics/BaseExecutorMetricsRegistrar.java
+++ b/platform-sdk/swirlds-base/src/main/java/com/swirlds/base/metrics/BaseExecutorMetricsRegistrar.java
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.base.metrics;
+
+import com.swirlds.base.internal.BaseExecutorFactory;
+import com.swirlds.base.internal.observe.BaseExecutorObserver;
+import com.swirlds.base.internal.observe.BaseTaskDefinition;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A small, public-facing registrar that allows external modules to observe base-executor events without
+ * depending on internal swirlds packages.
+ */
+public final class BaseExecutorMetricsRegistrar {
+
+    private BaseExecutorMetricsRegistrar() {}
+
+    /** A lightweight description of a task submitted to the base executor. */
+    public static final class TaskInfo {
+        private final String type;
+
+        private TaskInfo(final String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        static TaskInfo of(final BaseTaskDefinition def) {
+            return new TaskInfo(def.type());
+        }
+    }
+
+    /** Public observer interface for base-executor events. */
+    public interface Observer {
+        void onTaskSubmitted(@NonNull TaskInfo taskInfo);
+
+        void onTaskStarted(@NonNull TaskInfo taskInfo);
+
+        void onTaskDone(@NonNull TaskInfo taskInfo, @NonNull Duration duration);
+
+        void onTaskFailed(@NonNull TaskInfo taskInfo, @NonNull Duration duration);
+    }
+
+    private static final Map<Observer, BaseExecutorObserver> ADAPTERS = new ConcurrentHashMap<>();
+
+    /**
+     * Register an observer. The observer will be adapted to the internal observer and registered with
+     * the internal BaseExecutorFactory.
+     */
+    public static void addObserver(@NonNull final Observer observer) {
+        Objects.requireNonNull(observer, "observer must not be null");
+
+        final BaseExecutorObserver adapter = new BaseExecutorObserver() {
+            @Override
+            public void onTaskSubmitted(@NonNull final BaseTaskDefinition taskDefinition) {
+                observer.onTaskSubmitted(TaskInfo.of(taskDefinition));
+            }
+
+            @Override
+            public void onTaskStarted(@NonNull final BaseTaskDefinition taskDefinition) {
+                observer.onTaskStarted(TaskInfo.of(taskDefinition));
+            }
+
+            @Override
+            public void onTaskDone(@NonNull final BaseTaskDefinition taskDefinition, @NonNull final Duration duration) {
+                observer.onTaskDone(TaskInfo.of(taskDefinition), duration);
+            }
+
+            @Override
+            public void onTaskFailed(
+                    @NonNull final BaseTaskDefinition taskDefinition, @NonNull final Duration duration) {
+                observer.onTaskFailed(TaskInfo.of(taskDefinition), duration);
+            }
+        };
+        ADAPTERS.put(observer, adapter);
+        BaseExecutorFactory.addObserver(adapter);
+    }
+
+    /**
+     * Removes a previously registered observer.
+     */
+    public static void removeObserver(@NonNull final Observer observer) {
+        Objects.requireNonNull(observer, "observer must not be null");
+        final BaseExecutorObserver adapter = ADAPTERS.remove(observer);
+        if (adapter != null) {
+            BaseExecutorFactory.removeObserver(adapter);
+        }
+    }
+}

--- a/platform-sdk/swirlds-base/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-base/src/main/java/module-info.java
@@ -32,10 +32,11 @@ module com.swirlds.base {
             com.swirlds.config.impl,
             com.swirlds.logging,
             com.swirlds.logging.test.fixtures,
-            com.swirlds.metrics.api,
-            org.hiero.consensus.metrics;
+            com.swirlds.metrics.api;
     exports com.swirlds.base.time.internal to
             org.hiero.consensus.event.creator.impl;
+    exports com.swirlds.base.metrics to
+            org.hiero.consensus.metrics;
     exports com.swirlds.base.units.internal to
             com.swirlds.base.test.fixtures,
             com.swirlds.common,

--- a/platform-sdk/swirlds-base/src/timingSensitive/java/com/swirlds/base/test/metrics/BaseExecutorMetricsRegistrarTest.java
+++ b/platform-sdk/swirlds-base/src/timingSensitive/java/com/swirlds/base/test/metrics/BaseExecutorMetricsRegistrarTest.java
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.base.test.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import com.swirlds.base.internal.BaseExecutorFactory;
+import com.swirlds.base.metrics.BaseExecutorMetricsRegistrar;
+import com.swirlds.base.metrics.BaseExecutorMetricsRegistrar.Observer;
+import com.swirlds.base.metrics.BaseExecutorMetricsRegistrar.TaskInfo;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class BaseExecutorMetricsRegistrarTest {
+
+    private static final int TIMEOUT_MS = 2000;
+
+    private final AtomicReference<TaskInfo> submitted = new AtomicReference<>();
+    private final AtomicReference<TaskInfo> started = new AtomicReference<>();
+    private final AtomicReference<TaskInfo> done = new AtomicReference<>();
+    private final AtomicReference<TaskInfo> failed = new AtomicReference<>();
+    private final AtomicReference<Duration> doneDuration = new AtomicReference<>();
+    private final AtomicReference<Duration> failedDuration = new AtomicReference<>();
+
+    private final CountDownLatch submittedLatch = new CountDownLatch(1);
+    private final CountDownLatch startedLatch = new CountDownLatch(1);
+    private final CountDownLatch doneLatch = new CountDownLatch(1);
+    private final CountDownLatch failedLatch = new CountDownLatch(1);
+
+    private final Observer observer = new Observer() {
+        @Override
+        public void onTaskSubmitted(TaskInfo taskInfo) {
+            submitted.set(taskInfo);
+            submittedLatch.countDown();
+        }
+
+        @Override
+        public void onTaskStarted(TaskInfo taskInfo) {
+            started.set(taskInfo);
+            startedLatch.countDown();
+        }
+
+        @Override
+        public void onTaskDone(TaskInfo taskInfo, Duration duration) {
+            done.set(taskInfo);
+            doneDuration.set(duration);
+            doneLatch.countDown();
+        }
+
+        @Override
+        public void onTaskFailed(TaskInfo taskInfo, Duration duration) {
+            failed.set(taskInfo);
+            failedDuration.set(duration);
+            failedLatch.countDown();
+        }
+    };
+
+    @BeforeEach
+    void setUp() {
+        BaseExecutorMetricsRegistrar.addObserver(observer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        BaseExecutorMetricsRegistrar.removeObserver(observer);
+    }
+
+    @Test
+    void testHappyPathTaskEvents() throws Exception {
+        final BaseExecutorFactory factory = BaseExecutorFactory.getInstance();
+
+        final CountDownLatch runLatch = new CountDownLatch(1);
+        final Future<Void> future = factory.submit(() -> runLatch.countDown());
+
+        assertThatNoException().isThrownBy(() -> runLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertThatNoException().isThrownBy(() -> future.get(1, TimeUnit.SECONDS));
+
+        // wait for adapter events
+        assertThatNoException().isThrownBy(() -> submittedLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertThatNoException().isThrownBy(() -> startedLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertThatNoException().isThrownBy(() -> doneLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        assertThat(submitted.get()).isNotNull();
+        assertThat(started.get()).isNotNull();
+        assertThat(done.get()).isNotNull();
+        assertThat(doneDuration.get()).isNotNull();
+    }
+
+    @Test
+    void testFailedTaskEvents() throws Exception {
+        final BaseExecutorFactory factory = BaseExecutorFactory.getInstance();
+
+        final Future<Void> future = factory.submit(() -> {
+            throw new RuntimeException("expected");
+        });
+
+        try {
+            future.get(1, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+            // expected
+        }
+
+        assertThatNoException().isThrownBy(() -> submittedLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertThatNoException().isThrownBy(() -> startedLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+        assertThatNoException().isThrownBy(() -> failedLatch.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+
+        assertThat(submitted.get()).isNotNull();
+        assertThat(started.get()).isNotNull();
+        assertThat(failed.get()).isNotNull();
+        assertThat(failedDuration.get()).isNotNull();
+    }
+}


### PR DESCRIPTION
**Description**:
This PR cleans up the architectural relationship between `BaseExecutorFactory` and `BaseExecutorFactoryMetrics` by decoupling the metrics extension from internal implementation details. It introduces a public registrar to adapt internal executor events into a stable API.
- Create `BaseExecutorMetricsRegistrar` and TaskInfo in a new `com.swirlds.base.metrics` package.
- Refactor `BaseExecutorFactoryMetrics` to utilize the new public registrar instead of internal observers.
- Update `module-info.java` to export `com.swirlds.base.metrics` specifically to `org.hiero.consensus.metrics`.
- Remove the legacy qualified export of `com.swirlds.base.internal.observe` to the metrics module.

**Related issue(s)**:
Fixes #22687 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
