### PR TITLE
ci: add prepare solo step timeout to avoid longer hanging

### DIFF
--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -156,6 +156,7 @@ jobs:
       # Prepare Hiero Solo
       - name: Prepare Hiero Solo
         id: solo-action
+        timeout-minutes: 20
         uses: hiero-ledger/hiero-solo-action@8cda77e13916d1ed8f80eb07361a474a264be005 # latest on `main` currently
         with:
           installMirrorNode: true


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
The SDK TCK Regression panel hangs at the Prepare Hiero Solo step resulting in a 6 hour wait time before it times out.
This PR adds a custom timeout of 20 minutes for that specific step only in order to fail earlier if the process hangs and avoid waiting for 6 hours or manually monitoring and cancelling the job.

**Related issue(s)**:

Fixes #24818 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
