### PR TITLE
fix: 24802 Disable EVM hook count validation for TestNet 

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/EntityIdCountValidator.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/EntityIdCountValidator.java
@@ -106,7 +106,7 @@ public class EntityIdCountValidator implements LeafBytesValidator {
         ValidationAssertions.requireNonNull(entityCounts, getName());
 
         final boolean ok;
-        if (NET_NAME.equals("Mainnet")) {
+        if (NET_NAME.equals("Mainnet") || NET_NAME.equals("Previewnet")) {
             ok = entityCounts.numAccounts() == accountCount.get()
                     && entityCounts.numAliases() == aliasesCount.get()
                     && entityCounts.numTokens() == tokenCount.get()
@@ -124,7 +124,7 @@ public class EntityIdCountValidator implements LeafBytesValidator {
                     && entityCounts.numHooks() == hookCount.get()
                     && entityCounts.numEvmHookStorageSlots() == evmHookStorageCount.get();
         } else {
-            // PreviewNet and TestNet have numEvmHookStorageSlots count validation disabled
+            // TestNet have numEvmHookStorageSlots count validation disabled
             // See https://github.com/hiero-ledger/hiero-consensus-node/issues/24802
             ok = entityCounts.numAccounts() == accountCount.get()
                     && entityCounts.numAliases() == aliasesCount.get()


### PR DESCRIPTION
**Description**:

This is a cherry-pick of https://github.com/hiero-ledger/hiero-consensus-node/pull/24817 into `release/0.73` branch

(cherry picked from commit 9a5f9762e7ac15cc0ec2ef65b023b59545cc3a67)

**Related issue(s)**:

Fixes #24802 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
