### PR TITLE
fix: 25204 Fix race condition in file assignment and reduce consolidation aggressiveness

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -587,11 +587,14 @@ class MerkleDbCompactionCoordinator {
             if (alreadyAssigned.contains(reader)) {
                 continue;
             }
-            // If we include files at level 0, the consolidation gets too aggressive and does a lot of unnecessary work -
-            // level 0 files are naturally smaller, most likely will get stale soon and should be handled by either compaction or be absorbed.
-            // Without this limitation, consolidation would take care of these files as soon as the counter reaches minFileCount which
+            // If we include files at level 0, the consolidation gets too aggressive and does a lot of unnecessary work
+            // -
+            // level 0 files are naturally smaller, most likely will get stale soon and should be handled by either
+            // compaction or be absorbed.
+            // Without this limitation, consolidation would take care of these files as soon as the counter reaches
+            // minFileCount which
             // oftentimes is unnecessary.
-            if(fs.compactionLevel() == 0) {
+            if (fs.compactionLevel() == 0) {
                 continue;
             }
             if (reader.getSize() < consolidationMaxInputSizeBytes) {
@@ -731,13 +734,12 @@ class MerkleDbCompactionCoordinator {
                 // Filter out files that were already compacted and deleted since the scan
                 final Set<DataFileReader> currentFiles =
                         new HashSet<>(compactor.getDataFileCollection().getAllCompletedFiles());
-                final List<DataFileReader> validFiles =
-                        assignedFiles.stream()
-                                .filter(currentFiles::contains)
-                                // Mark files as being compacted — scanner will skip them
-                                // If the file is already being compacted, skip it
-                                .filter(DataFileReader::setCompactionInProgress)
-                                .toList();
+                final List<DataFileReader> validFiles = assignedFiles.stream()
+                        .filter(currentFiles::contains)
+                        // Mark files as being compacted — scanner will skip them
+                        // If the file is already being compacted, skip it
+                        .filter(DataFileReader::setCompactionInProgress)
+                        .toList();
                 if (validFiles.isEmpty()) {
                     return false;
                 }

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -355,6 +355,13 @@ class MerkleDbCompactionCoordinator {
                         groups.size(),
                         level,
                         eligible.size());
+            } else {
+                logger.info(
+                        MERKLE_DB.getMarker(),
+                        "[{}] Submitted a compaction tasks for level {} ({} eligible files)",
+                        storeName,
+                        level,
+                        eligible.size());
             }
         }
         // Second pass: consolidation of small files regardless of garbage ratio
@@ -580,6 +587,13 @@ class MerkleDbCompactionCoordinator {
             if (alreadyAssigned.contains(reader)) {
                 continue;
             }
+            // If we include files at level 0, the consolidation gets too aggressive and does a lot of unnecessary work -
+            // level 0 files are naturally smaller, most likely will get stale soon and should be handled by either compaction or be absorbed.
+            // Without this limitation, consolidation would take care of these files as soon as the counter reaches minFileCount which
+            // oftentimes is unnecessary.
+            if(fs.compactionLevel() == 0) {
+                continue;
+            }
             if (reader.getSize() < consolidationMaxInputSizeBytes) {
                 smallFilesByLevel
                         .computeIfAbsent(fs.compactionLevel(), _ -> new ArrayList<>())
@@ -718,13 +732,16 @@ class MerkleDbCompactionCoordinator {
                 final Set<DataFileReader> currentFiles =
                         new HashSet<>(compactor.getDataFileCollection().getAllCompletedFiles());
                 final List<DataFileReader> validFiles =
-                        assignedFiles.stream().filter(currentFiles::contains).toList();
+                        assignedFiles.stream()
+                                .filter(currentFiles::contains)
+                                // Mark files as being compacted — scanner will skip them
+                                // If the file is already being compacted, skip it
+                                .filter(DataFileReader::setCompactionInProgress)
+                                .toList();
                 if (validFiles.isEmpty()) {
                     return false;
                 }
 
-                // Mark files as being compacted — scanner will skip them
-                validFiles.forEach(DataFileReader::setCompactionInProgress);
                 final int targetLevel = Math.min(sourceLevel + 1, config.maxCompactionLevel());
                 return compactor.compactSingleLevel(validFiles, targetLevel);
 

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -347,21 +347,25 @@ class MerkleDbCompactionCoordinator {
                 executor.submit(new CompactionTask(taskKey, levelKey, level, groups.get(i), compactorFactory, config));
             }
 
+            final List<Integer> fileIndices =
+                    eligible.stream().map(DataFileReader::getIndex).toList();
             if (groups.size() > 1) {
                 logger.info(
                         MERKLE_DB.getMarker(),
-                        "[{}] Submitted {} compaction tasks for level {} ({} eligible files)",
+                        "[{}] Submitted {} compaction tasks for level {} ({} eligible files - {})",
                         storeName,
                         groups.size(),
                         level,
-                        eligible.size());
+                        eligible.size(),
+                        fileIndices);
             } else {
                 logger.info(
                         MERKLE_DB.getMarker(),
-                        "[{}] Submitted a compaction tasks for level {} ({} eligible files)",
+                        "[{}] Submitted a compaction tasks for level {} ({} eligible files - {})",
                         storeName,
                         level,
-                        eligible.size());
+                        eligible.size(),
+                        fileIndices);
             }
         }
         // Second pass: consolidation of small files regardless of garbage ratio
@@ -721,6 +725,7 @@ class MerkleDbCompactionCoordinator {
 
         @Override
         public Boolean call() {
+            boolean success = false;
             try {
                 // Create a compactor and register it for pause/resume/interrupt
                 final DataFileCompactor compactor = compactorFactory.get();
@@ -745,15 +750,18 @@ class MerkleDbCompactionCoordinator {
                 }
 
                 final int targetLevel = Math.min(sourceLevel + 1, config.maxCompactionLevel());
-                return compactor.compactSingleLevel(validFiles, targetLevel);
+                success = compactor.compactSingleLevel(validFiles, targetLevel);
+                return success;
 
             } catch (final InterruptedException | ClosedByInterruptException e) {
                 logger.info(MERKLE_DB.getMarker(), "Interrupted while compacting [{}], this is allowed", taskKey);
             } catch (Exception e) {
                 logger.error(EXCEPTION.getMarker(), "[{}] Compaction failed", taskKey, e);
             } finally {
-                // Reset flag so files become visible to scanner again if compaction failed
-                assignedFiles.forEach(DataFileReader::resetCompactionInProgress);
+                if (!success) {
+                    // Reset flag so files become visible to scanner again if compaction failed
+                    assignedFiles.forEach(DataFileReader::resetCompactionInProgress);
+                }
                 synchronized (MerkleDbCompactionCoordinator.this) {
                     compactorsByName.remove(taskKey);
                     taskKeys.remove(taskKey);

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
@@ -179,9 +179,10 @@ public final class DataFileReader implements Comparable<DataFileReader>, Indexed
 
     /**
      * Marks this file as being actively compacted.
+     * @return {@code true} if the compaction flag was set to {@code false} and the flag was set to
      */
-    public void setCompactionInProgress() {
-        compactionInProgress.set(true);
+    public boolean setCompactionInProgress() {
+        return compactionInProgress.compareAndSet(false, true);
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
@@ -179,7 +179,7 @@ public final class DataFileReader implements Comparable<DataFileReader>, Indexed
 
     /**
      * Marks this file as being actively compacted.
-     * @return {@code true} if the compaction flag was set to {@code false} and the flag was set to
+     * @return {@code true} if the compaction flag successfully updated from {@code false} to {@code true}
      */
     public boolean setCompactionInProgress() {
         return compactionInProgress.compareAndSet(false, true);

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
@@ -710,6 +710,30 @@ class MerkleDbCompactionCoordinatorTest {
     }
 
     @Test
+    void testCompactionTaskDoesNotResetFlagOnSuccess() throws InterruptedException, IOException {
+        // After successful compaction, the flag must stay true — resetting it would
+        // allow a concurrent task's CAS to succeed on a file that's already been deleted.
+        final DataFileReader file = mockFileReader(1, 0, 100, 1000);
+
+        final DataFileCollection fileCollection = mock(DataFileCollection.class);
+        when(fileCollection.getAllCompletedFiles()).thenReturn(List.of(file));
+
+        publishScanStats(ID_TO_HASH_CHUNK, buildStats(new StatsEntry(file, 20)));
+
+        final DataFileCompactor compactor = mock(DataFileCompactor.class);
+        when(compactor.compactSingleLevel(anyList(), anyInt())).thenReturn(true);
+        when(compactor.getDataFileCollection()).thenReturn(fileCollection);
+
+        coordinator.submitCompactionTasks(ID_TO_HASH_CHUNK, () -> compactor, config);
+
+        coordinator.awaitForCurrentCompactionsToComplete(2000);
+
+        // Flag was set but must NOT be reset after success
+        verify(file).setCompactionInProgress();
+        verify(file, never()).resetCompactionInProgress();
+    }
+
+    @Test
     void testIsCompactionRunningDetectsGarbageCompactionTask() throws InterruptedException, IOException {
         final DataFileReader level0File = mockFileReader(1, 0, 100, 1000);
 

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
@@ -327,7 +328,7 @@ class MerkleDbCompactionCoordinatorTest {
         final List<DataFileReader> smallFiles = new ArrayList<>();
         final List<StatsEntry> statsEntries = new ArrayList<>();
         for (int i = 1; i <= 12; i++) {
-            final DataFileReader f = mockFileReader(i, 0, 100, 5 * 1024 * 1024); // 5 MB
+            final DataFileReader f = mockFileReader(i, 1, 100, 5 * 1024 * 1024); // 5 MB
             smallFiles.add(f);
             statsEntries.add(new StatsEntry(f, 100)); // all alive → d/a = 0.0
         }
@@ -359,11 +360,9 @@ class MerkleDbCompactionCoordinatorTest {
     void testConsolidationSkipsWhenBelowMinFileCount() throws InterruptedException, IOException {
         // 5 small files, but minFileCount = 10 → no consolidation
         final MerkleDbConfig consolidationConfig = configWithConsolidation(50, 10);
-        final List<DataFileReader> smallFiles = new ArrayList<>();
         final List<StatsEntry> statsEntries = new ArrayList<>();
         for (int i = 1; i <= 5; i++) {
-            final DataFileReader f = mockFileReader(i, 0, 100, 5 * 1024 * 1024);
-            smallFiles.add(f);
+            final DataFileReader f = mockFileReader(i, 1, 100, 5 * 1024 * 1024);
             statsEntries.add(new StatsEntry(f, 100));
         }
 
@@ -385,12 +384,12 @@ class MerkleDbCompactionCoordinatorTest {
         final List<DataFileReader> files = new ArrayList<>();
         final List<StatsEntry> statsEntries = new ArrayList<>();
         for (int i = 1; i <= 10; i++) {
-            final DataFileReader f = mockFileReader(i, 0, 100, 5 * 1024 * 1024); // 5 MB
+            final DataFileReader f = mockFileReader(i, 1, 100, 5 * 1024 * 1024); // 5 MB
             files.add(f);
             statsEntries.add(new StatsEntry(f, 100));
         }
-        final DataFileReader large1 = mockFileReader(11, 0, 100, 100 * 1024 * 1024); // 100 MB
-        final DataFileReader large2 = mockFileReader(12, 0, 100, 100 * 1024 * 1024); // 100 MB
+        final DataFileReader large1 = mockFileReader(11, 1, 100, 100 * 1024 * 1024); // 100 MB
+        final DataFileReader large2 = mockFileReader(12, 1, 100, 100 * 1024 * 1024); // 100 MB
         files.add(large1);
         files.add(large2);
         statsEntries.add(new StatsEntry(large1, 100));
@@ -431,8 +430,8 @@ class MerkleDbCompactionCoordinatorTest {
         final List<StatsEntry> statsEntries = new ArrayList<>();
 
         // 2 dirty files at level 1 (d/a > 0.5)
-        final DataFileReader dirty1 = mockFileReader(1, 1, 100, 5 * 1024 * 1024);
-        final DataFileReader dirty2 = mockFileReader(2, 1, 100, 5 * 1024 * 1024);
+        final DataFileReader dirty1 = mockFileReader(1, 2, 100, 5 * 1024 * 1024);
+        final DataFileReader dirty2 = mockFileReader(2, 3, 100, 5 * 1024 * 1024);
         files.add(dirty1);
         files.add(dirty2);
         statsEntries.add(new StatsEntry(dirty1, 20)); // d/a = 4.0
@@ -440,7 +439,7 @@ class MerkleDbCompactionCoordinatorTest {
 
         // 10 clean files (d/a = 0.0)
         for (int i = 3; i <= 12; i++) {
-            final DataFileReader f = mockFileReader(i, 0, 100, 5 * 1024 * 1024);
+            final DataFileReader f = mockFileReader(i, 1, 100, 5 * 1024 * 1024);
             files.add(f);
             statsEntries.add(new StatsEntry(f, 100));
         }
@@ -485,7 +484,7 @@ class MerkleDbCompactionCoordinatorTest {
         final List<DataFileReader> files = new ArrayList<>();
         final List<StatsEntry> statsEntries = new ArrayList<>();
         for (int i = 1; i <= 20; i++) {
-            final DataFileReader f = mockFileReader(i, 0, 100, 1024); // 1 KB — tiny
+            final DataFileReader f = mockFileReader(i, 1, 100, 1024); // 1 KB — tiny
             files.add(f);
             statsEntries.add(new StatsEntry(f, 100)); // all alive
         }
@@ -498,6 +497,75 @@ class MerkleDbCompactionCoordinatorTest {
         coordinator.awaitForCurrentCompactionsToComplete(2000);
 
         verify(compactor, never()).compactSingleLevel(anyList(), anyInt());
+    }
+
+    @Test
+    void testConsolidationSkipsLevelZeroFiles() throws InterruptedException, IOException {
+        // 15 small clean files at level 0 — enough to trigger consolidation by count,
+        // but level 0 should be excluded from consolidation entirely
+        final MerkleDbConfig consolidationConfig = configWithConsolidation(50, 10);
+        final List<StatsEntry> statsEntries = new ArrayList<>();
+        for (int i = 1; i <= 15; i++) {
+            final DataFileReader f = mockFileReader(i, 0, 100, 5 * 1024 * 1024); // 5 MB, level 0
+            statsEntries.add(new StatsEntry(f, 100)); // all alive → d/a = 0.0
+        }
+
+        publishScanStats(ID_TO_HASH_CHUNK, buildStats(statsEntries.toArray(StatsEntry[]::new)));
+
+        final DataFileCompactor compactor = mock(DataFileCompactor.class);
+        coordinator.submitCompactionTasks(ID_TO_HASH_CHUNK, () -> compactor, consolidationConfig);
+
+        coordinator.awaitForCurrentCompactionsToComplete(2000);
+
+        // No tasks should be submitted — all files are level 0
+        verify(compactor, never()).compactSingleLevel(anyList(), anyInt());
+    }
+
+    @Test
+    void testConsolidationSkipsLevelZeroButProcessesHigherLevels() throws InterruptedException, IOException {
+        // Mix of level 0 and level 1 small files — only level 1 should be consolidated
+        final MerkleDbConfig consolidationConfig = configWithConsolidation(50, 10);
+        final List<DataFileReader> files = new ArrayList<>();
+        final List<StatsEntry> statsEntries = new ArrayList<>();
+
+        // 15 files at level 0 (should be skipped)
+        for (int i = 1; i <= 15; i++) {
+            final DataFileReader f = mockFileReader(i, 0, 100, 5 * 1024 * 1024);
+            files.add(f);
+            statsEntries.add(new StatsEntry(f, 100));
+        }
+
+        // 12 files at level 1 (should be consolidated)
+        for (int i = 16; i <= 27; i++) {
+            final DataFileReader f = mockFileReader(i, 1, 100, 5 * 1024 * 1024);
+            files.add(f);
+            statsEntries.add(new StatsEntry(f, 100));
+        }
+
+        final DataFileCollection fileCollection = mock(DataFileCollection.class);
+        when(fileCollection.getAllCompletedFiles()).thenReturn(files);
+
+        publishScanStats(ID_TO_HASH_CHUNK, buildStats(statsEntries.toArray(StatsEntry[]::new)));
+
+        final CountDownLatch taskDone = new CountDownLatch(1);
+        final List<DataFileReader> compactedFiles = new ArrayList<>();
+        final DataFileCompactor compactor = mock(DataFileCompactor.class);
+        when(compactor.compactSingleLevel(anyList(), anyInt())).thenAnswer(invocation -> {
+            compactedFiles.addAll(invocation.getArgument(0));
+            taskDone.countDown();
+            return true;
+        });
+        when(compactor.getDataFileCollection()).thenReturn(fileCollection);
+
+        coordinator.submitCompactionTasks(ID_TO_HASH_CHUNK, () -> compactor, consolidationConfig);
+
+        assertTrue(taskDone.await(2, TimeUnit.SECONDS), "Consolidation task should complete");
+
+        // Only level 1 files should be consolidated (12 files)
+        assertEquals(12, compactedFiles.size(), "Only level 1 files should be consolidated");
+        for (final DataFileReader f : compactedFiles) {
+            assertEquals(1, f.getMetadata().getCompactionLevel(), "All consolidated files should be level 1");
+        }
     }
 
     // ========================================================================
@@ -682,7 +750,7 @@ class MerkleDbCompactionCoordinatorTest {
         final List<DataFileReader> smallFiles = new ArrayList<>();
         final List<StatsEntry> statsEntries = new ArrayList<>();
         for (int i = 1; i <= 12; i++) {
-            final DataFileReader f = mockFileReader(i, 0, 100, 5 * 1024 * 1024);
+            final DataFileReader f = mockFileReader(i, 1, 100, 5 * 1024 * 1024);
             smallFiles.add(f);
             statsEntries.add(new StatsEntry(f, 100)); // all alive → d/a = 0.0
         }
@@ -757,6 +825,62 @@ class MerkleDbCompactionCoordinatorTest {
         coordinator.awaitForCurrentCompactionsToComplete(2000);
     }
 
+    @Test
+    void testSetCompactionInProgressCASPreventsDoubleAssignment() throws InterruptedException, IOException {
+        // A file that appears in both a garbage task and a consolidation task from different
+        // submitCompactionTasks calls. The CAS on setCompactionInProgress ensures only the
+        // first task to execute claims the file.
+        final DataFileReader sharedFile = mockFileReader(1, 1, 100, 5 * 1024 * 1024);
+
+        // Use a real AtomicBoolean to simulate CAS behavior
+        final AtomicBoolean flag = new AtomicBoolean(false);
+        when(sharedFile.setCompactionInProgress()).thenAnswer(_ -> flag.compareAndSet(false, true));
+        when(sharedFile.isCompactionInProgress()).thenAnswer(_ -> flag.get());
+
+        // 20 alive out of 100 → d/a = 4.0 → eligible for garbage compaction
+        publishScanStats(ID_TO_HASH_CHUNK, buildStats(new StatsEntry(sharedFile, 20)));
+
+        final DataFileCollection fileCollection = mock(DataFileCollection.class);
+        when(fileCollection.getAllCompletedFiles()).thenReturn(List.of(sharedFile));
+
+        // First task: grabs the file via CAS
+        final CountDownLatch task1Started = new CountDownLatch(1);
+        final CountDownLatch task1Release = new CountDownLatch(1);
+        final List<DataFileReader> task1Files = new ArrayList<>();
+        final DataFileCompactor compactor1 = mock(DataFileCompactor.class);
+        when(compactor1.compactSingleLevel(anyList(), anyInt())).thenAnswer(invocation -> {
+            task1Files.addAll(invocation.getArgument(0));
+            task1Started.countDown();
+            task1Release.await(2, TimeUnit.SECONDS);
+            return true;
+        });
+        when(compactor1.getDataFileCollection()).thenReturn(fileCollection);
+
+        // Submit first task
+        coordinator.submitCompactionTasks(ID_TO_HASH_CHUNK, () -> compactor1, config);
+        assertTrue(task1Started.await(1, TimeUnit.SECONDS), "First task should start");
+
+        // File is now flagged via CAS — second task should not be able to claim it
+        assertTrue(flag.get(), "File should be flagged after first task starts");
+
+        // Submit second task (simulating a second submitCompactionTasks call)
+        final List<DataFileReader> task2Files = new ArrayList<>();
+        final DataFileCompactor compactor2 = mock(DataFileCompactor.class);
+        when(compactor2.compactSingleLevel(anyList(), anyInt())).thenAnswer(invocation -> {
+            task2Files.addAll(invocation.getArgument(0));
+            return true;
+        });
+        when(compactor2.getDataFileCollection()).thenReturn(fileCollection);
+
+        coordinator.submitCompactionTasks(ID_TO_HASH_CHUNK, () -> compactor2, config);
+        task1Release.countDown();
+        coordinator.awaitForCurrentCompactionsToComplete(2000);
+
+        // First task should have the file, second task should have been filtered out
+        assertEquals(1, task1Files.size(), "First task should have claimed the file");
+        assertTrue(task2Files.isEmpty(), "Second task should not have claimed the file");
+    }
+
     // ========================================================================
     // Helper methods
     // ========================================================================
@@ -809,6 +933,7 @@ class MerkleDbCompactionCoordinatorTest {
         when(reader.getIndex()).thenReturn(fileIndex);
         when(reader.getMetadata()).thenReturn(metadata);
         when(reader.getSize()).thenReturn(sizeBytes);
+        when(reader.setCompactionInProgress()).thenReturn(true);
         return reader;
     }
 


### PR DESCRIPTION
**Description**:

**CAS-based `setCompactionInProgress`:** Changed `DataFileReader.setCompactionInProgress()` from `set(true)` to `compareAndSet(false, true)`, returning whether the flag was newly set. The compaction task now filters files through this CAS as part of the stale-file check. This prevents the same file from being claimed by two tasks submitted from different `submitCompactionTasks` cycles — the first task to execute wins, the second silently skips the file. Previously this race could cause `NoSuchFileException` when the second task tried to delete an already-compacted file.

**Skip level 0 in consolidation:** Level 0 files are naturally small (fresh flush output) and are expected to be consumed by garbage-based compaction or phase 2 absorption. Including them in consolidation caused unnecessary I/O — files were merged before garbage compaction had a chance to process them.

**Related issue(s)**:

Fixes #25204

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
