### PR TITLE
fix: raise platform.wiring.healthLogThreshold to 5s for hapiTestRestart

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -193,7 +193,7 @@ val prCheckPropOverrides =
             "tss.historyEnabled=false,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestSmartContractSerial" to "tss.historyEnabled=false",
         "hapiTestRestart" to
-            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
+            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5,platform.wiring.healthLogThreshold=5s",
         "hapiTestWrapsDownload" to
             "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.initialCrsParties=16,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,tss.wrapsProvingKeyDownloadEnabled=true,tss.wrapsProvingKeyPath=testfiles/valid-wraps-proving-key.tar.gz,tss.wrapsProvingKeyHash=da83f3ae5eaa8575f5bedf583de2826ccfa5bff80bd6f58a54b0bf7e934e98919b5bcdaa074b3ae248f161317b87a22a",
         "hapiTestMisc" to


### PR DESCRIPTION
## Summary
- Appends `platform.wiring.healthLogThreshold=5s` to the `hapiTestRestart` PR-check overrides in `hedera-node/test-clients/build.gradle.kts`.
- Aligns the `HealthMonitorLogger` WARN threshold with the existing `hedera.transaction.maximumPermissibleUnhealthySeconds=5` failure threshold, so the WARN only fires in the same window that also triggers transaction rejection.
- Previously, #25085 raised the failure threshold but left the default 1s log threshold in place — `LogValidationTest#logsContainNoUnexpectedProblems` continued to flake on transient backpressure during PCES replay after restart.

Fixes #25101