### PR TITLE
refactor: 25249 Refactor `BlockStreamRecoveryWorkflow` to use `BinaryState`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BinaryStateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BinaryStateChangesValidator.java
@@ -25,6 +25,7 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.swirlds.state.BinaryState;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.state.merkle.VirtualMapStateImpl;
+import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
@@ -56,7 +57,7 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
     private static final int HASH_SIZE = 48;
     private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+");
 
-    private final Bytes expectedRootHash;
+    private final Bytes expectedRootHashBytes;
     private final Path pathToNode0SwirldsLog;
     private final StateChangesSummary stateChangesSummary = new StateChangesSummary(new TreeMap<>());
 
@@ -118,8 +119,8 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
     }
 
     public BinaryStateChangesValidator(
-            @NonNull final Bytes expectedRootHash, @NonNull final Path pathToNode0SwirldsLog) {
-        this.expectedRootHash = requireNonNull(expectedRootHash);
+            @NonNull final Bytes expectedRootHashBytes, @NonNull final Path pathToNode0SwirldsLog) {
+        this.expectedRootHashBytes = requireNonNull(expectedRootHashBytes);
         this.pathToNode0SwirldsLog = requireNonNull(pathToNode0SwirldsLog);
 
         final var platformConfig = ServicesMain.buildPlatformConfig();
@@ -129,7 +130,7 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
 
     @Override
     public void validateBlocks(@NonNull final List<Block> blocks) {
-        logger.info("Beginning binary replay validation of expected root hash {}", expectedRootHash);
+        logger.info("Beginning binary replay validation of expected root hash {}", expectedRootHashBytes);
         for (final var block : blocks) {
             for (final var item : block.items()) {
                 if (!item.hasStateChanges()) {
@@ -137,7 +138,7 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
                 }
                 final var changes = item.stateChangesOrThrow();
                 final var at = asInstant(changes.consensusTimestampOrThrow());
-                if (false && lastStateChangesTime != null && at.isBefore(lastStateChangesTime)) {
+                if (lastStateChangesTime != null && at.isBefore(lastStateChangesTime)) {
                     Assertions.fail("State changes are not in chronological order at " + at);
                 }
                 lastStateChangesTime = at;
@@ -148,20 +149,19 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
         logger.info("Summary of binary-applied changes by state:\n{}", stateChangesSummary);
 
         // Make the underlying VirtualMap immutable by creating a mutable copy, then hash the original
-        final var virtualMap = state.getRoot();
-        final var mutableCopy = virtualMap.copy();
-        mutableCopy.registerMetrics(new NoOpMetrics());
-        final var rootHash = requireNonNull(virtualMap.getHash()).getBytes();
-        logger.info("Validating binary replay root hash {}", rootHash);
+        final VirtualMap virtualMap = state.getRoot();
+        virtualMap.copy().release();
+        final Bytes rootHashBytes = requireNonNull(virtualMap.getHash()).getBytes();
+        logger.info("Validating binary replay root hash {}", rootHashBytes);
 
-        if (!expectedRootHash.equals(rootHash)) {
+        if (!expectedRootHashBytes.equals(rootHashBytes)) {
             final var expectedRootMnemonic = getMaybeLastHashMnemonics(pathToNode0SwirldsLog);
             final var actualRootMnemonic = Mnemonics.generateMnemonic(virtualMap.getHash());
             final var errorMsg = new StringBuilder("Binary replay hash mismatch");
             errorMsg.append("\n    * root hash - expected ")
-                    .append(expectedRootHash)
+                    .append(expectedRootHashBytes)
                     .append(", was ")
-                    .append(rootHash);
+                    .append(rootHashBytes);
             if (expectedRootMnemonic != null) {
                 errorMsg.append("\n    * root mnemonic - expected ")
                         .append(expectedRootMnemonic)

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -9,15 +9,21 @@ import static org.hiero.consensus.platformstate.PlatformStateUtils.roundOf;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.output.StateChanges;
+import com.hedera.hapi.node.base.TokenAssociation;
+import com.hedera.hapi.node.state.common.EntityIDPair;
 import com.hedera.node.app.hapi.utils.blocks.BlockStreamAccess;
-import com.hedera.node.app.hapi.utils.blocks.BlockStreamUtils;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.ProtoConstants;
+import com.hedera.pbj.runtime.ProtoParserTools;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.statevalidation.util.StateUtils;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.state.snapshot.SignedStateFileWriter;
+import com.swirlds.state.BinaryState;
 import com.swirlds.state.StateLifecycleManager;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.state.merkle.VirtualMapStateLifecycleManager;
-import com.swirlds.state.spi.CommittableWritableStates;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -31,7 +37,13 @@ import org.hiero.consensus.state.signed.SignedState;
 
 /**
  * This workflow applies a set of blocks to a given state and creates a new snapshot once the state
- * is advanced to the target round
+ * is advanced to the target round.
+ *
+ * <p>State changes from the block stream are applied through the {@link BinaryState} API,
+ * which operates directly on raw protobuf bytes without deserializing into domain objects.
+ * This avoids the overhead of the codec-based State API (WritableStates, WritableKVState, etc.)
+ * where each state change would require deserialization to a Java domain object, buffering in
+ * writable state adapters, and re-serialization on commit.
  */
 public class BlockStreamRecoveryWorkflow {
 
@@ -120,7 +132,7 @@ public class BlockStreamRecoveryWorkflow {
                 }
 
                 if (item.hasStateChanges()) {
-                    applyStateChanges(item.stateChangesOrThrow());
+                    applyStateChanges(state, item.stateChangesOrThrow());
                 }
             }
         });
@@ -165,63 +177,248 @@ public class BlockStreamRecoveryWorkflow {
         }
     }
 
-    private void applyStateChanges(@NonNull final StateChanges stateChanges) {
-        String lastService = null;
-        CommittableWritableStates lastWritableStates = null;
+    /**
+     * Applies state changes through the {@link BinaryState} API by parsing the binary protobuf
+     * wire format directly, avoiding deserialization into domain objects.
+     */
+    private static void applyStateChanges(
+            @NonNull final BinaryState binaryState, @NonNull final StateChanges stateChanges) {
+        BinaryStateChangeApplier.applyStateChanges(binaryState, StateChanges.PROTOBUF.toBytes(stateChanges));
+    }
 
-        final int n = stateChanges.stateChanges().size();
+    /**
+     * Parses binary protobuf {@link StateChanges} and applies mutations through the {@link BinaryState} API.
+     *
+     * <p>The parser reads the protobuf wire format to extract state change operations
+     * (singleton updates, map updates/deletes, queue pushes/pops) and delegates them to the
+     * corresponding {@link BinaryState} methods, which handle key composition, value wrapping,
+     * and queue state management internally.
+     */
+    private static final class BinaryStateChangeApplier {
+        private static void applyStateChanges(
+                @NonNull final BinaryState binaryState, @NonNull final Bytes stateChangesBytes) {
+            final ReadableSequentialData input = stateChangesBytes.toReadableSequentialData();
+            while (input.hasRemaining()) {
+                final int tag = input.readVarInt(false);
+                switch (tag) {
+                    // consensus_timestamp: field 1, message => (1 << 3) | 2 = 10
+                    case 10 -> skipMessage(input);
+                    // state_changes:       field 2, message => (2 << 3) | 2 = 18
+                    case 18 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            final long endPosition = input.position() + messageLength;
+                            processStateChange(binaryState, input, endPosition);
+                        }
+                    }
+                    default -> skipField(input, tag);
+                }
+            }
+        }
 
-        for (int i = 0; i < n; i++) {
-            final var stateChange = stateChanges.stateChanges().get(i);
+        private static void processStateChange(
+                @NonNull final BinaryState binaryState,
+                @NonNull final ReadableSequentialData input,
+                final long endPosition) {
+            int stateId = -1;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                switch (tag) {
+                    // state_id: field 1, uint32 varint => (1 << 3) | 0 = 8
+                    case 8 -> stateId = ProtoParserTools.readUint32(input);
+                    // state_add: field 2, message => (2 << 3) | 2 = 18
+                    // state_remove: field 3, message => (3 << 3) | 2 = 26
+                    case 18, 26 -> skipMessage(input);
+                    // singleton_update: field 4, message => (4 << 3) | 2 = 34
+                    case 34 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            final Bytes rawValue =
+                                    readOneOfPayload(input, input.position() + messageLength, "SingletonUpdateChange");
+                            binaryState.updateSingleton(requireStateId(stateId), rawValue);
+                        }
+                    }
+                    // map_update: field 5, message => (5 << 3) | 2 = 42
+                    case 42 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            processMapUpdate(
+                                    binaryState, requireStateId(stateId), input, input.position() + messageLength);
+                        }
+                    }
+                    // map_delete: field 6, message => (6 << 3) | 2 = 50
+                    case 50 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            processMapDelete(
+                                    binaryState, requireStateId(stateId), input, input.position() + messageLength);
+                        }
+                    }
+                    // queue_push: field 7, message => (7 << 3) | 2 = 58
+                    case 58 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            final Bytes rawElement =
+                                    readOneOfPayload(input, input.position() + messageLength, "QueuePushChange");
+                            binaryState.pushQueue(requireStateId(stateId), rawElement);
+                        }
+                    }
+                    // queue_pop: field 8, message => (8 << 3) | 2 = 66
+                    case 66 -> {
+                        skipMessage(input);
+                        binaryState.popQueue(requireStateId(stateId));
+                    }
+                    default -> skipField(input, tag);
+                }
+            }
+        }
 
