### PR TITLE
fix: ensure xfersScenario transfers reach consensus before record assertion

### DIFF
--- a/hedera-node/yahcli/src/main/java/com/hedera/services/yahcli/commands/ivy/suites/IvyXfersScenarioSuite.java
+++ b/hedera-node/yahcli/src/main/java/com/hedera/services/yahcli/commands/ivy/suites/IvyXfersScenarioSuite.java
@@ -46,8 +46,8 @@ public class IvyXfersScenarioSuite extends AbstractIvySuite {
                 .given(ensureScenarioPayer())
                 .when()
                 .then(IntStream.range(0, networkSize)
+                        // Each transfer must wait for consensus so records are available for the test assertion
                         .mapToObj(i -> cryptoTransfer(tinyBarsFromTo(SCENARIO_PAYER_NAME, FUNDING, 1L))
-                                .hasAnyStatusAtAll()
                                 .payingWith(SCENARIO_PAYER_NAME)
                                 .setNodeFrom(nodeAccounts.get())
                                 .logged())


### PR DESCRIPTION
## Summary
- Fixes flaky test `XferScenarioTest#xfersScenarioSubmitsOneXferPerNode`
- Removes `.hasAnyStatusAtAll()` from crypto transfers in `IvyXfersScenarioSuite`
- `.hasAnyStatusAtAll()` caused each transfer to return on the first receipt poll (even `UNKNOWN`), skipping the consensus wait loop. The test's subsequent `getAccountRecords` query then sometimes found only 3 of 4 expected records because the last transfer hadn't reached consensus yet.

Closes #24961