### PR TITLE
chore: Fix `(AccountID, TokenID)` field order in block stream `StateChanges`

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/output/state_changes.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/output/state_changes.proto
@@ -816,18 +816,13 @@ message MapDeleteChange {
  * A key identifying a specific entry in a key-value "virtual map".
  */
 message MapChangeKey {
+    reserved 2;
+
     oneof key_choice {
         /**
          * A key for a change affecting a map keyed by an Account identifier.
          */
         proto.AccountID account_id_key = 1;
-
-        /**
-         * A change to the token relationships virtual map.<br/>
-         * This map is keyed by the pair of account identifier and
-         * token identifier.
-         */
-        proto.TokenAssociation token_relationship_key = 2;
 
         /**
          * A change to a map keyed by an EntityNumber (which is a whole number).
@@ -946,6 +941,13 @@ message MapChangeKey {
          * An EVM hook's storage slot key.
          */
         com.hedera.hapi.node.state.hooks.EvmHookSlotKey evm_hook_slot_key = 24;
+
+        /**
+         * A change to the token relationships virtual map.<br/>
+         * This map is keyed by the pair of account identifier and
+         * token identifier.
+         */
+        proto.AccountTokenAssociation token_relationship_key = 25;
     }
 }
 

--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/basic_types.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/basic_types.proto
@@ -2496,6 +2496,26 @@ message TokenAssociation {
 }
 
 /**
+ * An association between an account and a token; this message exists in addition
+ * to TokenAssociation because we wanted a more readable name for EntityIDPair;
+ * but for the block stream state changes, we *also* needed to preserve the relative
+ * order of the account id and token id. (TokenAssociation accidentally reversed the
+ * order of those fields, changing the serialized bytes and breaking binary-only
+ * replay of state changes.)
+ */
+message AccountTokenAssociation {
+    /**
+     * An account identifier for the associated account.
+     */
+    AccountID account_id = 1;
+
+    /**
+     * A token identifier for the associated token.
+     */
+    TokenID token_id = 2;
+}
+
+/**
  * Staking information for an account or a contract.
  *
  * This is used for responses returned from `CryptoGetInfo` or

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/blocks/BlockStreamUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/blocks/BlockStreamUtils.java
@@ -6,7 +6,7 @@ import com.hedera.hapi.block.stream.output.MapChangeValue;
 import com.hedera.hapi.block.stream.output.QueuePushChange;
 import com.hedera.hapi.block.stream.output.SingletonUpdateChange;
 import com.hedera.hapi.block.stream.output.StateIdentifier;
-import com.hedera.hapi.node.base.TokenAssociation;
+import com.hedera.hapi.node.base.AccountTokenAssociation;
 import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
@@ -199,7 +199,7 @@ public final class BlockStreamUtils {
         };
     }
 
-    public static EntityIDPair pairFrom(@NonNull final TokenAssociation tokenAssociation) {
+    public static EntityIDPair pairFrom(@NonNull final AccountTokenAssociation tokenAssociation) {
         return new EntityIDPair(tokenAssociation.accountId(), tokenAssociation.tokenId());
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/ImmediateStateChangeListener.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/ImmediateStateChangeListener.java
@@ -13,6 +13,7 @@ import com.hedera.hapi.block.stream.output.QueuePopChange;
 import com.hedera.hapi.block.stream.output.QueuePushChange;
 import com.hedera.hapi.block.stream.output.StateChange;
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.AccountTokenAssociation;
 import com.hedera.hapi.node.base.ContractID;
 import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.base.HookId;
@@ -20,7 +21,6 @@ import com.hedera.hapi.node.base.NftID;
 import com.hedera.hapi.node.base.PendingAirdropId;
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.TimestampSeconds;
-import com.hedera.hapi.node.base.TokenAssociation;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TopicID;
 import com.hedera.hapi.node.state.addressbook.Node;
@@ -195,7 +195,7 @@ public class ImmediateStateChangeListener implements StateChangeListener {
             case EntityIDPair entityIDPair ->
                 new MapChangeKey(new OneOf<>(
                         MapChangeKey.KeyChoiceOneOfType.TOKEN_RELATIONSHIP_KEY,
-                        new TokenAssociation(entityIDPair.tokenId(), entityIDPair.accountId())));
+                        new AccountTokenAssociation(entityIDPair.accountId(), entityIDPair.tokenId())));
             case EntityNumber entityNumber ->
                 new MapChangeKey(new OneOf<>(MapChangeKey.KeyChoiceOneOfType.ENTITY_NUMBER_KEY, entityNumber.number()));
             case FileID fileID -> new MapChangeKey(new OneOf<>(MapChangeKey.KeyChoiceOneOfType.FILE_ID_KEY, fileID));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/SwirldsLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/SwirldsLogValidator.java
@@ -66,6 +66,7 @@ public class SwirldsLogValidator {
         private static final List<List<String>> PROBLEM_PATTERNS_TO_IGNORE = List.of(
                 List.of("PcesFileTracker", "No preconsensus event files"),
                 List.of("PcesFileTracker", "insufficient data to guarantee"),
+                List.of("BestEffortPcesFileCopy", "No preconsensus event files"),
                 List.of("OSHealthChecker"),
                 List.of("DefaultSignedStateSentinel", "Old signed state detected"));
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BinaryStateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BinaryStateChangesValidator.java
@@ -16,8 +16,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.output.StateChanges;
-import com.hedera.hapi.node.base.TokenAssociation;
-import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.node.app.ServicesMain;
 import com.hedera.node.app.hapi.utils.blocks.BlockStreamAccess;
 import com.hedera.pbj.runtime.ParseException;
@@ -288,7 +286,7 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
                     case 10 -> {
                         final int messageLength = input.readVarInt(false);
                         if (messageLength > 0) {
-                            final Bytes rawKey = readMapKeyPayload(stateId, input, input.position() + messageLength);
+                            final Bytes rawKey = readMapKeyPayload(input, input.position() + messageLength);
                             mapKeyAsStateKey = kvKey(stateId, rawKey);
                         }
                     }
@@ -323,7 +321,7 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
                     case 10 -> {
                         final int messageLength = input.readVarInt(false);
                         if (messageLength > 0) {
-                            final Bytes rawKey = readMapKeyPayload(stateId, input, input.position() + messageLength);
+                            final Bytes rawKey = readMapKeyPayload(input, input.position() + messageLength);
                             mapKeyAsStateKey = kvKey(stateId, rawKey);
                         }
                     }
@@ -399,15 +397,12 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
          * VirtualMap. Token relationship keys are the important exception: block stream uses TokenAssociation
          * while state stores EntityIDPair, whose field ordering is different.
          */
-        private static Bytes readMapKeyPayload(
-                final int stateId, @NonNull final ReadableSequentialData input, final long endPosition) {
+        private static Bytes readMapKeyPayload(@NonNull final ReadableSequentialData input, final long endPosition) {
             Bytes payload = null;
-            Integer fieldNumber = null;
             while (input.position() < endPosition) {
                 final int tag = input.readVarInt(false);
                 final var wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
                 if (payload == null && wireType == ProtoConstants.WIRE_TYPE_DELIMITED) {
-                    fieldNumber = tag >>> ProtoParserTools.TAG_FIELD_OFFSET;
                     final int length = input.readVarInt(false);
                     payload = input.readBytes(length);
                 } else {
@@ -416,20 +411,6 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
             }
             if (payload == null) {
                 throw new IllegalStateException("MapChangeKey payload missing");
-            }
-            return normalizeMapKeyPayload(stateId, fieldNumber, payload);
-        }
-
-        private static Bytes normalizeMapKeyPayload(
-                final int stateId, final int fieldNumber, @NonNull final Bytes payload) {
-            if (stateId == 9 && fieldNumber == 2) {
-                try {
-                    final var tokenAssociation = TokenAssociation.PROTOBUF.parse(payload);
-                    return EntityIDPair.PROTOBUF.toBytes(
-                            new EntityIDPair(tokenAssociation.accountId(), tokenAssociation.tokenId()));
-                } catch (ParseException e) {
-                    throw new IllegalStateException("Failed to normalize token relationship key", e);
-                }
             }
             return payload;
         }


### PR DESCRIPTION
**Description**:
 - Closes #25169 