### PR TITLE
fix: 25225 Fix race condition in EntityIdUniquenessValidator 

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/EntityIdUniquenessValidator.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/EntityIdUniquenessValidator.java
@@ -35,6 +35,7 @@ import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -58,6 +59,8 @@ public class EntityIdUniquenessValidator implements LeafBytesValidator {
 
     private final AtomicLong idCounter = new AtomicLong(0);
     private final AtomicLong issuesFound = new AtomicLong(0);
+
+    private final ReentrantReadWriteLock cacheLock = new ReentrantReadWriteLock();
 
     /**
      * {@inheritDoc}
@@ -152,69 +155,78 @@ public class EntityIdUniquenessValidator implements LeafBytesValidator {
     private void checkEntityUniqueness(long entityId) {
         // From time to time we need to reset cache to prevent OOM errors
         if (idCounter.incrementAndGet() % 100_000 == 0) {
-            StateUtils.resetStateCache();
+            cacheLock.writeLock().lock();
+            try {
+                StateUtils.resetStateCache();
+            } finally {
+                cacheLock.writeLock().unlock();
+            }
         }
-
-        int counter = 0;
-        final Token token = tokensState.get(new TokenID(0, 0, entityId));
-        if (token != null) {
-            counter++;
-        }
-
-        final Account account =
-                accountState.get(AccountID.newBuilder().accountNum(entityId).build());
-        if (account != null) {
-            counter++;
-        }
-
-        final Bytecode contract = smartContractState.get(
-                ContractID.newBuilder().contractNum(entityId).build());
-
-        if (contract != null) {
-            counter++;
-        }
-
-        final Topic topic =
-                topicState.get(TopicID.newBuilder().topicNum(entityId).build());
-
-        if (topic != null) {
-            counter++;
-        }
-
-        final File file = fileState.get(FileID.newBuilder().fileNum(entityId).build());
-        if (file != null) {
-            counter++;
-        }
-
-        final Schedule schedule = scheduleState.get(new ScheduleID(0, 0, entityId));
-        if (schedule != null) {
-            counter++;
-        }
-
-        if (counter == 0) {
-            final String errorMessage = String.format("No entity found for Entity ID %d", entityId);
-            log.error(errorMessage);
-            issuesFound.incrementAndGet();
-        }
-        if (counter > 1) {
-            if ((account != null) && (contract != null) && (counter == 2)) {
-                // if it's a smart contract account, we expect it to have a contract with matching id
-                return;
+        cacheLock.readLock().lock();
+        try {
+            int counter = 0;
+            final Token token = tokensState.get(new TokenID(0, 0, entityId));
+            if (token != null) {
+                counter++;
             }
 
-            final String errorMessage =
-                    String.format("""
-            Entity ID %d is not unique, found %d entities.\s
-             Token = %s, \
-            \s
-             Account = %s,\s
-             Contract = %s, \s
-             Topic = %s,\s
-             File = %s,\s
-             Schedule = %s
-            """, entityId, counter, token, account, contract, topic, file, schedule);
-            log.error(errorMessage);
-            issuesFound.incrementAndGet();
+            final Account account =
+                    accountState.get(AccountID.newBuilder().accountNum(entityId).build());
+            if (account != null) {
+                counter++;
+            }
+
+            final Bytecode contract = smartContractState.get(
+                    ContractID.newBuilder().contractNum(entityId).build());
+
+            if (contract != null) {
+                counter++;
+            }
+
+            final Topic topic =
+                    topicState.get(TopicID.newBuilder().topicNum(entityId).build());
+
+            if (topic != null) {
+                counter++;
+            }
+
+            final File file =
+                    fileState.get(FileID.newBuilder().fileNum(entityId).build());
+            if (file != null) {
+                counter++;
+            }
+
+            final Schedule schedule = scheduleState.get(new ScheduleID(0, 0, entityId));
+            if (schedule != null) {
+                counter++;
+            }
+            if (counter == 0) {
+                final String errorMessage = String.format("No entity found for Entity ID %d", entityId);
+                log.error(errorMessage);
+                issuesFound.incrementAndGet();
+            }
+            if (counter > 1) {
+                if ((account != null) && (contract != null) && (counter == 2)) {
+                    // if it's a smart contract account, we expect it to have a contract with matching id
+                    return;
+                }
+
+                final String errorMessage =
+                        String.format("""
+                                      Entity ID %d is not unique, found %d entities.\s
+                                       Token = %s, \
+                                      \s
+                                       Account = %s,\s
+                                       Contract = %s, \s
+                                       Topic = %s,\s
+                                       File = %s,\s
+                                       Schedule = %s
+                          """, entityId, counter, token, account, contract, topic, file, schedule);
+                log.error(errorMessage);
+                issuesFound.incrementAndGet();
+            }
+        } finally {
+            cacheLock.readLock().unlock();
         }
     }
 }


### PR DESCRIPTION
### Problem
`EntityIdUniquenessValidator#checkEntityUniqueness` is invoked concurrently by multiple `ProcessorTask` threads. Every 100,000 entities, one thread calls `StateUtils.resetStateCache()` (to prevent OOM), which clears the `readCache` of every `ReadableKVState` while sibling threads are mid-`get()`. Since `ReadableKVStateBase.get()` writes to the cache and then re-reads it to produce its return value, a reset between those two steps causes `get()` to return `null` for an entity that actually exists. The result: `counter` ends up at `0` and the validator reports a spurious *"No entity found for Entity ID X"* failure.

This manifested as intermittent failures on different entity IDs across runs.

### Fix
Guard state access with a `ReentrantReadWriteLock`:
- Reads (`state.get(...)`) acquire the read lock — concurrency preserved.
- `resetStateCache()` acquires the write lock — waits for in-flight reads to drain before clearing caches.


Fixes #25225 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
