### PR TITLE
fix: 24956: Fix IndexOutOfBoundsException in KeyValueStoreBench

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
@@ -53,7 +53,7 @@ public class KeyValueStoreBench extends BaseBench {
         // Write files
         long start = System.currentTimeMillis();
         for (int i = 0; i < numFiles; i++) {
-            store.updateValidKeyRange(0, maxKey);
+            store.updateValidKeyRange(0, maxKey - 1);
             store.startWriting();
             resetKeys();
             for (int j = 0; j < numRecords; ++j) {


### PR DESCRIPTION
**Description**:
This PR fixes an `IndexOutOfBoundsException` in `KeyValueStoreBench` by using `maxKey - 1` as the max valid index (consistent with `DataFileCollectionBench` and all tests).

**Related issue(s)**:
Fixes #24956
