### PR TITLE
fix: 25277: LongListDisk is not thread safe

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -67,6 +68,12 @@ public class LongListDisk extends AbstractLongList<Long> {
     private final Deque<Long> freeChunks = new ConcurrentLinkedDeque<>();
 
     /**
+     * The number of chunks in the temp file. Increased when a new chunk is created and
+     * appended to the file.
+     */
+    private final AtomicInteger numAllocatedChunks;
+
+    /**
      * Protects readers and writers from observing a chunk file-offset
      * that has been recycled by a concurrent
      * {@link #updateValidRange} → {@link #closeChunk} → {@link #createChunk}
@@ -111,6 +118,7 @@ public class LongListDisk extends AbstractLongList<Long> {
         super(capacity, configuration);
         initFileChannel(configuration);
         fillBufferWithZeroes(initOrGetTransferBuffer());
+        numAllocatedChunks = new AtomicInteger(0);
     }
 
     /**
@@ -130,6 +138,7 @@ public class LongListDisk extends AbstractLongList<Long> {
         super(longsPerChunk, capacity, reservedBufferSize);
         initFileChannel(configuration);
         fillBufferWithZeroes(initOrGetTransferBuffer());
+        numAllocatedChunks = new AtomicInteger(0);
     }
 
     /**
@@ -147,6 +156,9 @@ public class LongListDisk extends AbstractLongList<Long> {
      */
     public LongListDisk(@NonNull final Path file, final long capacity, @NonNull final Configuration configuration)
             throws IOException {
+        // Initialize numAllocatedChunks before super(), since it's used in readBodyFromFileChannelOnInit(),
+        // which is called from super()
+        numAllocatedChunks = new AtomicInteger(0);
         super(file, capacity, configuration);
         if (tempFile == null) {
             throw new IllegalStateException("The temp file is not initialized");
@@ -175,6 +187,9 @@ public class LongListDisk extends AbstractLongList<Long> {
             final long reservedBufferSize,
             final @NonNull Configuration configuration)
             throws IOException {
+        // Initialize numAllocatedChunks before super(), since it's used in readBodyFromFileChannelOnInit(),
+        // which is called from super()
+        numAllocatedChunks = new AtomicInteger(0);
         super(path, longsPerChunk, capacity, reservedBufferSize, configuration);
         // IDE complains that the tempFile is not initialized, but it's initialized in readBodyFromFileChannelOnInit
         // which is called from the constructor of the parent class
@@ -228,6 +243,8 @@ public class LongListDisk extends AbstractLongList<Long> {
             final long chunk = ((long) (chunkIndex - firstChunkIndex) * memoryChunkSize);
             setChunk(chunkIndex, chunk);
         }
+
+        numAllocatedChunks.set(lastChunkIndex - firstChunkIndex + 1);
     }
 
     /** {@inheritDoc} */
@@ -516,6 +533,7 @@ public class LongListDisk extends AbstractLongList<Long> {
      */
     @Override
     protected void closeChunk(@NonNull final Long chunk) {
+        System.err.println("Close chunk: " + chunk);
         // Zero out the chunk region in the backing file.
         // This can happen outside the lock – the chunk-list entry is
         // already null, so no NEW reader can reach this offset.
@@ -557,12 +575,7 @@ public class LongListDisk extends AbstractLongList<Long> {
     protected Long createChunk() {
         Long chunkOffset = freeChunks.poll();
         if (chunkOffset == null) {
-            long maxOffset = -1;
-            for (int i = 0; i < chunkList.length(); i++) {
-                Long currentOffset = chunkList.get(i);
-                maxOffset = Math.max(maxOffset, currentOffset == null ? -1 : currentOffset);
-            }
-            final long chunk = maxOffset == -1 ? 0 : maxOffset + memoryChunkSize;
+            final long chunk = (long) numAllocatedChunks.getAndIncrement() * memoryChunkSize;
             try {
                 // Append the full chunk to the end of the backing file
                 final ByteBuffer tmp = initOrGetTransferBuffer();

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
@@ -533,7 +533,6 @@ public class LongListDisk extends AbstractLongList<Long> {
      */
     @Override
     protected void closeChunk(@NonNull final Long chunk) {
-        System.err.println("Close chunk: " + chunk);
         // Zero out the chunk region in the backing file.
         // This can happen outside the lock – the chunk-list entry is
         // already null, so no NEW reader can reach this offset.

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
@@ -572,9 +572,9 @@ public class LongListDisk extends AbstractLongList<Long> {
     /** {@inheritDoc} */
     @Override
     protected Long createChunk() {
-        Long chunkOffset = freeChunks.poll();
-        if (chunkOffset == null) {
-            final long chunk = (long) numAllocatedChunks.getAndIncrement() * memoryChunkSize;
+        Long chunk = freeChunks.poll();
+        if (chunk == null) {
+            chunk = (long) numAllocatedChunks.getAndIncrement() * memoryChunkSize;
             try {
                 // Append the full chunk to the end of the backing file
                 final ByteBuffer tmp = initOrGetTransferBuffer();
@@ -583,10 +583,8 @@ public class LongListDisk extends AbstractLongList<Long> {
             } catch (final IOException e) {
                 throw new UncheckedIOException(e);
             }
-            return chunk;
-        } else {
-            return chunkOffset;
         }
+        return chunk;
     }
 
     // exposed for test purposes only - DO NOT USE IN PROD CODE

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -40,10 +40,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 import java.util.function.LongConsumer;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.io.TempDir;
@@ -1376,6 +1378,27 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
             } finally {
                 // Clean up the temporary file after the test
                 Files.deleteIfExists(longListFile);
+            }
+        }
+    }
+
+    @RepeatedTest(100)
+    void concurrentPutTest() {
+        final int CHUNK_SIZE = 1000;
+        final int LIST_SIZE = CHUNK_SIZE * 128;
+        try (final LongList list = createLongList(CHUNK_SIZE, LIST_SIZE, 0)) {
+            final int THREADS = 8;
+            final int UPDATES = 1000;
+            final int size = THREADS * UPDATES;
+            list.updateValidRange(0, size - 1);
+            IntStream.range(0, THREADS).parallel().forEach(t -> {
+                for (int i = 0; i < UPDATES; i++) {
+                    final long v = t + i * THREADS;
+                    list.put(v, v + 1);
+                }
+            });
+            for (long v = 0; v < size; v++) {
+                assertEquals(v + 1, list.get(v));
             }
         }
     }


### PR DESCRIPTION
Fix summary:
* `LongListDisk.createChunk()` is changed to use an atomic integer to find an offset for a new chunk. It makes the method thread safe
* A new test case is added to `AbstractLongListTest`

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/25277
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
