### PR TITLE
ci(workflows): Update solo install source to hiero-ledger

### DIFF
--- a/.github/workflows/050-user-memory-profile-ctrl.yaml
+++ b/.github/workflows/050-user-memory-profile-ctrl.yaml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Install Solo
         run: |
-          npm install -g "@hashgraph/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
 
           # verify the installation
           solo --version

--- a/.github/workflows/zxc-block-node-regression.yaml
+++ b/.github/workflows/zxc-block-node-regression.yaml
@@ -200,7 +200,7 @@ jobs:
       # Install solo and configure to use the artifacts from
       # the hiero-consensus-node build
       - name: Install Solo
-        run: npm install -g @hashgraph/solo@latest
+        run: npm install -g @hiero-ledger/solo@latest
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind

--- a/.github/workflows/zxc-json-rpc-relay-regression.yaml
+++ b/.github/workflows/zxc-json-rpc-relay-regression.yaml
@@ -100,7 +100,7 @@ jobs:
       # Install solo and configure to use the artifacts from
       # the hiero-consensus-node build
       - name: Install Solo
-        run: npm install -g @hashgraph/solo@${{ inputs.solo-version || 'latest' }}
+        run: npm install -g @hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind

--- a/.github/workflows/zxc-merge-queue-performance-test.yaml
+++ b/.github/workflows/zxc-merge-queue-performance-test.yaml
@@ -286,7 +286,7 @@ jobs:
 
       - name: Install Solo
         run: |
-          npm install -g "@hashgraph/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
 
           # verify the installation
           solo --version

--- a/.github/workflows/zxc-mirror-node-regression.yaml
+++ b/.github/workflows/zxc-mirror-node-regression.yaml
@@ -85,7 +85,7 @@ jobs:
         run: ${GRADLE_EXEC} assemble
 
       - name: Install Solo
-        run: npm install -g @hashgraph/solo@${{ inputs.solo-version || 'latest' }}
+        run: npm install -g @hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}
 
       - name: Setup Kind
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0

--- a/.github/workflows/zxc-single-day-longevity-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-test.yaml
@@ -263,7 +263,7 @@ jobs:
 
       - name: Install Solo
         run: |
-          npm install -g "@hashgraph/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
 
           # verify the installation
           solo --version

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -287,7 +287,7 @@ jobs:
 
       - name: Install Solo
         run: |
-          npm install -g "@hashgraph/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
 
           # verify the installation
           solo --version


### PR DESCRIPTION
## Description

This pull request updates the installation of the `Solo` tool across several GitHub Actions workflow files. The main change is switching the npm package from `@hashgraph/solo` to `@hiero-ledger/solo` to reflect the new package source. No other workflow logic is affected.

**Dependency update:**

* All relevant workflow files now install `@hiero-ledger/solo` instead of `@hashgraph/solo` using npm. This affects the following files:
  * `.github/workflows/050-user-memory-profile-ctrl.yaml`
  * `.github/workflows/zxc-block-node-regression.yaml`
  * `.github/workflows/zxc-json-rpc-relay-regression.yaml`
  * `.github/workflows/zxc-merge-queue-performance-test.yaml`
  * `.github/workflows/zxc-mirror-node-regression.yaml`
  * `.github/workflows/zxc-single-day-longevity-test.yaml`
  * `.github/workflows/zxc-single-day-performance-test.yaml`

## Related Issue(s)

Closes #24812

## Testing

- [x] [Short version SDPT](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/24091578236)
- [x] [Short version SDLT](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/24091566121)
- [x] [XTS](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/24085414648)
- [x] [MATS](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/24085493727)