-            final var stateName = BlockStreamUtils.stateNameOf(stateChange.stateId());
-            final var delimIndex = stateName.indexOf('.');
-            if (delimIndex == -1) {
-                throw new RuntimeException("State name '" + stateName + "' is not in the correct format");
-            }
-            final var serviceName = stateName.substring(0, delimIndex);
-            final var state = stateLifecycleManager.getMutableState();
-            final var writableStates = state.getWritableStates(serviceName);
-            switch (stateChange.changeOperation().kind()) {
-                case UNSET -> throw new IllegalStateException("Change operation is not set");
-                case STATE_ADD, STATE_REMOVE -> {
-                    // No-op
-                }
-                case SINGLETON_UPDATE -> {
-                    final var singletonState = writableStates.getSingleton(stateChange.stateId());
-                    final var singleton = BlockStreamUtils.singletonPutFor(stateChange.singletonUpdateOrThrow());
-                    singletonState.put(singleton);
-                }
-                case MAP_UPDATE -> {
-                    final var mapState = writableStates.get(stateChange.stateId());
-                    final var key = BlockStreamUtils.mapKeyFor(
-                            stateChange.mapUpdateOrThrow().keyOrThrow());
-                    final var value = BlockStreamUtils.mapValueFor(
-                            stateChange.mapUpdateOrThrow().valueOrThrow());
-                    mapState.put(key, value);
-                }
-                case MAP_DELETE -> {
-                    final var mapState = writableStates.get(stateChange.stateId());
-                    mapState.remove(BlockStreamUtils.mapKeyFor(
-                            stateChange.mapDeleteOrThrow().keyOrThrow()));
-                }
-                case QUEUE_PUSH -> {
-                    final var queueState = writableStates.getQueue(stateChange.stateId());
-                    queueState.add(BlockStreamUtils.queuePushFor(stateChange.queuePushOrThrow()));
-                }
-                case QUEUE_POP -> {
-                    final var queueState = writableStates.getQueue(stateChange.stateId());
-                    queueState.poll();
+        private static void processMapUpdate(
+                @NonNull final BinaryState binaryState,
+                final int stateId,
+                @NonNull final ReadableSequentialData input,
+                final long endPosition) {
+            Bytes rawKey = null;
+            Bytes rawValue = null;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                switch (tag) {
+                    // key: field 1, message => (1 << 3) | 2 = 10K
+                    case 10 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            rawKey = readMapKeyPayload(stateId, input, input.position() + messageLength);
+                        }
+                    }
+                    // value: field 2, message => (2 << 3) | 2 = 18
+                    case 18 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            rawValue = readOneOfPayload(input, input.position() + messageLength, "MapChangeValue");
+                        }
+                    }
+                    default -> skipField(input, tag);
                 }
             }
