### PR TITLE
fix: 24802 Disable EVM hook count validation for PreviewNet and TestNet

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/EntityIdCountValidator.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/EntityIdCountValidator.java
@@ -108,7 +108,7 @@ public class EntityIdCountValidator implements LeafBytesValidator {
         }
 
         final boolean ok;
-        if (!NET_NAME.equals("Mainnet")) {
+        if (NET_NAME.equals("Mainnet")) {
             ok = entityCounts.numAccounts() == accountCount.get()
                     && entityCounts.numAliases() == aliasesCount.get()
                     && entityCounts.numTokens() == tokenCount.get()


### PR DESCRIPTION
**Description**:

This PR fixes inverted condition for EntityIdCountValidator.java

**Related issue(s)**:

Fixes #24802 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
