### PR TITLE
fix: Change the included submit message bytes from 1024 to 100 (#24505)

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/fees/fee_schedule.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/fees/fee_schedule.proto
@@ -101,6 +101,8 @@ enum Extra {
   RECORDS=21;
   STATE_BYTES=22;       // For state-persisting operations (file uploads)
   PROCESSING_BYTES=23;  // For node/network processing fees
+  CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES=24;
+  CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES=25;
 }
 
 /**

--- a/hedera-node/configuration/mainnet/upgrade/simpleFeesSchedules.json
+++ b/hedera-node/configuration/mainnet/upgrade/simpleFeesSchedules.json
@@ -3,7 +3,7 @@
     "baseFee": 100000,
     "extras": [
       {
-        "name": "PROCESSING_BYTES", "includedCount": 1024
+        "name": "PROCESSING_BYTES", "includedCount": 1350
       },
       {
         "name": "SIGNATURES", "includedCount": 1
@@ -38,7 +38,9 @@
     { "name":  "TOKEN_TRANSFER_BASE",                       "fee": 9000000 },
     { "name":  "TOKEN_TRANSFER_BASE_CUSTOM_FEES",           "fee": 19000000 },
     { "name":  "CONSENSUS_CREATE_TOPIC_WITH_CUSTOM_FEE",    "fee": 19900000000 },
-    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",  "fee": 492000000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",  "fee": 498300000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES", "fee": 1000000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES", "fee": 6800},
     { "name":  "SCHEDULE_CREATE_CONTRACT_CALL_BASE",        "fee": 900000000},
     { "name":  "HOOK_EXECUTION",                            "fee": 50000000 },
     { "name":  "HOOK_SLOT_UPDATE",                          "fee": 50000000 }
@@ -187,10 +189,11 @@
         },
         {
           "name": "ConsensusSubmitMessage",
-          "baseFee": 7000000,
+          "baseFee": 700000,
           "extras": [
-            { "name": "STATE_BYTES",      "includedCount": 1024 },
-            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE", "includedCount": 0 }
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES",  "includedCount": 100 },
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES",     "includedCount": 1024 },
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",           "includedCount": 0 }
           ]
         },
         {

--- a/hedera-node/configuration/previewnet/upgrade/simpleFeesSchedules.json
+++ b/hedera-node/configuration/previewnet/upgrade/simpleFeesSchedules.json
@@ -3,7 +3,7 @@
     "baseFee": 100000,
     "extras": [
       {
-        "name": "PROCESSING_BYTES", "includedCount": 1024
+        "name": "PROCESSING_BYTES", "includedCount": 1350
       },
       {
         "name": "SIGNATURES", "includedCount": 1
@@ -38,7 +38,9 @@
     { "name":  "TOKEN_TRANSFER_BASE",                       "fee": 9000000 },
     { "name":  "TOKEN_TRANSFER_BASE_CUSTOM_FEES",           "fee": 19000000 },
     { "name":  "CONSENSUS_CREATE_TOPIC_WITH_CUSTOM_FEE",    "fee": 19900000000 },
-    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",  "fee": 492000000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",  "fee": 498300000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES", "fee": 1000000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES", "fee": 6800},
     { "name":  "SCHEDULE_CREATE_CONTRACT_CALL_BASE",        "fee": 900000000},
     { "name":  "HOOK_EXECUTION",                            "fee": 50000000 },
     { "name":  "HOOK_SLOT_UPDATE",                          "fee": 50000000 }
@@ -187,10 +189,11 @@
         },
         {
           "name": "ConsensusSubmitMessage",
-          "baseFee": 7000000,
+          "baseFee": 700000,
           "extras": [
-            { "name": "STATE_BYTES",      "includedCount": 1024 },
-            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE", "includedCount": 0 }
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES",  "includedCount": 100 },
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES",     "includedCount": 1024 },
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",           "includedCount": 0 }
           ]
         },
         {

--- a/hedera-node/configuration/testnet/upgrade/simpleFeesSchedules.json
+++ b/hedera-node/configuration/testnet/upgrade/simpleFeesSchedules.json
@@ -3,7 +3,7 @@
     "baseFee": 100000,
     "extras": [
       {
-        "name": "PROCESSING_BYTES", "includedCount": 1024
+        "name": "PROCESSING_BYTES", "includedCount": 1350
       },
       {
         "name": "SIGNATURES", "includedCount": 1
@@ -38,7 +38,9 @@
     { "name":  "TOKEN_TRANSFER_BASE",                       "fee": 9000000 },
     { "name":  "TOKEN_TRANSFER_BASE_CUSTOM_FEES",           "fee": 19000000 },
     { "name":  "CONSENSUS_CREATE_TOPIC_WITH_CUSTOM_FEE",    "fee": 19900000000 },
-    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",  "fee": 492000000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",  "fee": 498300000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES", "fee": 1000000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES", "fee": 6800},
     { "name":  "SCHEDULE_CREATE_CONTRACT_CALL_BASE",        "fee": 900000000},
     { "name":  "HOOK_EXECUTION",                            "fee": 50000000 },
     { "name":  "HOOK_SLOT_UPDATE",                          "fee": 50000000 }
@@ -187,10 +189,11 @@
         },
         {
           "name": "ConsensusSubmitMessage",
-          "baseFee": 7000000,
+          "baseFee": 700000,
           "extras": [
-            { "name": "STATE_BYTES",      "includedCount": 1024 },
-            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE", "includedCount": 0 }
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES",  "includedCount": 100 },
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES",     "includedCount": 1024 },
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",           "includedCount": 0 }
           ]
         },
         {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/StandaloneFeeCalculatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/StandaloneFeeCalculatorTest.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.api.Test;
 
 public class StandaloneFeeCalculatorTest {
     static final long TINY_CENTS = 100_000_000L;
-    static final long CREATE_TOPIC_BASE = 99000000L;
-    static final long SUBMIT_MESSAGE_BASE = 7000000L;
+    static final long CREATE_TOPIC_BASE = 99_000_000L;
+    static final long SUBMIT_MESSAGE_BASE = 700_000L;
     static final long NODE_BASE = 100000;
     static final long SIG_EXTRA = 100000;
 
@@ -290,8 +290,9 @@ public class StandaloneFeeCalculatorTest {
                 .build();
         final Transaction txn = Transaction.newBuilder().body(body).build();
         final FeeResult result = calc.calculateIntrinsic(txn);
-        assertThat(result.getServiceTotalTinycents()).isEqualTo(7_000_000L);
-        assertThat(result.totalTinycents()).isEqualTo(7_000_000 + 1_000_000L); // add in the node + network fee
+        assertThat(result.getServiceTotalTinycents()).isEqualTo(SUBMIT_MESSAGE_BASE);
+        assertThat(result.totalTinycents())
+                .isEqualTo(SUBMIT_MESSAGE_BASE + 1_000_000L); // add in the node + network fee
     }
 
     @Test
@@ -349,7 +350,8 @@ public class StandaloneFeeCalculatorTest {
                 .bodyBytes(TransactionBody.PROTOBUF.toBytes(body))
                 .build();
         final FeeResult result = calc.calculateIntrinsic(txn);
-        assertThat(result.getServiceTotalTinycents()).isEqualTo(7_000_000L);
-        assertThat(result.totalTinycents()).isEqualTo(7_000_000 + 1_000_000L); // add in the node + network fee
+        assertThat(result.getServiceTotalTinycents()).isEqualTo(SUBMIT_MESSAGE_BASE);
+        assertThat(result.totalTinycents())
+                .isEqualTo(SUBMIT_MESSAGE_BASE + 1_000_000L); // add in the node + network fee
     }
 }

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/calculator/ConsensusSubmitMessageFeeCalculator.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/calculator/ConsensusSubmitMessageFeeCalculator.java
@@ -30,16 +30,25 @@ public class ConsensusSubmitMessageFeeCalculator implements ServiceFeeCalculator
         final var op = txnBody.consensusSubmitMessageOrThrow();
 
         final var msgSize = op.message().length();
-        addExtraFee(feeResult, serviceDef, Extra.STATE_BYTES, feeSchedule, msgSize);
+        var hasCustomFees = false;
         if (simpleFeeContext.feeContext() != null) {
             final var topic = simpleFeeContext
                     .feeContext()
                     .readableStore(ReadableTopicStore.class)
                     .getTopic(op.topicIDOrThrow());
-            final var hasCustomFees = (topic != null && !topic.customFees().isEmpty());
-            if (hasCustomFees) {
-                addExtraFee(feeResult, serviceDef, Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE, feeSchedule, 1);
-            }
+            hasCustomFees = topic != null && !topic.customFees().isEmpty();
+        }
+        if (hasCustomFees) {
+            addExtraFee(feeResult, serviceDef, Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE, feeSchedule, 1);
+            addExtraFee(
+                    feeResult, serviceDef, Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, feeSchedule, msgSize);
+        } else {
+            addExtraFee(
+                    feeResult,
+                    serviceDef,
+                    Extra.CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES,
+                    feeSchedule,
+                    msgSize);
         }
     }
 

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusSubmitMessageFeeCalculatorTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/ConsensusSubmitMessageFeeCalculatorTest.java
@@ -128,14 +128,16 @@ public class ConsensusSubmitMessageFeeCalculatorTest extends ConsensusTestBase {
                 .extras(
                         makeExtraDef(Extra.SIGNATURES, 1000000L),
                         makeExtraDef(Extra.KEYS, 100000000L),
-                        makeExtraDef(Extra.STATE_BYTES, 110L),
+                        makeExtraDef(Extra.CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES, 110L),
+                        makeExtraDef(Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 110L),
                         makeExtraDef(Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE, 500000000))
                 .services(makeService(
                         "Consensus",
                         makeServiceFee(
                                 HederaFunctionality.CONSENSUS_SUBMIT_MESSAGE,
                                 498500000L,
-                                makeExtraIncluded(Extra.STATE_BYTES, 1024),
+                                makeExtraIncluded(Extra.CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES, 100),
+                                makeExtraIncluded(Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 1024),
                                 makeExtraIncluded(Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE, 0))))
                 .build();
     }

--- a/hedera-node/hedera-file-service-impl/src/main/resources/genesis/simpleFeesSchedules.json
+++ b/hedera-node/hedera-file-service-impl/src/main/resources/genesis/simpleFeesSchedules.json
@@ -3,7 +3,7 @@
     "baseFee": 100000,
     "extras": [
       {
-        "name": "PROCESSING_BYTES", "includedCount": 1024
+        "name": "PROCESSING_BYTES", "includedCount": 1350
       },
       {
         "name": "SIGNATURES", "includedCount": 1
@@ -38,7 +38,9 @@
     { "name":  "TOKEN_TRANSFER_BASE",                       "fee": 9000000 },
     { "name":  "TOKEN_TRANSFER_BASE_CUSTOM_FEES",           "fee": 19000000 },
     { "name":  "CONSENSUS_CREATE_TOPIC_WITH_CUSTOM_FEE",    "fee": 19900000000 },
-    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",  "fee": 492000000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",  "fee": 498300000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES", "fee": 1000000},
+    { "name":  "CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES", "fee": 6800},
     { "name":  "SCHEDULE_CREATE_CONTRACT_CALL_BASE",        "fee": 900000000},
     { "name":  "HOOK_EXECUTION",                            "fee": 50000000 },
     { "name":  "HOOK_SLOT_UPDATE",                          "fee": 50000000 }
@@ -187,10 +189,11 @@
         },
         {
           "name": "ConsensusSubmitMessage",
-          "baseFee": 7000000,
+          "baseFee": 700000,
           "extras": [
-            { "name": "STATE_BYTES",      "includedCount": 1024 },
-            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE", "includedCount": 0 }
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES",  "includedCount": 100 },
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES",     "includedCount": 1024 },
+            { "name": "CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE",           "includedCount": 0 }
           ]
         },
         {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/ConsensusServiceFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/ConsensusServiceFeesSuite.java
@@ -12,7 +12,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.updateTopic;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedConsensusHbarFee;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.safeValidateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.safeValidateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
@@ -20,10 +19,10 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdW
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.THREE_MONTHS_IN_SECONDS;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedFeeFromBytesFor;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTopicSubmitMessageFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.signedTxnSizeFor;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.QUERY_BASE_FEE;
-import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SUBMIT_MESSAGE_FULL_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.TOPIC_CREATE_WITH_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 
@@ -126,7 +125,7 @@ public class ConsensusServiceFeesSuite {
                         .payingWith(PAYER)
                         .message(new String(messageBytes100))
                         .hasRetryPrecheckFrom(BUSY)
-                        .via("submitMessage"),
+                        .via("submitMessage100"),
                 submitMessageTo(TOPIC_NAME)
                         .blankMemo()
                         .payingWith(PAYER)
@@ -140,15 +139,28 @@ public class ConsensusServiceFeesSuite {
                         .hasRetryPrecheckFrom(BUSY)
                         .via("submitMessage1024"),
                 sleepFor(1000),
-                validateChargedUsd("submitMessage", SUBMIT_MESSAGE_FULL_FEE_USD),
-                safeValidateChargedUsd("submitMessage500", 0.00088, SUBMIT_MESSAGE_FULL_FEE_USD),
                 withOpContext((spec, log) -> allRunFor(
                         spec,
+                        safeValidateChargedUsdWithin(
+                                "submitMessage100",
+                                0.001,
+                                1.0,
+                                expectedTopicSubmitMessageFullFeeUsd(
+                                        1, 100, signedTxnSizeFor(spec, "submitMessage100")),
+                                3.0),
+                        safeValidateChargedUsdWithin(
+                                "submitMessage500",
+                                0.000_88,
+                                1.0,
+                                expectedTopicSubmitMessageFullFeeUsd(
+                                        1, 500, signedTxnSizeFor(spec, "submitMessage500")),
+                                3.0),
                         safeValidateChargedUsdWithin(
                                 "submitMessage1024",
                                 0.001,
                                 1.0,
-                                SUBMIT_MESSAGE_FULL_FEE_USD + expectedFeeFromBytesFor(spec, log, "submitMessage1024"),
+                                expectedTopicSubmitMessageFullFeeUsd(
+                                        1, 1024, signedTxnSizeFor(spec, "submitMessage1024")),
                                 3.0))));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/ConsensusServiceSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/ConsensusServiceSimpleFeesSuite.java
@@ -23,6 +23,7 @@ import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.exp
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTopicCreateFullFeeUsd;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTopicCreateWithCustomFeeFullFeeUsd;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTopicDeleteFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTopicSubmitMessageFullFeeUsd;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTopicUpdateFullFeeUsd;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.signedTxnSizeFor;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SUBMIT_MESSAGE_FULL_FEE_USD;
@@ -271,7 +272,8 @@ public class ConsensusServiceSimpleFeesSuite {
                         .payingWith("payer")
                         .fee(ONE_HBAR)
                         .via("submitTxn"),
-                validateChargedUsd("submitTxn", SUBMIT_MESSAGE_FULL_FEE_USD));
+                withOpContext((spec, opLog) ->
+                        validateChargedUsd("submitTxn", expectedTopicSubmitMessageFullFeeUsd(0, 4, 4))));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/FileServiceFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/FileServiceFeesSuite.java
@@ -20,7 +20,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.THREE_MONTHS_IN_SECONDS;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.FILE_GET_CONTENTS_QUERY_BASE_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.FILE_GET_INFO_QUERY_BASE_FEE_USD;
-import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.PROCESSING_BYTES_FEE_USD;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.spec.keys.KeyShape;
@@ -34,7 +33,7 @@ public class FileServiceFeesSuite {
     private static final String MEMO = "Really quite something!";
     private static final String CIVILIAN = "civilian";
     private static final String KEY = "key";
-    private static final double BASE_FEE_FILE_CREATE = 0.0506;
+    private static final double BASE_FEE_FILE_CREATE = 0.05;
     private static final double BASE_FEE_FILE_UPDATE = 0.05;
     private static final double BASE_FEE_FILE_DELETE = 0.007;
     private static final double BASE_FEE_FILE_APPEND = 0.05;
@@ -57,10 +56,7 @@ public class FileServiceFeesSuite {
                         .contents(contents)
                         .payingWith(CIVILIAN)
                         .via("fileCreateBasic"),
-                safeValidateChargedUsd(
-                        "fileCreateBasic",
-                        BASE_FEE_FILE_CREATE,
-                        BASE_FEE_FILE_CREATE + 196 * PROCESSING_BYTES_FEE_USD * 10));
+                safeValidateChargedUsd("fileCreateBasic", BASE_FEE_FILE_CREATE, BASE_FEE_FILE_CREATE));
     }
 
     @HapiTest
@@ -78,10 +74,7 @@ public class FileServiceFeesSuite {
                         .memo(MEMO)
                         .payingWith(CIVILIAN)
                         .via("fileUpdateBasic"),
-                safeValidateChargedUsd(
-                        "fileUpdateBasic",
-                        BASE_FEE_FILE_UPDATE,
-                        BASE_FEE_FILE_UPDATE + 156 * PROCESSING_BYTES_FEE_USD * 10));
+                safeValidateChargedUsd("fileUpdateBasic", BASE_FEE_FILE_UPDATE, BASE_FEE_FILE_UPDATE));
     }
 
     @HapiTest
@@ -124,8 +117,7 @@ public class FileServiceFeesSuite {
                         .content(contentBuilder.toString())
                         .payingWith(civilian)
                         .via(baseAppend),
-                safeValidateChargedUsd(
-                        baseAppend, BASE_FEE_FILE_APPEND, BASE_FEE_FILE_APPEND + 100 * PROCESSING_BYTES_FEE_USD * 10));
+                safeValidateChargedUsd(baseAppend, BASE_FEE_FILE_APPEND, BASE_FEE_FILE_APPEND));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/FeesChargingUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/FeesChargingUtils.java
@@ -27,6 +27,7 @@ import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleCon
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONS_DELETE_TOPIC_BASE_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONS_SUBMIT_MESSAGE_BASE_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONS_SUBMIT_MESSAGE_INCLUDED_BYTES;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONS_UPDATE_TOPIC_BASE_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONS_UPDATE_TOPIC_INCLUDED_KEYS;
@@ -1139,14 +1140,15 @@ public class FeesChargingUtils {
         final double networkFee = nodeFee * NETWORK_MULTIPLIER;
 
         // ----- service fees -----
-        final long byteExtrasService = Math.max(0L, messageBytes - CONS_SUBMIT_MESSAGE_INCLUDED_BYTES);
-        final double serviceBytesExtrasFee = byteExtrasService * STATE_BYTES_FEE_USD;
 
-        double serviceBaseFee = CONS_SUBMIT_MESSAGE_BASE_FEE_USD;
+        double serviceFee = 0;
         if (includesCustomFee) {
-            serviceBaseFee += CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_USD;
+            serviceFee = CONS_SUBMIT_MESSAGE_BASE_FEE_USD + CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_USD;
+        } else {
+            final long byteExtrasService = Math.max(0L, messageBytes - CONS_SUBMIT_MESSAGE_INCLUDED_BYTES);
+            final double serviceBytesExtrasFee = byteExtrasService * CONS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES;
+            serviceFee = CONS_SUBMIT_MESSAGE_BASE_FEE_USD + serviceBytesExtrasFee;
         }
-        final double serviceFee = serviceBaseFee + serviceBytesExtrasFee;
 
         return nodeFee + networkFee + serviceFee;
     }
@@ -1178,7 +1180,7 @@ public class FeesChargingUtils {
     public static double expectedTopicSubmitMessageWithCustomFeeFullFeeUsd(final Map<Extra, Long> extras) {
         return expectedTopicSubmitMessageWithCustomFeeFullFeeUsd(
                 extras.getOrDefault(Extra.SIGNATURES, 0L),
-                extras.getOrDefault(Extra.STATE_BYTES, 0L),
+                extras.getOrDefault(Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 0L),
                 Math.toIntExact(extras.getOrDefault(Extra.PROCESSING_BYTES, 0L)));
     }
 
@@ -1193,6 +1195,18 @@ public class FeesChargingUtils {
 
         // ----- network fees -----
         return nodeFee * NETWORK_MULTIPLIER;
+    }
+
+    public static double expectedTopicSubmitMessageServiceOnly(long messageBytes, boolean includesCustomFee) {
+        double serviceFee = 0;
+        if (includesCustomFee) {
+            serviceFee = CONS_SUBMIT_MESSAGE_BASE_FEE_USD + CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_USD;
+        } else {
+            final long byteExtrasService = Math.max(0L, messageBytes - CONS_SUBMIT_MESSAGE_INCLUDED_BYTES);
+            final double serviceBytesExtrasFee = byteExtrasService * CONS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES;
+            serviceFee = CONS_SUBMIT_MESSAGE_BASE_FEE_USD + serviceBytesExtrasFee;
+        }
+        return serviceFee;
     }
 
     // -------- TokenCreate simple fees utils ---------//

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/SimpleFeesScheduleConstantsInUsd.java
@@ -11,7 +11,7 @@ public class SimpleFeesScheduleConstantsInUsd {
 
     public static final double NODE_BASE_FEE_USD = 0.00001;
     public static final long NODE_INCLUDED_SIGNATURES = 1L;
-    public static final long NODE_INCLUDED_BYTES = 1024L;
+    public static final long NODE_INCLUDED_BYTES = 1350L;
 
     public static final int NETWORK_MULTIPLIER = 9;
     public static final double NETWORK_BASE_FEE = NODE_BASE_FEE_USD * NETWORK_MULTIPLIER;
@@ -55,12 +55,13 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final double TOKEN_TRANSFER_BASE_FEE_USD = 0.0009;
     public static final double TOKEN_TRANSFER_BASE_CUSTOM_FEES_USD = 0.0019;
 
-    public static final double CONS_SUBMIT_MESSAGE_BASE_FEE_USD = 0.0007;
-    public static final long CONS_SUBMIT_MESSAGE_INCLUDED_BYTES = 1024L;
+    public static final double CONS_SUBMIT_MESSAGE_BASE_FEE_USD = 0.000_07;
+    public static final long CONS_SUBMIT_MESSAGE_INCLUDED_BYTES = 100L;
+    public static final double CONS_SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTES = 0.000_000_680;
     public static final long CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_INCLUDED_COUNT = 0L;
     public static final double CONS_CREATE_TOPIC_WITH_CUSTOM_FEE_USD = 1.99;
-    public static final double CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_USD = 0.0492;
-    public static final double SCHEDULE_CREATE_CONTRACT_CALL_BASE_FEE_USD = 0.0499;
+    public static final double CONS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_USD = 0.049_83;
+    public static final double SCHEDULE_CREATE_CONTRACT_CALL_BASE_FEE_USD = 0.049_9;
 
     /* ---------- Crypto service ---------- */
 
@@ -102,6 +103,8 @@ public class SimpleFeesScheduleConstantsInUsd {
     public static final long CONS_UPDATE_TOPIC_INCLUDED_KEYS = 1L;
 
     public static final double SUBMIT_MESSAGE_FULL_FEE_USD = 0.0008;
+    public static final double SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_INCLUDED = 100;
+    public static final double SUBMIT_MESSAGE_WITHOUT_CUSTOM_FEE_BYTE_USD = 0.000_1;
     public static final double SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BASE_USD = 0.05;
 
     public static final double CONS_DELETE_TOPIC_BASE_FEE_USD = 0.0049;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeSubmitMessageTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeSubmitMessageTest.java
@@ -59,8 +59,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CUSTOM_FEE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_VALID_MAX_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+import static org.hiero.hapi.support.fees.Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES;
 import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
-import static org.hiero.hapi.support.fees.Extra.STATE_BYTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -2096,7 +2096,7 @@ class AtomicTopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                     // --- Fee validations in simple fees - legacy fees dual-mode ---//
                     validateFeeModeAwareWithTxnSize(
                             "simpleSubmit",
-                            Map.of(SIGNATURES, 1L, STATE_BYTES, testMsgBytes),
+                            Map.of(SIGNATURES, 1L, CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, testMsgBytes),
                             Map.of(LEGACY_EXPECTED_USD, 0.05, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn),
@@ -2104,7 +2104,7 @@ class AtomicTopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                             "submit513",
                             Map.of(
                                     SIGNATURES, 1L,
-                                    STATE_BYTES, 513L),
+                                    CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 513L),
                             Map.of(LEGACY_EXPECTED_USD, 0.051, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn),
@@ -2112,7 +2112,7 @@ class AtomicTopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                             "submit800",
                             Map.of(
                                     SIGNATURES, 1L,
-                                    STATE_BYTES, 800L),
+                                    CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 800L),
                             Map.of(
                                     LEGACY_EXPECTED_USD,
                                     0.055999,
@@ -2124,7 +2124,7 @@ class AtomicTopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                             "submit1000",
                             Map.of(
                                     SIGNATURES, 1L,
-                                    STATE_BYTES, 1000L),
+                                    CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 1000L),
                             Map.of(LEGACY_EXPECTED_USD, 0.06, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn),
@@ -2132,13 +2132,13 @@ class AtomicTopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                             "submit1024",
                             Map.of(
                                     SIGNATURES, 1L,
-                                    STATE_BYTES, 1024L),
+                                    CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 1024L),
                             Map.of(LEGACY_EXPECTED_USD, 0.06, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn),
                     validateFeeModeAwareWithTxnSize(
                             "extraSigs",
-                            Map.of(SIGNATURES, 2L, STATE_BYTES, testMsgBytes),
+                            Map.of(SIGNATURES, 2L, CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, testMsgBytes),
                             Map.of(LEGACY_EXPECTED_USD, 0.0792, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn)));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/TopicCustomFeeSubmitMessageTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/TopicCustomFeeSubmitMessageTest.java
