### PR TITLE
ci: switch PR title check to step-security/action-semantic-pull-request

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -36,7 +36,7 @@ jobs:
           egress-policy: audit
 
       - name: Check PR Title
-        uses: step-security/conventional-pr-title-action@101b3d5adffb51b5789997fea508c8313c8ddf02 # v3.2.2
+        uses: step-security/action-semantic-pull-request@75d2dd5deafa3e9fccc1626ecd58d076ed1d2c79 # v6.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Replaces `step-security/conventional-pr-title-action@v3.2.2` with `step-security/action-semantic-pull-request@v6.1.2` in `.github/workflows/flow-pull-request-formatting.yaml`.
- Action pinned by commit SHA (`75d2dd5deafa3e9fccc1626ecd58d076ed1d2c79`) per repo convention.
- Uses the action's default configuration, which enforces the standard Conventional Commits types.

## Test plan
- [ ] Verify the `PR Formatting / Title Check` job runs against this PR and passes on this conventionally-formatted title.
- [ ] Open a follow-up draft PR with a non-conventional title to confirm the check fails as expected.