### PR TITLE
fix: mark test as leaky

### DIFF
--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/AccountsCommandsTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/AccountsCommandsTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.yahcli.test.profile.Civilian;
 import java.util.concurrent.atomic.AtomicLong;
@@ -56,7 +57,7 @@ public class AccountsCommandsTest {
                         .has(accountWith().balance(ONE_HBAR).memo("Who danced between"))));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"hedera.transaction.maxMemoUtf8Bytes"})
     final Stream<DynamicTest> governanceTransactionWithLargerTxnSize() {
         final var newAccountNum = new AtomicLong();
         return hapiTest(


### PR DESCRIPTION
**Description**:
Mark `AccountsCommandsTest.governanceTransactionWithLargerTxnSize()` as leaky hapi test as it overrides the `hedera.transaction.maxMemoUtf8Bytes` property to pass an oversized memo

**Related issue(s)**:

Fixes #24930 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