@@ -63,8 +63,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CUSTOM_FEE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_VALID_MAX_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+import static org.hiero.hapi.support.fees.Extra.CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES;
 import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
-import static org.hiero.hapi.support.fees.Extra.STATE_BYTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1852,7 +1852,7 @@ public class TopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                     // --- Fee validations in simple fees - legacy fees dual-mode ---//
                     validateFeeModeAwareWithTxnSize(
                             "simpleSubmit",
-                            Map.of(SIGNATURES, 1L, STATE_BYTES, testMsgBytes),
+                            Map.of(SIGNATURES, 1L, CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, testMsgBytes),
                             Map.of(LEGACY_EXPECTED_USD, 0.05, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn),
@@ -1860,7 +1860,7 @@ public class TopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                             "submit513",
                             Map.of(
                                     SIGNATURES, 1L,
-                                    STATE_BYTES, 513L),
+                                    CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 513L),
                             Map.of(LEGACY_EXPECTED_USD, 0.051, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn),
@@ -1868,7 +1868,7 @@ public class TopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                             "submit800",
                             Map.of(
                                     SIGNATURES, 1L,
-                                    STATE_BYTES, 800L),
+                                    CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 800L),
                             Map.of(
                                     LEGACY_EXPECTED_USD,
                                     0.055999,
@@ -1880,7 +1880,7 @@ public class TopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                             "submit1000",
                             Map.of(
                                     SIGNATURES, 1L,
-                                    STATE_BYTES, 1000L),
+                                    CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 1000L),
                             Map.of(LEGACY_EXPECTED_USD, 0.06, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn),
