### PR TITLE
chore: Clean up dependencies of hashgraph-impl tests

### DIFF
--- a/platform-sdk/base-crypto/build.gradle.kts
+++ b/platform-sdk/base-crypto/build.gradle.kts
@@ -23,7 +23,6 @@ testModuleInfo {
 }
 
 timingSensitiveModuleInfo {
-    runtimeOnly("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.api")
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("org.hiero.base.crypto")

--- a/platform-sdk/consensus-hashgraph-impl/build.gradle.kts
+++ b/platform-sdk/consensus-hashgraph-impl/build.gradle.kts
@@ -12,8 +12,6 @@ testModuleInfo {
     requires("org.hiero.consensus.gui")
     requires("com.swirlds.base.test.fixtures")
     requires("org.hiero.base.utility.test.fixtures")
-    requires("com.swirlds.common")
-    requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("com.swirlds.platform.core.test.fixtures")
     requires("org.hiero.base.utility.test.fixtures")
@@ -32,6 +30,5 @@ jmhModuleInfo {
     requires("jmh.core")
     requires("org.hiero.base.concurrent")
     requires("org.hiero.consensus.hashgraph.impl.test.fixtures")
-    requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
 }

--- a/platform-sdk/consensus-hashgraph-impl/src/jmh/java/org/hiero/consensus/hashgraph/ConsensusImplBenchmark.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/jmh/java/org/hiero/consensus/hashgraph/ConsensusImplBenchmark.java
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph;
 
-import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -49,8 +50,6 @@ public class ConsensusImplBenchmark {
 
     @Setup(Level.Invocation)
     public void setup() {
-        final PlatformContext platformContext =
-                TestPlatformContextBuilder.create().build();
         final GeneratorEventGraphSource generator = GeneratorEventGraphSourceBuilder.builder()
                 .seed(SEED)
                 .maxOtherParents(numOP)
@@ -70,11 +69,10 @@ public class ConsensusImplBenchmark {
             linkedEvents.add(linkedEvent);
         }
 
-        consensus = new ConsensusImpl(
-                platformContext.getConfiguration(),
-                platformContext.getTime(),
-                new NoOpConsensusMetrics(),
-                generator.getRoster());
+        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
+        final Time time = Time.getCurrent();
+
+        consensus = new ConsensusImpl(configuration, time, new NoOpConsensusMetrics(), generator.getRoster());
     }
 
     @Benchmark

--- a/platform-sdk/consensus-hashgraph-impl/src/jmh/java/org/hiero/consensus/hashgraph/HashgraphModuleBenchmark.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/jmh/java/org/hiero/consensus/hashgraph/HashgraphModuleBenchmark.java
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph;
 
-import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
+import com.swirlds.base.time.Time;
 import com.swirlds.component.framework.WiringConfig;
 import com.swirlds.component.framework.model.WiringModel;
 import com.swirlds.component.framework.model.WiringModelBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.metrics.api.Metrics;
 import java.util.List;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
@@ -16,6 +16,7 @@ import org.hiero.consensus.hashgraph.config.ConsensusConfig_;
 import org.hiero.consensus.hashgraph.impl.DefaultHashgraphModule;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.GeneratorEventGraphSource;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.GeneratorEventGraphSourceBuilder;
+import org.hiero.consensus.metrics.noop.NoOpMetrics;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.test.fixtures.event.EventCounter;
@@ -74,8 +75,8 @@ public class HashgraphModuleBenchmark {
                 // does not seem to have any effect on performance
                 .withValue(ConsensusConfig_.ROUNDS_NON_ANCIENT, 26)
                 .getOrCreateConfig();
-        final PlatformContext platformContext =
-                TestPlatformContextBuilder.create().withConfiguration(config).build();
+        final Metrics metrics = new NoOpMetrics();
+        final Time time = Time.getCurrent();
         final GeneratorEventGraphSource generator = GeneratorEventGraphSourceBuilder.builder()
                 .seed(SEED)
                 .maxOtherParents(numOP)
@@ -85,16 +86,16 @@ public class HashgraphModuleBenchmark {
                 .configuration(config)
                 .build();
         events = generator.nextEvents(NUMBER_OF_EVENTS);
-        model = WiringModelBuilder.create(platformContext.getMetrics(), platformContext.getTime())
+        model = WiringModelBuilder.create(metrics, time)
                 .withDefaultPool(threadPool)
-                .withWiringConfig(platformContext.getConfiguration().getConfigData(WiringConfig.class))
+                .withWiringConfig(config.getConfigData(WiringConfig.class))
                 .build();
         hashgraphModule = new DefaultHashgraphModule();
         hashgraphModule.initialize(
                 model,
-                platformContext.getConfiguration(),
-                platformContext.getMetrics(),
-                platformContext.getTime(),
+                config,
+                metrics,
+                time,
                 generator.getRoster(),
                 NodeId.of(generator.getRoster().rosterEntries().getFirst().nodeId()),
                 i -> false,

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/AncientParentsTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/AncientParentsTest.java
@@ -3,10 +3,10 @@ package org.hiero.consensus.hashgraph.impl.consensus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
+import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.metrics.api.Metrics;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -19,6 +19,7 @@ import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.OtherPar
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.StandardGraphGenerator;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.source.EventSource;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.source.StandardEventSource;
+import org.hiero.consensus.metrics.noop.NoOpMetrics;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.hashgraph.EventWindow;
@@ -55,18 +56,17 @@ class AncientParentsTest {
                 .withValue(ConsensusConfig_.ROUNDS_EXPIRED, 25)
                 .getOrCreateConfig();
 
-        final PlatformContext platformContext = TestPlatformContextBuilder.create()
-                .withConfiguration(configuration)
-                .build();
+        final Metrics metrics = new NoOpMetrics();
+        final Time time = Time.getCurrent();
 
         final List<EventSource> eventSources = Stream.generate(StandardEventSource::new)
                 .map(ses -> (EventSource) ses)
                 .limit(numNodes)
                 .toList();
-        final StandardGraphGenerator generator = new StandardGraphGenerator(
-                configuration, platformContext.getMetrics(), platformContext.getTime(), seed, eventSources);
-        final TestIntake node1 = new TestIntake(platformContext, generator.getRoster());
-        final TestIntake node2 = new TestIntake(platformContext, generator.getRoster());
+        final StandardGraphGenerator generator =
+                new StandardGraphGenerator(configuration, metrics, time, seed, eventSources);
+        final TestIntake node1 = new TestIntake(configuration, metrics, time, generator.getRoster());
+        final TestIntake node2 = new TestIntake(configuration, metrics, time, generator.getRoster());
 
         // first, we generate events regularly, until we have some ancient rounds
         for (final PlatformEvent event : generator.generateEvents(FIRST_BATCH_SIZE)) {

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/CoinRoundTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/CoinRoundTest.java
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
-import static com.swirlds.platform.test.fixtures.PlatformTestUtils.createConfigurationWithMarkerFilesDir;
-
 import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -33,7 +32,7 @@ public class CoinRoundTest {
             + "Since ancient threshold migration we no longer support these old files. "
             + "Once a coin round occurs with birth rounds new PCES files can be added and this test can be re-enabled.")
     void coinRound(final String resources) throws URISyntaxException, IOException {
-        final Configuration configuration = createConfigurationWithMarkerFilesDir();
+        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
 
         final Path dir = ResourceLoader.getFile(resources + "events");
         final TestIntake intake =

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/CoinRoundTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/CoinRoundTest.java
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
-import static com.swirlds.platform.test.fixtures.PlatformTestUtils.createDefaultPlatformContext;
+import static com.swirlds.platform.test.fixtures.PlatformTestUtils.createConfigurationWithMarkerFilesDir;
 
 import com.hedera.hapi.node.state.roster.Roster;
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.config.api.Configuration;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
@@ -33,10 +33,11 @@ public class CoinRoundTest {
             + "Since ancient threshold migration we no longer support these old files. "
             + "Once a coin round occurs with birth rounds new PCES files can be added and this test can be re-enabled.")
     void coinRound(final String resources) throws URISyntaxException, IOException {
-        final PlatformContext context = createDefaultPlatformContext();
+        final Configuration configuration = createConfigurationWithMarkerFilesDir();
 
         final Path dir = ResourceLoader.getFile(resources + "events");
-        final TestIntake intake = new TestIntake(context, Roster.newBuilder().build());
+        final TestIntake intake =
+                new TestIntake(configuration, Roster.newBuilder().build());
         try (final IOIterator<PlatformEvent> eventIterator = PcesFileIteratorFactory.createIterator(dir)) {
             while (eventIterator.hasNext()) {
                 final PlatformEvent event = eventIterator.next();

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusEngineContractTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusEngineContractTest.java
@@ -8,8 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
-import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,6 +25,7 @@ import org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.TestIntake;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.emitter.EventEmitterFactory;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.emitter.StandardEventEmitter;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.OtherParentMatrixFactory;
+import org.hiero.consensus.metrics.noop.NoOpMetrics;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.roster.test.fixtures.RandomRosterBuilder;
@@ -40,8 +43,6 @@ import org.junit.jupiter.api.Test;
  */
 public class ConsensusEngineContractTest {
     private static final int NUMBER_OF_EVENTS_PER_TEST = 10_000;
-    private static final PlatformContext CONTEXT =
-            TestPlatformContextBuilder.create().build();
 
     /**
      * Tests that the consensus engine can restart from a snapshot and still fulfill its event contract.
@@ -60,7 +61,7 @@ public class ConsensusEngineContractTest {
         final List<PlatformEvent> generatedEvents = generateEvents(random, roster);
 
         // start from genesis, validate the output
-        final TestIntake genesisIntake = new TestIntake(CONTEXT, roster);
+        final TestIntake genesisIntake = new TestIntake(roster);
         addToIntake(generatedEvents, random, genesisIntake);
         validateOutputContract(genesisIntake.getOutput());
 
@@ -68,7 +69,7 @@ public class ConsensusEngineContractTest {
         final ConsensusSnapshot snapshot = getMiddleSnapshot(genesisIntake);
 
         // load the snapshot into a new intake and validate that the output is consistent
-        final TestIntake restartIntake = new TestIntake(CONTEXT, roster);
+        final TestIntake restartIntake = new TestIntake(roster);
         restartIntake.loadSnapshot(snapshot);
         addToIntake(generatedEvents, random, restartIntake);
 
@@ -97,7 +98,7 @@ public class ConsensusEngineContractTest {
         final List<PlatformEvent> generatedEvents = generateEvents(random, roster);
 
         // first part
-        final TestIntake genesisIntake = new TestIntake(CONTEXT, roster);
+        final TestIntake genesisIntake = new TestIntake(roster);
         addToIntake(generatedEvents, random, genesisIntake);
 
         validateOutputContract(genesisIntake.getOutput());
@@ -107,7 +108,7 @@ public class ConsensusEngineContractTest {
 
         // second part
         final ConsensusSnapshot snapshot = getMiddleSnapshot(genesisIntake);
-        final TestIntake restartIntake = new TestIntake(CONTEXT, modifiedRoster);
+        final TestIntake restartIntake = new TestIntake(modifiedRoster);
         restartIntake.loadSnapshot(snapshot);
         addToIntake(generatedEvents, random, restartIntake);
         validateOutputContract(restartIntake.getOutput());
@@ -122,12 +123,16 @@ public class ConsensusEngineContractTest {
         final int shunnedNodeIndex = 0; // the first node will be shunned
 
         // setup
+        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
+        final Metrics metrics = new NoOpMetrics();
+        final Time time = Time.getCurrent();
         final Randotron random = Randotron.create();
         final Roster roster = RandomRosterBuilder.create(random)
                 .withWeightGenerator(WeightGenerators.BALANCED)
                 .withSize(random.nextInt(minNodes, maxNodes))
                 .build();
-        final StandardEventEmitter eventEmitter = new EventEmitterFactory(CONTEXT, random, roster).newStandardEmitter();
+        final StandardEventEmitter eventEmitter =
+                new EventEmitterFactory(configuration, metrics, time, random, roster).newStandardEmitter();
         eventEmitter
                 .getGraphGenerator()
                 .setOtherParentAffinity(OtherParentMatrixFactory.createShunnedNodeOtherParentAffinityMatrix(
@@ -135,7 +140,7 @@ public class ConsensusEngineContractTest {
         final List<PlatformEvent> generatedEvents = eventEmitter.emitEvents(NUMBER_OF_EVENTS_PER_TEST);
 
         // start from genesis, validate the output
-        final TestIntake genesisIntake = new TestIntake(CONTEXT, roster);
+        final TestIntake genesisIntake = new TestIntake(configuration, metrics, time, roster);
         addToIntake(generatedEvents, random, genesisIntake);
         validateOutputContract(genesisIntake.getOutput());
 
@@ -146,7 +151,7 @@ public class ConsensusEngineContractTest {
         final ConsensusSnapshot snapshot = getMiddleSnapshot(genesisIntake);
 
         // load the snapshot into a new intake and validate that the output is consistent
-        final TestIntake restartIntake = new TestIntake(CONTEXT, roster);
+        final TestIntake restartIntake = new TestIntake(configuration, metrics, time, roster);
         restartIntake.loadSnapshot(snapshot);
         addToIntake(generatedEvents, random, restartIntake);
 
@@ -206,7 +211,11 @@ public class ConsensusEngineContractTest {
      */
     @NonNull
     private static List<PlatformEvent> generateEvents(@NonNull final Random random, @NonNull final Roster roster) {
-        final StandardEventEmitter eventEmitter = new EventEmitterFactory(CONTEXT, random, roster).newStandardEmitter();
+        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
+        final Metrics metrics = new NoOpMetrics();
+        final Time time = Time.getCurrent();
+        final StandardEventEmitter eventEmitter =
+                new EventEmitterFactory(configuration, metrics, time, random, roster).newStandardEmitter();
         return eventEmitter.emitEvents(NUMBER_OF_EVENTS_PER_TEST);
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTestArgs.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTestArgs.java
@@ -9,8 +9,6 @@ import static org.hiero.consensus.test.fixtures.WeightGenerators.RANDOM;
 import static org.hiero.consensus.test.fixtures.WeightGenerators.RANDOM_REAL_WEIGHT;
 import static org.hiero.consensus.test.fixtures.WeightGenerators.SINGLE_NODE_STRONG_MINORITY;
 
-import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import java.util.stream.Stream;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.ConsensusTestParams;
 
@@ -22,9 +20,6 @@ public class ConsensusTestArgs {
     public static final String SINGLE_NODE_STRONG_MINORITY_DESC = "Single Node With Strong Minority Weight";
     public static final String ONE_THIRD_NODES_ZERO_WEIGHT_DESC = "One Third of Nodes Have Zero Weight";
     public static final String RANDOM_WEIGHT_DESC = "Random Weight, Real Total Weight Value";
-    /** The default platform context to use for tests. */
-    public static final PlatformContext DEFAULT_PLATFORM_CONTEXT =
-            TestPlatformContextBuilder.create().build();
 
     static Stream<ConsensusTestParams> orderInvarianceTests() {
         return Stream.of(

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTestDebugGui.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTestDebugGui.java
@@ -32,8 +32,8 @@ public final class ConsensusTestDebugGui {
         final ConsensusTestNode node =
                 orchestrator.getNodes().stream().findAny().orElseThrow();
         new TestGuiSource(
-                        orchestrator.getPlatformContext().getMetrics(),
-                        orchestrator.getPlatformContext().getConfiguration(),
+                        orchestrator.getMetrics(),
+                        orchestrator.getConfiguration(),
                         orchestrator.getRoster(),
                         new ListEventProvider(node.getOutput().getAddedEvents()))
                 .runGui();

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTestDefinitions.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTestDefinitions.java
@@ -550,7 +550,7 @@ public final class ConsensusTestDefinitions {
 
         orchestrator.generateEvents(0.5);
         orchestrator.validate(consensusOutputValidatorWithConsensusRatio05);
-        orchestrator.addReconnectNode(input.platformContext());
+        orchestrator.addReconnectNode(input.configuration(), input.metrics(), input.time());
 
         orchestrator.clearOutput();
         orchestrator.generateEvents(0.5);

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTests.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTests.java
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
-import static com.swirlds.platform.test.fixtures.PlatformTestUtils.createPlatformContext;
-
-import com.swirlds.common.context.PlatformContext;
-import java.util.List;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.platform.test.fixtures.PlatformTestUtils;
 import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.ConsensusTestParams;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.ConsensusTestRunner;
@@ -22,13 +20,7 @@ class ConsensusTests {
      */
     private final int NUM_ITER = 1;
 
-    /**
-     * Create a list of platform contexts to use for testing.
-     * @return a list of platform contexts
-     */
-    private List<PlatformContext> contexts() {
-        return List.of(createPlatformContext(null, null));
-    }
+    private static final Configuration CONFIGURATION = PlatformTestUtils.createConfigurationWithMarkerFilesDir();
 
     @ParameterizedTest
     @MethodSource("org.hiero.consensus.hashgraph.impl.consensus.ConsensusTestArgs#orderInvarianceTests")
@@ -39,7 +31,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::orderInvarianceTests)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -53,7 +45,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::reconnect)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -67,7 +59,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::stale)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -81,7 +73,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::branchingTests)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -95,7 +87,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::partitionTests)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -109,7 +101,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::subQuorumPartitionTests)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -123,7 +115,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::cliqueTests)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -137,7 +129,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::variableRateTests)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -151,7 +143,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::usesStaleOtherParents)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -165,7 +157,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::providesStaleOtherParents)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -179,7 +171,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::quorumOfNodesGoDown)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -193,7 +185,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::subQuorumOfNodesGoDown)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -207,7 +199,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::repeatedTimestampTest)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -221,7 +213,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::ancient)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -235,7 +227,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::restart)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -249,7 +241,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::removeNode)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -263,7 +255,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::genesisSnapshotTest)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }
@@ -277,7 +269,7 @@ class ConsensusTests {
         ConsensusTestRunner.create()
                 .setTest(ConsensusTestDefinitions::consensusFreezeTests)
                 .setParams(params)
-                .setContexts(contexts())
+                .setConfiguration(CONFIGURATION)
                 .setIterations(NUM_ITER)
                 .run();
     }

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTests.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusTests.java
@@ -2,7 +2,7 @@
 package org.hiero.consensus.hashgraph.impl.consensus;
 
 import com.swirlds.config.api.Configuration;
-import com.swirlds.platform.test.fixtures.PlatformTestUtils;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.ConsensusTestParams;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.ConsensusTestRunner;
@@ -20,7 +20,7 @@ class ConsensusTests {
      */
     private final int NUM_ITER = 1;
 
-    private static final Configuration CONFIGURATION = PlatformTestUtils.createConfigurationWithMarkerFilesDir();
+    private static final Configuration CONFIGURATION = new TestConfigBuilder().getOrCreateConfig();
 
     @ParameterizedTest
     @MethodSource("org.hiero.consensus.hashgraph.impl.consensus.ConsensusTestArgs#orderInvarianceTests")

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/EventEmitterTests.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/EventEmitterTests.java
@@ -9,8 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import java.util.List;
 import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.emitter.CollectingEventEmitter;
@@ -29,9 +27,6 @@ import org.junit.jupiter.api.Test;
  */
 @DisplayName("Event Emitter Tests")
 public class EventEmitterTests {
-
-    private static final PlatformContext DEFAULT_PLATFORM_CONTEXT =
-            TestPlatformContextBuilder.create().build();
 
     /**
      * Assert that two lists of events are distinct but equal objects.

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/GraphGeneratorTests.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/GraphGeneratorTests.java
@@ -14,8 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.node.state.roster.Roster;
-import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.HashSet;
@@ -34,6 +36,7 @@ import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.GraphGen
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.StandardGraphGenerator;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.source.BranchingEventSource;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.source.StandardEventSource;
+import org.hiero.consensus.metrics.noop.NoOpMetrics;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.roster.RosterUtils;
@@ -48,8 +51,9 @@ import org.junit.jupiter.api.Test;
 @DisplayName("Event Generator Tests")
 public class GraphGeneratorTests {
 
-    private static final PlatformContext DEFAULT_PLATFORM_CONTEXT =
-            TestPlatformContextBuilder.create().build();
+    private static final Configuration CONFIGURATION = new TestConfigBuilder().getOrCreateConfig();
+    private static final Metrics METRICS = new NoOpMetrics();
+    private static final Time TIME = Time.getCurrent();
 
     /**
      * Assert that two lists of events are distinct but equal objects.
@@ -487,9 +491,9 @@ public class GraphGeneratorTests {
         final int numberOfEvents = 1000;
 
         final StandardGraphGenerator generator = new StandardGraphGenerator(
-                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
-                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
-                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                CONFIGURATION,
+                METRICS,
+                TIME,
                 0,
                 new StandardEventSource(),
                 new StandardEventSource(),
@@ -604,9 +608,9 @@ public class GraphGeneratorTests {
 
         // A default generator uses a power distribution with alpha = 0.95
         StandardGraphGenerator generator = new StandardGraphGenerator(
-                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
-                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
-                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                CONFIGURATION,
+                METRICS,
+                TIME,
                 0,
                 new StandardEventSource(),
                 new StandardEventSource(),
@@ -620,9 +624,9 @@ public class GraphGeneratorTests {
 
         // Completely disable old other parents
         generator = new StandardGraphGenerator(
-                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
-                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
-                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                CONFIGURATION,
+                METRICS,
+                TIME,
                 0,
                 new StandardEventSource().setRequestedOtherParentAgeDistribution(staticDynamicValue(0)),
                 new StandardEventSource().setRequestedOtherParentAgeDistribution(staticDynamicValue(0)),
@@ -637,9 +641,9 @@ public class GraphGeneratorTests {
 
         // One node is much more likely to create events with old other parents
         generator = new StandardGraphGenerator(
-                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
-                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
-                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                CONFIGURATION,
+                METRICS,
+                TIME,
                 0,
                 new StandardEventSource(),
                 new StandardEventSource(),
@@ -668,9 +672,9 @@ public class GraphGeneratorTests {
 
         // One node likes to consistently provide old other parents, all others always provide most recent parent
         generator = new StandardGraphGenerator(
-                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
-                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
-                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                CONFIGURATION,
+                METRICS,
+                TIME,
                 0,
                 new StandardEventSource().setRequestedOtherParentAgeDistribution(staticDynamicValue(0)),
                 new StandardEventSource().setRequestedOtherParentAgeDistribution(staticDynamicValue(0)),
@@ -712,9 +716,9 @@ public class GraphGeneratorTests {
 
         // A default generator uses a power distribution with alpha = 0.95
         final StandardGraphGenerator generator = new StandardGraphGenerator(
-                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
-                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
-                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                CONFIGURATION,
+                METRICS,
+                TIME,
                 0,
                 new StandardEventSource(),
                 new StandardEventSource(),
@@ -754,9 +758,9 @@ public class GraphGeneratorTests {
     void nodeRemoveTest() {
         final int numberOfEvents = 10_000;
         final StandardGraphGenerator generator = new StandardGraphGenerator(
-                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
-                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
-                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                CONFIGURATION,
+                METRICS,
+                TIME,
                 0,
                 new StandardEventSource(),
                 new StandardEventSource(),

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/MaxRoundCreatedTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/MaxRoundCreatedTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
-import static com.swirlds.platform.test.fixtures.PlatformTestUtils.createConfigurationWithMarkerFilesDir;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -10,6 +9,7 @@ import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.test.fixtures.resource.ResourceLoader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -67,7 +67,7 @@ public class MaxRoundCreatedTest {
         final Path rosterPath = testDataDirectory.resolve(ROSTER_FILE);
         final Roster roster = Roster.JSON.parse(new ReadableStreamingData(new FileInputStream(rosterPath.toFile())));
 
-        final Configuration configuration = createConfigurationWithMarkerFilesDir();
+        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
 
         final TestIntake intake = new TestIntake(configuration, roster);
         final ConsensusOutput output = intake.getOutput();

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/MaxRoundCreatedTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/MaxRoundCreatedTest.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
-import static com.swirlds.platform.test.fixtures.PlatformTestUtils.createDefaultPlatformContext;
+import static com.swirlds.platform.test.fixtures.PlatformTestUtils.createConfigurationWithMarkerFilesDir;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.test.fixtures.resource.ResourceLoader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -67,9 +67,9 @@ public class MaxRoundCreatedTest {
         final Path rosterPath = testDataDirectory.resolve(ROSTER_FILE);
         final Roster roster = Roster.JSON.parse(new ReadableStreamingData(new FileInputStream(rosterPath.toFile())));
 
-        final PlatformContext context = createDefaultPlatformContext();
+        final Configuration configuration = createConfigurationWithMarkerFilesDir();
 
-        final TestIntake intake = new TestIntake(context, roster);
+        final TestIntake intake = new TestIntake(configuration, roster);
         final ConsensusOutput output = intake.getOutput();
 
         ConsensusRound latestRound = null;

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/module-info.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/module-info.java
@@ -2,7 +2,6 @@
 open module org.hiero.consensus.hashgraph.impl.test.fixtures {
     requires transitive com.hedera.node.hapi;
     requires transitive com.swirlds.base;
-    requires transitive com.swirlds.common;
     requires transitive com.swirlds.component.framework;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/ConsensusTestOrchestrator.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/ConsensusTestOrchestrator.java
@@ -2,7 +2,9 @@
 package org.hiero.consensus.hashgraph.impl.test.fixtures.consensus;
 
 import com.hedera.hapi.node.state.roster.Roster;
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.function.Consumer;
@@ -15,18 +17,21 @@ import org.hiero.consensus.model.node.NodeId;
 
 /** A type which orchestrates the generation of events and the validation of the consensus output */
 public class ConsensusTestOrchestrator {
-    private final PlatformContext platformContext;
+    private final Configuration configuration;
+    private final Metrics metrics;
     private final List<ConsensusTestNode> nodes;
     private long currentSequence = 0;
     private final List<Long> weights;
     private final int totalEventNum;
 
     public ConsensusTestOrchestrator(
-            final PlatformContext platformContext,
+            final Configuration configuration,
+            final Metrics metrics,
             final List<ConsensusTestNode> nodes,
             final List<Long> weights,
             final int totalEventNum) {
-        this.platformContext = platformContext;
+        this.configuration = configuration;
+        this.metrics = metrics;
         this.nodes = nodes;
         this.weights = weights;
         this.totalEventNum = totalEventNum;
@@ -35,10 +40,13 @@ public class ConsensusTestOrchestrator {
     /**
      * Adds a new node to the test context by simulating a reconnect
      *
-     * @param platformContext the platform context to use for the new node
+     * @param configuration the configuration to use for the new node
+     * @param metrics the metrics to use for the new node
+     * @param time the time to use for the new node
      */
-    public void addReconnectNode(@NonNull PlatformContext platformContext) {
-        final ConsensusTestNode node = nodes.get(0).reconnect(platformContext);
+    public void addReconnectNode(
+            @NonNull final Configuration configuration, @NonNull final Metrics metrics, @NonNull final Time time) {
+        final ConsensusTestNode node = nodes.get(0).reconnect(configuration, metrics, time);
         node.getEventEmitter().setCheckpoint(currentSequence);
         node.addEvents(currentSequence);
         nodes.add(node);
@@ -191,7 +199,12 @@ public class ConsensusTestOrchestrator {
     }
 
     @NonNull
-    public PlatformContext getPlatformContext() {
-        return platformContext;
+    public Configuration getConfiguration() {
+        return configuration;
+    }
+
+    @NonNull
+    public Metrics getMetrics() {
+        return metrics;
     }
 }

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/ConsensusTestRunner.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/ConsensusTestRunner.java
@@ -1,16 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.test.fixtures.consensus;
 
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
 import java.util.Random;
 import org.assertj.core.api.ThrowingConsumer;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.framework.TestInput;
+import org.hiero.consensus.metrics.noop.NoOpMetrics;
 
 public class ConsensusTestRunner {
+    private final Metrics metrics = new NoOpMetrics();
+    private final Time time = Time.getCurrent();
+
     private ConsensusTestParams params;
-    private List<PlatformContext> contexts;
+    private Configuration configuration;
     private ThrowingConsumer<TestInput> test;
     private int iterations = 1;
     private int eventsToGenerate = 10_000;
@@ -24,8 +29,8 @@ public class ConsensusTestRunner {
         return this;
     }
 
-    public @NonNull ConsensusTestRunner setContexts(@NonNull final List<PlatformContext> contexts) {
-        this.contexts = contexts;
+    public @NonNull ConsensusTestRunner setConfiguration(@NonNull final Configuration configuration) {
+        this.configuration = configuration;
         return this;
     }
 
@@ -58,10 +63,8 @@ public class ConsensusTestRunner {
     private void runWithSeed(final long seed) {
         System.out.println("Running seed: " + seed);
         try {
-            for (final PlatformContext context : contexts) {
-                test.accept(
-                        new TestInput(context, params.numNodes(), params.weightGenerator(), seed, eventsToGenerate));
-            }
+            test.accept(new TestInput(
+                    configuration, metrics, time, params.numNodes(), params.weightGenerator(), seed, eventsToGenerate));
         } catch (final Throwable e) {
             throw new RuntimeException(e);
         }

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/GenerateConsensus.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/GenerateConsensus.java
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.test.fixtures.consensus;
 
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.IntStream;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.StandardGraphGenerator;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.source.EventSource;
@@ -22,26 +23,26 @@ public final class GenerateConsensus {
     /**
      * Generate consensus rounds
      *
-     * @param numNodes
-     * 		the number of nodes in the hypothetical network
-     * @param numEvents
-     * 		the number of pre-consensus events to generate
-     * @param seed
-     * 		the seed to use
+     * @param configuration the configuration to use
+     * @param metrics the metrics to use
+     * @param time the time to use
+     * @param numNodes the number of nodes in the hypothetical network
+     * @param numEvents the number of pre-consensus events to generate
+     * @param seed the seed to use
      * @return consensus rounds
      */
     public static Deque<ConsensusRound> generateConsensusRounds(
-            @NonNull PlatformContext platformContext, final int numNodes, final int numEvents, final long seed) {
-        Objects.requireNonNull(platformContext);
+            @NonNull final Configuration configuration,
+            @NonNull final Metrics metrics,
+            @NonNull final Time time,
+            final int numNodes,
+            final int numEvents,
+            final long seed) {
         final List<EventSource> eventSources = new ArrayList<>();
         IntStream.range(0, numNodes).forEach(i -> eventSources.add(new StandardEventSource(false)));
-        final StandardGraphGenerator generator = new StandardGraphGenerator(
-                platformContext.getConfiguration(),
-                platformContext.getMetrics(),
-                platformContext.getTime(),
-                seed,
-                eventSources);
-        final TestIntake intake = new TestIntake(platformContext, generator.getRoster());
+        final StandardGraphGenerator generator =
+                new StandardGraphGenerator(configuration, metrics, time, seed, eventSources);
+        final TestIntake intake = new TestIntake(configuration, metrics, time, generator.getRoster());
 
         // generate events and feed them to consensus
         for (int i = 0; i < numEvents; i++) {

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/TestIntake.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/TestIntake.java
@@ -6,13 +6,16 @@ import static com.swirlds.component.framework.wires.SolderType.INJECT;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.swirlds.base.test.fixtures.time.FakeTime;
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.base.time.Time;
 import com.swirlds.component.framework.component.ComponentWiring;
 import com.swirlds.component.framework.model.DeterministicWiringModel;
 import com.swirlds.component.framework.model.WiringModelBuilder;
 import com.swirlds.component.framework.schedulers.TaskScheduler;
 import com.swirlds.component.framework.schedulers.builders.TaskSchedulerType;
 import com.swirlds.component.framework.wires.output.OutputWire;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.components.DefaultEventWindowManager;
 import com.swirlds.platform.components.EventWindowManager;
 import com.swirlds.platform.wiring.components.PassThroughWiring;
@@ -59,15 +62,39 @@ public class TestIntake {
     private final FakeTime time = new FakeTime(Duration.of(1, ChronoUnit.SECONDS));
 
     /**
-     * @param platformContext the platform context used to configure this intake.
+     * Constructor. Uses default configuration, metrics, and time.
+     *
      * @param roster the roster used by this intake
      */
-    public TestIntake(@NonNull final PlatformContext platformContext, @NonNull final Roster roster) {
+    public TestIntake(@NonNull final Roster roster) {
+        this(new TestConfigBuilder().getOrCreateConfig(), roster);
+    }
+
+    /**
+     * Constructor. Uses default metrics and time.
+     *
+     * @param configuration the configuration to use for this intake.
+     * @param roster the roster used by this intake
+     */
+    public TestIntake(@NonNull final Configuration configuration, @NonNull final Roster roster) {
+        this(configuration, new NoOpMetrics(), Time.getCurrent(), roster);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param configuration the configuration to use for this intake.
+     * @param metrics the metrics to use for this intake.
+     * @param time the time to use for this intake.
+     * @param roster the roster used by this intake
+     */
+    public TestIntake(
+            @NonNull final Configuration configuration,
+            @NonNull final Metrics metrics,
+            @NonNull final Time time,
+            @NonNull final Roster roster) {
         final NodeId selfId = NodeId.of(0);
-        roundsNonAncient = platformContext
-                .getConfiguration()
-                .getConfigData(ConsensusConfig.class)
-                .roundsNonAncient();
+        roundsNonAncient = configuration.getConfigData(ConsensusConfig.class).roundsNonAncient();
 
         output = new ConsensusOutput();
 
@@ -83,7 +110,7 @@ public class TestIntake {
                 new PassThroughWiring(model, "PlatformEvent", "postHashCollector", TaskSchedulerType.DIRECT);
 
         final IntakeEventCounter intakeEventCounter = new NoOpIntakeEventCounter();
-        final OrphanBuffer orphanBuffer = new DefaultOrphanBuffer(platformContext.getMetrics(), intakeEventCounter);
+        final OrphanBuffer orphanBuffer = new DefaultOrphanBuffer(metrics, intakeEventCounter);
         orphanBufferWiring = new ComponentWiring<>(model, OrphanBuffer.class, scheduler("orphanBuffer"));
         orphanBufferWiring.bind(orphanBuffer);
 
@@ -94,13 +121,8 @@ public class TestIntake {
             }
         };
 
-        final ConsensusEngine consensusEngine = new DefaultConsensusEngine(
-                platformContext.getConfiguration(),
-                platformContext.getMetrics(),
-                platformContext.getTime(),
-                roster,
-                selfId,
-                localFreezeCheck);
+        final ConsensusEngine consensusEngine =
+                new DefaultConsensusEngine(configuration, metrics, time, roster, selfId, localFreezeCheck);
 
         consensusEngineWiring = new ComponentWiring<>(model, ConsensusEngine.class, scheduler("consensusEngine"));
         consensusEngineWiring.bind(consensusEngine);

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/framework/ConsensusTestNode.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/framework/ConsensusTestNode.java
@@ -4,7 +4,9 @@ package org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.framework;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.LinkedList;
 import java.util.Objects;
@@ -40,15 +42,22 @@ public class ConsensusTestNode {
     /**
      * Creates a new instance with a freshly seeded {@link EventEmitter}.
      *
-     * @param platformContext the platform context
+     * @param configuration   the configuration to use for the intake and emitter
+     * @param metrics         the metrics to use for the intake and emitter
+     * @param time            the time to use for the intake and emitter
      * @param eventEmitter    the emitter of events
      */
     public static @NonNull ConsensusTestNode genesisContext(
-            @NonNull final PlatformContext platformContext, @NonNull final EventEmitter eventEmitter) {
+            @NonNull final Configuration configuration,
+            @NonNull final Metrics metrics,
+            @NonNull final Time time,
+            @NonNull final EventEmitter eventEmitter) {
         return new ConsensusTestNode(
                 eventEmitter,
                 new TestIntake(
-                        Objects.requireNonNull(platformContext),
+                        configuration,
+                        metrics,
+                        time,
                         eventEmitter.getGraphGenerator().getRoster()));
     }
 
@@ -85,17 +94,24 @@ public class ConsensusTestNode {
     /**
      * Create a new {@link ConsensusTestNode} that will be created by simulating a reconnect with this context
      *
-     * @param platformContext the platform context
+     * @param configuration the configuration to use for the new node
+     * @param metrics the metrics to use for the new node
+     * @param time the time to use for the new node
      * @return a new {@link ConsensusTestNode}
      */
-    public @NonNull ConsensusTestNode reconnect(@NonNull final PlatformContext platformContext) {
+    public @NonNull ConsensusTestNode reconnect(
+            @NonNull final Configuration configuration, @NonNull final Metrics metrics, @NonNull final Time time) {
         // create a new context
         final EventEmitter newEmitter = eventEmitter.cleanCopy(random.nextLong());
         newEmitter.reset();
 
         final ConsensusTestNode consensusTestNode = new ConsensusTestNode(
                 newEmitter,
-                new TestIntake(platformContext, newEmitter.getGraphGenerator().getRoster()));
+                new TestIntake(
+                        configuration,
+                        metrics,
+                        time,
+                        newEmitter.getGraphGenerator().getRoster()));
         consensusTestNode.intake.loadSnapshot(
                 Objects.requireNonNull(getOutput().getConsensusRounds().peekLast())
                         .getSnapshot());

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/framework/OrchestratorBuilder.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/framework/OrchestratorBuilder.java
@@ -5,7 +5,9 @@ import static org.hiero.consensus.test.fixtures.WeightGenerators.BALANCED;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +35,10 @@ public class OrchestratorBuilder {
     private int totalEventNum = 10_000;
     private Function<List<Long>, List<EventSource>> eventSourceBuilder = null;
     private Consumer<EventSource> eventSourceConfigurator = es -> {};
-    private PlatformContext platformContext;
+    private Configuration configuration;
+    private Metrics metrics;
+    private Time time;
+
     /**
      * A function that creates an event emitter based on a graph generator and a seed. They should produce emitters that
      * will emit events in different orders. For example, nothing would be tested if both returned a
@@ -60,7 +65,9 @@ public class OrchestratorBuilder {
         weightGenerator = testInput.weightGenerator();
         seed = testInput.seed();
         totalEventNum = testInput.eventsToGenerate();
-        platformContext = testInput.platformContext();
+        configuration = testInput.configuration();
+        metrics = testInput.metrics();
+        time = testInput.time();
         return this;
     }
 
@@ -111,13 +118,7 @@ public class OrchestratorBuilder {
         // randomise the number of other parents to increase test coverage
         final int numOtherParents = random.nextInt(1, numberOfNodes);
         final StandardGraphGenerator graphGenerator = new StandardGraphGenerator(
-                platformContext.getConfiguration(),
-                platformContext.getMetrics(),
-                platformContext.getTime(),
-                graphSeed,
-                numOtherParents,
-                eventSources,
-                roster);
+                configuration, metrics, time, graphSeed, numOtherParents, eventSources, roster);
 
         // Make the graph generators create a fresh set of events.
         // Use the same seed so that they create identical graphs.
@@ -129,9 +130,9 @@ public class OrchestratorBuilder {
         final List<ConsensusTestNode> nodes = new ArrayList<>();
         // Create two instances to run consensus on. Each instance reseeds the emitter so that they
         // emit events in different orders.
-        nodes.add(ConsensusTestNode.genesisContext(platformContext, node1Emitter));
-        nodes.add(ConsensusTestNode.genesisContext(platformContext, node2Emitter));
+        nodes.add(ConsensusTestNode.genesisContext(configuration, metrics, time, node1Emitter));
+        nodes.add(ConsensusTestNode.genesisContext(configuration, metrics, time, node2Emitter));
 
-        return new ConsensusTestOrchestrator(platformContext, nodes, weights, totalEventNum);
+        return new ConsensusTestOrchestrator(configuration, metrics, nodes, weights, totalEventNum);
     }
 }

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/framework/TestInput.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/consensus/framework/TestInput.java
@@ -1,20 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.test.fixtures.consensus.framework;
 
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.hiero.consensus.test.fixtures.WeightGenerator;
 
 /**
  * Holds the input to a consensus test.
- * @param platformContext the {@link PlatformContext} to use for the test
+ *
+ * @param configuration the {@link Configuration} to use for the test
+ * @param metrics the {@link Metrics} to use for the test
+ * @param time the {@link Time} to use for the test
  * @param numberOfNodes the number of nodes in the test
  * @param weightGenerator the {@link WeightGenerator} to use for the test
  * @param seed the seed for the random number generator
  * @param eventsToGenerate the number of events to generate
  */
 public record TestInput(
-        @NonNull PlatformContext platformContext,
+        @NonNull Configuration configuration,
+        @NonNull Metrics metrics,
+        @NonNull Time time,
         int numberOfNodes,
         @NonNull WeightGenerator weightGenerator,
         long seed,
@@ -27,6 +34,6 @@ public record TestInput(
      * @return a new {@link TestInput} with the updated number of nodes
      */
     public @NonNull TestInput setNumberOfNodes(int numberOfNodes) {
-        return new TestInput(platformContext, numberOfNodes, weightGenerator, seed, eventsToGenerate);
+        return new TestInput(configuration, metrics, time, numberOfNodes, weightGenerator, seed, eventsToGenerate);
     }
 }

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/emitter/EventEmitterFactory.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/emitter/EventEmitterFactory.java
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.test.fixtures.event.emitter;
 
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.hapi.node.state.roster.Roster;
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Objects;
 import java.util.Random;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.StandardGraphGenerator;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.source.BranchingEventSource;
@@ -23,32 +26,41 @@ public class EventEmitterFactory {
     /** the roster to use */
     private final Roster roster;
     /**
-     * Seed used for the standard generator. Must be same for all instances to ensure the same events are
-     * generated for different instances. Differences in the graphs are managed in other ways and are defined in each
-     * test.
+     * Seed used for the standard generator. Must be same for all instances to ensure the same events are generated
+     * for different instances. Differences in the graphs are managed in other ways and are defined in each test.
      */
     private final long commonSeed;
-    /** the platform context containing configuration */
-    private final PlatformContext platformContext;
+
+    private final Configuration configuration;
+
+    private final Metrics metrics;
+
+    private final Time time;
 
     private final EventSourceFactory sourceFactory;
 
     /**
      * Create a new factory.
      *
-     * @param platformContext the platform context
+     * @param configuration   the configuration to use
+     * @param metrics         the metrics to use
+     * @param time            the time to use
      * @param random          the random number generator to use
      * @param roster          the roster to use
      */
     public EventEmitterFactory(
-            @NonNull final PlatformContext platformContext,
+            @NonNull final Configuration configuration,
+            @NonNull final Metrics metrics,
+            @NonNull final Time time,
             @NonNull final Random random,
             @NonNull final Roster roster) {
-        this.random = Objects.requireNonNull(random);
-        this.roster = Objects.requireNonNull(roster);
+        this.configuration = requireNonNull(configuration);
+        this.metrics = requireNonNull(metrics);
+        this.time = requireNonNull(time);
+        this.random = requireNonNull(random);
+        this.roster = requireNonNull(roster);
         this.commonSeed = random.nextLong();
         this.sourceFactory = new EventSourceFactory(roster.rosterEntries().size());
-        this.platformContext = Objects.requireNonNull(platformContext);
     }
 
     /**
@@ -92,9 +104,9 @@ public class EventEmitterFactory {
 
     private StandardGraphGenerator newStandardGraphGenerator(final List<EventSource> eventSources) {
         return new StandardGraphGenerator(
-                platformContext.getConfiguration(),
-                platformContext.getMetrics(),
-                platformContext.getTime(),
+                configuration,
+                metrics,
+                time,
                 commonSeed, // standard seed must be the same across all generators
                 eventSources,
                 roster);
@@ -103,9 +115,9 @@ public class EventEmitterFactory {
     private ShuffledEventEmitter newShuffledEmitter(final List<EventSource> eventSources) {
         return new ShuffledEventEmitter(
                 new StandardGraphGenerator(
-                        platformContext.getConfiguration(),
-                        platformContext.getMetrics(),
-                        platformContext.getTime(),
+                        configuration,
+                        metrics,
+                        time,
                         commonSeed, // standard seed must be the same across all generators
                         eventSources),
                 random.nextLong() // shuffle seed changes every time

--- a/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/graph/utils/TestEventUtils.java
+++ b/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/graph/utils/TestEventUtils.java
@@ -55,7 +55,9 @@ public class TestEventUtils {
             @NonNull final PlatformContext context,
             @NonNull final Roster roster,
             @Nullable final Map<NodeId, KeysAndCerts> keysAndCertsMap) {
-        final StandardEventEmitter eventEmitter = new EventEmitterFactory(context, random, roster).newStandardEmitter();
+        final StandardEventEmitter eventEmitter = new EventEmitterFactory(
+                        context.getConfiguration(), context.getMetrics(), context.getTime(), random, roster)
+                .newStandardEmitter();
 
         Stream<PlatformEvent> stream = eventEmitter.emitEvents(numEvents).stream();
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/report/EventStreamReportingToolTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/report/EventStreamReportingToolTest.java
@@ -47,7 +47,12 @@ class EventStreamReportingToolTest {
 
         // generate consensus events
         final Deque<ConsensusRound> rounds = GenerateConsensus.generateConsensusRounds(
-                DEFAULT_PLATFORM_CONTEXT, numNodes, numEvents, random.nextLong());
+                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
+                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
+                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                numNodes,
+                numEvents,
+                random.nextLong());
         if (rounds.isEmpty()) {
             Assertions.fail("events are excepted to reach consensus");
         }
@@ -89,7 +94,12 @@ class EventStreamReportingToolTest {
 
         // generate consensus events
         final Deque<ConsensusRound> rounds = GenerateConsensus.generateConsensusRounds(
-                DEFAULT_PLATFORM_CONTEXT, numNodes, numEvents, random.nextLong());
+                DEFAULT_PLATFORM_CONTEXT.getConfiguration(),
+                DEFAULT_PLATFORM_CONTEXT.getMetrics(),
+                DEFAULT_PLATFORM_CONTEXT.getTime(),
+                numNodes,
+                numEvents,
+                random.nextLong());
         if (rounds.isEmpty()) {
             Assertions.fail("events are excepted to reach consensus");
         }

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/PlatformTestUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/PlatformTestUtils.java
@@ -7,7 +7,6 @@ import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
-import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -80,28 +79,6 @@ public class PlatformTestUtils {
             platformContextModifier.apply(platformContextBuilder);
         }
         return platformContextBuilder.build();
-    }
-
-    /**
-     * Generates a configuration with the temp directory for marker files set.
-     *
-     * @return the configuration
-     */
-    @NonNull
-    public static Configuration createConfigurationWithMarkerFilesDir() {
-        final Path tmpDir;
-        try {
-            tmpDir = Files.createTempDirectory("");
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-
-        return new TestConfigBuilder()
-                .withValue(
-                        PathsConfig_.MARKER_FILES_DIR,
-                        tmpDir.resolve(TEST_MARKER_FILE_DIRECTORY).toString())
-                .withValue(PathsConfig_.WRITE_PLATFORM_MARKER_FILES, true)
-                .getOrCreateConfig();
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/PlatformTestUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/PlatformTestUtils.java
@@ -7,6 +7,7 @@ import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
+import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -79,6 +80,28 @@ public class PlatformTestUtils {
             platformContextModifier.apply(platformContextBuilder);
         }
         return platformContextBuilder.build();
+    }
+
+    /**
+     * Generates a configuration with the temp directory for marker files set.
+     *
+     * @return the configuration
+     */
+    @NonNull
+    public static Configuration createConfigurationWithMarkerFilesDir() {
+        final Path tmpDir;
+        try {
+            tmpDir = Files.createTempDirectory("");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return new TestConfigBuilder()
+                .withValue(
+                        PathsConfig_.MARKER_FILES_DIR,
+                        tmpDir.resolve(TEST_MARKER_FILE_DIRECTORY).toString())
+                .withValue(PathsConfig_.WRITE_PLATFORM_MARKER_FILES, true)
+                .getOrCreateConfig();
     }
 
     /**


### PR DESCRIPTION
**Description**:

This PR removes `swirlds-common` dependencies from tests and test fixtures in `consensus-hashgraph-impl`

**Related issue(s)**:

Fixes #25283 