### PR TITLE
ci(workflows-citr): Add read chewie response logic to sdlt

### DIFF
--- a/.github/workflows/801-read-chewie-response.yaml
+++ b/.github/workflows/801-read-chewie-response.yaml
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "801: [CITR] Read Chewie Response"
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        description: "The git ref to read the Chewie response from (branch, tag, or commit SHA)."
+        type: string
+      test-asset:
+        required: true
+        description: "The test asset to read the Chewie response for."
+        type: string
+      test-type:
+        required: true
+        description: "One of [sdpt,sdlt,mqpt,mdlt]"
+        type: string
+    secrets:
+      github-token:
+        required: true
+        description: "GitHub Authorization Token for the workflow"
+    outputs:
+      namespace:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.namespace }}
+      fqdn:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.fqdn }}
+      cn-quantity:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.cn-quantity }}
+      aux-quantity:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.aux-quantity }}
+      cn-tolerations:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.cn-tolerations }}
+      aux-tolerations:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.aux-tolerations }}
+      cn-role:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.cn-role }}
+      aux-role:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.aux-role }}
+      network-id:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.network-id }}
+      owner:
+        value: ${{ jobs.acquire-kubernetes-resources.outputs.owner }}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  acquire-kubernetes-resources:
+    name: Get Kubernetes Resources
+    runs-on: hl-cn-default-lin-sm
+    outputs:
+      namespace: ${{ steps.read-chewie-response.outputs.namespace }}
+      fqdn: ${{ steps.read-chewie-response.outputs.kubernetes-fqdn }}
+      cn-quantity: ${{ steps.read-chewie-response.outputs.cn-quantity }}
+      aux-quantity: ${{ steps.read-chewie-response.outputs.aux-quantity }}
+      cn-tolerations: ${{ steps.read-chewie-response.outputs.cn-tolerations }}
+      aux-tolerations: ${{ steps.read-chewie-response.outputs.aux-tolerations }}
+      cn-role: ${{ steps.read-chewie-response.outputs.cn-role }}
+      aux-role: ${{ steps.read-chewie-response.outputs.aux-role }}
+      network-id: ${{ steps.read-chewie-response.outputs.network-id }}
+      owner: ${{ steps.read-chewie-response.outputs.owner }}
+    steps:
+      - name: Initialize Job
+        uses: PandasWhoCode/initialize-github-job@47186ab8b59085a7406a53c0b7a98031bcf4c4cc # v1.0.7
+        with:
+          checkout: true
+          checkout-token: ${{ secrets.github-token }}
+          checkout-ref: ${{ inputs.ref }}
+
+      - name: Validate Test Type
+        run: |
+          VALID_TEST_TYPES=("sdpt" "sdlt" "mqpt" "mdlt")
+          if [[ ! " ${VALID_TEST_TYPES[@]} " =~ "${{ inputs.test-type }}" ]]; then
+            echo "::error::Invalid test type: ${{ inputs.test-type }}. Must be one of: ${VALID_TEST_TYPES[*]}"
+            exit 1
+          fi
+
+      - name: Set up JQ
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      # Once chewie is ready and installed on the network this job will
+      # be responsible for making the api calls to chewie with requested
+      # resources so that chewie can find a suitable cluster and namespace
+      # for the test.
+      #
+      # The response from chewie will be a json object that we can parse.
+      - name: Read Chewie Response
+        id: read-chewie-response
+        run: |
+          echo "::group::Collect Chewie Response for test asset: ${{ inputs.test-asset }}"
+          JSON_RESPONSE_FILE="${{ github.workspace }}/.github/workflows/support/chewie/${{ inputs.test-asset }}-${{ inputs.test-type }}.json"
+          if [[ ! -f "${JSON_RESPONSE_FILE}" ]]; then
+              echo "::error::file ${JSON_RESPONSE_FILE} does not exist."
+              exit 1
+          fi
+          echo "::endgroup::"
+
+          echo "::group::Collect Chewie Data"
+          # Now that we have the response "from chewie" we can parse out the necessary information
+          # to set up the init-containers-values files for solo.
+          NAMESPACE=$(jq -r '.namespace' "${JSON_RESPONSE_FILE}")
+          CLUSTER_FQDN=$(jq -r '.cluster_fqdn' "${JSON_RESPONSE_FILE}")
+
+          # CN Data
+          CN_QTY=$(jq -r '.instances[] | select(.group=="cn-nodes") | .spec.quantity' "${JSON_RESPONSE_FILE}")
+          CN_TOLERATIONS=$(jq -c '.instances[] | select(.group=="cn-nodes") | .tolerations' "${JSON_RESPONSE_FILE}")
+          CN_LABELS=$(jq -c '.instances[] | select(.group=="cn-nodes") | .labels' "${JSON_RESPONSE_FILE}")
+          CN_ROLE="$(jq -r '."solo.hashgraph.io/role"' <<< "${CN_LABELS}")"
+
+          # AUX Data
+          AUX_QTY=$(jq -r '.instances[] | select(.group=="aux-nodes") | .spec.quantity' "${JSON_RESPONSE_FILE}")
+          AUX_TOLERATIONS=$(jq -c '.instances[] | select(.group=="aux-nodes") | .tolerations' "${JSON_RESPONSE_FILE}")
+          AUX_LABELS=$(jq -c '.instances[] | select(.group=="aux-nodes") | .labels' "${JSON_RESPONSE_FILE}")
+          AUX_ROLE="$(jq -r '."solo.hashgraph.io/role"' <<< "${AUX_LABELS}")"
+
+          # Get Owner and network-id
+          NETWORK_ID="$(jq -r '."solo.hashgraph.io/network-id"' <<< "${CN_LABELS}")"
+          OWNER="$(jq -r '."solo.hashgraph.io/owner"' <<< "${CN_LABELS}")"
+
+          # Set outputs
+          echo "namespace=${NAMESPACE}" | tee -a "${GITHUB_OUTPUT}"
+          echo "kubernetes-fqdn=${CLUSTER_FQDN}" | tee -a "${GITHUB_OUTPUT}"
+          echo "network-id=${NETWORK_ID}" | tee -a "${GITHUB_OUTPUT}"
+          echo "owner=${OWNER}" | tee -a "${GITHUB_OUTPUT}"
+          echo "cn-quantity=${CN_QTY}" | tee -a "${GITHUB_OUTPUT}"
+          echo "cn-role=${CN_ROLE}" | tee -a "${GITHUB_OUTPUT}"
+          echo "aux-quantity=${AUX_QTY}" | tee -a "${GITHUB_OUTPUT}"
+          echo "aux-role=${AUX_ROLE}" | tee -a "${GITHUB_OUTPUT}"
+          echo "cn-tolerations=${CN_TOLERATIONS}" | tee -a "${GITHUB_OUTPUT}"
+          echo "aux-tolerations=${AUX_TOLERATIONS}" | tee -a "${GITHUB_OUTPUT}"
+          echo "::endgroup::"
+
+          # Write step summary
+          echo "## Chewie Response Read" >> "${GITHUB_STEP_SUMMARY}"
+          echo "namespace=${NAMESPACE}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "test asset=${{ inputs.test-asset }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Network ID=${NETWORK_ID}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Owner=${OWNER}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "CN Quantity=${CN_QTY}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "AUX Quantity=${AUX_QTY}" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/docs/workflow-manifest.md
+++ b/.github/workflows/docs/workflow-manifest.md
@@ -30,6 +30,7 @@
 | zxc-execute-hapi-tests.yaml                           | ZXC: Execute HAPI Tests                                           |                  |                      |
 | zxc-execute-timing-sensitive-tests.yaml               | ZXC: Execute Timing Sensitive Tests                               |                  |                      |
 | zxc-execute-hammer-tests.yaml                         | ZXC: Execute Hammer Tests                                         |                  |                      |
+| 801-read-chewie-response.yaml                         | 801: [CITR] Read Chewie Response                                  |                  |                      |
 |                                                       |                                                                   |                  |                      |
 | # CICD                                                |                                                                   |                  |                      |
 | zxf-collect-workflow-logs.yaml                        | ZXF: Collect Workflow Run Logs                                    |                  |                      |

--- a/.github/workflows/zxc-single-day-longevity-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-test.yaml
@@ -53,6 +53,9 @@ on:
       slack-report-webhook:
         required: true
         description: "Slack webhook for SDLT outputs notifications"
+      github-token:
+        required: true
+        description: "GitHub Authorization Token for the workflow"
     outputs:
       result:
         description: "Result of the SDLT Run"
@@ -64,7 +67,6 @@ permissions:
   actions: write
 
 env:
-  NAMESPACE_PREFIX: solo-sdlt-n
   TIMEOUT_6H_LIMIT: 340
   GS_ROOT_DIR: gs://performance-engineering-reports/ephemeral/test_runs
   GS_ROOT_HTTPS: https://perf.analytics.eng.hashgraph.io/ephemeral/test_runs
@@ -75,14 +77,27 @@ env:
   NLG_VERSION: 0.13.2
 
 jobs:
+  acquire-kubernetes-resources:
+    # TODO: This will use the chewie-action as chewie develops.
+    name: Acquire Kubernetes Resources
+    uses: ./.github/workflows/801-read-chewie-response.yaml
+    with:
+      ref: ${{ inputs.ref }}
+      test-asset: ${{ inputs.test-asset }}
+      test-type: "sdlt"
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
   longevity-tests-start:
     name: Start
     runs-on: hl-cn-sdlt-lin-lg
     outputs:
-      namespace: ${{ steps.set-namespace.outputs.namespace }}
+      run-hcn-version: ${{ steps.set-hcn-version.outputs.run-hcn-version }}
       commit-sha: ${{ steps.hederahash.outputs.sha }}
       waiterMatrix: ${{ steps.matrix.outputs.value }}
       kubernetes-cluster: ${{ steps.set-k8s-cluster.outputs.kubernetes-cluster }}
+    needs:
+      - acquire-kubernetes-resources
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -97,10 +112,9 @@ jobs:
       - name: Check Test Asset
         id: set-k8s-cluster
         run: |
-          K8S_CLUSTER="k8s.pft.dal.lat.ope.eng.hashgraph.io"
+          K8S_CLUSTER="${{ needs.acquire-kubernetes-resources.outputs.fqdn }}"
           grafana_url="${{ env.GRAFANA_SYSADM_DAL }}"
-          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]+$ ]]; then
-            K8S_CLUSTER="k8s.pft.chi.lat.ope.eng.hashgraph.io"
+          if [[ "${{ needs.acquire-kubernetes-resources.outputs.fqdn }}" =~ [.]chi[.] ]]; then
             grafana_url="${{ env.GRAFANA_SYSADM_CHI }}"
           fi
           echo "kubernetes-cluster=${K8S_CLUSTER}" >> "${GITHUB_OUTPUT}"
