### PR TITLE
feat: Add code delegations feature flag

### DIFF
--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -28,7 +28,7 @@ grpc.nodeOperatorPortEnabled=true
 networkAdmin.preserveStateWeightsDuringOverride=false
 contracts.systemContract.hts.addresses=359,364
 contracts.evm.version=v0.70
-contracts.evm.pectra.enabled=true
+contracts.codeDelegations.enabled=false
 #Enforce native lib verification to not halt node on dev env
 contracts.evm.nativeLibVerification.halt.enabled=false
 # Disable TSS for PR checks by default because of the time overhead

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -151,14 +151,14 @@ public record ContractsConfig(
         @ConfigProperty(value = "evm.nonExtantContractsFail", defaultValue = "0") @NetworkProperty
         Set<Long> evmNonExtantContractsFail,
 
-        @ConfigProperty(value = "evm.version", defaultValue = "v0.67") @NetworkProperty
+        @ConfigProperty(value = "evm.version", defaultValue = "v0.70") @NetworkProperty
         String evmVersion,
-
-        @ConfigProperty(value = "evm.pectra.enabled", defaultValue = "true") @NetworkProperty
-        boolean evmPectraEnabled,
 
         @ConfigProperty(value = "evm.nativeLibVerification.halt.enabled", defaultValue = "false") @NetworkProperty
         boolean nativeLibVerificationHaltEnabled,
+
+        @ConfigProperty(value = "codeDelegations.enabled", defaultValue = "false") @NetworkProperty
+        boolean codeDelegationsEnabled,
 
         @ConfigProperty(value = "metrics.smartContract.primary.enabled", defaultValue = "true") @NetworkProperty
         boolean metricsSmartContractPrimaryEnabled,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/FeatureFlags.java
@@ -5,7 +5,6 @@ import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.co
 
 import com.hedera.hapi.streams.SidecarType;
 import com.hedera.node.config.data.ContractsConfig;
-import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -50,40 +49,6 @@ public interface FeatureFlags {
      */
     default boolean isAllowCallsToNonContractAccountsEnabled(
             @NonNull final ContractsConfig config, @Nullable Long possiblyGrandFatheredEntityNum) {
-        return false;
-    }
-
-    /**
-     *  If true, charge intrinsic gas for calls that fail with a pre-EVM exception.
-     * @param config the active configuration
-     * @return true whether to  charge intrinsic gas for calls that fail with a pre-EVM exception.
-     */
-    default boolean isChargeGasOnPreEvmException(@NonNull Configuration config) {
-        return false;
-    }
-
-    /**
-     *  If true, enable calls to the Hedera Account Service system contract
-     * @param config the active configuration
-     * @return true whether calls to Hedera Account Service system contract are enabled.
-     */
-    default boolean isHederaAccountServiceEnabled(@NonNull Configuration config) {
-        return false;
-    }
-
-    /**
-     * @param config the active configuration
-     * @return true whether authorized raw method is enabled.
-     */
-    default boolean isAuthorizedRawMethodEnabled(@NonNull Configuration config) {
-        return false;
-    }
-
-    /**
-     *  If true, type 4 Ethereum transactions (EIP-7702 authorization lists) will be supported.
-     * @return true if type 4 Ethereum transactions are supported.
-     */
-    default boolean isAuthorizationListEnabled(@NonNull Configuration config) {
         return false;
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionProcessor.java
@@ -148,7 +148,7 @@ public class TransactionProcessor {
 
         final var lazyCreationGasAvailable = transaction.gasLimit() - gasCharges.intrinsicGas();
         final CodeDelegationResult codeDelegationResult;
-        if (hasCodeDelegations && contractsConfig.evmPectraEnabled()) {
+        if (hasCodeDelegations && contractsConfig.codeDelegationsEnabled()) {
             // Gas amount available for charging Hedera-specific hollow account creation cost
             // when processing code delegations.
             // Note that the base EIP-7702 gas cost for authorizations is already deducted in `intrinsicGas`.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v046/Version046FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v046/Version046FeatureFlags.java
@@ -3,7 +3,6 @@ package com.hedera.node.app.service.contract.impl.exec.v046;
 
 import com.hedera.node.app.service.contract.impl.exec.v034.Version034FeatureFlags;
 import com.hedera.node.config.data.ContractsConfig;
-import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import javax.inject.Inject;
@@ -22,10 +21,5 @@ public class Version046FeatureFlags extends Version034FeatureFlags {
         final var grandfathered = possiblyGrandFatheredEntityNum != null
                 && config.evmNonExtantContractsFail().contains(possiblyGrandFatheredEntityNum);
         return config.evmAllowCallsToNonContractAccounts() && !grandfathered;
-    }
-
-    @Override
-    public boolean isChargeGasOnPreEvmException(@NonNull Configuration config) {
-        return config.getConfigData(ContractsConfig.class).chargeGasOnEvmHandleException();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v051/Version051FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v051/Version051FeatureFlags.java
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl.exec.v051;
 
-import static java.util.Objects.requireNonNull;
-
 import com.hedera.node.app.service.contract.impl.exec.v050.Version050FeatureFlags;
-import com.hedera.node.config.data.ContractsConfig;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -15,17 +10,5 @@ public class Version051FeatureFlags extends Version050FeatureFlags {
     @Inject
     public Version051FeatureFlags() {
         // Dagger2
-    }
-
-    @Override
-    public boolean isHederaAccountServiceEnabled(@NonNull Configuration config) {
-        requireNonNull(config);
-        return config.getConfigData(ContractsConfig.class).systemContractAccountServiceEnabled();
-    }
-
-    @Override
-    public boolean isAuthorizedRawMethodEnabled(@NonNull Configuration config) {
-        requireNonNull(config);
-        return config.getConfigData(ContractsConfig.class).systemContractAccountServiceIsAuthorizedRawEnabled();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v070/Version070FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v070/Version070FeatureFlags.java
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl.exec.v070;
 
-import static java.util.Objects.requireNonNull;
-
 import com.hedera.node.app.service.contract.impl.exec.v065.Version065FeatureFlags;
-import com.hedera.node.config.data.ContractsConfig;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -15,11 +10,5 @@ public class Version070FeatureFlags extends Version065FeatureFlags {
     @Inject
     public Version070FeatureFlags() {
         // Dagger2
-    }
-
-    @Override
-    public boolean isAuthorizationListEnabled(@NonNull Configuration config) {
-        requireNonNull(config);
-        return config.getConfigData(ContractsConfig.class).evmPectraEnabled();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/EthereumTransactionHandler.java
@@ -280,6 +280,6 @@ public class EthereumTransactionHandler extends AbstractContractTransactionHandl
         validateTruePreCheck(type >= 0, NOT_SUPPORTED);
 
         // Type 4 transactions are only supported if the feature flag is disabled
-        validateTruePreCheck(contractsConfig.evmPectraEnabled() || type < 4, NOT_SUPPORTED);
+        validateTruePreCheck(contractsConfig.codeDelegationsEnabled() || type < 4, NOT_SUPPORTED);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
@@ -18,6 +18,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SEND_RECORD_THR
 import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_NOT_PROVIDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_REQUIRED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
 import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
 import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.CREATE_SLOT_MULTIPLIER;
@@ -77,6 +78,7 @@ import com.hedera.node.app.spi.workflows.PureChecksContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
 import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.config.data.AccountsConfig;
+import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
@@ -130,8 +132,6 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
         requireNonNull(context);
         final var txn = context.body();
         final var op = txn.cryptoCreateAccountOrThrow();
-        // TODO(Pectra): add feature flag
-        // validateTruePreCheck(op.delegationAddress().length() == 0, NOT_SUPPORTED);
 
         // Note: validation lives here for now but should take place in handle in the future
         validateTruePreCheck(op.hasAutoRenewPeriod(), INVALID_RENEWAL_PERIOD);
@@ -347,6 +347,7 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
         final var tokensConfig = context.configuration().getConfigData(TokensConfig.class);
         final var accountsConfig = context.configuration().getConfigData(AccountsConfig.class);
         final var hederaConfig = context.configuration().getConfigData(HederaConfig.class);
+        final var contractsConfig = context.configuration().getConfigData(ContractsConfig.class);
         final var alias = op.alias();
 
         final var txn = context.body();
@@ -424,6 +425,11 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
                     accountStore,
                     context.networkInfo());
         }
+
+        validateTrue(
+                contractsConfig.codeDelegationsEnabled()
+                        || op.delegationAddress().length() == 0,
+                NOT_SUPPORTED);
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -10,6 +10,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_MAX_AUTO_ASSOCIATIONS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
 import static com.hedera.node.app.hapi.fees.pricing.BaseOperationUsage.THREE_MONTHS_IN_SECONDS;
@@ -63,6 +64,7 @@ import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
 import com.hedera.node.config.data.AutoRenewConfig;
+import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.TokensConfig;
@@ -97,8 +99,6 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
         requireNonNull(context);
         final var txn = context.body();
         final var op = txn.cryptoUpdateAccountOrThrow();
-        //        TODO(Pectra): add feature flag
-        //        validateTruePreCheck(op.delegationAddress().length() == 0, NOT_SUPPORTED);
         validateTruePreCheck(op.hasAccountIDToUpdate(), ACCOUNT_ID_DOES_NOT_EXIST);
         validateFalsePreCheck(
                 op.hasProxyAccountID() && !op.proxyAccountID().equals(AccountID.DEFAULT),
@@ -314,6 +314,7 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
         final var tokensConfig = context.configuration().getConfigData(TokensConfig.class);
         final var ledgerConfig = context.configuration().getConfigData(LedgerConfig.class);
         final var entitiesConfig = context.configuration().getConfigData(EntitiesConfig.class);
+        final var contractsConfig = context.configuration().getConfigData(ContractsConfig.class);
 
         // validate expiry metadata
         final var currentMetadata = new ExpiryMeta(
@@ -352,6 +353,11 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
 
         // validate if account is not deleted
         validateFalse(updateAccount.deleted(), ACCOUNT_DELETED);
+
+        validateTrue(
+                contractsConfig.codeDelegationsEnabled()
+                        || op.delegationAddress().length() == 0,
+                NOT_SUPPORTED);
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
@@ -15,6 +15,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SEND_RECORD_THRESHOLD;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_REQUIRED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MEMO_TOO_LONG;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
 import static com.hedera.hapi.node.base.SubType.DEFAULT;
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.ACCOUNTS_STATE_ID;
@@ -196,15 +197,23 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
     }
 
     @Test
-    @DisplayName("pureChecks fail when delegation address is not empty")
-    void whenDelegationAddressIsNonEmpty() {
+    void cryptoCreateWithDelegationAddressIsRejectedWithDefaultConfig() {
         txn = new CryptoCreateBuilder()
-                .withDelegationAddress(Bytes.fromHex("cafebabe"))
+                .withDelegationAddress(Bytes.fromHex("00000000000000000000000000000000000000AA"))
+                .withStakedAccountId(3)
+                .withShardId(0)
+                .withRealmId(0)
                 .build();
-        //        given(pureChecksContext.body()).willReturn(txn);
-        //        final var msg = assertThrows(PreCheckException.class, () -> subject.pureChecks(pureChecksContext));
-        //        TOOD(Pectra): verify with feature flag off
-        //        assertThat(NOT_SUPPORTED).isEqualTo(msg.responseCode());
+        given(handleContext.body()).willReturn(txn);
+
+        given(handleContext.consensusNow()).willReturn(consensusInstant);
+        given(handleContext.payer()).willReturn(id);
+        final var config = HederaTestConfigBuilder.create().getOrCreateConfig();
+        given(handleContext.configuration()).willReturn(config);
+
+        assertThatThrownBy(() -> subject.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(NOT_SUPPORTED));
     }
 
     @Test
@@ -677,8 +686,11 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
         given(handleContext.consensusNow()).willReturn(consensusInstant);
         given(entityNumGenerator.newEntityNum()).willReturn(1000L);
 
-        setupConfig();
         setupExpiryValidator();
+        final var config = HederaTestConfigBuilder.create()
+                .withValue("contracts.codeDelegations.enabled", true)
+                .getOrCreateConfig();
+        given(handleContext.configuration()).willReturn(config);
 
         subject.handle(handleContext);
 
@@ -700,8 +712,11 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
         given(handleContext.consensusNow()).willReturn(consensusInstant);
         given(entityNumGenerator.newEntityNum()).willReturn(1000L);
 
-        setupConfig();
         setupExpiryValidator();
+        final var config = HederaTestConfigBuilder.create()
+                .withValue("contracts.codeDelegations.enabled", true)
+                .getOrCreateConfig();
+        given(handleContext.configuration()).willReturn(config);
 
         subject.handle(handleContext);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -13,6 +13,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MEMO_TOO_LONG;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC_ASSOCIATIONS_EXCEEDS_ASSOCIATION_LIMIT;
@@ -171,16 +172,32 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
     }
 
     @Test
-    void cryptoUpdateWithDelegationAddressIsRejected() {
+    void cryptoUpdateWithDelegationAddressIsRejectedWithDefaultConfig() {
         final var txn = new CryptoUpdateBuilder()
                 .withKey(key)
-                .withDelegationAddress(Bytes.fromHex("cafebabe"))
+                .withDelegationAddress(Bytes.fromHex("00000000000000000000000000000000000000AA"))
                 .build();
+        givenTxnWith(txn);
 
-        //        given(pureChecksContext.body()).willReturn(txn);
+        assertThatThrownBy(() -> subject.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(NOT_SUPPORTED));
+    }
 
-        // TODO(Pectra): verify the feature flag
-        //        assertThrowsPreCheck(() -> subject.pureChecks(pureChecksContext), NOT_SUPPORTED);
+    @Test
+    void cryptoUpdateWithDelegationAddressIsAcceptedWhenEnabled() {
+        final var txn = new CryptoUpdateBuilder()
+                .withKey(key)
+                .withDelegationAddress(Bytes.fromHex("00000000000000000000000000000000000000AA"))
+                .build();
+        givenTxnWith(txn);
+
+        final var config = HederaTestConfigBuilder.create()
+                .withValue("contracts.codeDelegations.enabled", true)
+                .getOrCreateConfig();
+        given(handleContext.configuration()).willReturn(config);
+
+        assertDoesNotThrow(() -> subject.handle(handleContext));
     }
 
     @Test
@@ -291,11 +308,16 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
 
     @Test
     void setAndClearDelegationAddressTest() {
+        final var config = HederaTestConfigBuilder.create()
+                .withValue("contracts.codeDelegations.enabled", true)
+                .getOrCreateConfig();
+
         final var validAddressBytes = Bytes.fromHex("0000000000000000000000000000000000000123");
         final var setTxn = new CryptoUpdateBuilder()
                 .withDelegationAddress(validAddressBytes)
                 .build();
         givenTxnWith(setTxn);
+        given(handleContext.configuration()).willReturn(config);
         subject.handle(handleContext);
         assertEquals(validAddressBytes, writableStore.get(updateAccountId).delegationAddress());
 
@@ -303,6 +325,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         final var noOpTxn =
                 new CryptoUpdateBuilder().withDelegationAddress(Bytes.EMPTY).build();
         givenTxnWith(noOpTxn);
+        given(handleContext.configuration()).willReturn(config);
         subject.handle(handleContext);
         // The delegation address is unchanged
         assertEquals(validAddressBytes, writableStore.get(updateAccountId).delegationAddress());
@@ -312,6 +335,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
                 .withDelegationAddress(Bytes.fromHex("0000000000000000000000000000000000000000"))
                 .build();
         givenTxnWith(clearTxn);
+        given(handleContext.configuration()).willReturn(config);
         subject.handle(handleContext);
         // The delegation address should be cleared
         assertEquals(Bytes.EMPTY, writableStore.get(updateAccountId).delegationAddress());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/AccessListTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/AccessListTest.java
@@ -30,6 +30,7 @@ import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -81,6 +82,7 @@ public class AccessListTest {
                             TARGET_CONTRACT_ADDRESS_BYTES.set(
                                     Bytes.fromHexString(address.startsWith("0x") ? address : "0x" + address));
                         })));
+        lifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
     }
 
     // ------------------------------- Utils -------------------------------

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/AccessListTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/AccessListTest.java
@@ -9,6 +9,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCall;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
@@ -22,6 +23,7 @@ import com.hedera.node.app.hapi.utils.ethereum.AccessListItem;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.dsl.annotations.Account;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
@@ -30,7 +32,6 @@ import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -82,7 +83,6 @@ public class AccessListTest {
                             TARGET_CONTRACT_ADDRESS_BYTES.set(
                                     Bytes.fromHexString(address.startsWith("0x") ? address : "0x" + address));
                         })));
-        lifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
     }
 
     // ------------------------------- Utils -------------------------------
@@ -184,11 +184,13 @@ public class AccessListTest {
                         .toList()));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> accessListDiscountForDelegationCallTest() {
         final AtomicReference<Bytes> signerAddress = new AtomicReference<>();
         final var originalGas = new AtomicLong();
         return hapiTest(flattened(
+                overriding("contracts.codeDelegations.enabled", "true"),
+
                 // prepare sender
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                 cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationAtomicBatchTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationAtomicBatchTest.java
@@ -20,6 +20,7 @@ import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
@@ -36,8 +37,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.esaulpaugh.headlong.abi.Address;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
-import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.dsl.annotations.Account;
@@ -102,11 +103,12 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 1.1: atomicBatch(type-4 sets delegation on A, valid transfer) - batch succeeds
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationCommitedInSuccessfulAtomicBatch() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var delegatingAccount = "DelegatingAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(delegatingAccount),
                 getAliasedAccountInfo(delegatingAccount).hasNoDelegation(),
                 atomicBatch(
@@ -126,11 +128,12 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 1.2: atomicBatch(type-4 sets delegation on A, invalid transfer) - batch fails
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationSurvivesAtomicBatchRollback() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var delegatingAccount = "DelegatingAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(delegatingAccount),
                 getAliasedAccountInfo(delegatingAccount).hasNoDelegation(),
                 atomicBatch(
@@ -155,11 +158,12 @@ public class CodeDelegationAtomicBatchTest {
 
     // 1.3: atomicBatch(type-4 sets delegation + calls contract that reverts) - batch fails due to
     // CONTRACT_REVERT_EXECUTED
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationSurvivesRevertingType4InAtomicBatch() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var delegatingAccount = "DelegatingAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(delegatingAccount),
                 getAliasedAccountInfo(delegatingAccount).hasNoDelegation(),
                 atomicBatch(ethereumCall(REVERTING_CONTRACT, "revertWithRevertReason")
@@ -179,11 +183,12 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 1.4: atomicBatch(invalid transfer, type-4 sets delegation on A) - batch fails before type-4 tx is dispatched
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testNoDelegationWhenBatchFailsBeforeType4TxDispatched() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var delegatingAccount = "DelegatingAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(delegatingAccount),
                 getAliasedAccountInfo(delegatingAccount).hasNoDelegation(),
                 atomicBatch(
@@ -204,11 +209,12 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 2.1: atomicBatch(CryptoCreate(A), type-4 delegates A) - batch succeeds
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testAtomicBatchCryptoCreateThenType4DelegatesInSameBatch() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var accountInBatch = "AccountCreatedInBatch";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 newKeyNamed(accountInBatch).shape(SECP_256K1_SHAPE),
                 atomicBatch(
                                 cryptoCreate(accountInBatch)
@@ -229,12 +235,13 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 2.2: atomicBatch(CryptoCreate(A), type-4 delegates A, invalid transfer) - batch fails
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testAtomicBatchCryptoCreateAndType4DelegateRolledBackOnFailure() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var delegatingAccount = "DelegatingAccount";
         final var accountInBatch = "AccountCreatedInBatch";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 newKeyNamed(accountInBatch).shape(SECP_256K1_SHAPE),
                 createFundedAccount(delegatingAccount),
                 atomicBatch(
@@ -266,12 +273,13 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 2.3: atomicBatch(CryptoCreate(A, initialDelegation=D1), type-4 updates A delegation to D2) - batch succeeds
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testAtomicBatchCryptoCreateSetsDelegationThenType4UpdatesIt() {
         final var initialDelegationAddress = ByteString.copyFrom(explicitFromHeadlong(DELEGATION_TARGET.get())); // D1
         final var delegationTargetAddress = DELEGATION_TARGET_2.get(); // D2
         final var accountInBatch = "AccountCreatedInBatch";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 newKeyNamed(accountInBatch).shape(SECP_256K1_SHAPE),
                 atomicBatch(
                                 cryptoCreate(accountInBatch)
@@ -293,12 +301,13 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 3.1: Account A exists with no delegation. atomicBatch(type-4 delegates to A, invalid transfer) - batch fails
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testExistingAccountDelegationSurvivesRollback() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var sender = "SenderAccount";
         final var authorityAccount = "AuthorityAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(sender),
                 createFundedAccount(authorityAccount),
                 getAliasedAccountInfo(authorityAccount).hasNoDelegation(),
@@ -325,13 +334,14 @@ public class CodeDelegationAtomicBatchTest {
 
     // 3.2: Account A exists with delegation D1. atomicBatch(type-4 changes A delegation to D2, invalid transfer) -
     // batch fails
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testExistingDelegationUpdatedByType4SurvivesRollback() {
         final var delegationTargetAddress = DELEGATION_TARGET.get(); // d1
         final var revertingDelegationTargetAddress = DELEGATION_TARGET_2.get(); // d2
         final var sender = "SenderAccount";
         final var authorityAccount = "AuthorityAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(sender),
                 createFundedAccountWithDelegation(authorityAccount, delegationTargetAddress),
                 getAliasedAccountInfo(authorityAccount).hasDelegationAddress(delegationTargetAddress),
@@ -359,12 +369,13 @@ public class CodeDelegationAtomicBatchTest {
 
     // 4.1: Account A has delegation. atomicBatch(type-4 sets A delegation to zero address, valid transfer) - batch
     // succeeds
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationClearedByZeroAddress() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var sender = "SenderAccount";
         final var authorityAccount = "AuthorityAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(sender),
                 createFundedAccountWithDelegation(authorityAccount, delegationTargetAddress),
                 getAliasedAccountInfo(authorityAccount).hasDelegationAddress(delegationTargetAddress),
@@ -387,12 +398,13 @@ public class CodeDelegationAtomicBatchTest {
 
     // 4.2: Account A has delegation. atomicBatch(type-4 sets A delegation to zero address, invalid transfer) - batch
     // fails
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationClearedByZeroAddressSurvivesRollback() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var sender = "SenderAccount";
         final var authorityAccount = "AuthorityAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(sender),
                 createFundedAccountWithDelegation(authorityAccount, delegationTargetAddress),
                 getAliasedAccountInfo(authorityAccount).hasDelegationAddress(delegationTargetAddress),
@@ -419,7 +431,7 @@ public class CodeDelegationAtomicBatchTest {
 
     // 6.1: atomicBatch(CryptoUpdate sets delegation on D, type-4 with 2 valid + 2 invalid auth entries) - batch
     // succeeds
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testAtomicBatchType4PartialCommitAcrossAccountsWithInvalidAuthorization() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var delegationAddress = ByteString.copyFrom(explicitFromHeadlong(delegationTargetAddress));
@@ -428,6 +440,7 @@ public class CodeDelegationAtomicBatchTest {
         final var authority2 = "Auth2";
         final var authority3 = "Auth3";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 // Split into two calls to avoid MAX_CHILD_RECORDS_EXCEEDED
                 createHollowAccounts(sender, authority1),
                 createHollowAccounts(authority2, authority3),
@@ -462,7 +475,7 @@ public class CodeDelegationAtomicBatchTest {
 
     // 6.2: atomicBatch(CryptoUpdate sets delegation on D, type-4 with 2 valid + 2 invalid auth entries, invalid
     // transfer) - batch fails
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testAtomicBatchType4PartialCommitIsRolledBackOnInnerTxFailureAcrossAccounts() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var initialDelegationAddress = ByteString.copyFrom(explicitFromHeadlong(delegationTargetAddress));
@@ -471,6 +484,7 @@ public class CodeDelegationAtomicBatchTest {
         final var authority2 = "Auth2";
         final var authority3 = "Auth3";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 // Split into two calls to avoid MAX_CHILD_RECORDS_EXCEEDED
                 createHollowAccounts(sender, authority1),
                 createHollowAccounts(authority2, authority3),
@@ -519,7 +533,7 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 8.1: atomicBatch(type-4 with 3 auth entries) - batch succeeds. Nonces incremented.
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testAtomicBatchType4NoncesOnSuccess() {
         final var sender = "SenderAccount";
         final var authAccount1 = "Auth1";
@@ -532,6 +546,7 @@ public class CodeDelegationAtomicBatchTest {
         final var auth1NonceAfter = new AtomicLong();
         final var auth2NonceAfter = new AtomicLong();
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createHollowAccounts(sender, authAccount1),
                 createHollowAccounts(authAccount2),
                 getAliasedAccountInfo(sender).exposingEthereumNonceTo(senderNonceBefore::set),
@@ -571,7 +586,7 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 8.2: atomicBatch(type-4 tx, invalid transfer) - batch fails. Nonces and delegations should survive.
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testAtomicBatchType4NoncesOnRollback() {
         final var sender = "SenderAccount";
         final var authAccount1 = "Auth1";
@@ -584,6 +599,7 @@ public class CodeDelegationAtomicBatchTest {
         final var auth1NonceAfter = new AtomicLong();
         final var auth2NonceAfter = new AtomicLong();
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createHollowAccounts(sender, authAccount1),
                 createHollowAccounts(authAccount2),
                 getAliasedAccountInfo(sender).exposingEthereumNonceTo(senderNonceBefore::set),
@@ -637,7 +653,7 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 9.1: atomicBatch(type-4 delegates A, valid transfer) - batch succeeds.
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testTx4GasChargesOnSuccessfulBatch() {
         // Intrinsic gas components
         final long TX_BASE_COST = 21_000L;
@@ -653,6 +669,7 @@ public class CodeDelegationAtomicBatchTest {
         final var senderBalanceAfter = new AtomicLong();
 
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(sender),
                 getAccountBalance(sender).exposingBalanceTo(senderBalanceBefore::set),
                 atomicBatch(
@@ -697,7 +714,7 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 9.1.1: Compare sender gas charges between successful and failed batch.
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testSenderGasChargesSameOnSuccessAndRollback() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
 
@@ -712,6 +729,7 @@ public class CodeDelegationAtomicBatchTest {
         final var rollbackSenderAfter = new AtomicLong();
 
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(successSender),
                 createFundedAccount(rollbackSender),
 
@@ -798,7 +816,7 @@ public class CodeDelegationAtomicBatchTest {
     // Gas charged for all inner txs despite rollback. Account creation fee for CryptoCreate correctly replayed despite
     // account being rolled back and is included as part of the tx4 tx charge. Successful path should charge less fees
     // (minus account creation), since account creation was successful.
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testGasAndFeesChargedOnRollbackWithCryptoCreate() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         final var rollbackPayer = "PayerOnRollbackAccount";
@@ -814,6 +832,7 @@ public class CodeDelegationAtomicBatchTest {
         final var payerBalanceAfter = new AtomicLong();
 
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 newKeyNamed(accountInBatch).shape(SECP_256K1_SHAPE),
                 newKeyNamed(accountInBatchRollback).shape(SECP_256K1_SHAPE),
                 createFundedAccount(rollbackPayer),
@@ -907,11 +926,12 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 10.1: atomicBatch(CryptoUpdate sets delegation on A, invalid transfer) - batch fails
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testCryptoUpdateDelegationRolledBackOnBatchFailure() {
         final var delegationAddress = ByteString.copyFrom(explicitFromHeadlong(DELEGATION_TARGET.get()));
         final var preCreatedAccount = "PreCreatedAccount";
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createFundedAccount(preCreatedAccount),
                 getAliasedAccountInfo(preCreatedAccount).hasNoDelegation(),
                 atomicBatch(
@@ -929,12 +949,13 @@ public class CodeDelegationAtomicBatchTest {
     }
 
     // 10.2: atomicBatch(CryptoUpdate sets delegation on A, type-4 sets delegation on B, invalid transfer)
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testAtomicBatchRevertsAllDelegationTransactionsOnInnerTxFailure() {
         final var initialDelegationAddress = ByteString.copyFrom(explicitFromHeadlong(DELEGATION_TARGET.get()));
         final var delegatingAccount = "DelegatingAccount";
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 createHollowAccounts(delegatingAccount),
                 createFundedAccount(CRYPTO_CREATE_DELEGATING_ACCOUNT),
                 getAccountInfo(CRYPTO_CREATE_DELEGATING_ACCOUNT).hasNoDelegation(),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationChainingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationChainingTest.java
@@ -13,20 +13,31 @@ import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(SMART_CONTRACT)
 @DisplayName("Code Delegation Chaining Tests")
+@HapiTestLifecycle
 public class CodeDelegationChainingTest extends CodeDelegationTestBase {
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
+    }
 
     @HapiTest
     @DisplayName("Delegation chain through two EOAs fails with banned opcode")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationChainingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationChainingTest.java
@@ -5,6 +5,7 @@ import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,37 +13,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(SMART_CONTRACT)
 @DisplayName("Code Delegation Chaining Tests")
-@HapiTestLifecycle
 public class CodeDelegationChainingTest extends CodeDelegationTestBase {
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
-    }
-
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     @DisplayName("Delegation chain through two EOAs fails with banned opcode")
     final Stream<DynamicTest> testDelegationChainThroughTwoEoasResultsInFailure() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -69,10 +60,12 @@ public class CodeDelegationChainingTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     @DisplayName("Delegation loop between two EOAs fails with banned opcode")
     final Stream<DynamicTest> testDelegationLoopResultsInFailure() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -105,10 +98,12 @@ public class CodeDelegationChainingTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     @DisplayName("Self-delegation fails with banned opcode")
     final Stream<DynamicTest> testSelfDelegationResultsInFailure() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -129,10 +124,12 @@ public class CodeDelegationChainingTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     @DisplayName("Delegation to non-existent address is a no-op with value transfer")
     final Stream<DynamicTest> testDelegationToNonExistentAddressIsNoOp() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -168,10 +165,12 @@ public class CodeDelegationChainingTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     @DisplayName("Delegation chain reached via inner CALL reverts the inner call")
     final Stream<DynamicTest> testDelegationChainViaInnerCallReverts() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTests.java
@@ -66,7 +66,11 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
+        // spotless:off
+        testLifecycle.overrideInClass(Map.of(
+                "hooks.hooksEnabled", "true",
+                "contracts.codeDelegations.enabled", "true"));
+        // spotless:on
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTests.java
@@ -16,6 +16,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
@@ -38,44 +39,31 @@ import com.hedera.hapi.node.base.EvmHookCall;
 import com.hedera.hapi.node.base.HookCall;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import com.hederahashgraph.api.proto.java.ContractFunctionResult;
 import com.hederahashgraph.api.proto.java.ContractLoginfo;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import com.hederahashgraph.api.proto.java.TransferList;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(SMART_CONTRACT)
 @DisplayName("Code Delegation Tests")
-@HapiTestLifecycle
 public class CodeDelegationTests extends CodeDelegationTestBase {
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        // spotless:off
-        testLifecycle.overrideInClass(Map.of(
-                "hooks.hooksEnabled", "true",
-                "contracts.codeDelegations.enabled", "true"));
-        // spotless:on
-    }
-
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testCodeDelegationFallbackMethod() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -120,9 +108,11 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testCodeDelegationStorage() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -185,9 +175,11 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testCodeDelegationInternalHtsTransfer() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -245,9 +237,11 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testCodeDelegationInnerCall() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -299,12 +293,14 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     /* This scenario is equivalent to chaining delegations (since token account delegates to the HTS
     System Contract), so we expect the second delegation code to be treated literally and fail
     due to trying to execute an invalid op code. */
     final Stream<DynamicTest> testDelegationToHtsTokenReverts() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -359,7 +355,7 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationToSystemContractsAndPrecompilesAllowsValueTransfer() {
         /*
          * For each test case we're going to:
@@ -389,6 +385,8 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
 
         return testCases.stream()
                 .flatMap(testCase -> hapiTest(withOpContext((spec, opLog) -> {
+                    allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
                     final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
                     final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -442,9 +440,14 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
                 })));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled", "hooks.hooksEnabled"})
     final Stream<DynamicTest> testCodeDelegationDuringHookExecution() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(
+                    spec,
+                    overriding("hooks.hooksEnabled", "true"),
+                    overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -526,9 +529,14 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
     /// and a call is made to that EOA inside a hook.
     /// This should resolve the target address literally, and result in a no-op, because
     /// no entity actually has address 0x16d.
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled", "hooks.hooksEnabled"})
     final Stream<DynamicTest> testCodeDelegationToHookAddressDuringHookExecution() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(
+                    spec,
+                    overriding("hooks.hooksEnabled", "true"),
+                    overriding("contracts.codeDelegations.enabled", "true"));
+
             final var payer = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
             final var caller = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
 
@@ -594,9 +602,11 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testCrossAPIDelegationNativeToType4() {
         return hapiTest(withOpContext((spec, opLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             // Create delegation target and account
             final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);
@@ -620,9 +630,11 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testCrossAPIDelegationType4ToNative() {
         return hapiTest(withOpContext(((spec, assertLog) -> {
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"));
+
             // Create delegation target and account
             final var delegationTargetContract = deployEvmContract(spec, CODE_DELEGATION_CONTRACT);
             final var delegatingEoa = createFundedEvmAccountWithKey(spec, ONE_HUNDRED_HBARS);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationType4TransactionTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationType4TransactionTest.java
@@ -35,6 +35,7 @@ import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
@@ -56,6 +57,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
                 uploadInitCode(CODE_DELEGATION_CONTRACT),
                 contractCreate(CODE_DELEGATION_CONTRACT).exposingAddressTo(DELEGATION_TARGET::set),
                 cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS));
+        lifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationType4TransactionTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationType4TransactionTest.java
@@ -14,6 +14,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
@@ -26,8 +27,8 @@ import com.esaulpaugh.headlong.abi.Address;
 import com.esaulpaugh.headlong.abi.Function;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
-import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts;
@@ -35,7 +36,6 @@ import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
@@ -57,10 +57,9 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
                 uploadInitCode(CODE_DELEGATION_CONTRACT),
                 contractCreate(CODE_DELEGATION_CONTRACT).exposingAddressTo(DELEGATION_TARGET::set),
                 cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS));
-        lifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testCodeDelegationSetViaEthCall() {
 
         final var delegatedFunctionSelector = Hex.toHexString(
@@ -71,6 +70,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
             allRunFor(
                     spec,
+                    overriding("contracts.codeDelegations.enabled", "true"),
                     cryptoTransfer(TokenMovement.movingHbar(ONE_HUNDRED_HBARS).between(GENESIS, DELEGATING_ACCOUNT))
                             .via(CREATION),
                     getTxnRecord(CREATION).exposingCreationsTo(creations -> {
@@ -116,7 +116,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testMultipleCodeDelegationsSetViaEthCall() {
         final var delegationTargetAddress = DELEGATION_TARGET.get();
         return hapiTest(withOpContext((spec, _) -> {
@@ -125,6 +125,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
                     spec, DELEGATING_ACCOUNT, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
             allRunFor(
                     spec,
+                    overriding("contracts.codeDelegations.enabled", "true"),
                     cryptoTransfer(TokenMovement.movingHbar(ONE_HUNDRED_HBARS)
                             .distributing(GENESIS, DELEGATING_ACCOUNT, DELEGATING_ACCOUNT_1)),
                     cryptoTransfer(TokenMovement.movingHbar(ONE_HUNDRED_HBARS)
@@ -168,7 +169,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegatingToKey() {
         return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, CONTRACT);
@@ -176,6 +177,7 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
             allRunFor(
                     spec,
+                    overriding("contracts.codeDelegations.enabled", "true"),
                     sourcing(() -> ethereumCall(CONTRACT, "create")
                             .signingWith(PAYER_KEY)
                             .payingWith(RELAYER)
@@ -210,13 +212,14 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationSetToHollowAccountWithRevertingCall() {
         return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, REVERTING_CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT);
-            allRunFor(spec, sourcing(() -> ethereumCall(REVERTING_CONTRACT, "revertWithRevertReason")
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"), sourcing(() -> ethereumCall(
+                            REVERTING_CONTRACT, "revertWithRevertReason")
                     .signingWith(PAYER_KEY)
                     .payingWith(RELAYER)
                     .type(EthTransactionType.EIP7702)
@@ -252,13 +255,14 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationSetToMultipleHollowAccountsWithRevertingCall() {
         return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, REVERTING_CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
-            allRunFor(spec, sourcing(() -> ethereumCall(REVERTING_CONTRACT, "revertWithRevertReason")
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"), sourcing(() -> ethereumCall(
+                            REVERTING_CONTRACT, "revertWithRevertReason")
                     .signingWith(PAYER_KEY)
                     .payingWith(RELAYER)
                     .type(EthTransactionType.EIP7702)
@@ -309,13 +313,14 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationSetToExistingAccountWithRevertingCall() {
         return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, REVERTING_CONTRACT);
             createPayerAccountWithAlias(spec);
             final var delegatingAccount = createEvmAccountWithKey(spec);
-            allRunFor(spec, sourcing(() -> ethereumCall(REVERTING_CONTRACT, "revertWithRevertReason")
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"), sourcing(() -> ethereumCall(
+                            REVERTING_CONTRACT, "revertWithRevertReason")
                     .signingWith(PAYER_KEY)
                     .payingWith(RELAYER)
                     .type(EthTransactionType.EIP7702)
@@ -340,13 +345,14 @@ public class CodeDelegationType4TransactionTest extends CodeDelegationTestBase {
         }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> testDelegationWithMultipleAccountsAndNotEnoughGasForLazyCreation() {
         return hapiTest(withOpContext((spec, _) -> {
             deployEvmContract(spec, CONTRACT);
             createPayerAccountWithAlias(spec);
             createSecp256k1Keys(spec, DELEGATING_ACCOUNT_1, DELEGATING_ACCOUNT_2, DELEGATING_ACCOUNT_3);
-            allRunFor(spec, sourcing(() -> ethereumCall(CONTRACT, "create")
+            allRunFor(spec, overriding("contracts.codeDelegations.enabled", "true"), sourcing(() -> ethereumCall(
+                            CONTRACT, "create")
                     .signingWith(PAYER_KEY)
                     .payingWith(RELAYER)
                     .gasLimit(1_500_000L)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -81,7 +81,6 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.RealmID;
 import com.hederahashgraph.api.proto.java.ShardID;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
-
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -67,7 +67,9 @@ import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import com.esaulpaugh.headlong.abi.Address;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
@@ -79,14 +81,18 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.RealmID;
 import com.hederahashgraph.api.proto.java.ShardID;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
+
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.hiero.base.utility.CommonUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(CRYPTO)
+@HapiTestLifecycle
 public class CryptoCreateSuite {
     public static final String ACCOUNT = "account";
     public static final String ANOTHER_ACCOUNT = "anotherAccount";
@@ -98,6 +104,11 @@ public class CryptoCreateSuite {
     public static final String SHORT_KEY = "shortKey";
     public static final String EMPTY_KEY_STRING = "emptyKey";
     private static final String ED_KEY = "EDKEY";
+
+    @BeforeAll
+    public static void setup(final TestLifecycle lifecycle) {
+        lifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
+    }
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -67,9 +67,8 @@ import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import com.esaulpaugh.headlong.abi.Address;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
@@ -81,17 +80,14 @@ import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.RealmID;
 import com.hederahashgraph.api.proto.java.ShardID;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.hiero.base.utility.CommonUtils;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(CRYPTO)
-@HapiTestLifecycle
 public class CryptoCreateSuite {
     public static final String ACCOUNT = "account";
     public static final String ANOTHER_ACCOUNT = "anotherAccount";
@@ -103,11 +99,6 @@ public class CryptoCreateSuite {
     public static final String SHORT_KEY = "shortKey";
     public static final String EMPTY_KEY_STRING = "emptyKey";
     private static final String ED_KEY = "EDKEY";
-
-    @BeforeAll
-    public static void setup(final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
@@ -1048,12 +1039,13 @@ public class CryptoCreateSuite {
                         .hasKnownStatus(INVALID_ACCOUNT_ID));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> createAccountWithDelegationAddress() {
         final var longZeroAddress = ByteString.copyFrom(CommonUtils.unhex("0000000000000000000000000000000fffffffff"));
         final var emptyAddress = ByteString.empty();
         final var badAddress = ByteString.copyFrom(CommonUtils.unhex("0fffffffff"));
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 cryptoCreate("withDelegationAddress").balance(ONE_HUNDRED_HBARS).delegationAddress(longZeroAddress),
                 getAccountInfo("withDelegationAddress").has(accountWith().delegationAddress(longZeroAddress)),
                 cryptoCreate("withEmptyAddress").balance(ONE_HUNDRED_HBARS).delegationAddress(emptyAddress),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -67,12 +67,10 @@ import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TokenType;
-
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -57,7 +57,9 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.assertions.ContractInfoAsserts;
 import com.hedera.services.bdd.spec.keys.KeyLabels;
 import com.hedera.services.bdd.spec.keys.KeyShape;
@@ -65,13 +67,18 @@ import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TokenType;
+
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(CRYPTO)
+@HapiTestLifecycle
 @SuppressWarnings("java:S1192") // "string literal should not be duplicated" - this rule makes test suites worse
 public class CryptoUpdateSuite {
     private static final String TEST_ACCOUNT = "testAccount";
@@ -109,6 +116,11 @@ public class CryptoUpdateSuite {
             2,
             SigControl.threshSigs(1, OFF, OFF, OFF, OFF, OFF, OFF, OFF),
             SigControl.threshSigs(3, ON, ON, OFF, OFF, OFF, OFF, ON));
+
+    @BeforeAll
+    public static void setup(final TestLifecycle lifecycle) {
+        lifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
+    }
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -30,6 +30,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doWithStartupConfigNow;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
@@ -57,9 +58,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.assertions.ContractInfoAsserts;
 import com.hedera.services.bdd.spec.keys.KeyLabels;
 import com.hedera.services.bdd.spec.keys.KeyShape;
@@ -67,16 +67,13 @@ import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.TokenType;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(CRYPTO)
-@HapiTestLifecycle
 @SuppressWarnings("java:S1192") // "string literal should not be duplicated" - this rule makes test suites worse
 public class CryptoUpdateSuite {
     private static final String TEST_ACCOUNT = "testAccount";
@@ -114,11 +111,6 @@ public class CryptoUpdateSuite {
             2,
             SigControl.threshSigs(1, OFF, OFF, OFF, OFF, OFF, OFF, OFF),
             SigControl.threshSigs(3, ON, ON, OFF, OFF, OFF, OFF, ON));
-
-    @BeforeAll
-    public static void setup(final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("contracts.codeDelegations.enabled", "true"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
@@ -513,7 +505,7 @@ public class CryptoUpdateSuite {
                 cryptoUpdate(account).payingWith(DEFAULT_PAYER).expiring(-1).hasKnownStatus(INVALID_EXPIRATION_TIME));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.codeDelegations.enabled"})
     final Stream<DynamicTest> updateAccountWithDelegationAddress() {
         final var accountTotest = "accountToTest";
         final var longZeroAddress = ByteString.fromHex("0000000000000000000000000000000fffffffff");
@@ -521,6 +513,7 @@ public class CryptoUpdateSuite {
         final var emptyAddress = ByteString.empty();
         final var badAddress = ByteString.fromHex("0fffffffff");
         return hapiTest(
+                overriding("contracts.codeDelegations.enabled", "true"),
                 cryptoCreate(accountTotest).balance(ONE_HUNDRED_HBARS),
                 // Delegation is initially empty
                 getAccountInfo(accountTotest).has(accountWith().delegationAddress(emptyAddress)),

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -12,13 +12,13 @@ val besu = "26.2.0"
 val bouncycastle = "1.83"
 val dagger = "2.59.2"
 val eclipseCollections = "13.0.0"
-val grpc = "1.73.0"
+val grpc = "1.79.0"
 val hederaCryptography = "3.7.8"
 val helidon = "4.4.0"
 val jackson = "2.21.1"
 val junit5 = "5.10.3!!" // no updates beyond 5.10.3 until #17125 is resolved
 val log4j = "2.25.3"
-val mockito = "5.18.0"
+val mockito = "5.21.0"
 val pbj = pluginVersions.version("com.hedera.pbj.pbj-compiler")
 val protobuf = "4.33.5"
 val blockNodeProtobufSources = "0.30.2"
@@ -42,13 +42,11 @@ dependencies.constraints {
     api("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jackson") {
         because("com.fasterxml.jackson.dataformat.yaml")
     }
-    api("com.github.ben-manes.caffeine:caffeine:3.2.0") { because("com.github.benmanes.caffeine") }
+    api("com.github.ben-manes.caffeine:caffeine:3.2.3") { because("com.github.benmanes.caffeine") }
     api("com.github.docker-java:docker-java-api:3.7.0") { because("com.github.dockerjava.api") }
     api("com.github.spotbugs:spotbugs-annotations:4.9.3") {
         because("com.github.spotbugs.annotations")
     }
-    api("com.google.guava:guava:33.4.8-jre") { because("com.google.common") }
-    api("com.google.j2objc:j2objc-annotations:3.0.0") { because("com.google.j2objc.annotations") }
     api("com.google.jimfs:jimfs:1.3.1") { because("com.google.common.jimfs") }
     api("com.google.protobuf:protobuf-java:$protobuf") { because("com.google.protobuf") }
     api("com.google.protobuf:protobuf-java-util:$protobuf") { because("com.google.protobuf.util") }
@@ -77,7 +75,7 @@ dependencies.constraints {
     api("net.i2p.crypto:eddsa:0.3.0") { because("net.i2p.crypto.eddsa") }
     api("org.antlr:antlr4-runtime:4.13.2") { because("org.antlr.antlr4.runtime") }
     api("commons-codec:commons-codec:1.21.0") { because("org.apache.commons.codec") }
-    api("commons-io:commons-io:2.20.0") { because("org.apache.commons.io") }
+    api("commons-io:commons-io:2.21.0") { because("org.apache.commons.io") }
     api("org.apache.commons:commons-lang3:3.20.0") { because("org.apache.commons.lang3") }
     api("org.apache.commons:commons-compress:1.28.0") { because("org.apache.commons.compress") }
     api("org.apache.logging.log4j:log4j-api:$log4j") { because("org.apache.logging.log4j") }
@@ -85,7 +83,7 @@ dependencies.constraints {
     api("org.apache.logging.log4j:log4j-slf4j2-impl:$log4j") {
         because("org.apache.logging.log4j.slf4j2.impl")
     }
-    api("org.assertj:assertj-core:3.27.3") { because("org.assertj.core") }
+    api("org.assertj:assertj-core:3.27.7") { because("org.assertj.core") }
     api("org.bouncycastle:bcpkix-jdk18on:$bouncycastle") { because("org.bouncycastle.pkix") }
     api("org.bouncycastle:bcprov-jdk18on:$bouncycastle") { because("org.bouncycastle.provider") }
     api("org.eclipse.collections:eclipse-collections-api:$eclipseCollections") {


### PR DESCRIPTION
- rename the existing `evmPectraEnabled` flag to `codeDelegationsEnabled` (it's a closer match - some parts of Pectra aren't covered by this flag)
- use the flag in CryptoCreateHandler / CryptoUpdateHandler
- FeatureFlags drive by cleanup - remove unused configs