### PR TITLE
chore: Disable Hooks

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HooksConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HooksConfig.java
@@ -13,7 +13,7 @@ public record HooksConfig(
         @ConfigProperty(defaultValue = "10") @NetworkProperty
         int maxHookInvocationsPerTransaction,
 
-        @ConfigProperty(defaultValue = "true") @NetworkProperty
+        @ConfigProperty(defaultValue = "false") @NetworkProperty
         boolean hooksEnabled,
 
         @ConfigProperty(defaultValue = "5000000") @NetworkProperty

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoTransferSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoTransferSimpleFeesSuite.java
@@ -4,20 +4,16 @@ package com.hedera.services.bdd.suites.fees;
 import static com.google.protobuf.ByteString.copyFromUtf8;
 import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.royaltyFeeNoFallback;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
@@ -53,8 +49,6 @@ public class CryptoTransferSimpleFeesSuite {
     private static final double ADDITIONAL_ACCOUNT_FEE = 0.0001;
     private static final double TOKEN_TYPES_EXTRA_FEE = 0.0001;
     private static final double ADDITIONAL_NFT_SERIAL_FEE = 0.0001;
-    private static final double HOOK_INVOCATION_USD = 0.005;
-    private static final double NFT_TRANSFER_BASE_USD = 0.001;
 
     // Entity names
     private static final String PAYER = "payer";
@@ -67,11 +61,10 @@ public class CryptoTransferSimpleFeesSuite {
     private static final String FUNGIBLE_TOKEN_WITH_FEES = "fungibleTokenWithFees";
     private static final String NFT_TOKEN = "nftToken";
     private static final String NFT_TOKEN_WITH_FEES = "nftTokenWithFees";
-    private static final String HOOK_CONTRACT = "TruePreHook";
 
     @BeforeAll
     public static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
     }
 
     // ==================== FEE TIER TESTS ====================
@@ -400,94 +393,6 @@ public class CryptoTransferSimpleFeesSuite {
                 // + 3 fungible tokens
                 // + 3 NFT serials (6 total - 1 included)
                 validateChargedUsd("complexTxn", TOKEN_TRANSFER_CUSTOM_FEE + 5 * TOKEN_TYPES_EXTRA_FEE));
-    }
-
-    // ==================== HOOK TESTS ====================
-
-    @HapiTest
-    @DisplayName("HOOKS: HBAR transfer with single hook")
-    final Stream<DynamicTest> hbarTransferWithHook() {
-        return hapiTest(
-                uploadInitCode(HOOK_CONTRACT),
-                contractCreate(HOOK_CONTRACT).gas(5_000_000),
-                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS).withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
-                cryptoCreate(RECEIVER).balance(0L),
-                cryptoTransfer(movingHbar(ONE_HBAR).between(PAYER, RECEIVER))
-                        .withPreHookFor(PAYER, 1L, 5_000_000L, "")
-                        .payingWith(PAYER)
-                        .signedBy(PAYER)
-                        .fee(50 * ONE_HBAR)
-                        .via("hbarWithHookTxn"),
-                sourcingContextual(spec -> {
-                    final long tinybarGasCost =
-                            5_000_000L * spec.ratesProvider().currentTinybarGasPrice();
-                    final double usdGasCost = spec.ratesProvider().toUsdWithActiveRates(tinybarGasCost);
-                    return validateChargedUsd("hbarWithHookTxn", HBAR_TRANSFER_FEE + HOOK_INVOCATION_USD + usdGasCost);
-                }));
-    }
-
-    @HapiTest
-    @DisplayName("HOOKS: Token transfer with single hook")
-    final Stream<DynamicTest> tokenTransferWithHook() {
-        return hapiTest(
-                uploadInitCode(HOOK_CONTRACT),
-                contractCreate(HOOK_CONTRACT).gas(5_000_000),
-                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS).withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
-                cryptoCreate(RECEIVER).balance(0L),
-                tokenCreate(FUNGIBLE_TOKEN)
-                        .tokenType(FUNGIBLE_COMMON)
-                        .initialSupply(1000L)
-                        .treasury(PAYER)
-                        .fee(ONE_HUNDRED_HBARS)
-                        .payingWith(PAYER),
-                tokenAssociate(RECEIVER, FUNGIBLE_TOKEN),
-                cryptoTransfer(moving(100, FUNGIBLE_TOKEN).between(PAYER, RECEIVER))
-                        .withPreHookFor(PAYER, 1L, 5_000_000L, "")
-                        .payingWith(PAYER)
-                        .signedBy(PAYER)
-                        .fee(50 * ONE_HBAR)
-                        .via("tokenWithHookTxn"),
-                sourcingContextual(spec -> {
-                    final long tinybarGasCost =
-                            5_000_000L * spec.ratesProvider().currentTinybarGasPrice();
-                    final double usdGasCost = spec.ratesProvider().toUsdWithActiveRates(tinybarGasCost);
-                    return validateChargedUsd(
-                            "tokenWithHookTxn", TOKEN_TRANSFER_FEE + HOOK_INVOCATION_USD + usdGasCost);
-                }));
-    }
-
-    @HapiTest
-    @DisplayName("HOOKS: NFT transfer with multiple hooks (sender + receiver)")
-    final Stream<DynamicTest> nftTransferWithMultipleHooks() {
-        return hapiTest(
-                uploadInitCode(HOOK_CONTRACT),
-                contractCreate(HOOK_CONTRACT).gas(5_000_000),
-                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS).withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
-                cryptoCreate(RECEIVER).balance(ONE_HUNDRED_HBARS).withHook(accountAllowanceHook(2L, HOOK_CONTRACT)),
-                tokenCreate(NFT_TOKEN)
-                        .tokenType(NON_FUNGIBLE_UNIQUE)
-                        .initialSupply(0L)
-                        .supplyKey(PAYER)
-                        .treasury(PAYER)
-                        .fee(ONE_HUNDRED_HBARS)
-                        .payingWith(PAYER),
-                mintToken(NFT_TOKEN, List.of(metadata(1))),
-                tokenAssociate(RECEIVER, NFT_TOKEN),
-                cryptoTransfer(movingUnique(NFT_TOKEN, 1L).between(PAYER, RECEIVER))
-                        .withNftSenderPreHookFor(PAYER, 1L, 5_000_000L, "")
-                        .withNftReceiverPreHookFor(RECEIVER, 2L, 5_000_000L, "")
-                        .payingWith(PAYER)
-                        .signedBy(PAYER)
-                        .fee(50 * ONE_HBAR)
-                        .via("nftWithHooksTxn"),
-                // 2 hooks (sender + receiver)
-                sourcingContextual(spec -> {
-                    final long tinybarGasCost =
-                            5_000_000L * 2 * spec.ratesProvider().currentTinybarGasPrice();
-                    final double usdGasCost = spec.ratesProvider().toUsdWithActiveRates(tinybarGasCost);
-                    return validateChargedUsd(
-                            "nftWithHooksTxn", NFT_TRANSFER_BASE_USD + 2 * HOOK_INVOCATION_USD + usdGasCost);
-                }));
     }
 
     private static ByteString metadata(final int idNumber) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoTransferWithHooksSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoTransferWithHooksSimpleFeesSuite.java
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.fees;
+
+import static com.google.protobuf.ByteString.copyFromUtf8;
+import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
+import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@Tag(SIMPLE_FEES)
+@OrderedInIsolation
+@HapiTestLifecycle
+public class CryptoTransferWithHooksSimpleFeesSuite {
+    private static final double HBAR_TRANSFER_FEE = 0.0001;
+    private static final double TOKEN_TRANSFER_FEE = 0.001;
+    private static final double HOOK_INVOCATION_USD = 0.005;
+    private static final double NFT_TRANSFER_BASE_USD = 0.001;
+
+    private static final String PAYER = "payer";
+    private static final String RECEIVER = "receiver";
+    private static final String FUNGIBLE_TOKEN = "fungibleToken";
+    private static final String NFT_TOKEN = "nftToken";
+    private static final String HOOK_CONTRACT = "TruePreHook";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true", "hooks.hooksEnabled", "true"));
+    }
+
+    @HapiTest
+    @DisplayName("HOOKS: HBAR transfer with single hook")
+    final Stream<DynamicTest> hbarTransferWithHook() {
+        return hapiTest(
+                uploadInitCode(HOOK_CONTRACT),
+                contractCreate(HOOK_CONTRACT).gas(5_000_000),
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS).withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
+                cryptoCreate(RECEIVER).balance(0L),
+                cryptoTransfer(movingHbar(ONE_HBAR).between(PAYER, RECEIVER))
+                        .withPreHookFor(PAYER, 1L, 5_000_000L, "")
+                        .payingWith(PAYER)
+                        .signedBy(PAYER)
+                        .fee(50 * ONE_HBAR)
+                        .via("hbarWithHookTxn"),
+                sourcingContextual(spec -> {
+                    final long tinybarGasCost =
+                            5_000_000L * spec.ratesProvider().currentTinybarGasPrice();
+                    final double usdGasCost = spec.ratesProvider().toUsdWithActiveRates(tinybarGasCost);
+                    return validateChargedUsd("hbarWithHookTxn", HBAR_TRANSFER_FEE + HOOK_INVOCATION_USD + usdGasCost);
+                }));
+    }
+
+    @HapiTest
+    @DisplayName("HOOKS: Token transfer with single hook")
+    final Stream<DynamicTest> tokenTransferWithHook() {
+        return hapiTest(
+                uploadInitCode(HOOK_CONTRACT),
+                contractCreate(HOOK_CONTRACT).gas(5_000_000),
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS).withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
+                cryptoCreate(RECEIVER).balance(0L),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .initialSupply(1000L)
+                        .treasury(PAYER)
+                        .fee(ONE_HUNDRED_HBARS)
+                        .payingWith(PAYER),
+                tokenAssociate(RECEIVER, FUNGIBLE_TOKEN),
+                cryptoTransfer(moving(100, FUNGIBLE_TOKEN).between(PAYER, RECEIVER))
+                        .withPreHookFor(PAYER, 1L, 5_000_000L, "")
+                        .payingWith(PAYER)
+                        .signedBy(PAYER)
+                        .fee(50 * ONE_HBAR)
+                        .via("tokenWithHookTxn"),
+                sourcingContextual(spec -> {
+                    final long tinybarGasCost =
+                            5_000_000L * spec.ratesProvider().currentTinybarGasPrice();
+                    final double usdGasCost = spec.ratesProvider().toUsdWithActiveRates(tinybarGasCost);
+                    return validateChargedUsd(
+                            "tokenWithHookTxn", TOKEN_TRANSFER_FEE + HOOK_INVOCATION_USD + usdGasCost);
+                }));
+    }
+
+    @HapiTest
+    @DisplayName("HOOKS: NFT transfer with multiple hooks (sender + receiver)")
+    final Stream<DynamicTest> nftTransferWithMultipleHooks() {
+        return hapiTest(
+                uploadInitCode(HOOK_CONTRACT),
+                contractCreate(HOOK_CONTRACT).gas(5_000_000),
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS).withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
+                cryptoCreate(RECEIVER).balance(ONE_HUNDRED_HBARS).withHook(accountAllowanceHook(2L, HOOK_CONTRACT)),
+                tokenCreate(NFT_TOKEN)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0L)
+                        .supplyKey(PAYER)
+                        .treasury(PAYER)
+                        .fee(ONE_HUNDRED_HBARS)
+                        .payingWith(PAYER),
+                mintToken(NFT_TOKEN, List.of(metadata(1))),
+                tokenAssociate(RECEIVER, NFT_TOKEN),
+                cryptoTransfer(movingUnique(NFT_TOKEN, 1L).between(PAYER, RECEIVER))
+                        .withNftSenderPreHookFor(PAYER, 1L, 5_000_000L, "")
+                        .withNftReceiverPreHookFor(RECEIVER, 2L, 5_000_000L, "")
+                        .payingWith(PAYER)
+                        .signedBy(PAYER)
+                        .fee(50 * ONE_HBAR)
+                        .via("nftWithHooksTxn"),
+                sourcingContextual(spec -> {
+                    final long tinybarGasCost =
+                            5_000_000L * 2 * spec.ratesProvider().currentTinybarGasPrice();
+                    final double usdGasCost = spec.ratesProvider().toUsdWithActiveRates(tinybarGasCost);
+                    return validateChargedUsd(
+                            "nftWithHooksTxn", NFT_TRANSFER_BASE_USD + 2 * HOOK_INVOCATION_USD + usdGasCost);
+                }));
+    }
+
+    private static ByteString metadata(final int idNumber) {
+        return copyFromUtf8("metadata" + idNumber);
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1195/Hip1195StreamParityTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1195/Hip1195StreamParityTest.java
@@ -54,6 +54,7 @@ import com.esaulpaugh.headlong.abi.TupleType;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.annotations.FungibleToken;
@@ -77,8 +78,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 
-// Hooks are enabled by default so it is safe to run this concurrently
+// This class uses class-scoped hook overrides and must not share a concurrent subprocess network.
 @HapiTestLifecycle
+@OrderedInIsolation
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class Hip1195StreamParityTest {
     public static final String HOOK_CONTRACT_NUM = "365";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1195/HookTimingBalanceOrderTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1195/HookTimingBalanceOrderTest.java
@@ -24,6 +24,7 @@ import com.hedera.hapi.node.base.HookCall;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
@@ -38,8 +39,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 
-// Hooks are enabled by default so it is safe to run this concurrently
+// This class uses class-scoped hook overrides and must not share a concurrent subprocess network.
 @HapiTestLifecycle
+@OrderedInIsolation
 public class HookTimingBalanceOrderTest {
     private static final String OWNER = "owner";
     private static final String RECEIVER = "receiver";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateSimpleFeesTest.java
@@ -14,11 +14,8 @@ import static com.hedera.services.bdd.spec.keys.SigControl.OFF;
 import static com.hedera.services.bdd.spec.keys.SigControl.ON;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
@@ -44,7 +41,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MEMO_TOO_LONG;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECORD_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_EXPIRED;
 import static org.hiero.base.utility.CommonUtils.hex;
-import static org.hiero.hapi.support.fees.Extra.HOOK_EXECUTION;
 import static org.hiero.hapi.support.fees.Extra.KEYS;
 import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
 import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
@@ -88,7 +84,6 @@ public class CryptoCreateSimpleFeesTest {
     private static final String PAYER = "payer";
     private static final String ADMIN_KEY = "adminKey";
     private static final String PAYER_KEY = "payerKey";
-    private static final String HOOK_CONTRACT = "TruePreHook";
     private static final String VALID_ALIAS_ED25519_KEY = "ValidAliasEd25519Key";
     private static final String DUPLICATE_TXN_ID = "duplicateTxnId";
     private static final String NEW_KEY = "newPayerKey";
@@ -96,9 +91,7 @@ public class CryptoCreateSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
     }
 
     @Nested
@@ -221,88 +214,6 @@ public class CryptoCreateSimpleFeesTest {
                             txnSize -> expectedCryptoCreateFullFeeUsd(Map.of(
                                     SIGNATURES, 2L,
                                     KEYS, 2L,
-                                    PROCESSING_BYTES, (long) txnSize)),
-                            0.0001));
-        }
-
-        @HapiTest
-        @DisplayName("CryptoCreate - with hook creation details - full charging without extras")
-        Stream<DynamicTest> cryptoCreateWithIncludedSigAndHook() {
-            return hapiTest(
-                    uploadInitCode(HOOK_CONTRACT),
-                    contractCreate(HOOK_CONTRACT).gas(5_000_000L),
-                    cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
-                    cryptoCreate("testAccount")
-                            .withHooks(accountAllowanceHook(1L, HOOK_CONTRACT))
-                            .payingWith(PAYER)
-                            .signedBy(PAYER)
-                            .fee(ONE_HUNDRED_HBARS)
-                            .via("cryptoCreateTxn"),
-                    validateChargedUsdWithinWithTxnSize(
-                            "cryptoCreateTxn",
-                            txnSize -> expectedCryptoCreateFullFeeUsd(Map.of(
-                                    SIGNATURES, 1L,
-                                    HOOK_EXECUTION, 1L,
-                                    PROCESSING_BYTES, (long) txnSize)),
-                            0.0001));
-        }
-
-        @HapiTest
-        @DisplayName("CryptoCreate - with included hook, signature and key - full charging without extras")
-        Stream<DynamicTest> cryptoCreateWithIncludedHookSigAndKey() {
-            return hapiTest(
-                    uploadInitCode(HOOK_CONTRACT),
-                    contractCreate(HOOK_CONTRACT).gas(5_000_000L),
-                    cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
-                    newKeyNamed(ADMIN_KEY),
-                    cryptoCreate("testAccount")
-                            .withHooks(accountAllowanceHook(1L, HOOK_CONTRACT))
-                            .key(ADMIN_KEY)
-                            .payingWith(PAYER)
-                            .signedBy(PAYER)
-                            .fee(ONE_HUNDRED_HBARS)
-                            .via("cryptoCreateTxn"),
-                    validateChargedUsdWithinWithTxnSize(
-                            "cryptoCreateTxn",
-                            txnSize -> expectedCryptoCreateFullFeeUsd(Map.of(
-                                    SIGNATURES, 1L,
-                                    KEYS, 1L,
-                                    HOOK_EXECUTION, 1L,
-                                    PROCESSING_BYTES, (long) txnSize)),
-                            0.0001));
-        }
-
-        @HapiTest
-        @DisplayName("CryptoCreate - with extra hooks, signatures and keys - full charging without extras")
-        Stream<DynamicTest> cryptoCreateWithExtraHookSigAndKey() {
-            // Define a threshold submit key that requires two simple keys signatures
-            KeyShape keyShape = threshOf(2, SIMPLE, SIMPLE);
-
-            // Create a valid signature with both simple keys signing
-            SigControl validSig = keyShape.signedWith(sigs(ON, ON));
-            return hapiTest(
-                    uploadInitCode(HOOK_CONTRACT),
-                    contractCreate(HOOK_CONTRACT).gas(5_000_000L),
-                    newKeyNamed(PAYER_KEY).shape(keyShape),
-                    cryptoCreate(PAYER)
-                            .key(PAYER_KEY)
-                            .sigControl(forKey(PAYER_KEY, validSig))
-                            .balance(ONE_HUNDRED_HBARS),
-                    cryptoCreate("testAccount")
-                            .memo("Test")
-                            .key(PAYER_KEY)
-                            .sigControl(forKey(PAYER_KEY, validSig))
-                            .withHooks(accountAllowanceHook(2L, HOOK_CONTRACT), accountAllowanceHook(3L, HOOK_CONTRACT))
-                            .payingWith(PAYER)
-                            .signedBy(PAYER_KEY)
-                            .fee(ONE_HUNDRED_HBARS)
-                            .via("cryptoCreateTxn"),
-                    validateChargedUsdWithinWithTxnSize(
-                            "cryptoCreateTxn",
-                            txnSize -> expectedCryptoCreateFullFeeUsd(Map.of(
-                                    SIGNATURES, 2L,
-                                    KEYS, 2L,
-                                    HOOK_EXECUTION, 2L,
                                     PROCESSING_BYTES, (long) txnSize)),
                             0.0001));
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateWithHooksSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateWithHooksSimpleFeesTest.java
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.hip1261;
+
+import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.keys.ControlForKey.forKey;
+import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
+import static com.hedera.services.bdd.spec.keys.KeyShape.sigs;
+import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
+import static com.hedera.services.bdd.spec.keys.SigControl.ON;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoCreateFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateChargedUsdWithinWithTxnSize;
+import static org.hiero.hapi.support.fees.Extra.HOOK_EXECUTION;
+import static org.hiero.hapi.support.fees.Extra.KEYS;
+import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
+import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
+
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.keys.SigControl;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@Tag(SIMPLE_FEES)
+@OrderedInIsolation
+@HapiTestLifecycle
+public class CryptoCreateWithHooksSimpleFeesTest {
+    private static final String PAYER = "payer";
+    private static final String ADMIN_KEY = "adminKey";
+    private static final String PAYER_KEY = "payerKey";
+    private static final String HOOK_CONTRACT = "TruePreHook";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true", "hooks.hooksEnabled", "true"));
+    }
+
+    @HapiTest
+    @DisplayName("CryptoCreate - with hook creation details - full charging without extras")
+    Stream<DynamicTest> cryptoCreateWithIncludedSigAndHook() {
+        return hapiTest(
+                uploadInitCode(HOOK_CONTRACT),
+                contractCreate(HOOK_CONTRACT).gas(5_000_000L),
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("testAccount")
+                        .withHooks(accountAllowanceHook(1L, HOOK_CONTRACT))
+                        .payingWith(PAYER)
+                        .signedBy(PAYER)
+                        .fee(ONE_HUNDRED_HBARS)
+                        .via("cryptoCreateTxn"),
+                validateChargedUsdWithinWithTxnSize(
+                        "cryptoCreateTxn",
+                        txnSize -> expectedCryptoCreateFullFeeUsd(Map.of(
+                                SIGNATURES, 1L,
+                                HOOK_EXECUTION, 1L,
+                                PROCESSING_BYTES, (long) txnSize)),
+                        0.0001));
+    }
+
+    @HapiTest
+    @DisplayName("CryptoCreate - with included hook, signature and key - full charging without extras")
+    Stream<DynamicTest> cryptoCreateWithIncludedHookSigAndKey() {
+        return hapiTest(
+                uploadInitCode(HOOK_CONTRACT),
+                contractCreate(HOOK_CONTRACT).gas(5_000_000L),
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                newKeyNamed(ADMIN_KEY),
+                cryptoCreate("testAccount")
+                        .withHooks(accountAllowanceHook(1L, HOOK_CONTRACT))
+                        .key(ADMIN_KEY)
+                        .payingWith(PAYER)
+                        .signedBy(PAYER)
+                        .fee(ONE_HUNDRED_HBARS)
+                        .via("cryptoCreateTxn"),
+                validateChargedUsdWithinWithTxnSize(
+                        "cryptoCreateTxn",
+                        txnSize -> expectedCryptoCreateFullFeeUsd(Map.of(
+                                SIGNATURES, 1L,
+                                KEYS, 1L,
+                                HOOK_EXECUTION, 1L,
+                                PROCESSING_BYTES, (long) txnSize)),
+                        0.0001));
+    }
+
+    @HapiTest
+    @DisplayName("CryptoCreate - with extra hooks, signatures and keys - full charging without extras")
+    Stream<DynamicTest> cryptoCreateWithExtraHookSigAndKey() {
+        final KeyShape keyShape = threshOf(2, SIMPLE, SIMPLE);
+        final SigControl validSig = keyShape.signedWith(sigs(ON, ON));
+        return hapiTest(
+                uploadInitCode(HOOK_CONTRACT),
+                contractCreate(HOOK_CONTRACT).gas(5_000_000L),
+                newKeyNamed(PAYER_KEY).shape(keyShape),
+                cryptoCreate(PAYER)
+                        .key(PAYER_KEY)
+                        .sigControl(forKey(PAYER_KEY, validSig))
+                        .balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("testAccount")
+                        .memo("Test")
+                        .key(PAYER_KEY)
+                        .sigControl(forKey(PAYER_KEY, validSig))
+                        .withHooks(accountAllowanceHook(2L, HOOK_CONTRACT), accountAllowanceHook(3L, HOOK_CONTRACT))
+                        .payingWith(PAYER)
+                        .signedBy(PAYER_KEY)
+                        .fee(ONE_HUNDRED_HBARS)
+                        .via("cryptoCreateTxn"),
+                validateChargedUsdWithinWithTxnSize(
+                        "cryptoCreateTxn",
+                        txnSize -> expectedCryptoCreateFullFeeUsd(Map.of(
+                                SIGNATURES, 2L,
+                                KEYS, 2L,
+                                HOOK_EXECUTION, 2L,
+                                PROCESSING_BYTES, (long) txnSize)),
+                        0.0001));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferSimpleFeesTest.java
@@ -17,14 +17,11 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
@@ -110,9 +107,6 @@ public class CryptoTransferSimpleFeesTest {
     private static final String PAYER = "payer";
     private static final String THRESHOLD_PAYER = "thresholdPayer";
     private static final String PAYER_INSUFFICIENT_BALANCE = "payerInsufficientBalance";
-    private static final String PAYER_WITH_HOOK = "payerWithHook";
-    private static final String PAYER_WITH_TWO_HOOKS = "payerWithTwoHooks";
-    private static final String PAYER_WITH_THREE_HOOKS = "payerWithThreeHooks";
     private static final String RECEIVER_ASSOCIATED_FIRST = "receiverAssociatedFirst";
     private static final String RECEIVER_ASSOCIATED_SECOND = "receiverAssociatedSecond";
     private static final String RECEIVER_ASSOCIATED_THIRD = "receiverAssociatedThird";
@@ -137,13 +131,9 @@ public class CryptoTransferSimpleFeesTest {
     private static final String adminKey = "adminKey";
     private static final String supplyKey = "supplyKey";
     private static final String PAYER_KEY = "payerKey";
-    private static final String HOOK_CONTRACT = "TruePreHook";
-
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
     }
 
     @Nested
@@ -2154,332 +2144,6 @@ public class CryptoTransferSimpleFeesTest {
                                     .hasTokenBalance(FUNGIBLE_TOKEN_2, 90L)));
                 }
             }
-
-            @Nested
-            @DisplayName("Crypto Transfer With Hooks - Simple Fees Positive Tests")
-            class CryptoTransferWithHooksSimpleFeesPositiveTests {
-                @HapiTest
-                @DisplayName("Crypto Transfer HBAR with hook execution - extra hook full charging")
-                final Stream<DynamicTest> cryptoTransferHBARWithOneHookExtraHookFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-
-                            // transfer tokens
-                            cryptoTransfer(movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST))
-                                    .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK)
-                                    .fee(ONE_MILLION_HBARS)
-                                    .via("hbarTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "hbarTransferTxn",
-                                    txnSize -> expectedCryptoTransferHbarFullFeeUsd(Map.of(
-                                            SIGNATURES, 1L,
-                                            HOOK_EXECUTION, 1L,
-                                            ACCOUNTS, 2L,
-                                            GAS, 5_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001)));
-                }
-
-                @HapiTest
-                @DisplayName("Crypto Transfer FT with hook execution - extra hook full charging")
-                final Stream<DynamicTest> cryptoTransferFTWithOneHookExtraHookFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_HOOK, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FUNGIBLE_TOKEN),
-
-                            // transfer tokens
-                            cryptoTransfer(moving(10L, FUNGIBLE_TOKEN)
-                                            .between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST))
-                                    .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK)
-                                    .fee(ONE_HUNDRED_HBARS)
-                                    .via("ftTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "ftTransferTxn",
-                                    txnSize -> expectedCryptoTransferFTFullFeeUsd(Map.of(
-                                            SIGNATURES, 1L,
-                                            HOOK_EXECUTION, 1L,
-                                            ACCOUNTS, 2L,
-                                            TOKEN_TYPES, 1L,
-                                            GAS, 5_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001),
-                            getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 90L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(FUNGIBLE_TOKEN, 10L)));
-                }
-
-                @HapiTest
-                @DisplayName("Crypto Transfer FT with same hook executed twice - extra hook full charging")
-                final Stream<DynamicTest> cryptoTransferFTWithOneHookExecutedTwiceExtraHookFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_HOOK, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FUNGIBLE_TOKEN),
-                            tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FUNGIBLE_TOKEN),
-
-                            // transfer tokens
-                            cryptoTransfer(
-                                            moving(10L, FUNGIBLE_TOKEN)
-                                                    .between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
-                                            moving(10L, FUNGIBLE_TOKEN)
-                                                    .between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_SECOND))
-                                    .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK)
-                                    .fee(ONE_HUNDRED_HBARS)
-                                    .via("ftTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "ftTransferTxn",
-                                    txnSize -> expectedCryptoTransferFTFullFeeUsd(Map.of(
-                                            SIGNATURES, 1L,
-                                            HOOK_EXECUTION, 1L,
-                                            ACCOUNTS, 3L,
-                                            TOKEN_TYPES, 1L,
-                                            GAS, 5_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001),
-                            getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 80L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(FUNGIBLE_TOKEN, 10L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_SECOND).hasTokenBalance(FUNGIBLE_TOKEN, 10L)));
-                }
-
-                @HapiTest
-                @DisplayName("Crypto Transfer NFT with hook execution - extra hook full charging")
-                final Stream<DynamicTest> cryptoTransferNFTWithOneHookExtraHookFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createNonFungibleTokenWithoutCustomFees(
-                                    NON_FUNGIBLE_TOKEN, PAYER_WITH_HOOK, supplyKey, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NON_FUNGIBLE_TOKEN),
-                            mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
-
-                            // transfer tokens
-                            cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L)
-                                            .between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST))
-                                    .withNftSenderPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK)
-                                    .fee(ONE_HUNDRED_HBARS)
-                                    .via("nftTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "nftTransferTxn",
-                                    txnSize -> expectedCryptoTransferNFTFullFeeUsd(Map.of(
-                                            SIGNATURES, 1L,
-                                            HOOK_EXECUTION, 1L,
-                                            ACCOUNTS, 2L,
-                                            TOKEN_TYPES, 1L,
-                                            GAS, 5_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001),
-                            getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(NON_FUNGIBLE_TOKEN, 3L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L)));
-                }
-
-                @HapiTest
-                @DisplayName("Crypto Transfer HBAR and FT with hook execution - extra hooks full charging")
-                final Stream<DynamicTest> cryptoTransferHBARAndFtWithTwoHooksExtraHookFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_TWO_HOOKS, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FUNGIBLE_TOKEN),
-
-                            // transfer tokens
-                            cryptoTransfer(
-                                            movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
-                                            moving(10L, FUNGIBLE_TOKEN)
-                                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
-                                    .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
-                                    .withPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK, PAYER_WITH_TWO_HOOKS)
-                                    .fee(ONE_HUNDRED_HBARS)
-                                    .via("tokenTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "tokenTransferTxn",
-                                    txnSize -> expectedCryptoTransferHBARAndFTFullFeeUsd(Map.of(
-                                            SIGNATURES, 2L,
-                                            HOOK_EXECUTION, 2L,
-                                            ACCOUNTS, 3L,
-                                            TOKEN_TYPES, 1L,
-                                            GAS, 10_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001),
-                            getAccountBalance(PAYER_WITH_TWO_HOOKS).hasTokenBalance(FUNGIBLE_TOKEN, 90L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(FUNGIBLE_TOKEN, 10L)));
-                }
-
-                @HapiTest
-                @DisplayName("Crypto Transfer HBAR and NFT with hook execution - extra hooks full charging")
-                final Stream<DynamicTest> cryptoTransferHBARAndNFtWithOneHookExtraHookFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createNonFungibleTokenWithoutCustomFees(
-                                    NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NON_FUNGIBLE_TOKEN),
-                            mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
-
-                            // transfer tokens
-                            cryptoTransfer(
-                                            movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
-                                            movingUnique(NON_FUNGIBLE_TOKEN, 1L)
-                                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
-                                    .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
-                                    .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK, PAYER_WITH_TWO_HOOKS)
-                                    .fee(ONE_HUNDRED_HBARS)
-                                    .via("tokenTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "tokenTransferTxn",
-                                    txnSize -> expectedCryptoTransferHBARAndNFTFullFeeUsd(Map.of(
-                                            SIGNATURES, 2L,
-                                            HOOK_EXECUTION, 2L,
-                                            ACCOUNTS, 3L,
-                                            TOKEN_TYPES, 1L,
-                                            GAS, 10_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001),
-                            getAccountBalance(PAYER_WITH_TWO_HOOKS).hasTokenBalance(NON_FUNGIBLE_TOKEN, 3L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L)));
-                }
-
-                @HapiTest
-                @DisplayName(
-                        "Crypto Transfer HBAR, FT and NFT with hook execution - extra hooks and accounts full charging")
-                final Stream<DynamicTest> cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndAccountsFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_TWO_HOOKS, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FUNGIBLE_TOKEN),
-                            createNonFungibleTokenWithoutCustomFees(
-                                    NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NON_FUNGIBLE_TOKEN),
-                            mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
-
-                            // transfer tokens
-                            cryptoTransfer(
-                                            movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
-                                            moving(10L, FUNGIBLE_TOKEN)
-                                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_SECOND),
-                                            movingUnique(NON_FUNGIBLE_TOKEN, 1L)
-                                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD))
-                                    .withPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 5_000_000L, "")
-                                    .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK, PAYER_WITH_TWO_HOOKS)
-                                    .fee(ONE_MILLION_HBARS)
-                                    .via("tokenTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "tokenTransferTxn",
-                                    txnSize -> expectedCryptoTransferHBARAndFTAndNFTFullFeeUsd(Map.of(
-                                            SIGNATURES, 2L,
-                                            HOOK_EXECUTION, 2L,
-                                            ACCOUNTS, 5L,
-                                            TOKEN_TYPES, 2L,
-                                            GAS, 10_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001),
-                            getAccountBalance(PAYER_WITH_TWO_HOOKS)
-                                    .hasTokenBalance(FUNGIBLE_TOKEN, 90L)
-                                    .hasTokenBalance(NON_FUNGIBLE_TOKEN, 3L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_SECOND).hasTokenBalance(FUNGIBLE_TOKEN, 10L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_THIRD).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L)));
-                }
-
-                @HapiTest
-                @DisplayName(
-                        "Crypto Transfer HBAR, FT and NFT with hook execution - extra hooks, tokens and accounts full charging")
-                final Stream<DynamicTest>
-                        cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndTokensAndAccountsFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_TWO_HOOKS, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FUNGIBLE_TOKEN),
-                            createNonFungibleTokenWithoutCustomFees(
-                                    NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
-                            tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NON_FUNGIBLE_TOKEN),
-                            mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
-
-                            // transfer tokens
-                            cryptoTransfer(
-                                            movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
-                                            moving(10L, FUNGIBLE_TOKEN)
-                                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_SECOND),
-                                            movingUnique(NON_FUNGIBLE_TOKEN, 1L)
-                                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD))
-                                    .withPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 5_000_000L, "")
-                                    .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK, PAYER_WITH_TWO_HOOKS)
-                                    .fee(ONE_HUNDRED_HBARS)
-                                    .via("tokenTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "tokenTransferTxn",
-                                    txnSize -> expectedCryptoTransferHBARAndFTAndNFTFullFeeUsd(Map.of(
-                                            SIGNATURES, 2L,
-                                            HOOK_EXECUTION, 2L,
-                                            ACCOUNTS, 5L,
-                                            TOKEN_TYPES, 2L,
-                                            GAS, 10_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001),
-                            getAccountBalance(PAYER_WITH_TWO_HOOKS)
-                                    .hasTokenBalance(FUNGIBLE_TOKEN, 90L)
-                                    .hasTokenBalance(NON_FUNGIBLE_TOKEN, 3L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_SECOND).hasTokenBalance(FUNGIBLE_TOKEN, 10L),
-                            getAccountBalance(RECEIVER_ASSOCIATED_THIRD).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L)));
-                }
-
-                @HapiTest
-                @DisplayName(
-                        "Crypto Transfer - Auto Create Accounts with FT moving and with hook execution - extra hook full charging")
-                final Stream<DynamicTest> cryptoTransferFTAutoAccountCreationWithOneHookExtraHookFullCharging() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_HOOK, adminKey),
-
-                            // transfer tokens
-                            cryptoTransfer(moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_HOOK, VALID_ALIAS_ED25519))
-                                    .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK)
-                                    .fee(ONE_HUNDRED_HBARS)
-                                    .via("ftTransferTxn"),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "ftTransferTxn",
-                                    txnSize -> expectedCryptoTransferFTFullFeeUsd(Map.of(
-                                                    SIGNATURES, 1L,
-                                                    HOOK_EXECUTION, 1L,
-                                                    ACCOUNTS, 2L,
-                                                    TOKEN_TYPES, 1L,
-                                                    GAS, 5_000_000L,
-                                                    PROCESSING_BYTES, (long) txnSize))
-                                            + TOKEN_ASSOCIATE_EXTRA_FEE_USD,
-                                    0.001),
-                            // validate auto-created account properties
-                            getAliasedAccountInfo(VALID_ALIAS_ED25519)
-                                    .hasToken(relationshipWith(FUNGIBLE_TOKEN))
-                                    .has(accountWith()
-                                            .key(VALID_ALIAS_ED25519)
-                                            .alias(VALID_ALIAS_ED25519)
-                                            .maxAutoAssociations(-1)),
-                            // validate balances
-                            getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 90L)));
-                }
-            }
         }
 
         @Nested
