### PR TITLE
feat: 24903: Clarify virtual map sizing across swirlds-benchmarks

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
@@ -61,11 +61,15 @@ public abstract class BaseBench {
      * {@code [0, maxKey)}. The ratio to {@code numFiles × numRecords}
      * controls density: smaller means update-heavy, larger means create-heavy.
      * <p>
+     * In {@code VirtualMapBench.read()}, used as the exact map population
+     * size — all keys in {@code [0, maxKey)} are inserted, then read
+     * randomly. Map copies during population are spaced to avoid OOM.
+     * <p>
      * In low-level storage benchmarks ({@code DataFileCollectionBench},
      * {@code HalfDiskMapBench}, {@code KeyValueStoreBench}), used as
      * the physical index capacity.
      * <p>
-     * Not used by full-population benchmarks, which derive map size
+     * Not used by {@code ReconnectBench}, which derives map size
      * from {@code numFiles × numRecords}.
      */
     @Param({"1000000"})

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
@@ -35,12 +35,39 @@ public abstract class BaseBench {
 
     private static final Logger logger = LogManager.getLogger(BaseBench.class);
 
+    /**
+     * Number of outer iterations. Meaning depends on the benchmark:
+     * data files written, VirtualMap copy-cycles, etc.
+     * <p>
+     * {@code numFiles × numRecords} is the total number of operations.
+     * Full-population benchmarks also use this product as the map size.
+     */
     @Param({"100"})
     public int numFiles = 500;
 
+    /**
+     * Number of operations per iteration.
+     *
+     * @see #numFiles
+     */
     @Param({"100000"})
     public int numRecords = 10_000;
 
+    /**
+     * Upper bound of the key space for random-access and low-level storage benchmarks.
+     * <p>
+     * In random-access benchmarks ({@code CryptoBench},
+     * {@code VirtualMapBench.update/create/delete}), keys are drawn from
+     * {@code [0, maxKey)}. The ratio to {@code numFiles × numRecords}
+     * controls density: smaller means update-heavy, larger means create-heavy.
+     * <p>
+     * In low-level storage benchmarks ({@code DataFileCollectionBench},
+     * {@code HalfDiskMapBench}, {@code KeyValueStoreBench}), used as
+     * the physical index capacity.
+     * <p>
+     * Not used by full-population benchmarks, which derive map size
+     * from {@code numFiles × numRecords}.
+     */
     @Param({"1000000"})
     public int maxKey = 10_000_000;
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
@@ -198,24 +198,20 @@ public class VirtualMapBench extends VirtualMapBaseBench {
         if (virtualMapP == null) {
             virtualMapP = createEmptyMap();
             final AtomicReference<VirtualMap> mapRef = new AtomicReference<>(virtualMapP);
+            final long recordsPerCopy = maxKey / numFiles;
 
             final long start = System.currentTimeMillis();
             new StateBuilder(BenchmarkKeyUtils::longToKey, i -> new BenchmarkValue(nextValue()))
                     .populateState(
                             0,
-                            (long) numRecords * numFiles,
+                            maxKey,
                             i -> {
-                                if (i % numRecords == 0) {
-                                    logger.info("Copying files for i={}", i);
+                                if (i > 0 && i % recordsPerCopy == 0) {
                                     mapRef.set(virtualMapP = copyMap(virtualMapP));
                                 }
                             },
                             StateBuilder.buildVMPopulator(mapRef));
-
-            logger.info(
-                    "Pre-created {} records in {} ms",
-                    (long) numRecords * numFiles,
-                    System.currentTimeMillis() - start);
+            logger.info("Pre-created {} records in {} ms", maxKey, System.currentTimeMillis() - start);
 
             virtualMapP = flushAndOptionallySaveMap(virtualMapP);
         }
@@ -225,7 +221,7 @@ public class VirtualMapBench extends VirtualMapBaseBench {
         IntStream.range(0, numThreads).parallel().forEach(thread -> {
             long sum = 0;
             for (int i = 0; i < numRecords; ++i) {
-                final long id = Utils.randomLong((long) numRecords * numFiles);
+                final long id = Utils.randomLong(maxKey);
                 final BenchmarkValue value = virtualMapP.get(longToKey(id), BenchmarkValueCodec.INSTANCE);
                 sum += value.hashCode();
             }

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
@@ -198,20 +198,24 @@ public class VirtualMapBench extends VirtualMapBaseBench {
         if (virtualMapP == null) {
             virtualMapP = createEmptyMap();
             final AtomicReference<VirtualMap> mapRef = new AtomicReference<>(virtualMapP);
-            final long recordsPerCopy = maxKey / numFiles;
 
             final long start = System.currentTimeMillis();
             new StateBuilder(BenchmarkKeyUtils::longToKey, i -> new BenchmarkValue(nextValue()))
                     .populateState(
                             0,
-                            maxKey,
+                            (long) numRecords * numFiles,
                             i -> {
-                                if (i > 0 && i % recordsPerCopy == 0) {
+                                if (i % numRecords == 0) {
+                                    logger.info("Copying files for i={}", i);
                                     mapRef.set(virtualMapP = copyMap(virtualMapP));
                                 }
                             },
                             StateBuilder.buildVMPopulator(mapRef));
-            logger.info("Pre-created {} records in {} ms", maxKey, System.currentTimeMillis() - start);
+
+            logger.info(
+                    "Pre-created {} records in {} ms",
+                    (long) numRecords * numFiles,
+                    System.currentTimeMillis() - start);
 
             virtualMapP = flushAndOptionallySaveMap(virtualMapP);
         }
@@ -221,7 +225,7 @@ public class VirtualMapBench extends VirtualMapBaseBench {
         IntStream.range(0, numThreads).parallel().forEach(thread -> {
             long sum = 0;
             for (int i = 0; i < numRecords; ++i) {
-                final long id = Utils.randomLong(maxKey);
+                final long id = Utils.randomLong((long) numRecords * numFiles);
                 final BenchmarkValue value = virtualMapP.get(longToKey(id), BenchmarkValueCodec.INSTANCE);
                 sum += value.hashCode();
             }


### PR DESCRIPTION
**Description**:
Investigated usage of `maxKey` vs `numFiles × numRecords`across benchmarks.
There are two main patterns: 
- random-access (keys drawn randomly from [0, maxKey)) 
- full-population (sequential keys, exact entry count)

`maxKey` usages are tightly coupled by design:
- Random key bound (Crypto and VirtualMap benchmarks) → verification array size → HDHM size hint (all must track the key space)
- Index capacity → `nextAscKey()` range (HalfDisk, KeyValue and Compaction benchmarks)
No easy way to decouple these without over-engineering, so the fix is scoped to the one method that was genuinely wrong.

**Related issue(s)**:
Fixes #24903