### PR TITLE
test: Pectra branch tests fixes

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/infra/HevmTransactionFactory.java
@@ -38,6 +38,7 @@ import static org.apache.tuweni.bytes.Bytes.EMPTY;
 
 import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.Duration;
 import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.base.HederaFunctionality;
@@ -291,12 +292,17 @@ public class HevmTransactionFactory {
             @NonNull final TransactionBody body, @NonNull final HandleException exception) {
         AccountID sender = null;
         AccountID relayer = null;
+        ContractID contractId = null;
 
         final var gasLimit =
                 switch (body.data().kind()) {
                     case CONTRACT_CREATE_INSTANCE ->
                         body.contractCreateInstanceOrThrow().gas();
-                    case CONTRACT_CALL -> body.contractCallOrThrow().gas();
+                    case CONTRACT_CALL -> {
+                        final var contractCall = body.contractCallOrThrow();
+                        contractId = contractCall.contractID();
+                        yield contractCall.gas();
+                    }
                     case ETHEREUM_TRANSACTION -> {
                         final var ethTxData = assertValidEthTx(body.ethereumTransactionOrThrow());
                         sender = asAliasedSender(ethTxData);
@@ -314,7 +320,7 @@ public class HevmTransactionFactory {
         return new HederaEvmTransaction(
                 sender == null ? AccountID.DEFAULT : sender,
                 relayer,
-                null,
+                contractId,
                 NOT_APPLICABLE,
                 Bytes.EMPTY,
                 null,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
@@ -119,6 +119,21 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                 "10000")); // to avoid memo size limit
     }
 
+    // Prefix example for 6kb:
+    // 0x424cb7f8000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000018
+    // prefixZeros = 62
+    // prefixNonZeros = 6
+    // Prefix example for 127kb:
+    // 0x424cb7f80000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000001fc
+    // prefixZeros = 61
+    // prefixNonZeros = 7
+    private static int expectedGasCalculator(int prefixZeros, int prefixNonZeros, int txnSize) {
+        final var payloadLength = prefixZeros + prefixNonZeros + txnSize;
+        final var zeros = prefixZeros + txnSize; // transaction consists from zeros
+        // minimumGasUsed according to https://eips.ethereum.org/EIPS/eip-7623
+        return 21_000 + (zeros + (payloadLength - zeros) * 4) * 10;
+    }
+
     @HapiTest
     @DisplayName("Jumbo transaction should pass")
     public Stream<DynamicTest> jumboTransactionShouldPass() {
@@ -132,7 +147,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                 cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS),
                 // send jumbo payload to non jumbo endpoint
-                contractCall(CONTRACT_CALLDATA_SIZE, FUNCTION, jumboPayload)
+                contractCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) jumboPayload)
                         .gas(1_000_000L)
                         .payingWith(PAYER)
                         .hasPrecheck(TRANSACTION_OVERSIZE)
@@ -140,12 +155,12 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                         .orUnavailableStatus(),
 
                 // send too big payload to jumbo endpoint
-                ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, tooBigPayload)
+                ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) tooBigPayload)
                         .payingWith(RELAYER)
                         .signingWith(SECP_256K1_SOURCE_KEY)
                         .markAsJumboTxn()
                         .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L)
+                        .gasLimit(1_350_000L)
                         .hasPrecheck(TRANSACTION_OVERSIZE)
                         // gRPC request terminated immediately
                         .orUnavailableStatus(),
@@ -153,13 +168,16 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                 // send jumbo payload to jumbo endpoint and assert the used gas
                 jumboEthCall(jumboPayload)
                         .gasLimit(800000)
-                        .exposingGasTo((s, gasUsed) -> assertEquals(124_260, gasUsed)),
+                        .exposingGasTo((_, gasUsed) ->
+                                assertEquals(expectedGasCalculator(62, 6, jumboPayload.length), gasUsed)),
                 jumboEthCall(halfJumboPayload)
                         .gasLimit(500000)
