### PR TITLE
feat: add internal State ID consistency check to LeafBytesIntegrityValidator

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/LeafBytesIntegrityValidator.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/LeafBytesIntegrityValidator.java
@@ -3,6 +3,7 @@ package com.hedera.statevalidation.validator;
 
 import static com.hedera.statevalidation.util.LogUtils.printFileDataLocationError;
 
+import com.hedera.hapi.platform.state.StateKey;
 import com.hedera.hapi.platform.state.StateValue;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
@@ -51,6 +52,7 @@ public class LeafBytesIntegrityValidator implements LeafBytesValidator {
     private final AtomicLong hashMismatchCount = new AtomicLong(0);
     private final AtomicLong indexMismatchCount = new AtomicLong(0);
     private final AtomicLong storeMismatchCount = new AtomicLong(0);
+    private final AtomicLong stateIdMismatchCount = new AtomicLong(0);
 
     // A minor optimization to avoid multiple chunk loads from disk
     private final ThreadLocal<VirtualHashChunk> lastChunk = new ThreadLocal<>();
@@ -118,6 +120,22 @@ public class LeafBytesIntegrityValidator implements LeafBytesValidator {
             if (!valueBytes.equals(virtualMap.getBytes(keyBytes))) {
                 valueErrorCount.incrementAndGet();
                 log.error("Value mismatch for path={}, value={}", p2KvPath, parseValue(valueBytes));
+                return;
+            }
+
+            final StateKey parsedKey = StateKey.PROTOBUF.parse(keyBytes);
+            final StateValue parsedValue = parseValue(valueBytes);
+            final int keyStateId = parsedKey.key().kind().protoOrdinal();
+            final int valueStateId = parsedValue.value().kind().protoOrdinal();
+            if (keyStateId != valueStateId) {
+                stateIdMismatchCount.incrementAndGet();
+                log.error(
+                        "State id mismatch at path={}. keyStateId={} vs valueStateId={} key={} value={}",
+                        p2KvPath,
+                        keyStateId,
+                        valueStateId,
+                        parsedKey,
+                        parsedValue);
                 return;
             }
 
@@ -208,6 +226,7 @@ public class LeafBytesIntegrityValidator implements LeafBytesValidator {
                 && hashMismatchCount.get() == 0
                 && indexMismatchCount.get() == 0
                 && storeMismatchCount.get() == 0
+                && stateIdMismatchCount.get() == 0
                 && exceptionCount.get() == 0;
 
         if (!ok) {
@@ -216,7 +235,7 @@ public class LeafBytesIntegrityValidator implements LeafBytesValidator {
                     ("%s validation failed. "
                                     + "successCount=%d vs expectedCount=%d, "
                                     + "pathMismatchCount=%d, valueErrorCount=%d, hashMismatchCount=%d, "
-                                    + "indexMismatchCount=%d, exceptionCount=%d")
+                                    + "indexMismatchCount=%d, storeMismatchCount=%d, stateIdMismatchCount=%d, exceptionCount=%d")
                             .formatted(
                                     getName(),
                                     successCount.get(),
@@ -226,6 +245,7 @@ public class LeafBytesIntegrityValidator implements LeafBytesValidator {
                                     hashMismatchCount.get(),
                                     indexMismatchCount.get(),
                                     storeMismatchCount.get(),
+                                    stateIdMismatchCount.get(),
                                     exceptionCount.get()));
         }
     }


### PR DESCRIPTION
**Description**:
Adds State ID integrity validation to the `LeafBytesIntegrityValidator` to ensure internal consistency between record keys and values.
- Extract State IDs from `StateKey` and `StateValue` and compare key and value State IDs during leaf processing to detect cross-service data corruption
- Add `stateIdMismatchCount` to track and report identity discrepancies
- Update `validate()` to fail the validation if any State ID mismatches are found

**Related issue(s)**:
Fixes #23352 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
