### PR TITLE
fix: 24952 Added missing `BlockRecordStreamConfig` to `ConfigurationBuilder`

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ConfigUtils.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ConfigUtils.java
@@ -22,7 +22,9 @@ import com.hedera.node.config.converter.ScaleFactorConverter;
 import com.hedera.node.config.converter.SemanticVersionConverter;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.ApiPermissionConfig;
+import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.node.config.data.BlockStreamJumpstartConfig;
 import com.hedera.node.config.data.BootstrapConfig;
 import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.HederaConfig;
@@ -115,6 +117,8 @@ public final class ConfigUtils {
                 .withConfigDataType(PcesConfig.class)
                 .withConfigDataType(BasicConfig.class)
                 .withConfigDataType(MetricsConfig.class)
+                .withConfigDataType(BlockRecordStreamConfig.class)
+                .withConfigDataType(BlockStreamJumpstartConfig.class)
                 .withSource(new SimpleConfigSource().withValue("merkleDb.usePbj", false))
                 .withSource(new SimpleConfigSource().withValue("merkleDb.minNumberOfFilesInCompaction", 2))
                 .withSource(new SimpleConfigSource().withValue("merkleDb.maxFileChannelsPerFileReader", FILE_CHANNELS))


### PR DESCRIPTION
**Description**:

This PR adds missing `BlockRecordStreamConfig` to the `ConfigurationBuilder` of the State Operator

**Related issue(s)**:

Fixes #24952 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
