### PR TITLE
fix: Fix bug in flaky test detection when using cached test results

### DIFF
--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -181,9 +181,19 @@ jobs:
             **/yahcli/build/test-results/**/TEST-*.xml
           retention-days: 7
 
+      - name: Check If Tests Executed (Misc)
+        id: check-tests-executed-hapi-misc
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" -o -path "*/yahcli/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Misc)
         id: detect-flaky-hapi-misc
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-misc.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null \
@@ -265,9 +275,19 @@ jobs:
           path: "**/test-clients/build/test-results/**/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Misc Records)
+        id: check-tests-executed-hapi-misc-records
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Misc Records)
         id: detect-flaky-hapi-misc-records
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-misc-records.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -343,9 +363,19 @@ jobs:
           path: "**/test-clients/build/test-results/**/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Crypto)
+        id: check-tests-executed-hapi-crypto
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Crypto)
         id: detect-flaky-hapi-crypto
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-crypto.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -421,9 +451,19 @@ jobs:
           path: "**/test-clients/build/test-results/**/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Simple Fees)
+        id: check-tests-executed-hapi-simplefees
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Simple Fees)
         id: detect-flaky-hapi-simplefees
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-simplefees.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -499,9 +539,19 @@ jobs:
           path: "**/test-clients/build/test-results/**/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Token)
+        id: check-tests-executed-hapi-token
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Token)
         id: detect-flaky-hapi-token
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-token.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -577,9 +627,19 @@ jobs:
           path: "**/test-clients/build/test-results/**/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Smart Contract)
+        id: check-tests-executed-hapi-smart-contract
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Smart Contract)
         id: detect-flaky-hapi-smart-contract
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-smart-contract.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -655,9 +715,19 @@ jobs:
           path: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Time Consuming)
+        id: check-tests-executed-hapi-time-consuming
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Time Consuming)
         id: detect-flaky-hapi-time-consuming
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-time-consuming.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -733,9 +803,19 @@ jobs:
           path: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Restart)
+        id: check-tests-executed-hapi-restart
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Restart)
         id: detect-flaky-hapi-restart
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-restart.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -811,9 +891,19 @@ jobs:
           path: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Node Death Reconnect)
+        id: check-tests-executed-hapi-nd-reconnect
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Node Death Reconnect)
         id: detect-flaky-hapi-nd-reconnect
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-nd-reconnect.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -889,9 +979,19 @@ jobs:
           path: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (ISS)
+        id: check-tests-executed-hapi-iss
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (ISS)
         id: detect-flaky-hapi-iss
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-iss.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -967,9 +1067,19 @@ jobs:
           path: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Block Node Communication)
+        id: check-tests-executed-hapi-bn-communication
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Block Node Communication)
         id: detect-flaky-hapi-bn-communication
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-bn-communication.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -1043,9 +1153,19 @@ jobs:
           path: "**/test-clients/build/test-results/**/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Atomic Batch)
+        id: check-tests-executed-hapi-atomic-batch
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Atomic Batch)
         id: detect-flaky-hapi-atomic-batch
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-atomic-batch.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -1121,9 +1241,19 @@ jobs:
           path: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (State Throttling)
+        id: check-tests-executed-hapi-state-throttling
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/test-clients/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (State Throttling)
         id: detect-flaky-hapi-state-throttling
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-hapi-state-throttling.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" hedera-node/test-clients/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then

--- a/.github/workflows/zxc-execute-integration-tests.yaml
+++ b/.github/workflows/zxc-execute-integration-tests.yaml
@@ -88,6 +88,16 @@ jobs:
         id: gradle-integration-tests
         run: ${GRADLE_EXEC} testIntegration
 
+      - name: Check If Tests Executed
+        id: check-tests-executed
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/build/test-executed/testIntegration.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Publish Integration Test Report
         id: publish-test-report
         uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
@@ -107,7 +117,7 @@ jobs:
 
       - name: Detect Flaky Tests (Integration)
         id: detect-flaky-integration-tests
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if find . -path "*/build/test-results/testIntegration/TEST-*.xml" 2>/dev/null \

--- a/.github/workflows/zxc-execute-otter-tests.yaml
+++ b/.github/workflows/zxc-execute-otter-tests.yaml
@@ -121,9 +121,19 @@ jobs:
           path: "**/consensus-otter-tests/build/test-results/testContainer/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Full Otter)
+        id: check-tests-executed-full-otter
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/consensus-otter-tests/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Full Otter)
         id: detect-flaky-full-otter
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-full-otter.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" platform-sdk/consensus-otter-tests/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -184,9 +194,19 @@ jobs:
           path: "**/consensus-otter-tests/build/test-results/testOtter/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Fast Otter)
+        id: check-tests-executed-fast-otter
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/consensus-otter-tests/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Fast Otter)
         id: detect-flaky-fast-otter
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-fast-otter.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" platform-sdk/consensus-otter-tests/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then
@@ -255,9 +275,19 @@ jobs:
           path: "**/consensus-otter-tests/build/test-results/testChaos/TEST-*.xml"
           retention-days: 7
 
+      - name: Check If Tests Executed (Chaos Otter)
+        id: check-tests-executed-chaos-otter
+        if: ${{ !cancelled() }}
+        run: |
+          tests_executed="false"
+          if find . -path "*/consensus-otter-tests/build/test-executed/*.marker" 2>/dev/null | grep -q .; then
+            tests_executed="true"
+          fi
+          echo "tests-executed=${tests_executed}" >> "${GITHUB_OUTPUT}"
+
       - name: Detect Flaky Tests (Chaos Otter)
         id: detect-flaky-chaos-otter
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.check-tests-executed-chaos-otter.outputs.tests-executed == 'true' }}
         run: |
           has_flaky="false"
           if grep -rql "<flakyFailure" platform-sdk/consensus-otter-tests/build/test-results/ --include="TEST-*.xml" 2>/dev/null; then

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,14 @@ gradle.allprojects {
                 failOnPassedAfterRetry.set(false)
             }
             reports.junitXml.mergeReruns.set(true)
+
+            // Write a marker when tests actually execute (not on cache restore)
+            doLast {
+                layout.buildDirectory.file("test-executed/${name}.marker").get().asFile.apply {
+                    parentFile.mkdirs()
+                    writeText(java.time.Instant.now().toString())
+                }
+            }
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,12 +17,13 @@ gradle.allprojects {
             }
             reports.junitXml.mergeReruns.set(true)
 
-            // Write a marker when tests actually execute (not on cache restore)
+            // Write a marker when tests actually execute (not on cache restore).
+            // Resolve eagerly to avoid capturing Project in the doLast closure (configuration
+            // cache).
+            val markerFile = layout.buildDirectory.file("test-executed/${name}.marker").get().asFile
             doLast {
-                layout.buildDirectory.file("test-executed/${name}.marker").get().asFile.apply {
-                    parentFile.mkdirs()
-                    writeText(java.time.Instant.now().toString())
-                }
+                markerFile.parentFile.mkdirs()
+                markerFile.writeText(java.time.Instant.now().toString())
             }
         }
     }


### PR DESCRIPTION
### Description

This fixes a problem where flaky tests were being reported even when tests were not run - cached test results were used instead. Cached test results contain the `<flakyFailure>` tag and are restored when none of the tested code has changed. The flaky test detection looks for this tag and treats it as a new flaky failure.

This PR adds a variable that captures if the tests were actually run vs. restoring results from a cache. The flaky test detection is now gated behind this variable.

Fixes #24941 