@@ -1888,13 +1888,13 @@ public class TopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                             "submit1024",
                             Map.of(
                                     SIGNATURES, 1L,
-                                    STATE_BYTES, 1024L),
+                                    CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, 1024L),
                             Map.of(LEGACY_EXPECTED_USD, 0.06, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn),
                     validateFeeModeAwareWithTxnSize(
                             "extraSigs",
-                            Map.of(SIGNATURES, 2L, STATE_BYTES, testMsgBytes),
+                            Map.of(SIGNATURES, 2L, CONSENSUS_SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BYTES, testMsgBytes),
                             Map.of(LEGACY_EXPECTED_USD, 0.0792, LEGACY_ALLOWED_PERCENT_DIFF, legacyAllowedPercentDiff),
                             simpleFeesAllowedPercentDiff,
                             submitExpectedFn)));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleExecutionTest.java
@@ -49,8 +49,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
-import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONS_SUBMIT_MESSAGE_BASE_FEE_USD;
-import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.STATE_BYTES_FEE_USD;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedTopicSubmitMessageServiceOnly;
 import static com.hedera.services.bdd.suites.hip904.UnlimitedAutoAssociationSuite.UNLIMITED_AUTO_ASSOCIATION_SLOTS;
 import static com.hedera.services.bdd.suites.schedule.ScheduleUtils.ADMIN;
 import static com.hedera.services.bdd.suites.schedule.ScheduleUtils.A_SCHEDULE;
