### PR TITLE
test: fix Node Death reconnect test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/FakeNmt.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/FakeNmt.java
@@ -88,16 +88,6 @@ public class FakeNmt {
     }
 
     /**
-     * Returns an operation that restarts the node with the given name.
-     *
-     * @param name the name of the node to restart
-     * @return the operation that restarts the node
-     */
-    public static TryToStartNodesOp restartNode(@NonNull final String name) {
-        return restartNode(NodeSelector.byName(name));
-    }
-
-    /**
      * Returns an operation that restarts the selected nodes with the given config version.
      *
      * @param selector the selector for the nodes to restart
@@ -107,16 +97,6 @@ public class FakeNmt {
     public static TryToStartNodesOp restartWithConfigVersion(
             @NonNull final NodeSelector selector, final int configVersion) {
         return new TryToStartNodesOp(selector, configVersion);
-    }
-
-    /**
-     * Returns an operation that shuts down the named node within the given timeout.
-     * @param name the name of the node to shut down
-     * @param timeout the timeout for the shutdown
-     * @return the operation that shuts down the node
-     */
-    public static ShutdownWithinOp shutdownWithin(@NonNull final String name, @NonNull final Duration timeout) {
-        return shutdownWithin(NodeSelector.byName(name), timeout);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -799,10 +799,6 @@ public class UtilVerbs {
         return new ContextualActionOp(action);
     }
 
-    public static WaitForStatusOp waitForActive(String name, Duration timeout) {
-        return waitForActive(NodeSelector.byName(name), timeout);
-    }
-
     public static WaitForStatusOp waitForActive(@NonNull final NodeSelector selector, @NonNull final Duration timeout) {
         return new WaitForStatusOp(selector, timeout, ACTIVE);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.suites.regression.system;
 
 import static com.hedera.services.bdd.junit.TestTags.ND_RECONNECT;
+import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
@@ -24,29 +25,29 @@ import org.junit.jupiter.api.Tag;
 @Tag(ND_RECONNECT)
 public class MixedOpsNodeDeathReconnectTest implements LifecycleTest {
 
+    /** Subprocess node id 2 — classic operator account 0.0.5 ({@code setNode("5")}). */
+    private static final long RECONNECT_NODE_ID = 2L;
+
     @HapiTest
     final Stream<DynamicTest> reconnectMixedOps() {
         return defaultHapiSpec("RestartMixedOps")
                 .given(
-                        // Validate we can initially submit transactions to node2
+                        // Validate we can initially submit transactions to 0.0.5 (node id 2)
                         cryptoCreate("nobody").setNode("5"),
                         // Run some mixed transactions
                         burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
-                        // Stop node 2
-                        FakeNmt.shutdownWithin("Carol", SHUTDOWN_TIMEOUT),
-                        logIt("Node 2 is supposedly down"),
+                        FakeNmt.shutdownWithin(byNodeId(RECONNECT_NODE_ID), SHUTDOWN_TIMEOUT),
+                        logIt("Node id " + RECONNECT_NODE_ID + " is supposedly down"),
                         sleepFor(PORT_UNBINDING_WAIT_PERIOD.toMillis()))
                 .when(
-                        // Submit operations when node 2 is down
+                        // Submit operations while that node is down
                         burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
-                        // Restart node2
-                        FakeNmt.restartNode("Carol"),
-                        // Wait for node2 ACTIVE (BUSY and RECONNECT_COMPLETE are too transient to reliably poll for)
-                        waitForActive("Carol", RESTART_TO_ACTIVE_TIMEOUT))
+                        FakeNmt.restartNode(byNodeId(RECONNECT_NODE_ID)),
+                        // ACTIVE (BUSY and RECONNECT_COMPLETE are too transient to reliably poll for)
+                        waitForActive(byNodeId(RECONNECT_NODE_ID), RESTART_TO_ACTIVE_TIMEOUT))
                 .then(
                         // Run some more transactions
                         burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
-                        // And validate we can still submit transactions to node2
                         cryptoCreate("somebody").setNode("5"));
     }
 }


### PR DESCRIPTION
**Description**:
This pull request refactors the way nodes are referenced in test operations by replacing string-based node identification with the `NodeSelector` abstraction. This fixes the node death reconnect test in which the node didn't actually shut down.

**Refactoring node selection to use `NodeSelector`:**

* Updated `MixedOpsNodeDeathReconnectTest` to use `NodeSelector.byNodeId` instead of string node names for shutdown, restart, and wait-for-active operations, improving type safety and clarity.
* Removed overloads in `FakeNmt.java` and `UtilVerbs.java` that accepted node names as strings for `restartNode`, `shutdownWithin`, and `waitForActive`, since callers now use the `NodeSelector` abstraction.

**Related issue(s)**:

Fixes #24976 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
