### PR TITLE
fix: fix flaky balance check

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetInfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractGetInfoSuite.java
@@ -3,7 +3,6 @@ package com.hedera.services.bdd.suites.contract.hapi;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
-import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.approxChangeFromSnapshot;
 import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
@@ -12,17 +11,13 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sendModified;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateNonZeroNodePaymentForQuery;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withTargetLedgerId;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedQueryIds;
 import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
-import static com.hedera.services.bdd.suites.HapiSuite.TINY_PARTS_PER_WHOLE;
 import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.MEMO;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
@@ -33,7 +28,6 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -57,12 +51,9 @@ public class ContractGetInfoSuite {
     final Stream<DynamicTest> getInfoWorks() {
         final var contract = "Multipurpose";
         final var MEMO = "This is a test.";
-        final var canonicalUsdPrice = 0.0001;
-        final var canonicalQueryFeeAtActiveRate = new AtomicLong();
         return hapiTest(
                 newKeyNamed("adminKey"),
                 cryptoCreate(CIVILIAN_PAYER).balance(ONE_HUNDRED_HBARS),
-                balanceSnapshot("beforeQuery", CIVILIAN_PAYER),
                 uploadInitCode(contract),
                 // refuse eth conversion because ethereum transaction is missing admin key and memo is same as
                 // parent
@@ -71,22 +62,13 @@ public class ContractGetInfoSuite {
                         .entityMemo(MEMO)
                         .autoRenewSecs(6999999L)
                         .refusingEthConversion(),
-                withOpContext((spec, opLog) -> canonicalQueryFeeAtActiveRate.set(spec.ratesProvider()
-                        .toTbWithActiveRates((long) (canonicalUsdPrice * 100 * TINY_PARTS_PER_WHOLE)))),
                 withTargetLedgerId(ledgerId -> getContractInfo(contract)
                         .payingWith(CIVILIAN_PAYER)
                         .hasEncodedLedgerId(ledgerId)
                         .hasExpectedInfo()
-                        .has(contractWith().memo(MEMO).adminKey("adminKey"))),
-                // Wait for the query payment transaction to be handled
-                sleepFor(5_000),
-                sourcing(() -> getAccountBalance(CIVILIAN_PAYER)
-                        .hasTinyBars(
-                                // Just sanity-check a fee within 50% of the canonical fee to be safe
-                                approxChangeFromSnapshot(
-                                        "beforeQuery",
-                                        -canonicalQueryFeeAtActiveRate.get(),
-                                        canonicalQueryFeeAtActiveRate.get() / 2))));
+                        .has(contractWith().memo(MEMO).adminKey("adminKey"))
+                        .via("queryRecord")),
+                validateNonZeroNodePaymentForQuery("queryRecord"));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
Replace flaky `sleepFor(5_000)` + balance snapshot assertion with `validateNonZeroNodePaymentForQuery`, which reads the fee from the transaction record directly — no timing dependency.

**Related issue(s)**:

Fixes #24735 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