@@ -3801,38 +3465,6 @@ public class CryptoTransferSimpleFeesTest {
                                         checkOwnerBalance);
                             })));
                 }
-
-                @HapiTest
-                @DisplayName("Crypto Transfer - Auto Create Accounts with FT moving and failing hook - fails on handle")
-                final Stream<DynamicTest> cryptoTransferFTAutoAccountCreationWithFailingHookFailsOnHandle() {
-                    return hapiTest(flattened(
-                            // create keys, tokens and accounts
-                            createAccountsAndKeys(),
-                            createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_HOOK, adminKey),
-
-                            // transfer tokens
-                            cryptoTransfer(moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_HOOK, VALID_ALIAS_ED25519))
-                                    .withPreHookFor(PAYER_WITH_HOOK, 1L, 10L, "")
-                                    .payingWith(PAYER_WITH_HOOK)
-                                    .signedBy(PAYER_WITH_HOOK)
-                                    .fee(ONE_HUNDRED_HBARS)
-                                    .via("ftTransferTxn")
-                                    .hasKnownStatus(INSUFFICIENT_GAS),
-                            validateChargedUsdWithinWithTxnSize(
-                                    "ftTransferTxn",
-                                    txnSize -> expectedCryptoTransferFTFullFeeUsd(Map.of(
-                                            SIGNATURES, 1L,
-                                            HOOK_EXECUTION, 1L,
-                                            ACCOUNTS, 2L,
-                                            TOKEN_TYPES, 1L,
-                                            GAS, 10L,
-                                            PROCESSING_BYTES, (long) txnSize)),
-                                    0.001),
-                            // validate no auto-created account exists
-                            getAliasedAccountInfo(VALID_ALIAS_ED25519).hasCostAnswerPrecheck(INVALID_ACCOUNT_ID),
-                            // validate balances
-                            getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 100L)));
-                }
             }
         }
 
