### PR TITLE
ci(workflows): update trigger on unapprove PR workflow

### DIFF
--- a/.github/workflows/080-flow-auto-unapprove.yaml
+++ b/.github/workflows/080-flow-auto-unapprove.yaml
@@ -3,6 +3,7 @@ name: "080: [FLOW] Auto Unapprove PR"
 on:
   pull_request:
     types:
+      - opened
       - ready_for_review
       - reopened
       - synchronize


### PR DESCRIPTION
**Description**:
This pull request makes a small update to the workflow configuration for auto-unapproving pull requests. The workflow will now also trigger when a pull request is opened.

**Related issue(s)**:

Fixes #25264 
