### PR TITLE
fix: gradle test task failing and yahcli tests in CI

### DIFF
--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -155,19 +155,30 @@ jobs:
         # Run each task in isolation with clean builds because we dynamically reconfigure Log4j for each mode
         run: ${GRADLE_EXEC} hapiTestMisc --no-daemon && ${GRADLE_EXEC} hapiTestMiscEmbedded --no-daemon && ${GRADLE_EXEC} hapiTestMiscRepeatable --no-daemon && ${GRADLE_EXEC} hapiTestMiscSerial --no-daemon
 
+      - name: YahCLI Subprocess Regression Tests
+        id: gradle-yahcli-misc
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: ${GRADLE_EXEC} :yahcli:testSubprocess --no-daemon
+
       - name: Publish HAPI Test (Misc) Report
         uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
         with:
           check_name: "Node: HAPI Test (Misc) Results"
           json_thousands_separator: ","
-          junit_files: "**/test-clients/build/test-results/**/TEST-*.xml"
+          junit_files: |
+            **/test-clients/build/test-results/**/TEST-*.xml
+            **/yahcli/build/test-results/**/TEST-*.xml
           comment_mode: errors # only comment if we could not find or parse the JUnit XML files
 
       - name: Upload HAPI Test (Misc) Report Artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: HAPI Test (Misc) Reports
-          path: "**/test-clients/build/test-results/**/TEST-*.xml"
+          path: |
+            **/test-clients/build/test-results/**/TEST-*.xml
+            **/yahcli/build/test-results/**/TEST-*.xml
           retention-days: 7
 
       - name: Detect Flaky Tests (Misc)
@@ -175,25 +186,28 @@ jobs:
         if: ${{ !cancelled() }}
         run: |
           has_flaky="false"
-          if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
+          if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null \
+            || grep -rql "<flakyFailure" hedera-node/yahcli/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
             has_flaky="true"
           fi
           echo "has-flaky=${has_flaky}" >> "${GITHUB_OUTPUT}"
 
       - name: Upload HAPI Test (Misc) Network Logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ !cancelled() && inputs.enable-network-log-capture && (steps.gradle-hapi-misc.conclusion == 'failure' || steps.detect-flaky-hapi-misc.outputs.has-flaky == 'true') }}
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && (steps.gradle-hapi-misc.conclusion == 'failure' || steps.gradle-yahcli-misc.conclusion == 'failure' || steps.detect-flaky-hapi-misc.outputs.has-flaky == 'true') }}
         with:
           name: HAPI Test (Misc) Network Logs
           path: |
             hedera-node/test-clients/build/hapi-test/**/output/**
             hedera-node/test-clients/build/hapi-test/*.log
             hedera-node/test-clients/output/**
+            hedera-node/yahcli/build/hapi-test/**/output/**
+            hedera-node/yahcli/build/hapi-test/**/*.log
           retention-days: 7
 
       - name: Upload HAPI Test (Misc) Failure Artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if: ${{ !cancelled() && (steps.gradle-hapi-misc.conclusion == 'failure' || steps.detect-flaky-hapi-misc.outputs.has-flaky == 'true') }}
+        if: ${{ !cancelled() && (steps.gradle-hapi-misc.conclusion == 'failure' || steps.gradle-yahcli-misc.conclusion == 'failure' || steps.detect-flaky-hapi-misc.outputs.has-flaky == 'true') }}
         with:
           name: HAPI Test (Misc) Failure Artifacts
           path: |
@@ -204,6 +218,9 @@ jobs:
             hedera-node/test-clients/build/hapi-test/**/output/**
             hedera-node/test-clients/build/hapi-test/**/*.log
             hedera-node/test-clients/output/**
+            hedera-node/yahcli/build/reports/tests/testSubprocess/**
+            hedera-node/yahcli/build/hapi-test/**/output/**
+            hedera-node/yahcli/build/hapi-test/**/*.log
           retention-days: 7
 
   hapi-tests-misc-records:

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":swirlds-platform-base-example"))
     // projects that only contain tests (and no production code)
     implementation(project(":test-clients"))
+    implementation(project(":yahcli"))
     implementation(project(":consensus-otter-docker-app"))
     implementation(project(":consensus-otter-tests"))
 }

