### PR TITLE
chore: Update ingest parse metrics

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -52,6 +52,8 @@ import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.EOFException;
+import java.nio.BufferUnderflowException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -90,12 +92,39 @@ public class TransactionChecker {
     private static final String NON_GOVERNANCE_OVERSIZED_TXNS_DESC =
             "number of oversized txns received from a non-governance payer";
 
+    // Metric config for tracking parse failures by cause type
+    private static final String COUNTER_PARSE_ERR_UNKNOWN_FIELD_NAME = "ParseErrUnknownFieldRcv";
+    private static final String COUNTER_PARSE_ERR_UNKNOWN_FIELD_DESC =
+            "number of txns rejected due to unknown protobuf fields (newer client on older network)";
+    private static final String COUNTER_PARSE_ERR_BUF_UNDERFLOW_NAME = "ParseErrBufUnderflowRcv";
+    private static final String COUNTER_PARSE_ERR_BUF_UNDERFLOW_DESC =
+            "number of txns rejected due to protobuf BufferUnderflowException (truncated bytes)";
+    private static final String COUNTER_PARSE_ERR_EOF_NAME = "ParseErrEofRcv";
+    private static final String COUNTER_PARSE_ERR_EOF_DESC =
+            "number of txns rejected due to protobuf EOFException (unexpected end of stream)";
+    private static final String COUNTER_PARSE_ERR_STRUCTURAL_NAME = "ParseErrStructuralRcv";
+    private static final String COUNTER_PARSE_ERR_STRUCTURAL_DESC =
+            "number of txns rejected due to structural protobuf violations (max depth or field size exceeded)";
+    private static final String COUNTER_PARSE_ERR_OTHER_NAME = "ParseErrOtherRcv";
+    private static final String COUNTER_PARSE_ERR_OTHER_DESC =
+            "number of txns rejected due to other unexpected protobuf parse failures";
+
     /** The {@link Counter} used to track the number of deprecated transactions (bodyBytes, sigMap) received. */
     private final Counter deprecatedCounter;
     /** The {@link Counter} used to track the number of super deprecated transactions (body, sigs) received. */
     private final Counter superDeprecatedCounter;
     /** The {@link Counter} used to track the number of oversized transactions from a non-governance payer. */
     private final Counter nonGovernanceOversizedTransactionsCounter;
+    /** The {@link Counter} used to track parse failures caused by {@link UnknownFieldException}. */
+    private final Counter parseErrUnknownFieldCounter;
+    /** The {@link Counter} used to track parse failures caused by {@link BufferUnderflowException}. */
+    private final Counter parseErrBufferUnderflowCounter;
+    /** The {@link Counter} used to track parse failures caused by {@link EOFException}. */
+    private final Counter parseErrEofCounter;
+    /** The {@link Counter} used to track parse failures from direct structural violations (max depth, field size). */
+    private final Counter parseErrStructuralCounter;
+    /** The {@link Counter} used to track parse failures from other unexpected causes. */
+    private final Counter parseErrOtherCounter;
 
     private final ConfigProvider configProvider;
 
@@ -122,6 +151,19 @@ public class TransactionChecker {
         this.nonGovernanceOversizedTransactionsCounter =
                 metrics.getOrCreate(new Counter.Config("app", COUNTER_NON_GOVERNANCE_OVERSIZED_TXNS)
                         .withDescription(NON_GOVERNANCE_OVERSIZED_TXNS_DESC));
+        this.parseErrUnknownFieldCounter =
+                metrics.getOrCreate(new Counter.Config("app", COUNTER_PARSE_ERR_UNKNOWN_FIELD_NAME)
+                        .withDescription(COUNTER_PARSE_ERR_UNKNOWN_FIELD_DESC));
+        this.parseErrBufferUnderflowCounter =
+                metrics.getOrCreate(new Counter.Config("app", COUNTER_PARSE_ERR_BUF_UNDERFLOW_NAME)
+                        .withDescription(COUNTER_PARSE_ERR_BUF_UNDERFLOW_DESC));
+        this.parseErrEofCounter = metrics.getOrCreate(
+                new Counter.Config("app", COUNTER_PARSE_ERR_EOF_NAME).withDescription(COUNTER_PARSE_ERR_EOF_DESC));
+        this.parseErrStructuralCounter =
+                metrics.getOrCreate(new Counter.Config("app", COUNTER_PARSE_ERR_STRUCTURAL_NAME)
+                        .withDescription(COUNTER_PARSE_ERR_STRUCTURAL_DESC));
+        this.parseErrOtherCounter = metrics.getOrCreate(
+                new Counter.Config("app", COUNTER_PARSE_ERR_OTHER_NAME).withDescription(COUNTER_PARSE_ERR_OTHER_DESC));
     }
 
     /**
@@ -625,13 +667,24 @@ public class TransactionChecker {
         try {
             return codec.parse(data, true, false, DEFAULT_MAX_DEPTH, maxSize);
         } catch (ParseException e) {
+            recordParseErrorMetric(e);
             if (e.getCause() instanceof UnknownFieldException) {
                 // We do not allow newer clients to send transactions to older networks.
                 throw new PreCheckException(TRANSACTION_HAS_UNKNOWN_FIELDS);
             }
-            // Either the protobuf was malformed, or something else failed during parsing
-            logger.warn("ParseException while parsing protobuf", e);
+            logger.debug("ParseException while parsing protobuf: {}", e.getMessage());
             throw new PreCheckException(parseErrorCode);
+        }
+    }
+
+    private void recordParseErrorMetric(@NonNull final ParseException e) {
+        final var cause = e.getCause();
+        switch (cause) {
+            case UnknownFieldException _ -> parseErrUnknownFieldCounter.increment();
+            case BufferUnderflowException _ -> parseErrBufferUnderflowCounter.increment();
+            case EOFException _ -> parseErrEofCounter.increment();
+            case null -> parseErrStructuralCounter.increment();
+            default -> parseErrOtherCounter.increment();
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -52,7 +52,6 @@ import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.io.EOFException;
 import java.nio.BufferUnderflowException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -99,9 +98,6 @@ public class TransactionChecker {
     private static final String COUNTER_PARSE_ERR_BUF_UNDERFLOW_NAME = "ParseErrBufUnderflowRcv";
     private static final String COUNTER_PARSE_ERR_BUF_UNDERFLOW_DESC =
             "number of txns rejected due to protobuf BufferUnderflowException (truncated bytes)";
-    private static final String COUNTER_PARSE_ERR_EOF_NAME = "ParseErrEofRcv";
-    private static final String COUNTER_PARSE_ERR_EOF_DESC =
-            "number of txns rejected due to protobuf EOFException (unexpected end of stream)";
     private static final String COUNTER_PARSE_ERR_STRUCTURAL_NAME = "ParseErrStructuralRcv";
     private static final String COUNTER_PARSE_ERR_STRUCTURAL_DESC =
             "number of txns rejected due to structural protobuf violations (max depth or field size exceeded)";
@@ -119,8 +115,6 @@ public class TransactionChecker {
     private final Counter parseErrUnknownFieldCounter;
     /** The {@link Counter} used to track parse failures caused by {@link BufferUnderflowException}. */
     private final Counter parseErrBufferUnderflowCounter;
-    /** The {@link Counter} used to track parse failures caused by {@link EOFException}. */
-    private final Counter parseErrEofCounter;
     /** The {@link Counter} used to track parse failures from direct structural violations (max depth, field size). */
     private final Counter parseErrStructuralCounter;
     /** The {@link Counter} used to track parse failures from other unexpected causes. */
@@ -157,8 +151,6 @@ public class TransactionChecker {
         this.parseErrBufferUnderflowCounter =
                 metrics.getOrCreate(new Counter.Config("app", COUNTER_PARSE_ERR_BUF_UNDERFLOW_NAME)
                         .withDescription(COUNTER_PARSE_ERR_BUF_UNDERFLOW_DESC));
-        this.parseErrEofCounter = metrics.getOrCreate(
-                new Counter.Config("app", COUNTER_PARSE_ERR_EOF_NAME).withDescription(COUNTER_PARSE_ERR_EOF_DESC));
         this.parseErrStructuralCounter =
                 metrics.getOrCreate(new Counter.Config("app", COUNTER_PARSE_ERR_STRUCTURAL_NAME)
                         .withDescription(COUNTER_PARSE_ERR_STRUCTURAL_DESC));
@@ -672,7 +664,7 @@ public class TransactionChecker {
                 // We do not allow newer clients to send transactions to older networks.
                 throw new PreCheckException(TRANSACTION_HAS_UNKNOWN_FIELDS);
             }
-            logger.debug("ParseException while parsing protobuf: {}", e.getMessage());
+            logger.debug("ParseException while parsing protobuf: ", e);
             throw new PreCheckException(parseErrorCode);
         }
     }