@@ -3880,20 +3512,6 @@ public class CryptoTransferSimpleFeesTest {
             return List.of(
                     cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                     cryptoCreate(PAYER_INSUFFICIENT_BALANCE).balance(ONE_HBAR / 100000),
-                    uploadInitCode(HOOK_CONTRACT),
-                    contractCreate(HOOK_CONTRACT).gas(5_000_000),
-                    cryptoCreate(PAYER_WITH_HOOK)
-                            .balance(ONE_MILLION_HBARS)
-                            .withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
-                    cryptoCreate(PAYER_WITH_TWO_HOOKS)
-                            .balance(ONE_HUNDRED_HBARS)
-                            .withHook(accountAllowanceHook(1L, HOOK_CONTRACT))
-                            .withHook(accountAllowanceHook(2L, HOOK_CONTRACT)),
-                    cryptoCreate(PAYER_WITH_THREE_HOOKS)
-                            .balance(ONE_HUNDRED_HBARS)
-                            .withHook(accountAllowanceHook(1L, HOOK_CONTRACT))
-                            .withHook(accountAllowanceHook(2L, HOOK_CONTRACT))
-                            .withHook(accountAllowanceHook(3L, HOOK_CONTRACT)),
                     cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
                     cryptoCreate(HBAR_OWNER_INSUFFICIENT_BALANCE).balance(ONE_HBAR / 100000),
                     cryptoCreate(RECEIVER_ASSOCIATED_FIRST).balance(ONE_HBAR),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferSimpleFeesTest.java
@@ -50,7 +50,6 @@ import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.val
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.TOKEN_ASSOCIATE_EXTRA_FEE_USD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
@@ -131,6 +130,7 @@ public class CryptoTransferSimpleFeesTest {
     private static final String adminKey = "adminKey";
     private static final String supplyKey = "supplyKey";
     private static final String PAYER_KEY = "payerKey";
+
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesAndHooksSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesAndHooksSimpleFeesTest.java
@@ -14,7 +14,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
-import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
@@ -32,6 +31,7 @@ import static org.hiero.hapi.support.fees.Extra.HOOK_EXECUTION;
 import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
 import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 import static org.hiero.hapi.support.fees.Extra.TOKEN_TYPES;
+
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
@@ -81,8 +81,10 @@ public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
     @DisplayName("Crypto Transfer with Custom Fees and Hooks - Simple Fees Test")
     class PositiveTests {
         @HapiTest
-        @DisplayName("Crypto Transfer FT and NFT with custom fees and with hook execution - extra hooks, tokens and accounts full charging")
-        final Stream<DynamicTest> cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndTokensAndAccountsFullCharging() {
+        @DisplayName(
+                "Crypto Transfer FT and NFT with custom fees and with hook execution - extra hooks, tokens and accounts full charging")
+        final Stream<DynamicTest>
+                cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndTokensAndAccountsFullCharging() {
             return hapiTest(flattened(
                     createAccountsAndKeysWithHooks(),
                     createFungibleTokenWithAdminKey(DENOM_TOKEN, 100, DENOM_TREASURY, adminKey),
@@ -94,14 +96,16 @@ public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
                             moving(10, DENOM_TOKEN).between(DENOM_TREASURY, PAYER_WITH_TWO_HOOKS),
                             moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_FIRST),
                             moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_THIRD)),
-                    createFungibleTokenWithFixedHtsFee(FT_WITH_HTS_FIXED_FEE, 100L, PAYER_WITH_TWO_HOOKS, adminKey, HTS_FEE),
+                    createFungibleTokenWithFixedHtsFee(
+                            FT_WITH_HTS_FIXED_FEE, 100L, PAYER_WITH_TWO_HOOKS, adminKey, HTS_FEE),
                     tokenAssociate(HTS_COLLECTOR, FT_WITH_HTS_FIXED_FEE),
                     tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_WITH_HTS_FIXED_FEE),
                     tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FT_WITH_HTS_FIXED_FEE),
                     tokenAssociate(RECEIVER_ASSOCIATED_THIRD, FT_WITH_HTS_FIXED_FEE),
                     cryptoTransfer(
                             moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
-                            moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
+                            moving(10L, FT_WITH_HTS_FIXED_FEE)
+                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
                     createNFTWithFixedFee(NFT_WITH_HTS_FEE, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey, HTS_FEE),
                     mintNFT(NFT_WITH_HTS_FEE, 0, 5),
                     tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_WITH_HTS_FEE),
@@ -109,7 +113,8 @@ public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
                     tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NFT_WITH_HTS_FEE),
                     cryptoTransfer(
                             moving(20L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
-                            movingUnique(NFT_WITH_HTS_FEE, 1L, 2L, 3L).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
+                            movingUnique(NFT_WITH_HTS_FEE, 1L, 2L, 3L)
+                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
                     cryptoTransfer(
                                     moving(10L, FT_WITH_HTS_FIXED_FEE)
                                             .between(RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_SECOND),
@@ -176,14 +181,16 @@ public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
                             moving(10, DENOM_TOKEN).between(DENOM_TREASURY, PAYER_WITH_TWO_HOOKS),
                             moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_FIRST),
                             moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_THIRD)),
-                    createFungibleTokenWithFixedHtsFee(FT_WITH_HTS_FIXED_FEE, 100L, PAYER_WITH_TWO_HOOKS, adminKey, HTS_FEE),
+                    createFungibleTokenWithFixedHtsFee(
+                            FT_WITH_HTS_FIXED_FEE, 100L, PAYER_WITH_TWO_HOOKS, adminKey, HTS_FEE),
                     tokenAssociate(HTS_COLLECTOR, FT_WITH_HTS_FIXED_FEE),
                     tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_WITH_HTS_FIXED_FEE),
                     tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FT_WITH_HTS_FIXED_FEE),
                     tokenAssociate(RECEIVER_ASSOCIATED_THIRD, FT_WITH_HTS_FIXED_FEE),
                     cryptoTransfer(
                             moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
-                            moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
+                            moving(10L, FT_WITH_HTS_FIXED_FEE)
+                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
                     createNFTWithFixedFee(NFT_WITH_HTS_FEE, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey, HTS_FEE),
                     mintNFT(NFT_WITH_HTS_FEE, 0, 5),
                     tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_WITH_HTS_FEE),
