### PR TITLE
chore: List-of-RSA-signatures for WRBs

### DIFF
--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/NoOpDependencies.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/NoOpDependencies.java
@@ -90,20 +90,6 @@ public final class NoOpDependencies {
         }
     }
 
-    /** No-op BlockHashSigner (deprecated - use createRealTssBlockHashSigner() for production realism) */
-    @Deprecated
-    public static class NoOpBlockHashSigner implements BlockHashSigner {
-        @Override
-        public boolean isReady() {
-            return true;
-        }
-
-        @Override
-        public Attempt sign(@NonNull Bytes blockHash) {
-            return new Attempt(null, null, CompletableFuture.completedFuture(Bytes.wrap(new byte[64])));
-        }
-    }
-
     /** No-op BlockItemWriter */
     public static class NoOpBlockItemWriter implements BlockItemWriter {
         @Override

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/NoOpDependencies.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/utils/NoOpDependencies.java
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.blocks.utils;
 
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.SUCCINCT_SIGNATURE;
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.roster.Roster;
@@ -69,7 +72,12 @@ public final class NoOpDependencies {
         }
 
         @Override
-        public Attempt sign(@NonNull Bytes blockHash) {
+        public Attempt sign(@NonNull final Bytes blockHash, @NonNull final Request request) {
+            requireNonNull(blockHash);
+            requireNonNull(request);
+            if (request != SUCCINCT_SIGNATURE) {
+                throw new IllegalArgumentException("Realistic benchmark signer only supports succinct signatures");
+            }
             // Simulate production behavior: async SHA-384 hash computation
             // This matches TssBlockHashSigner when TSS is disabled (no hintsService)
             return new Attempt(

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -57,7 +57,9 @@ import com.hedera.node.app.config.BootstrapConfigProviderImpl;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.fees.FeeService;
 import com.hedera.node.app.hints.HintsService;
+import com.hedera.node.app.hints.impl.BlockHashSigning;
 import com.hedera.node.app.hints.impl.ReadableHintsStoreImpl;
+import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.node.app.hints.impl.WritableHintsStoreImpl;
 import com.hedera.node.app.history.HistoryService;
 import com.hedera.node.app.history.HttpWrapsProvingKeyDownloader;
@@ -99,6 +101,8 @@ import com.hedera.node.app.store.ReadableStoreFactoryImpl;
 import com.hedera.node.app.throttle.AppScheduleThrottleFactory;
 import com.hedera.node.app.throttle.CongestionThrottleService;
 import com.hedera.node.app.throttle.ThrottleAccumulator;
+import com.hedera.node.app.tss.TssBlockHashSigner;
+import com.hedera.node.app.tss.TssSubmissions;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.handle.HandleWorkflow;
 import com.hedera.node.app.workflows.ingest.IngestWorkflow;
@@ -152,6 +156,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
@@ -431,9 +436,10 @@ public final class Hedera
     public interface BlockHashSignerFactory {
         @NonNull
         BlockHashSigner apply(
-                @NonNull HintsService hintsService,
-                @NonNull HistoryService historyService,
-                @NonNull ConfigProvider configProvider);
+                @NonNull RsaContext rsaContext,
+                @NonNull ConcurrentMap<Bytes, BlockHashSigning> rsaSignings,
+                @NonNull TssSubmissions submissions,
+                @NonNull BlockHashSigner succinctSignatureDelegate);
     }
 
     /*==================================================================================================================
@@ -1280,7 +1286,12 @@ public final class Hedera
                 configProvider,
                 () -> requireNonNull(genesisNetworkSupplier).get());
         final var selfNodeAccountIdManager = new SelfNodeAccountIdManagerImpl(configProvider, networkInfo, state);
-        final var blockHashSigner = blockHashSignerFactory.apply(hintsService, historyService, configProvider);
+        final var succinctSignatureDelegate = new TssBlockHashSigner(hintsService, historyService, configProvider);
+        final var blockHashSigner = blockHashSignerFactory.apply(
+                hintsService.rsaSigningContext(),
+                hintsService.rsaSignings(),
+                hintsService.submissions(),
+                succinctSignatureDelegate);
         // Fully qualified so as to not confuse javadoc
         daggerApp = DaggerHederaInjectionComponent.builder()
                 .configProviderImpl(configProvider)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -156,6 +156,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiPredicate;
@@ -273,6 +274,16 @@ public final class Hedera
      * (once in constructor to register schemas, again inside Dagger component).
      */
     private final HistoryService historyService;
+
+    /**
+     * The RSA signing context shared by the block hash signer and the hinTS partial signature handler.
+     */
+    private final RsaContext rsaContext;
+
+    /**
+     * The in-progress RSA block hash signing attempts shared by the block hash signer and handler.
+     */
+    private final ConcurrentMap<Bytes, BlockHashSigning> rsaSignings = new ConcurrentHashMap<>();
 
     /**
      * The util service singleton, kept as a field here to avoid constructing twice
@@ -423,7 +434,11 @@ public final class Hedera
     @FunctionalInterface
     public interface HintsServiceFactory {
         @NonNull
-        HintsService apply(@NonNull AppContext appContext, @NonNull Configuration bootstrapConfig);
+        HintsService apply(
+                @NonNull AppContext appContext,
+                @NonNull Configuration bootstrapConfig,
+                @NonNull RsaContext rsaContext,
+                @NonNull ConcurrentMap<Bytes, BlockHashSigning> rsaSignings);
     }
 
     @FunctionalInterface
@@ -534,7 +549,8 @@ public final class Hedera
                 () -> daggerApp.appFeeCharging(),
                 new AppEntityIdFactory(bootstrapConfig));
         boundaryStateChangeListener = new BoundaryStateChangeListener(storeMetricsService, configSupplier);
-        hintsService = hintsServiceFactory.apply(appContext, bootstrapConfig);
+        rsaContext = new RsaContext(configSupplier);
+        hintsService = hintsServiceFactory.apply(appContext, bootstrapConfig, rsaContext, rsaSignings);
         historyService = historyServiceFactory.apply(appContext, bootstrapConfig);
         utilServiceImpl = new UtilServiceImpl(appContext, (txnBytes, config) -> daggerApp
                 .transactionChecker()
@@ -1279,6 +1295,10 @@ public final class Hedera
         final var rosterStore = new ReadableStoreFactoryImpl(state).readableStore(ReadableRosterStore.class);
         final var currentRoster =
                 trigger == GENESIS ? genesisRosterOrThrow() : requireNonNull(rosterStore.getActiveRoster());
+        rsaContext.initialize(currentRoster, nodeId -> {
+            final var entry = RosterUtils.getRosterEntryOrNull(currentRoster, nodeId);
+            return entry == null ? 0L : entry.weight();
+        });
         final var networkInfo = new StateNetworkInfo(
                 platform.getSelfId().id(),
                 trigger == GENESIS ? null : state,
@@ -1288,10 +1308,7 @@ public final class Hedera
         final var selfNodeAccountIdManager = new SelfNodeAccountIdManagerImpl(configProvider, networkInfo, state);
         final var succinctSignatureDelegate = new TssBlockHashSigner(hintsService, historyService, configProvider);
         final var blockHashSigner = blockHashSignerFactory.apply(
-                hintsService.rsaSigningContext(),
-                hintsService.rsaSignings(),
-                hintsService.submissions(),
-                succinctSignatureDelegate);
+                rsaContext, rsaSignings, hintsService.submissions(), succinctSignatureDelegate);
         // Fully qualified so as to not confuse javadoc
         daggerApp = DaggerHederaInjectionComponent.builder()
                 .configProviderImpl(configProvider)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -322,12 +322,14 @@ public class ServicesMain {
                 new OrderedServiceMigrator(),
                 InstantSource.system(),
                 DiskStartupNetworks::new,
-                (appContext, bootstrapConfig) -> new HintsServiceImpl(
+                (appContext, bootstrapConfig, rsaContext, rsaSignings) -> new HintsServiceImpl(
                         metrics,
                         ForkJoinPool.commonPool(),
                         appContext,
                         new HintsLibraryImpl(),
-                        bootstrapConfig.getConfigData(BlockStreamConfig.class).blockPeriod()),
+                        bootstrapConfig.getConfigData(BlockStreamConfig.class).blockPeriod(),
+                        rsaContext,
+                        rsaSignings),
                 (appContext, bootstrapConfig) -> new HistoryServiceImpl(
                         metrics, ForkJoinPool.commonPool(), appContext, new HistoryLibraryImpl()),
                 DualBlockHashSigner::new,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -38,7 +38,7 @@ import com.hedera.node.app.service.entityid.impl.ReadableEntityIdStoreImpl;
 import com.hedera.node.app.services.OrderedServiceMigrator;
 import com.hedera.node.app.services.ServicesRegistryImpl;
 import com.hedera.node.app.store.ReadableStoreFactoryImpl;
-import com.hedera.node.app.tss.TssBlockHashSigner;
+import com.hedera.node.app.tss.DualBlockHashSigner;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.BlockStreamJumpstartConfig;
@@ -330,7 +330,7 @@ public class ServicesMain {
                         bootstrapConfig.getConfigData(BlockStreamConfig.class).blockPeriod()),
                 (appContext, bootstrapConfig) -> new HistoryServiceImpl(
                         metrics, ForkJoinPool.commonPool(), appContext, new HistoryLibraryImpl()),
-                TssBlockHashSigner::new,
+                DualBlockHashSigner::new,
                 configuration,
                 metrics,
                 time);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockHashSigner.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockHashSigner.java
@@ -12,6 +12,20 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface BlockHashSigner {
     /**
+     * The type of block hash signature being requested.
+     */
+    enum Request {
+        /**
+         * A succinct signature over the block hash.
+         */
+        SUCCINCT_SIGNATURE,
+        /**
+         * A list of partial signatures over the block hash.
+         */
+        LIST_OF_PARTIAL_SIGNATURES
+    }
+
+    /**
      * The result of attempting to sign a block hash.
      * @param verificationKey if not null, the verification key being used for the attempt
      * @param chainOfTrustProof if not null, the chain of trust proof for the verification key being used
@@ -30,7 +44,8 @@ public interface BlockHashSigner {
     /**
      * Returns an attempt to sign the given block hash.
      * @param blockHash the block hash
+     * @param request the type of signature being requested
      * @return the signing attempt
      */
-    Attempt sign(@NonNull Bytes blockHash);
+    Attempt sign(@NonNull Bytes blockHash, @NonNull Request request);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -114,7 +114,6 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
 
     private final int roundsPerBlock;
     private final Duration blockPeriod;
-    private final int hashCombineBatchSize;
     private final BlockHashSigner blockHashSigner;
     private final SemanticVersion version;
     private final SemanticVersion hapiVersion;
@@ -221,7 +220,6 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         final var blockStreamConfig = config.getConfigData(BlockStreamConfig.class);
         this.roundsPerBlock = blockStreamConfig.roundsPerBlock();
         this.blockPeriod = blockStreamConfig.blockPeriod();
-        this.hashCombineBatchSize = blockStreamConfig.hashCombineBatchSize();
         final var networkAdminConfig = config.getConfigData(NetworkAdminConfig.class);
         this.diskNetworkExport = networkAdminConfig.diskNetworkExport();
         this.diskNetworkExportFile = networkAdminConfig.diskNetworkExportFile();
@@ -849,14 +847,6 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                 indirectProofCounter.increment();
             }
 
-            // (FUTURE: GH issue #22676) Re-enable setting the verification key and chain of trust proof
-            // once the API is finalized
-            //            if (verificationKey != null) {
-            //                proof.verificationKey(verificationKey);
-            //                if (chainOfTrustProof != null) {
-            //                    proof.verificationKeyProof(chainOfTrustProof);
-            //                }
-            //            }
             final var proofItem = BlockItem.newBuilder().blockProof(proof).build();
             currentPendingBlock.writer().writePbjItemAndBytes(proofItem, BlockItem.PROTOBUF.toBytes(proofItem));
             currentPendingBlock.writer().closeCompleteBlock();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -5,6 +5,7 @@ import static com.hedera.hapi.block.stream.output.StateIdentifier.STATE_ID_BLOCK
 import static com.hedera.hapi.node.base.BlockHashAlgorithm.SHA2_384;
 import static com.hedera.hapi.util.HapiUtils.asInstant;
 import static com.hedera.hapi.util.HapiUtils.asTimestamp;
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.SUCCINCT_SIGNATURE;
 import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.GENESIS_WORK;
 import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.NONE;
 import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.POST_UPGRADE_WORK;
@@ -605,7 +606,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                     block.writer().flushPendingBlock(pendingProof);
                 });
             } else {
-                final var attempt = blockHashSigner.sign(finalBlockRootHash);
+                final var attempt = blockHashSigner.sign(finalBlockRootHash, SUCCINCT_SIGNATURE);
                 attempt.signatureFuture()
                         .thenAcceptAsync(signature -> {
                             if (signature == null || Objects.equals(signature, Bytes.EMPTY)) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/HintsService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/HintsService.java
@@ -8,7 +8,7 @@ import com.hedera.hapi.node.state.hints.HintsConstruction;
 import com.hedera.hapi.node.state.hints.NodePartyId;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.node.app.hints.handlers.HintsHandlers;
-import com.hedera.node.app.hints.impl.HintsContext;
+import com.hedera.node.app.hints.impl.BlockHashSigning;
 import com.hedera.node.app.hints.impl.HintsController;
 import com.hedera.node.app.hints.impl.OnHintsFinished;
 import com.hedera.node.app.service.roster.impl.ActiveRosters;
@@ -86,7 +86,8 @@ public interface HintsService extends Service {
     /**
      * Signs the given block hash.
      */
-    HintsContext.Signing sign(@NonNull Bytes blockHash);
+    @NonNull
+    BlockHashSigning sign(@NonNull Bytes blockHash);
 
     /**
      * Sets the callback for when a hinTS construction is finished. Only one callback is active at a time.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/HintsService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/HintsService.java
@@ -11,10 +11,12 @@ import com.hedera.node.app.hints.handlers.HintsHandlers;
 import com.hedera.node.app.hints.impl.BlockHashSigning;
 import com.hedera.node.app.hints.impl.HintsController;
 import com.hedera.node.app.hints.impl.OnHintsFinished;
+import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.node.app.service.roster.impl.ActiveRosters;
 import com.hedera.node.app.service.roster.impl.RosterServiceImpl;
 import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory;
+import com.hedera.node.app.tss.TssSubmissions;
 import com.hedera.node.config.data.TssConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.lifecycle.SchemaRegistry;
@@ -24,6 +26,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Orchestrates the hinTS algorithms for,
@@ -88,6 +91,24 @@ public interface HintsService extends Service {
      */
     @NonNull
     BlockHashSigning sign(@NonNull Bytes blockHash);
+
+    /**
+     * Returns the context used to orchestrate RSA block hash signing attempts.
+     */
+    @NonNull
+    RsaContext rsaSigningContext();
+
+    /**
+     * Returns the in-progress RSA block hash signing attempts.
+     */
+    @NonNull
+    ConcurrentMap<Bytes, BlockHashSigning> rsaSignings();
+
+    /**
+     * Returns the TSS node-transaction submission helper.
+     */
+    @NonNull
+    TssSubmissions submissions();
 
     /**
      * Sets the callback for when a hinTS construction is finished. Only one callback is active at a time.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/HintsService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/HintsService.java
@@ -11,7 +11,6 @@ import com.hedera.node.app.hints.handlers.HintsHandlers;
 import com.hedera.node.app.hints.impl.BlockHashSigning;
 import com.hedera.node.app.hints.impl.HintsController;
 import com.hedera.node.app.hints.impl.OnHintsFinished;
-import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.node.app.service.roster.impl.ActiveRosters;
 import com.hedera.node.app.service.roster.impl.RosterServiceImpl;
 import com.hedera.node.app.spi.info.NetworkInfo;
@@ -26,7 +25,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * Orchestrates the hinTS algorithms for,
@@ -91,18 +89,6 @@ public interface HintsService extends Service {
      */
     @NonNull
     BlockHashSigning sign(@NonNull Bytes blockHash);
-
-    /**
-     * Returns the context used to orchestrate RSA block hash signing attempts.
-     */
-    @NonNull
-    RsaContext rsaSigningContext();
-
-    /**
-     * Returns the in-progress RSA block hash signing attempts.
-     */
-    @NonNull
-    ConcurrentMap<Bytes, BlockHashSigning> rsaSignings();
 
     /**
      * Returns the TSS node-transaction submission helper.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/handlers/HintsPartialSignatureHandler.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/handlers/HintsPartialSignatureHandler.java
@@ -7,7 +7,10 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.hedera.hapi.services.auxiliary.hints.HintsPartialSignatureTransactionBody;
 import com.hedera.node.app.hints.ReadableHintsStore;
+import com.hedera.node.app.hints.impl.BlockHashSigning;
 import com.hedera.node.app.hints.impl.HintsContext;
+import com.hedera.node.app.hints.impl.HintsModule;
+import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -22,6 +25,7 @@ import java.time.Duration;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -31,9 +35,14 @@ public class HintsPartialSignatureHandler implements TransactionHandler {
     private static final Logger log = LogManager.getLogger(HintsPartialSignatureHandler.class);
 
     @NonNull
-    private final ConcurrentMap<Bytes, HintsContext.Signing> signings;
+    private final ConcurrentMap<Bytes, BlockHashSigning> signings;
+
+    @NonNull
+    private final ConcurrentMap<Bytes, BlockHashSigning> rsaSignings;
 
     private final HintsContext hintsContext;
+
+    private final RsaContext rsaContext;
 
     private final LoadingCache<PartialSignature, Boolean> cache;
 
@@ -59,10 +68,14 @@ public class HintsPartialSignatureHandler implements TransactionHandler {
     @Inject
     public HintsPartialSignatureHandler(
             @NonNull final Duration blockPeriod,
-            @NonNull final ConcurrentMap<Bytes, HintsContext.Signing> signings,
-            @NonNull final HintsContext context) {
+            @Named(HintsModule.HINTS_SIGNINGS) @NonNull final ConcurrentMap<Bytes, BlockHashSigning> signings,
+            @Named(HintsModule.RSA_SIGNINGS) @NonNull final ConcurrentMap<Bytes, BlockHashSigning> rsaSignings,
+            @NonNull final HintsContext context,
+            @NonNull final RsaContext rsaContext) {
         this.signings = requireNonNull(signings);
+        this.rsaSignings = requireNonNull(rsaSignings);
         this.hintsContext = requireNonNull(context);
+        this.rsaContext = requireNonNull(rsaContext);
         // Only used when waiting for consensus to construct deterministic signatures
         cache = Caffeine.newBuilder()
                 .expireAfterAccess(Math.max(1, 2 * blockPeriod.getSeconds()), TimeUnit.SECONDS)
@@ -78,13 +91,26 @@ public class HintsPartialSignatureHandler implements TransactionHandler {
     @Override
     public void preHandle(@NonNull final PreHandleContext context) throws PreCheckException {
         requireNonNull(context);
+        final var creatorId = context.creatorInfo().nodeId();
+        final HintsPartialSignatureTransactionBody op;
+        final TssConfig tssConfig;
+        try {
+            op = context.body().hintsPartialSignatureOrThrow();
+            tssConfig = context.configuration().getConfigData(TssConfig.class);
+            if (op.constructionId() == RsaContext.CONSTRUCTION_ID) {
+                if (!tssConfig.useDeterministicHintsSignatures()) {
+                    incorporateRsaIfValid(op, creatorId);
+                }
+                return;
+            }
+        } catch (Exception e) {
+            log.debug("Ignoring partial signature in pre-handle for node {}", creatorId, e);
+            return;
+        }
         final var hintsStore = context.createStore(ReadableHintsStore.class);
         final var crs = requireNonNull(hintsStore.crsIfKnown());
-        final var creatorId = context.creatorInfo().nodeId();
         try {
-            final var op = context.body().hintsPartialSignatureOrThrow();
             final var partialSignature = new PartialSignature(hintsContext.constructionIdOrThrow(), crs, creatorId, op);
-            final var tssConfig = context.configuration().getConfigData(TssConfig.class);
             if (tssConfig.useDeterministicHintsSignatures()) {
                 //noinspection ResultOfMethodCallIgnored
                 cache.get(partialSignature);
@@ -107,9 +133,15 @@ public class HintsPartialSignatureHandler implements TransactionHandler {
         requireNonNull(context);
         final var op = context.body().hintsPartialSignatureOrThrow();
         final var creatorId = context.creatorInfo().nodeId();
+        final var tssConfig = context.configuration().getConfigData(TssConfig.class);
+        if (op.constructionId() == RsaContext.CONSTRUCTION_ID) {
+            if (tssConfig.useDeterministicHintsSignatures()) {
+                incorporateRsaIfValid(op, creatorId);
+            }
+            return;
+        }
         final var hintsStore = context.storeFactory().readableStore(ReadableHintsStore.class);
         final var crs = requireNonNull(hintsStore.crsIfKnown());
-        final var tssConfig = context.configuration().getConfigData(TssConfig.class);
         // Only something to do at handle if using deterministic hinTS signatures
         if (tssConfig.useDeterministicHintsSignatures()) {
             final boolean isValid = Boolean.TRUE.equals(cache.get(new PartialSignature(
@@ -122,6 +154,15 @@ public class HintsPartialSignatureHandler implements TransactionHandler {
                                 op.message(), b -> hintsContext.newSigning(b, () -> signings.remove(op.message())))
                         .incorporateValid(crs, creatorId, op.partialSignature());
             }
+        }
+    }
+
+    private void incorporateRsaIfValid(@NonNull final HintsPartialSignatureTransactionBody op, final long creatorId) {
+        if (rsaContext.validate(creatorId, op)) {
+            rsaSignings
+                    .computeIfAbsent(
+                            op.message(), b -> rsaContext.newSigning(b, () -> rsaSignings.remove(op.message())))
+                    .incorporateValid(Bytes.EMPTY, creatorId, op.partialSignature());
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/BlockHashSigning.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/BlockHashSigning.java
@@ -1,12 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.hints.impl;
 
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 /**
- * TODO - sealed interface first permitting just HintsContext.Signing and exposing
- * public methods exactly as used by any current client of HintsContext.Signing
- * <b>other than</b> {@link com.hedera.node.app.tss.TssBlockHashSigner}
- *
- * Then eliminate direct use of HintsContext.Signing everywhere except TssBlockHashSigner,
- * replacing those usage sites with BlockHashSigning
+ * The mechanism-independent orchestration of an in-progress block hash signing.
  */
-public interface BlockHashSigning {
+public sealed interface BlockHashSigning permits HintsContext.Signing, RsaContext.Signing {
+    /**
+     * Incorporates a node's pre-validated signature contribution into this signing attempt.
+     *
+     * @param crs the final CRS used by the network
+     * @param nodeId the node ID
+     * @param signature the pre-validated signature contribution
+     */
+    void incorporateValid(@NonNull Bytes crs, long nodeId, @NonNull Bytes signature);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/BlockHashSigning.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/BlockHashSigning.java
@@ -11,9 +11,9 @@ public sealed interface BlockHashSigning permits HintsContext.Signing, RsaContex
     /**
      * Incorporates a node's pre-validated signature contribution into this signing attempt.
      *
-     * @param crs the final CRS used by the network
+     * @param context any additional signing context required to incorporate the signature
      * @param nodeId the node ID
      * @param signature the pre-validated signature contribution
      */
-    void incorporateValid(@NonNull Bytes crs, long nodeId, @NonNull Bytes signature);
+    void incorporateValid(@NonNull Bytes context, long nodeId, @NonNull Bytes signature);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/BlockHashSigning.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/BlockHashSigning.java
@@ -4,6 +4,9 @@ package com.hedera.node.app.hints.impl;
  * TODO - sealed interface first permitting just HintsContext.Signing and exposing
  * public methods exactly as used by any current client of HintsContext.Signing
  * <b>other than</b> {@link com.hedera.node.app.tss.TssBlockHashSigner}
+ *
+ * Then eliminate direct use of HintsContext.Signing everywhere except TssBlockHashSigner,
+ * replacing those usage sites with BlockHashSigning
  */
 public interface BlockHashSigning {
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/BlockHashSigning.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/BlockHashSigning.java
@@ -1,0 +1,9 @@
+package com.hedera.node.app.hints.impl;
+
+/**
+ * TODO - sealed interface first permitting just HintsContext.Signing and exposing
+ * public methods exactly as used by any current client of HintsContext.Signing
+ * <b>other than</b> {@link com.hedera.node.app.tss.TssBlockHashSigner}
+ */
+public interface BlockHashSigning {
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsContext.java
@@ -157,7 +157,7 @@ public class HintsContext {
      * @param onCompletion a callback to run when the signing process completes
      * @return the signing process
      */
-    public @NonNull Signing newSigning(@NonNull final Bytes blockHash, @NonNull final Runnable onCompletion) {
+    public @NonNull BlockHashSigning newSigning(@NonNull final Bytes blockHash, @NonNull final Runnable onCompletion) {
         requireNonNull(blockHash);
         requireNonNull(onCompletion);
         throwIfNotReady();
@@ -206,7 +206,7 @@ public class HintsContext {
     /**
      * A signing process spawned from this context.
      */
-    public class Signing {
+    public non-sealed class Signing implements BlockHashSigning {
         private final long startNanos;
         private final long thresholdWeight;
         private final long thresholdDenominator;
@@ -283,6 +283,7 @@ public class HintsContext {
          * @param nodeId the node ID
          * @param signature the pre-validated partial signature
          */
+        @Override
         public void incorporateValid(@NonNull final Bytes crs, final long nodeId, @NonNull final Bytes signature) {
             requireNonNull(crs);
             requireNonNull(signature);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsModule.java
@@ -19,10 +19,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 @Module
 public interface HintsModule {
+    String HINTS_SIGNINGS = "hinTS signings";
+    String RSA_SIGNINGS = "RSA signings";
+
     @Provides
     @Singleton
     static Supplier<NodeInfo> provideSelfNodeInfoSupplier(@NonNull final AppContext appContext) {
@@ -41,7 +45,15 @@ public interface HintsModule {
 
     @Provides
     @Singleton
-    static ConcurrentMap<Bytes, HintsContext.Signing> providePendingSignatures() {
+    @Named(HINTS_SIGNINGS)
+    static ConcurrentMap<Bytes, BlockHashSigning> providePendingSignatures() {
+        return new ConcurrentHashMap<>();
+    }
+
+    @Provides
+    @Singleton
+    @Named(RSA_SIGNINGS)
+    static ConcurrentMap<Bytes, BlockHashSigning> providePendingRsaSignatures() {
         return new ConcurrentHashMap<>();
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsModule.java
@@ -52,13 +52,6 @@ public interface HintsModule {
 
     @Provides
     @Singleton
-    @Named(RSA_SIGNINGS)
-    static ConcurrentMap<Bytes, BlockHashSigning> providePendingRsaSignatures() {
-        return new ConcurrentHashMap<>();
-    }
-
-    @Provides
-    @Singleton
     static HintsHandlers provideHintsHandlers(
             @NonNull final HintsKeyPublicationHandler keyPublicationHandler,
             @NonNull final HintsPreprocessingVoteHandler preprocessingVoteHandler,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceComponent.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 @Singleton
@@ -35,9 +36,15 @@ public interface HintsServiceComponent {
 
     HintsContext signingContext();
 
+    RsaContext rsaSigningContext();
+
     HintsControllers controllers();
 
-    ConcurrentMap<Bytes, HintsContext.Signing> signings();
+    @Named(HintsModule.HINTS_SIGNINGS)
+    ConcurrentMap<Bytes, BlockHashSigning> signings();
+
+    @Named(HintsModule.RSA_SIGNINGS)
+    ConcurrentMap<Bytes, BlockHashSigning> rsaSignings();
 
     @Deprecated
     Supplier<Configuration> configSupplier();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceComponent.java
@@ -27,7 +27,9 @@ public interface HintsServiceComponent {
                 @BindsInstance Executor executor,
                 @BindsInstance Metrics metrics,
                 @BindsInstance Duration blockPeriod,
-                @BindsInstance OnHintsFinished onHintsFinished);
+                @BindsInstance OnHintsFinished onHintsFinished,
+                @BindsInstance RsaContext rsaContext,
+                @BindsInstance @Named(HintsModule.RSA_SIGNINGS) ConcurrentMap<Bytes, BlockHashSigning> rsaSignings);
     }
 
     HintsHandlers handlers();
@@ -36,15 +38,10 @@ public interface HintsServiceComponent {
 
     HintsContext signingContext();
 
-    RsaContext rsaSigningContext();
-
     HintsControllers controllers();
 
     @Named(HintsModule.HINTS_SIGNINGS)
     ConcurrentMap<Bytes, BlockHashSigning> signings();
-
-    @Named(HintsModule.RSA_SIGNINGS)
-    ConcurrentMap<Bytes, BlockHashSigning> rsaSignings();
 
     @Deprecated
     Supplier<Configuration> configSupplier();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceImpl.java
@@ -23,6 +23,7 @@ import com.hedera.node.app.hints.schemas.V073HintsSchema;
 import com.hedera.node.app.service.roster.impl.ActiveRosters;
 import com.hedera.node.app.spi.AppContext;
 import com.hedera.node.app.spi.info.NetworkInfo;
+import com.hedera.node.app.tss.TssSubmissions;
 import com.hedera.node.config.data.TssConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
@@ -33,6 +34,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -97,6 +99,7 @@ public class HintsServiceImpl implements HintsService, OnHintsFinished {
 
     @Override
     public @NonNull BlockHashSigning sign(@NonNull final Bytes blockHash) {
+        requireNonNull(blockHash);
         if (!isReady()) {
             throw new IllegalStateException("hinTS service not ready to sign block hash " + blockHash);
         }
@@ -108,6 +111,21 @@ public class HintsServiceImpl implements HintsService, OnHintsFinished {
             return null;
         });
         return signing;
+    }
+
+    @Override
+    public @NonNull RsaContext rsaSigningContext() {
+        return component.rsaSigningContext();
+    }
+
+    @Override
+    public @NonNull ConcurrentMap<Bytes, BlockHashSigning> rsaSignings() {
+        return component.rsaSignings();
+    }
+
+    @Override
+    public @NonNull TssSubmissions submissions() {
+        return component.submissions();
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceImpl.java
@@ -96,7 +96,7 @@ public class HintsServiceImpl implements HintsService, OnHintsFinished {
     }
 
     @Override
-    public HintsContext.Signing sign(@NonNull final Bytes blockHash) {
+    public @NonNull BlockHashSigning sign(@NonNull final Bytes blockHash) {
         if (!isReady()) {
             throw new IllegalStateException("hinTS service not ready to sign block hash " + blockHash);
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsServiceImpl.java
@@ -57,11 +57,13 @@ public class HintsServiceImpl implements HintsService, OnHintsFinished {
             @NonNull final Executor executor,
             @NonNull final AppContext appContext,
             @NonNull final HintsLibrary library,
-            @NonNull final Duration blockPeriod) {
+            @NonNull final Duration blockPeriod,
+            @NonNull final RsaContext rsaContext,
+            @NonNull final ConcurrentMap<Bytes, BlockHashSigning> rsaSignings) {
         this.library = requireNonNull(library);
         // Fully qualified for benefit of javadoc
         this.component = com.hedera.node.app.hints.impl.DaggerHintsServiceComponent.factory()
-                .create(library, appContext, executor, metrics, blockPeriod, this);
+                .create(library, appContext, executor, metrics, blockPeriod, this, rsaContext, rsaSignings);
     }
 
     @VisibleForTesting
@@ -111,16 +113,6 @@ public class HintsServiceImpl implements HintsService, OnHintsFinished {
             return null;
         });
         return signing;
-    }
-
-    @Override
-    public @NonNull RsaContext rsaSigningContext() {
-        return component.rsaSigningContext();
-    }
-
-    @Override
-    public @NonNull ConcurrentMap<Bytes, BlockHashSigning> rsaSignings() {
-        return component.rsaSignings();
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsSubmissions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/HintsSubmissions.java
@@ -126,4 +126,14 @@ public class HintsSubmissions extends TssSubmissions {
                 },
                 onFailure);
     }
+
+    /**
+     * Attempts to submit an RSA signature using the node's platform signing key.
+     *
+     * @param message the message to sign
+     * @return a future that completes when the signature has been submitted
+     */
+    public CompletableFuture<Void> submitRsaSignature(@NonNull final Bytes message) {
+        return submitRsaSignature(message, onFailure);
+    }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/RsaContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/RsaContext.java
@@ -81,18 +81,8 @@ public class RsaContext {
         }
         rosterHash = RosterUtils.hash(roster).getBytes();
         publicKeys = Map.copyOf(keys);
-        verifiers.remove();
-        reassignWeights(weightFn);
-    }
-
-    /**
-     * Updates the signing weights used by new RSA signing attempts.
-     *
-     * @param weightFn the function assigning signing weights by node id
-     */
-    public void reassignWeights(@NonNull final LongUnaryOperator weightFn) {
-        requireNonNull(weightFn);
         weights = publicKeys.keySet().stream().collect(toMap(identity(), nodeId -> weightFor(weightFn, nodeId)));
+        verifiers.remove();
     }
 
     /**
@@ -229,13 +219,13 @@ public class RsaContext {
          * required threshold, completes the future returned from {@link #future()} with the serialized
          * {@link RosterSignatures}.
          *
-         * @param crs ignored for RSA signing
+         * @param ignored ignored for RSA signing
          * @param nodeId the node ID
          * @param signature the pre-validated RSA signature
          */
         @Override
-        public void incorporateValid(@NonNull final Bytes crs, final long nodeId, @NonNull final Bytes signature) {
-            requireNonNull(crs);
+        public void incorporateValid(@NonNull final Bytes ignored, final long nodeId, @NonNull final Bytes signature) {
+            requireNonNull(ignored);
             requireNonNull(signature);
             if (completed.get()) {
                 return;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/RsaContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/RsaContext.java
@@ -16,7 +16,6 @@ import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.PublicKey;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -244,10 +243,10 @@ public class RsaContext {
         }
 
         private RosterSignatures rosterSignatures() {
-            final var nodeSignatures = new ArrayList<>(signatures.entrySet().stream()
+            final var nodeSignatures = signatures.entrySet().stream()
                     .sorted(Map.Entry.comparingByKey())
                     .map(entry -> new NodeSignature(entry.getKey(), entry.getValue()))
-                    .toList());
+                    .toList();
             return new RosterSignatures(rosterHash, nodeSignatures);
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/RsaContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/RsaContext.java
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.hints.impl;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
+import com.hedera.hapi.node.state.roster.NodeSignature;
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterSignatures;
+import com.hedera.hapi.services.auxiliary.hints.HintsPartialSignatureTransactionBody;
+import com.hedera.node.config.data.TssConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.PublicKey;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongUnaryOperator;
+import java.util.function.Supplier;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hiero.base.crypto.BytesSignatureVerifier;
+import org.hiero.base.crypto.CryptographyException;
+import org.hiero.base.crypto.SigningFactory;
+import org.hiero.consensus.roster.RosterUtils;
+
+/**
+ * The RSA context that can be used to request signatures using the roster's gossip signing keys.
+ */
+@Singleton
+public class RsaContext {
+    private static final Logger log = LogManager.getLogger(RsaContext.class);
+
+    public static final long CONSTRUCTION_ID = 0L;
+
+    // For a quiesced network, a signature list could in principle take an entire day to assemble
+    private static final Duration SIGNING_ATTEMPT_TIMEOUT = Duration.ofDays(1);
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final Supplier<Configuration> configProvider;
+
+    private volatile Bytes rosterHash = Bytes.EMPTY;
+    private volatile Map<Long, PublicKey> publicKeys = Map.of();
+    private volatile Map<Long, Long> weights = Map.of();
+    private final ThreadLocal<Map<Long, BytesSignatureVerifier>> verifiers = ThreadLocal.withInitial(HashMap::new);
+
+    @Inject
+    public RsaContext(@NonNull final Supplier<Configuration> configProvider) {
+        this.configProvider = requireNonNull(configProvider);
+    }
+
+    /**
+     * Initializes the RSA verification context from the given roster and node weight function.
+     *
+     * @param roster the roster whose gossip signing keys should be used
+     * @param weightFn the function assigning signing weights by node id
+     */
+    public void initialize(@NonNull final Roster roster, @NonNull final LongUnaryOperator weightFn) {
+        requireNonNull(roster);
+        requireNonNull(weightFn);
+        final Map<Long, PublicKey> keys = new HashMap<>();
+        for (final var entry : roster.rosterEntries()) {
+            final var certificate = RosterUtils.fetchGossipCaCertificate(entry);
+            final var publicKey = certificate == null ? null : certificate.getPublicKey();
+            if (publicKey != null && "RSA".equals(publicKey.getAlgorithm())) {
+                keys.put(entry.nodeId(), publicKey);
+            }
+        }
+        rosterHash = RosterUtils.hash(roster).getBytes();
+        publicKeys = Map.copyOf(keys);
+        verifiers.remove();
+        reassignWeights(weightFn);
+    }
+
+    /**
+     * Updates the signing weights used by new RSA signing attempts.
+     *
+     * @param weightFn the function assigning signing weights by node id
+     */
+    public void reassignWeights(@NonNull final LongUnaryOperator weightFn) {
+        requireNonNull(weightFn);
+        weights = publicKeys.keySet().stream().collect(toMap(identity(), nodeId -> weightFor(weightFn, nodeId)));
+    }
+
+    /**
+     * Whether this context has initialized RSA public keys.
+     *
+     * @return whether this context is ready
+     */
+    public boolean isReady() {
+        return !publicKeys.isEmpty();
+    }
+
+    /**
+     * Validates an RSA signature transaction body under the current roster.
+     *
+     * @param nodeId the signing node id
+     * @param body the transaction body
+     * @return whether the signature is valid
+     */
+    public boolean validate(final long nodeId, @NonNull final HintsPartialSignatureTransactionBody body) {
+        requireNonNull(body);
+        if (body.constructionId() != CONSTRUCTION_ID) {
+            return false;
+        }
+        return validate(nodeId, body.message(), body.partialSignature());
+    }
+
+    /**
+     * Validates an RSA signature under the current roster.
+     *
+     * @param nodeId the signing node id
+     * @param message the signed message
+     * @param signature the RSA signature
+     * @return whether the signature is valid
+     */
+    public boolean validate(final long nodeId, @NonNull final Bytes message, @NonNull final Bytes signature) {
+        requireNonNull(message);
+        requireNonNull(signature);
+        final var publicKey = publicKeys.get(nodeId);
+        if (publicKey == null) {
+            return false;
+        }
+        try {
+            final var verifier =
+                    verifiers.get().computeIfAbsent(nodeId, ignore -> SigningFactory.createVerifier(publicKey));
+            return verifier.verify(message, signature);
+        } catch (final CryptographyException e) {
+            log.debug("Failed to validate RSA signature from node {}", nodeId, e);
+            return false;
+        }
+    }
+
+    /**
+     * Creates a new asynchronous RSA signing process for the given block hash.
+     *
+     * @param blockHash the block hash
+     * @param onCompletion a callback to run when the signing process completes
+     * @return the signing process
+     */
+    public @NonNull BlockHashSigning newSigning(@NonNull final Bytes blockHash, @NonNull final Runnable onCompletion) {
+        requireNonNull(blockHash);
+        requireNonNull(onCompletion);
+        if (!isReady()) {
+            throw new IllegalStateException("RSA signing context not ready");
+        }
+        final var weightSnapshot = Map.copyOf(weights);
+        final long totalWeight =
+                weightSnapshot.values().stream().mapToLong(Long::longValue).sum();
+        final var tssConfig = configProvider.get().getConfigData(TssConfig.class);
+        final int divisor = Math.max(1, tssConfig.signingThresholdDivisor());
+        final long threshold = totalWeight / divisor;
+        return new Signing(blockHash, requireNonNull(rosterHash), threshold, weightSnapshot, onCompletion);
+    }
+
+    private static long weightFor(@NonNull final LongUnaryOperator weightFn, final long nodeId) {
+        final long weight = weightFn.applyAsLong(nodeId);
+        if (weight < 0) {
+            throw new IllegalArgumentException("Node " + nodeId + " has negative RSA signing weight " + weight);
+        }
+        return weight;
+    }
+
+    /**
+     * A signing process spawned from this context.
+     */
+    public non-sealed class Signing implements BlockHashSigning {
+        private final Bytes blockHash;
+        private final Bytes rosterHash;
+        private final long thresholdWeight;
+        private final Map<Long, Long> nodeWeights;
+        private final CompletableFuture<Bytes> future = new CompletableFuture<>();
+        private final ConcurrentMap<Long, Bytes> signatures = new ConcurrentHashMap<>();
+        private final AtomicLong weightOfSignatures = new AtomicLong();
+        private final AtomicBoolean completed = new AtomicBoolean();
+
+        public Signing(
+                @NonNull final Bytes blockHash,
+                @NonNull final Bytes rosterHash,
+                final long thresholdWeight,
+                @NonNull final Map<Long, Long> nodeWeights,
+                @NonNull final Runnable onCompletion) {
+            this.blockHash = requireNonNull(blockHash);
+            this.rosterHash = requireNonNull(rosterHash);
+            this.thresholdWeight = thresholdWeight;
+            this.nodeWeights = requireNonNull(nodeWeights);
+            requireNonNull(onCompletion);
+            executor.schedule(
+                    () -> {
+                        if (!future.isDone()) {
+                            log.warn(
+                                    "Completing RSA signing attempt on '{}' without obtaining a signature list (had {} from nodes {} for total weight {}/{} required)",
+                                    blockHash,
+                                    signatures.size(),
+                                    signatures.keySet(),
+                                    weightOfSignatures.get(),
+                                    thresholdWeight);
+                        }
+                        onCompletion.run();
+                    },
+                    SIGNING_ATTEMPT_TIMEOUT.getSeconds(),
+                    SECONDS);
+        }
+
+        /**
+         * The future that will complete when sufficient RSA signatures have been collected.
+         *
+         * @return the future
+         */
+        public CompletableFuture<Bytes> future() {
+            return future;
+        }
+
+        /**
+         * Incorporates a node's pre-validated RSA signature into the list. If including this node's weight passes the
+         * required threshold, completes the future returned from {@link #future()} with the serialized
+         * {@link RosterSignatures}.
+         *
+         * @param crs ignored for RSA signing
+         * @param nodeId the node ID
+         * @param signature the pre-validated RSA signature
+         */
+        @Override
+        public void incorporateValid(@NonNull final Bytes crs, final long nodeId, @NonNull final Bytes signature) {
+            requireNonNull(crs);
+            requireNonNull(signature);
+            if (completed.get()) {
+                return;
+            }
+            final var weight = nodeWeights.get(nodeId);
+            if (weight == null || weight == 0) {
+                return;
+            }
+            if (signatures.put(nodeId, signature) != null) {
+                return;
+            }
+            final var totalWeight = weightOfSignatures.addAndGet(weight);
+            if (totalWeight > thresholdWeight && completed.compareAndSet(false, true)) {
+                future.complete(RosterSignatures.PROTOBUF.toBytes(rosterSignatures()));
+            }
+        }
+
+        private RosterSignatures rosterSignatures() {
+            final var nodeSignatures = new ArrayList<>(signatures.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .map(entry -> new NodeSignature(entry.getKey(), entry.getValue()))
+                    .toList());
+            return new RosterSignatures(rosterHash, nodeSignatures);
+        }
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.records;
 
+import com.hedera.node.app.blocks.BlockHashSigner;
 import com.hedera.node.app.blocks.BlockItemWriter;
 import com.hedera.node.app.quiescence.QuiescedHeartbeat;
 import com.hedera.node.app.quiescence.QuiescenceController;
@@ -75,6 +76,7 @@ public abstract class BlockRecordInjectionModule {
             @NonNull final QuiescedHeartbeat quiescedHeartbeat,
             @NonNull final Platform platform,
             @NonNull final WrappedRecordFileBlockHashesDiskWriter wrappedRecordHashesDiskWriter,
+            @NonNull final BlockHashSigner blockHashSigner,
             @NonNull @Named("wrb") final Supplier<BlockItemWriter> wrbWriterSupplier) {
         final var merkleState = state.getState();
         if (merkleState == null) {
@@ -89,6 +91,7 @@ public abstract class BlockRecordInjectionModule {
                 platform,
                 wrappedRecordHashesDiskWriter,
                 wrbWriterSupplier,
+                blockHashSigner,
                 initTrigger);
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -3,6 +3,7 @@ package com.hedera.node.app.records.impl;
 
 import static com.hedera.hapi.util.HapiUtils.asInstant;
 import static com.hedera.hapi.util.HapiUtils.asTimestamp;
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.LIST_OF_PARTIAL_SIGNATURES;
 import static com.hedera.node.app.blocks.BlockStreamManager.HASH_OF_ZERO;
 import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
 import static com.hedera.node.app.records.BlockRecordService.EPOCH;
@@ -19,13 +20,20 @@ import static org.hiero.consensus.platformstate.V0540PlatformStateSchema.PLATFOR
 
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.block.internal.WrappedRecordFileBlockHashes;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.BlockProof;
+import com.hedera.hapi.block.stream.RecordFileSignature;
+import com.hedera.hapi.block.stream.SignedRecordFileProof;
+import com.hedera.hapi.block.stream.output.BlockFooter;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.hapi.node.state.blockrecords.MigrationWrappedHashes;
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.hapi.node.state.roster.RosterSignatures;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.hapi.streams.RecordStreamItem;
 import com.hedera.hapi.streams.TransactionSidecarRecord;
+import com.hedera.node.app.blocks.BlockHashSigner;
 import com.hedera.node.app.blocks.BlockItemWriter;
 import com.hedera.node.app.blocks.impl.BlockImplUtils;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
@@ -44,6 +52,7 @@ import com.hedera.node.config.data.StakingConfig;
 import com.hedera.node.config.data.VersionConfig;
 import com.hedera.node.config.types.StreamMode;
 import com.hedera.node.internal.network.PendingProof;
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.stream.LinkedObjectStreamUtilities;
 import com.swirlds.platform.system.InitTrigger;
@@ -56,6 +65,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -108,7 +118,9 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
     private final AtomicReference<QuiescenceCommand> lastQuiescenceCommand = new AtomicReference<>(DONT_QUIESCE);
     private final StreamMode streamMode;
     private final int maxSideCarSizeInBytes;
+    private final int recordFileVersion;
     private final WrappedRecordFileBlockHashesDiskWriter wrappedRecordHashesDiskWriter;
+    private final BlockHashSigner blockHashSigner;
 
     /**
      * Supplier of a fresh {@link BlockItemWriter} (in practice a {@code GrpcBlockItemWriter}) used to forward
@@ -124,12 +136,8 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
     /**
      * Holds the open {@link BlockItemWriter} for each WRB whose header + record-file items have been written
      * but whose {@code BlockFooter} / {@code BlockProof} have not yet been produced. Keyed by block number.
-     * Drained on shutdown via {@link BlockItemWriter#flushPendingBlock}.
-     *
-     * <p>TODO(#24774 follow-up under epic #24381): the follow-up that produces {@code BlockFooter} +
-     * {@code BlockProof} and calls {@code closeCompleteBlock} on the writer is also responsible for
-     * removing the corresponding entry from this map. Until that follow-up lands, this map grows
-     * unboundedly while the {@code streamWrappedRecordBlocks} flag is enabled.
+     * Drained on shutdown via {@link BlockItemWriter#flushPendingBlock}; removed when the RSA proof is written
+     * and the block is closed.
      */
     private final Map<Long, BlockItemWriter> openWrbWriters = new ConcurrentHashMap<>();
 
@@ -173,6 +181,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
             @NonNull final Platform platform,
             @NonNull final WrappedRecordFileBlockHashesDiskWriter wrappedRecordHashesDiskWriter,
             @NonNull final Supplier<BlockItemWriter> wrbWriterSupplier,
+            @NonNull final BlockHashSigner blockHashSigner,
             @NonNull final InitTrigger initTrigger) {
         this.platform = platform;
         requireNonNull(state);
@@ -182,6 +191,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
         this.configProvider = requireNonNull(configProvider);
         this.wrappedRecordHashesDiskWriter = requireNonNull(wrappedRecordHashesDiskWriter);
         this.wrbWriterSupplier = requireNonNull(wrbWriterSupplier);
+        this.blockHashSigner = requireNonNull(blockHashSigner);
         final var config = configProvider.getConfiguration();
         final var blockStreamConfig = config.getConfigData(BlockStreamConfig.class);
         this.streamMode = blockStreamConfig.streamMode();
@@ -196,6 +206,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
         this.blockPeriodInSeconds = recordStreamConfig.logPeriod();
         this.numBlockHashesToKeepBytes = recordStreamConfig.numOfBlockHashesInState() * HASH_SIZE;
         this.maxSideCarSizeInBytes = recordStreamConfig.sidecarMaxSizeMb() * 1024 * 1024;
+        this.recordFileVersion = recordStreamConfig.recordFileVersion();
 
         final RunningHashes lastRunningHashes;
         if (initTrigger == InitTrigger.GENESIS) {
@@ -674,21 +685,21 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
         final var result = WrappedRecordFileBlockHashesCalculator.computeWithItems(input);
         final var entry = result.hashes();
 
+        final Bytes previousBlockRootHash = requireNonNull(previousWrappedRecordBlockRootHash);
         // Compute the all-previous-blocks root hash from the hasher BEFORE adding this block
         final Bytes allPrevBlocksRootHash = Bytes.wrap(prevWrappedRecordBlockHashes.computeRootHash());
 
         // Compute the wrapped record block root hash for this block
         final Bytes blockRootHash =
-                computeWrappedRecordBlockRootHash(previousWrappedRecordBlockRootHash, allPrevBlocksRootHash, entry);
+                computeWrappedRecordBlockRootHash(previousBlockRootHash, allPrevBlocksRootHash, entry);
 
         // Update running state: add this block's root hash as a leaf to the streaming hasher
         prevWrappedRecordBlockHashes.addNodeByHash(requireNonNull(blockRootHash).toByteArray());
         previousWrappedRecordBlockRootHash = requireNonNull(blockRootHash);
 
         // If enabled, forward the WRB items to a GrpcBlockItemWriter so they reach the BlockBufferService
-        // and onward to block nodes. The block is intentionally left open: BlockFooter / BlockProof items
-        // and the eventual closeCompleteBlock are produced by a follow-up step (issue #24774 follow-up
-        // under epic #24381).
+        // and onward to block nodes. The block is left open until the RSA signature-list future can complete
+        // it with a BlockFooter and BlockProof.
         if (streamWrbEnabled) {
             try {
                 final var writer = wrbWriterSupplier.get();
@@ -696,7 +707,8 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
                 writer.writePbjItem(result.headerItem());
                 writer.writePbjItem(result.recordFileItem());
                 openWrbWriters.put(justFinishedBlockNumber, writer);
-                submitWrappedRecordBlockRsaSignaturePlaceholder(justFinishedBlockNumber, blockRootHash);
+                signAndCloseWrbAsync(
+                        justFinishedBlockNumber, blockRootHash, previousBlockRootHash, allPrevBlocksRootHash);
             } catch (final RuntimeException e) {
                 // Never let WRB streaming failures take down record-stream production
                 logger.warn(
@@ -707,17 +719,88 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
     }
 
     /**
-     * Placeholder for the RSA signature system transaction that will eventually be submitted on the network
-     * for each wrapped record block. The full implementation (encoding via {@code Hedera.encodeSystemTransaction}
-     * and submission via {@code transactionPool.submitPriorityTransaction}) is tracked as a follow-up to
-     * issue #24774 under epic #24381.
+     * Initiates signing process over the wrapped record block hash and, once enough signatures are gathered,
+     * closes the WRB block with a footer and {@link SignedRecordFileProof}.
      */
-    private void submitWrappedRecordBlockRsaSignaturePlaceholder(
-            final long blockNumber, @NonNull final Bytes blockRootHash) {
-        // TODO(#24774 follow-up under epic #24381): build a node-signed system transaction carrying this
-        // node's RSA signature over blockRootHash, encode via Hedera.encodeSystemTransaction(...), and
-        // submit via transactionPool.submitPriorityTransaction(...).
-        logger.debug("WRB RSA signature placeholder for block {} (root {})", blockNumber, blockRootHash);
+    private void signAndCloseWrbAsync(
+            final long blockNumber,
+            @NonNull final Bytes blockRootHash,
+            @NonNull final Bytes previousBlockRootHash,
+            @NonNull final Bytes allPrevBlocksRootHash) {
+        requireNonNull(blockRootHash);
+        requireNonNull(previousBlockRootHash);
+        requireNonNull(allPrevBlocksRootHash);
+        try {
+            final var attempt = blockHashSigner.sign(blockRootHash, LIST_OF_PARTIAL_SIGNATURES);
+            attempt.signatureFuture()
+                    .thenAcceptAsync(serializedRosterSignatures -> finishWrappedRecordBlockWithSignatureList(
+                            blockNumber,
+                            blockRootHash,
+                            previousBlockRootHash,
+                            allPrevBlocksRootHash,
+                            serializedRosterSignatures))
+                    .exceptionally(t -> {
+                        logger.warn(
+                                "Unhandled exception while signing WRB block #{} with hash {}",
+                                blockNumber,
+                                blockRootHash,
+                                t);
+                        return null;
+                    });
+        } catch (final RuntimeException e) {
+            logger.warn(
+                    "Failed to request RSA signature list for WRB block #{} with hash {}",
+                    blockNumber,
+                    blockRootHash,
+                    e);
+        }
+    }
+
+    private void finishWrappedRecordBlockWithSignatureList(
+            final long blockNumber,
+            @NonNull final Bytes blockRootHash,
+            @NonNull final Bytes previousBlockRootHash,
+            @NonNull final Bytes allPrevBlocksRootHash,
+            @NonNull final Bytes serializedRosterSignatures) {
+        final var writer = openWrbWriters.get(blockNumber);
+        if (writer == null) {
+            logger.debug(
+                    "Ignoring RSA signature list for already finalized WRB block #{} with hash {}",
+                    blockNumber,
+                    blockRootHash);
+            return;
+        }
+        final var footer = BlockFooter.newBuilder()
+                .previousBlockRootHash(previousBlockRootHash)
+                .rootHashOfAllBlockHashesTree(allPrevBlocksRootHash)
+                .startOfBlockStateRootHash(HASH_OF_ZERO)
+                .build();
+        final var footerItem = BlockItem.newBuilder().blockFooter(footer).build();
+        writer.writePbjItem(footerItem);
+        final var proofItem = signedRecordFileProofItem(blockNumber, serializedRosterSignatures);
+        writer.writePbjItem(proofItem);
+        writer.closeCompleteBlock();
+        openWrbWriters.remove(blockNumber, writer);
+    }
+
+    private BlockItem signedRecordFileProofItem(
+            final long blockNumber, @NonNull final Bytes serializedRosterSignatures) {
+        requireNonNull(serializedRosterSignatures);
+        final RosterSignatures rosterSignatures;
+        try {
+            rosterSignatures = RosterSignatures.PROTOBUF.parse(serializedRosterSignatures);
+        } catch (final ParseException e) {
+            throw new CompletionException("Unable to parse RSA signature list for WRB block #" + blockNumber, e);
+        }
+        final var recordFileSignatures = rosterSignatures.nodeSignatures().stream()
+                .map(nodeSignature -> new RecordFileSignature(nodeSignature.nodeSignature(), nodeSignature.nodeId()))
+                .toList();
+        final var signedRecordFileProof = new SignedRecordFileProof(recordFileVersion, recordFileSignatures);
+        final var proof = BlockProof.newBuilder()
+                .block(blockNumber)
+                .signedRecordFileProof(signedRecordFileProof)
+                .build();
+        return BlockItem.newBuilder().blockProof(proof).build();
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -65,6 +65,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -140,6 +141,11 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
      * and the block is closed.
      */
     private final Map<Long, BlockItemWriter> openWrbWriters = new ConcurrentHashMap<>();
+    /**
+     * Futures for the legacy record file hashes signed by {@code BlockRecordWriter} close. Keyed by block number.
+     * WRB RSA signing waits on these futures so its signature list covers exactly the legacy record file hash.
+     */
+    private final Map<Long, CompletableFuture<Bytes>> recordFileHashFutures = new ConcurrentHashMap<>();
 
     private Bytes currentBlockStartRunningHash;
     private final List<RecordStreamItem> currentBlockRecordStreamItems = new ArrayList<>();
@@ -283,6 +289,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
             }
         }
         openWrbWriters.clear();
+        recordFileHashFutures.clear();
     }
 
     // =================================================================================================================
@@ -560,8 +567,10 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
      * @param consensusTime the consensus time at which to switch to the current block
      */
     public void switchBlocksAt(@NonNull final Instant consensusTime) {
-        final long blockNo = lastBlockInfo.lastBlockNumber() + 1;
-        streamFileProducer.switchBlocks(lastBlockInfo.lastBlockNumber(), blockNo, consensusTime);
+        final long closedBlockNo = lastBlockInfo.lastBlockNumber();
+        final long blockNo = closedBlockNo + 1;
+        final var recordFileHashFuture = streamFileProducer.switchBlocks(closedBlockNo, blockNo, consensusTime);
+        observeRecordFileHash(closedBlockNo, recordFileHashFuture);
         if (streamMode == RECORDS) {
             quiescenceController.finishHandlingInProgressBlock();
             // All no-ops below if quiescence is disabled
@@ -570,6 +579,29 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
                 quiescenceController.blockFullySigned(blockNo - 1);
             }
         }
+    }
+
+    private void observeRecordFileHash(
+            final long blockNumber, @NonNull final CompletableFuture<Bytes> recordFileHashFuture) {
+        requireNonNull(recordFileHashFuture);
+        if (!streamWrbEnabled) {
+            return;
+        }
+        final var pending = recordFileHashFutures.get(blockNumber);
+        if (pending == null) {
+            // For blocks that started WRB RSA signing, signAndCloseWrbAsync() creates this future before
+            // switchBlocksAt() observes the writer close result. A missing future means no WRB signing pipeline was
+            // started for this block (e.g. empty records, restart boundary, disabled/gated wrapping, or writer setup
+            // failure), so there is nothing to complete.
+            return;
+        }
+        recordFileHashFuture.whenComplete((recordFileHash, t) -> {
+            if (t != null) {
+                pending.completeExceptionally(t);
+            } else {
+                pending.complete(requireNonNull(recordFileHash));
+            }
+        });
     }
 
     /**
@@ -719,7 +751,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
     }
 
     /**
-     * Initiates signing process over the wrapped record block hash and, once enough signatures are gathered,
+     * Initiates signing process over the legacy record file hash and, once enough signatures are gathered,
      * closes the WRB block with a footer and {@link SignedRecordFileProof}.
      */
     private void signAndCloseWrbAsync(
@@ -730,29 +762,37 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
         requireNonNull(blockRootHash);
         requireNonNull(previousBlockRootHash);
         requireNonNull(allPrevBlocksRootHash);
+        final var recordFileHashFuture =
+                recordFileHashFutures.computeIfAbsent(blockNumber, ignore -> new CompletableFuture<>());
+        recordFileHashFuture
+                .whenComplete((ignore, t) -> recordFileHashFutures.remove(blockNumber, recordFileHashFuture))
+                .thenCompose(recordFileHash -> requestRecordFileSignatureList(blockNumber, recordFileHash))
+                .thenAcceptAsync(serializedRosterSignatures -> finishWrappedRecordBlockWithSignatureList(
+                        blockNumber,
+                        blockRootHash,
+                        previousBlockRootHash,
+                        allPrevBlocksRootHash,
+                        serializedRosterSignatures))
+                .exceptionally(t -> {
+                    logger.warn(
+                            "Unhandled exception while signing WRB block #{} after record file close", blockNumber, t);
+                    return null;
+                });
+    }
+
+    private CompletableFuture<Bytes> requestRecordFileSignatureList(
+            final long blockNumber, @NonNull final Bytes recordFileHash) {
+        requireNonNull(recordFileHash);
         try {
-            final var attempt = blockHashSigner.sign(blockRootHash, LIST_OF_PARTIAL_SIGNATURES);
-            attempt.signatureFuture()
-                    .thenAcceptAsync(serializedRosterSignatures -> finishWrappedRecordBlockWithSignatureList(
-                            blockNumber,
-                            blockRootHash,
-                            previousBlockRootHash,
-                            allPrevBlocksRootHash,
-                            serializedRosterSignatures))
-                    .exceptionally(t -> {
-                        logger.warn(
-                                "Unhandled exception while signing WRB block #{} with hash {}",
-                                blockNumber,
-                                blockRootHash,
-                                t);
-                        return null;
-                    });
+            final var attempt = blockHashSigner.sign(recordFileHash, LIST_OF_PARTIAL_SIGNATURES);
+            return attempt.signatureFuture();
         } catch (final RuntimeException e) {
             logger.warn(
-                    "Failed to request RSA signature list for WRB block #{} with hash {}",
+                    "Failed to request RSA signature list for WRB block #{} with record file hash {}",
                     blockNumber,
-                    blockRootHash,
+                    recordFileHash,
                     e);
+            return CompletableFuture.failedFuture(e);
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordStreamProducer.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordStreamProducer.java
@@ -7,6 +7,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 /**
@@ -55,8 +56,9 @@ public interface BlockRecordStreamProducer extends AutoCloseable {
      * @param newBlockFirstTransactionConsensusTime The consensus time of the first <b>user</b> transaction in the new
      *                                              block. It must be the adjusted consensus time not the platform
      *                                              assigned consensus time, if the two are different.
+     * @return a future that completes with the record file hash signed while closing the previous block
      */
-    void switchBlocks(
+    CompletableFuture<Bytes> switchBlocks(
             long lastBlockNumber, long newBlockNumber, @NonNull Instant newBlockFirstTransactionConsensusTime);
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockRecordWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/BlockRecordWriter.java
@@ -3,6 +3,7 @@ package com.hedera.node.app.records.impl.producers;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.streams.HashObject;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.UncheckedIOException;
 import java.time.Instant;
@@ -54,8 +55,9 @@ public interface BlockRecordWriter {
      * {@link #init(SemanticVersion, HashObject, Instant, long)}.
      *
      * @param endRunningHash  the ending running hash after the last record stream item
+     * @return the record file hash signed by this writer
      * @throws IllegalStateException if called before {@link #init(SemanticVersion, HashObject, Instant, long)}.
      * @throws UncheckedIOException if there is an error writing to the destination
      */
-    void close(@NonNull HashObject endRunningHash);
+    Bytes close(@NonNull HashObject endRunningHash);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerConcurrent.java
@@ -3,6 +3,7 @@ package com.hedera.node.app.records.impl.producers;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
@@ -16,6 +17,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -37,6 +39,15 @@ import org.apache.logging.log4j.Logger;
 public final class StreamFileProducerConcurrent implements BlockRecordStreamProducer {
     /** Simple pair class */
     record TwoResults<A, B>(A a, B b) {}
+
+    /**
+     * The result of closing a record file writer. Includes the last running hash so the next writer can still be
+     * opened with the correct starting hash even if closing the previous writer failed.
+     */
+    record CloseResult(
+            @NonNull Bytes lastRunningHash,
+            @Nullable Bytes recordFileHash,
+            @Nullable Throwable failure) {}
 
     /** The logger */
     private static final Logger logger = LogManager.getLogger(StreamFileProducerConcurrent.class);
@@ -131,7 +142,7 @@ public final class StreamFileProducerConcurrent implements BlockRecordStreamProd
 
     /** {@inheritDoc} */
     @Override
-    public void switchBlocks(
+    public CompletableFuture<Bytes> switchBlocks(
             final long lastBlockNumber,
             final long newBlockNumber,
             @NonNull final Instant newBlockFirstTransactionConsensusTime) {
@@ -152,23 +163,41 @@ public final class StreamFileProducerConcurrent implements BlockRecordStreamProd
                 // one which creates a new file and writes initializes it in the background
                 currentRecordFileWriter = lastRecordHashingResult.thenApply(lastRunningHash -> createBlockRecordWriter(
                         lastRunningHash, newBlockFirstTransactionConsensusTime, newBlockNumber));
+                return completedFuture(Bytes.EMPTY);
             } else {
                 // Reassign our fileWriter future to a future that will complete once:
                 //   (1) The running hash of the last record in the current block is available; and,
                 //   (2) We have finished writing and closed the current block's record file.
                 // The VALUE of this future, when it completes, will be the writer for the file of
                 // the new block we are just starting.
-                currentRecordFileWriter = currentRecordFileWriter
-                        .thenCombine(lastRecordHashingResult, TwoResults::new)
+                final var closingRecordHashingResult = lastRecordHashingResult;
+                final var closeResult = currentRecordFileWriter
+                        .thenCombine(closingRecordHashingResult, TwoResults::new)
                         .thenApplyAsync(
                                 twoResults -> {
                                     final var writer = twoResults.a();
                                     final var lastRunningHash = twoResults.b();
-                                    closeWriter(writer, lastRunningHash);
-                                    return createBlockRecordWriter(
-                                            lastRunningHash, newBlockFirstTransactionConsensusTime, newBlockNumber);
+                                    return closeWriter(writer, lastRunningHash);
                                 },
-                                executorService);
+                                executorService)
+                        .exceptionally(t -> {
+                            final var cause =
+                                    t instanceof CompletionException && t.getCause() != null ? t.getCause() : t;
+                            return new CloseResult(closingRecordHashingResult.join(), null, cause);
+                        });
+                currentRecordFileWriter = closeResult.thenApplyAsync(
+                        result -> {
+                            if (result.failure() != null) {
+                                logger.error(
+                                        "Error closing record file writer for block {}",
+                                        lastBlockNumber,
+                                        result.failure());
+                            }
+                            return createBlockRecordWriter(
+                                    result.lastRunningHash(), newBlockFirstTransactionConsensusTime, newBlockNumber);
+                        },
+                        executorService);
+                return recordFileHashFuture(closeResult);
             }
         } finally {
             lock.unlock(); // Always unlock.
@@ -258,7 +287,13 @@ public final class StreamFileProducerConcurrent implements BlockRecordStreamProd
                         .thenAccept(aVoid -> {
                             final var writer = currentRecordFileWriter.join();
                             final var lastRunningHash = lastRecordHashingResult.join();
-                            closeWriter(writer, lastRunningHash);
+                            final var result = closeWriter(writer, lastRunningHash);
+                            if (result.failure() != null) {
+                                logger.error(
+                                        "Error closing record file writer for block {}",
+                                        currentBlockNumber,
+                                        result.failure());
+                            }
                         })
                         .join();
 
@@ -290,17 +325,27 @@ public final class StreamFileProducerConcurrent implements BlockRecordStreamProd
         }
     }
 
-    private void closeWriter(BlockRecordWriter writer, Bytes lastRunningHash) {
+    private CloseResult closeWriter(BlockRecordWriter writer, Bytes lastRunningHash) {
         // An error here is bad news. But at least, let us catch this error and log it, and
         // move forward with the next block.
         try {
-            writer.close(asHashObject(lastRunningHash));
+            return new CloseResult(lastRunningHash, writer.close(asHashObject(lastRunningHash)), null);
         } catch (final Exception e) {
-            logger.error("Error closing record file writer", e);
+            return new CloseResult(lastRunningHash, null, e);
         }
     }
 
     private HashObject asHashObject(@NonNull final Bytes hash) {
         return new HashObject(HashAlgorithm.SHA_384, (int) hash.length(), hash);
+    }
+
+    private static CompletableFuture<Bytes> recordFileHashFuture(@NonNull final CompletableFuture<CloseResult> future) {
+        requireNonNull(future);
+        return future.thenCompose(result -> {
+            if (result.failure() != null) {
+                return failedFuture(result.failure());
+            }
+            return completedFuture(requireNonNull(result.recordFileHash()));
+        });
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/StreamFileProducerSingleThreaded.java
@@ -2,6 +2,8 @@
 package com.hedera.node.app.records.impl.producers;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
@@ -13,6 +15,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import org.apache.logging.log4j.LogManager;
@@ -70,7 +73,7 @@ public final class StreamFileProducerSingleThreaded implements BlockRecordStream
 
     /** {@inheritDoc} */
     @Override
-    public void switchBlocks(
+    public CompletableFuture<Bytes> switchBlocks(
             final long lastBlockNumber,
             final long newBlockNumber,
             @NonNull final Instant newBlockFirstTransactionConsensusTime) {
@@ -82,12 +85,13 @@ public final class StreamFileProducerSingleThreaded implements BlockRecordStream
         requireNonNull(newBlockFirstTransactionConsensusTime);
         this.currentBlockNumber = newBlockNumber;
         final var lastRunningHash = asHashObject(getRunningHash());
-        closeWriter(lastRunningHash, lastBlockNumber);
+        final var closedRecordFileHash = closeWriter(lastRunningHash, lastBlockNumber);
         openWriter(newBlockNumber, lastRunningHash, newBlockFirstTransactionConsensusTime);
         logger.debug(
                 "Initializing block record writer for block {} with running hash {}",
                 currentBlockNumber,
                 lastRunningHash);
+        return closedRecordFileHash;
     }
 
     /** {@inheritDoc} */
@@ -173,7 +177,8 @@ public final class StreamFileProducerSingleThreaded implements BlockRecordStream
         return new HashObject(HashAlgorithm.SHA_384, (int) hash.length(), hash);
     }
 
-    private void closeWriter(@NonNull final HashObject lastRunningHash, final long lastBlockNumber) {
+    private CompletableFuture<Bytes> closeWriter(
+            @NonNull final HashObject lastRunningHash, final long lastBlockNumber) {
         if (writer != null) {
             logger.debug(
                     "Closing block record writer for block {} with running hash {}", lastBlockNumber, lastRunningHash);
@@ -182,11 +187,13 @@ public final class StreamFileProducerSingleThreaded implements BlockRecordStream
             // Make sure this is logged. In the FUTURE we may need to do something more drastic, like shut down the
             // node, or maybe retry a number of times before giving up.
             try {
-                writer.close(lastRunningHash);
+                return completedFuture(writer.close(lastRunningHash));
             } catch (final Exception e) {
                 logger.error("Error closing block record writer for block {}", lastBlockNumber, e);
+                return failedFuture(e);
             }
         }
+        return completedFuture(Bytes.EMPTY);
     }
 
     private void openWriter(

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
@@ -242,7 +242,7 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
 
     /** {@inheritDoc} */
     @Override
-    public void close(@NonNull final HashObject endRunningHash) {
+    public Bytes close(@NonNull final HashObject endRunningHash) {
         if (state != State.OPEN) {
             throw new IllegalStateException("Cannot close a BlockRecordWriterV6 that is not open");
         }
@@ -262,10 +262,11 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
             if (gzipOutputStream != null) gzipOutputStream.close();
             fileOutputStream.close();
 
+            final var recordFileHash = Bytes.wrap(hashingOutputStream.getDigest());
             // write signature file, this tells the uploader that this record file set is complete
             writeSignatureFile(
                     recordFilePath,
-                    Bytes.wrap(hashingOutputStream.getDigest()),
+                    recordFileHash,
                     signer,
                     true,
                     6,
@@ -275,6 +276,7 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
                     endRunningHash.hash());
 
             this.state = State.CLOSED;
+            return recordFileHash;
         } catch (final IOException e) {
             logger.warn("Error closing record file {}", recordFilePath, e);
             throw new UncheckedIOException(e);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/DualBlockHashSigner.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/DualBlockHashSigner.java
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.tss;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.blocks.BlockHashSigner;
+import com.hedera.node.app.hints.impl.BlockHashSigning;
+import com.hedera.node.app.hints.impl.RsaContext;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * A {@link BlockHashSigner} that delegates succinct signature requests and directly orchestrates RSA
+ * list-of-partial-signature requests.
+ */
+public class DualBlockHashSigner implements BlockHashSigner {
+    private static final Logger log = LogManager.getLogger(DualBlockHashSigner.class);
+
+    private final RsaContext rsaContext;
+    private final ConcurrentMap<Bytes, BlockHashSigning> rsaSignings;
+    private final TssSubmissions submissions;
+    private final BlockHashSigner succinctSignatureDelegate;
+
+    public DualBlockHashSigner(
+            @NonNull final RsaContext rsaContext,
+            @NonNull final ConcurrentMap<Bytes, BlockHashSigning> rsaSignings,
+            @NonNull final TssSubmissions submissions,
+            @NonNull final BlockHashSigner succinctSignatureDelegate) {
+        this.rsaContext = requireNonNull(rsaContext);
+        this.rsaSignings = requireNonNull(rsaSignings);
+        this.submissions = requireNonNull(submissions);
+        this.succinctSignatureDelegate = requireNonNull(succinctSignatureDelegate);
+    }
+
+    @Override
+    public boolean isReady() {
+        return succinctSignatureDelegate.isReady() && rsaContext.isReady();
+    }
+
+    @Override
+    public Attempt sign(@NonNull final Bytes blockHash, @NonNull final Request request) {
+        requireNonNull(blockHash);
+        requireNonNull(request);
+        return switch (request) {
+            case SUCCINCT_SIGNATURE -> succinctSignatureDelegate.sign(blockHash, request);
+            case LIST_OF_PARTIAL_SIGNATURES -> {
+                if (!rsaContext.isReady()) {
+                    throw new IllegalStateException("RSA signing context not ready to sign block hash " + blockHash);
+                }
+                final var signing = rsaSignings.computeIfAbsent(
+                        blockHash, b -> rsaContext.newSigning(b, () -> rsaSignings.remove(blockHash)));
+                if (!(signing instanceof RsaContext.Signing rsaSigning)) {
+                    throw new IllegalStateException("RSA signing required for block hash " + blockHash);
+                }
+                submissions.submitRsaSignature(blockHash).exceptionally(t -> {
+                    log.warn("Failed to submit RSA signature for block hash {}", blockHash, t);
+                    return null;
+                });
+                yield new Attempt(null, null, rsaSigning.future());
+            }
+        };
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/TssBlockHashSigner.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/TssBlockHashSigner.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.tss;
 
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.SUCCINCT_SIGNATURE;
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.node.config.types.StreamMode.RECORDS;
 import static java.util.Objects.requireNonNull;
@@ -93,8 +94,12 @@ public class TssBlockHashSigner implements BlockHashSigner {
     }
 
     @Override
-    public Attempt sign(@NonNull final Bytes blockHash) {
+    public Attempt sign(@NonNull final Bytes blockHash, @NonNull final Request request) {
         requireNonNull(blockHash);
+        requireNonNull(request);
+        if (request != SUCCINCT_SIGNATURE) {
+            throw new IllegalArgumentException("TSS signer only supports succinct block hash signatures");
+        }
         if (!isReady()) {
             throw new IllegalStateException("TSS protocol not ready to sign block hash " + blockHash);
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/TssBlockHashSigner.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/TssBlockHashSigner.java
@@ -7,6 +7,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.blocks.BlockHashSigner;
 import com.hedera.node.app.hints.HintsService;
+import com.hedera.node.app.hints.impl.HintsContext;
 import com.hedera.node.app.history.HistoryService;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockStreamConfig;
@@ -101,7 +102,9 @@ public class TssBlockHashSigner implements BlockHashSigner {
         if (tssConfig.forceMockSignatures() || hintsService == null) {
             return new Attempt(null, null, CompletableFuture.supplyAsync(() -> noThrowSha384HashOf(blockHash)));
         } else {
-            final var signing = hintsService.sign(blockHash);
+            if (!(hintsService.sign(blockHash) instanceof HintsContext.Signing signing)) {
+                throw new IllegalStateException("hinTS signing required for TSS block hash " + blockHash);
+            }
             if (historyService == null) {
                 return new Attempt(signing.verificationKey(), null, signing.future());
             } else {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/TssSubmissions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/TssSubmissions.java
@@ -5,9 +5,12 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.hapi.services.auxiliary.hints.HintsPartialSignatureTransactionBody;
+import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.node.app.spi.AppContext;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.NetworkAdminConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -16,6 +19,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hiero.base.crypto.Signature;
 
 /**
  * Base class for submitting node transactions to the network within an application context using a given executor.
@@ -25,6 +29,8 @@ public class TssSubmissions {
 
     private final Executor executor;
     private final AppContext appContext;
+    private final BiConsumer<TransactionBody, String> onFailure =
+            (body, reason) -> log.warn("Failed to submit {} ({})", body, reason);
 
     public TssSubmissions(@NonNull final Executor executor, @NonNull final AppContext appContext) {
         this.executor = requireNonNull(executor);
@@ -67,5 +73,45 @@ public class TssSubmissions {
                         adminConfig.distinctTxnIdsToTry(),
                         adminConfig.retryDelay(),
                         onFailure);
+    }
+
+    /**
+     * Signs the given bytes with the node's platform RSA signing key.
+     *
+     * @param bytes the bytes to sign
+     * @return the platform signature
+     */
+    protected Signature sign(@NonNull final byte[] bytes) {
+        return appContext.gossip().sign(bytes);
+    }
+
+    /**
+     * Attempts to submit an RSA signature using the node's platform signing key.
+     *
+     * @param message the message to sign
+     * @return a future that completes when the signature has been submitted
+     */
+    public CompletableFuture<Void> submitRsaSignature(@NonNull final Bytes message) {
+        return submitRsaSignature(message, onFailure);
+    }
+
+    /**
+     * Attempts to submit an RSA signature using the node's platform signing key.
+     *
+     * @param message the message to sign
+     * @param onFailure a consumer to call if the transaction fails to submit
+     * @return a future that completes when the signature has been submitted
+     */
+    protected CompletableFuture<Void> submitRsaSignature(
+            @NonNull final Bytes message, @NonNull final BiConsumer<TransactionBody, String> onFailure) {
+        requireNonNull(message);
+        requireNonNull(onFailure);
+        return submitIfActive(
+                b -> {
+                    final var signature = sign(message.toByteArray()).getBytes();
+                    b.hintsPartialSignature(new HintsPartialSignatureTransactionBody(
+                            RsaContext.CONSTRUCTION_ID, message, requireNonNull(signature)));
+                },
+                onFailure);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutors.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutors.java
@@ -292,7 +292,9 @@ public enum TransactionExecutors {
                 ForkJoinPool.commonPool(),
                 appContext,
                 new HintsLibraryImpl(),
-                bootstrapConfig.getConfigData(BlockStreamConfig.class).blockPeriod());
+                bootstrapConfig.getConfigData(BlockStreamConfig.class).blockPeriod(),
+                new com.hedera.node.app.hints.impl.RsaContext(appContext.configSupplier()),
+                new java.util.concurrent.ConcurrentHashMap<>());
         final var historyService =
                 new HistoryServiceImpl(NO_OP_METRICS, ForkJoinPool.commonPool(), appContext, new HistoryLibraryImpl());
         final var standaloneNetworkInfo = new StandaloneNetworkInfo(configProvider);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
@@ -3,6 +3,7 @@ package com.hedera.node.app.blocks.impl;
 
 import static com.hedera.hapi.util.HapiUtils.asInstant;
 import static com.hedera.hapi.util.HapiUtils.asTimestamp;
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.SUCCINCT_SIGNATURE;
 import static com.hedera.node.app.blocks.BlockStreamManager.HASH_OF_ZERO;
 import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.NONE;
 import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.POST_UPGRADE_WORK;
@@ -26,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
@@ -380,7 +382,7 @@ class BlockStreamManagerImplTest {
         subject.writeItem(FAKE_RECORD_FILE_ITEM);
 
         // Immediately resolve to the expected ledger signature
-        given(blockHashSigner.sign(any(), any()))
+        given(blockHashSigner.sign(any(), eq(SUCCINCT_SIGNATURE)))
                 .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
@@ -392,6 +394,7 @@ class BlockStreamManagerImplTest {
         // End the round
         subject.endRound(state, ROUND_NO);
 
+        verify(blockHashSigner).sign(any(), eq(SUCCINCT_SIGNATURE));
         verify(aWriter).openBlock(N_BLOCK_NO);
 
         // Assert the internal state of the subject has changed as expected and the writer has been closed

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
@@ -380,7 +380,8 @@ class BlockStreamManagerImplTest {
         subject.writeItem(FAKE_RECORD_FILE_ITEM);
 
         // Immediately resolve to the expected ledger signature
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -469,7 +470,7 @@ class BlockStreamManagerImplTest {
         subject.endRound(state, ROUND_NO);
 
         // Verify signer was checked but never asked to sign
-        verify(blockHashSigner, never()).sign(any());
+        verify(blockHashSigner, never()).sign(any(), any());
     }
 
     @Test
@@ -495,7 +496,8 @@ class BlockStreamManagerImplTest {
         subject.writeItem(FAKE_STATE_CHANGES);
 
         final CompletableFuture<Void> postAcceptFuture = (CompletableFuture<Void>) mock(CompletableFuture.class);
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         given(mockSigningFuture.thenAcceptAsync(any())).willReturn(postAcceptFuture);
 
         assertTrue(subject.endRound(state, ROUND_NO));
@@ -551,7 +553,7 @@ class BlockStreamManagerImplTest {
         subject.writeItem(FAKE_RECORD_FILE_ITEM);
 
         // Immediately resolve to the expected ledger signature
-        given(blockHashSigner.sign(any()))
+        given(blockHashSigner.sign(any(), any()))
                 .willReturn(new BlockHashSigner.Attempt(null, null, completedFuture(FIRST_FAKE_SIGNATURE)));
         // End the round
         subject.endRound(state, ROUND_NO);
@@ -647,7 +649,8 @@ class BlockStreamManagerImplTest {
         }
 
         // Immediately resolve to the expected ledger signature
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -731,7 +734,7 @@ class BlockStreamManagerImplTest {
         final CompletableFuture<Bytes> secondSignature = (CompletableFuture<Bytes>) mock(CompletableFuture.class);
         given(firstSignature.thenAcceptAsync(any())).willReturn(completedFuture(null));
         given(secondSignature.thenAcceptAsync(any())).willReturn(completedFuture(null));
-        given(blockHashSigner.sign(any()))
+        given(blockHashSigner.sign(any(), any()))
                 .willReturn(new BlockHashSigner.Attempt(null, null, firstSignature))
                 .willReturn(new BlockHashSigner.Attempt(null, null, secondSignature));
         // End the round in block N
@@ -800,7 +803,8 @@ class BlockStreamManagerImplTest {
         given(blockHashSigner.isReady()).willReturn(true);
 
         // Set up the signature future to complete immediately and run the callback synchronously
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -890,7 +894,8 @@ class BlockStreamManagerImplTest {
                         PlatformState.newBuilder().latestFreezeRound(ROUND_NO).build());
 
         // Set up the signature future to complete immediately and run the callback synchronously
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -931,7 +936,8 @@ class BlockStreamManagerImplTest {
         given(blockHashSigner.isReady()).willReturn(true);
 
         // Set up the signature future to complete immediately and run the callback synchronously
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -1005,7 +1011,8 @@ class BlockStreamManagerImplTest {
         given(blockHashSigner.isReady()).willReturn(true);
 
         // Set up the signature future to complete immediately
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -1076,7 +1083,7 @@ class BlockStreamManagerImplTest {
         given(blockHashSigner.isReady()).willReturn(true);
 
         // Set up the signature future to complete immediately
-        given(blockHashSigner.sign(any()))
+        given(blockHashSigner.sign(any(), any()))
                 .willReturn(new BlockHashSigner.Attempt(
                         Bytes.EMPTY,
                         ChainOfTrustProof.newBuilder()
@@ -1141,7 +1148,7 @@ class BlockStreamManagerImplTest {
         given(blockHashSigner.isReady()).willReturn(true);
 
         // Set up the signature future
-        given(blockHashSigner.sign(any()))
+        given(blockHashSigner.sign(any(), any()))
                 .willReturn(new BlockHashSigner.Attempt(
                         Bytes.EMPTY,
                         ChainOfTrustProof.newBuilder()
@@ -1216,7 +1223,7 @@ class BlockStreamManagerImplTest {
         final CompletableFuture<Bytes> secondSignature = (CompletableFuture<Bytes>) mock(CompletableFuture.class);
         given(firstSignature.thenAcceptAsync(any())).willReturn(completedFuture(null));
         given(secondSignature.thenAcceptAsync(any())).willReturn(completedFuture(null));
-        given(blockHashSigner.sign(any()))
+        given(blockHashSigner.sign(any(), any()))
                 .willReturn(new BlockHashSigner.Attempt(Bytes.EMPTY, ChainOfTrustProof.DEFAULT, firstSignature))
                 .willReturn(new BlockHashSigner.Attempt(Bytes.EMPTY, ChainOfTrustProof.DEFAULT, secondSignature));
 
@@ -1291,7 +1298,8 @@ class BlockStreamManagerImplTest {
         givenEndOfRoundSetup(null, 1L);
         given(blockHashSigner.isReady()).willReturn(true);
         // Set up the async signature to return control to this test immediately upon completion
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -1329,7 +1337,8 @@ class BlockStreamManagerImplTest {
         givenEndOfRoundSetup();
         given(blockHashSigner.isReady()).willReturn(true);
         // Set up the async signature to return control to this test immediately upon completion
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -1374,7 +1383,8 @@ class BlockStreamManagerImplTest {
         givenEndOfRoundSetup();
         given(blockHashSigner.isReady()).willReturn(true);
         // Set up the async signature to return control to this test immediately upon completion
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);
@@ -1545,7 +1555,8 @@ class BlockStreamManagerImplTest {
                 aWriter);
         givenEndOfRoundSetup();
         lenient().when(blockHashSigner.isReady()).thenReturn(true);
-        given(blockHashSigner.sign(any())).willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
         doAnswer(invocationOnMock -> {
                     final Consumer<Bytes> consumer = invocationOnMock.getArgument(0);
                     consumer.accept(FIRST_FAKE_SIGNATURE);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/components/IngestComponentTest.java
@@ -134,7 +134,9 @@ class IngestComponentTest {
                 ForkJoinPool.commonPool(),
                 appContext,
                 new HintsLibraryImpl(),
-                DEFAULT_CONFIG.getConfigData(BlockStreamConfig.class).blockPeriod());
+                DEFAULT_CONFIG.getConfigData(BlockStreamConfig.class).blockPeriod(),
+                new com.hedera.node.app.hints.impl.RsaContext(appContext.configSupplier()),
+                new java.util.concurrent.ConcurrentHashMap<>());
         final var historyService =
                 new HistoryServiceImpl(NO_OP_METRICS, ForkJoinPool.commonPool(), appContext, new HistoryLibraryImpl());
         final var state = new FakeState();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/handlers/HintsPartialSignatureHandlerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/handlers/HintsPartialSignatureHandlerTest.java
@@ -18,7 +18,9 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.services.auxiliary.hints.HintsPartialSignatureTransactionBody;
 import com.hedera.node.app.hints.ReadableHintsStore;
+import com.hedera.node.app.hints.impl.BlockHashSigning;
 import com.hedera.node.app.hints.impl.HintsContext;
+import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.node.app.spi.info.NodeInfo;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -51,8 +53,17 @@ class HintsPartialSignatureHandlerTest {
             .partialSignature(PARTIAL_SIGNATURE)
             .build();
 
+    private static final HintsPartialSignatureTransactionBody RSA_OP = HintsPartialSignatureTransactionBody.newBuilder()
+            .constructionId(RsaContext.CONSTRUCTION_ID)
+            .message(MESSAGE)
+            .partialSignature(PARTIAL_SIGNATURE)
+            .build();
+
     @Mock
     private HintsContext hintsContext;
+
+    @Mock
+    private RsaContext rsaContext;
 
     @Mock
     private PureChecksContext pureChecksContext;
@@ -81,14 +92,21 @@ class HintsPartialSignatureHandlerTest {
     @Mock
     private HintsContext.Signing signing;
 
-    private ConcurrentMap<Bytes, HintsContext.Signing> signings;
+    @Mock
+    private RsaContext.Signing rsaSigning;
+
+    private ConcurrentMap<Bytes, BlockHashSigning> signings;
+
+    private ConcurrentMap<Bytes, BlockHashSigning> rsaSignings;
 
     HintsPartialSignatureHandler subject;
 
     @BeforeEach
     void setUp() {
         signings = new ConcurrentHashMap<>();
-        subject = new HintsPartialSignatureHandler(Duration.ofSeconds(2), signings, hintsContext);
+        rsaSignings = new ConcurrentHashMap<>();
+        subject = new HintsPartialSignatureHandler(
+                Duration.ofSeconds(2), signings, rsaSignings, hintsContext, rsaContext);
 
         final var body = TransactionBody.newBuilder().hintsPartialSignature(OP).build();
         lenient().when(preHandleContext.body()).thenReturn(body);
@@ -119,13 +137,28 @@ class HintsPartialSignatureHandlerTest {
     void constructorRejectsNullDependencies() {
         assertThrows(
                 NullPointerException.class,
-                () -> new HintsPartialSignatureHandler(null, new ConcurrentHashMap<>(), hintsContext));
+                () -> new HintsPartialSignatureHandler(
+                        null, new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), hintsContext, rsaContext));
         assertThrows(
                 NullPointerException.class,
-                () -> new HintsPartialSignatureHandler(Duration.ofSeconds(2), null, hintsContext));
+                () -> new HintsPartialSignatureHandler(
+                        Duration.ofSeconds(2), null, new ConcurrentHashMap<>(), hintsContext, rsaContext));
         assertThrows(
                 NullPointerException.class,
-                () -> new HintsPartialSignatureHandler(Duration.ofSeconds(2), new ConcurrentHashMap<>(), null));
+                () -> new HintsPartialSignatureHandler(
+                        Duration.ofSeconds(2), new ConcurrentHashMap<>(), null, hintsContext, rsaContext));
+        assertThrows(
+                NullPointerException.class,
+                () -> new HintsPartialSignatureHandler(
+                        Duration.ofSeconds(2), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), null, rsaContext));
+        assertThrows(
+                NullPointerException.class,
+                () -> new HintsPartialSignatureHandler(
+                        Duration.ofSeconds(2),
+                        new ConcurrentHashMap<>(),
+                        new ConcurrentHashMap<>(),
+                        hintsContext,
+                        null));
     }
 
     @Test
@@ -194,6 +227,37 @@ class HintsPartialSignatureHandlerTest {
     }
 
     @Test
+    void preHandleNonDeterministicValidRsaSignatureCreatesAndIncorporatesSigning() {
+        givenRsaOp();
+        given(tssConfig.useDeterministicHintsSignatures()).willReturn(false);
+        given(rsaContext.validate(NODE_ID, RSA_OP)).willReturn(true);
+        given(rsaContext.newSigning(eq(MESSAGE), any(Runnable.class))).willReturn(rsaSigning);
+
+        assertDoesNotThrow(() -> subject.preHandle(preHandleContext));
+
+        verify(rsaContext).validate(NODE_ID, RSA_OP);
+        verify(rsaContext).newSigning(eq(MESSAGE), any(Runnable.class));
+        verify(rsaSigning).incorporateValid(Bytes.EMPTY, NODE_ID, PARTIAL_SIGNATURE);
+        verify(hintsContext, never()).constructionIdOrThrow();
+        assertSame(rsaSigning, rsaSignings.get(MESSAGE));
+        assertTrue(signings.isEmpty());
+    }
+
+    @Test
+    void preHandleNonDeterministicInvalidRsaSignatureDoesNotIncorporate() {
+        givenRsaOp();
+        given(tssConfig.useDeterministicHintsSignatures()).willReturn(false);
+        given(rsaContext.validate(NODE_ID, RSA_OP)).willReturn(false);
+
+        assertDoesNotThrow(() -> subject.preHandle(preHandleContext));
+
+        verify(rsaContext).validate(NODE_ID, RSA_OP);
+        verify(rsaContext, never()).newSigning(any(), any());
+        assertTrue(rsaSignings.isEmpty());
+        assertTrue(signings.isEmpty());
+    }
+
+    @Test
     void deterministicFlowCachesValidResultFromPreHandleForHandle() {
         given(tssConfig.useDeterministicHintsSignatures()).willReturn(true);
         given(hintsContext.validate(eq(NODE_ID), eq(CRS), any(HintsPartialSignatureTransactionBody.class)))
@@ -243,6 +307,36 @@ class HintsPartialSignatureHandlerTest {
         verify(hintsContext, never()).validate(anyLong(), any(), any());
         verify(hintsContext, never()).newSigning(any(), any());
         assertTrue(signings.isEmpty());
+    }
+
+    @Test
+    void handleDeterministicValidRsaSignatureCreatesAndIncorporatesSigning() {
+        givenRsaOp();
+        given(tssConfig.useDeterministicHintsSignatures()).willReturn(true);
+        given(rsaContext.validate(NODE_ID, RSA_OP)).willReturn(true);
+        given(rsaContext.newSigning(eq(MESSAGE), any(Runnable.class))).willReturn(rsaSigning);
+
+        subject.handle(handleContext);
+
+        verify(rsaContext).validate(NODE_ID, RSA_OP);
+        verify(rsaContext).newSigning(eq(MESSAGE), any(Runnable.class));
+        verify(rsaSigning).incorporateValid(Bytes.EMPTY, NODE_ID, PARTIAL_SIGNATURE);
+        verify(handleContext, never()).storeFactory();
+        assertSame(rsaSigning, rsaSignings.get(MESSAGE));
+        assertTrue(signings.isEmpty());
+    }
+
+    @Test
+    void handleDeterministicValidRsaSignatureReusesExistingSigning() {
+        givenRsaOp();
+        given(tssConfig.useDeterministicHintsSignatures()).willReturn(true);
+        given(rsaContext.validate(NODE_ID, RSA_OP)).willReturn(true);
+        rsaSignings.put(MESSAGE, rsaSigning);
+
+        subject.handle(handleContext);
+
+        verify(rsaContext, never()).newSigning(any(), any());
+        verify(rsaSigning).incorporateValid(Bytes.EMPTY, NODE_ID, PARTIAL_SIGNATURE);
     }
 
     @Test
@@ -328,5 +422,12 @@ class HintsPartialSignatureHandlerTest {
         verify(hintsContext, never()).newSigning(any(), any());
         verifyNoInteractions(signing);
         assertTrue(signings.isEmpty());
+    }
+
+    private void givenRsaOp() {
+        final var body =
+                TransactionBody.newBuilder().hintsPartialSignature(RSA_OP).build();
+        lenient().when(preHandleContext.body()).thenReturn(body);
+        lenient().when(handleContext.body()).thenReturn(body);
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/handlers/HintsPartialSignatureHandlerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/handlers/HintsPartialSignatureHandlerTest.java
@@ -258,6 +258,19 @@ class HintsPartialSignatureHandlerTest {
     }
 
     @Test
+    void preHandleDeterministicRsaSignatureDoesNothing() {
+        givenRsaOp();
+        given(tssConfig.useDeterministicHintsSignatures()).willReturn(true);
+
+        assertDoesNotThrow(() -> subject.preHandle(preHandleContext));
+
+        verifyNoInteractions(rsaContext);
+        verify(hintsContext, never()).constructionIdOrThrow();
+        assertTrue(rsaSignings.isEmpty());
+        assertTrue(signings.isEmpty());
+    }
+
+    @Test
     void deterministicFlowCachesValidResultFromPreHandleForHandle() {
         given(tssConfig.useDeterministicHintsSignatures()).willReturn(true);
         given(hintsContext.validate(eq(NODE_ID), eq(CRS), any(HintsPartialSignatureTransactionBody.class)))
@@ -310,6 +323,19 @@ class HintsPartialSignatureHandlerTest {
     }
 
     @Test
+    void handleNonDeterministicRsaSignatureDoesNothing() {
+        givenRsaOp();
+        given(tssConfig.useDeterministicHintsSignatures()).willReturn(false);
+
+        subject.handle(handleContext);
+
+        verifyNoInteractions(rsaContext);
+        verify(handleContext, never()).storeFactory();
+        assertTrue(rsaSignings.isEmpty());
+        assertTrue(signings.isEmpty());
+    }
+
+    @Test
     void handleDeterministicValidRsaSignatureCreatesAndIncorporatesSigning() {
         givenRsaOp();
         given(tssConfig.useDeterministicHintsSignatures()).willReturn(true);
@@ -337,6 +363,20 @@ class HintsPartialSignatureHandlerTest {
 
         verify(rsaContext, never()).newSigning(any(), any());
         verify(rsaSigning).incorporateValid(Bytes.EMPTY, NODE_ID, PARTIAL_SIGNATURE);
+    }
+
+    @Test
+    void handleDeterministicInvalidRsaSignatureDoesNotIncorporate() {
+        givenRsaOp();
+        given(tssConfig.useDeterministicHintsSignatures()).willReturn(true);
+        given(rsaContext.validate(NODE_ID, RSA_OP)).willReturn(false);
+
+        subject.handle(handleContext);
+
+        verify(rsaContext).validate(NODE_ID, RSA_OP);
+        verify(rsaContext, never()).newSigning(any(), any());
+        verifyNoInteractions(rsaSigning);
+        assertTrue(rsaSignings.isEmpty());
     }
 
     @Test
@@ -408,6 +448,22 @@ class HintsPartialSignatureHandlerTest {
         completionCaptor.getValue().run();
 
         assertTrue(signings.isEmpty());
+    }
+
+    @Test
+    void rsaCompletionCallbackRemovesSigningEntry() {
+        givenRsaOp();
+        final var completionCaptor = ArgumentCaptor.forClass(Runnable.class);
+        given(tssConfig.useDeterministicHintsSignatures()).willReturn(false);
+        given(rsaContext.validate(NODE_ID, RSA_OP)).willReturn(true);
+        given(rsaContext.newSigning(eq(MESSAGE), completionCaptor.capture())).willReturn(rsaSigning);
+
+        assertDoesNotThrow(() -> subject.preHandle(preHandleContext));
+        assertSame(rsaSigning, rsaSignings.get(MESSAGE));
+
+        completionCaptor.getValue().run();
+
+        assertTrue(rsaSignings.isEmpty());
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsContextTest.java
@@ -138,7 +138,7 @@ class HintsContextTest {
 
         subject.setConstruction(CONSTRUCTION);
 
-        final var signing = subject.newSigning(BLOCK_HASH, () -> {});
+        final var signing = (HintsContext.Signing) subject.newSigning(BLOCK_HASH, () -> {});
         final var future = signing.future();
 
         signing.incorporateValid(CRS, A_NODE_PARTY_ID.nodeId(), signature);
@@ -175,7 +175,7 @@ class HintsContextTest {
 
         subject.setConstruction(construction);
 
-        final var signing = subject.newSigning(BLOCK_HASH, () -> {});
+        final var signing = (HintsContext.Signing) subject.newSigning(BLOCK_HASH, () -> {});
         final var future = signing.future();
 
         // Exactly half (5 out of 10 total weight): should NOT complete, need strictly > 1/2
@@ -253,7 +253,7 @@ class HintsContextTest {
 
         subject.setConstruction(CONSTRUCTION);
 
-        final var signing = subject.newSigning(BLOCK_HASH, () -> {});
+        final var signing = (HintsContext.Signing) subject.newSigning(BLOCK_HASH, () -> {});
         final var future = signing.future();
         signing.incorporateValid(CRS, D_NODE_PARTY_ID.nodeId(), signature);
 
@@ -275,7 +275,7 @@ class HintsContextTest {
 
         subject.setConstruction(CONSTRUCTION);
 
-        final var signing = subject.newSigning(BLOCK_HASH, () -> {});
+        final var signing = (HintsContext.Signing) subject.newSigning(BLOCK_HASH, () -> {});
         final var future = signing.future();
         signing.incorporateValid(CRS, D_NODE_PARTY_ID.nodeId(), signature);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsServiceImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsServiceImplTest.java
@@ -193,7 +193,7 @@ class HintsServiceImplTest {
     @Test
     void signCreatesSigningSubmitsPartialSignatureAndRemovesFromMapOnCompletion() {
         final var blockHash = Bytes.wrap("block-hash".getBytes());
-        final var signings = new ConcurrentHashMap<Bytes, HintsContext.Signing>();
+        final var signings = new ConcurrentHashMap<Bytes, BlockHashSigning>();
         given(component.signingContext()).willReturn(context);
         given(context.isReady()).willReturn(true);
         given(component.signings()).willReturn(signings);
@@ -217,7 +217,7 @@ class HintsServiceImplTest {
     @Test
     void signReusesExistingSigningForSameBlockHash() {
         final var blockHash = Bytes.wrap("same-hash".getBytes());
-        final var signings = new ConcurrentHashMap<Bytes, HintsContext.Signing>();
+        final var signings = new ConcurrentHashMap<Bytes, BlockHashSigning>();
         signings.put(blockHash, signing);
         given(component.signingContext()).willReturn(context);
         given(context.isReady()).willReturn(true);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsSubmissionsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsSubmissionsTest.java
@@ -236,6 +236,9 @@ class HintsSubmissionsTest {
         final var spec = captor.getValue();
         final var builder = TransactionBody.newBuilder();
         spec.accept(builder);
+        final ArgumentCaptor<byte[]> bytesCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(gossip).sign(bytesCaptor.capture());
+        assertArrayEquals(msg.toByteArray(), bytesCaptor.getValue());
         final var body = builder.build();
         assertTrue(body.hasHintsPartialSignature());
         final var expectedBody = HintsPartialSignatureTransactionBody.newBuilder()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsSubmissionsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsSubmissionsTest.java
@@ -22,6 +22,8 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.time.Instant;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import org.hiero.base.crypto.Signature;
+import org.hiero.base.crypto.SignatureType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -199,6 +201,45 @@ class HintsSubmissionsTest {
         assertTrue(body.hasHintsPartialSignature());
         final var expectedBody = HintsPartialSignatureTransactionBody.newBuilder()
                 .constructionId(123L)
+                .message(msg)
+                .partialSignature(sig)
+                .build();
+        assertEquals(expectedBody, body.hintsPartialSignatureOrThrow());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void usesPlatformSignerForRsaSignature() {
+        given(selfNodeInfo.accountId()).willReturn(AccountID.DEFAULT);
+        given(appContext.selfNodeInfoSupplier()).willReturn(() -> selfNodeInfo);
+        given(appContext.instantSource()).willReturn(() -> Instant.EPOCH);
+        given(appContext.configSupplier()).willReturn(() -> DEFAULT_CONFIG);
+        given(appContext.gossip()).willReturn(gossip);
+        final var msg = Bytes.wrap("M");
+        final var sig = Bytes.wrap("RSA");
+        given(gossip.sign(any(byte[].class))).willReturn(new Signature(SignatureType.RSA, sig));
+
+        subject.submitRsaSignature(msg);
+
+        final ArgumentCaptor<Consumer<TransactionBody.Builder>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(gossip)
+                .submitFuture(
+                        eq(AccountID.DEFAULT),
+                        eq(Instant.EPOCH),
+                        any(),
+                        captor.capture(),
+                        any(),
+                        anyInt(),
+                        anyInt(),
+                        any(),
+                        any());
+        final var spec = captor.getValue();
+        final var builder = TransactionBody.newBuilder();
+        spec.accept(builder);
+        final var body = builder.build();
+        assertTrue(body.hasHintsPartialSignature());
+        final var expectedBody = HintsPartialSignatureTransactionBody.newBuilder()
+                .constructionId(RsaContext.CONSTRUCTION_ID)
                 .message(msg)
                 .partialSignature(sig)
                 .build();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/RsaContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/RsaContextTest.java
@@ -76,6 +76,26 @@ class RsaContextTest {
     }
 
     @Test
+    void ignoresRosterEntriesWithoutRsaCertificates() {
+        final var roster = new Roster(
+                List.of(RosterEntry.newBuilder().nodeId(1L).weight(10L).build()));
+
+        subject.initialize(roster, nodeId -> 10L);
+
+        assertFalse(subject.isReady());
+        assertFalse(subject.validate(1L, MESSAGE, Bytes.wrap("signature")));
+        assertThrows(IllegalStateException.class, () -> subject.newSigning(MESSAGE, () -> {}));
+    }
+
+    @Test
+    void rejectsNegativeWeights() throws Exception {
+        final var keys = KeysAndCertsGenerator.generate(NodeId.of(1L));
+        final var roster = new Roster(List.of(entryFor(1L, 10L, keys)));
+
+        assertThrows(IllegalArgumentException.class, () -> subject.initialize(roster, nodeId -> -1L));
+    }
+
+    @Test
     void signingUsesWeightSnapshotAndSerializesRosterSignatures() throws Exception {
         final var keys1 = KeysAndCertsGenerator.generate(NodeId.of(1L));
         final var keys2 = KeysAndCertsGenerator.generate(NodeId.of(2L));
@@ -126,6 +146,27 @@ class RsaContextTest {
                 RosterSignatures.PROTOBUF.parse(signing.future().join());
         assertEquals(1L, rosterSignatures.nodeSignatures().get(0).nodeId());
         assertEquals(2L, rosterSignatures.nodeSignatures().get(1).nodeId());
+    }
+
+    @Test
+    void zeroAndUnknownWeightSignaturesDoNotContribute() throws Exception {
+        final var keys1 = KeysAndCertsGenerator.generate(NodeId.of(1L));
+        final var keys2 = KeysAndCertsGenerator.generate(NodeId.of(2L));
+        final var roster = new Roster(List.of(entryFor(1L, 0L, keys1), entryFor(2L, 4L, keys2)));
+        final var sig1 = new PlatformSigner(keys1).sign(MESSAGE.toByteArray()).getBytes();
+        final var sig2 = new PlatformSigner(keys2).sign(MESSAGE.toByteArray()).getBytes();
+
+        subject.initialize(roster, nodeId -> nodeId == 1L ? 0L : 4L);
+        final var signing = (RsaContext.Signing) subject.newSigning(MESSAGE, () -> {});
+
+        signing.incorporateValid(Bytes.EMPTY, 1L, sig1);
+        signing.incorporateValid(Bytes.EMPTY, 3L, Bytes.wrap("unknown"));
+
+        assertFalse(signing.future().isDone());
+
+        signing.incorporateValid(Bytes.EMPTY, 2L, sig2);
+
+        assertTrue(signing.future().isDone());
     }
 
     private static RosterEntry entryFor(final long nodeId, final long weight, final KeysAndCerts keysAndCerts)

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/RsaContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/RsaContextTest.java
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.hints.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import com.hedera.hapi.node.state.roster.RosterSignatures;
+import com.hedera.hapi.services.auxiliary.hints.HintsPartialSignatureTransactionBody;
+import com.hedera.node.config.data.TssConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
+import java.util.List;
+import java.util.function.Supplier;
+import org.hiero.consensus.crypto.KeysAndCertsGenerator;
+import org.hiero.consensus.crypto.PlatformSigner;
+import org.hiero.consensus.model.node.KeysAndCerts;
+import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.roster.RosterUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RsaContextTest {
+    private static final Bytes MESSAGE = Bytes.wrap("message");
+
+    @Mock
+    private Supplier<Configuration> configProvider;
+
+    @Mock
+    private Configuration configuration;
+
+    @Mock
+    private TssConfig tssConfig;
+
+    private RsaContext subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new RsaContext(configProvider);
+        lenient().when(configProvider.get()).thenReturn(configuration);
+        lenient().when(configuration.getConfigData(TssConfig.class)).thenReturn(tssConfig);
+        lenient().when(tssConfig.signingThresholdDivisor()).thenReturn(2);
+    }
+
+    @Test
+    void notReadyUntilInitialized() {
+        assertFalse(subject.isReady());
+
+        assertThrows(IllegalStateException.class, () -> subject.newSigning(MESSAGE, () -> {}));
+    }
+
+    @Test
+    void validatesRsaSignaturesFromRoster() throws Exception {
+        final var keys = KeysAndCertsGenerator.generate(NodeId.of(1L));
+        final var roster = new Roster(List.of(entryFor(1L, 10L, keys)));
+        final var signature =
+                new PlatformSigner(keys).sign(MESSAGE.toByteArray()).getBytes();
+
+        subject.initialize(roster, nodeId -> 10L);
+
+        assertTrue(subject.isReady());
+        assertTrue(subject.validate(1L, MESSAGE, signature));
+        assertTrue(subject.validate(
+                1L, new HintsPartialSignatureTransactionBody(RsaContext.CONSTRUCTION_ID, MESSAGE, signature)));
+        assertFalse(subject.validate(1L, Bytes.wrap("wrong-message"), signature));
+        assertFalse(subject.validate(2L, MESSAGE, signature));
+        assertFalse(subject.validate(1L, new HintsPartialSignatureTransactionBody(123L, MESSAGE, signature)));
+    }
+
+    @Test
+    void signingUsesWeightSnapshotAndSerializesRosterSignatures() throws Exception {
+        final var keys1 = KeysAndCertsGenerator.generate(NodeId.of(1L));
+        final var keys2 = KeysAndCertsGenerator.generate(NodeId.of(2L));
+        final var roster = new Roster(List.of(entryFor(1L, 6L, keys1), entryFor(2L, 4L, keys2)));
+        final var sig1 = new PlatformSigner(keys1).sign(MESSAGE.toByteArray()).getBytes();
+        final var sig2 = new PlatformSigner(keys2).sign(MESSAGE.toByteArray()).getBytes();
+
+        subject.initialize(roster, nodeId -> nodeId == 1L ? 6L : 4L);
+        final var signing = (RsaContext.Signing) subject.newSigning(MESSAGE, () -> {});
+        subject.reassignWeights(nodeId -> nodeId == 1L ? 0L : 10L);
+
+        signing.incorporateValid(Bytes.EMPTY, 1L, sig1);
+
+        assertTrue(signing.future().isDone());
+        final var rosterSignatures =
+                RosterSignatures.PROTOBUF.parse(signing.future().join());
+        assertEquals(RosterUtils.hash(roster).getBytes(), rosterSignatures.rosterHash());
+        assertEquals(1, rosterSignatures.nodeSignatures().size());
+        assertEquals(1L, rosterSignatures.nodeSignatures().getFirst().nodeId());
+        assertEquals(sig1, rosterSignatures.nodeSignatures().getFirst().nodeSignature());
+
+        final var signingAfterReassign = (RsaContext.Signing) subject.newSigning(MESSAGE, () -> {});
+        signingAfterReassign.incorporateValid(Bytes.EMPTY, 1L, sig1);
+        assertFalse(signingAfterReassign.future().isDone());
+
+        signingAfterReassign.incorporateValid(Bytes.EMPTY, 2L, sig2);
+        assertTrue(signingAfterReassign.future().isDone());
+    }
+
+    @Test
+    void duplicateSignaturesDoNotAccumulateWeight() throws Exception {
+        final var keys1 = KeysAndCertsGenerator.generate(NodeId.of(1L));
+        final var keys2 = KeysAndCertsGenerator.generate(NodeId.of(2L));
+        final var roster = new Roster(List.of(entryFor(1L, 4L, keys1), entryFor(2L, 4L, keys2)));
+        final var sig1 = new PlatformSigner(keys1).sign(MESSAGE.toByteArray()).getBytes();
+        final var sig2 = new PlatformSigner(keys2).sign(MESSAGE.toByteArray()).getBytes();
+
+        subject.initialize(roster, nodeId -> 4L);
+        final var signing = (RsaContext.Signing) subject.newSigning(MESSAGE, () -> {});
+
+        signing.incorporateValid(Bytes.EMPTY, 2L, sig2);
+        signing.incorporateValid(Bytes.EMPTY, 2L, sig2);
+        assertFalse(signing.future().isDone());
+
+        signing.incorporateValid(Bytes.EMPTY, 1L, sig1);
+
+        final var rosterSignatures =
+                RosterSignatures.PROTOBUF.parse(signing.future().join());
+        assertEquals(1L, rosterSignatures.nodeSignatures().get(0).nodeId());
+        assertEquals(2L, rosterSignatures.nodeSignatures().get(1).nodeId());
+    }
+
+    private static RosterEntry entryFor(final long nodeId, final long weight, final KeysAndCerts keysAndCerts)
+            throws Exception {
+        return RosterEntry.newBuilder()
+                .nodeId(nodeId)
+                .weight(weight)
+                .gossipCaCertificate(Bytes.wrap(keysAndCerts.sigCert().getEncoded()))
+                .build();
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/RsaContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/RsaContextTest.java
@@ -96,16 +96,14 @@ class RsaContextTest {
     }
 
     @Test
-    void signingUsesWeightSnapshotAndSerializesRosterSignatures() throws Exception {
+    void signingUsesInitializedWeightsAndSerializesRosterSignatures() throws Exception {
         final var keys1 = KeysAndCertsGenerator.generate(NodeId.of(1L));
         final var keys2 = KeysAndCertsGenerator.generate(NodeId.of(2L));
         final var roster = new Roster(List.of(entryFor(1L, 6L, keys1), entryFor(2L, 4L, keys2)));
         final var sig1 = new PlatformSigner(keys1).sign(MESSAGE.toByteArray()).getBytes();
-        final var sig2 = new PlatformSigner(keys2).sign(MESSAGE.toByteArray()).getBytes();
 
         subject.initialize(roster, nodeId -> nodeId == 1L ? 6L : 4L);
         final var signing = (RsaContext.Signing) subject.newSigning(MESSAGE, () -> {});
-        subject.reassignWeights(nodeId -> nodeId == 1L ? 0L : 10L);
 
         signing.incorporateValid(Bytes.EMPTY, 1L, sig1);
 
@@ -116,13 +114,6 @@ class RsaContextTest {
         assertEquals(1, rosterSignatures.nodeSignatures().size());
         assertEquals(1L, rosterSignatures.nodeSignatures().getFirst().nodeId());
         assertEquals(sig1, rosterSignatures.nodeSignatures().getFirst().nodeSignature());
-
-        final var signingAfterReassign = (RsaContext.Signing) subject.newSigning(MESSAGE, () -> {});
-        signingAfterReassign.incorporateValid(Bytes.EMPTY, 1L, sig1);
-        assertFalse(signingAfterReassign.future().isDone());
-
-        signingAfterReassign.incorporateValid(Bytes.EMPTY, 2L, sig2);
-        assertTrue(signingAfterReassign.future().isDone());
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/WritableHintsStoreImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/WritableHintsStoreImplTest.java
@@ -477,7 +477,9 @@ class WritableHintsStoreImplTest {
                 ForkJoinPool.commonPool(),
                 appContext,
                 library,
-                DEFAULT_CONFIG.getConfigData(BlockStreamConfig.class).blockPeriod());
+                DEFAULT_CONFIG.getConfigData(BlockStreamConfig.class).blockPeriod(),
+                new RsaContext(appContext.configSupplier()),
+                new java.util.concurrent.ConcurrentHashMap<>());
         Set.of(new EntityIdServiceImpl(), hintsServiceImpl).forEach(servicesRegistry::register);
         final var migrator = new FakeServiceMigrator();
         final var bootstrapConfig = new BootstrapConfigProviderImpl().getConfiguration();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockOpeningTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockOpeningTest.java
@@ -3,6 +3,7 @@ package com.hedera.node.app.records.impl;
 
 import static com.hedera.hapi.util.HapiUtils.asTimestamp;
 import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
+import static com.hedera.node.app.records.impl.BlockRecordManagerTestFixtures.NO_OP_BLOCK_HASH_SIGNER;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCKS_STATE_ID;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING_HASHES_STATE_ID;
 import static org.hiero.consensus.model.quiescence.QuiescenceCommand.DONT_QUIESCE;
@@ -155,6 +156,7 @@ class BlockOpeningTest {
                 platform,
                 wrappedRecordHashesDiskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART);
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
@@ -2,8 +2,10 @@
 package com.hedera.node.app.records.impl;
 
 import static com.hedera.hapi.streams.schema.SidecarFileSchema.SIDECAR_RECORDS;
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.LIST_OF_PARTIAL_SIGNATURES;
 import static com.hedera.node.app.blocks.BlockStreamManager.HASH_OF_ZERO;
 import static com.hedera.node.app.records.BlockRecordService.EPOCH;
+import static com.hedera.node.app.records.impl.BlockRecordManagerTestFixtures.NO_OP_BLOCK_HASH_SIGNER;
 import static com.hedera.node.app.records.impl.producers.BlockRecordFormat.TAG_TYPE_BITS;
 import static com.hedera.node.app.records.impl.producers.BlockRecordFormat.WIRE_TYPE_DELIMITED;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCKS_STATE_ID;
@@ -17,11 +19,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.RecordFileItem;
@@ -32,6 +37,8 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.hapi.node.state.roster.NodeSignature;
+import com.hedera.hapi.node.state.roster.RosterSignatures;
 import com.hedera.hapi.platform.state.PlatformState;
 import com.hedera.hapi.streams.ContractBytecode;
 import com.hedera.hapi.streams.HashAlgorithm;
@@ -42,6 +49,7 @@ import com.hedera.hapi.streams.SidecarFile;
 import com.hedera.hapi.streams.SidecarMetadata;
 import com.hedera.hapi.streams.SidecarType;
 import com.hedera.hapi.streams.TransactionSidecarRecord;
+import com.hedera.node.app.blocks.BlockHashSigner;
 import com.hedera.node.app.blocks.BlockItemWriter;
 import com.hedera.node.app.blocks.impl.BlockImplUtils;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
@@ -66,6 +74,7 @@ import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
@@ -128,6 +137,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);
@@ -191,6 +201,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
 
             final var creationTime = new Timestamp(10, 1);
@@ -343,6 +354,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             // Trigger a block boundary immediately; since no endUserTransaction was called, there are no captured
             // items.
@@ -402,6 +414,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);
@@ -466,6 +479,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);
@@ -532,6 +546,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);
@@ -604,6 +619,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);
@@ -670,6 +686,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);
@@ -731,6 +748,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             // Trigger a block boundary without any endUserTransaction calls (empty items)
             final var t1 = InstantUtils.instant(13, 1);
@@ -815,6 +833,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART)) {
             // Drive a block boundary: start block 0 (EPOCH path), add items, cross period
             final var t0 = InstantUtils.instant(10, 1);
@@ -904,6 +923,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART)) {
             // First boundary: freeze-restart with null currentBlockStartRunningHash (preserves state)
             final var t0 = InstantUtils.instant(200, 0);
@@ -973,6 +993,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             // Open block 0 via EPOCH path
             final var t0 = InstantUtils.instant(10, 1);
@@ -1040,6 +1061,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);
@@ -1103,6 +1125,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             mgr.writeFreezeBlockWrappedRecordFileBlockHashesToDisk(state);
         }
@@ -1158,6 +1181,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);
@@ -1221,6 +1245,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART)) {
             mgr.syncFinalizedMigrationHashes(syncedPrevHash, syncedIntermediate, 1);
             // Freeze persistence should use the synced in-memory wrapped hash state.
@@ -1290,6 +1315,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART)) {
             // Open first block
             final var t0 = InstantUtils.instant(200, 1);
@@ -1367,6 +1393,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART)) {
             mgr.syncFinalizedMigrationHashes(syncedPrevHash, List.of(Bytes.wrap(new byte[48])), 1);
             mgr.writeFreezeBlockWrappedRecordFileBlockHashesToState(state);
@@ -1449,6 +1476,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART)) {
             // First boundary after restart: freeze-restart with null currentBlockStartRunningHash
             final var t0 = InstantUtils.instant(200, 0);
@@ -1514,6 +1542,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             // Open block 0 (EPOCH path), add items, cross period
             final var t0 = InstantUtils.instant(10, 1);
@@ -1583,6 +1612,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT)) {
             // Open block 0 (EPOCH path), add items, cross period boundary
             final var t0 = InstantUtils.instant(10, 1);
@@ -1722,6 +1752,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 capturingSupplier,
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT);
 
         // Block 0: emit one record at t0
@@ -1765,6 +1796,86 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
     }
 
     @Test
+    void closesWrappedRecordBlockWithRsaProofWhenSignatureListCompletes() {
+        final var app = appBuilder()
+                .withService(new BlockRecordService())
+                .withService(new PlatformStateService())
+                .withConfigValue("hedera.recordStream.liveWritePrevWrappedRecordHashes", true)
+                .withConfigValue("blockStream.streamWrappedRecordBlocks", true)
+                .build();
+
+        seedRequiredState(app);
+
+        final var state = requireNonNullState(app.workingStateAccessor().getState());
+        final var producer = new FakeStreamProducer();
+        final var controller = new QuiescenceController(
+                new QuiescenceConfig(false, Duration.ofSeconds(5)), InstantSource.system(), () -> 0);
+        final var heartbeat = new QuiescedHeartbeat(controller, app.platform());
+        final var diskWriter = mock(WrappedRecordFileBlockHashesDiskWriter.class);
+        final var blockHashSigner = mock(BlockHashSigner.class);
+        final var signatureListFuture = new CompletableFuture<Bytes>();
+        when(blockHashSigner.sign(any(), eq(LIST_OF_PARTIAL_SIGNATURES)))
+                .thenReturn(new BlockHashSigner.Attempt(null, null, signatureListFuture));
+
+        final List<BlockItemWriter> handedOutWriters = new ArrayList<>();
+        final Supplier<BlockItemWriter> capturingSupplier = () -> {
+            final var w = mock(BlockItemWriter.class);
+            handedOutWriters.add(w);
+            return w;
+        };
+
+        final var mgr = new BlockRecordManagerImpl(
+                app.configProvider(),
+                state,
+                producer,
+                controller,
+                heartbeat,
+                app.platform(),
+                diskWriter,
+                capturingSupplier,
+                blockHashSigner,
+                InitTrigger.RECONNECT);
+
+        final var t0 = InstantUtils.instant(10, 1);
+        mgr.startUserTransaction(t0, state);
+        mgr.endUserTransaction(Stream.of(sampleTxnRecord(t0, List.of())), state);
+        final var t1 = InstantUtils.instant(13, 1);
+        mgr.startUserTransaction(t1, state);
+
+        assertEquals(1, handedOutWriters.size(), "one writer should have been handed out");
+        verify(blockHashSigner).sign(any(), eq(LIST_OF_PARTIAL_SIGNATURES));
+
+        final var signatureBytes = Bytes.wrap("node-3-signature");
+        final var rosterSignatures =
+                new RosterSignatures(Bytes.wrap("roster-hash"), List.of(new NodeSignature(3L, signatureBytes)));
+        signatureListFuture.complete(RosterSignatures.PROTOBUF.toBytes(rosterSignatures));
+
+        final var writer = handedOutWriters.getFirst();
+        verify(writer, timeout(1_000)).closeCompleteBlock();
+
+        final var captor = ArgumentCaptor.forClass(BlockItem.class);
+        verify(writer, times(4)).writePbjItem(captor.capture());
+        final var items = captor.getAllValues();
+        assertNotNull(items.get(0).blockHeader(), "first item must be a BlockHeader");
+        assertNotNull(items.get(1).recordFile(), "second item must be a RecordFile");
+        final var footer = items.get(2).blockFooterOrThrow();
+        assertEquals(Bytes.EMPTY, footer.previousBlockRootHash());
+        assertEquals(HASH_OF_ZERO, footer.startOfBlockStateRootHash());
+        final var proof = items.get(3).blockProofOrThrow();
+        assertEquals(0L, proof.block());
+        assertTrue(proof.hasSignedRecordFileProof());
+        final var signedRecordFileProof = proof.signedRecordFileProofOrThrow();
+        assertEquals(6, signedRecordFileProof.version());
+        final var recordFileSignature =
+                signedRecordFileProof.recordFileSignatures().getFirst();
+        assertEquals(3L, recordFileSignature.nodeId());
+        assertEquals(signatureBytes, recordFileSignature.signaturesBytes());
+
+        mgr.close();
+        verify(writer, never()).flushPendingBlock(any(PendingProof.class));
+    }
+
+    @Test
     void closeFlushesPendingWrbWritersWhenFlagEnabled() {
         final var app = appBuilder()
                 .withService(new BlockRecordService())
@@ -1798,6 +1909,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 app.platform(),
                 diskWriter,
                 capturingSupplier,
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RECONNECT);
 
         final var t0 = InstantUtils.instant(10, 1);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
@@ -86,6 +86,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase {
+    private static final Bytes LEGACY_RECORD_FILE_HASH = Bytes.wrap("legacy-record-file-hash");
 
     @Test
     void doesNotAppendWhenFeatureFlagDisabled() {
@@ -1670,7 +1671,16 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
      * A minimal record-stream producer for tests. Keeps a constant running hash.
      */
     private static final class FakeStreamProducer implements BlockRecordStreamProducer {
+        private final CompletableFuture<Bytes> recordFileHashFuture;
         private Bytes runningHash = Bytes.wrap(new byte[48]);
+
+        private FakeStreamProducer() {
+            this(CompletableFuture.completedFuture(LEGACY_RECORD_FILE_HASH));
+        }
+
+        private FakeStreamProducer(final CompletableFuture<Bytes> recordFileHashFuture) {
+            this.recordFileHashFuture = requireNonNull(recordFileHashFuture);
+        }
 
         @Override
         public void initRunningHash(final com.hedera.hapi.node.state.blockrecords.RunningHashes runningHashes) {
@@ -1688,11 +1698,11 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
         }
 
         @Override
-        public void switchBlocks(
+        public CompletableFuture<Bytes> switchBlocks(
                 final long lastBlockNumber,
                 final long newBlockNumber,
                 final java.time.Instant newBlockFirstTransactionConsensusTime) {
-            // no-op
+            return recordFileHashFuture;
         }
 
         @Override
@@ -1807,7 +1817,8 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
         seedRequiredState(app);
 
         final var state = requireNonNullState(app.workingStateAccessor().getState());
-        final var producer = new FakeStreamProducer();
+        final var recordFileHashFuture = new CompletableFuture<Bytes>();
+        final var producer = new FakeStreamProducer(recordFileHashFuture);
         final var controller = new QuiescenceController(
                 new QuiescenceConfig(false, Duration.ofSeconds(5)), InstantSource.system(), () -> 0);
         final var heartbeat = new QuiescedHeartbeat(controller, app.platform());
@@ -1843,7 +1854,9 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
         mgr.startUserTransaction(t1, state);
 
         assertEquals(1, handedOutWriters.size(), "one writer should have been handed out");
-        verify(blockHashSigner).sign(any(), eq(LIST_OF_PARTIAL_SIGNATURES));
+        verify(blockHashSigner, never()).sign(any(), eq(LIST_OF_PARTIAL_SIGNATURES));
+        recordFileHashFuture.complete(LEGACY_RECORD_FILE_HASH);
+        verify(blockHashSigner, timeout(1_000)).sign(eq(LEGACY_RECORD_FILE_HASH), eq(LIST_OF_PARTIAL_SIGNATURES));
 
         final var signatureBytes = Bytes.wrap("node-3-signature");
         final var rosterSignatures =

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
@@ -1876,6 +1876,64 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
     }
 
     @Test
+    void leavesWrappedRecordBlockPendingWhenRsaProofCannotBeParsed() {
+        final var app = appBuilder()
+                .withService(new BlockRecordService())
+                .withService(new PlatformStateService())
+                .withConfigValue("hedera.recordStream.liveWritePrevWrappedRecordHashes", true)
+                .withConfigValue("blockStream.streamWrappedRecordBlocks", true)
+                .build();
+
+        seedRequiredState(app);
+
+        final var state = requireNonNullState(app.workingStateAccessor().getState());
+        final var producer = new FakeStreamProducer();
+        final var controller = new QuiescenceController(
+                new QuiescenceConfig(false, Duration.ofSeconds(5)), InstantSource.system(), () -> 0);
+        final var heartbeat = new QuiescedHeartbeat(controller, app.platform());
+        final var diskWriter = mock(WrappedRecordFileBlockHashesDiskWriter.class);
+        final var blockHashSigner = mock(BlockHashSigner.class);
+        final var signatureListFuture = new CompletableFuture<Bytes>();
+        when(blockHashSigner.sign(any(), eq(LIST_OF_PARTIAL_SIGNATURES)))
+                .thenReturn(new BlockHashSigner.Attempt(null, null, signatureListFuture));
+
+        final List<BlockItemWriter> handedOutWriters = new ArrayList<>();
+        final Supplier<BlockItemWriter> capturingSupplier = () -> {
+            final var w = mock(BlockItemWriter.class);
+            handedOutWriters.add(w);
+            return w;
+        };
+
+        final var mgr = new BlockRecordManagerImpl(
+                app.configProvider(),
+                state,
+                producer,
+                controller,
+                heartbeat,
+                app.platform(),
+                diskWriter,
+                capturingSupplier,
+                blockHashSigner,
+                InitTrigger.RECONNECT);
+
+        final var t0 = InstantUtils.instant(10, 1);
+        mgr.startUserTransaction(t0, state);
+        mgr.endUserTransaction(Stream.of(sampleTxnRecord(t0, List.of())), state);
+        final var t1 = InstantUtils.instant(13, 1);
+        mgr.startUserTransaction(t1, state);
+
+        final var writer = handedOutWriters.getFirst();
+        signatureListFuture.complete(Bytes.wrap(new byte[] {(byte) 0xff}));
+
+        verify(writer, timeout(1_000).times(3)).writePbjItem(any());
+        verify(writer, never()).closeCompleteBlock();
+
+        mgr.close();
+
+        verify(writer).flushPendingBlock(PendingProof.DEFAULT);
+    }
+
+    @Test
     void closeFlushesPendingWrbWritersWhenFlagEnabled() {
         final var app = appBuilder()
                 .withService(new BlockRecordService())

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerTestFixtures.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerTestFixtures.java
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.records.impl;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.blocks.BlockHashSigner;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.CompletableFuture;
+
+public final class BlockRecordManagerTestFixtures {
+    public static final BlockHashSigner NO_OP_BLOCK_HASH_SIGNER = new BlockHashSigner() {
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public Attempt sign(@NonNull final Bytes blockHash, @NonNull final Request request) {
+            requireNonNull(blockHash);
+            requireNonNull(request);
+            return new Attempt(null, null, new CompletableFuture<>());
+        }
+    };
+
+    private BlockRecordManagerTestFixtures() {}
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/DualBlockHashSignerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/DualBlockHashSignerTest.java
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.tss;
+
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.LIST_OF_PARTIAL_SIGNATURES;
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.SUCCINCT_SIGNATURE;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.hedera.node.app.blocks.BlockHashSigner;
+import com.hedera.node.app.hints.impl.BlockHashSigning;
+import com.hedera.node.app.hints.impl.RsaContext;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DualBlockHashSignerTest {
+    private static final Bytes BLOCK_HASH = Bytes.wrap("block-hash");
+    private static final Bytes RSA_SIGNATURES = Bytes.wrap("rsa-signatures");
+
+    @Mock
+    private RsaContext rsaContext;
+
+    @Mock
+    private TssSubmissions submissions;
+
+    @Mock
+    private BlockHashSigner succinctSignatureDelegate;
+
+    @Mock
+    private RsaContext.Signing rsaSigning;
+
+    private ConcurrentHashMap<Bytes, BlockHashSigning> rsaSignings;
+    private DualBlockHashSigner subject;
+
+    @BeforeEach
+    void setUp() {
+        rsaSignings = new ConcurrentHashMap<>();
+        subject = new DualBlockHashSigner(rsaContext, rsaSignings, submissions, succinctSignatureDelegate);
+    }
+
+    @Test
+    void isReadyRequiresBothSuccinctDelegateAndRsaContext() {
+        given(succinctSignatureDelegate.isReady()).willReturn(true);
+        given(rsaContext.isReady()).willReturn(true);
+
+        assertTrue(subject.isReady());
+
+        given(rsaContext.isReady()).willReturn(false);
+
+        assertFalse(subject.isReady());
+
+        given(succinctSignatureDelegate.isReady()).willReturn(false);
+
+        assertFalse(subject.isReady());
+    }
+
+    @Test
+    void delegatesSuccinctSignatureRequests() {
+        final var attempt =
+                new BlockHashSigner.Attempt(Bytes.EMPTY, null, CompletableFuture.completedFuture(Bytes.EMPTY));
+        given(succinctSignatureDelegate.sign(BLOCK_HASH, SUCCINCT_SIGNATURE)).willReturn(attempt);
+
+        assertSame(attempt, subject.sign(BLOCK_HASH, SUCCINCT_SIGNATURE));
+        verifyNoInteractions(rsaContext, submissions);
+    }
+
+    @Test
+    void listOfPartialSignaturesThrowsIfRsaContextIsNotReady() {
+        given(rsaContext.isReady()).willReturn(false);
+
+        assertThrows(IllegalStateException.class, () -> subject.sign(BLOCK_HASH, LIST_OF_PARTIAL_SIGNATURES));
+        verifyNoInteractions(submissions);
+    }
+
+    @Test
+    void listOfPartialSignaturesCreatesRsaSigningSubmitsSignatureAndRemovesFromMapOnCompletion() {
+        given(rsaContext.isReady()).willReturn(true);
+        given(rsaContext.newSigning(eq(BLOCK_HASH), any(Runnable.class))).willReturn(rsaSigning);
+        given(submissions.submitRsaSignature(BLOCK_HASH)).willReturn(CompletableFuture.completedFuture(null));
+        given(rsaSigning.future()).willReturn(CompletableFuture.completedFuture(RSA_SIGNATURES));
+
+        final var attempt = subject.sign(BLOCK_HASH, LIST_OF_PARTIAL_SIGNATURES);
+
+        assertNull(attempt.verificationKey());
+        assertNull(attempt.chainOfTrustProof());
+        assertSame(RSA_SIGNATURES, attempt.signatureFuture().join());
+        assertSame(rsaSigning, rsaSignings.get(BLOCK_HASH));
+        final var onCompletion = ArgumentCaptor.forClass(Runnable.class);
+        verify(rsaContext).newSigning(eq(BLOCK_HASH), onCompletion.capture());
+        verify(submissions).submitRsaSignature(BLOCK_HASH);
+
+        onCompletion.getValue().run();
+
+        assertFalse(rsaSignings.containsKey(BLOCK_HASH));
+    }
+
+    @Test
+    void listOfPartialSignaturesReusesExistingRsaSigning() {
+        rsaSignings.put(BLOCK_HASH, rsaSigning);
+        given(rsaContext.isReady()).willReturn(true);
+        given(submissions.submitRsaSignature(BLOCK_HASH)).willReturn(CompletableFuture.completedFuture(null));
+        given(rsaSigning.future()).willReturn(CompletableFuture.completedFuture(RSA_SIGNATURES));
+
+        final var attempt = subject.sign(BLOCK_HASH, LIST_OF_PARTIAL_SIGNATURES);
+
+        assertSame(RSA_SIGNATURES, attempt.signatureFuture().join());
+        verify(rsaContext, never()).newSigning(any(), any(Runnable.class));
+        verify(submissions).submitRsaSignature(BLOCK_HASH);
+    }
+
+    @Test
+    void rejectsNullArguments() {
+        assertThrows(NullPointerException.class, () -> subject.sign(null, SUCCINCT_SIGNATURE));
+        assertThrows(NullPointerException.class, () -> subject.sign(BLOCK_HASH, null));
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/DualBlockHashSignerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/DualBlockHashSignerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.node.app.blocks.BlockHashSigner;
 import com.hedera.node.app.hints.impl.BlockHashSigning;
+import com.hedera.node.app.hints.impl.HintsContext;
 import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.util.concurrent.CompletableFuture;
@@ -44,6 +45,9 @@ class DualBlockHashSignerTest {
 
     @Mock
     private RsaContext.Signing rsaSigning;
+
+    @Mock
+    private HintsContext.Signing hintsSigning;
 
     private ConcurrentHashMap<Bytes, BlockHashSigning> rsaSignings;
     private DualBlockHashSigner subject;
@@ -122,6 +126,17 @@ class DualBlockHashSignerTest {
         assertSame(RSA_SIGNATURES, attempt.signatureFuture().join());
         verify(rsaContext, never()).newSigning(any(), any(Runnable.class));
         verify(submissions).submitRsaSignature(BLOCK_HASH);
+    }
+
+    @Test
+    void listOfPartialSignaturesRejectsNonRsaSigningInMap() {
+        rsaSignings.put(BLOCK_HASH, hintsSigning);
+        given(rsaContext.isReady()).willReturn(true);
+
+        assertThrows(IllegalStateException.class, () -> subject.sign(BLOCK_HASH, LIST_OF_PARTIAL_SIGNATURES));
+
+        verify(rsaContext, never()).newSigning(any(), any(Runnable.class));
+        verifyNoInteractions(submissions);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/TssBlockHashSignerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/TssBlockHashSignerTest.java
@@ -16,6 +16,7 @@ import com.hedera.hapi.node.state.history.ChainOfTrustProof;
 import com.hedera.node.app.hapi.utils.CommonUtils;
 import com.hedera.node.app.hints.HintsService;
 import com.hedera.node.app.hints.impl.HintsContext;
+import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.node.app.history.HistoryService;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
@@ -46,6 +47,9 @@ class TssBlockHashSignerTest {
 
     @Mock
     private HintsContext.Signing signing;
+
+    @Mock
+    private RsaContext.Signing rsaSigning;
 
     private TssBlockHashSigner subject;
 
@@ -176,6 +180,15 @@ class TssBlockHashSignerTest {
         givenSubjectWith(HintsEnabled.NO, HistoryEnabled.NO);
 
         assertThrows(IllegalArgumentException.class, () -> subject.sign(FAKE_BLOCK_HASH, LIST_OF_PARTIAL_SIGNATURES));
+    }
+
+    @Test
+    void rejectsNonHintsSigningReturnedByHintsService() {
+        givenSubjectWith(HintsEnabled.YES, HistoryEnabled.NO);
+        given(hintsService.isReady()).willReturn(true);
+        given(hintsService.sign(FAKE_BLOCK_HASH)).willReturn(rsaSigning);
+
+        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE));
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/TssBlockHashSignerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/TssBlockHashSignerTest.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.tss;
 
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.LIST_OF_PARTIAL_SIGNATURES;
+import static com.hedera.node.app.blocks.BlockHashSigner.Request.SUCCINCT_SIGNATURE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -68,7 +70,9 @@ class TssBlockHashSignerTest {
 
         assertTrue(subject.isReady());
 
-        final var signature = subject.sign(FAKE_BLOCK_HASH).signatureFuture().join();
+        final var signature = subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE)
+                .signatureFuture()
+                .join();
 
         assertEquals(FAKE_HINTS_SIGNATURE, signature);
     }
@@ -79,14 +83,14 @@ class TssBlockHashSignerTest {
         final var verificationKey = Bytes.wrap("verification-key");
 
         assertFalse(subject.isReady());
-        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH));
+        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE));
         given(hintsService.isReady()).willReturn(true);
         assertTrue(subject.isReady());
         given(signing.future()).willReturn(CompletableFuture.completedFuture(FAKE_HINTS_SIGNATURE));
         given(signing.verificationKey()).willReturn(verificationKey);
         given(hintsService.sign(FAKE_BLOCK_HASH)).willReturn(signing);
 
-        final var attempt = subject.sign(FAKE_BLOCK_HASH);
+        final var attempt = subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE);
         final var signature = attempt.signatureFuture().join();
 
         assertSame(FAKE_HINTS_SIGNATURE, signature);
@@ -99,11 +103,13 @@ class TssBlockHashSignerTest {
         givenSubjectWith(HintsEnabled.NO, HistoryEnabled.YES);
 
         assertFalse(subject.isReady());
-        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH));
+        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE));
         given(historyService.isReady()).willReturn(true);
         assertTrue(subject.isReady());
 
-        final var signature = subject.sign(FAKE_BLOCK_HASH).signatureFuture().join();
+        final var signature = subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE)
+                .signatureFuture()
+                .join();
 
         assertEquals(FAKE_HINTS_SIGNATURE, signature);
     }
@@ -117,10 +123,10 @@ class TssBlockHashSignerTest {
                 .build();
 
         assertFalse(subject.isReady());
-        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH));
+        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE));
         given(historyService.isReady()).willReturn(true);
         assertFalse(subject.isReady());
-        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH));
+        assertThrows(IllegalStateException.class, () -> subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE));
         given(hintsService.isReady()).willReturn(true);
         assertTrue(subject.isReady());
         given(signing.future()).willReturn(CompletableFuture.completedFuture(FAKE_HINTS_SIGNATURE));
@@ -128,7 +134,7 @@ class TssBlockHashSignerTest {
         given(hintsService.sign(FAKE_BLOCK_HASH)).willReturn(signing);
         given(historyService.getCurrentChainOfTrustProof(verificationKey)).willReturn(chainOfTrustProof);
 
-        final var attempt = subject.sign(FAKE_BLOCK_HASH);
+        final var attempt = subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE);
         final var signature = attempt.signatureFuture().join();
 
         assertEquals(FAKE_HINTS_SIGNATURE, signature);
@@ -143,7 +149,7 @@ class TssBlockHashSignerTest {
         assertTrue(subject.isReady());
         assertTrue(subject.isReady());
 
-        final var attempt = subject.sign(FAKE_BLOCK_HASH);
+        final var attempt = subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE);
 
         assertNull(attempt.verificationKey());
         assertNull(attempt.chainOfTrustProof());
@@ -157,7 +163,7 @@ class TssBlockHashSignerTest {
 
         assertTrue(subject.isReady());
 
-        final var attempt = subject.sign(FAKE_BLOCK_HASH);
+        final var attempt = subject.sign(FAKE_BLOCK_HASH, SUCCINCT_SIGNATURE);
 
         assertNull(attempt.verificationKey());
         assertNull(attempt.chainOfTrustProof());
@@ -166,10 +172,18 @@ class TssBlockHashSignerTest {
     }
 
     @Test
+    void rejectsListOfPartialSignatureRequests() {
+        givenSubjectWith(HintsEnabled.NO, HistoryEnabled.NO);
+
+        assertThrows(IllegalArgumentException.class, () -> subject.sign(FAKE_BLOCK_HASH, LIST_OF_PARTIAL_SIGNATURES));
+    }
+
+    @Test
     void rejectsNullBlockHash() {
         givenSubjectWith(HintsEnabled.NO, HistoryEnabled.NO);
 
-        assertThrows(NullPointerException.class, () -> subject.sign(null));
+        assertThrows(NullPointerException.class, () -> subject.sign(null, SUCCINCT_SIGNATURE));
+        assertThrows(NullPointerException.class, () -> subject.sign(FAKE_BLOCK_HASH, null));
     }
 
     private void givenSubjectWith(

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -12,6 +12,7 @@ import static com.hedera.node.app.records.RecordTestData.STARTING_RUNNING_HASH_O
 import static com.hedera.node.app.records.RecordTestData.TEST_BLOCKS;
 import static com.hedera.node.app.records.RecordTestData.USER_PUBLIC_KEY;
 import static com.hedera.node.app.records.impl.BlockRecordInfoUtils.HASH_SIZE;
+import static com.hedera.node.app.records.impl.BlockRecordManagerTestFixtures.NO_OP_BLOCK_HASH_SIGNER;
 import static com.hedera.node.app.records.impl.producers.formats.v6.RecordStreamV6Verifier.validateRecordStreamFiles;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCKS_STATE_ID;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCKS_STATE_LABEL;
@@ -227,6 +228,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                 platform,
                 wrappedRecordHashesDiskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART)) {
             if (!startMode.equals("GENESIS")) {
                 blockRecordManager.switchBlocksAt(FORCED_BLOCK_SWITCH_TIME);
@@ -326,6 +328,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                 platform,
                 wrappedRecordHashesDiskWriter,
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART)) {
             blockRecordManager.switchBlocksAt(FORCED_BLOCK_SWITCH_TIME);
             // write a blocks & record files
@@ -518,6 +521,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                 platform,
                 mock(WrappedRecordFileBlockHashesDiskWriter.class),
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART);
 
         final var result = subject.consTimeOfLastHandledTxn();
@@ -545,6 +549,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                 platform,
                 mock(WrappedRecordFileBlockHashesDiskWriter.class),
                 () -> mock(BlockItemWriter.class),
+                NO_OP_BLOCK_HASH_SIGNER,
                 InitTrigger.RESTART);
 
         final var result = subject.consTimeOfLastHandledTxn();
@@ -636,6 +641,7 @@ final class BlockRecordManagerTest extends AppTestBase {
                     platform,
                     diskWriter,
                     () -> mock(BlockItemWriter.class),
+                    NO_OP_BLOCK_HASH_SIGNER,
                     trigger);
         }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/StreamFileProducerTest.java
@@ -257,7 +257,7 @@ abstract class StreamFileProducerTest extends AppTestBase {
         void errorClosingWriter() throws Exception {
             subject = createStreamProducer(() -> new BlockRecordWriterDummy() {
                 @Override
-                public void close(@NonNull final HashObject endRunningHash) {
+                public Bytes close(@NonNull final HashObject endRunningHash) {
                     throw new RuntimeException("Close throws!");
                 }
             });
@@ -320,12 +320,13 @@ abstract class StreamFileProducerTest extends AppTestBase {
         }
 
         @Override
-        public void close(@NonNull final HashObject endRunningHash) {
+        public Bytes close(@NonNull final HashObject endRunningHash) {
             assertThat(initialized).isTrue();
             assertThat(closed).isFalse();
             assertThat(endRunningHash).isNotNull();
             this.endRunningHash = endRunningHash;
             this.closed = true;
+            return Bytes.wrap("record-file-hash");
         }
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
@@ -317,7 +317,7 @@ final class BlockRecordWriterV6Test extends AppTestBase {
                 if (!rec.transactionSidecarRecords().isEmpty()) hasSidecars = true;
             }
             final var endRunningHash = new HashObject(HashAlgorithm.SHA_384, (int) previousHash.length(), previousHash);
-            writer.close(endRunningHash);
+            final var signedRecordFileHash = writer.close(endRunningHash);
 
             // read written file and validate hashes
             final var readRecordStreamFile =
@@ -343,6 +343,7 @@ final class BlockRecordWriterV6Test extends AppTestBase {
             final var messageDigest = MessageDigest.getInstance(DigestType.SHA_384.algorithmName());
             final var fileBytes = new GZIPInputStream(Files.newInputStream(recordPath)).readAllBytes();
             byte[] fileHash = messageDigest.digest(fileBytes);
+            assertThat(signedRecordFileHash).isEqualTo(Bytes.wrap(fileHash));
             final var dupe = fileSystem.getPath("/sigCheck.rcd");
             SignatureWriterV6.writeSignatureFile(
                     dupe,

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
@@ -15,7 +15,6 @@ import java.time.Duration;
  * @param streamMode Value of RECORDS disables the block stream; BOTH enables it
  * @param writerMode if we are writing to a file or gRPC stream
  * @param blockFileDir directory to store block files
- * @param hashCombineBatchSize the number of items to hash in a batch
  * @param roundsPerBlock the number of rounds per block
  * @param blockPeriod the block period
  * @param receiptEntriesBatchSize the maximum number of receipts to accumulate in a {@link com.hedera.hapi.node.state.recordcache.TransactionReceiptEntries} wrapper before writing a queue state changes item to the block stream
@@ -35,9 +34,6 @@ public record BlockStreamConfig(
 
         @ConfigProperty(defaultValue = "/opt/hgcapp/blockStreams") @NodeProperty
         String blockFileDir,
-
-        @ConfigProperty(defaultValue = "32") @NetworkProperty
-        int hashCombineBatchSize,
 
         @ConfigProperty(defaultValue = "1") @NetworkProperty int roundsPerBlock,
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -280,7 +280,8 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
                 new FakeServiceMigrator(),
                 this::now,
                 DiskStartupNetworks::new,
-                (appContext, bootstrapConfig) -> this.hintsService = new FakeHintsService(appContext, bootstrapConfig),
+                (appContext, bootstrapConfig, rsaContext, rsaSignings) ->
+                        this.hintsService = new FakeHintsService(appContext, bootstrapConfig, rsaContext, rsaSignings),
                 (appContext, bootstrapConfig) -> this.historyService = new FakeHistoryService(appContext),
                 (rsaContext, rsaSignings, submissions, delegate) -> this.blockHashSigner = new LapsingBlockHashSigner(
                         new DualBlockHashSigner(rsaContext, rsaSignings, submissions, delegate)),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -21,6 +21,7 @@ import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.hints.impl.HintsServiceImpl;
 import com.hedera.node.app.history.impl.HistoryServiceImpl;
 import com.hedera.node.app.info.DiskStartupNetworks;
+import com.hedera.node.app.tss.DualBlockHashSigner;
 import com.hedera.node.internal.network.Network;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -114,8 +115,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     protected FakeHistoryService historyService;
     /**
      * Non-final because the compiler can't tell that the {@link com.hedera.node.app.Hedera.BlockHashSignerFactory}
-     * lambda we give the {@link Hedera} constructor will always set this (the fake's delegate will ultimately need
-     * needs to be constructed from the Hedera instance's {@code HintsService} and {@code HistoryService}).
+     * lambda we give the {@link Hedera} constructor will always set this.
      */
     protected LapsingBlockHashSigner blockHashSigner;
 
@@ -282,8 +282,8 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
                 DiskStartupNetworks::new,
                 (appContext, bootstrapConfig) -> this.hintsService = new FakeHintsService(appContext, bootstrapConfig),
                 (appContext, bootstrapConfig) -> this.historyService = new FakeHistoryService(appContext),
-                (hints, history, configProvider) ->
-                        this.blockHashSigner = new LapsingBlockHashSigner(hints, history, configProvider),
+                (rsaContext, rsaSignings, submissions, delegate) -> this.blockHashSigner = new LapsingBlockHashSigner(
+                        new DualBlockHashSigner(rsaContext, rsaSignings, submissions, delegate)),
                 PLATFORM_CONFIG,
                 metrics,
                 new FakeTime());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeHintsService.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeHintsService.java
@@ -6,7 +6,7 @@ import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.node.app.hints.HintsService;
 import com.hedera.node.app.hints.WritableHintsStore;
 import com.hedera.node.app.hints.handlers.HintsHandlers;
-import com.hedera.node.app.hints.impl.HintsContext;
+import com.hedera.node.app.hints.impl.BlockHashSigning;
 import com.hedera.node.app.hints.impl.HintsLibraryImpl;
 import com.hedera.node.app.hints.impl.HintsServiceImpl;
 import com.hedera.node.app.hints.impl.OnHintsFinished;
@@ -54,7 +54,7 @@ public class FakeHintsService implements HintsService {
     }
 
     @Override
-    public HintsContext.Signing sign(@NonNull final Bytes blockHash) {
+    public @NonNull BlockHashSigning sign(@NonNull final Bytes blockHash) {
         return delegate.sign(blockHash);
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeHintsService.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeHintsService.java
@@ -32,13 +32,19 @@ public class FakeHintsService implements HintsService {
     private final HintsService delegate;
     private final Queue<Runnable> pendingHintsSubmissions = new ArrayDeque<>();
 
-    public FakeHintsService(@NonNull final AppContext appContext, @NonNull final Configuration bootstrapConfig) {
+    public FakeHintsService(
+            @NonNull final AppContext appContext,
+            @NonNull final Configuration bootstrapConfig,
+            @NonNull final RsaContext rsaContext,
+            @NonNull final ConcurrentMap<Bytes, BlockHashSigning> rsaSignings) {
         delegate = new HintsServiceImpl(
                 new NoOpMetrics(),
                 pendingHintsSubmissions::offer,
                 appContext,
                 new HintsLibraryImpl(),
-                bootstrapConfig.getConfigData(BlockStreamConfig.class).blockPeriod());
+                bootstrapConfig.getConfigData(BlockStreamConfig.class).blockPeriod(),
+                rsaContext,
+                rsaSignings);
     }
 
     @Override
@@ -59,16 +65,6 @@ public class FakeHintsService implements HintsService {
     @Override
     public @NonNull BlockHashSigning sign(@NonNull final Bytes blockHash) {
         return delegate.sign(blockHash);
-    }
-
-    @Override
-    public @NonNull RsaContext rsaSigningContext() {
-        return delegate.rsaSigningContext();
-    }
-
-    @Override
-    public @NonNull ConcurrentMap<Bytes, BlockHashSigning> rsaSignings() {
-        return delegate.rsaSignings();
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeHintsService.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeHintsService.java
@@ -10,9 +10,11 @@ import com.hedera.node.app.hints.impl.BlockHashSigning;
 import com.hedera.node.app.hints.impl.HintsLibraryImpl;
 import com.hedera.node.app.hints.impl.HintsServiceImpl;
 import com.hedera.node.app.hints.impl.OnHintsFinished;
+import com.hedera.node.app.hints.impl.RsaContext;
 import com.hedera.node.app.service.roster.impl.ActiveRosters;
 import com.hedera.node.app.spi.AppContext;
 import com.hedera.node.app.spi.info.NetworkInfo;
+import com.hedera.node.app.tss.TssSubmissions;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.TssConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -23,6 +25,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentMap;
 import org.hiero.consensus.metrics.noop.NoOpMetrics;
 
 public class FakeHintsService implements HintsService {
@@ -56,6 +59,21 @@ public class FakeHintsService implements HintsService {
     @Override
     public @NonNull BlockHashSigning sign(@NonNull final Bytes blockHash) {
         return delegate.sign(blockHash);
+    }
+
+    @Override
+    public @NonNull RsaContext rsaSigningContext() {
+        return delegate.rsaSigningContext();
+    }
+
+    @Override
+    public @NonNull ConcurrentMap<Bytes, BlockHashSigning> rsaSignings() {
+        return delegate.rsaSignings();
+    }
+
+    @Override
+    public @NonNull TssSubmissions submissions() {
+        return delegate.submissions();
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/LapsingBlockHashSigner.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/LapsingBlockHashSigner.java
@@ -30,6 +30,10 @@ public class LapsingBlockHashSigner implements BlockHashSigner {
         this.delegate = new TssBlockHashSigner(hintsService, historyService, configProvider);
     }
 
+    public LapsingBlockHashSigner(@NonNull final BlockHashSigner delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
     /**
      * When called, will start ignoring any requests for ledger signatures.
      */
@@ -50,7 +54,7 @@ public class LapsingBlockHashSigner implements BlockHashSigner {
     }
 
     @Override
-    public Attempt sign(@NonNull final Bytes blockHash) {
-        return ignoreRequests ? new Attempt(null, null, new CompletableFuture<>()) : delegate.sign(blockHash);
+    public Attempt sign(@NonNull final Bytes blockHash, @NonNull final Request request) {
+        return ignoreRequests ? new Attempt(null, null, new CompletableFuture<>()) : delegate.sign(blockHash, request);
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/StateUtils.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/StateUtils.java
@@ -264,7 +264,9 @@ public final class StateUtils {
                                 new HintsLibraryImpl(),
                                 bootstrapConfig
                                         .getConfigData(BlockStreamConfig.class)
-                                        .blockPeriod()),
+                                        .blockPeriod(),
+                                new com.hedera.node.app.hints.impl.RsaContext(appContext.configSupplier()),
+                                new java.util.concurrent.ConcurrentHashMap<>()),
                         new RosterServiceImpl(roster -> true, (r, b) -> {}, () -> {
                             throw new UnsupportedOperationException("No startup networks available");
                         }),


### PR DESCRIPTION
**Description**:
 - Closes #24769 
 - Aggregates RSA signatures over the legacy record file hash for a WRB from nodes holding >1/2 weight [into a `SignedRecordFileProof`](https://github.com/hiero-ledger/hiero-consensus-node/blob/24769-rsa-signature-gossip/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java#L795).
     * Gossip is done via a `HintsPartialSignatureTransactionBody` using a sentinel of `0` for the `constructionId`; the `HintsPartialSignatureHandler` now injects both the `HintsContext` and `RsaContext` to support incorporating valid signatures into signings within either context as required by app config.
 - ⚠️ Does not yet provide a satisfactory solution for the case of blocks not signed by the end of a freeze round.
     * Follow-up work continues in issues https://github.com/hiero-ledger/hiero-consensus-node/issues/25202 and https://github.com/hiero-ledger/hiero-consensus-node/issues/25201
     * If these do not pan out, we will have no option but to use the roster in release `N+1` to sign the final WRBs produced by software in release `N`.