### PR TITLE
fix: handle receiving less crypto transfers because of busy status

### DIFF
--- a/hedera-node/yahcli/src/main/java/com/hedera/services/yahcli/commands/ivy/suites/IvyXfersScenarioSuite.java
+++ b/hedera-node/yahcli/src/main/java/com/hedera/services/yahcli/commands/ivy/suites/IvyXfersScenarioSuite.java
@@ -4,6 +4,7 @@ package com.hedera.services.yahcli.commands.ivy.suites;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.yahcli.commands.ivy.scenarios.ScenariosConfig.SCENARIO_PAYER_NAME;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.SpecOperation;
@@ -48,6 +49,7 @@ public class IvyXfersScenarioSuite extends AbstractIvySuite {
                 .then(IntStream.range(0, networkSize)
                         .mapToObj(i -> cryptoTransfer(tinyBarsFromTo(SCENARIO_PAYER_NAME, FUNDING, 1L))
                                 .hasAnyStatusAtAll()
+                                .hasRetryPrecheckFrom(BUSY)
                                 .payingWith(SCENARIO_PAYER_NAME)
                                 .setNodeFrom(nodeAccounts.get())
                                 .logged())


### PR DESCRIPTION
**Description**:
Fixes a flaky yahcli xfers scenario test failure where `XferScenarioTest.xfersScenarioSubmitsOneXferPerNode` observed 3 `CryptoTransfer` records instead of 4.

`IvyXfersScenarioSuite` submits one transfer per node, but transient node precheck `BUSY` can cause a submission attempt to be dropped before consensus handling. When that happens, one intended transfer has no record, and the downstream assertion fails.

 In IvyXfersScenarioSuite, each transfer op now retries on BUSY precheck -> Added `hasRetryPrecheckFrom(BUSY)` to the transfer operation chain.

Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/24961

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