@@ -191,7 +198,8 @@ public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
                     tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NFT_WITH_HTS_FEE),
                     cryptoTransfer(
                             moving(20L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
-                            movingUnique(NFT_WITH_HTS_FEE, 1L, 2L, 3L).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
+                            movingUnique(NFT_WITH_HTS_FEE, 1L, 2L, 3L)
+                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
                     cryptoTransfer(
                                     moving(10L, FT_WITH_HTS_FIXED_FEE)
                                             .between(RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_SECOND),
@@ -242,7 +250,11 @@ public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
     }
 
     private HapiTokenCreate createFungibleTokenWithFixedHtsFee(
-            final String tokenName, final long supply, final String treasury, final String adminKey, final long htsFee) {
+            final String tokenName,
+            final long supply,
+            final String treasury,
+            final String adminKey,
+            final long htsFee) {
         return tokenCreate(tokenName)
                 .initialSupply(supply)
                 .treasury(treasury)
@@ -253,7 +265,11 @@ public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
     }
 
     private HapiTokenCreate createNFTWithFixedFee(
-            final String tokenName, final String treasury, final String supplyKey, final String adminKey, final long htsFee) {
+            final String tokenName,
+            final String treasury,
+            final String supplyKey,
+            final String adminKey,
+            final long htsFee) {
         return tokenCreate(tokenName)
                 .initialSupply(0)
                 .treasury(treasury)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesAndHooksSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesAndHooksSimpleFeesTest.java
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.hip1261;
+
+import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferTokenWithCustomFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateChargedUsdWithinWithTxnSize;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.TOKEN_ASSOCIATE_EXTRA_FEE_USD;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
+import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
+import static org.hiero.hapi.support.fees.Extra.ACCOUNTS;
+import static org.hiero.hapi.support.fees.Extra.GAS;
+import static org.hiero.hapi.support.fees.Extra.HOOK_EXECUTION;
+import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
+import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
+import static org.hiero.hapi.support.fees.Extra.TOKEN_TYPES;
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.SpecOperation;
+import com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate;
+import com.hedera.services.bdd.spec.transactions.token.HapiTokenMint;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+
+@Tag(SIMPLE_FEES)
+@OrderedInIsolation
+@HapiTestLifecycle
+public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
+    private static final String FT_WITH_HTS_FIXED_FEE = "ftWithHtsFixedFee";
+    private static final String NFT_WITH_HTS_FEE = "nftWithHtsFee";
+    private static final String DENOM_TOKEN = "denomToken";
+    private static final String HTS_COLLECTOR = "htsCollector";
+    private static final String DENOM_COLLECTOR = "denomCollector";
+    private static final String DENOM_TREASURY = "denomTreasury";
+    private static final String RECEIVER_ASSOCIATED_FIRST = "receiverAssociatedFirst";
+    private static final String RECEIVER_ASSOCIATED_SECOND = "receiverAssociatedSecond";
+    private static final String RECEIVER_ASSOCIATED_THIRD = "receiverAssociatedThird";
+    private static final String RECEIVER_FREE_AUTO_ASSOCIATIONS = "receiverFreeAutoAssociations";
+    private static final long HTS_FEE = 1L;
+    private static final String adminKey = "adminKey";
+    private static final String feeScheduleKey = "feeScheduleKey";
+    private static final String supplyKey = "supplyKey";
+    private static final String HOOK_CONTRACT = "TruePreHook";
+    private static final String PAYER_WITH_TWO_HOOKS = "payerWithTwoHooks";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true", "hooks.hooksEnabled", "true"));
+    }
+
+    @Nested
+    @DisplayName("Crypto Transfer with Custom Fees and Hooks - Simple Fees Test")
+    class PositiveTests {
+        @HapiTest
+        @DisplayName("Crypto Transfer FT and NFT with custom fees and with hook execution - extra hooks, tokens and accounts full charging")
+        final Stream<DynamicTest> cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndTokensAndAccountsFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithAdminKey(DENOM_TOKEN, 100, DENOM_TREASURY, adminKey),
+                    tokenAssociate(DENOM_COLLECTOR, DENOM_TOKEN),
+                    tokenAssociate(PAYER_WITH_TWO_HOOKS, DENOM_TOKEN),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, DENOM_TOKEN),
+                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, DENOM_TOKEN),
+                    cryptoTransfer(
+                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, PAYER_WITH_TWO_HOOKS),
+                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_FIRST),
+                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_THIRD)),
+                    createFungibleTokenWithFixedHtsFee(FT_WITH_HTS_FIXED_FEE, 100L, PAYER_WITH_TWO_HOOKS, adminKey, HTS_FEE),
+                    tokenAssociate(HTS_COLLECTOR, FT_WITH_HTS_FIXED_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_WITH_HTS_FIXED_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FT_WITH_HTS_FIXED_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, FT_WITH_HTS_FIXED_FEE),
+                    cryptoTransfer(
+                            moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
+                            moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
+                    createNFTWithFixedFee(NFT_WITH_HTS_FEE, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey, HTS_FEE),
+                    mintNFT(NFT_WITH_HTS_FEE, 0, 5),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_WITH_HTS_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, NFT_WITH_HTS_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NFT_WITH_HTS_FEE),
+                    cryptoTransfer(
+                            moving(20L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
+                            movingUnique(NFT_WITH_HTS_FEE, 1L, 2L, 3L).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
+                    cryptoTransfer(
+                                    moving(10L, FT_WITH_HTS_FIXED_FEE)
+                                            .between(RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_SECOND),
+                                    movingUnique(NFT_WITH_HTS_FEE, 1L)
+                                            .between(RECEIVER_ASSOCIATED_THIRD, RECEIVER_ASSOCIATED_FIRST),
+                                    movingUnique(NFT_WITH_HTS_FEE, 2L)
+                                            .between(RECEIVER_ASSOCIATED_THIRD, RECEIVER_ASSOCIATED_SECOND),
+                                    movingUnique(NFT_WITH_HTS_FEE, 4L)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_FREE_AUTO_ASSOCIATIONS),
+                                    movingUnique(NFT_WITH_HTS_FEE, 5L)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
+                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 5_000_000L, "")
+                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_TWO_HOOKS)
+                            .signedBy(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_THIRD)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("tokenTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "tokenTransferTxn",
+                            txnSize -> expectedCryptoTransferTokenWithCustomFullFeeUsd(Map.of(
+                                            SIGNATURES, 3L,
+                                            HOOK_EXECUTION, 2L,
+                                            ACCOUNTS, 5L,
+                                            TOKEN_TYPES, 5L,
+                                            GAS, 10_000_000L,
+                                            PROCESSING_BYTES, (long) txnSize))
+                                    + TOKEN_ASSOCIATE_EXTRA_FEE_USD,
+                            0.001),
+                    getAccountBalance(HTS_COLLECTOR).hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 2L),
+                    getAccountBalance(DENOM_COLLECTOR).hasTokenBalance(DENOM_TOKEN, 2L),
+                    getAccountBalance(PAYER_WITH_TWO_HOOKS)
+                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 60L)
+                            .hasTokenBalance(NFT_WITH_HTS_FEE, 0L)
+                            .hasTokenBalance(DENOM_TOKEN, 10L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST)
+                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 20L)
+                            .hasTokenBalance(NFT_WITH_HTS_FEE, 2L)
+                            .hasTokenBalance(DENOM_TOKEN, 9L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_SECOND)
+                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 10L)
+                            .hasTokenBalance(NFT_WITH_HTS_FEE, 1L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_THIRD)
+                            .hasTokenBalance(NFT_WITH_HTS_FEE, 1L)
+                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 8L)
+                            .hasTokenBalance(DENOM_TOKEN, 9L),
+                    getAccountBalance(RECEIVER_FREE_AUTO_ASSOCIATIONS).hasTokenBalance(NFT_WITH_HTS_FEE, 1L)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Crypto Transfer with Failing Hooks - Simple Fees Negative Tests")
+    class NegativeTests {
+        @HapiTest
+        @DisplayName("Crypto Transfer FT and NFT with custom fees and with failing hook - fails on handle")
+        final Stream<DynamicTest> cryptoTransferHBARAndFtAndNFTWithCustomFeesAndWithFailingHookFailsOnHandle() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithAdminKey(DENOM_TOKEN, 100, DENOM_TREASURY, adminKey),
+                    tokenAssociate(DENOM_COLLECTOR, DENOM_TOKEN),
+                    tokenAssociate(PAYER_WITH_TWO_HOOKS, DENOM_TOKEN),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, DENOM_TOKEN),
+                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, DENOM_TOKEN),
+                    cryptoTransfer(
+                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, PAYER_WITH_TWO_HOOKS),
+                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_FIRST),
+                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_THIRD)),
+                    createFungibleTokenWithFixedHtsFee(FT_WITH_HTS_FIXED_FEE, 100L, PAYER_WITH_TWO_HOOKS, adminKey, HTS_FEE),
+                    tokenAssociate(HTS_COLLECTOR, FT_WITH_HTS_FIXED_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_WITH_HTS_FIXED_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FT_WITH_HTS_FIXED_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, FT_WITH_HTS_FIXED_FEE),
+                    cryptoTransfer(
+                            moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
+                            moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
+                    createNFTWithFixedFee(NFT_WITH_HTS_FEE, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey, HTS_FEE),
+                    mintNFT(NFT_WITH_HTS_FEE, 0, 5),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_WITH_HTS_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, NFT_WITH_HTS_FEE),
+                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NFT_WITH_HTS_FEE),
+                    cryptoTransfer(
+                            moving(20L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
+                            movingUnique(NFT_WITH_HTS_FEE, 1L, 2L, 3L).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
+                    cryptoTransfer(
+                                    moving(10L, FT_WITH_HTS_FIXED_FEE)
+                                            .between(RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_SECOND),
+                                    movingUnique(NFT_WITH_HTS_FEE, 1L)
+                                            .between(RECEIVER_ASSOCIATED_THIRD, RECEIVER_ASSOCIATED_FIRST),
+                                    movingUnique(NFT_WITH_HTS_FEE, 2L)
+                                            .between(RECEIVER_ASSOCIATED_THIRD, RECEIVER_ASSOCIATED_SECOND),
+                                    movingUnique(NFT_WITH_HTS_FEE, 4L)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_FREE_AUTO_ASSOCIATIONS),
+                                    movingUnique(NFT_WITH_HTS_FEE, 5L)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
+                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 10L, "")
+                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 10L, "")
+                            .payingWith(PAYER_WITH_TWO_HOOKS)
+                            .signedBy(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_THIRD)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("tokenTransferTxn")
+                            .hasKnownStatus(INSUFFICIENT_GAS),
+                    validateChargedUsdWithinWithTxnSize(
+                            "tokenTransferTxn",
+                            txnSize -> expectedCryptoTransferTokenWithCustomFullFeeUsd(Map.of(
+                                    SIGNATURES, 3L,
+                                    HOOK_EXECUTION, 2L,
+                                    ACCOUNTS, 5L,
+                                    TOKEN_TYPES, 5L,
+                                    GAS, 20L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAccountBalance(HTS_COLLECTOR).hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 0L),
+                    getAccountBalance(DENOM_COLLECTOR).hasTokenBalance(DENOM_TOKEN, 0L),
+                    getAccountBalance(PAYER_WITH_TWO_HOOKS)
+                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 60L)
+                            .hasTokenBalance(NFT_WITH_HTS_FEE, 2L)
+                            .hasTokenBalance(DENOM_TOKEN, 10L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST)
+                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 30L)
+                            .hasTokenBalance(NFT_WITH_HTS_FEE, 0L)
+                            .hasTokenBalance(DENOM_TOKEN, 10L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_SECOND)
+                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 0L)
+                            .hasTokenBalance(NFT_WITH_HTS_FEE, 0L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_THIRD)
+                            .hasTokenBalance(NFT_WITH_HTS_FEE, 3L)
+                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 10L)
+                            .hasTokenBalance(DENOM_TOKEN, 10L),
+                    getAccountBalance(RECEIVER_FREE_AUTO_ASSOCIATIONS).hasTokenBalance(NFT_WITH_HTS_FEE, 0L)));
+        }
+    }
+
+    private HapiTokenCreate createFungibleTokenWithFixedHtsFee(
+            final String tokenName, final long supply, final String treasury, final String adminKey, final long htsFee) {
+        return tokenCreate(tokenName)
+                .initialSupply(supply)
+                .treasury(treasury)
+                .adminKey(adminKey)
+                .feeScheduleKey(feeScheduleKey)
+                .tokenType(FUNGIBLE_COMMON)
+                .withCustom(fixedHtsFee(htsFee, DENOM_TOKEN, DENOM_COLLECTOR));
+    }
+
+    private HapiTokenCreate createNFTWithFixedFee(
+            final String tokenName, final String treasury, final String supplyKey, final String adminKey, final long htsFee) {
+        return tokenCreate(tokenName)
+                .initialSupply(0)
+                .treasury(treasury)
+                .tokenType(NON_FUNGIBLE_UNIQUE)
+                .supplyKey(supplyKey)
+                .adminKey(adminKey)
+                .feeScheduleKey(feeScheduleKey)
+                .withCustom(fixedHtsFee(htsFee, FT_WITH_HTS_FIXED_FEE, HTS_COLLECTOR));
+    }
+
+    private HapiTokenMint mintNFT(final String tokenName, final int rangeStart, final int rangeEnd) {
+        return mintToken(
+                tokenName,
+                IntStream.range(rangeStart, rangeEnd)
+                        .mapToObj(a -> ByteString.copyFromUtf8(String.valueOf(a)))
+                        .toList());
+    }
+
+    private HapiTokenCreate createFungibleTokenWithAdminKey(
+            final String tokenName, final long supply, final String treasury, final String adminKey) {
+        return tokenCreate(tokenName)
+                .initialSupply(supply)
+                .treasury(treasury)
+                .adminKey(adminKey)
+                .feeScheduleKey(feeScheduleKey)
+                .tokenType(FUNGIBLE_COMMON);
+    }
+
+    private List<SpecOperation> createAccountsAndKeysWithHooks() {
+        return Stream.concat(createAccountsAndKeys().stream(), createHookAccountsAndKeys().stream())
+                .toList();
+    }
+
+    private List<SpecOperation> createAccountsAndKeys() {
+        return List.of(
+                cryptoCreate(RECEIVER_ASSOCIATED_FIRST).balance(ONE_HBAR),
+                cryptoCreate(RECEIVER_ASSOCIATED_SECOND).balance(ONE_HBAR),
+                cryptoCreate(RECEIVER_ASSOCIATED_THIRD).balance(ONE_HBAR),
+                cryptoCreate(RECEIVER_FREE_AUTO_ASSOCIATIONS).balance(ONE_HBAR).maxAutomaticTokenAssociations(1),
+                cryptoCreate(HTS_COLLECTOR).balance(0L),
+                cryptoCreate(DENOM_COLLECTOR).balance(0L),
+                cryptoCreate(DENOM_TREASURY).balance(0L),
+                newKeyNamed(adminKey),
+                newKeyNamed(feeScheduleKey),
+                newKeyNamed(supplyKey));
+    }
+
+    private List<SpecOperation> createHookAccountsAndKeys() {
+        return List.of(
+                uploadInitCode(HOOK_CONTRACT),
+                contractCreate(HOOK_CONTRACT).gas(5_000_000),
+                cryptoCreate(PAYER_WITH_TWO_HOOKS)
+                        .balance(ONE_HUNDRED_HBARS)
+                        .withHook(accountAllowanceHook(1L, HOOK_CONTRACT))
+                        .withHook(accountAllowanceHook(2L, HOOK_CONTRACT)));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesSimpleFeesTest.java
@@ -4,14 +4,11 @@ package com.hedera.services.bdd.suites.hip1261;
 import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFeeInheritingRoyaltyCollector;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
@@ -40,7 +37,6 @@ import static org.hiero.hapi.support.fees.Extra.HOOK_EXECUTION;
 import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
 import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 import static org.hiero.hapi.support.fees.Extra.TOKEN_TYPES;
-
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
@@ -99,17 +95,11 @@ public class CryptoTransferWithCustomFeesSimpleFeesTest {
     private static final String feeScheduleKey = "feeScheduleKey";
     private static final String supplyKey = "supplyKey";
 
-    private static final String HOOK_CONTRACT = "TruePreHook";
-    private static final String PAYER_WITH_HOOK = "payerWithHook";
-    private static final String PAYER_WITH_TWO_HOOKS = "payerWithTwoHooks";
-
     private static final String DUMMY_TOKEN = "dummyToken";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
     }
 
     @Nested
@@ -1011,92 +1001,6 @@ public class CryptoTransferWithCustomFeesSimpleFeesTest {
                     getAccountBalance(RECEIVER_ASSOCIATED_SECOND).hasTokenBalance(FT_WITH_HBAR_FIXED_FEE, 10L),
                     getAccountBalance(RECEIVER_FREE_AUTO_ASSOCIATIONS).hasTokenBalance(FT_WITH_HBAR_FIXED_FEE, 5L)));
         }
