### PR TITLE
chore: Update default BlockStreamConfig for WRB

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockRecordStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockRecordStreamConfig.java
@@ -54,14 +54,14 @@ public record BlockRecordStreamConfig(
         @ConfigProperty(defaultValue = "concurrent") @NetworkProperty
         String streamFileProducer,
 
-        @ConfigProperty(defaultValue = "false") @NetworkProperty
+        @ConfigProperty(defaultValue = "true") @NetworkProperty
         boolean writeWrappedRecordFileBlockHashesToDisk,
 
         @ConfigProperty(defaultValue = "/opt/hgcapp/wrappedRecordHashes") @NodeProperty
         String wrappedRecordHashesDir,
 
-        @ConfigProperty(defaultValue = "true") @NetworkProperty
+        @ConfigProperty(defaultValue = "false") @NetworkProperty
         boolean computeHashesFromWrappedRecordBlocks,
 
-        @ConfigProperty(defaultValue = "true") @NetworkProperty
+        @ConfigProperty(defaultValue = "false") @NetworkProperty
         boolean liveWritePrevWrappedRecordHashes) {}


### PR DESCRIPTION
**Description**:
This pull request updates the default configuration values for block record streaming in `BlockRecordStreamConfig`. The changes primarily reverse the default settings for writing and computing wrapped record file block hashes. In 0.74, writing of wrapped record hashes to disk is required.

Configuration default changes:

* Changed the default value of `writeWrappedRecordFileBlockHashesToDisk` from `false` to `true`, so block hashes will now be written to disk by default.
* Changed the default value of `computeHashesFromWrappedRecordBlocks` from `true` to `false`, disabling hash computation from wrapped record blocks by default.
* Changed the default value of `liveWritePrevWrappedRecordHashes` from `true` to `false`, so previous wrapped record hashes will not be written live by default.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
