### PR TITLE
chore: Change log level in WrappedRecordFileBlockHashesDiskWriter

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesDiskWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesDiskWriter.java
@@ -130,7 +130,7 @@ public class WrappedRecordFileBlockHashesDiskWriter implements AutoCloseable {
 
                             final var newlyLoggedGaps = index.addAndGetNewGaps(entry.blockNumber());
                             for (final var gap : newlyLoggedGaps) {
-                                logger.warn(
+                                logger.info(
                                         "Wrapped record hashes file has a gap: missing record blocks {}..{} (observed range {}..{})",
                                         gap.startInclusive(),
                                         gap.endInclusive(),
@@ -212,7 +212,7 @@ public class WrappedRecordFileBlockHashesDiskWriter implements AutoCloseable {
         if (index.highestBlock() >= 0) {
             final var initGaps = index.addAndGetNewGaps(index.highestBlock());
             for (final var gap : initGaps) {
-                logger.warn(
+                logger.info(
                         "Wrapped record hashes file has a gap: missing record blocks {}..{} (observed range {}..{})",
                         gap.startInclusive(),
                         gap.endInclusive(),


### PR DESCRIPTION
**Description**:
This pull request makes a minor change to the logging level for messages about missing record block gaps in the `WrappedRecordFileBlockHashesDiskWriter` class. Specifically, it reduces the severity of these log messages from "warn" to "info" to prevent unnecessary warning logs for expected or non-critical gaps.

**Related issue(s)**:

Fixes #24871 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
