### PR TITLE
fix: increase stream assertion timeout

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractKeysStillWorkAsExpectedSuite.java
@@ -49,6 +49,7 @@ import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenType;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -82,7 +83,8 @@ public class ContractKeysStillWorkAsExpectedSuite {
                                     assertTrue(adjust.getIsApproval());
                                 }
                             }
-                        })),
+                        }),
+                        Duration.ofSeconds(15)),
                 someWellKnownTokensAndAccounts(
                         fungibleTokenMirrorAddr,
                         nonFungibleTokenMirrorAddr,


### PR DESCRIPTION
**Description**:
Increases the `recordStreamMustIncludePassFrom` stream assertion timeout from the default 5s to 15s in `approvalFallbacksRequiredWithoutTopLevelSigAccess`. The test was flaky in CI because the record stream file containing the expected child transaction wasn’t always flushed within the 5-second window under load

**Related issue(s)**:

Fixes #24720 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
