### PR TITLE
fix: use correct method for the CountDownLatch in a test

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
@@ -432,14 +432,14 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
 
         block.addItem(item);
 
-        // Wait for the close() path to complete; use recordConnectionClosed since it is only called from close().
+        // Wait for the close() path to complete; use notifyConnectionClosed since it is only called from close().
         final CountDownLatch connectionClosedLatch = new CountDownLatch(1);
         doAnswer(invocation -> {
                     connectionClosedLatch.countDown();
                     return null;
                 })
-                .when(metrics)
-                .recordConnectionClosed();
+                .when(connectionManager)
+                .notifyConnectionClosed(connection);
 
         connection.updateConnectionState(ConnectionState.ACTIVE);
 


### PR DESCRIPTION
**Description**:
The `CountDownLatch` was looking for `recordConnectionClosed()` instead of `notifyConnectionClosed()` which should be the correct trigger

**Related issue(s)**:

Fixes #24819 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
