### PR TITLE
chore: 25223: A typo in DataFileReader when allocating local read buffers

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileReader.java
@@ -501,7 +501,7 @@ public final class DataFileReader implements Comparable<DataFileReader>, Indexed
                     return readBuf;
                 }
                 // Otherwise read it separately
-                if (readBB.capacity() <= totalSize) {
+                if (readBB.capacity() < totalSize) {
                     readBB = ByteBuffer.allocate(totalSize);
                     BUFFER_CACHE.set(readBB);
                     readBuf = BufferedData.wrap(readBB);


### PR DESCRIPTION
Fix summary: fixed the typo.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/25223
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
