### PR TITLE
fix: ignore recoverable WRAPS signing retry warning in log validator

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
@@ -104,6 +104,7 @@ public class HgcaaLogValidator {
                 List.of("No block nodes available to connect to"),
                 // Not present on OS X
                 List.of("Native library besu blake2bf is not present"),
+                List.of("Restarted WRAPS signing"),
                 // Expected as part of WRAPS proving key verification tests
                 List.of("WRAPS proving key hash mismatch at"),
                 List.of("Failed to extract WRAPS proving key archive"),


### PR DESCRIPTION
**Description**:
HgcaaLogValidator was flagging a WARN from ProofControllerImpl about WRAPS signing retries as a test failure. This warning is logged when a node misses R1 messages by the time R3 starts and the signing round is restarted — a known recoverable condition. Added "Restarted WRAPS signing" to PROBLEM_PATTERNS_TO_IGNORE, consistent with how other WRAPS-related warnings are already handled.

**Related issue(s)**:
Fixes #24738
