### PR TITLE
fix: 25162 silence yahcli JDK 25 warnings from protobuf and netty

### DIFF
--- a/hedera-node/yahcli/assets/screened-launch.sh
+++ b/hedera-node/yahcli/assets/screened-launch.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
-java -jar /opt/bin/yahcli.jar "$@" 2>syserr.log
+# Silence protobuf's UnsafeUtil sun.misc.Unsafe deprecation warnings on JDK 25.
+# The netty System.loadLibrary warning is handled via the JAR's Enable-Native-Access manifest.
+java --sun-misc-unsafe-memory-access=allow -jar /opt/bin/yahcli.jar "$@" 2>syserr.log
 RC=$?
 cat syserr.log
 exit $RC

--- a/hedera-node/yahcli/build.gradle.kts
+++ b/hedera-node/yahcli/build.gradle.kts
@@ -32,7 +32,14 @@ val yahCliJar =
         archiveClassifier = "shadow"
         configurations = listOf(project.configurations["runtimeClasspath"])
 
-        manifest { attributes("Main-Class" to "com.hedera.services.yahcli.Yahcli") }
+        manifest {
+            attributes(
+                "Main-Class" to "com.hedera.services.yahcli.Yahcli",
+                // Declares JNI usage (netty's NativeLibraryUtil) so the JDK does not print a
+                // restricted-method warning for callers in the unnamed module of this JAR.
+                "Enable-Native-Access" to "ALL-UNNAMED",
+            )
+        }
 
         // Include all classes and resources from the main source set
         from(sourceSets["main"].output)

--- a/hedera-node/yahcli/yahcli
+++ b/hedera-node/yahcli/yahcli
@@ -1,2 +1,4 @@
 #! /bin/sh
-java -jar yahcli.jar "${@}"
+# Silence protobuf's UnsafeUtil sun.misc.Unsafe deprecation warnings on JDK 25.
+# The netty System.loadLibrary warning is handled via the JAR's Enable-Native-Access manifest.
+java --sun-misc-unsafe-memory-access=allow -jar yahcli.jar "${@}"


### PR DESCRIPTION
**Description**:

Silence the four JDK 25 JVM warnings reported in #25162 that yahcli emits on every network-touching invocation. `protobuf-java` (4.33.5) and `netty` (4.2.4.Final) are already at their latest versions, so the warnings cannot be eliminated by version bumps; this PR applies the JDK-documented mitigations:

* Add `Enable-Native-Access: ALL-UNNAMED` to the yahcli shadow JAR manifest (`hedera-node/yahcli/build.gradle.kts`). Per JEP 472, this is the declarative way for an executable JAR to opt into JNI; it silences the netty `System::loadLibrary` restricted-method warning regardless of how the JAR is launched (Docker entrypoint, local wrapper, or `java -jar` directly).
* Add `--sun-misc-unsafe-memory-access=allow` to both yahcli launcher scripts (`assets/screened-launch.sh` Docker entrypoint and the local `yahcli` wrapper) to silence the protobuf `sun.misc.Unsafe::arrayBaseOffset` deprecation warning. There is no manifest equivalent for this flag.

**Related issue(s)**:

Fixes #25162

**Notes for reviewer**:

Verified locally on JDK 25.0.2:

* Inspected the rebuilt JAR's `META-INF/MANIFEST.MF` to confirm `Enable-Native-Access: ALL-UNNAMED` is present.
* A/B tested the manifest attribute with two minimal jars calling `System.loadLibrary("nope")`. Without the attribute the JDK prints the same 4 `WARNING` lines reported in #25162; with the attribute it prints none.
* Ran the patched local `yahcli -p 2 version` against an unreachable endpoint: the protobuf `sun.misc.Unsafe::arrayBaseOffset` warning is no longer printed (down from 4 lines), and the underlying gRPC error behavior is unchanged.
* The netty `System::loadLibrary` warning could not be reproduced locally on macOS (gRPC fell back to the NIO transport instead of loading native epoll), but the manifest attribute is JDK-documented and was independently validated by the A/B test above; it will silence the warning in the Linux Docker image where netty does load native epoll.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)