### PR TITLE
fix: use already established timeout for restart to active

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
@@ -12,6 +12,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForActive;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForAny;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilNextBlocks;
+import static com.hedera.services.bdd.suites.regression.system.LifecycleTest.RESTART_TO_ACTIVE_TIMEOUT;
 
 import com.hedera.services.bdd.HapiBlockNode;
 import com.hedera.services.bdd.HapiBlockNode.BlockNodeConfig;
@@ -203,6 +204,6 @@ public class BlockNodeBackPressureSuite {
                         spec -> LockSupport.parkNanos(Duration.ofMinutes(1).toNanos())),
                 blockNode(0).startImmediately(),
                 blockNode(1).startImmediately(),
-                waitForAny(allNodes(), Duration.ofSeconds(120), PlatformStatus.ACTIVE));
+                waitForAny(allNodes(), RESTART_TO_ACTIVE_TIMEOUT, PlatformStatus.ACTIVE));
     }
 }


### PR DESCRIPTION
**Description**:
The `backPressureAllNodesCheckingScenario` test flakes because the 120s timeout for all 4 nodes to recover from `BEHIND` to `ACTIVE` after a 1-minute network stall is too tight in CI. The codebase already has an established `RESTART_TO_ACTIVE_TIMEOUT` of 210s used consistently in all other tests (`NodeDeathReconnectBlockNodeSuite`, `MixedOpsNodeDeathReconnectTest`, `LifecycleTest`) for this exact scenario. This change aligns the back pressure test with that standard.

**Related issue(s)**:

Fixes #24804 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