-            if ((lastService != null && !lastService.equals(serviceName))) {
-                lastWritableStates.commit();
+            if (rawKey == null || rawValue == null) {
+                throw new IllegalStateException("MapChangeKey or MapChangeValue missing");
             }
-            if (i == n - 1) {
-                ((CommittableWritableStates) writableStates).commit();
+            binaryState.updateKv(stateId, rawKey, rawValue);
+        }
+
+        private static void processMapDelete(
+                @NonNull final BinaryState binaryState,
+                final int stateId,
+                @NonNull final ReadableSequentialData input,
+                final long endPosition) {
+            Bytes rawKey = null;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                // key: field 1, message => (1 << 3) | 2 = 10
+                if (tag == 10) {
+                    final int messageLength = input.readVarInt(false);
+                    if (messageLength > 0) {
+                        rawKey = readMapKeyPayload(stateId, input, input.position() + messageLength);
+                    }
+                } else {
+                    skipField(input, tag);
+                }
             }
-            lastService = serviceName;
-            lastWritableStates = (CommittableWritableStates) writableStates;
+            if (rawKey == null) {
+                throw new IllegalStateException("MapChangeKey missing in MapDeleteChange");
+            }
+            binaryState.removeKv(stateId, rawKey);
+        }
+
+        /**
+         * Reads the first delimited (length-prefixed) field payload within a protobuf message.
+         * Used for extracting raw key/value bytes from oneOf wrappers and map key messages.
+         */
+        private static Bytes readOneOfPayload(
+                @NonNull final ReadableSequentialData input,
+                final long endPosition,
+                @NonNull final String description) {
+            Bytes payload = null;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                final var wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+                if (payload == null && wireType == ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    final int length = input.readVarInt(false);
+                    payload = input.readBytes(length);
+                } else {
+                    skipField(input, wireType);
+                }
+            }
+            if (payload == null) {
+                throw new IllegalStateException(description + " payload missing");
+            }
+            return payload;
+        }
+
+        /**
+         * Reads the first delimited field payload from a map key message.
+         * Most block-stream key payloads are byte-compatible with the state key bytes stored in the
+         * VirtualMap. Token relationship keys are the important exception: block stream uses
+         * TokenAssociation while state stores EntityIDPair, whose field ordering is different.
+         */
+        private static Bytes readMapKeyPayload(
+                final int stateId, @NonNull final ReadableSequentialData input, final long endPosition) {
+            Bytes payload = null;
+            Integer fieldNumber = null;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                final var wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+                if (payload == null && wireType == ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    fieldNumber = tag >>> ProtoParserTools.TAG_FIELD_OFFSET;
+                    final int length = input.readVarInt(false);
+                    payload = input.readBytes(length);
+                } else {
+                    skipField(input, wireType);
+                }
+            }
+            if (payload == null) {
+                throw new IllegalStateException("MapChangeKey payload missing");
+            }
+            return normalizeMapKeyPayload(stateId, fieldNumber, payload);
+        }
+
+        private static Bytes normalizeMapKeyPayload(
+                final int stateId, final int fieldNumber, @NonNull final Bytes payload) {
+            if (stateId == 9 && fieldNumber == 2) {
+                try {
+                    final var tokenAssociation = TokenAssociation.PROTOBUF.parse(payload);
+                    return EntityIDPair.PROTOBUF.toBytes(
+                            new EntityIDPair(tokenAssociation.accountId(), tokenAssociation.tokenId()));
+                } catch (ParseException e) {
+                    throw new IllegalStateException("Failed to normalize token relationship key", e);
+                }
+            }
+            return payload;
+        }
+
+        private static int requireStateId(final int stateId) {
+            if (stateId < 0) {
+                throw new IllegalStateException("StateChange missing state_id");
+            }
+            return stateId;
+        }
+
+        private static void skipField(@NonNull final ReadableSequentialData input, final int tag) {
+            skipField(input, ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK));
+        }
+
+        private static void skipField(
+                @NonNull final ReadableSequentialData input, @NonNull final ProtoConstants wireType) {
+            try {
+                ProtoParserTools.skipField(input, wireType);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to skip protobuf field with wire type " + wireType, e);
+            }
+        }
+
+        private static void skipMessage(@NonNull final ReadableSequentialData input) {
+            final int messageLength = input.readVarInt(false);
+            input.skip(messageLength);
         }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -132,7 +132,8 @@ public class BlockStreamRecoveryWorkflow {
                 }
 
                 if (item.hasStateChanges()) {
-                    applyStateChanges(state, item.stateChangesOrThrow());
+                    BinaryStateChangeApplier.applyStateChanges(
+                            state, StateChanges.PROTOBUF.toBytes(item.stateChangesOrThrow()));
                 }
             }
         });
