### PR TITLE
ci(workflow-mats): remove spotless field from MATS workflows

### DIFF
--- a/.github/workflows/flow-dry-run-mats-suite.yaml
+++ b/.github/workflows/flow-dry-run-mats-suite.yaml
@@ -7,11 +7,6 @@ on:
         description: "The git ref (branch or tag) to checkout"
         required: false
         default: ""
-      enable-spotless-check:
-        description: "Spotless Check Enabled"
-        type: boolean
-        required: false
-        default: true
       enable-dependency-check:
         description: "Dependency Check Enabled"
         type: boolean
@@ -77,7 +72,6 @@ jobs:
     uses: ./.github/workflows/zxc-mats-tests.yaml
     with:
       ref: ${{ inputs.ref || '' }}
-      enable-spotless-check: "${{ inputs.enable-spotless-check || 'false' }}"
       enable-dependency-check: "${{ inputs.enable-dependency-check || 'false' }}"
       enable-unit-tests: "${{ inputs.enable-unit-tests || 'false' }}"
       enable-integration-tests: "${{ inputs.enable-integration-tests || 'false' }}"

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -25,7 +25,6 @@ jobs:
     uses: ./.github/workflows/zxc-mats-tests.yaml
     with:
       ref: ${{ github.ref }}
-      enable-spotless-check: "true"
       enable-dependency-check: "true"
       enable-unit-tests: "true"
       enable-integration-tests: "true"

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -58,7 +58,6 @@ jobs:
     uses: ./.github/workflows/zxc-mats-tests.yaml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
-      enable-spotless-check: "true"
       enable-dependency-check: ${{ needs.detect-change-type.outputs.enable-tests }}
       enable-unit-tests: ${{ needs.detect-change-type.outputs.enable-tests }}
       enable-integration-tests: ${{ needs.detect-change-type.outputs.enable-tests }}

--- a/.github/workflows/zxc-mats-tests.yaml
+++ b/.github/workflows/zxc-mats-tests.yaml
@@ -13,11 +13,6 @@ on:
         type: string
         required: false
         default: "false"
-      enable-spotless-check:
-        description: "Spotless Check Enabled"
-        type: string
-        required: false
-        default: "false"
       enable-unit-tests:
         description: "Unit Testing Enabled"
         type: string
@@ -179,7 +174,6 @@ jobs:
 
   spotless:
     name: "${{ inputs.custom-job-label }} Spotless"
-    if: ${{ inputs.enable-spotless-check == 'true' }}
     uses: ./.github/workflows/zxc-spotless-check.yaml
     needs:
       - commit-info


### PR DESCRIPTION
**Description**:

Spotless should be run on every MATS run. This PR removes the spotless field so spotless is always run.

**Related Issue(s)**:

Implements #24909
