### PR TITLE
fix: stabilize failToUpdateNFTsMetadataWithEmptySerialNumbers by using virtual time

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/address_16c/NumericValidation16c.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/address_16c/NumericValidation16c.java
@@ -58,7 +58,7 @@ public class NumericValidation16c {
                         .andAssert(txn -> txn.hasKnownStatuses(CONTRACT_REVERT_EXECUTED, INVALID_NFT_ID))));
     }
 
-    @HapiTest
+    @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
     @DisplayName("when using updateNFTsMetadata for specific NFT from NFT collection with empty serial numbers")
     public Stream<DynamicTest> failToUpdateNFTsMetadataWithEmptySerialNumbers() {
         return hapiTest(numericContract


### PR DESCRIPTION
## Summary
- Fixes flaky test `NumericValidation16c#failToUpdateNFTsMetadataWithEmptySerialNumbers` by changing `@HapiTest` to `@RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)`
- The test was timing out (`Result future not scheduled within PT10S`) due to shared entity creation races on `SHARED_NETWORK`
- This is consistent with sibling tests in the same class which already use `@RepeatableHapiTest`

Fixes #24778