### PR TITLE
chore: Update test constructor invocation to fix compile error

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
@@ -732,6 +732,7 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
                 heartbeat,
                 app.platform(),
                 diskWriter,
+                () -> mock(BlockItemWriter.class),
                 InitTrigger.RECONNECT)) {
             final var t0 = InstantUtils.instant(10, 1);
             mgr.startUserTransaction(t0, state);


### PR DESCRIPTION
Merging (the approved) PR #24986 is causing a signature mismatch compilation error in a test class. We fix it here. 