### PR TITLE
refactor: 24917: Clean up testDir in swirlds-benchmarks

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
@@ -60,12 +60,10 @@ public abstract class BaseBench {
 
     /* Directory for the entire benchmark */
     private static Path benchDir;
-    /* Directory for each iteration */
-    private Path testDir;
+    /* Directory for storing data files. */
+    private Path storeDir;
     /* Verify benchmark results */
     protected boolean verify;
-
-    private boolean keepTestDir;
 
     protected static Configuration configuration;
 
@@ -207,8 +205,7 @@ public abstract class BaseBench {
 
     /**
      * JMH invocation-level teardown. Calls {@link #onInvocationTearDown()}, does base invocation
-     * teardown, and deletes the test directory (unless {@link #preserveTestDir()}
-     * was called during the invocation).
+     * teardown, and deletes the store directory.
      *
      * <p><b>Important:</b> see {@link #setupTrial()} for why subclasses must not add
      * their own {@code @TearDown} annotations.
@@ -227,11 +224,10 @@ public abstract class BaseBench {
             Utils.printClassHistogram(15);
         }
 
-        // Always clean up testDir at the end unless explicitly preserved
-        if (!keepTestDir && testDir != null) {
-            Utils.deleteRecursively(testDir);
+        // Clean up storeDir at the end of each invocation
+        if (storeDir != null) {
+            Utils.deleteRecursively(storeDir);
         }
-        keepTestDir = false;
     }
 
     /**
@@ -248,26 +244,18 @@ public abstract class BaseBench {
         // no-op by default
     }
 
-    // ── Test directory utilities ─────────────────────────────────────
-
-    /**
-     * Call from a @Benchmark method to preserve the test directory for this invocation.
-     * Useful for benchmarks like {@code read()} where data is reused across invocations.
-     */
-    protected void preserveTestDir() {
-        this.keepTestDir = true;
-    }
+    // ── Benchmark directory utilities ─────────────────────────────────────
 
     public static Path getBenchDir() {
         return benchDir;
     }
 
-    public Path getTestDir() {
-        return testDir;
+    public Path getStoreDir() {
+        return storeDir;
     }
 
-    public void setTestDir(String name) {
-        testDir = benchDir.resolve(name);
+    public void setStoreDir(String name) {
+        storeDir = benchDir.resolve(name);
     }
 
     // ── Misc ─────────────────────────────────────

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/CryptoBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/CryptoBench.java
@@ -112,8 +112,6 @@ public class CryptoBench extends VirtualMapBench {
      */
     @Benchmark
     public void transferSerial() throws Exception {
-        setTestDir("transferSerial");
-
         logger.info(RUN_DELIMITER);
 
         if (getBenchmarkConfig().enableSnapshots()) {
@@ -195,8 +193,6 @@ public class CryptoBench extends VirtualMapBench {
 
     @Benchmark
     public void transferPrefetch() throws Exception {
-        setTestDir("transferPrefetch");
-
         logger.info(RUN_DELIMITER);
 
         if (getBenchmarkConfig().enableSnapshots()) {
@@ -398,8 +394,6 @@ public class CryptoBench extends VirtualMapBench {
      */
     @Benchmark
     public void transferParallel() throws Exception {
-        setTestDir("transferParallel");
-
         logger.info(RUN_DELIMITER);
 
         if (getBenchmarkConfig().enableSnapshots()) {

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
@@ -39,8 +39,8 @@ public class DataFileCollectionBench extends BaseBench {
 
     @Benchmark
     public void compaction() throws Exception {
-        String storeName = "compactionBench";
-        setTestDir(storeName);
+        final String storeName = "compactionBench";
+        setStoreDir(storeName);
 
         logger.info(RUN_DELIMITER);
 
@@ -49,7 +49,7 @@ public class DataFileCollectionBench extends BaseBench {
         final BenchmarkRecord[] map = new BenchmarkRecord[verify ? maxKey : 0];
         final MerkleDbConfig dbConfig = getConfig(MerkleDbConfig.class);
         final var store =
-                new DataFileCollection(dbConfig, getTestDir(), storeName, null, (dataLocation, dataValue) -> {}) {
+                new DataFileCollection(dbConfig, getStoreDir(), storeName, null, (dataLocation, dataValue) -> {}) {
                     BenchmarkRecord read(long dataLocation) throws IOException {
                         final BufferedData recordData = readDataItem(dataLocation);
                         if (recordData == null) {

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
@@ -37,15 +37,15 @@ public class HalfDiskMapBench extends BaseBench {
 
     @Benchmark
     public void merge() throws Exception {
-        String storeName = "mergeBench";
-        setTestDir(storeName);
+        final String storeName = "mergeBench";
+        setStoreDir(storeName);
 
         logger.info(RUN_DELIMITER);
 
         final long[] map = new long[verify ? maxKey : 0];
         Arrays.fill(map, INVALID_PATH);
 
-        final var store = new HalfDiskHashMap(configuration, maxKey, getTestDir(), storeName, null, false);
+        final var store = new HalfDiskHashMap(configuration, maxKey, getStoreDir(), storeName, null, false);
         final var dataFileCompactor = new DataFileCompactor(
                 storeName, store.getFileCollection(), store.getBucketIndexToBucketLocation(), null, null, null, null);
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
@@ -35,8 +35,8 @@ public class KeyValueStoreBench extends BaseBench {
 
     @Benchmark
     public void merge() throws Exception {
-        String storeName = "mergeBench";
-        setTestDir(storeName);
+        final String storeName = "mergeBench";
+        setStoreDir(storeName);
 
         logger.info(RUN_DELIMITER);
 
@@ -44,7 +44,7 @@ public class KeyValueStoreBench extends BaseBench {
         LongListSegment keyToDiskLocationIndex = new LongListSegment(1024 * 1024, maxKey, 256 * 1024);
         final MerkleDbConfig dbConfig = getConfig(MerkleDbConfig.class);
         final var store = new MemoryIndexDiskKeyValueStore(
-                dbConfig, getTestDir(), storeName, null, (dataLocation, dataValue) -> {}, keyToDiskLocationIndex);
+                dbConfig, getStoreDir(), storeName, null, (dataLocation, dataValue) -> {}, keyToDiskLocationIndex);
         final DataFileCompactor compactor = new DataFileCompactor(
                 storeName, store.getFileCollection(), keyToDiskLocationIndex, null, null, null, null);
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/ReconnectBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/ReconnectBench.java
@@ -93,8 +93,6 @@ public class ReconnectBench extends VirtualMapBaseBench {
     protected void onTrialSetup() {
         super.onTrialSetup();
 
-        setTestDir("reconnect");
-
         final Random random = new Random(randomSeed);
 
         if (getBenchmarkConfig().saveDataDirectory()) {

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
@@ -37,8 +37,6 @@ public class VirtualMapBench extends VirtualMapBaseBench {
      */
     @Benchmark
     public void update() throws Exception {
-        setTestDir("update");
-
         logger.info(RUN_DELIMITER);
 
         final long[] map = new long[verify ? maxKey : 0];
@@ -92,8 +90,6 @@ public class VirtualMapBench extends VirtualMapBaseBench {
      */
     @Benchmark
     public void create() throws Exception {
-        setTestDir("create");
-
         logger.info(RUN_DELIMITER);
 
         final long[] map = new long[verify ? maxKey : 0];
@@ -132,8 +128,6 @@ public class VirtualMapBench extends VirtualMapBaseBench {
      */
     @Benchmark
     public void delete() throws Exception {
-        setTestDir("delete");
-
         logger.info(RUN_DELIMITER);
 
         final long[] map = new long[verify ? maxKey : 0];
@@ -199,9 +193,6 @@ public class VirtualMapBench extends VirtualMapBaseBench {
      */
     @Benchmark
     public void read() {
-        setTestDir("read");
-        preserveTestDir();
-
         logger.info(RUN_DELIMITER);
 
         if (virtualMapP == null) {


### PR DESCRIPTION
**Description**:
Rename `testDir` → `storeDir`, remove its usages in VirtualMap-based benchmarks (as they never used `testDir` for their data), and remove `preserveTestDir()` mechanism.

**Related issue(s)**:
Fixes #24917