@@ -184,23 +198,19 @@ jobs:
         run: |
           mkdir "${{ github.workspace }}"/report
 
-      - name: Set namespace
-        id: set-namespace
+      - name: Set CN Version
+        id: set-hcn-version
         run: |
           set +x
           set +e
-          #trim RUN_HCN_VERSION
-          echo "RUN_HCN_VERSION=$(echo ${{ inputs.ref }} | awk '{print $1}')" >> "${GITHUB_ENV}"
-          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHocSD|AdHoc|SDPT|SDLT)(\d+)$/')"
-          echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_ENV}"
-          echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_OUTPUT}"
-          echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_STEP_SUMMARY}"
+          # trim the input ref
+          echo "run-hcn-version=$(echo ${{ inputs.ref }} | awk '{print $1}')" >> "${GITHUB_OUTPUT}"
 
       - name: Check for namespace collision
         run: |
           set +e
           set +x
-          NETWORK_ID="$(echo "${{ steps.set-namespace.outputs.namespace }}" | perl -pne '~s/^.*[^\d](\d+)$/$1/g')"
+          NETWORK_ID="${{ needs.acquire-kubernetes-resources.outputs.network-id }}"
 
           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt get namespaces | grep -E "solo-.*t-n${NETWORK_ID}[ \t]"
           if [[ ${?} -eq 0 ]]
@@ -270,7 +280,6 @@ jobs:
 
       - name: Deploy with Solo
         env:
-          NAMESPACE_ALIAS: ${{ inputs.test-asset }}
           CONTEXT: hashgraph.teleport.sh-${{ steps.set-k8s-cluster.outputs.kubernetes-cluster }}
         run: |
           set +x
@@ -296,20 +305,13 @@ jobs:
           cp "${{ github.workspace }}"/.github/workflows/support/citr/init-containers-values7.yaml init-containers-values7.yaml
 
           # Update Taskfile values
