### PR TITLE
fix: retry on all unavailable grpc errors

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -601,7 +601,7 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         return msg.contains("NO_ERROR")
                 || msg.contains("Received unexpected EOS on DATA frame from server")
                 || msg.contains("REFUSED_STREAM")
-                || msg.contains("UNAVAILABLE: Channel shutdown invoked");
+                || msg.contains("UNAVAILABLE");
     }
 
     private void pause(long forMs) {


### PR DESCRIPTION
**Description**:
Broadens `isRecognizedRecoverable()` in `HapiTxnOp` to treat all gRPC `UNAVAILABLE` errors as retryable, not just `"UNAVAILABLE: Channel shutdown invoked"`

After a network restart, the freshly-rebuilt channels can produce transient UNAVAILABLE variants (e.g. UNAVAILABLE: io exception) that were not matched by the narrow string check, causing an immediate fatal HapiTxnCheckStateException instead of a retry.

**Related issue(s)**:

Fixes #24866 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
