### PR TITLE
fix(yahcli): restore log output by bundling a dedicated log4j2 config

### DIFF
--- a/hedera-node/yahcli/build.gradle.kts
+++ b/hedera-node/yahcli/build.gradle.kts
@@ -41,6 +41,13 @@ val yahCliJar =
             )
         }
 
+        // Strip log4j2 configs contributed by transitive deps so they do not shadow
+        // yahcli's own config or mislead operators inspecting the jar. yahcli's own
+        // log config uses a distinct filename (src/main/resources/log4j2-yahcli.xml,
+        // pinned via src/main/resources/log4j2.component.properties), so this
+        // exclude does not affect it.
+        exclude("log4j2.xml", "log4j2-test-client.xml", "log4j2-JRS.xml", "regression-log4j2.xml")
+
         // Include all classes and resources from the main source set
         from(sourceSets["main"].output)
     }

--- a/hedera-node/yahcli/src/main/resources/log4j2-yahcli.xml
+++ b/hedera-node/yahcli/src/main/resources/log4j2-yahcli.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<Configuration status="WARN">
+    <Properties>
+        <Property name="logDir">${sys:yahcli.log.dir:-output}</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1} - %m%n"/>
+        </Console>
+        <RollingFile name="RollingFile"
+                     fileName="${logDir}/yahcli.log"
+                     filePattern="${logDir}/yahcli.log-%d{yyyy-MM-dd}-%i.log">
+            <PatternLayout>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
+            </PatternLayout>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="RollingFile"/>
+        </Root>
+        <Logger name="com.swirlds" level="WARN" additivity="false">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+        <Logger name="org.hiero" level="WARN" additivity="false">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="RollingFile"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/hedera-node/yahcli/src/main/resources/log4j2-yahcli.xml
+++ b/hedera-node/yahcli/src/main/resources/log4j2-yahcli.xml
@@ -7,11 +7,12 @@
 
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %c{1} - %m%n"/>
+            <!-- 'tc' -> 'test-clients': distinguishes framework log lines from yahcli's first-level stdout -->
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} &lt;tc&gt; %-5p %c{1} - %m%n"/>
         </Console>
         <RollingFile name="RollingFile"
-                     fileName="${logDir}/yahcli.log"
-                     filePattern="${logDir}/yahcli.log-%d{yyyy-MM-dd}-%i.log">
+                     fileName="${logDir}/yahcli-tc.log"
+                     filePattern="${logDir}/yahcli-tc.log-%d{yyyy-MM-dd}-%i.log">
             <PatternLayout>
                 <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p %-4L %c{1} - %m{nolookups}%n</pattern>
             </PatternLayout>

--- a/hedera-node/yahcli/src/main/resources/log4j2.component.properties
+++ b/hedera-node/yahcli/src/main/resources/log4j2.component.properties
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pin log4j2 to yahcli's bundled configuration. Without this, log4j2's
+# auto-discovery scans for `log4j2.xml` first, which can be satisfied by any
+# transitive dependency (swirlds-platform-core ships an OFF-level config).
+log4j2.configurationFile=log4j2-yahcli.xml


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                   
                                                                                                                                                                                                               
  Yahcli was producing **zero log output** in preprod.                                                                                                   
                                                                                                                                                                                                               
  **Root cause:** The shadow jar bundles four `log4j2` configs from transitive deps. Log4j2's auto-discovery picks the canonical filename `log4j2.xml`, which is the one shipped by `swirlds-platform-core` —  
  and it sets `<Root level="off">`.
                                                                                                                                                                                                               
  ## Fix          

  - Add `src/main/resources/log4j2-yahcli.xml` — Console + RollingFile, root `INFO`.                                                                                                                           
  - Add `src/main/resources/log4j2.component.properties` — pins log4j2 to the new config.
  - `build.gradle.kts`: exclude the four stale transitive configs (`log4j2.xml`, `log4j2-test-client.xml`, `log4j2-JRS.xml`, `regression-log4j2.xml`) from the shadow jar.                                     
                                                                                                                                                                                                               
  No launcher/Dockerfile changes.                                                                                        