-          sed -i -e "s@%HOME%@${HOME}@g" -e "s@%SOLO_NAMESPACE%@${{ steps.set-namespace.outputs.namespace }}@g" \
+          sed -i -e "s@%HOME%@${HOME}@g" -e "s@%SOLO_NAMESPACE%@${{ needs.acquire-kubernetes-resources.outputs.namespace }}@g" \
           -e "s@%HEDERA_SERVICES_ROOT%@${curdir}@g" Taskfile.yml
 
           # Update Init Containers values
-          NETWORK_ID="$(echo "${{ steps.set-namespace.outputs.namespace }}" | perl -pne '~s/^.*[^\d](\d+)$/$1/g')"
+          NETWORK_ID="${{ needs.acquire-kubernetes-resources.outputs.network-id }}"
           sed -i -e "s@%NETWORK_ID%@${NETWORK_ID}@g" init-containers-values7.yaml
-
-          if [[ "${NAMESPACE_ALIAS}" =~ ^SDLT[0-9]+$ ]]; then
-            NETWORK_OWNER="single-day-longevity-test"
-          elif [[ "${NAMESPACE_ALIAS}" =~ ^AdHocSD[0-9]+$ ]]; then
-            NETWORK_OWNER="adhoc-single-day-test"
-          else
-            NETWORK_OWNER="adhoc-performance-test"
-          fi
+          NETWORK_OWNER="${{ needs.acquire-kubernetes-resources.outputs.owner }}"
           sed -i -e "s@%NETWORK_OWNER%@${NETWORK_OWNER}@g" init-containers-values7.yaml
 
           # Generate the application.properties file inline
@@ -346,13 +348,13 @@ jobs:
           fi
 
           sleep 30
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" get pods
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods
           cd "${{ github.workspace }}"
 
           mkdir solo_deploy
           cp -r "${HOME}"/.solo/logs solo_deploy/
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/getClusterErrors.sh "${{ steps.set-namespace.outputs.namespace }}"
-          cp -r podlog_"${{ steps.set-namespace.outputs.namespace }}" solo_deploy/
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/getClusterErrors.sh "${{ needs.acquire-kubernetes-resources.outputs.namespace }}"
+          cp -r podlog_"${{ needs.acquire-kubernetes-resources.outputs.namespace }}" solo_deploy/
           gcloud --no-user-output-enabled storage cp --recursive solo_deploy "${{ env.GS_ROOT_DIR }}/${{ inputs.ref }}_${{ inputs.test-asset }}_${{ github.run_number }}"/solo_deploy
           echo Done: solo deploy logs  in "${{ env.GS_ROOT_HTTPS }}/${{ inputs.ref }}_${{ inputs.test-asset }}_${{ github.run_number }}"/solo_deploy
 
@@ -362,16 +364,14 @@ jobs:
         run: cd "${{ github.workspace }}"
 
       - name: Prepare NLG parameters
-        env:
-          NAMESPACE_ALIAS: ${{ inputs.test-asset }}
         run: |
           set +x
           set +e
           cd ${{ github.workspace }}/solo
 
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt get svc -n "${{ steps.set-namespace.outputs.namespace }}" -l "solo.hedera.com/type=network-node-svc" |\
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt get svc -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" -l "solo.hedera.com/type=network-node-svc" |\
             grep -v 'node10' | grep -v 'CLUSTER-IP' > networks.txt
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt get svc -n "${{ steps.set-namespace.outputs.namespace }}" -l "solo.hedera.com/type=network-node-svc" |\
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt get svc -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" -l "solo.hedera.com/type=network-node-svc" |\
             grep 'node10' | grep -v 'CLUSTER-IP' >> networks.txt
 
           # Generate the nlg-values.yaml file inline
@@ -387,15 +387,9 @@ jobs:
           cat networks.txt | awk '{print $3}' | perl -ne "~s/\n//g; print \"     - '\$_\\\:50211=0.0.\".(3+\$.-1).\"'\n\"" >> new.yml
           mv new.yml nlg-values.yaml
 
-          NETWORK_ID="$(echo "${{ steps.set-namespace.outputs.namespace }}" | perl -pne '~s/^.*[^\d](\d+)$/$1/g')"
+          NETWORK_ID="${{ needs.acquire-kubernetes-resources.outputs.network-id }}"
           sed -i -e "s@%NETWORK_ID%@${NETWORK_ID}@g" nlg-values.yaml
-          if [[ "${NAMESPACE_ALIAS}" =~ ^SDLT[0-9]+$ ]]; then
-            NETWORK_OWNER="single-day-longevity-test"
-          elif [[ "${NAMESPACE_ALIAS}" =~ ^AdHocSD[0-9]+$ ]]; then
-            NETWORK_OWNER="adhoc-single-day-test"
-          else
-            NETWORK_OWNER="adhoc-performance-test"
-          fi
+          NETWORK_OWNER="${{ needs.acquire-kubernetes-resources.outputs.owner }}"
           sed -i -e "s@%NETWORK_OWNER%@${NETWORK_OWNER}@g" nlg-values.yaml
 
       - name: Deploy NLG test
@@ -403,22 +397,20 @@ jobs:
           set +x
           set +e
           cd "${{ github.workspace }}"/solo
-          /usr/bin/helm upgrade --install --set appName=nlg nlg oci://artifacts.hashgraph.io/load-generator-helm-release-local/network-load-generator --version "${{ env.NLG_VERSION }}" --values nlg-values.yaml -n "${{ steps.set-namespace.outputs.namespace }}"
+          /usr/bin/helm upgrade --install --set appName=nlg nlg oci://artifacts.hashgraph.io/load-generator-helm-release-local/network-load-generator --version "${{ env.NLG_VERSION }}" --values nlg-values.yaml -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}"
           sleep 180
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" get pods
-          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}')"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods
+          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}')"
 
           # Copy run version
           echo "run_number=${{ github.run_number }}" | tee -a "${{ github.workspace }}"/version_run.txt
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" cp "${{ github.workspace }}"/version_run.txt ${nlgpod}:/app/
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" cp "${{ github.workspace }}"/version_run.txt ${nlgpod}:/app/
 
       - name: Prepare NLG communication properties for CN
-        env:
-          NAMESPACE_ALIAS: ${{ inputs.test-asset }}
         run: |
           set +x
           set +e
-          NLG_IP=$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" describe pod nlg-network-load-generator | grep -E '^IP:' | awk '{print $2}')
+          NLG_IP=$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" describe pod nlg-network-load-generator | grep -E '^IP:' | awk '{print $2}')
 
           cat <<EOF > block-nodes.json
           {
@@ -428,24 +420,24 @@ jobs:
           }
           EOF
 