-
-        @HapiTest
-        @DisplayName(
-                "Crypto Transfer FT and NFT with custom fees and with hook execution - extra hooks, tokens and accounts full charging")
-        final Stream<DynamicTest>
-                cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndTokensAndAccountsFullCharging() {
-            return hapiTest(flattened(
-                    // create keys, tokens and accounts
-                    createAccountsAndKeys(),
-                    createFungibleTokenWithAdminKey(DENOM_TOKEN, 100, DENOM_TREASURY, adminKey),
-                    tokenAssociate(DENOM_COLLECTOR, DENOM_TOKEN),
-                    tokenAssociate(PAYER_WITH_TWO_HOOKS, DENOM_TOKEN),
-                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, DENOM_TOKEN),
-                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, DENOM_TOKEN),
-                    cryptoTransfer(
-                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, PAYER_WITH_TWO_HOOKS),
-                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_FIRST),
-                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_THIRD)),
-                    createFungibleTokenWithFixedHtsFee(
-                            FT_WITH_HTS_FIXED_FEE, 100L, PAYER_WITH_TWO_HOOKS, adminKey, HTS_FEE),
-                    tokenAssociate(HTS_COLLECTOR, FT_WITH_HTS_FIXED_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_WITH_HTS_FIXED_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FT_WITH_HTS_FIXED_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, FT_WITH_HTS_FIXED_FEE),
-                    cryptoTransfer(
-                            moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
-                            moving(10L, FT_WITH_HTS_FIXED_FEE)
-                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
-                    createNFTWithFixedFee(NFT_WITH_HTS_FEE, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey, HTS_FEE),
-                    mintNFT(NFT_WITH_HTS_FEE, 0, 5),
-                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_WITH_HTS_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, NFT_WITH_HTS_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NFT_WITH_HTS_FEE),
-
-                    // transfer tokens
-                    cryptoTransfer(
-                            moving(20L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
-                            movingUnique(NFT_WITH_HTS_FEE, 1L, 2L, 3L)
-                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
-                    cryptoTransfer(
-                                    moving(10L, FT_WITH_HTS_FIXED_FEE)
-                                            .between(RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_SECOND),
-                                    movingUnique(NFT_WITH_HTS_FEE, 1L)
-                                            .between(RECEIVER_ASSOCIATED_THIRD, RECEIVER_ASSOCIATED_FIRST),
-                                    movingUnique(NFT_WITH_HTS_FEE, 2L)
-                                            .between(RECEIVER_ASSOCIATED_THIRD, RECEIVER_ASSOCIATED_SECOND),
-                                    movingUnique(NFT_WITH_HTS_FEE, 4L)
-                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_FREE_AUTO_ASSOCIATIONS),
-                                    movingUnique(NFT_WITH_HTS_FEE, 5L)
-                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
-                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 5_000_000L, "")
-                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
-                            .payingWith(PAYER_WITH_TWO_HOOKS)
-                            .signedBy(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_THIRD)
-                            .fee(ONE_HUNDRED_HBARS)
-                            .via("tokenTransferTxn"),
-                    validateChargedUsdWithinWithTxnSize(
-                            "tokenTransferTxn",
-                            txnSize -> expectedCryptoTransferTokenWithCustomFullFeeUsd(Map.of(
-                                            SIGNATURES, 3L,
-                                            HOOK_EXECUTION, 2L,
-                                            ACCOUNTS, 5L,
-                                            TOKEN_TYPES, 5L,
-                                            GAS, 10_000_000L,
-                                            PROCESSING_BYTES, (long) txnSize))
-                                    + TOKEN_ASSOCIATE_EXTRA_FEE_USD,
-                            0.001),
-                    getAccountBalance(HTS_COLLECTOR).hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 2L),
-                    getAccountBalance(DENOM_COLLECTOR).hasTokenBalance(DENOM_TOKEN, 2L),
-                    getAccountBalance(PAYER_WITH_TWO_HOOKS)
-                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 60L)
-                            .hasTokenBalance(NFT_WITH_HTS_FEE, 0L)
-                            .hasTokenBalance(DENOM_TOKEN, 10L),
-                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST)
-                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 20L)
-                            .hasTokenBalance(NFT_WITH_HTS_FEE, 2L)
-                            .hasTokenBalance(DENOM_TOKEN, 9L),
-                    getAccountBalance(RECEIVER_ASSOCIATED_SECOND)
-                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 10L)
-                            .hasTokenBalance(NFT_WITH_HTS_FEE, 1L),
-                    getAccountBalance(RECEIVER_ASSOCIATED_THIRD)
-                            .hasTokenBalance(NFT_WITH_HTS_FEE, 1L)
-                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 8L)
-                            .hasTokenBalance(DENOM_TOKEN, 9L),
-                    getAccountBalance(RECEIVER_FREE_AUTO_ASSOCIATIONS).hasTokenBalance(NFT_WITH_HTS_FEE, 1L)));
-        }
     }
 
     @Nested