@@ -1042,15 +1041,17 @@ public class ScheduleExecutionTest {
                                             / 100;
                             // Scheduled execution charges service-only: base + byte overage
                             Assertions.assertEquals(
-                                    CONS_SUBMIT_MESSAGE_BASE_FEE_USD,
+                                    expectedTopicSubmitMessageServiceOnly(1024L, false),
                                     successUsd,
-                                    0.01 * CONS_SUBMIT_MESSAGE_BASE_FEE_USD,
+                                    0.01 * expectedTopicSubmitMessageServiceOnly(1024L, false),
                                     String.format("Success fee (%s) not within 1%% of expected!", successUsd));
                             Assertions.assertEquals(
-                                    CONS_SUBMIT_MESSAGE_BASE_FEE_USD + STATE_BYTES_FEE_USD,
+                                    expectedTopicSubmitMessageServiceOnly(1025L, false),
                                     failureUsd,
-                                    0.01 * (CONS_SUBMIT_MESSAGE_BASE_FEE_USD + STATE_BYTES_FEE_USD),
-                                    String.format("Failure fee (%s) not within 1%% of expected!", failureUsd));
+                                    0.01 * expectedTopicSubmitMessageServiceOnly(1025L, false),
+                                    String.format(
+                                            "Failure fee (%s) expectedTopicSubmitMessageServiceOnly within 1%% of expected!",
+                                            failureUsd));
                         });
                     } else {
                         return assertionsHold((spec, opLog) ->


### PR DESCRIPTION
(cherry picked from commit 6d945a38d0eec201be9f7d9df96e14d331309e9f)

**Description**:

Cherry picks [this PR](https://github.com/hiero-ledger/hiero-consensus-node/pull/24505) to release 73. 

It changes the included bytes for Submit Message from 1024 to 100, so that the cost will scale more cleanly. Messages with custom fees have a flat rate regardless of the number of bytes. Also changes the number of included processing bytes from 1024 to 1350 so that the top price for submit message is 0.008.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