@@ -682,7 +674,6 @@ public class TransactionChecker {
         switch (cause) {
             case UnknownFieldException _ -> parseErrUnknownFieldCounter.increment();
             case BufferUnderflowException _ -> parseErrBufferUnderflowCounter.increment();
-            case EOFException _ -> parseErrEofCounter.increment();
             case null -> parseErrStructuralCounter.increment();
             default -> parseErrOtherCounter.increment();
         }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -43,6 +44,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.util.HapiUtils;
 import com.hedera.hapi.util.UnknownHederaFunctionality;
 import com.hedera.node.app.fixtures.AppTestBase;
+import com.hedera.node.app.spi.fixtures.util.LogCaptor;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
@@ -58,6 +60,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
@@ -275,6 +278,79 @@ final class TransactionCheckerTest extends AppTestBase {
             assertThatThrownBy(() -> checker.check(transaction, Integer.MAX_VALUE))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(INVALID_TRANSACTION_BODY));
+        }
+
+        @Test
+        @DisplayName("Malformed protobuf does not emit WARN logs")
+        void malformedProtobufDoesNotWarn() {
+            final var logCaptor = new LogCaptor(LogManager.getLogger(TransactionChecker.class));
+            try {
+                assertThatThrownBy(() -> checker.parseAndCheck(randomBytes(100)))
+                        .isInstanceOf(PreCheckException.class)
+                        .has(responseCode(INVALID_TRANSACTION));
+                assertTrue(logCaptor.warnLogs().isEmpty(), "Malformed ingest input must not emit WARN logs");
+            } finally {
+                logCaptor.stopCapture();
+            }
+        }
+
+        @Test
+        @DisplayName("Truncated protobuf increments the BufferUnderflow parse error counter")
+        void parseErrorBufferUnderflowCounterIncrements() {
+            // A single valid field-1 tag byte with no following length varint causes
+            // BufferUnderflowException when the codec tries to read the message length.
+            final var truncatedBytes = Bytes.wrap(new byte[] {0x0A}); // field 1, wire type 2
+            assertThatThrownBy(() -> checker.parseAndCheck(truncatedBytes))
+                    .isInstanceOf(PreCheckException.class)
+                    .has(responseCode(INVALID_TRANSACTION));
+            assertThat(counterMetric("ParseErrBufUnderflowRcv").get()).isEqualTo(1);
+            assertThat(counterMetric("ParseErrUnknownFieldRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrEofRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrStructuralRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrOtherRcv").get()).isZero();
+        }
+
+        @Test
+        @DisplayName("Protobuf with oversized field declaration increments the structural parse error counter")
+        void parseErrorStructuralCounterIncrements() {
+            // Disable governance and jumbo so maxIngestParseSize() == MAX_TX_SIZE (6144).
+            props = () -> new VersionedConfigImpl(
+                    HederaTestConfigBuilder.create()
+                            .withValue("governanceTransactions.isEnabled", false)
+                            .withValue("jumboTransactions.isEnabled", false)
+                            .withValue("hedera.transaction.maxBytes", MAX_TX_SIZE)
+                            .getOrCreateConfig(),
+                    1);
+            checker = new TransactionChecker(props, metrics);
+
+            // field 5 (signedTransactionBytes, tag=0x2A) followed by varint(100000) as the
+            // declared byte-field length. 100000 > 6144 triggers a direct ParseException with
+            // no cause from ProtoParserTools.readBytes. Total buffer is 4 bytes, well under
+            // the 6144 limit, so TRANSACTION_OVERSIZE is never thrown.
+            final var craftedBytes = Bytes.wrap(new byte[] {0x2A, (byte) 0xA0, (byte) 0x8D, 0x06});
+            assertThatThrownBy(() -> checker.parseAndCheck(craftedBytes))
+                    .isInstanceOf(PreCheckException.class)
+                    .has(responseCode(INVALID_TRANSACTION));
+            assertThat(counterMetric("ParseErrStructuralRcv").get()).isEqualTo(1);
+            assertThat(counterMetric("ParseErrUnknownFieldRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrBufUnderflowRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrEofRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrOtherRcv").get()).isZero();
+        }
+
+        @Test
+        @DisplayName("Protobuf with unknown fields increments the unknown field parse error counter")
+        void parseErrorUnknownFieldCounterIncrements() {
+            // appendUnknownField appends a field number not defined in the Transaction proto
+            inputBuffer = Bytes.wrap(appendUnknownField(asByteArray(tx)));
+            assertThatThrownBy(() -> checker.parseAndCheck(inputBuffer))
+                    .isInstanceOf(PreCheckException.class)
+                    .has(responseCode(TRANSACTION_HAS_UNKNOWN_FIELDS));
+            assertThat(counterMetric("ParseErrUnknownFieldRcv").get()).isEqualTo(1);
+            assertThat(counterMetric("ParseErrBufUnderflowRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrEofRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrStructuralRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrOtherRcv").get()).isZero();
         }
 
         /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -305,7 +305,6 @@ final class TransactionCheckerTest extends AppTestBase {
                     .has(responseCode(INVALID_TRANSACTION));
             assertThat(counterMetric("ParseErrBufUnderflowRcv").get()).isEqualTo(1);
             assertThat(counterMetric("ParseErrUnknownFieldRcv").get()).isZero();
-            assertThat(counterMetric("ParseErrEofRcv").get()).isZero();
             assertThat(counterMetric("ParseErrStructuralRcv").get()).isZero();
             assertThat(counterMetric("ParseErrOtherRcv").get()).isZero();
         }
