### PR TITLE
fix: 24799 Fixed handling null array of `ImmutableIndexedObjectListUsingArray`

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArray.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArray.java
@@ -87,6 +87,10 @@ public class ImmutableIndexedObjectListUsingArray<T extends IndexedObject> imple
             return this;
         }
 
+        if (isEmpty()) {
+            return new ImmutableIndexedObjectListUsingArray<>(arrayProvider, List.of(newObject));
+        }
+
         // Create a temp array list with just non-null objects that belong to the new list
         final List<T> newDataArray = new ArrayList<>(Arrays.asList(dataArray));
         newDataArray.removeIf(next -> next == null || next.getIndex() == newObject.getIndex());
@@ -142,7 +146,7 @@ public class ImmutableIndexedObjectListUsingArray<T extends IndexedObject> imple
     /** {@inheritDoc} */
     @Override
     public Stream<T> stream() {
-        return Arrays.stream(dataArray).filter(Objects::nonNull);
+        return isEmpty() ? Stream.empty() : Arrays.stream(dataArray).filter(Objects::nonNull);
     }
 
     @Override

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArrayTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArrayTest.java
@@ -146,6 +146,29 @@ class ImmutableIndexedObjectListUsingArrayTest {
         assertNull(emptyList.get(42), "Empty lists should always return null");
     }
 
+    @Test
+    @Order(10)
+    void emptyListProducesEmptyStream() {
+        final ImmutableIndexedObjectList<TestIndexedObject> emptyList =
+                factoryForReaderToTest(new TestIndexedObject[0]);
+
+        assertEquals(0, emptyList.stream().count(), "Empty lists should produce empty streams");
+    }
+
+    @Test
+    @Order(11)
+    void withAddedObjectOnEmptyListAddsObject() {
+        final ImmutableIndexedObjectList<TestIndexedObject> emptyList =
+                factoryForReaderToTest(new TestIndexedObject[0]);
+        final TestIndexedObject object42 = new TestIndexedObject(42);
+
+        final ImmutableIndexedObjectList<TestIndexedObject> updatedList = emptyList.withAddedObject(object42);
+
+        assertEquals(1, updatedList.size(), "Adding to an empty list should create a singleton list");
+        assertSame(object42, updatedList.get(42), "Added object should be retrievable by index");
+        assertSame(object42, updatedList.getLast(), "Added object should become the last element");
+    }
+
     private static void checkRange(int max) {
         max++; // add one to make range exclusive from inclusive
         TestIndexedObject[] objects = list.stream().toArray(TestIndexedObject[]::new);


### PR DESCRIPTION
**Description**:

This PR fixes handling null `dataArray` in `ImmutableIndexedObjectListUsingArray` in `stream` and `withAddedObject` methods


**Related issue(s)**:

Fixes #24799 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
