### PR TITLE
fix: override HAPI Restart maximumPermissibleUnhealthySeconds, broaden CI log globs

### DIFF
--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -733,7 +733,7 @@ jobs:
   hapi-tests-restart:
     name: "HAPI Tests (Restart)"
     if: ${{ inputs.enable-hapi-tests-restart == 'true' }}
-    runs-on: hl-cn-hapi-lin-xl
+    runs-on: hl-cn-hapi-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
     steps:

--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -207,8 +207,8 @@ jobs:
         with:
           name: HAPI Test (Misc) Network Logs
           path: |
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
             hedera-node/test-clients/output/**
             hedera-node/yahcli/build/hapi-test/**/output/**
             hedera-node/yahcli/build/hapi-test/**/*.log
@@ -224,8 +224,8 @@ jobs:
             hedera-node/test-clients/build/**/*.rcd.gz
             hedera-node/test-clients/build/**/*.pb
             hedera-node/test-clients/build/**/*.pces
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/**/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
             hedera-node/yahcli/build/reports/tests/testSubprocess/**
             hedera-node/yahcli/build/hapi-test/**/output/**
@@ -335,8 +335,8 @@ jobs:
         with:
           name: HAPI Test (Misc Records, Crypto & Misc Serial) Network Logs
           path: |
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -350,8 +350,8 @@ jobs:
             hedera-node/test-clients/build/**/*.rcd.gz
             hedera-node/test-clients/build/**/*.pb
             hedera-node/test-clients/build/**/*.pces
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/**/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -456,8 +456,8 @@ jobs:
         with:
           name: HAPI Test (Token & Time Consuming) Network Logs
           path: |
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -471,8 +471,8 @@ jobs:
             hedera-node/test-clients/build/**/*.rcd.gz
             hedera-node/test-clients/build/**/*.pb
             hedera-node/test-clients/build/**/*.pces
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/**/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -577,8 +577,8 @@ jobs:
         with:
           name: HAPI Test (Simple Fees & ND Reconnect) Network Logs
           path: |
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -592,8 +592,8 @@ jobs:
             hedera-node/test-clients/build/**/*.rcd.gz
             hedera-node/test-clients/build/**/*.pb
             hedera-node/test-clients/build/**/*.pces
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/**/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -697,8 +697,8 @@ jobs:
         with:
           name: HAPI Test (Smart Contracts & ISS) Network Logs
           path: |
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -712,8 +712,8 @@ jobs:
             hedera-node/test-clients/build/**/*.rcd.gz
             hedera-node/test-clients/build/**/*.pb
             hedera-node/test-clients/build/**/*.pces
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/**/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -733,7 +733,7 @@ jobs:
   hapi-tests-restart:
     name: "HAPI Tests (Restart)"
     if: ${{ inputs.enable-hapi-tests-restart == 'true' }}
-    runs-on: hl-cn-hapi-lin-lg
+    runs-on: hl-cn-hapi-lin-xl
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
     steps:
@@ -800,8 +800,8 @@ jobs:
         with:
           name: HAPI Test (Restart) Network Logs
           path: |
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -815,8 +815,8 @@ jobs:
             hedera-node/test-clients/build/**/*.rcd.gz
             hedera-node/test-clients/build/**/*.pb
             hedera-node/test-clients/build/**/*.pces
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/**/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -1021,8 +1021,8 @@ jobs:
         with:
           name: HAPI Test (Atomic Batch) Network Logs
           path: |
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -1036,8 +1036,8 @@ jobs:
             hedera-node/test-clients/build/**/*.rcd.gz
             hedera-node/test-clients/build/**/*.pb
             hedera-node/test-clients/build/**/*.pces
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/**/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -1124,8 +1124,8 @@ jobs:
         with:
           name: HAPI Test (State Throttling) Network Logs
           path: |
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 
@@ -1139,8 +1139,8 @@ jobs:
             hedera-node/test-clients/build/**/*.rcd.gz
             hedera-node/test-clients/build/**/*.pb
             hedera-node/test-clients/build/**/*.pces
-            hedera-node/test-clients/build/hapi-test/**/output/**
-            hedera-node/test-clients/build/hapi-test/**/*.log
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
           retention-days: 7
 

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -193,7 +193,7 @@ val prCheckPropOverrides =
             "tss.historyEnabled=false,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestSmartContractSerial" to "tss.historyEnabled=false",
         "hapiTestRestart" to
-            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestWrapsDownload" to
             "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.initialCrsParties=16,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,tss.wrapsProvingKeyDownloadEnabled=true,tss.wrapsProvingKeyPath=testfiles/valid-wraps-proving-key.tar.gz,tss.wrapsProvingKeyHash=da83f3ae5eaa8575f5bedf583de2826ccfa5bff80bd6f58a54b0bf7e934e98919b5bcdaa074b3ae248f161317b87a22a",
         "hapiTestMisc" to


### PR DESCRIPTION
## Summary
- build.gradle.kts - add hedera.transaction.maximumPermissibleUnhealthySeconds=5 to hapiTestRestart property overrides. During PCES replay after restart, each consensus round is amplified by TransactionHandlerDataCounter to at least capacity / LOW_TPS_TARGET_ROUNDS = 4000 scheduled tasks. A 85-round replay backlog yields 340k queued tasks against a 100k-capacity SEQUENTIAL_THREAD scheduler. The platform healthLogThreshold (1s) logs a WARN once the scheduler has been over capacity for a second. Most HAPI suites (token, misc, crypto, smart-contract, time-consuming) already override hedera.transaction.maximumPermissibleUnhealthySeconds=5 to tolerate replay bursts.
- Broadens CI artifact upload globs from `build/hapi-test/**` to `build/*-test/**` across all 8 HAPI test jobs. Previously, failing-run logs from embedded scopes were silently dropped because only subprocess logs were captured.

Fixes #24975 