### PR TITLE
docs(ai): forbid AI origin/attribution markers in repo content

### DIFF
--- a/.github/ai/instructions.md
+++ b/.github/ai/instructions.md
@@ -39,3 +39,4 @@ The `./gradlew` wrapper handles it.
 - If there is a file called `ai.local` at the project root then the agent will take additional instructions from that file.
 - The agent shall never generate a commit. The user must always review and create commits themselves.
 - The agent is not an author of the code, only the user.
+- The agent shall never add origin or attribution information (such as "Created by Claude", "Generated with Claude Code", "Co-Authored-By: Claude", or any similar marker) to commit messages, pull request titles, pull request descriptions, code comments, or any other repository content.


### PR DESCRIPTION
## Summary
- Adds a requirement to `.github/ai/instructions.md` prohibiting AI agents from adding attribution markers (e.g., "Created by Claude", "Generated with Claude Code", `Co-Authored-By: Claude`) to commit messages, PR titles, PR descriptions, code comments, or any other repository content.
- Reinforces the existing rule that the agent is not an author of the code; only the user is.

## Test plan
- [ ] Reviewer confirms the wording covers commits, PR titles/bodies, and in-code comments.
- [ ] No CI behavior change expected (documentation-only).