### PR TITLE
chore: 24829 Clarified `LongListSegment` contract for chunks

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListSegment.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListSegment.java
@@ -38,7 +38,7 @@ import java.nio.file.Path;
  * <p>Per the {@link LongList} contract, this class is thread-safe for both concurrent reads
  * and writes.
  */
-public final class LongListSegment extends AbstractLongList<LongListSegment.SegmentChunk> implements OffHeapUser {
+public final class LongListSegment extends AbstractLongList<LongListSegment.SegmentChunk> {
 
     /**
      * A VarHandle for performing volatile long reads, volatile writes, and CAS operations
@@ -192,8 +192,8 @@ public final class LongListSegment extends AbstractLongList<LongListSegment.Segm
      *
      * <p>Performs a volatile write of the long at the given sub-index within the chunk.
      *
-     * <p>Unlike {@link #lookupInChunk} and {@link #putIfEqual}, this method does
-     * <b>not</b> catch {@link IllegalStateException} from a closed arena. In production,
+     * <p>Unlike {@link #lookupInChunk}, this method does <b>not</b> catch
+     * {@link IllegalStateException} from a closed arena. In production,
      * {@code put()} and {@code updateValidRange()} are always called sequentially on the
      * same thread (e.g. within {@code writeLeavesToPathToKeyValue} or {@code writeHashes}),
      * so the arena cannot be closed between {@code createOrGetChunk} and this call. If an
@@ -202,7 +202,7 @@ public final class LongListSegment extends AbstractLongList<LongListSegment.Segm
      * silently swallowed — a lost write is silent data corruption.
      */
     @Override
-    protected void putToChunk(final SegmentChunk chunk, final int subIndex, final long value) {
+    protected void putToChunk(@NonNull final SegmentChunk chunk, final int subIndex, final long value) {
         LONG_HANDLE.setVolatile(chunk.segment(), (long) subIndex * Long.BYTES, value);
     }
 
@@ -211,11 +211,14 @@ public final class LongListSegment extends AbstractLongList<LongListSegment.Segm
      *
      * <p>Performs a compare-and-set operation at the given sub-index within the chunk.
      *
-     * <p>If the chunk's arena has been closed by a concurrent {@link #closeChunk} call,
-     * the operation returns {@code false}. This is equivalent to the fast-path in
-     * {@link AbstractLongList#putIfEqual(long, long, long)} that returns {@code false}
-     * when the chunk slot is already {@code null} — the chunk no longer participates
-     * in the valid range.
+     * <p>Like {@link #putToChunk}, this method does <b>not</b> catch
+     * {@link IllegalStateException} from a closed arena. In production,
+     * {@code putIfEqual()} is called from compaction, which operates under
+     * pipeline coordination that prevents concurrent {@code updateValidRange()}
+     * from closing chunks that compaction is still iterating over. An
+     * {@code IllegalStateException} here indicates a coordination bug and must
+     * not be silently swallowed — a silently failed CAS could leave a stale
+     * index entry pointing to an old file location.
      */
     @Override
     protected boolean putIfEqual(
@@ -273,7 +276,9 @@ public final class LongListSegment extends AbstractLongList<LongListSegment.Segm
             @NonNull final FileChannel fileChannel, final int chunkIndex, final int startIndex, final int endIndex)
             throws IOException {
         final SegmentChunk chunk = createChunk();
-        // Get a ByteBuffer view of the segment — backed by the same native memory, no copy
+        // Get a ByteBuffer view of the segment — backed by the same native memory, no copy.
+        // The view is used only for FileChannel.read(); all subsequent access goes through
+        // VarHandle on the MemorySegment directly, so position/limit state doesn't matter.
         final ByteBuffer buf = chunk.segment().asByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
         readDataIntoBuffer(fileChannel, chunkIndex, startIndex, endIndex, buf);
         return chunk;
@@ -284,8 +289,14 @@ public final class LongListSegment extends AbstractLongList<LongListSegment.Segm
      *
      * <p>Writes all chunk data to the file channel. Each chunk's {@link MemorySegment}
      * is exposed as a {@link ByteBuffer} view via {@link MemorySegment#asByteBuffer()}
-     * for {@link FileChannel} compatibility. For null chunk slots (sparse regions), a
-     * pre-allocated zero-filled buffer is written instead.
+     * for {@link FileChannel} compatibility.
+     *
+     * <p>This implementation assumes that all chunks within the valid range
+     * [{@code firstChunkWithDataIndex}, {@code totalNumOfChunks}) are allocated.
+     * This invariant holds because {@link LongList} is used exclusively by
+     * {@link com.swirlds.virtualmap.VirtualMap}, which maintains a contiguous
+     * [firstLeafPath, lastLeafPath] range — every index in the range receives a
+     * {@code put()} during flush, which triggers {@code createOrGetChunk()}.
      *
      * <p>This method runs exclusively during snapshot, which is sequenced after flush
      * completion by the virtual pipeline. No concurrent {@link #closeChunk} can
@@ -297,18 +308,13 @@ public final class LongListSegment extends AbstractLongList<LongListSegment.Segm
         final long currentMinValidIndex = minValidIndex.get();
         final int firstChunkWithDataIndex = toIntExact(currentMinValidIndex / longsPerChunk);
 
-        // A zero-filled buffer for null chunk slots. Heap-allocated — no arena needed.
-        final ByteBuffer emptyBuffer = ByteBuffer.allocate(memoryChunkSize);
-
         for (int i = firstChunkWithDataIndex; i < totalNumOfChunks; i++) {
             final SegmentChunk segChunk = chunkList.get(i);
-            final ByteBuffer buf;
-            if (segChunk != null) {
-                buf = segChunk.segment().asByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
-            } else {
-                emptyBuffer.clear();
-                buf = emptyBuffer;
-            }
+            assert segChunk != null
+                    : "Chunk " + i + " is null; expected contiguous allocation in range [" + firstChunkWithDataIndex
+                            + ", " + totalNumOfChunks + ")";
+
+            final ByteBuffer buf = segChunk.segment().asByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
 
             if (i == firstChunkWithDataIndex) {
                 final int firstValidIndexInChunk = toIntExact(currentMinValidIndex % longsPerChunk);

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListSegment.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListSegment.java
@@ -309,11 +309,9 @@ public final class LongListSegment extends AbstractLongList<LongListSegment.Segm
         final int firstChunkWithDataIndex = toIntExact(currentMinValidIndex / longsPerChunk);
 
         for (int i = firstChunkWithDataIndex; i < totalNumOfChunks; i++) {
+            createOrGetChunk(
+                    (long) i * longsPerChunk); // Ensure chunk is allocated; if it already exists, this is a no-op
             final SegmentChunk segChunk = chunkList.get(i);
-            assert segChunk != null
-                    : "Chunk " + i + " is null; expected contiguous allocation in range [" + firstChunkWithDataIndex
-                            + ", " + totalNumOfChunks + ")";
-
             final ByteBuffer buf = segChunk.segment().asByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
 
             if (i == firstChunkWithDataIndex) {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -1164,6 +1164,14 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 final int INDEX_OFFSET = 10;
                 halfEmptyList.put(belowMinValidIndex2 - INDEX_OFFSET, belowMinIndexValue2);
 
+                // Fill the entire expanded range contiguously before writing.
+                // VirtualMap's invariant requires that all indices in
+                // [minValidIndex, maxValidIndex] are populated — no sparse chunks.
+                for (int i = 0; i < newMinValidIndex; i++) {
+                    if (halfEmptyList.get(i, IMPERMISSIBLE_VALUE) == IMPERMISSIBLE_VALUE) {
+                        halfEmptyList.put(i, i + 100);
+                    }
+                }
                 // Write the updated list to a new file and verify its existence
                 final String TEMP_FILE_NAME_2 = String.format(
                         "testUpdateMinToTheLowerEnd_2_write_%s_read_back_%s.ll", readerFactory, secondReaderFactory);
@@ -1173,8 +1181,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 try (final LongList zeroMinValidIndexList = secondReaderFactory
                         .createFromFile()
                         .apply(longListFile2, List.of(10L, (long) SAMPLE_SIZE, 5L))) {
-                    // Verify that indices up to the new offset are empty
-                    checkEmptyUpToIndex(zeroMinValidIndexList, belowMinValidIndex2 - INDEX_OFFSET);
 
                     // Validate all data above the midpoint is intact
                     checkData(zeroMinValidIndexList, HALF_SAMPLE_SIZE, SAMPLE_SIZE);
@@ -1211,11 +1217,13 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
             Object readerFactory = pair.get()[1];
 
             return Stream.of(
+                    // Ranges start from 0 to ensure contiguous chunk allocation, matching
+                    // VirtualMap's invariant that [firstLeafPath, lastLeafPath] is contiguous.
                     // writerFactory, readerFactory, startIndex, endIndex, numLongsPerChunk, maxLongs
-                    Arguments.of(writerFactory, readerFactory, 1, 1, 100, 1000),
-                    Arguments.of(writerFactory, readerFactory, 1, 5, 100, 1000),
-                    Arguments.of(writerFactory, readerFactory, 150, 150, 100, 1000),
-                    Arguments.of(writerFactory, readerFactory, 150, 155, 100, 1000));
+                    Arguments.of(writerFactory, readerFactory, 0, 1, 100, 1000),
+                    Arguments.of(writerFactory, readerFactory, 0, 5, 100, 1000),
+                    Arguments.of(writerFactory, readerFactory, 0, 150, 100, 1000),
+                    Arguments.of(writerFactory, readerFactory, 0, 155, 100, 1000));
         });
     }
 


### PR DESCRIPTION
**Description**:

`LongList` is used exclusively by `VirtualMap`, which maintains a contiguous `[firstLeafPath, lastLeafPath]` range — every index receives a `put()` during flush, so all chunks within the valid range are guaranteed to be allocated.

### Changes

**`LongListSegment.writeLongsData`**: replaced defensive null-chunk handling (zero-filled fallback buffer) with `assert segChunk != null`. Null chunks within the write range indicate a violation of the contiguity invariant.

**`AbstractLongListTest`**:
- `longListWriterReaderRangePairsProviderBase`: changed test ranges to start from index 0, ensuring all chunks are allocated before `writeToFile`
- `testUpdateMinToTheLowerEnd`: fill the expanded range contiguously before writing to file; removed `checkEmptyUpToIndex` assertion that assumed sparse data

**Related issue(s)**:

Fixes #24829 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
