### PR TITLE
chore: Move MockAppender

### DIFF
--- a/platform-sdk/base-crypto/build.gradle.kts
+++ b/platform-sdk/base-crypto/build.gradle.kts
@@ -14,6 +14,7 @@ testModuleInfo {
     requires("com.swirlds.common")
     requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
+    requires("com.swirlds.logging.test.fixtures")
     requires("org.hiero.base.crypto")
     requires("org.hiero.base.crypto.test.fixtures")
     requires("org.assertj.core")

--- a/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/KeystorePasswordPolicyTest.java
+++ b/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/KeystorePasswordPolicyTest.java
@@ -3,7 +3,7 @@ package org.hiero.base.crypto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.swirlds.common.test.fixtures.logging.MockAppender;
+import com.swirlds.logging.test.fixtures.MockAppender;
 import java.util.List;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;

--- a/platform-sdk/swirlds-common/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/module-info.java
@@ -10,7 +10,6 @@ open module com.swirlds.common.test.fixtures {
     exports com.swirlds.common.test.fixtures.set;
     exports com.swirlds.common.test.fixtures.stream;
     exports com.swirlds.common.test.fixtures.platform;
-    exports com.swirlds.common.test.fixtures.logging;
 
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.base;
@@ -25,11 +24,11 @@ open module com.swirlds.common.test.fixtures {
     requires transitive org.hiero.consensus.model;
     requires transitive org.hiero.consensus.reconnect;
     requires transitive org.hiero.consensus.utility;
-    requires transitive org.apache.logging.log4j.core;
     requires com.swirlds.config.extensions.test.fixtures;
     requires com.swirlds.logging;
     requires org.hiero.base.utility.test.fixtures;
     requires org.hiero.consensus.metrics;
+    requires org.apache.logging.log4j.core;
     requires org.apache.logging.log4j;
     requires org.junit.jupiter.api;
     requires org.mockito;

--- a/platform-sdk/swirlds-logging/src/testFixtures/java/com/swirlds/logging/test/fixtures/MockAppender.java
+++ b/platform-sdk/swirlds-logging/src/testFixtures/java/com/swirlds/logging/test/fixtures/MockAppender.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.common.test.fixtures.logging;
+package com.swirlds.logging.test.fixtures;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/platform-sdk/swirlds-logging/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-logging/src/testFixtures/java/module-info.java
@@ -8,7 +8,9 @@ open module com.swirlds.logging.test.fixtures {
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.config.extensions.test.fixtures;
     requires transitive com.swirlds.logging;
+    requires transitive org.apache.logging.log4j.core;
     requires transitive org.junit.jupiter.api;
     requires com.swirlds.base.test.fixtures;
+    requires org.apache.logging.log4j;
     requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-merkledb/build.gradle.kts
+++ b/platform-sdk/swirlds-merkledb/build.gradle.kts
@@ -27,6 +27,7 @@ testModuleInfo {
     requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.extensions")
     requires("com.swirlds.config.extensions.test.fixtures")
+    requires("com.swirlds.logging.test.fixtures")
     requires("com.swirlds.merkledb.test.fixtures")
     requires("com.swirlds.virtualmap.test.fixtures")
     requires("org.apache.logging.log4j.core")

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.swirlds.base.units.UnitConstants;
-import com.swirlds.common.test.fixtures.logging.MockAppender;
+import com.swirlds.logging.test.fixtures.MockAppender;
 import com.swirlds.merkledb.KeyRange;
 import com.swirlds.merkledb.collections.CASableLongIndex;
 import com.swirlds.merkledb.collections.ImmutableIndexedObjectListUsingArray;


### PR DESCRIPTION
**Description**:

This PR moves the `MockAppender` to the test fixtures of `swirlds-logging`.

**Related issue(s)**:

Fixes #23586 