--- a/hedera-node/yahcli/build.gradle.kts
+++ b/hedera-node/yahcli/build.gradle.kts
@@ -51,7 +51,9 @@ tasks.register<Copy>("copyYahCli") {
 tasks.named("compileTestJava") { mustRunAfter(tasks.named("copyYahCli")) }
 
 tasks.test {
-    useJUnitPlatform {}
+    // Keep default `test` fast and deterministic; subprocess HAPI-style suites run under
+    // `testSubprocess`.
+    useJUnitPlatform { excludeTags("REGRESSION") }
 
     // Limit heap and number of processors
     maxHeapSize = "8g"

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/bdd/YahcliVerbs.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/bdd/YahcliVerbs.java
@@ -43,7 +43,8 @@ public class YahcliVerbs {
             Pattern.compile("freeze scheduled for (\\d{4}-\\d{2}-\\d{2}\\.\\d{2}:\\d{2}:\\d{2})");
     private static final Pattern ABORT_FREEZE_PATTERN =
             Pattern.compile("freeze aborted and/or staged upgrade discarded");
-    private static final Pattern SCHEDULE_ID_PATTERN = Pattern.compile(" with schedule ID (\\d+\\.\\d+\\.\\d+)");
+    private static final Pattern SCHEDULE_ID_PATTERN =
+            Pattern.compile(" (?:with|and) schedule ID (\\d+\\.\\d+\\.\\d+)");
 
     public static final AtomicReference<String> DEFAULT_CONFIG_LOC = new AtomicReference<>();
     public static final AtomicReference<String> DEFAULT_WORKING_DIR = new AtomicReference<>();
@@ -474,7 +475,7 @@ public class YahcliVerbs {
             if (m.find()) {
                 cb.accept(m.group(1));
             } else {
-                Assertions.fail("Expected '" + output + "' to contain '" + SCHEDULE_FREEZE_PATTERN.pattern() + "'");
+                Assertions.fail("Expected '" + output + "' to contain '" + SCHEDULE_ID_PATTERN.pattern() + "'");
             }
         };
     }

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/FreezeCommandsTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/FreezeCommandsTest.java
@@ -2,19 +2,25 @@
 package com.hedera.services.yahcli.test.regression;
 
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.yahcli.test.YahcliTestBase.REGRESSION;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.freezeAbortIsSuccessful;
+import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.newFileHashCapturer;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.scheduleFreezeCapturer;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliFreezeAbort;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliFreezeOnly;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliFreezeUpgrade;
+import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliPrepareUpgrade;
+import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliSysFiles;
 import static java.time.ZoneId.systemDefault;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.services.bdd.junit.HapiTest;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,10 +30,13 @@ import org.junit.jupiter.api.Tag;
 
 @Tag(REGRESSION)
 public class FreezeCommandsTest {
+    private static final String UPDATE_FILE_LOCATION =
+            Path.of("build/resources/test/testFiles").toAbsolutePath().toString();
 
     @HapiTest
     final Stream<DynamicTest> readmeScheduleFreezeExample() {
         final var freezeDate = new AtomicReference<String>();
+        final var fileHash = new AtomicReference<String>();
         final var fiveDaysFromNow = getFiveDaysFromNowString();
         return hapiTest(
                 // vanilla freeze
@@ -35,13 +44,16 @@ public class FreezeCommandsTest {
                         .exposingOutputTo(scheduleFreezeCapturer(freezeDate::set)),
                 doingContextual(spec -> assertEquals(freezeDate.get(), fiveDaysFromNow)),
                 yahcliFreezeAbort().exposingOutputTo(freezeAbortIsSuccessful()),
+                // stage an upgrade before scheduling freeze-upgrade
+                yahcliSysFiles("upload", "-s", UPDATE_FILE_LOCATION, "software-zip"),
+                yahcliSysFiles("hash-check", "software-zip").exposingOutputTo(newFileHashCapturer(fileHash::set)),
+                doingContextual(spec -> assertTrue(!fileHash.get().isBlank())),
+                doingContextual(spec -> allRunFor(spec, yahcliPrepareUpgrade("-f", "150", "-h", fileHash.get()))),
                 // freeze with upgrade
-                yahcliFreezeUpgrade(
-                                "--start-time",
-                                fiveDaysFromNow,
-                                "--upgrade-zip-hash",
-                                "5d3b0e619d8513dfbf606ef00a2e83ba97d736f5f5ba61561d895ea83a6d4c34fce05d6cd74c83ec171f710e37e12aab")
-                        .exposingOutputTo(output -> assertTrue(output.contains("NMT software upgrade in motion from"))),
+                sourcing(
+                        () -> yahcliFreezeUpgrade("--start-time", fiveDaysFromNow, "--upgrade-zip-hash", fileHash.get())
+                                .exposingOutputTo(
+                                        output -> assertTrue(output.contains("NMT software upgrade in motion from")))),
                 yahcliFreezeAbort().exposingOutputTo(freezeAbortIsSuccessful()));
     }
 

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodesCommandsTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodesCommandsTest.java
@@ -35,10 +35,14 @@ public class NodesCommandsTest {
     @HapiTest
     final Stream<DynamicTest> basicNodeCommandsTest() {
         final var newNodeNum = new AtomicLong();
+        final var nodeAccountNum = new AtomicLong();
         final var adminKey = getUniqueAdminKey();
         final var adminKeyFileName = adminKey + ".pem";
         final var certFilePath = loadResourceFile("testFiles/s-public-node1.pem");
         return hapiTest(
+                cryptoCreate("basicNodeAccount")
+                        .balance(100_000_000L)
+                        .exposingCreatedIdTo(id -> nodeAccountNum.set(id.getAccountNum())),
                 newKeyNamed(adminKey)
                         .shape(SigControl.ED25519_ON)
                         .exportingTo(() -> asYcDefaultNetworkKey(adminKeyFileName), "keypass"),
@@ -47,7 +51,7 @@ public class NodesCommandsTest {
                         yahcliNodes(
                                         "create",
                                         "-a",
-                                        "23",
+                                        Long.toString(nodeAccountNum.get()),
                                         "-d",
                                         "Test node",
                                         "-k",
@@ -83,6 +87,7 @@ public class NodesCommandsTest {
     @LeakyHapiTest(overrides = {"nodes.updateAccountIdAllowed"})
     final Stream<DynamicTest> updateNodeAccountIdCommandTest() {
         final var newNodeNum = new AtomicLong();
+        final var nodeCreateAccNum = new AtomicLong();
         final var zeroBalanceAccNum = new AtomicLong();
         final var newAccNum = new AtomicLong();
 
@@ -108,6 +113,10 @@ public class NodesCommandsTest {
                         .balance(100_000_000L)
                         .exposingCreatedIdTo(id -> newAccNum.set(id.getAccountNum())),
                 saveAccountKeyToFile(newAccount),
+                // create account to assign at node-creation time
+                cryptoCreate("nodeCreateAccount")
+                        .balance(100_000_000L)
+                        .exposingCreatedIdTo(id -> nodeCreateAccNum.set(id.getAccountNum())),
 
                 // Create new node
                 doingContextual(spec -> allRunFor(
@@ -115,7 +124,7 @@ public class NodesCommandsTest {
                         yahcliNodes(
                                         "create",
                                         "-a",
-                                        "23",
+                                        Long.toString(nodeCreateAccNum.get()),
                                         "-d",
                                         "Test node",
                                         "-k",
@@ -173,10 +182,14 @@ public class NodesCommandsTest {
     final Stream<DynamicTest> createNodeWithAssociatedRegisteredNode() {
         final var registeredNodeId = new AtomicLong();
         final var newNodeNum = new AtomicLong();
+        final var nodeAccountNum = new AtomicLong();
         final var adminKeyFileName = "create_areg_dab.pem";
         final var rnAdminKeyFile = "create_areg_rn.pem";
         final var certFilePath = loadResourceFile("testFiles/s-public-node1.pem");
         return hapiTest(
+                cryptoCreate("createAssocNodeAccount")
+                        .balance(100_000_000L)
+                        .exposingCreatedIdTo(id -> nodeAccountNum.set(id.getAccountNum())),
                 newKeyNamed("create_areg_dab_key")
                         .shape(SigControl.ED25519_ON)
                         .exportingTo(() -> asYcDefaultNetworkKey(adminKeyFileName), "keypass"),
@@ -197,7 +210,7 @@ public class NodesCommandsTest {
                         sourcing(() -> yahcliNodes(
                                         "create",
                                         "-a",
-                                        "23",
+                                        Long.toString(nodeAccountNum.get()),
                                         "-d",
                                         "Node with associated registered node",
                                         "-k",
@@ -225,10 +238,14 @@ public class NodesCommandsTest {
     final Stream<DynamicTest> updateNodeAssociatedRegisteredNodes() {
         final var registeredNodeId = new AtomicLong();
         final var newNodeNum = new AtomicLong();
+        final var nodeAccountNum = new AtomicLong();
         final var adminKeyFileName = "update_areg_dab.pem";
         final var rnAdminKeyFile = "update_areg_rn.pem";
         final var certFilePath = loadResourceFile("testFiles/s-public-node1.pem");
         return hapiTest(
+                cryptoCreate("updateAssocNodeAccount")
+                        .balance(100_000_000L)
+                        .exposingCreatedIdTo(id -> nodeAccountNum.set(id.getAccountNum())),
                 newKeyNamed("update_areg_dab_key")
                         .shape(SigControl.ED25519_ON)
                         .exportingTo(() -> asYcDefaultNetworkKey(adminKeyFileName), "keypass"),
@@ -249,7 +266,7 @@ public class NodesCommandsTest {
                         yahcliNodes(
                                         "create",
                                         "-a",
-                                        "23",
+                                        Long.toString(nodeAccountNum.get()),
                                         "-d",
                                         "Node to update associations",
                                         "-k",
@@ -283,9 +300,13 @@ public class NodesCommandsTest {
 
     @LeakyHapiTest
     final Stream<DynamicTest> createNodeWithNonExistentAssociatedRegisteredNodeFails() {
+        final var nodeAccountNum = new AtomicLong();
         final var adminKeyFileName = "create_bogus_areg_dab.pem";
         final var certFilePath = loadResourceFile("testFiles/s-public-node1.pem");
         return hapiTest(
+                cryptoCreate("createBogusAssocNodeAccount")
+                        .balance(100_000_000L)
+                        .exposingCreatedIdTo(id -> nodeAccountNum.set(id.getAccountNum())),
                 newKeyNamed("create_bogus_areg_dab_key")
                         .shape(SigControl.ED25519_ON)
                         .exportingTo(() -> asYcDefaultNetworkKey(adminKeyFileName), "keypass"),
@@ -294,7 +315,7 @@ public class NodesCommandsTest {
                         yahcliNodes(
                                         "create",
                                         "-a",
-                                        "23",
+                                        Long.toString(nodeAccountNum.get()),
                                         "-d",
                                         "Node with bogus associated registered node",
                                         "-k",
@@ -316,9 +337,13 @@ public class NodesCommandsTest {
     @LeakyHapiTest
     final Stream<DynamicTest> updateNodeWithNonExistentAssociatedRegisteredNodeFails() {
         final var newNodeNum = new AtomicLong();
+        final var nodeAccountNum = new AtomicLong();
         final var adminKeyFileName = "update_bogus_areg_dab.pem";
         final var certFilePath = loadResourceFile("testFiles/s-public-node1.pem");
         return hapiTest(
+                cryptoCreate("updateBogusAssocNodeAccount")
+                        .balance(100_000_000L)
+                        .exposingCreatedIdTo(id -> nodeAccountNum.set(id.getAccountNum())),
                 newKeyNamed("update_bogus_areg_dab_key")
                         .shape(SigControl.ED25519_ON)
                         .exportingTo(() -> asYcDefaultNetworkKey(adminKeyFileName), "keypass"),
@@ -327,7 +352,7 @@ public class NodesCommandsTest {
                         yahcliNodes(
                                         "create",
                                         "-a",
-                                        "23",
+                                        Long.toString(nodeAccountNum.get()),
                                         "-d",
                                         "Node to update with bogus association",
                                         "-k",


### PR DESCRIPTION
**Description**:

This pull request fixes the failures in the gradle test task related to YahCLI. It also enhances the YahCLI regression test coverage, improves reliability in node creation tests, and updates the CI workflow to better handle YahCLI test results and artifacts. The most significant changes are grouped below by theme.

**CI Workflow and Reporting Improvements:**

* Added a YahCLI subprocess regression test step to the `.github/workflows/zxc-execute-hapi-tests.yaml` workflow, ensuring YahCLI tests are run and their results are included in published reports and artifact uploads. Also updated flaky test detection and artifact upload conditions to cover YahCLI test outcomes. 
* Updated the `gradle/aggregation/build.gradle.kts` to include the `yahcli` project as a dependency, ensuring its tests are aggregated and executed in the build.

**YahCLI Test Enhancements:**

* Modified the YahCLI test suite so that the default `test` task excludes regression-tagged tests; regression tests now run under a dedicated `testSubprocess` task.
* Improved the schedule ID pattern in `YahcliVerbs.java` to match both "with" and "and" schedule ID output formats and fixed an assertion message to reference the correct pattern. 

**Regression Test Coverage and Reliability:**

* Updated `FreezeCommandsTest.java` to dynamically compute and use the software update file hash instead of hardcoding it, ensuring the test is robust to changes in the update file.
* Refactored all node creation tests in `NodesCommandsTest.java` to create and use new accounts for the node account number instead of hardcoding values, improving test isolation and reliability. This affects basic node commands, account ID updates, associated registered node creation, and negative test cases. 

**Related issue(s)**:

Fixes #24897 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