@@ -1287,90 +1191,6 @@ public class CryptoTransferWithCustomFeesSimpleFeesTest {
                     getAccountBalance(RECEIVER_ASSOCIATED_SECOND).hasTokenBalance(FT_WITH_HBAR_FIXED_FEE, 0L),
                     getAccountBalance(RECEIVER_FREE_AUTO_ASSOCIATIONS).hasTokenBalance(FT_WITH_HBAR_FIXED_FEE, 0L)));
         }
-
-        @HapiTest
-        @DisplayName("Crypto Transfer FT and NFT with custom fees and with failing hook - fails on handle")
-        final Stream<DynamicTest> cryptoTransferHBARAndFtAndNFTWithCustomFeesAndWithFailingHookFailsOnHandle() {
-            return hapiTest(flattened(
-                    // create keys, tokens and accounts
-                    createAccountsAndKeys(),
-                    createFungibleTokenWithAdminKey(DENOM_TOKEN, 100, DENOM_TREASURY, adminKey),
-                    tokenAssociate(DENOM_COLLECTOR, DENOM_TOKEN),
-                    tokenAssociate(PAYER_WITH_TWO_HOOKS, DENOM_TOKEN),
-                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, DENOM_TOKEN),
-                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, DENOM_TOKEN),
-                    cryptoTransfer(
-                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, PAYER_WITH_TWO_HOOKS),
-                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_FIRST),
-                            moving(10, DENOM_TOKEN).between(DENOM_TREASURY, RECEIVER_ASSOCIATED_THIRD)),
-                    createFungibleTokenWithFixedHtsFee(
-                            FT_WITH_HTS_FIXED_FEE, 100L, PAYER_WITH_TWO_HOOKS, adminKey, HTS_FEE),
-                    tokenAssociate(HTS_COLLECTOR, FT_WITH_HTS_FIXED_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_WITH_HTS_FIXED_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FT_WITH_HTS_FIXED_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, FT_WITH_HTS_FIXED_FEE),
-                    cryptoTransfer(
-                            moving(10L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
-                            moving(10L, FT_WITH_HTS_FIXED_FEE)
-                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
-                    createNFTWithFixedFee(NFT_WITH_HTS_FEE, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey, HTS_FEE),
-                    mintNFT(NFT_WITH_HTS_FEE, 0, 5),
-                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_WITH_HTS_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, NFT_WITH_HTS_FEE),
-                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NFT_WITH_HTS_FEE),
-
-                    // transfer tokens
-                    cryptoTransfer(
-                            moving(20L, FT_WITH_HTS_FIXED_FEE).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST),
-                            movingUnique(NFT_WITH_HTS_FEE, 1L, 2L, 3L)
-                                    .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD)),
-                    cryptoTransfer(
-                                    moving(10L, FT_WITH_HTS_FIXED_FEE)
-                                            .between(RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_SECOND),
-                                    movingUnique(NFT_WITH_HTS_FEE, 1L)
-                                            .between(RECEIVER_ASSOCIATED_THIRD, RECEIVER_ASSOCIATED_FIRST),
-                                    movingUnique(NFT_WITH_HTS_FEE, 2L)
-                                            .between(RECEIVER_ASSOCIATED_THIRD, RECEIVER_ASSOCIATED_SECOND),
-                                    movingUnique(NFT_WITH_HTS_FEE, 4L)
-                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_FREE_AUTO_ASSOCIATIONS),
-                                    movingUnique(NFT_WITH_HTS_FEE, 5L)
-                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
-                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 10L, "")
-                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 10L, "")
-                            .payingWith(PAYER_WITH_TWO_HOOKS)
-                            .signedBy(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST, RECEIVER_ASSOCIATED_THIRD)
-                            .fee(ONE_HUNDRED_HBARS)
-                            .via("tokenTransferTxn")
-                            .hasKnownStatus(INSUFFICIENT_GAS),
-                    validateChargedUsdWithinWithTxnSize(
-                            "tokenTransferTxn",
-                            txnSize -> expectedCryptoTransferTokenWithCustomFullFeeUsd(Map.of(
-                                    SIGNATURES, 3L,
-                                    HOOK_EXECUTION, 2L,
-                                    ACCOUNTS, 5L,
-                                    TOKEN_TYPES, 5L,
-                                    GAS, 20L,
-                                    PROCESSING_BYTES, (long) txnSize)),
-                            0.001),
-                    getAccountBalance(HTS_COLLECTOR).hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 0L),
-                    getAccountBalance(DENOM_COLLECTOR).hasTokenBalance(DENOM_TOKEN, 0L),
-                    getAccountBalance(PAYER_WITH_TWO_HOOKS)
-                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 60L)
-                            .hasTokenBalance(NFT_WITH_HTS_FEE, 2L)
-                            .hasTokenBalance(DENOM_TOKEN, 10L),
-                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST)
-                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 30L)
-                            .hasTokenBalance(NFT_WITH_HTS_FEE, 0L)
-                            .hasTokenBalance(DENOM_TOKEN, 10L),
-                    getAccountBalance(RECEIVER_ASSOCIATED_SECOND)
-                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 0L)
-                            .hasTokenBalance(NFT_WITH_HTS_FEE, 0L),
-                    getAccountBalance(RECEIVER_ASSOCIATED_THIRD)
-                            .hasTokenBalance(NFT_WITH_HTS_FEE, 3L)
-                            .hasTokenBalance(FT_WITH_HTS_FIXED_FEE, 10L)
-                            .hasTokenBalance(DENOM_TOKEN, 10L),
-                    getAccountBalance(RECEIVER_FREE_AUTO_ASSOCIATIONS).hasTokenBalance(NFT_WITH_HTS_FEE, 0L)));
-        }
     }
 
     private HapiTokenCreate createFungibleTokenWithFixedHbarFee(
@@ -1489,15 +1309,6 @@ public class CryptoTransferWithCustomFeesSimpleFeesTest {
         return List.of(
                 cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                 cryptoCreate(PAYER_INSUFFICIENT_BALANCE).balance(ONE_HBAR / 100000),
-                uploadInitCode(HOOK_CONTRACT),
-                contractCreate(HOOK_CONTRACT).gas(5_000_000),
-                cryptoCreate(PAYER_WITH_HOOK)
-                        .balance(ONE_HUNDRED_HBARS)
-                        .withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
-                cryptoCreate(PAYER_WITH_TWO_HOOKS)
-                        .balance(ONE_HUNDRED_HBARS)
-                        .withHook(accountAllowanceHook(1L, HOOK_CONTRACT))
-                        .withHook(accountAllowanceHook(2L, HOOK_CONTRACT)),
                 cryptoCreate(OWNER).balance(ONE_MILLION_HBARS),
                 cryptoCreate(NEW_TREASURY_WITH_UNLIMITED_AUTO_ASSOCIATIONS)
                         .balance(ONE_HUNDRED_HBARS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesSimpleFeesTest.java
@@ -26,17 +26,15 @@ import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferTokenWithCustomFullFeeUsd;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateChargedUsdWithinWithTxnSize;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.TOKEN_ASSOCIATE_EXTRA_FEE_USD;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static org.hiero.hapi.support.fees.Extra.ACCOUNTS;
-import static org.hiero.hapi.support.fees.Extra.GAS;
-import static org.hiero.hapi.support.fees.Extra.HOOK_EXECUTION;
 import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
 import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 import static org.hiero.hapi.support.fees.Extra.TOKEN_TYPES;
+
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithHooksSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithHooksSimpleFeesTest.java
@@ -1,0 +1,449 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.hip1261;
+
+import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
+import static com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel.relationshipWith;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.accountAllowanceHook;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferFTFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferHBARAndFTAndNFTFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferHBARAndFTFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferHBARAndNFTFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferHbarFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferNFTFullFeeUsd;
+import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateChargedUsdWithinWithTxnSize;
+import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.TOKEN_ASSOCIATE_EXTRA_FEE_USD;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
+import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
+import static org.hiero.hapi.support.fees.Extra.ACCOUNTS;
+import static org.hiero.hapi.support.fees.Extra.GAS;
+import static org.hiero.hapi.support.fees.Extra.HOOK_EXECUTION;
+import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
+import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
+import static org.hiero.hapi.support.fees.Extra.TOKEN_TYPES;
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.SpecOperation;
+import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate;
+import com.hedera.services.bdd.spec.transactions.token.HapiTokenMint;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+
+@Tag(SIMPLE_FEES)
+@OrderedInIsolation
+@HapiTestLifecycle
+public class CryptoTransferWithHooksSimpleFeesTest {
+    private static final String PAYER_WITH_HOOK = "payerWithHook";
+    private static final String PAYER_WITH_TWO_HOOKS = "payerWithTwoHooks";
+    private static final String RECEIVER_ASSOCIATED_FIRST = "receiverAssociatedFirst";
+    private static final String RECEIVER_ASSOCIATED_SECOND = "receiverAssociatedSecond";
+    private static final String RECEIVER_ASSOCIATED_THIRD = "receiverAssociatedThird";
+    private static final String VALID_ALIAS_ED25519 = "validAliasED25519";
+    private static final String FUNGIBLE_TOKEN = "fungibleToken";
+    private static final String NON_FUNGIBLE_TOKEN = "nonFungibleToken";
+    private static final String adminKey = "adminKey";
+    private static final String supplyKey = "supplyKey";
+    private static final String HOOK_CONTRACT = "TruePreHook";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true", "hooks.hooksEnabled", "true"));
+    }
+
+    @Nested
+    @DisplayName("Crypto Transfer With Hooks - Simple Fees Positive Tests")
+    class PositiveTests {
+        @HapiTest
+        @DisplayName("Crypto Transfer HBAR with hook execution - extra hook full charging")
+        final Stream<DynamicTest> cryptoTransferHBARWithOneHookExtraHookFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    cryptoTransfer(movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST))
+                            .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK)
+                            .fee(ONE_MILLION_HBARS)
+                            .via("hbarTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "hbarTransferTxn",
+                            txnSize -> expectedCryptoTransferHbarFullFeeUsd(Map.of(
+                                    SIGNATURES, 1L,
+                                    HOOK_EXECUTION, 1L,
+                                    ACCOUNTS, 2L,
+                                    GAS, 5_000_000L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001)));
+        }
+
+        @HapiTest
+        @DisplayName("Crypto Transfer FT with hook execution - extra hook full charging")
+        final Stream<DynamicTest> cryptoTransferFTWithOneHookExtraHookFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_HOOK, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FUNGIBLE_TOKEN),
+                    cryptoTransfer(moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST))
+                            .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("ftTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "ftTransferTxn",
+                            txnSize -> expectedCryptoTransferFTFullFeeUsd(Map.of(
+                                    SIGNATURES, 1L,
+                                    HOOK_EXECUTION, 1L,
+                                    ACCOUNTS, 2L,
+                                    TOKEN_TYPES, 1L,
+                                    GAS, 5_000_000L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 90L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(FUNGIBLE_TOKEN, 10L)));
+        }
+
+        @HapiTest
+        @DisplayName("Crypto Transfer FT with same hook executed twice - extra hook full charging")
+        final Stream<DynamicTest> cryptoTransferFTWithOneHookExecutedTwiceExtraHookFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_HOOK, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FUNGIBLE_TOKEN),
+                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FUNGIBLE_TOKEN),
+                    cryptoTransfer(
+                                    moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
+                                    moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_SECOND))
+                            .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("ftTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "ftTransferTxn",
+                            txnSize -> expectedCryptoTransferFTFullFeeUsd(Map.of(
+                                    SIGNATURES, 1L,
+                                    HOOK_EXECUTION, 1L,
+                                    ACCOUNTS, 3L,
+                                    TOKEN_TYPES, 1L,
+                                    GAS, 5_000_000L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 80L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(FUNGIBLE_TOKEN, 10L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_SECOND).hasTokenBalance(FUNGIBLE_TOKEN, 10L)));
+        }
+
+        @HapiTest
+        @DisplayName("Crypto Transfer NFT with hook execution - extra hook full charging")
+        final Stream<DynamicTest> cryptoTransferNFTWithOneHookExtraHookFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createNonFungibleTokenWithoutCustomFees(NON_FUNGIBLE_TOKEN, PAYER_WITH_HOOK, supplyKey, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NON_FUNGIBLE_TOKEN),
+                    mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
+                    cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST))
+                            .withNftSenderPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("nftTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "nftTransferTxn",
+                            txnSize -> expectedCryptoTransferNFTFullFeeUsd(Map.of(
+                                    SIGNATURES, 1L,
+                                    HOOK_EXECUTION, 1L,
+                                    ACCOUNTS, 2L,
+                                    TOKEN_TYPES, 1L,
+                                    GAS, 5_000_000L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(NON_FUNGIBLE_TOKEN, 3L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L)));
+        }
+
+        @HapiTest
+        @DisplayName("Crypto Transfer HBAR and FT with hook execution - extra hooks full charging")
+        final Stream<DynamicTest> cryptoTransferHBARAndFtWithTwoHooksExtraHookFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_TWO_HOOKS, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FUNGIBLE_TOKEN),
+                    cryptoTransfer(
+                                    movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
+                                    moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
+                            .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
+                            .withPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK, PAYER_WITH_TWO_HOOKS)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("tokenTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "tokenTransferTxn",
+                            txnSize -> expectedCryptoTransferHBARAndFTFullFeeUsd(Map.of(
+                                    SIGNATURES, 2L,
+                                    HOOK_EXECUTION, 2L,
+                                    ACCOUNTS, 3L,
+                                    TOKEN_TYPES, 1L,
+                                    GAS, 10_000_000L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAccountBalance(PAYER_WITH_TWO_HOOKS).hasTokenBalance(FUNGIBLE_TOKEN, 90L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(FUNGIBLE_TOKEN, 10L)));
+        }
+
+        @HapiTest
+        @DisplayName("Crypto Transfer HBAR and NFT with hook execution - extra hooks full charging")
+        final Stream<DynamicTest> cryptoTransferHBARAndNFtWithOneHookExtraHookFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createNonFungibleTokenWithoutCustomFees(NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NON_FUNGIBLE_TOKEN),
+                    mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
+                    cryptoTransfer(
+                                    movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
+                                    movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
+                            .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
+                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK, PAYER_WITH_TWO_HOOKS)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("tokenTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "tokenTransferTxn",
+                            txnSize -> expectedCryptoTransferHBARAndNFTFullFeeUsd(Map.of(
+                                    SIGNATURES, 2L,
+                                    HOOK_EXECUTION, 2L,
+                                    ACCOUNTS, 3L,
+                                    TOKEN_TYPES, 1L,
+                                    GAS, 10_000_000L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAccountBalance(PAYER_WITH_TWO_HOOKS).hasTokenBalance(NON_FUNGIBLE_TOKEN, 3L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_FIRST).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L)));
+        }
+
+        @HapiTest
+        @DisplayName("Crypto Transfer HBAR, FT and NFT with hook execution - extra hooks and accounts full charging")
+        final Stream<DynamicTest> cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndAccountsFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_TWO_HOOKS, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FUNGIBLE_TOKEN),
+                    createNonFungibleTokenWithoutCustomFees(NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NON_FUNGIBLE_TOKEN),
+                    mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
+                    cryptoTransfer(
+                                    movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
+                                    moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_SECOND),
+                                    movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD))
+                            .withPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 5_000_000L, "")
+                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK, PAYER_WITH_TWO_HOOKS)
+                            .fee(ONE_MILLION_HBARS)
+                            .via("tokenTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "tokenTransferTxn",
+                            txnSize -> expectedCryptoTransferHBARAndFTAndNFTFullFeeUsd(Map.of(
+                                    SIGNATURES, 2L,
+                                    HOOK_EXECUTION, 2L,
+                                    ACCOUNTS, 5L,
+                                    TOKEN_TYPES, 2L,
+                                    GAS, 10_000_000L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAccountBalance(PAYER_WITH_TWO_HOOKS)
+                            .hasTokenBalance(FUNGIBLE_TOKEN, 90L)
+                            .hasTokenBalance(NON_FUNGIBLE_TOKEN, 3L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_SECOND).hasTokenBalance(FUNGIBLE_TOKEN, 10L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_THIRD).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L)));
+        }
+
+        @HapiTest
+        @DisplayName("Crypto Transfer HBAR, FT and NFT with hook execution - extra hooks, tokens and accounts full charging")
+        final Stream<DynamicTest> cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndTokensAndAccountsFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_TWO_HOOKS, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FUNGIBLE_TOKEN),
+                    createNonFungibleTokenWithoutCustomFees(NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
+                    tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NON_FUNGIBLE_TOKEN),
+                    mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
+                    cryptoTransfer(
+                                    movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
+                                    moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_SECOND),
+                                    movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD))
+                            .withPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 5_000_000L, "")
+                            .withNftSenderPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK, PAYER_WITH_TWO_HOOKS)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("tokenTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "tokenTransferTxn",
+                            txnSize -> expectedCryptoTransferHBARAndFTAndNFTFullFeeUsd(Map.of(
+                                    SIGNATURES, 2L,
+                                    HOOK_EXECUTION, 2L,
+                                    ACCOUNTS, 5L,
+                                    TOKEN_TYPES, 2L,
+                                    GAS, 10_000_000L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAccountBalance(PAYER_WITH_TWO_HOOKS)
+                            .hasTokenBalance(FUNGIBLE_TOKEN, 90L)
+                            .hasTokenBalance(NON_FUNGIBLE_TOKEN, 3L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_SECOND).hasTokenBalance(FUNGIBLE_TOKEN, 10L),
+                    getAccountBalance(RECEIVER_ASSOCIATED_THIRD).hasTokenBalance(NON_FUNGIBLE_TOKEN, 1L)));
+        }
+
+        @HapiTest
+        @DisplayName("Crypto Transfer - Auto Create Accounts with FT moving and with hook execution - extra hook full charging")
+        final Stream<DynamicTest> cryptoTransferFTAutoAccountCreationWithOneHookExtraHookFullCharging() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_HOOK, adminKey),
+                    cryptoTransfer(moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_HOOK, VALID_ALIAS_ED25519))
+                            .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("ftTransferTxn"),
+                    validateChargedUsdWithinWithTxnSize(
+                            "ftTransferTxn",
+                            txnSize -> expectedCryptoTransferFTFullFeeUsd(Map.of(
+                                            SIGNATURES, 1L,
+                                            HOOK_EXECUTION, 1L,
+                                            ACCOUNTS, 2L,
+                                            TOKEN_TYPES, 1L,
+                                            GAS, 5_000_000L,
+                                            PROCESSING_BYTES, (long) txnSize))
+                                    + TOKEN_ASSOCIATE_EXTRA_FEE_USD,
+                            0.001),
+                    getAliasedAccountInfo(VALID_ALIAS_ED25519)
+                            .hasToken(relationshipWith(FUNGIBLE_TOKEN))
+                            .has(accountWith().key(VALID_ALIAS_ED25519).alias(VALID_ALIAS_ED25519).maxAutoAssociations(-1)),
+                    getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 90L)));
+        }
+    }
+
+    @Nested
+    @DisplayName("Crypto Transfer With Hooks Negative Tests")
+    class NegativeTests {
+        @HapiTest
+        @DisplayName("Crypto Transfer - Auto Create Accounts with FT moving and failing hook - fails on handle")
+        final Stream<DynamicTest> cryptoTransferFTAutoAccountCreationWithFailingHookFailsOnHandle() {
+            return hapiTest(flattened(
+                    createAccountsAndKeysWithHooks(),
+                    createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_HOOK, adminKey),
+                    cryptoTransfer(moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_HOOK, VALID_ALIAS_ED25519))
+                            .withPreHookFor(PAYER_WITH_HOOK, 1L, 10L, "")
+                            .payingWith(PAYER_WITH_HOOK)
+                            .signedBy(PAYER_WITH_HOOK)
+                            .fee(ONE_HUNDRED_HBARS)
+                            .via("ftTransferTxn")
+                            .hasKnownStatus(INSUFFICIENT_GAS),
+                    validateChargedUsdWithinWithTxnSize(
+                            "ftTransferTxn",
+                            txnSize -> expectedCryptoTransferFTFullFeeUsd(Map.of(
+                                    SIGNATURES, 1L,
+                                    HOOK_EXECUTION, 1L,
+                                    ACCOUNTS, 2L,
+                                    TOKEN_TYPES, 1L,
+                                    GAS, 10L,
+                                    PROCESSING_BYTES, (long) txnSize)),
+                            0.001),
+                    getAliasedAccountInfo(VALID_ALIAS_ED25519).hasCostAnswerPrecheck(INVALID_ACCOUNT_ID),
+                    getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 100L)));
+        }
+    }
+
+    private HapiTokenCreate createFungibleTokenWithoutCustomFees(
+            final String tokenName, final long supply, final String treasury, final String adminKey) {
+        return tokenCreate(tokenName)
+                .initialSupply(supply)
+                .treasury(treasury)
+                .adminKey(adminKey)
+                .tokenType(FUNGIBLE_COMMON);
+    }
+
+    private HapiTokenCreate createNonFungibleTokenWithoutCustomFees(
+            final String tokenName, final String treasury, final String supplyKey, final String adminKey) {
+        return tokenCreate(tokenName)
+                .initialSupply(0)
+                .treasury(treasury)
+                .tokenType(NON_FUNGIBLE_UNIQUE)
+                .supplyKey(supplyKey)
+                .adminKey(adminKey);
+    }
+
+    private HapiTokenMint mintNFT(final String tokenName, final int rangeStart, final int rangeEnd) {
+        return mintToken(
+                tokenName,
+                IntStream.range(rangeStart, rangeEnd)
+                        .mapToObj(a -> ByteString.copyFromUtf8(String.valueOf(a)))
+                        .toList());
+    }
+
+    private List<SpecOperation> createAccountsAndKeysWithHooks() {
+        return Stream.concat(createAccountsAndKeys().stream(), createHookAccountsAndKeys().stream())
+                .toList();
+    }
+
+    private List<SpecOperation> createAccountsAndKeys() {
+        return List.of(
+                cryptoCreate(RECEIVER_ASSOCIATED_FIRST).balance(ONE_HBAR),
+                cryptoCreate(RECEIVER_ASSOCIATED_SECOND).balance(ONE_HBAR),
+                cryptoCreate(RECEIVER_ASSOCIATED_THIRD).balance(ONE_HBAR),
+                newKeyNamed(VALID_ALIAS_ED25519).shape(KeyShape.ED25519),
+                newKeyNamed(adminKey),
+                newKeyNamed(supplyKey));
+    }
+
+    private List<SpecOperation> createHookAccountsAndKeys() {
+        return List.of(
+                uploadInitCode(HOOK_CONTRACT),
+                contractCreate(HOOK_CONTRACT).gas(5_000_000),
+                cryptoCreate(PAYER_WITH_HOOK)
+                        .balance(ONE_MILLION_HBARS)
+                        .withHook(accountAllowanceHook(1L, HOOK_CONTRACT)),
+                cryptoCreate(PAYER_WITH_TWO_HOOKS)
+                        .balance(ONE_HUNDRED_HBARS)
+                        .withHook(accountAllowanceHook(1L, HOOK_CONTRACT))
+                        .withHook(accountAllowanceHook(2L, HOOK_CONTRACT)));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithHooksSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithHooksSimpleFeesTest.java
@@ -41,6 +41,7 @@ import static org.hiero.hapi.support.fees.Extra.HOOK_EXECUTION;
 import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
 import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 import static org.hiero.hapi.support.fees.Extra.TOKEN_TYPES;
+
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
@@ -173,7 +174,8 @@ public class CryptoTransferWithHooksSimpleFeesTest {
                     createNonFungibleTokenWithoutCustomFees(NON_FUNGIBLE_TOKEN, PAYER_WITH_HOOK, supplyKey, adminKey),
                     tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NON_FUNGIBLE_TOKEN),
                     mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
-                    cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST))
+                    cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L)
+                                    .between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST))
                             .withNftSenderPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
                             .payingWith(PAYER_WITH_HOOK)
                             .signedBy(PAYER_WITH_HOOK)
