### PR TITLE
feat: Allow smart-contract sender for mirror node eth_estimateGas

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidator.java
@@ -195,11 +195,9 @@ public class DispatchValidator {
      * For the child and preceding transactions, the payer account can be null. Because the payer for contract
      * operations can be a token address.
      *
-     * <p>The smart-contract payer rejection can be opted out of by setting
-     * {@code accounts.smartContractSenderEnabled=true}. This is a {@link com.hedera.node.config.NodeProperty}
-     * intended only for the standalone {@code TransactionExecutor} used by mirror node to support
-     * {@code eth_estimateGas} simulations whose sender is a contract account; it must remain {@code false} on every
-     * consensus node.
+     * <p>The smart-contract payer rejection can be opted out of via
+     * {@code accounts.smartContractSenderEnabled}, intended for the standalone {@code TransactionExecutor}
+     * used by mirror node to support {@code eth_estimateGas} simulations whose sender is a contract account.
      *
      * @param storeFactory the store factory
      * @param accountID the account ID

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidator.java
@@ -28,6 +28,7 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.state.HederaRecordCache;
 import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.handle.Dispatch;
+import com.hedera.node.config.data.AccountsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -82,8 +83,11 @@ public class DispatchValidator {
         if (creatorError != null) {
             return newCreatorError(dispatch.creatorInfo().accountId(), creatorError);
         } else {
-            final var payer =
-                    getPayerAccount(dispatch.readableStoreFactory(), dispatch.payerId(), dispatch.txnCategory());
+            final var payer = getPayerAccount(
+                    dispatch.readableStoreFactory(),
+                    dispatch.payerId(),
+                    dispatch.txnCategory(),
+                    dispatch.config().getConfigData(AccountsConfig.class));
             final var category = dispatch.txnCategory();
             // Check payer signature for all batch inner transactions, scheduled, and user transactions
             final var requiresPayerSig = category == SCHEDULED || category == USER || category == BATCH_INNER;
@@ -191,15 +195,23 @@ public class DispatchValidator {
      * For the child and preceding transactions, the payer account can be null. Because the payer for contract
      * operations can be a token address.
      *
+     * <p>The smart-contract payer rejection can be opted out of by setting
+     * {@code accounts.smartContractSenderEnabled=true}. This is a {@link com.hedera.node.config.NodeProperty}
+     * intended only for the standalone {@code TransactionExecutor} used by mirror node to support
+     * {@code eth_estimateGas} simulations whose sender is a contract account; it must remain {@code false} on every
+     * consensus node.
+     *
      * @param storeFactory the store factory
      * @param accountID the account ID
      * @param category the transaction category
+     * @param accountsConfig the {@link AccountsConfig} for this dispatch
      * @return the payer account
      */
     private Account getPayerAccount(
             @NonNull final ReadableStoreFactory storeFactory,
             @NonNull final AccountID accountID,
-            @NonNull final HandleContext.TransactionCategory category) {
+            @NonNull final HandleContext.TransactionCategory category,
+            @NonNull final AccountsConfig accountsConfig) {
         final var accountStore = storeFactory.readableStore(ReadableAccountStore.class);
         final var account = accountStore.getAccountById(accountID);
         return switch (category) {
@@ -212,7 +224,7 @@ public class DispatchValidator {
                     throw new IllegalStateException(
                             String.format("Category %s payer account with id %s is deleted", category, accountID));
                 }
-                if (account.smartContract()) {
+                if (account.smartContract() && !accountsConfig.smartContractSenderEnabled()) {
                     throw new IllegalStateException(String.format(
                             "Category %s payer account with id %s is a smart contract", category, accountID));
                 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidatorTest.java
@@ -57,6 +57,7 @@ import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.handle.Dispatch;
 import com.hedera.node.app.workflows.prehandle.PreHandleResult;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
@@ -107,6 +108,7 @@ class DispatchValidatorTest {
     @BeforeEach
     void setUp() {
         subject = new DispatchValidator(recordCache, transactionChecker, new AppFeeCharging(solvencyPreCheck), null);
+        lenient().when(dispatch.config()).thenReturn(HederaTestConfigBuilder.createConfig());
     }
 
     @Test
@@ -392,6 +394,30 @@ class DispatchValidatorTest {
         givenPayer(payer -> payer.tinybarBalance(1L).smartContract(true));
         given(dispatch.txnInfo()).willReturn(TXN_INFO);
         assertThrows(IllegalStateException.class, () -> subject.validateFeeChargingScenario(dispatch));
+    }
+
+    @Test
+    void contractUserPayerIsAllowedWhenSmartContractSenderEnabled() {
+        // Mirror node opts in to this via accounts.smartContractSenderEnabled=true to support
+        // eth_estimateGas simulations whose sender is a contract. The same dispatch with the flag off
+        // (the consensus-node default) is rejected by contractUserPayerIsFailInvalid.
+        given(dispatch.config())
+                .willReturn(HederaTestConfigBuilder.create()
+                        .withValue("accounts.smartContractSenderEnabled", "true")
+                        .getOrCreateConfig());
+
+        givenCreatorInfo();
+        givenUserDispatch();
+        givenNonDuplicate();
+        givenSolvencyCheckSetup();
+        givenValidPayerSig();
+        given(dispatch.preHandleResult()).willReturn(SUCCESSFUL_PREHANDLE);
+        doCallRealMethod().when(dispatch).feeChargingOrElse(any());
+        final var payerAccount = givenPayer(payer -> payer.tinybarBalance(1L).smartContract(true));
+
+        final var report = subject.validateFeeChargingScenario(dispatch);
+
+        assertEquals(newSuccess(dispatch.creatorInfo().accountId(), payerAccount), report);
     }
 
     @Test

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.node.config.NetworkProperty;
-import com.hedera.node.config.NodeProperty;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -59,7 +58,7 @@ public record AccountsConfig(
         @ConfigProperty(value = "blocklist.path", defaultValue = "") @NetworkProperty
         String blocklistResource,
 
-        @ConfigProperty(defaultValue = "false") @NodeProperty
+        @ConfigProperty(defaultValue = "false") @NetworkProperty
         boolean smartContractSenderEnabled) {
 
     /**

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AccountsConfig.java
@@ -5,28 +5,62 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.node.config.NetworkProperty;
+import com.hedera.node.config.NodeProperty;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 @ConfigData("accounts")
 public record AccountsConfig(
-        @ConfigProperty(defaultValue = "54") @NetworkProperty long softwareUpdateAdmin,
-        @ConfigProperty(defaultValue = "55") @NetworkProperty long addressBookAdmin,
-        @ConfigProperty(defaultValue = "57") @NetworkProperty long exchangeRatesAdmin,
-        @ConfigProperty(defaultValue = "56") @NetworkProperty long feeSchedulesAdmin,
-        @ConfigProperty(defaultValue = "58") @NetworkProperty long freezeAdmin,
-        @ConfigProperty(defaultValue = "100") @NetworkProperty long lastThrottleExempt,
-        @ConfigProperty(defaultValue = "801") @NetworkProperty long nodeRewardAccount,
-        @ConfigProperty(defaultValue = "800") @NetworkProperty long stakingRewardAccount,
-        @ConfigProperty(defaultValue = "802") @NetworkProperty long feeCollectionAccount,
-        @ConfigProperty(defaultValue = "50") @NetworkProperty long systemAdmin,
-        @ConfigProperty(defaultValue = "59") @NetworkProperty long systemDeleteAdmin,
-        @ConfigProperty(defaultValue = "60") @NetworkProperty long systemUndeleteAdmin,
+        @ConfigProperty(defaultValue = "54") @NetworkProperty
+        long softwareUpdateAdmin,
+
+        @ConfigProperty(defaultValue = "55") @NetworkProperty
+        long addressBookAdmin,
+
+        @ConfigProperty(defaultValue = "57") @NetworkProperty
+        long exchangeRatesAdmin,
+
+        @ConfigProperty(defaultValue = "56") @NetworkProperty
+        long feeSchedulesAdmin,
+
+        @ConfigProperty(defaultValue = "58") @NetworkProperty
+        long freezeAdmin,
+
+        @ConfigProperty(defaultValue = "100") @NetworkProperty
+        long lastThrottleExempt,
+
+        @ConfigProperty(defaultValue = "801") @NetworkProperty
+        long nodeRewardAccount,
+
+        @ConfigProperty(defaultValue = "800") @NetworkProperty
+        long stakingRewardAccount,
+
+        @ConfigProperty(defaultValue = "802") @NetworkProperty
+        long feeCollectionAccount,
+
+        @ConfigProperty(defaultValue = "50") @NetworkProperty
+        long systemAdmin,
+
+        @ConfigProperty(defaultValue = "59") @NetworkProperty
+        long systemDeleteAdmin,
+
+        @ConfigProperty(defaultValue = "60") @NetworkProperty
+        long systemUndeleteAdmin,
+
         @ConfigProperty(defaultValue = "2") @NetworkProperty long treasury,
-        @ConfigProperty(defaultValue = "100000000") @NetworkProperty long maxNumber,
-        @ConfigProperty(value = "blocklist.enabled", defaultValue = "false") @NetworkProperty boolean blocklistEnabled,
-        @ConfigProperty(value = "blocklist.path", defaultValue = "") @NetworkProperty String blocklistResource) {
+
+        @ConfigProperty(defaultValue = "100000000") @NetworkProperty
+        long maxNumber,
+
+        @ConfigProperty(value = "blocklist.enabled", defaultValue = "false") @NetworkProperty
+        boolean blocklistEnabled,
+
+        @ConfigProperty(value = "blocklist.path", defaultValue = "") @NetworkProperty
+        String blocklistResource,
+
+        @ConfigProperty(defaultValue = "false") @NodeProperty
+        boolean smartContractSenderEnabled) {
 
     /**
      * Check if the given account is a superuser.


### PR DESCRIPTION
**Description**:

Add `accounts.smartContractSenderEnabled `(default `false`). When `true`,
`DispatchValidator` no longer rejects smart-contract accounts as user-transaction
payers. Lets mirror node simulate `eth_estimateGas` for contract senders via the
standalone `TransactionExecutor`.

**Fixes**:
https://github.com/hiero-ledger/hiero-consensus-node/issues/24675