-                        .exposingGasTo((s, gasUsed) -> assertEquals(73_060, gasUsed)),
+                        .exposingGasTo((_, gasUsed) ->
+                                assertEquals(expectedGasCalculator(62, 6, halfJumboPayload.length), gasUsed)),
                 jumboEthCall(thirdJumboPayload)
                         .gasLimit(300000)
-                        .exposingGasTo((s, gasUsed) -> assertEquals(52_580, gasUsed)));
+                        .exposingGasTo((_, gasUsed) ->
+                                assertEquals(expectedGasCalculator(62, 6, thirdJumboPayload.length), gasUsed)));
     }
 
     @Nested
@@ -171,32 +189,32 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                         SIX_KB_SIZE,
                         EthTxData.EthTransactionType.LEGACY_ETHEREUM,
                         400_000,
-                        83_300 /* TODO(Pectra): used to be 47_358 */),
+                        expectedGasCalculator(62, 6, SIX_KB_SIZE)),
                 new TestCombinationWithGas(
                         SIX_KB_SIZE,
                         EthTxData.EthTransactionType.EIP2930,
                         400_000,
-                        83_300 /* TODO(Pectra): used to be 47_358 */),
+                        expectedGasCalculator(62, 6, SIX_KB_SIZE)),
                 new TestCombinationWithGas(
                         SIX_KB_SIZE,
                         EthTxData.EthTransactionType.EIP1559,
                         400_000,
-                        83_300 /* TODO(Pectra): used to be 47_358 */),
+                        expectedGasCalculator(62, 6, SIX_KB_SIZE)),
                 new TestCombinationWithGas(
                         MAX_ALLOWED_SIZE,
                         EthTxData.EthTransactionType.LEGACY_ETHEREUM,
                         9_000_000,
-                        1_322_370 /* TODO(Pectra): used to be 542_986 */),
+                        expectedGasCalculator(61, 7, MAX_ALLOWED_SIZE)),
                 new TestCombinationWithGas(
                         MAX_ALLOWED_SIZE,
                         EthTxData.EthTransactionType.EIP2930,
                         9_000_000,
-                        1_322_370 /* TODO(Pectra): used to be 542_986 */),
+                        expectedGasCalculator(61, 7, MAX_ALLOWED_SIZE)),
                 new TestCombinationWithGas(
                         MAX_ALLOWED_SIZE,
                         EthTxData.EthTransactionType.EIP1559,
                         9_000_000,
-                        1_322_370 /* TODO(Pectra): used to be 542_986 */));
+                        expectedGasCalculator(61, 7, MAX_ALLOWED_SIZE)));
 
         @RepeatableHapiTest(RepeatableReason.NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
         @DisplayName("Jumbo Ethereum transactions should pass for valid sizes and expected gas used")
@@ -211,7 +229,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                                 tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
                         jumboEthCall(payload, test.type)
                                 .gasLimit(test.gasLimit)
-                                .exposingGasTo((s, gasUsed) -> assertEquals(
+                                .exposingGasTo((_, gasUsed) -> assertEquals(
                                         test.expectedGas,
                                         gasUsed,
                                         "Unexpected gas used for size: " + test.txnSize + ", type: " + test.type)));
@@ -228,16 +246,12 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
             final var ethereumCallTxn = "jumboTxnFromThresholdKeyAccount";
             final var payload = new byte[127 * 1024];
 
-            final AtomicReference<byte[]> rawPublicKey = new AtomicReference<>();
             final AtomicReference<AccountCreationDetails> creationDetails = new AtomicReference<>();
 
             return hapiTest(
 
                     // Create SECP key and extract raw bytes
-                    newKeyNamed(cryptoKey)
-                            .shape(SECP256K1_ON)
-                            .exposingKeyTo(
-                                    k -> rawPublicKey.set(k.getECDSASecp256K1().toByteArray())),
+                    newKeyNamed(cryptoKey).shape(SECP256K1_ON),
 
                     // Create alias account via cryptoTransfer
                     cryptoTransfer(tinyBarsFromToWithAlias(GENESIS, cryptoKey, 2 * ONE_HUNDRED_HBARS))
@@ -259,7 +273,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                             .signedBy(GENESIS, cryptoKey)),
 
                     // Submit jumbo Ethereum txn, signed with SECP key
-                    sourcing(() -> ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                    sourcing(() -> ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) payload)
                             .type(EthTxData.EthTransactionType.EIP1559)
                             .fee(ONE_MILLION_HBARS)
                             .markAsJumboTxn()
@@ -290,7 +304,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                     cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, "test3", ONE_HUNDRED_HBARS)),
                     cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, "test4", ONE_HUNDRED_HBARS)),
                     cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, "test5", ONE_HUNDRED_HBARS)),