-          NofNodes=$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" get pods | grep 'network-node' | wc -l)
+          NofNodes=$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep 'network-node' | wc -l)
 
           for i in $(seq 1 1 ${NofNodes})
           do
-            sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" cp ./block-nodes.json network-node${i}-0:/opt/hgcapp/services-hedera/HapiApp2.0/data/config/block-nodes.json
+            sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" cp ./block-nodes.json network-node${i}-0:/opt/hgcapp/services-hedera/HapiApp2.0/data/config/block-nodes.json
           done
 
       - name: Deploy Validator
         run: |
           set +x
           set +e
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" \
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             cp "${{ github.workspace }}"/hedera-state-validator/build/libs/hedera-state-validator-*-SNAPSHOT-all.jar network-node1-0:/tmp/
 
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" \
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             exec -it network-node1-0 -c root-container -- bash -c "mkdir /opt/hgcapp/services-hedera/HapiApp2.0/data/saved/validation.tmp"
 
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" \
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             cp "${{ github.workspace }}"/.github/workflows/support/citr/checkValidatorNode.sh network-node1-0:/opt/hgcapp/services-hedera/HapiApp2.0/checkValidatorNode.sh
 
       - name: Distribution of K8S nodes, SysAdmin Grafana
@@ -455,13 +447,13 @@ jobs:
 
           start_date=$(date +%Y-%m-%dT%T)
           echo "NODE                                      POD" | tee -a "${GITHUB_STEP_SUMMARY}"
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" get pods -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name | grep -v -w NODE |\
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name | grep -v -w NODE |\
             perl -ne "if (/^([^\s]+)\s+([^\s]+)\s*$/) {print \"[\$1\](${{ steps.set-k8s-cluster.outputs.grafana-url }}&from=${start_date}&var-nodename=\$1) \$2\n\"}" | tee -a "${GITHUB_STEP_SUMMARY}"
 
       - name: Start Longevity test
         run: |
           run_NLGDebugparams="-Dorg.slf4j.simpleLogger.defaultLogLevel=debug" # e.g. -Dorg.slf4j.simpleLogger.defaultLogLevel=debug
-          nlgpod=`sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ steps.set-namespace.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}'`
+          nlgpod=`sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}'`
           n=`expr ${{ inputs.nlg-accounts }} / 1000`
           NLG_c=32
 
@@ -469,11 +461,11 @@ jobs:
 
           NLGargs="-K ECDSA -R -c ${NLG_c} -a ${{ inputs.nlg-accounts }}  -n ${n} -T 1000 -S hot -p 50"
 
-          echo kubectl -n "${{ steps.set-namespace.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
+          echo kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
             ${run_NLGDebugparams} -cp /app/lib/*:\$(ls -1 /app/network-load-generator-*.jar) com.hedera.benchmark.${test} \
             ${NLGargs} -tt ${{ inputs.nlg-time }}m > client.log 2>&1 &"
 
-          kubectl -n "${{ steps.set-namespace.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
+          kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
             ${run_NLGDebugparams} -cp /app/lib/*:\$(ls -1 /app/network-load-generator-*.jar) com.hedera.benchmark.${test} \
             ${NLGargs} -tt ${{ inputs.nlg-time }}m > client.log 2>&1 &"
           sleep 30
@@ -490,6 +482,7 @@ jobs:
     runs-on: hl-cn-sdlt-lin-lg
     if: ${{ !cancelled() }}
     needs:
+      - acquire-kubernetes-resources
       - longevity-tests-start
     strategy:
       max-parallel: 1
@@ -506,10 +499,7 @@ jobs:
       - name: Check Test Asset
         id: set-k8s-cluster
         run: |
-          K8S_CLUSTER="k8s.pft.dal.lat.ope.eng.hashgraph.io"
-          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]+$ ]]; then
-            K8S_CLUSTER="k8s.pft.chi.lat.ope.eng.hashgraph.io"
-          fi
+          K8S_CLUSTER="${{ needs.acquire-kubernetes-resources.outputs.fqdn }}"
           echo "kubernetes-cluster=${K8S_CLUSTER}" >> "${GITHUB_OUTPUT}"
 
       - name: Install KubeCtl
@@ -536,7 +526,7 @@ jobs:
         with:
           proxy: hashgraph.teleport.sh:443
           token: gh-citr-performance-svcs-bot
-          kubernetes-cluster: ${{ needs.longevity-tests-start.outputs.kubernetes-cluster }}
+          kubernetes-cluster: ${{ steps.set-k8s-cluster.outputs.kubernetes-cluster }}
           certificate-ttl: 24h
 
       - name: Checkout Code
@@ -578,16 +568,16 @@ jobs:
 
           sleep 60
 
-          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}')"
+          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}')"
 
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "tail /app/client.log"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "tail /app/client.log"
 
           counter=0
           start_time=`date +%s`
           max_counter=${{ env.TIMEOUT_6H_LIMIT }}
 
           ec=2
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "ps -aef | grep -w java | grep 'com.hedera.benchmark' | grep -v grep" | grep -w java > /dev/null
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "ps -aef | grep -w java | grep 'com.hedera.benchmark' | grep -v grep" | grep -w java > /dev/null
           isRunning=${?}
 
           while [ \( ${isRunning} -eq 0 \) -a \( ${counter} -le ${max_counter} \) ]
@@ -598,13 +588,13 @@ jobs:
            counter=$(expr "${current_time}" - "${start_time}")
            counter=$(expr "${counter}" \/ 60)
 
-           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "tail /app/client.log" > client.log
+           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "tail /app/client.log" > client.log
            tail -n 1 client.log
 
-           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "ps -aef | grep -w java | grep 'com.hedera.benchmark' | grep -v grep" | grep -w java > /dev/null
+           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "ps -aef | grep -w java | grep 'com.hedera.benchmark' | grep -v grep" | grep -w java > /dev/null
            isRunning=${?}
 
-           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "grep -E 'ERROR com.hedera.benchmark|Finished .*Test' /app/client.log" > client_state.log
+           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "grep -E 'ERROR com.hedera.benchmark|Finished .*Test' /app/client.log" > client_state.log
            check_status client_state.log
            ec=${?}
            if [[ ${ec} -lt 2 ]] #any terminal states 0 or 1, ec=2 is to continue
@@ -618,7 +608,7 @@ jobs:
             rm -rf "${{ github.workspace }}"/report/*
           fi
 
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" cp ${nlgpod}:/app/client.log "${{ github.workspace }}"/report/client.log
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" cp ${nlgpod}:/app/client.log "${{ github.workspace }}"/report/client.log
 
           check_status "${{ github.workspace }}"/report/client.log
           ec=${?}
@@ -638,6 +628,7 @@ jobs:
     runs-on: hl-cn-sdlt-lin-lg
     if: ${{ !cancelled() }}
     needs:
+      - acquire-kubernetes-resources
       - longevity-tests-start
       - longevity-tests-wait
     outputs:
@@ -710,7 +701,7 @@ jobs:
         run: |
           set +x
           set +e
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" \
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
                       exec -it network-node1-0 -c root-container -- bash -c "cd /opt/hgcapp/services-hedera/HapiApp2.0/data/saved; d=\$(date +%Y-%d-%mT%T); s=\$(du -sk swirlds-tmp ); a=\$(du -sk .); echo \"\${d} \${s} \${a}\""
 
       - name: Run Validator
@@ -718,25 +709,25 @@ jobs:
         run: |
           set +x
           set +e
-          kubectl -n "${{ needs.longevity-tests-start.outputs.namespace }}" \
+          kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             exec -it network-node1-0 -c root-container -- bash -c "cd /opt/hgcapp/services-hedera/HapiApp2.0; sh checkValidatorNode.sh 0" 2>&1 | tee "${{ github.workspace }}"/report/validator_status.log
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" \
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             cp network-node1-0:/opt/hgcapp/services-hedera/HapiApp2.0/data/saved/validation.tmp/validator.log "${{ github.workspace }}"/report/validator.log
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" \
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             cp network-node1-0:/opt/hgcapp/services-hedera/HapiApp2.0/data/saved/validation.tmp/validatorRun.log "${{ github.workspace }}"/report/validatorRun.log
           grep -E 'validation .* is OK' "${{ github.workspace }}"/report/validator_status.log
           echo "value=${?}" >> "${GITHUB_OUTPUT}"
 
       - name: Copy logs
         run: |
-          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}')"
+          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}')"
           sleep 300 # known: to let all benchmark write down logs
 
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" cp ${nlgpod}:/app/client.log "${{ github.workspace }}"/report/client.log
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" cp ${nlgpod}:/app/client.log "${{ github.workspace }}"/report/client.log
           cat "${{ github.workspace }}"/report/client.log | perl -pne '~s/\b([A-Z_]+[\:]\d+)\b/\n$1\n/g' | perl "${{ github.workspace }}"/.github/workflows/support/citr/collectNLG_Errors.pl > "${{ github.workspace }}"/report/client.stats.txt
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/getClusterErrors.sh "${{ needs.longevity-tests-start.outputs.namespace }}"
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" cp ${nlgpod}:/app/version_run.txt "${{ github.workspace }}"/report/version_run.txt
-          cp -r podlog_"${{ needs.longevity-tests-start.outputs.namespace }}" "${{ github.workspace }}"/report/
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/getClusterErrors.sh "${{ needs.acquire-kubernetes-resources.outputs.namespace }}"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" cp ${nlgpod}:/app/version_run.txt "${{ github.workspace }}"/report/version_run.txt
+          cp -r podlog_"${{ needs.acquire-kubernetes-resources.outputs.namespace }}" "${{ github.workspace }}"/report/
 
       - name: Extract benchmark score of NftTransferLoadTest test
         id: NftTransferLoadTestLogs
@@ -796,7 +787,7 @@ jobs:
           echo Done: see results in "${{ env.GS_ROOT_HTTPS }}/${{ inputs.ref }}_${{ inputs.test-asset }}_${{ github.run_number }}/report/longevity"
 
           #echo "Truncating logs for next test..."
-          #sh "${{ github.workspace }}"/.github/workflows/support/citr/resetCNlogs.sh "${{ needs.longevity-tests-start.outputs.namespace }}"
+          #sh "${{ github.workspace }}"/.github/workflows/support/citr/resetCNlogs.sh "${{ needs.acquire-kubernetes-resources.outputs.namespace }}"
 
   # Send this output back to the caller workflow
   longevity-test-reconnect:
@@ -804,6 +795,7 @@ jobs:
     runs-on: hl-cn-sdlt-lin-lg
     if: ${{ !cancelled() }}
     needs:
+      - acquire-kubernetes-resources
       - longevity-tests-start
       - longevity-tests-finish
     outputs:
@@ -812,10 +804,7 @@ jobs:
       - name: Check Test Asset
         id: set-k8s-cluster
         run: |
-          K8S_CLUSTER="k8s.pft.dal.lat.ope.eng.hashgraph.io"
-          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]+$ ]]; then
-            K8S_CLUSTER="k8s.pft.chi.lat.ope.eng.hashgraph.io"
-          fi
+          K8S_CLUSTER=${{ needs.acquire-kubernetes-resources.outputs.fqdn }}
           echo "kubernetes-cluster=${K8S_CLUSTER}" >> "${GITHUB_OUTPUT}"
 
       - name: Install KubeCtl
@@ -868,7 +857,7 @@ jobs:
       - name: Start Longevity test
         run: |
           run_NLGDebugparams="-Dorg.slf4j.simpleLogger.defaultLogLevel=debug" # e.g. -Dorg.slf4j.simpleLogger.defaultLogLevel=debug
-          nlgpod=`sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" get pods | grep nlg-network-load-generator | awk '{print $1}'`
+          nlgpod=`sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep nlg-network-load-generator | awk '{print $1}'`
           n=`expr ${{ inputs.nlg-accounts }} / 1000`
           NLG_c=32
 
@@ -876,11 +865,11 @@ jobs:
 
           NLGargs="-K ECDSA -R -c ${NLG_c} -a ${{ inputs.nlg-accounts }}  -n ${n} -T 1000 -S hot -p 50"
 
-          echo kubectl -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
+          echo kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
             ${run_NLGDebugparams} -cp /app/lib/*:\$(ls -1 /app/network-load-generator-*.jar) com.hedera.benchmark.${test} \
             ${NLGargs} -tt ${{ inputs.nlg-time }}m > client.log 2>&1 &"
 
-          kubectl -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
+          kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
             ${run_NLGDebugparams} -cp /app/lib/*:\$(ls -1 /app/network-load-generator-*.jar) com.hedera.benchmark.${test} \
             ${NLGargs} -tt ${{ inputs.nlg-time }}m > client.log 2>&1 &"
           sleep 30
@@ -896,13 +885,13 @@ jobs:
           NofLoops=3
           result=13
 
-          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" get pods | grep nlg-network-load-generator | awk '{print $1}')"
+          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep nlg-network-load-generator | awk '{print $1}')"
           mkdir -p "${{ github.workspace }}"/report/reconnect
-          bash "${{ github.workspace }}"/.github/workflows/support/citr/profileReconnectLoopK8s.sh "${{ needs.longevity-tests-start.outputs.namespace }}" ${downtime} ${warmtime} ${NofLoops} 2>&1 | tee "${{ github.workspace }}"/report/reconnect/reconnect.log
+          bash "${{ github.workspace }}"/.github/workflows/support/citr/profileReconnectLoopK8s.sh "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" ${downtime} ${warmtime} ${NofLoops} 2>&1 | tee "${{ github.workspace }}"/report/reconnect/reconnect.log
 
-          nlgpod=`sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" get pods | grep nlg-network-load-generator | awk '{print $1}'`
-          kubectl -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "tail -n 20 /app/client.log"
-          kubectl -n "${{ needs.longevity-tests-start.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "ps -aef" | grep 'com.hedera.benchmark'
+          nlgpod=`sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep nlg-network-load-generator | awk '{print $1}'`
+          kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "tail -n 20 /app/client.log"
+          kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "ps -aef" | grep 'com.hedera.benchmark'
           result=$?
 
           if [ ${result} -ne 0 ]
@@ -921,11 +910,11 @@ jobs:
         run: |
           set +x
           set +e
-          kubectl -n "${{ needs.longevity-tests-start.outputs.namespace }}" \
+          kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             exec -it network-node1-0 -c root-container -- bash -c "cd /opt/hgcapp/services-hedera/HapiApp2.0; sh checkValidatorNode.sh 0" 2>&1 | tee "${{ github.workspace }}"/report/reconnect/validator_status.log
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" \
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             cp network-node1-0:/opt/hgcapp/services-hedera/HapiApp2.0/data/saved/validation.tmp/validator.log "${{ github.workspace }}"/report/reconnect/validator.log
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" \
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" \
             cp network-node1-0:/opt/hgcapp/services-hedera/HapiApp2.0/data/saved/validation.tmp/validatorRun.log "${{ github.workspace }}"/report/reconnect/validatorRun.log
           cat "${{ github.workspace }}"/report/reconnect/validator_status.log
           grep -E 'validation .* is OK' "${{ github.workspace }}"/report/reconnect/validator_status.log
@@ -941,13 +930,13 @@ jobs:
 
       - name: Copy logs
         run: |
-          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}')"
+          nlgpod="$(sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}')"
 
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" cp ${nlgpod}:/app/client.log "${{ github.workspace }}"/report/reconnect/client.log
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" cp ${nlgpod}:/app/client.log "${{ github.workspace }}"/report/reconnect/client.log
           cat "${{ github.workspace }}"/report/client.log | perl -pne '~s/\b([A-Z_]+[\:]\d+)\b/\n$1\n/g' | perl "${{ github.workspace }}"/.github/workflows/support/citr/collectNLG_Errors.pl > "${{ github.workspace }}"/report/reconnect/client.stats.txt
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/getClusterErrors.sh "${{ needs.longevity-tests-start.outputs.namespace }}"
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.longevity-tests-start.outputs.namespace }}" cp ${nlgpod}:/app/version_run.txt "${{ github.workspace }}"/report/reconnect/version_run.txt
-          cp -r podlog_"${{ needs.longevity-tests-start.outputs.namespace }}" "${{ github.workspace }}"/report/reconnect/
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/getClusterErrors.sh "${{ needs.acquire-kubernetes-resources.outputs.namespace }}"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" cp ${nlgpod}:/app/version_run.txt "${{ github.workspace }}"/report/reconnect/version_run.txt
+          cp -r podlog_"${{ needs.acquire-kubernetes-resources.outputs.namespace }}" "${{ github.workspace }}"/report/reconnect/
 
       - name: Publish logs
         if: ${{ !cancelled() }}
@@ -967,7 +956,7 @@ jobs:
       - name: Delete namespace
         if: ${{ inputs.delete-namespace == true }}
         run: |
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt delete namespace "${{ needs.longevity-tests-start.outputs.namespace }}"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt delete namespace "${{ needs.acquire-kubernetes-resources.outputs.namespace }}"
 
   # Send this output back to the caller workflow
   single-day-longevity-test-result:

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -72,8 +72,6 @@ permissions:
   actions: write
 
 env:
-  DEFAULT_NAMESPACE: AdHocSD8
-  DEFAULT_HCN_VERSION: main
   TIMEOUT_6H_LIMIT: 340
   GS_ROOT_DIR: gs://performance-engineering-reports/ephemeral/test_runs
   GS_ROOT_HTTPS: https://perf.analytics.eng.hashgraph.io/ephemeral/test_runs
@@ -99,74 +97,31 @@ env:
 
 jobs:
   acquire-kubernetes-resources:
-    name: Get Kubernetes Resources
-    runs-on: hl-cn-sdpt-lin-sm
-    outputs:
-      namespace: ${{ steps.read-chewie-response.outputs.namespace }}
-      fqdn: ${{ steps.read-chewie-response.outputs.kubernetes-fqdn }}
-      cn-quantity: ${{ steps.read-chewie-response.outputs.cn-quantity }}
-      aux-quantity: ${{ steps.read-chewie-response.outputs.aux-quantity }}
-      cn-tolerations: ${{ steps.read-chewie-response.outputs.cn-tolerations }}
-      aux-tolerations: ${{ steps.read-chewie-response.outputs.aux-tolerations }}
-      cn-labels: ${{ steps.read-chewie-response.outputs.cn-labels }}
-      aux-labels: ${{ steps.read-chewie-response.outputs.aux-labels }}
+    # TODO: This will use the chewie-action as chewie develops.
+    name: Acquire Kubernetes Resources
+    uses: ./.github/workflows/801-read-chewie-response.yaml
+    with:
+      ref: ${{ inputs.ref }}
+      test-asset: ${{ inputs.test-asset }}
+      test-type: "sdpt"
+    secrets:
+      github-token: ${{ secrets.github-token }}
+
+  print-kubernetes-resources:
+    name: Print Kubernetes Resources
+    runs-on: hl-cn-default-lin-sm
+    needs:
+      - acquire-kubernetes-resources
     steps:
-      - name: Initialize Job
-        uses: PandasWhoCode/initialize-github-job@47186ab8b59085a7406a53c0b7a98031bcf4c4cc # v1.0.7
-        with:
-          checkout: true
-          checkout-token: ${{ secrets.github-token }}
-          checkout-ref: ${{ inputs.ref }}
-
-      - name: Set up JQ
+      - name: Print Kubernetes Resources
         run: |
-          sudo apt-get update
-          sudo apt-get install -y jq
-
-      # Once chewie is ready and installed on the network this job will
-      # be responsible for making the api calls to chewie with requested
-      # resources so that chewie can find a suitable cluster and namespace
-      # for the test.
-      #
-      # The response from chewie will be a json object that we can parse.
-      - name: Read Chewie Response
-        id: read-chewie-response
-        run: |
-          JSON_RESPONSE_FILE="${{ github.workspace }}/.github/workflows/support/chewie/${{ inputs.test-asset }}-sdpt.json"
-          if [[ ! -f "${JSON_RESPONSE_FILE}" ]]; then
-              echo "::error file ${JSON_RESPONSE_FILE} does not exist."
-              exit 1
-          fi
-
-          # Now that we have the response "from chewie" we can parse out the necessary information
-          # to set up the init-containers-values files for solo.
-          NAMESPACE=$(jq -r '.namespace' "${JSON_RESPONSE_FILE}")
-          CLUSTER_FQDN=$(jq -r '.cluster_fqdn' "${JSON_RESPONSE_FILE}")
-
-          # CN Data
-          CN_QTY=$(jq -r '.instances[] | select(.group=="cn-nodes") | .spec.quantity' "${JSON_RESPONSE_FILE}")
-          CN_TOLERATIONS=$(jq -c '.instances[] | select(.group=="cn-nodes") | .tolerations' "${JSON_RESPONSE_FILE}")
-          CN_LABELS=$(jq -c '.instances[] | select(.group=="cn-nodes") | .labels' "${JSON_RESPONSE_FILE}")
-
-          # AUX Data
-          AUX_QTY=$(jq -r '.instances[] | select(.group=="aux-nodes") | .spec.quantity' "${JSON_RESPONSE_FILE}")
-          AUX_TOLERATIONS=$(jq -c '.instances[] | select(.group=="aux-nodes") | .tolerations' "${JSON_RESPONSE_FILE}")
-          AUX_LABELS=$(jq -c '.instances[] | select(.group=="aux-nodes") | .labels' "${JSON_RESPONSE_FILE}")
-
-          # Set outputs
-          echo "namespace=${NAMESPACE}" >> "${GITHUB_OUTPUT}"
-          echo "kubernetes-fqdn=${CLUSTER_FQDN}" >> "${GITHUB_OUTPUT}"
-          echo "cn-quantity=${CN_QTY}" >> "${GITHUB_OUTPUT}"
-          echo "cn-tolerations=${CN_TOLERATIONS}" >> "${GITHUB_OUTPUT}"
-          echo "cn-labels=${CN_LABELS}" >> "${GITHUB_OUTPUT}"
-          echo "aux-quantity=${AUX_QTY}" >> "${GITHUB_OUTPUT}"
-          echo "aux-tolerations=${AUX_TOLERATIONS}" >> "${GITHUB_OUTPUT}"
-          echo "aux-labels=${AUX_LABELS}" >> "${GITHUB_OUTPUT}"
-
-          # Write step summary
-          echo "## Chewie Response Read" >> "${GITHUB_STEP_SUMMARY}"
-          echo "namespace=${NAMESPACE}" >> "${GITHUB_STEP_SUMMARY}"
-          echo "test asset=${{ inputs.test-asset }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Namespace: ${{ needs.acquire-kubernetes-resources.outputs.namespace }}"
+          echo "FQDN: ${{ needs.acquire-kubernetes-resources.outputs.fqdn }}"
+          echo "CN Quantity: ${{ needs.acquire-kubernetes-resources.outputs.cn-quantity }}"
+          echo "Aux Quantity: ${{ needs.acquire-kubernetes-resources.outputs.aux-quantity }}"
+          echo "Aux Role: ${{ needs.acquire-kubernetes-resources.outputs.aux-role }}"
+          echo "Network ID: ${{ needs.acquire-kubernetes-resources.outputs.network-id }}"
+          echo "Owner: ${{ needs.acquire-kubernetes-resources.outputs.owner }}"
 
   performance-tests-start:
     name: Start
@@ -195,7 +150,7 @@ jobs:
         run: |
           K8S_CLUSTER="${{ needs.acquire-kubernetes-resources.outputs.fqdn }}"
           grafana_url="${{ env.GRAFANA_SYSADM_DAL }}"
-          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]+$ ]]; then
+          if [[ "${{ needs.acquire-kubernetes-resources.outputs.fqdn }}" =~ [.]chi[.] ]]; then
             grafana_url="${{ env.GRAFANA_SYSADM_CHI }}"
           fi
           echo "kubernetes-cluster=${K8S_CLUSTER}" >> "${GITHUB_OUTPUT}"
@@ -291,7 +246,7 @@ jobs:
         run: |
           set +e
           set +x
-          NETWORK_ID="$(echo "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" | perl -pne '~s/^.*[^\d](\d+)$/$1/g')"
+          NETWORK_ID="${{ needs.acquire-kubernetes-resources.outputs.network-id }}"
 
           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt get namespaces | grep -E "chewie-solo-.*t-n${NETWORK_ID}[ \t]"
           if [[ ${?} -eq 0 ]]
@@ -362,7 +317,6 @@ jobs:
 
       - name: Deploy with Solo
         env:
-          NAMESPACE_ALIAS: ${{ inputs.test-asset }}
           CONTEXT: hashgraph.teleport.sh-${{ steps.set-k8s-cluster.outputs.kubernetes-cluster }}
         run: |
           set +x
@@ -392,10 +346,10 @@ jobs:
           -e "s@%HEDERA_SERVICES_ROOT%@${curdir}@g" Taskfile.yml
 
           # Update Init Containers values
-          NETWORK_ID="$( jq -r '.[] | select(.key=="solo.hashgraph.io/network-id") | .value' <<< '${{ needs.acquire-kubernetes-resources.outputs.cn-tolerations }}')"
+          NETWORK_ID="${{ needs.acquire-kubernetes-resources.outputs.network-id }}"
           sed -i -e "s@%NETWORK_ID%@${NETWORK_ID}@g" init-containers-values7.yaml
 
-          NETWORK_OWNER="$( jq -r '.[] | select(.key=="solo.hashgraph.io/owner") | .value' <<< '${{ needs.acquire-kubernetes-resources.outputs.cn-tolerations }}')"
+          NETWORK_OWNER="${{ needs.acquire-kubernetes-resources.outputs.owner }}"
           sed -i -e "s@%NETWORK_OWNER%@${NETWORK_OWNER}@g" init-containers-values7.yaml
 
           # Generate the application.properties file inline
@@ -448,8 +402,6 @@ jobs:
         run: cd "${{ github.workspace }}"
 
       - name: Prepare NLG parameters
-        env:
-          NAMESPACE_ALIAS: ${{ inputs.test-asset }}
         run: |
           set +x
           set +e
@@ -473,16 +425,16 @@ jobs:
           cat networks.txt | awk '{print $3}' | perl -ne "~s/\n//g; print \"     - '\$_\\\:50211=0.0.\".(3+\$.-1).\"'\n\"" >> new.yml
           mv new.yml nlg-values.yaml
 
-          NETWORK_ID="$( jq -r '.[] | select(.key=="solo.hashgraph.io/network-id") | .value' <<< '${{ needs.acquire-kubernetes-resources.outputs.cn-tolerations }}')"
+          NETWORK_ID="${{ needs.acquire-kubernetes-resources.outputs.network-id }}"
           sed -i -e "s@%NETWORK_ID%@${NETWORK_ID}@g" nlg-values.yaml
 
-          NETWORK_OWNER="$( jq -r '.[] | select(.key=="solo.hashgraph.io/owner") | .value' <<< '${{ needs.acquire-kubernetes-resources.outputs.cn-tolerations }}')"
+          NETWORK_OWNER="${{ needs.acquire-kubernetes-resources.outputs.owner }}"
           sed -i -e "s@%NETWORK_OWNER%@${NETWORK_OWNER}@g" nlg-values.yaml
 
-          NETWORK_ID="$( jq -r '.[] | select(.key=="solo.hashgraph.io/network-id") | .value' <<< '${{ needs.acquire-kubernetes-resources.outputs.cn-tolerations }}')"
+          NETWORK_ID="${{ needs.acquire-kubernetes-resources.outputs.network-id }}"
           sed -i -e "s@%NETWORK_ID%@${NETWORK_ID}@g" merkledb-values.yaml
 
-          NETWORK_OWNER="$( jq -r '.[] | select(.key=="solo.hashgraph.io/owner") | .value' <<< '${{ needs.acquire-kubernetes-resources.outputs.cn-tolerations }}')"
+          NETWORK_OWNER="${{ needs.acquire-kubernetes-resources.outputs.owner }}"
           sed -i -e "s@%NETWORK_OWNER%@${NETWORK_OWNER}@g" merkledb-values.yaml
 
       - name: Deploy NLG test

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -16,6 +16,7 @@ on:
           - AdHoc5
           - AdHoc6
           - AdHoc7
+          - AdHoc13
           - AdHoc14
           - AdHocSD8
           - AdHocSD9
@@ -134,7 +135,7 @@ jobs:
     uses: ./.github/workflows/zxc-single-day-longevity-test.yaml
     if: ${{ needs.verify-tag.result == 'success' || inputs.disable-notifications == true }}
     with:
-      test-asset: "${{ inputs.test-asset }}"
+      test-asset: "${{ inputs.test-asset }}" # TODO: Once Chewie application is installed we can remove this input.
       ref: "${{ inputs.ref || github.ref }}"
       solo-version: "${{ vars.ADHOC_SOLO_VERSION }}"
       nlg-accounts: "${{ inputs.nlg-accounts }}"
@@ -145,6 +146,7 @@ jobs:
       delete-namespace: ${{ inputs.delete-namespace }}
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   tag-sdlt-result:
     name: Tag SDLT Result

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -62,7 +62,7 @@ jobs:
     uses: ./.github/workflows/zxc-single-day-longevity-test.yaml
     if: ${{ needs.verify-tag.result == 'success' }}
     with:
-      test-asset: "SDLT2"
+      test-asset: "SDLT2" # TODO: Once Chewie application is installed we can remove this input.
       ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "100000000"
@@ -73,6 +73,7 @@ jobs:
       delete-namespace: true
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+      github_token: ${{ secrets.GITHUB_TOKEN }}
 
   tag-sdlt-result:
     name: Tag SDLT Result


### PR DESCRIPTION
## Description

This pull request introduces a new reusable GitHub Actions workflow for reading the Chewie response and refactors the `zxc-single-day-longevity-test.yaml` workflow to leverage this new workflow for dynamic Kubernetes resource acquisition. The changes remove hardcoded namespace, network ID, and owner derivation logic, instead sourcing these values directly from the Chewie response, which improves maintainability and flexibility for running tests in different environments.

The most important changes are:

**New Reusable Workflow for Chewie Response:**
* Added `.github/workflows/801-read-chewie-response.yaml`, a reusable workflow that reads a Chewie response JSON file and exposes key Kubernetes resource parameters (namespace, FQDN, network ID, owner, etc.) as outputs for downstream jobs. This workflow validates the test type, installs `jq`, parses the Chewie response, and sets workflow outputs accordingly.
* Registered the new workflow in the workflow manifest documentation (`.github/workflows/docs/workflow-manifest.md`).

**Refactoring Resource Acquisition in SDLT Workflow:**
* Updated `zxc-single-day-longevity-test.yaml` to call the new `801-read-chewie-response.yaml` workflow as a job (`acquire-kubernetes-resources`), passing required inputs and secrets, and using its outputs throughout the workflow.
* Added `github-token` as a required secret input for the workflow and removed the unused `NAMESPACE_PREFIX` environment variable. [[1]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391R56-R58) [[2]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L67)

**Dynamic Resource Usage and Simplification:**
* Replaced all hardcoded or derived namespace, FQDN, network ID, and owner usages with references to the outputs from the new `acquire-kubernetes-resources` job, ensuring consistency and reducing duplication. This includes updating deployment, logging, and configuration steps to use these dynamic values. [[1]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L100-R117) [[2]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L187-R213) [[3]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L299-R314) [[4]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L349-R357) [[5]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L365-R374) [[6]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L390-R413) [[7]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L431-R440) [[8]](diffhunk://#diff-b43f8ad4a1585250886d22994d6113ea2765e897792cd2f70ab2129e95bf4391L273)

These changes centralize and standardize resource acquisition for test workflows, making them more robust and easier to maintain.

## Related Issue(s)

Closes #25088 