@@ -175,15 +176,6 @@ public class BlockStreamRecoveryWorkflow {
             throw new RuntimeException("Excepted and actual hashes do not match. \n Expected: %s \n Actual: %s "
                     .formatted(expectedRootHash, rootHash));
         }
-    }
-
-    /**
-     * Applies state changes through the {@link BinaryState} API by parsing the binary protobuf
-     * wire format directly, avoiding deserialization into domain objects.
-     */
-    private static void applyStateChanges(
-            @NonNull final BinaryState binaryState, @NonNull final StateChanges stateChanges) {
-        BinaryStateChangeApplier.applyStateChanges(binaryState, StateChanges.PROTOBUF.toBytes(stateChanges));
     }
 
     /**
@@ -382,6 +374,19 @@ public class BlockStreamRecoveryWorkflow {
             return normalizeMapKeyPayload(stateId, fieldNumber, payload);
         }
 
+        /**
+         * Normalizes map key payload bytes to match the format stored in the VirtualMap.
+         * Most block-stream keys are byte-compatible, but token relationship keys are an
+         * exception: the block stream encodes them as {@link TokenAssociation} (field 1 = token_id,
+         * field 2 = account_id), while the state stores {@link EntityIDPair} (field 1 = account_id,
+         * field 2 = token_id).
+         *
+         * @param stateId the numeric state identifier; 9 = token relationships
+         * @param fieldNumber the protobuf field number from the MapChangeKey oneOf wrapper;
+         *                    field 2 indicates a TokenAssociation encoding that needs conversion
+         * @param payload the raw key bytes extracted from the block stream
+         * @return normalized key bytes compatible with the VirtualMap key format
+         */
         private static Bytes normalizeMapKeyPayload(
                 final int stateId, final int fieldNumber, @NonNull final Bytes payload) {
             if (stateId == 9 && fieldNumber == 2) {
@@ -403,10 +408,22 @@ public class BlockStreamRecoveryWorkflow {
             return stateId;
         }
 
+        /**
+         * Skips a protobuf field based on the wire type encoded in the given tag.
+         *
+         * @param input the input stream positioned at the field's value
+         * @param tag the raw protobuf tag (field number + wire type)
+         */
         private static void skipField(@NonNull final ReadableSequentialData input, final int tag) {
             skipField(input, ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK));
         }
 
+        /**
+         * Skips a protobuf field value for the given wire type.
+         *
+         * @param input the input stream positioned at the field's value
+         * @param wireType the protobuf wire type indicating how to skip the value
+         */
         private static void skipField(
                 @NonNull final ReadableSequentialData input, @NonNull final ProtoConstants wireType) {
             try {


### PR DESCRIPTION
**Description**:

Replaces the codec-based State API path (`WritableStates`, `WritableKVState`, `WritableSingletonState`, `WritableQueueState`, `BlockStreamUtils`) with `BinaryState` methods (`updateSingleton`, `updateKv`, `removeKv`, `pushQueue`, `popQueue`). Raw protobuf bytes from the block stream are applied directly, skipping deserialization into domain objects, buffering in writable state adapters, and re-serialization on commit.

**What changed:**
- `applyStateChanges` replaced with a `BinaryStateChangeApplier` inner class that parses protobuf wire format and delegates to `BinaryState`
- Token relationship keys are normalized from `TokenAssociation` to `EntityIDPair` field ordering, matching the existing approach in `BinaryStateChangesValidator`
- `BlockStreamUtils`, `CommittableWritableStates`, and service-name resolution logic removed from the class
- Block/round management, hashing, and snapshot writing unchanged

**Related issue(s)**:

Fixes #25249 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