-                    sourcing(() -> ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                    sourcing(() -> ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) payload)
                             .type(EthTxData.EthTransactionType.EIP1559)
                             .markAsJumboTxn()
                             .signingWith(cryptoKey)
@@ -333,7 +347,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                     newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                     cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
                     cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, sixKbPayload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) sixKbPayload)
                             .markAsJumboTxn()
                             // Override the hedera functionality to make the framework send the request to the wrong
                             // endpoint
@@ -341,7 +355,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                             .type(EthTxData.EthTransactionType.EIP1559)
                             .gasLimit(1_350_000L)
                             .orUnavailableStatus(),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, moreThenSixKbPayload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) moreThenSixKbPayload)
                             .markAsJumboTxn()
                             // Override the hedera functionality to make the framework send the request to the wrong
                             // endpoint
@@ -349,7 +363,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                             .type(EthTxData.EthTransactionType.EIP1559)
                             .gasLimit(1_350_000L)
                             .orUnavailableStatus(),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, limitPayload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) limitPayload)
                             .markAsJumboTxn()
                             // Override the hedera functionality to make the framework send the request to the wrong
                             // endpoint
@@ -357,7 +371,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                             .type(EthTxData.EthTransactionType.EIP1559)
                             .gasLimit(1_350_000L)
                             .orUnavailableStatus(),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, tooBigPayload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) tooBigPayload)
                             .markAsJumboTxn()
                             // Override the hedera functionality to make the framework send the request to the wrong
                             // endpoint
@@ -382,7 +396,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                         jumboEthCall(payload, test.type)
                                 .gasLimit(test.gasLimit)
                                 .noLogging()
-                                .exposingGasTo((s, gasUsed) -> assertEquals(
+                                .exposingGasTo((_, gasUsed) -> assertEquals(
                                         test.expectedGas,
                                         gasUsed,
                                         "Unexpected gas used for txn size " + test.txnSize + " and type " + test.type))
@@ -439,12 +453,12 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                     newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                     cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
                     getAccountBalance(RELAYER).exposingBalanceTo(balance::set),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, corruptedPayload())
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) corruptedPayload())
                             .markAsJumboTxn()
                             .type(type)
                             .payingWith(RELAYER)
                             .signingWith(SECP_256K1_SOURCE_KEY)
-                            .gasLimit(1_400_000L /* TODO(Pectra): 1M used to be sufficient */)
+                            .gasLimit(1_350_000L)
                             .hasPrecheck(TRANSACTION_OVERSIZE),
                     getAccountBalance(RELAYER)
                             .exposingBalanceTo(newBalance -> assertTrue(
@@ -476,20 +490,20 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                     cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
                     cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
                             .via("autoAccount"),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) payload)
                             .markAsJumboTxn()
                             .type(EthTxData.EthTransactionType.EIP1559)
-                            .gasLimit(1_400_000L /* TODO(Pectra): 1M used to be sufficient */),
+                            .gasLimit(1_350_000L),
                     sleepFor(1000),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) payload)
                             .markAsJumboTxn()
                             .type(EthTxData.EthTransactionType.EIP1559)
-                            .gasLimit(1_400_000L /* TODO(Pectra): 1M used to be sufficient */),
+                            .gasLimit(1_350_000L),
                     sleepFor(1000),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) payload)
                             .markAsJumboTxn()
                             .type(EthTxData.EthTransactionType.EIP1559)
-                            .gasLimit(1_400_000L /* TODO(Pectra): 1M used to be sufficient */));
+                            .gasLimit(1_350_000L));
         }
 
         @HapiTest
