### PR TITLE
fix: do not increment the wanted block when BlockNodeStatus#latestBlockAvailable is -1

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNode.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNode.java
@@ -382,7 +382,8 @@ public class BlockNode {
      */
     void onServerStatusCheck(@NonNull final BlockNodeStatus status) {
         if (status.wasReachable()) {
-            wantedBlockRef.set(new WantedBlock(status.latestBlockAvailable() + 1, Instant.now(clock)));
+            final long wantedBlock = status.latestBlockAvailable() == -1 ? -1 : status.latestBlockAvailable() + 1;
+            wantedBlockRef.set(new WantedBlock(wantedBlock, Instant.now(clock)));
         } else {
             applyCoolDown(new ServiceConnectionFailure());
         }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeTest.java
@@ -575,6 +575,19 @@ class BlockNodeTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
+    void testOnServerStatusCheck_reachable_blockNotSpecified() {
+        final BlockNodeStatus nodeStatus = BlockNodeStatus.reachable(10, -1);
+
+        node.onServerStatusCheck(nodeStatus);
+
+        final AtomicReference<WantedBlock> wantedBlockRef = wantedBlockRef();
+        assertThat(wantedBlockRef).doesNotHaveNullValue();
+        final WantedBlock wantedBlock = wantedBlockRef.get();
+        // if the wanted block is -1, then it should be carried straight over without being incremented
+        assertThat(wantedBlock.blockNumber()).isEqualTo(-1);
+    }
+
+    @Test
     void testOnServerStatusCheck_notReachable() {
         final BlockNodeStatus nodeStatus = BlockNodeStatus.notReachable();
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -136,10 +136,10 @@ public class BlockNodeSuite {
                                 "/localhost:%s/ACTIVE] Connection state transitioned from READY to ACTIVE",
                                 portNumbers.get(1)),
                         String.format(
-                                "/localhost:%s/ACTIVE] Connection will be closed at the next block boundary (reason: HIGHER_PRIORITY_FOUND)",
+                                "/localhost:%s/ACTIVE] Connection will be closed at the next block boundary (reason: HIGHER_PRIORITY_FOUND",
                                 portNumbers.get(3)),
                         String.format(
-                                "/localhost:%s/CLOSING] Closing connection (reason: HIGHER_PRIORITY_FOUND)",
+                                "/localhost:%s/CLOSING] Closing connection (reason: HIGHER_PRIORITY_FOUND",
                                 portNumbers.get(3)))),
                 doingContextual(spec -> connectionDropTime.set(Instant.now())),
                 waitUntilNextBlocks(5),


### PR DESCRIPTION
**Description**:
This PR fixes a bug introduced where the wanted block was always the next block after the block node's server status API's latest block available. This is correct in all cases except for when the value is -1. This is a special value and indicates the consensus node should send whatever blocks it has available, and thus should _not_ be incremented.

**Related issue(s)**:

Fixes #25184 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
