### PR TITLE
fix: failing transactionOpsDurationMetricsAreRecordedAndRetrieved test

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/OpsDurationMetricsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/metrics/OpsDurationMetricsTest.java
@@ -2,7 +2,6 @@
 package com.hedera.node.app.service.contract.impl.test.exec.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.within;
 
 import com.hedera.node.app.service.contract.impl.exec.metrics.OpsDurationMetrics;
 import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
@@ -49,7 +48,7 @@ class OpsDurationMetricsTest {
         subject.recordPrecompileOpsDuration(precompile1, 100L);
         subject.recordPrecompileOpsDuration(precompile1, 200L);
         subject.recordPrecompileOpsDuration(precompile2, 300L);
-        assertThat(subject.getAveragePrecompileOpsDuration(precompile1)).isCloseTo(150.0, within(5.0));
+        assertThat(subject.getAveragePrecompileOpsDuration(precompile1)).isBetween(100.0, 200.0);
         assertThat(subject.getPrecompileOpsDurationCount(precompile1)).isEqualTo(2);
         assertThat(subject.getTotalPrecompileOpsDuration(precompile1)).isEqualTo(300L);
         assertThat(subject.getAveragePrecompileOpsDuration(precompile2)).isEqualTo(300.0);
@@ -59,11 +58,18 @@ class OpsDurationMetricsTest {
 
     @Test
     void transactionOpsDurationMetricsAreRecordedAndRetrieved() {
-        subject.recordTxnTotalOpsDuration(100L);
-        subject.recordTxnTotalOpsDuration(200L);
-        assertThat(subject.getAverageTransactionOpsDuration()).isCloseTo(150.0, within(5.0));
+        subject.recordTxnTotalOpsDuration(150L);
+        subject.recordTxnTotalOpsDuration(150L);
+        assertThat(subject.getAverageTransactionOpsDuration()).isEqualTo(150.0);
         assertThat(subject.getTransactionOpsDurationCount()).isEqualTo(2);
         assertThat(subject.getTotalTransactionOpsDuration()).isEqualTo(300L);
+    }
+
+    @Test
+    void transactionOpsDurationAverageStaysWithinObservedBounds() {
+        subject.recordTxnTotalOpsDuration(100L);
+        subject.recordTxnTotalOpsDuration(200L);
+        assertThat(subject.getAverageTransactionOpsDuration()).isBetween(100.0, 200.0);
     }
 
     @Test


### PR DESCRIPTION
**Description**:

`RunningAverageMetric` is time-weighted, so with mixed values for inputs the result depends on timing and is not guaranteed to be the arithmetic mean. The old `within(5.0)` expectation was a heuristic and sometimes is causing flakiness.

Changes:
- for identical inputs (150, 150), assert exact average 150
- for mixed inputs (100, 200), assert average stays within bounds [100,200] instead of 150 +/- 5

Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/24940

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