@@ -501,7 +515,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                     newKeyNamed("unrelatedKey").shape(SECP_256K1_SHAPE),
 
                     // Submit jumbo Ethereum txn with wrong key
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) payload)
                             .markAsJumboTxn()
                             .signingWith("unrelatedKey")
                             .payingWith(RELAYER)
@@ -518,7 +532,7 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                     cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
                     cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
                             .via("autoAccount"),
-                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) payload)
                             .markAsJumboTxn()
                             .type(EthTxData.EthTransactionType.EIP1559)
                             .gasLimit(1_000_000L),
@@ -576,10 +590,10 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                     overriding("jumboTransactions.maxBytesPerSec", String.valueOf(bytesPerSec)),
                     newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                     cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
-                    withOpContext((spec, op) -> allRunFor(
+                    withOpContext((spec, _) -> allRunFor(
                             spec,
                             getAccountInfo(DEFAULT_PAYER).exposingEthereumNonceTo(initialNonce::set),
-                            ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                            ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, (Object) payload)
                                     .nonce(initialNonce.get())
                                     .markAsJumboTxn()
                                     .gasLimit(1_350_000L)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/SimpleSmartContractServiceFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/SimpleSmartContractServiceFeesTest.java
@@ -56,6 +56,7 @@ import com.hedera.services.bdd.spec.dsl.annotations.Account;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.entities.SpecAccount;
 import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
+import com.hederahashgraph.api.proto.java.AccountAmount;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -66,8 +67,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 public class SimpleSmartContractServiceFeesTest {
     static final double EXPECTED_GAS_USED = 0.00184;
-    static final double ABORTED_CONTRACT_CALL_GAS_ONLY_FEE =
-            (21_000 + 32_000L /* mysterious new fee; TODO(Pectra) figure this out */) * GAS_FEE_USD;
+    static final double ABORTED_CONTRACT_CALL_GAS_ONLY_FEE = 21_000 * GAS_FEE_USD;
 
     @Contract(contract = "SmartContractsFees")
     static SpecContract contract;
@@ -188,7 +188,7 @@ public class SimpleSmartContractServiceFeesTest {
                         .via(highGasQuery),
                 validateNonZeroNodePaymentForQuery(lowGasQuery),
                 validateNonZeroNodePaymentForQuery(highGasQuery),
-                withOpContext((spec, opLog) -> {
+                withOpContext((spec, _) -> {
                     final var lowRecord = getTxnRecord(lowGasQuery);
                     final var highRecord = getTxnRecord(highGasQuery);
                     allRunFor(spec, lowRecord, highRecord);
@@ -196,12 +196,12 @@ public class SimpleSmartContractServiceFeesTest {
                     final var lowNodePayment =
                             lowRecord.getResponseRecord().getTransferList().getAccountAmountsList().stream()
                                     .filter(aa -> aa.getAccountID().equals(nodeId))
-                                    .mapToLong(aa -> aa.getAmount())
+                                    .mapToLong(AccountAmount::getAmount)
                                     .sum();
                     final var highNodePayment =
                             highRecord.getResponseRecord().getTransferList().getAccountAmountsList().stream()
                                     .filter(aa -> aa.getAccountID().equals(nodeId))
-                                    .mapToLong(aa -> aa.getAmount())
+                                    .mapToLong(AccountAmount::getAmount)
                                     .sum();
                     assertTrue(
                             highNodePayment > lowNodePayment,
@@ -239,15 +239,14 @@ public class SimpleSmartContractServiceFeesTest {
     final Stream<DynamicTest> jumboEthTransactionBaseUSDFee() {
         final var payloadSize = 10 * 1024;
         final var jumboPayload = new byte[payloadSize];
-        final var jumboGasUsed = 0.0054;
+        final var jumboGasUsed = 0.01058;
         return hapiTest(
                 overriding("contracts.evm.ethTransaction.zeroHapiFees.enabled", "false"),
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                 cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
                 ethereumCall(calldataContract.name(), "callme", (Object) jumboPayload)
                         .fee(ONE_HUNDRED_HBARS)
-                        .gasLimit(
-                                1_000_000L) /* TODO(Pectra): this used to work with a default gas limit; perhaps default needs to be updated? */
+                        .gasLimit(200_000L)
                         .memo("TESTT")
                         .type(EthTxData.EthTransactionType.EIP1559)
                         .signedBy(SECP_256K1_SOURCE_KEY)
@@ -262,13 +261,11 @@ public class SimpleSmartContractServiceFeesTest {
                     final var totalExpected = jumboGasUsed + ETHEREUM_CALL_BASE_FEE + expectedFeeFromBytes;
                     final var withoutGasExpected = ETHEREUM_CALL_BASE_FEE + expectedFeeFromBytes;
 
-                    /* TODO(Pectra): gas usage seems to have changed
                     allRunFor(
                             spec,
                             validateChargedUsdWithin("ethCall", totalExpected, 1),
                             validateChargedUsdForGasOnly("ethCall", jumboGasUsed, 1),
                             validateChargedUsdWithoutGas("ethCall", withoutGasExpected, 1));
-                     */
                 }));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationType4TransactionTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationType4TransactionTest.java
@@ -64,7 +64,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
         final var delegatedFunctionSelector = Hex.toHexString(
                 new Function("getValue()").encodeCall(Tuple.EMPTY).array());
 
-        return hapiTest(withOpContext((spec, opLog) -> {
+        return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, CONTRACT);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
             allRunFor(
@@ -117,7 +117,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
     @HapiTest
     final Stream<DynamicTest> testMultipleCodeDelegationsSetViaEthCall() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
-        return hapiTest(withOpContext((spec, opLog) -> {
+        return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, CONTRACT);
             createSecp256k1Keys(
                     spec, DELEGATING_ACCOUNT, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
@@ -168,7 +168,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
 
     @HapiTest
     final Stream<DynamicTest> testDelegatingToKey() {
-        return hapiTest(withOpContext((spec, opLog) -> {
+        return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
@@ -181,13 +181,12 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
                             .addCodeDelegationWithSpecNonce(DELEGATION_TARGET.get(), DELEGATING_ACCOUNT)
                             .gasLimit(2_000_000L)
                             .via(DELEGATION_SET)
-                            .exposingGasTo((s, gas) -> {
+                            .exposingGasTo((_, gas) -> {
                                 final var expectedGas = 21_000L /* intrinsic gas base fee */
                                         + 64 /* payload cost */
                                         + 25_000L /* code delegation fee with new account creation */
-                                        + 108_893L /*call costs in gas*/
-                                        + 554_517L /* auto creation hapi fee*/
-                                        + 32_337L /* mysterious new fee; TODO(Pectra) figure this out */;
+                                        + 108_893L /* call costs in gas */
+                                        + 586_854L /* auto creation hapi fee, proxyWorldUpdater.lazyCreationCostInGas(authorityAddress) */;
                                 assertEquals(expectedGas, gas);
                             })),
                     getAliasedAccountInfo(DELEGATING_ACCOUNT)
@@ -211,7 +210,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
 
     @HapiTest
     final Stream<DynamicTest> testDelegationSetToHollowAccountWithRevertingCall() {
-        return hapiTest(withOpContext((spec, opLog) -> {
+        return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, REVERTING_CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
@@ -223,13 +222,12 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
                     .gasLimit(2_000_000L)
                     .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
                     .via(DELEGATION_SET)
-                    .exposingGasTo((s, gas) -> {
+                    .exposingGasTo((_, gas) -> {
                         final var expectedGas = 21_000L /* intrinsic gas base fee */
                                 + 64 /* payload cost */
                                 + 25_000L /* code delegation fee with new account creation */
                                 + 408 /*call costs in gas*/
-                                + 554_517L /* auto creation hapi fee*/
-                                + 32_337L /* mysterious new fee; TODO(Pectra) figure this out */;
+                                + 586_854L /* auto creation hapi fee, proxyWorldUpdater.lazyCreationCostInGas(authorityAddress) */;
                         assertEquals(expectedGas, gas);
                     })));
             allRunFor(
@@ -254,7 +252,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
 
     @HapiTest
     final Stream<DynamicTest> testDelegationSetToMultipleHollowAccountsWithRevertingCall() {
-        return hapiTest(withOpContext((spec, opLog) -> {
+        return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, REVERTING_CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
@@ -268,13 +266,13 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
                     .gasLimit(2_000_000L)
                     .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
                     .via(DELEGATION_SET)
-                    .exposingGasTo((s, gas) -> {
+                    .exposingGasTo((_, gas) -> {
                         final var expectedGas = 21_000L /* intrinsic gas base fee */
                                 + 64 /* payload cost */
                                 + 3 * 25_000L /* code delegation fee with new account creation */
                                 + 408 /*call costs in gas*/
-                                + 3 * 554_517L /* auto creation hapi fee*/
-                                + 3 * 32_337L /* mysterious new fee; TODO(Pectra) figure this out */;
+                                + 3
+                                        * 586_854L /* auto creation hapi fee, proxyWorldUpdater.lazyCreationCostInGas(authorityAddress) */;
                         assertEquals(expectedGas, gas);
                     })));
             allRunFor(
@@ -311,7 +309,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
 
     @HapiTest
     final Stream<DynamicTest> testDelegationSetToExistingAccountWithRevertingCall() {
-        return hapiTest(withOpContext((spec, opLog) -> {
+        return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, REVERTING_CONTRACT);
             createPayerAccountWithAlias(spec);
             final var delegatingAccount = createEvmAccountWithKey(spec);
@@ -323,7 +321,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
                     .gasLimit(2_000_000L)
                     .hasKnownStatus(ResponseCodeEnum.CONTRACT_REVERT_EXECUTED)
                     .via(DELEGATION_SET)
-                    .exposingGasTo((s, gas) -> {
+                    .exposingGasTo((_, gas) -> {
                         final var numDelegations = 1;
                         final var expectedGas = 21_000L /* intrinsic gas base fee */
                                 + 64 /* payload cost */
@@ -342,7 +340,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
 
     @HapiTest
     final Stream<DynamicTest> testDelegationWithMultipleAccountsAndNotEnoughGasForLazyCreation() {
-        return hapiTest(withOpContext((spec, opLog) -> {
+        return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
@@ -356,13 +354,13 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
                     .addCodeDelegationWithSpecNonce(DELEGATION_TARGET.get(), DELEGATING_ACCOUNT_3)
                     .via(DELEGATION_SET)
                     .hasKnownStatus(ResponseCodeEnum.SUCCESS)
-                    .exposingGasTo((s, gas) -> {
+                    .exposingGasTo((_, gas) -> {
                         final var expectedGas = 21_000L /* intrinsic gas base fee */
                                 + 64 /* payload cost */
                                 + 3 * 25_000L /* code delegation fee with new account creation */
                                 + 108_893L /*call costs in gas*/
-                                + 2 * 554_517L /* auto creation hapi fee*/
-                                + 2 * 32_337L /* mysterious new fee; TODO(Pectra) figure this out */;
+                                + 2
+                                        * 586_854L /* auto creation hapi fee, proxyWorldUpdater.lazyCreationCostInGas(authorityAddress) */;
                         assertEquals(expectedGas, gas);
                     })));
             allRunFor(


### PR DESCRIPTION
Test fixes for `Pectra` branch after `main` merge

**Notes for reviewer**:
1. Most fixes related to `JumboTransaction` gas cost changes according to `CallData cost` feature. Seems like tests changes from [this commit](https://github.com/hiero-ledger/hiero-consensus-node/commit/7592850bfad2609dcfc5eb4558c1eb77a72240e3) was rolled back by `main` merge somehow.
2. `proxyWorldUpdater.lazyCreationCostInGas(authorityAddress)` value was changed (seems like by simple fees changes in main). I addressed this in tests.
3. Found a bug where exceptional `CONTRACT_CALL` was recognized as `contract create` during `chargeGasForAbortedTransaction`. Fixed. Bug also exists in `main`, maybe it worth to fix at `main` branch. Lets discuss on daily.