@@ -334,7 +333,6 @@ final class TransactionCheckerTest extends AppTestBase {
             assertThat(counterMetric("ParseErrStructuralRcv").get()).isEqualTo(1);
             assertThat(counterMetric("ParseErrUnknownFieldRcv").get()).isZero();
             assertThat(counterMetric("ParseErrBufUnderflowRcv").get()).isZero();
-            assertThat(counterMetric("ParseErrEofRcv").get()).isZero();
             assertThat(counterMetric("ParseErrOtherRcv").get()).isZero();
         }
 
@@ -348,9 +346,23 @@ final class TransactionCheckerTest extends AppTestBase {
                     .has(responseCode(TRANSACTION_HAS_UNKNOWN_FIELDS));
             assertThat(counterMetric("ParseErrUnknownFieldRcv").get()).isEqualTo(1);
             assertThat(counterMetric("ParseErrBufUnderflowRcv").get()).isZero();
-            assertThat(counterMetric("ParseErrEofRcv").get()).isZero();
             assertThat(counterMetric("ParseErrStructuralRcv").get()).isZero();
             assertThat(counterMetric("ParseErrOtherRcv").get()).isZero();
+        }
+
+        @Test
+        @DisplayName("Protobuf with invalid field number and wire type increments the other parse error counter")
+        void parseErrorOtherCounterIncrements() {
+            // field=0 and wire type=7 are both invalid; the codec throws a plain IOException (not
+            // UnknownFieldException or BufferUnderflowException), which is wrapped as the ParseException
+            // cause and hits the default branch.
+            assertThatThrownBy(() -> checker.parseAndCheck(Bytes.wrap(invalidProtobuf())))
+                    .isInstanceOf(PreCheckException.class)
+                    .has(responseCode(INVALID_TRANSACTION));
+            assertThat(counterMetric("ParseErrOtherRcv").get()).isEqualTo(1);
+            assertThat(counterMetric("ParseErrUnknownFieldRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrBufUnderflowRcv").get()).isZero();
+            assertThat(counterMetric("ParseErrStructuralRcv").get()).isZero();
         }
 
         /**


### PR DESCRIPTION
**Description**:
This pull request enhances the `TransactionChecker` to provide more granular tracking and handling of protobuf parse errors, and adds corresponding unit tests to ensure correct metric reporting and logging behavior. The changes improve observability and error categorization for transaction parsing failures.

**Enhanced parse error tracking and metrics:**

* Introduced new `Counter` metrics in `TransactionChecker` to separately track parse failures by cause: unknown protobuf fields, buffer underflow, EOF, structural violations, and other errors. These counters are initialized and incremented appropriately in the code.
* Added logic to the `parseStrict` method to record the specific parse error metric based on the exception cause, and changed logging for parse failures to use debug level instead of warn.

**Related issue(s)**:

Fixes #25254 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
