### PR TITLE
fix: 24802 Disable EVM hook count validation for TestNet

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/EntityIdCountValidator.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/EntityIdCountValidator.java
@@ -108,7 +108,7 @@ public class EntityIdCountValidator implements LeafBytesValidator {
         }
 
         final boolean ok;
-        if (NET_NAME.equals("Mainnet")) {
+        if (NET_NAME.equals("Mainnet") || NET_NAME.equals("Previewnet")) {
             ok = entityCounts.numAccounts() == accountCount.get()
                     && entityCounts.numAliases() == aliasesCount.get()
                     && entityCounts.numTokens() == tokenCount.get()
@@ -126,7 +126,7 @@ public class EntityIdCountValidator implements LeafBytesValidator {
                     && entityCounts.numHooks() == hookCount.get()
                     && entityCounts.numEvmHookStorageSlots() == evmHookStorageCount.get();
         } else {
-            // PreviewNet and TestNet have numEvmHookStorageSlots count validation disabled
+            // TestNet have numEvmHookStorageSlots count validation disabled
             // See https://github.com/hiero-ledger/hiero-consensus-node/issues/24802
             ok = entityCounts.numAccounts() == accountCount.get()
                     && entityCounts.numAliases() == aliasesCount.get()


### PR DESCRIPTION
**Description**:

This PR re-enables numEvmHookStorageSlots count validation for PreviewNet


**Related issue(s)**:

Fixes #24802 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
