### PR TITLE
feat: Use DataFileCollection store name for compaction logging

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/DataFileCollectionBench.java
@@ -64,7 +64,7 @@ public class DataFileCollectionBench extends BaseBench {
                     }
                 };
 
-        final var compactor = new DataFileCompactor(storeName, store, index, null, null, null, null);
+        final var compactor = new DataFileCompactor(store, index, null, null, null, null);
 
         // Write files
         long start = System.currentTimeMillis();

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/HalfDiskMapBench.java
@@ -49,7 +49,7 @@ public class HalfDiskMapBench extends BaseBench {
 
         final var store = new HalfDiskHashMap(configuration, maxKey, getStoreDir(), storeName, null, false);
         final var dataFileCompactor = new DataFileCompactor(
-                storeName, store.getFileCollection(), store.getBucketIndexToBucketLocation(), null, null, null, null);
+                store.getFileCollection(), store.getBucketIndexToBucketLocation(), null, null, null, null);
 
         // Write files
         long start = System.currentTimeMillis();

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
@@ -48,7 +48,7 @@ public class KeyValueStoreBench extends BaseBench {
         final var store = new MemoryIndexDiskKeyValueStore(
                 dbConfig, getStoreDir(), storeName, null, (dataLocation, dataValue) -> {}, keyToDiskLocationIndex);
         final DataFileCompactor compactor = new DataFileCompactor(
-                storeName, store.getFileCollection(), keyToDiskLocationIndex, null, null, null, null);
+                store.getFileCollection(), keyToDiskLocationIndex, null, null, null, null);
 
         // Write files
         long start = System.currentTimeMillis();

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/KeyValueStoreBench.java
@@ -47,8 +47,8 @@ public class KeyValueStoreBench extends BaseBench {
         final MerkleDbConfig dbConfig = getConfig(MerkleDbConfig.class);
         final var store = new MemoryIndexDiskKeyValueStore(
                 dbConfig, getStoreDir(), storeName, null, (dataLocation, dataValue) -> {}, keyToDiskLocationIndex);
-        final DataFileCompactor compactor = new DataFileCompactor(
-                store.getFileCollection(), keyToDiskLocationIndex, null, null, null, null);
+        final DataFileCompactor compactor =
+                new DataFileCompactor(store.getFileCollection(), keyToDiskLocationIndex, null, null, null, null);
 
         // Write files
         long start = System.currentTimeMillis();

--- a/platform-sdk/swirlds-merkledb/src/hammer/java/com/swirlds/merkledb/files/DataFileCollectionCompactionHammerTest.java
+++ b/platform-sdk/swirlds-merkledb/src/hammer/java/com/swirlds/merkledb/files/DataFileCollectionCompactionHammerTest.java
@@ -60,7 +60,7 @@ class DataFileCollectionCompactionHammerTest {
             final MerkleDbConfig dbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
             final var coll = new DataFileCollection(
                     dbConfig, tempFileDir.resolve(storeName), storeName, (dataLocation, dataValue) -> {});
-            final var compactor = new DataFileCompactor(storeName, coll, index, null, null, null, null);
+            final var compactor = new DataFileCompactor(coll, index, null, null, null, null);
 
             final Random rand = new Random(777);
             for (int i = 0; i < numFiles; i++) {
@@ -124,7 +124,7 @@ class DataFileCollectionCompactionHammerTest {
         final MerkleDbConfig dbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
         final var coll = new DataFileCollection(
                 dbConfig, tempFileDir.resolve(storeName), storeName, (dataLocation, dataValue) -> {});
-        final var compactor = new DataFileCompactor(storeName, coll, index, null, null, null, null);
+        final var compactor = new DataFileCompactor(coll, index, null, null, null, null);
 
         final Random rand = new Random(777);
         final AtomicBoolean stop = new AtomicBoolean(false);

--- a/platform-sdk/swirlds-merkledb/src/hammer/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreCompactionHammerTest.java
+++ b/platform-sdk/swirlds-merkledb/src/hammer/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreCompactionHammerTest.java
@@ -459,8 +459,7 @@ class MemoryIndexDiskKeyValueStoreCompactionHammerTest {
         private final DataFileCompactor compactor;
 
         Compactor(final MemoryIndexDiskKeyValueStore coll, LongListSegment storeIndex) {
-            compactor = new DataFileCompactor(
-                    "megaMergeHammerTest", coll.getFileCollection(), storeIndex, null, null, null, null);
+            compactor = new DataFileCompactor(coll.getFileCollection(), storeIndex, null, null, null, null);
         }
 
         @Override

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/GarbageScanner.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/GarbageScanner.java
@@ -56,13 +56,9 @@ public class GarbageScanner {
      *
      * @param index              the in-memory index to traverse
      * @param dataFileCollection the file collection whose files are scanned
-     * @param storeName          store name used for logging
      */
-    public GarbageScanner(
-            @NonNull final LongList index,
-            @NonNull final DataFileCollection dataFileCollection,
-            @NonNull final String storeName) {
-        this(index, dataFileCollection, storeName, false);
+    public GarbageScanner(@NonNull final LongList index, @NonNull final DataFileCollection dataFileCollection) {
+        this(index, dataFileCollection, false);
     }
 
     /**
@@ -70,7 +66,6 @@ public class GarbageScanner {
      *
      * @param index                      the in-memory index to traverse
      * @param dataFileCollection         the file collection whose files are scanned
-     * @param storeName                  store name used for logging
      * @param deduplicateMirroredEntries if {@code true}, enables HDHM bucket deduplication mode.
      *                                   After a {@link HalfDiskHashMap} doubles its bucket count,
      *                                   entries at index {@code x} and {@code x + N/2} may point
@@ -81,15 +76,13 @@ public class GarbageScanner {
     public GarbageScanner(
             @NonNull final LongList index,
             @NonNull final DataFileCollection dataFileCollection,
-            @NonNull final String storeName,
             final boolean deduplicateMirroredEntries) {
         requireNonNull(index);
         requireNonNull(dataFileCollection);
-        requireNonNull(storeName);
 
         this.index = index;
         this.dataFileCollection = dataFileCollection;
-        this.storeName = storeName;
+        this.storeName = dataFileCollection.getStoreName();
         this.deduplicateMirroredEntries = deduplicateMirroredEntries;
     }
 

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -489,12 +489,10 @@ public final class MerkleDbDataSource implements VirtualDataSource {
             enableBackgroundCompaction();
         }
 
-        chunkStoreScanner =
-                new GarbageScanner(idToDiskLocationHashChunks, hashChunkStore.getFileCollection(), ID_TO_HASH_CHUNK);
-        pathToKeyValueStoreScanner =
-                new GarbageScanner(pathToDiskLocationLeafNodes, keyValueStore.getFileCollection(), PATH_TO_KEY_VALUE);
-        objectKeyToPathScanner = new GarbageScanner(
-                keyToPath.getBucketIndexToBucketLocation(), keyToPath.getFileCollection(), OBJECT_KEY_TO_PATH, true);
+        chunkStoreScanner = new GarbageScanner(idToDiskLocationHashChunks, hashChunkStore.getFileCollection());
+        pathToKeyValueStoreScanner = new GarbageScanner(pathToDiskLocationLeafNodes, keyValueStore.getFileCollection());
+        objectKeyToPathScanner =
+                new GarbageScanner(keyToPath.getBucketIndexToBucketLocation(), keyToPath.getFileCollection(), true);
         COUNT_OF_OPEN_DATABASES.increment();
         logger.info(
                 MERKLE_DB.getMarker(),
@@ -1376,7 +1374,6 @@ public final class MerkleDbDataSource implements VirtualDataSource {
      */
     DataFileCompactor newHashChunkStoreCompactor() {
         return new DataFileCompactor(
-                tableName + "_" + ID_TO_HASH_CHUNK,
                 hashChunkStore.getFileCollection(),
                 idToDiskLocationHashChunks,
                 statisticsUpdater::setHashesStoreCompactionTimeMs,
@@ -1393,7 +1390,6 @@ public final class MerkleDbDataSource implements VirtualDataSource {
      */
     DataFileCompactor newKeyValueStoreCompactor() {
         return new DataFileCompactor(
-                tableName + "_" + PATH_TO_KEY_VALUE,
                 keyValueStore.getFileCollection(),
                 pathToDiskLocationLeafNodes,
                 statisticsUpdater::setLeavesStoreCompactionTimeMs,
@@ -1410,7 +1406,6 @@ public final class MerkleDbDataSource implements VirtualDataSource {
      */
     DataFileCompactor newKeyToPathCompactor() {
         return new DataFileCompactor(
-                tableName + "_" + OBJECT_KEY_TO_PATH,
                 keyToPath.getFileCollection(),
                 keyToPath.getBucketIndexToBucketLocation(),
                 statisticsUpdater::setLeafKeysStoreCompactionTimeMs,

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -260,6 +260,11 @@ public class DataFileCollection implements FileStatisticAware, Snapshotable {
         }
     }
 
+    @NonNull
+    public String getStoreName() {
+        return storeName;
+    }
+
     /**
      * Get the valid range of keys for data items currently stored by this data file collection. Any
      * data items with keys below this can be deleted during a merge.

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -146,7 +146,6 @@ public class DataFileCompactor {
     private volatile boolean interruptFlag = false;
 
     /**
-     * @param storeName                          name of the store to compact
      * @param dataFileCollection                 data file collection to compact
      * @param index                              index to update during compaction
      * @param reportDurationMetricFunction       function to report how long compaction took, in ms
@@ -155,14 +154,13 @@ public class DataFileCompactor {
      * @param updateTotalStatsFunction           updates statistics of total disk and off-heap usage
      */
     public DataFileCompactor(
-            final String storeName,
             final DataFileCollection dataFileCollection,
             CASableLongIndex index,
             @Nullable final BiConsumer<Integer, Long> reportDurationMetricFunction,
             @Nullable final BiConsumer<Integer, Double> reportSavedSpaceMetricFunction,
             @Nullable final BiConsumer<Integer, Double> reportFileSizeByLevelMetricFunction,
             @Nullable Runnable updateTotalStatsFunction) {
-        this.storeName = storeName;
+        this.storeName = dataFileCollection.getStoreName();
         this.dataFileCollection = dataFileCollection;
         this.index = index;
         this.reportDurationMetricFunction = reportDurationMetricFunction;
@@ -201,7 +199,7 @@ public class DataFileCompactor {
         final long filesToCompactSize = getSizeOfFiles(filesToCompact);
         logger.info(
                 MERKLE_DB.getMarker(),
-                "[{}] Starting compaction to level {} of {} files of size {} Mb ",
+                "[{}] Starting compaction to level {} of {} files of size {}",
                 storeName,
                 targetLevel,
                 filesCount,

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/GarbageScannerDeadAliveRatioTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/GarbageScannerDeadAliveRatioTest.java
@@ -182,7 +182,7 @@ class GarbageScannerDeadAliveRatioTest {
             final DataFileCollection fileCollection = mock(DataFileCollection.class);
             when(fileCollection.getAllCompletedFiles()).thenReturn(List.of(file));
 
-            final GarbageScanner scanner = new GarbageScanner(index, fileCollection, "ObjectKeyToPath", true);
+            final GarbageScanner scanner = new GarbageScanner(index, fileCollection, true);
 
             final IndexedGarbageFileStats stats = scanner.scan();
 
@@ -209,7 +209,7 @@ class GarbageScannerDeadAliveRatioTest {
             final DataFileCollection fileCollection = mock(DataFileCollection.class);
             when(fileCollection.getAllCompletedFiles()).thenReturn(List.of(file));
 
-            final GarbageScanner scanner = new GarbageScanner(index, fileCollection, "ObjectKeyToPath", true);
+            final GarbageScanner scanner = new GarbageScanner(index, fileCollection, true);
 
             final IndexedGarbageFileStats stats = scanner.scan();
 
@@ -358,7 +358,7 @@ class GarbageScannerDeadAliveRatioTest {
 
             final LongList index = emptyIndex();
 
-            final GarbageScanner scanner = new GarbageScanner(index, fileCollection, "test");
+            final GarbageScanner scanner = new GarbageScanner(index, fileCollection);
 
             final IndexedGarbageFileStats stats = scanner.scan();
             assertEquals(0, stats.garbageFileStats().length);
@@ -416,7 +416,7 @@ class GarbageScannerDeadAliveRatioTest {
             final DataFileCollection fileCollection = mock(DataFileCollection.class);
             when(fileCollection.getAllCompletedFiles()).thenReturn(List.of(normalFile, flaggedFile));
 
-            final GarbageScanner scanner = new GarbageScanner(index, fileCollection, "test");
+            final GarbageScanner scanner = new GarbageScanner(index, fileCollection);
 
             final IndexedGarbageFileStats stats = scanner.scan();
 
@@ -439,7 +439,7 @@ class GarbageScannerDeadAliveRatioTest {
             final DataFileCollection fileCollection = mock(DataFileCollection.class);
             when(fileCollection.getAllCompletedFiles()).thenReturn(List.of(file1, file2));
 
-            final GarbageScanner scanner = new GarbageScanner(index, fileCollection, "test");
+            final GarbageScanner scanner = new GarbageScanner(index, fileCollection);
 
             final IndexedGarbageFileStats stats = scanner.scan();
             assertEquals(0, stats.garbageFileStats().length);
@@ -453,7 +453,7 @@ class GarbageScannerDeadAliveRatioTest {
     private static GarbageScanner createScanner(final LongList index, final List<DataFileReader> files) {
         final DataFileCollection fileCollection = mock(DataFileCollection.class);
         when(fileCollection.getAllCompletedFiles()).thenReturn(files);
-        return new GarbageScanner(index, fileCollection, "test");
+        return new GarbageScanner(index, fileCollection);
     }
 
     private static LongList emptyIndex() {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/GarbageScannerTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/GarbageScannerTest.java
@@ -124,7 +124,7 @@ class GarbageScannerTest {
         final LongList index =
                 new LongListHeap(DEFAULT_CONFIG.longListChunkSize(), 1, DEFAULT_CONFIG.longListReservedBufferSize());
 
-        final GarbageScanner scanner = new GarbageScanner(index, fileCollection, "test-store");
+        final GarbageScanner scanner = new GarbageScanner(index, fileCollection);
 
         final IndexedGarbageFileStats stats = scanner.scan();
         assertEquals(0, stats.garbageFileStats().length);
@@ -155,7 +155,7 @@ class GarbageScannerTest {
     private static GarbageScanner createScanner(final LongList index, final List<DataFileReader> files) {
         final DataFileCollection fileCollection = mock(DataFileCollection.class);
         when(fileCollection.getAllCompletedFiles()).thenReturn(files);
-        return new GarbageScanner(index, fileCollection, "test-store");
+        return new GarbageScanner(index, fileCollection);
     }
 
     private static LongList indexWithEntries(final Map<Long, Long> indexEntries) {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
@@ -130,7 +130,7 @@ class DataFileCollectionCompactionTest {
                 return true;
             }
         };
-        final var compactor = new DataFileCompactor(storeName, coll, indexUpdater, null, null, null, null);
+        final var compactor = new DataFileCompactor(coll, indexUpdater, null, null, null, null);
         compactor.compactFiles(indexUpdater, getFilesToMerge(coll), 1);
 
         long prevKey = -1;
@@ -221,8 +221,7 @@ class DataFileCollectionCompactionTest {
                 }
             };
 
-            final DataFileCompactor compactor =
-                    new DataFileCompactor(storeName, store, indexUpdater, null, null, null, null);
+            final DataFileCompactor compactor = new DataFileCompactor(store, indexUpdater, null, null, null, null);
 
             try {
                 compactor.compactFiles(indexUpdater, filesToMerge, 1);
@@ -272,8 +271,7 @@ class DataFileCollectionCompactionTest {
                 }
             };
 
-            final DataFileCompactor compactor =
-                    new DataFileCompactor(storeName, store2, indexUpdater, null, null, null, null);
+            final DataFileCompactor compactor = new DataFileCompactor(store2, indexUpdater, null, null, null, null);
 
             if (filesToMerge.size() > 1) {
                 compactor.compactFiles(indexUpdater, filesToMerge, 1);
@@ -331,7 +329,7 @@ class DataFileCollectionCompactionTest {
 
                 if (filesToMerge.size() > 1) {
                     final DataFileCompactor compactor =
-                            new DataFileCompactor(storeName, store, indexUpdater, null, null, null, null);
+                            new DataFileCompactor(store, indexUpdater, null, null, null, null);
                     try {
                         compactor.compactFiles(indexUpdater, filesToMerge, 1);
                     } catch (Exception ex) {
@@ -407,7 +405,7 @@ class DataFileCollectionCompactionTest {
 
                 if (filesToMerge.size() > 1) {
                     final DataFileCompactor compactor =
-                            new DataFileCompactor(storeName, store, indexUpdater, null, null, null, null);
+                            new DataFileCompactor(store, indexUpdater, null, null, null, null);
                     try {
                         compactor.compactFiles(indexUpdater, filesToMerge, 1);
                     } catch (Exception ex) {
@@ -457,7 +455,7 @@ class DataFileCollectionCompactionTest {
         try (final LongListSegment index = new LongListSegment(numValues, numFiles * numValues, 0)) {
             index.updateValidRange(0, numFiles * numValues - 1);
             final DataFileCollection store = new DataFileCollection(MERKLE_DB_CONFIG, testDir, storeName, null);
-            final DataFileCompactor compactor = new DataFileCompactor(storeName, store, index, null, null, null, null);
+            final DataFileCompactor compactor = new DataFileCompactor(store, index, null, null, null, null);
             // Create a few files initially
             for (int i = 0; i < numFiles; i++) {
                 store.startWriting();
@@ -582,7 +580,7 @@ class DataFileCollectionCompactionTest {
         String storeName = "testInconsistentIndex";
         final Path testDir = tempFileDir.resolve(storeName);
         final DataFileCollection store = new DataFileCollection(MERKLE_DB_CONFIG, testDir, storeName, null);
-        final DataFileCompactor compactor = new DataFileCompactor(storeName, store, index, null, null, null, null);
+        final DataFileCompactor compactor = new DataFileCompactor(store, index, null, null, null, null);
 
         final int numFiles = 10; // should be greater than min number of files to compact
         index.updateValidRange(0, MAXKEYS - 1);

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -327,7 +327,7 @@ class DataFileCollectionTest {
     @EnumSource(FilesTestType.class)
     void merge(final FilesTestType testType) throws Exception {
         final DataFileCollection fileCollection = fileCollectionMap.get(testType);
-        final DataFileCompactor fileCompactor = createFileCompactor("merge", fileCollection, testType);
+        final DataFileCompactor fileCompactor = createFileCompactor(fileCollection, testType);
         final LongListHeap storedOffsets = storedOffsetsMap.get(testType);
         final AtomicBoolean mergeComplete = new AtomicBoolean(false);
         final int NUM_OF_KEYS = 1000;
@@ -487,7 +487,7 @@ class DataFileCollectionTest {
     @EnumSource(FilesTestType.class)
     void merge2(final FilesTestType testType) throws Exception {
         final DataFileCollection fileCollection = fileCollectionMap.get(testType);
-        final DataFileCompactor fileCompactor = createFileCompactor("merge2", fileCollection, testType);
+        final DataFileCompactor fileCompactor = createFileCompactor(fileCollection, testType);
         final LongListHeap storedOffsets = storedOffsetsMap.get(testType);
         final AtomicBoolean mergeComplete = new AtomicBoolean(false);
         // start compaction paused so that we can test pausing
@@ -597,9 +597,8 @@ class DataFileCollectionTest {
         }
     }
 
-    private static DataFileCompactor createFileCompactor(
-            String storeName, DataFileCollection fileCollection, FilesTestType testType) {
-        return new DataFileCompactor(storeName, fileCollection, storedOffsetsMap.get(testType), null, null, null, null);
+    private static DataFileCompactor createFileCompactor(DataFileCollection fileCollection, FilesTestType testType) {
+        return new DataFileCompactor(fileCollection, storedOffsetsMap.get(testType), null, null, null, null);
     }
 
     @Order(203)
@@ -648,8 +647,8 @@ class DataFileCollectionTest {
         fileCollection.close();
         // reopen
         final DataFileCollection fileCollection2 = new DataFileCollection(MERKLE_DB_CONFIG, dbDir, storeName, null);
-        final DataFileCompactor fileCompactor = new DataFileCompactor(
-                storeName, fileCollection2, storedOffsetsMap.get(testType), null, null, null, null);
+        final DataFileCompactor fileCompactor =
+                new DataFileCompactor(fileCollection2, storedOffsetsMap.get(testType), null, null, null, null);
         fileCollectionMap.put(testType, fileCollection2);
         // check 10 files were opened and data is correct
         assertSame(10, fileCollection2.getAllCompletedFiles().size(), "Should be 10 files");
@@ -720,7 +719,7 @@ class DataFileCollectionTest {
         final LongListHeap storedOffsets = new LongListHeap(5000, Integer.MAX_VALUE, 0);
         storedOffsets.updateValidRange(0, 1100);
         final DataFileCompactor compactor =
-                new DataFileCompactor(storeName, fileCollection, storedOffsets, null, null, null, null);
+                new DataFileCompactor(fileCollection, storedOffsets, null, null, null, null);
         populateDataFileCollection(FilesTestType.fixed, fileCollection, storedOffsets);
 
         final Thread thread = new Thread(() -> {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCompactorSingleLevelTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCompactorSingleLevelTest.java
@@ -93,7 +93,7 @@ class DataFileCompactorSingleLevelTest {
                 final MerkleDbConfig config,
                 final DataFileCollection dataFileCollection,
                 final CASableLongIndex index) {
-            super("test-store", dataFileCollection, index, null, null, null, null);
+            super(dataFileCollection, index, null, null, null, null);
         }
 
         @Override

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreTest.java
@@ -177,7 +177,6 @@ class MemoryIndexDiskKeyValueStoreTest {
         final MemoryIndexDiskKeyValueStore store =
                 new MemoryIndexDiskKeyValueStore(dbConfig, tempDir, storeName, null, null, index);
         final DataFileCompactor dataFileCompactor = new DataFileCompactor(
-                storeName,
                 store.fileCollection,
                 index,
                 (type, time) -> timeSpent.set(time),

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
@@ -146,13 +146,7 @@ class HalfDiskHashMapTest {
         // create map
         try (HalfDiskHashMap map = createNewTempMap("multipleWriteBatchesAndMerge", 10_000)) {
             final DataFileCompactor dataFileCompactor = new DataFileCompactor(
-                    "HalfDiskHashMapTest",
-                    map.getFileCollection(),
-                    map.getBucketIndexToBucketLocation(),
-                    null,
-                    null,
-                    null,
-                    null);
+                    map.getFileCollection(), map.getBucketIndexToBucketLocation(), null, null, null, null);
             // create some data
             createSomeData(testType, map, 1, 1111, 1);
             checkData(testType, map, 1, 1111, 1);


### PR DESCRIPTION
Use `DataFileCollection` store name for compaction logging

Fixes #24973