@@ -202,7 +204,8 @@ public class CryptoTransferWithHooksSimpleFeesTest {
                     tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FUNGIBLE_TOKEN),
                     cryptoTransfer(
                                     movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
-                                    moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
+                                    moving(10L, FUNGIBLE_TOKEN)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_FIRST))
                             .withPreHookFor(PAYER_WITH_HOOK, 1L, 5_000_000L, "")
                             .withPreHookFor(PAYER_WITH_TWO_HOOKS, 2L, 5_000_000L, "")
                             .payingWith(PAYER_WITH_HOOK)
@@ -228,7 +231,8 @@ public class CryptoTransferWithHooksSimpleFeesTest {
         final Stream<DynamicTest> cryptoTransferHBARAndNFtWithOneHookExtraHookFullCharging() {
             return hapiTest(flattened(
                     createAccountsAndKeysWithHooks(),
-                    createNonFungibleTokenWithoutCustomFees(NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
+                    createNonFungibleTokenWithoutCustomFees(
+                            NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
                     tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NON_FUNGIBLE_TOKEN),
                     mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
                     cryptoTransfer(
@@ -262,12 +266,14 @@ public class CryptoTransferWithHooksSimpleFeesTest {
                     createAccountsAndKeysWithHooks(),
                     createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_TWO_HOOKS, adminKey),
                     tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FUNGIBLE_TOKEN),
-                    createNonFungibleTokenWithoutCustomFees(NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
+                    createNonFungibleTokenWithoutCustomFees(
+                            NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
                     tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NON_FUNGIBLE_TOKEN),
                     mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
                     cryptoTransfer(
                                     movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
-                                    moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_SECOND),
+                                    moving(10L, FUNGIBLE_TOKEN)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_SECOND),
                                     movingUnique(NON_FUNGIBLE_TOKEN, 1L)
                                             .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD))
                             .withPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 5_000_000L, "")
@@ -294,18 +300,22 @@ public class CryptoTransferWithHooksSimpleFeesTest {
         }
 
         @HapiTest
-        @DisplayName("Crypto Transfer HBAR, FT and NFT with hook execution - extra hooks, tokens and accounts full charging")
-        final Stream<DynamicTest> cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndTokensAndAccountsFullCharging() {
+        @DisplayName(
+                "Crypto Transfer HBAR, FT and NFT with hook execution - extra hooks, tokens and accounts full charging")
+        final Stream<DynamicTest>
+                cryptoTransferHBARAndFtAndNFTWithTwoHooksExtraHooksAndTokensAndAccountsFullCharging() {
             return hapiTest(flattened(
                     createAccountsAndKeysWithHooks(),
                     createFungibleTokenWithoutCustomFees(FUNGIBLE_TOKEN, 100L, PAYER_WITH_TWO_HOOKS, adminKey),
                     tokenAssociate(RECEIVER_ASSOCIATED_SECOND, FUNGIBLE_TOKEN),
-                    createNonFungibleTokenWithoutCustomFees(NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
+                    createNonFungibleTokenWithoutCustomFees(
+                            NON_FUNGIBLE_TOKEN, PAYER_WITH_TWO_HOOKS, supplyKey, adminKey),
                     tokenAssociate(RECEIVER_ASSOCIATED_THIRD, NON_FUNGIBLE_TOKEN),
                     mintNFT(NON_FUNGIBLE_TOKEN, 1, 5),
                     cryptoTransfer(
                                     movingHbar(1L).between(PAYER_WITH_HOOK, RECEIVER_ASSOCIATED_FIRST),
-                                    moving(10L, FUNGIBLE_TOKEN).between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_SECOND),
+                                    moving(10L, FUNGIBLE_TOKEN)
+                                            .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_SECOND),
                                     movingUnique(NON_FUNGIBLE_TOKEN, 1L)
                                             .between(PAYER_WITH_TWO_HOOKS, RECEIVER_ASSOCIATED_THIRD))
                             .withPreHookFor(PAYER_WITH_TWO_HOOKS, 1L, 5_000_000L, "")
@@ -332,7 +342,8 @@ public class CryptoTransferWithHooksSimpleFeesTest {
         }
 
         @HapiTest
-        @DisplayName("Crypto Transfer - Auto Create Accounts with FT moving and with hook execution - extra hook full charging")
+        @DisplayName(
+                "Crypto Transfer - Auto Create Accounts with FT moving and with hook execution - extra hook full charging")
         final Stream<DynamicTest> cryptoTransferFTAutoAccountCreationWithOneHookExtraHookFullCharging() {
             return hapiTest(flattened(
                     createAccountsAndKeysWithHooks(),
@@ -356,7 +367,10 @@ public class CryptoTransferWithHooksSimpleFeesTest {
                             0.001),
                     getAliasedAccountInfo(VALID_ALIAS_ED25519)
                             .hasToken(relationshipWith(FUNGIBLE_TOKEN))
-                            .has(accountWith().key(VALID_ALIAS_ED25519).alias(VALID_ALIAS_ED25519).maxAutoAssociations(-1)),
+                            .has(accountWith()
+                                    .key(VALID_ALIAS_ED25519)
+                                    .alias(VALID_ALIAS_ED25519)
+                                    .maxAutoAssociations(-1)),
                     getAccountBalance(PAYER_WITH_HOOK).hasTokenBalance(FUNGIBLE_TOKEN, 90L)));
         }
     }


### PR DESCRIPTION
## Summary

This PR backports [#24783](https://github.com/hiero-ledger/hiero-consensus-node/pull/24783), which changes the default for `hooks.hooksEnabled` from `true` to `false`.

## Why additional test changes were needed

Disabling hooks by default exposed two existing test assumptions on `release/0.73`:

- The Simple Fees coverage introduced in [#22859](https://github.com/hiero-ledger/hiero-consensus-node/pull/22859) and [#22949](https://github.com/hiero-ledger/hiero-consensus-node/pull/22949) mixed hook-dependent scenarios into broader suites by using shared hook setup and class-wide hook enablement.
- Two HIP-1195 classes in `Misc` / `Misc Records` were being run in concurrent subprocess mode after [#23626](https://github.com/hiero-ledger/hiero-consensus-node/pull/23626). That was safe while hooks were effectively always available, but it is no longer safe once hooks default to `false`.

## What changed

- Broad Simple Fees suites remain hook-agnostic and continue to run concurrently.
- Hook-only Simple Fees scenarios were extracted into dedicated classes with explicit hook enablement.
- The minimum set of hook-heavy subprocess classes were isolated with `@OrderedInIsolation` so they run serially, while the rest of the suite stays concurrent.

In practice, this means:
- Non-hook Simple Fees tests no longer depend on hooks being enabled
- Hook-dependent Simple Fees tests declare that dependency explicitly
- The hooks test classes in in `Misc` / `Misc Records` no longer race in concurrent mode.

## Why this approach

This keeps the scope tight and preserves the performance improvement from #23626 by serializing only the smallest set of root classes that are actually hook-dependent. That fixes the failures without undoing the broader concurrency split.