### PR TITLE
fix: 25239 silence-jvm-warnings-in-consensus-node

### DIFF
--- a/hedera-node/docker/start-services.sh
+++ b/hedera-node/docker/start-services.sh
@@ -76,5 +76,7 @@ fi
   -XX:+ZGenerational \
   --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
   --add-opens java.base/java.nio=ALL-UNNAMED \
+  --enable-native-access=ALL-UNNAMED \
+  --sun-misc-unsafe-memory-access=allow \
   -Dio.netty.tryReflectionSetAccessible=true \
   com.swirlds.platform.Browser

--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -80,7 +80,15 @@ jmhModuleInfo {
 // Add all the libs dependencies into the jar manifest!
 tasks.jar {
     inputs.files(configurations.runtimeClasspath)
-    manifest { attributes("Main-Class" to "com.hedera.node.app.ServicesMain") }
+    manifest {
+        attributes(
+            "Main-Class" to "com.hedera.node.app.ServicesMain",
+            // Declares JNI usage (netty's NativeLibraryUtil) so the JDK does not print a
+            // restricted-method warning for callers in the unnamed module of this JAR
+            // when launched via `java -jar`.
+            "Enable-Native-Access" to "ALL-UNNAMED",
+        )
+    }
     doFirst {
         manifest.attributes(
             "Class-Path" to

--- a/hedera-node/infrastructure/docker/containers/local-node/main-network-node/entrypoint.sh
+++ b/hedera-node/infrastructure/docker/containers/local-node/main-network-node/entrypoint.sh
@@ -48,5 +48,5 @@ id
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END USER IDENT   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 echo
 
-/usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "data/lib/*"  com.swirlds.platform.Browser  > >(tee stdout.log) 2>&1
+/usr/bin/env java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "data/lib/*"  com.swirlds.platform.Browser  > >(tee stdout.log) 2>&1
 printf "java exit code %s" "${?}\n" >> stdout.log

--- a/hedera-node/infrastructure/docker/containers/production-next/consensus-node/entrypoint.sh
+++ b/hedera-node/infrastructure/docker/containers/production-next/consensus-node/entrypoint.sh
@@ -174,7 +174,7 @@ echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> BEGIN NODE OUTPUT >>>>>>>>>>>>>>
 ## starting the platform software if the exit code is 205 which indicates a config.txt/address book loading issue.
 ATTEMPTS=0
 while true; do
-  /usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}" ${CONSENSUS_NODE_ARGS}
+  /usr/bin/env java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}" ${CONSENSUS_NODE_ARGS}
   EC="${?}"
   if [[ "${EC}" -eq 205 && "${ATTEMPTS}" -lt 20 ]]; then
     printf "\n\n############# Retrying system initialization - DNS or Address Book Failure (Exit Code: %s) #############\n\n" "${EC}"

--- a/hedera-node/infrastructure/docker/containers/production/jrs-ar-network-node/entrypoint.sh
+++ b/hedera-node/infrastructure/docker/containers/production/jrs-ar-network-node/entrypoint.sh
@@ -66,9 +66,9 @@ echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END USER IDENT   <<<<<<<<<<<<<<<
 echo
 
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> BEGIN JAVA COMMAND >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-echo "/usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp \"${JAVA_CLASS_PATH}\" \"${JAVA_MAIN_CLASS}\" ${CONSENSUS_NODE_ARGS} 1> >(tee logs/stdout.log) 2> >(tee logs/stderr.log >&2)"
+echo "/usr/bin/env java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp \"${JAVA_CLASS_PATH}\" \"${JAVA_MAIN_CLASS}\" ${CONSENSUS_NODE_ARGS} 1> >(tee logs/stdout.log) 2> >(tee logs/stderr.log >&2)"
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END JAVA COMMAND   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 echo
 
-/usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}" ${CONSENSUS_NODE_ARGS} 1> >(tee logs/stdout.log) 2> >(tee logs/stderr.log >&2)
+/usr/bin/env java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}" ${CONSENSUS_NODE_ARGS} 1> >(tee logs/stdout.log) 2> >(tee logs/stderr.log >&2)
 printf "java exit code %s" "${?}\n" >>"logs/stdout.log"

--- a/hedera-node/infrastructure/docker/containers/production/jrs-network-node/entrypoint.sh
+++ b/hedera-node/infrastructure/docker/containers/production/jrs-network-node/entrypoint.sh
@@ -66,9 +66,9 @@ echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END USER IDENT   <<<<<<<<<<<<<<<
 echo
 
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> BEGIN JAVA COMMAND >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-echo "/usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp \"${JAVA_CLASS_PATH}\" \"${JAVA_MAIN_CLASS}\" ${CONSENSUS_NODE_ARGS} 1> >(tee logs/stdout.log) 2> >(tee logs/stderr.log >&2)"
+echo "/usr/bin/env java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp \"${JAVA_CLASS_PATH}\" \"${JAVA_MAIN_CLASS}\" ${CONSENSUS_NODE_ARGS} 1> >(tee logs/stdout.log) 2> >(tee logs/stderr.log >&2)"
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END JAVA COMMAND   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 echo
 
-/usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}" ${CONSENSUS_NODE_ARGS} 1> >(tee logs/stdout.log) 2> >(tee logs/stderr.log >&2)
+/usr/bin/env java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}" ${CONSENSUS_NODE_ARGS} 1> >(tee logs/stdout.log) 2> >(tee logs/stderr.log >&2)
 printf "java exit code %s" "${?}\n" >>"logs/stdout.log"

--- a/hedera-node/infrastructure/docker/containers/production/main-network-node/entrypoint.sh
+++ b/hedera-node/infrastructure/docker/containers/production/main-network-node/entrypoint.sh
@@ -66,9 +66,9 @@ echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END USER IDENT   <<<<<<<<<<<<<<<
 echo
 
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> BEGIN JAVA COMMAND >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
-echo "/usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp \"${JAVA_CLASS_PATH}\" \"${JAVA_MAIN_CLASS}\" ${CONSENSUS_NODE_ARGS}"
+echo "/usr/bin/env java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp \"${JAVA_CLASS_PATH}\" \"${JAVA_MAIN_CLASS}\" ${CONSENSUS_NODE_ARGS}"
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END JAVA COMMAND   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"
 echo
 
-/usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}" ${CONSENSUS_NODE_ARGS}
+/usr/bin/env java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}" ${CONSENSUS_NODE_ARGS}
 printf "java exit code %s" "${?}\n"

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -773,7 +773,13 @@ tasks.register<Test>("testRepeatable") {
 
 application.mainClass = "com.hedera.services.bdd.suites.SuiteRunner"
 
-tasks.shadowJar { archiveFileName.set("SuiteRunner.jar") }
+tasks.shadowJar {
+    archiveFileName.set("SuiteRunner.jar")
+    // Declares JNI usage (netty's NativeLibraryUtil) so the JDK does not print a
+    // restricted-method warning for callers in the unnamed module of this JAR
+    // when launched via `java -jar`.
+    manifest { attributes("Enable-Native-Access" to "ALL-UNNAMED") }
+}
 
 val rcdiffJar =
     tasks.register<ShadowJar>("rcdiffJar") {
@@ -783,5 +789,12 @@ val rcdiffJar =
         archiveFileName = "rcdiff.jar"
         configurations = listOf(project.configurations["rcdiffRuntimeClasspath"])
 
-        manifest { attributes("Main-Class" to "com.hedera.services.rcdiff.RcDiffCmdWrapper") }
+        manifest {
+            attributes(
+                "Main-Class" to "com.hedera.services.rcdiff.RcDiffCmdWrapper",
+                // Declares JNI usage (netty's NativeLibraryUtil) so the JDK does not print a
+                // restricted-method warning for callers in the unnamed module of this JAR.
+                "Enable-Native-Access" to "ALL-UNNAMED",
+            )
+        }
     }

--- a/hedera-node/test-clients/rcdiff/check.sh
+++ b/hedera-node/test-clients/rcdiff/check.sh
@@ -11,4 +11,6 @@ fi
 
 # Change -m value to limit the number of diffs written to file
 # Change -l value to diff a length other than 300 secs at a time
-java -jar rcdiff.jar -e $EXPECTED_LOC -a $ACTUAL_LOC -m 1000 -l 300
+# Silence protobuf's UnsafeUtil sun.misc.Unsafe deprecation warnings on JDK 25.
+# The netty System.loadLibrary warning is handled via the JAR's Enable-Native-Access manifest.
+java --sun-misc-unsafe-memory-access=allow -jar rcdiff.jar -e $EXPECTED_LOC -a $ACTUAL_LOC -m 1000 -l 300

--- a/hedera-node/test-clients/validation-scenarios/assets/screened-launch.sh
+++ b/hedera-node/test-clients/validation-scenarios/assets/screened-launch.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
-java -jar /opt/bin/ValidationScenarios.jar "$@" 2>syserr.log
+# Silence JDK 25 warnings: protobuf's sun.misc.Unsafe::arrayBaseOffset deprecation
+# and netty's System::loadLibrary restricted-method warning.
+java --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -jar /opt/bin/ValidationScenarios.jar "$@" 2>syserr.log
 RC=$?
   cat syserr.log
 exit $RC

--- a/platform-sdk/consensus-otter-docker-app/build.gradle.kts
+++ b/platform-sdk/consensus-otter-docker-app/build.gradle.kts
@@ -26,7 +26,15 @@ tasks.compileTestFixturesJava {
 
 tasks.testFixturesJar {
     inputs.files(configurations.testFixturesRuntimeClasspath)
-    manifest { attributes("Main-Class" to "org.hiero.consensus.otter.docker.app.DockerMain") }
+    manifest {
+        attributes(
+            "Main-Class" to "org.hiero.consensus.otter.docker.app.DockerMain",
+            // Declares JNI usage (netty's NativeLibraryUtil) so the JDK does not print a
+            // restricted-method warning for callers in the unnamed module of this JAR
+            // when launched via `java -jar` from the Docker image.
+            "Enable-Native-Access" to "ALL-UNNAMED",
+        )
+    }
     doFirst {
         manifest.attributes(
             "Class-Path" to

--- a/platform-sdk/consensus-otter-docker-app/src/testFixtures/docker/Dockerfile
+++ b/platform-sdk/consensus-otter-docker-app/src/testFixtures/docker/Dockerfile
@@ -14,4 +14,6 @@ COPY --chown=appuser:appuser lib/* /opt/DockerApp/lib/
 # Run as non-root user
 USER appuser
 
-CMD ["java", "-jar", "/opt/DockerApp/apps/DockerApp.jar"]
+# --sun-misc-unsafe-memory-access=allow silences protobuf's UnsafeUtil deprecation warning on JDK 25.
+# The netty System.loadLibrary warning is silenced via the JAR's Enable-Native-Access manifest entry.
+CMD ["java", "--sun-misc-unsafe-memory-access=allow", "-jar", "/opt/DockerApp/apps/DockerApp.jar"]

--- a/platform-sdk/consensus-sloth/build.gradle.kts
+++ b/platform-sdk/consensus-sloth/build.gradle.kts
@@ -23,7 +23,15 @@ testFixturesModuleInfo {
 
 tasks.testFixturesJar {
     inputs.files(configurations.testFixturesRuntimeClasspath)
-    manifest { attributes("Main-Class" to "org.hiero.sloth.fixtures.container.docker.DockerMain") }
+    manifest {
+        attributes(
+            "Main-Class" to "org.hiero.sloth.fixtures.container.docker.DockerMain",
+            // Declares JNI usage (netty's NativeLibraryUtil) so the JDK does not print a
+            // restricted-method warning for callers in the unnamed module of this JAR
+            // when launched via `java -jar` from the Docker image.
+            "Enable-Native-Access" to "ALL-UNNAMED",
+        )
+    }
     doFirst {
         manifest.attributes(
             "Class-Path" to

--- a/platform-sdk/consensus-sloth/src/testFixtures/docker/Dockerfile
+++ b/platform-sdk/consensus-sloth/src/testFixtures/docker/Dockerfile
@@ -14,4 +14,6 @@ COPY --chown=appuser:appuser lib/* /opt/DockerApp/lib/
 # Run as non-root user
 USER appuser
 
-CMD ["java", "-jar", "/opt/DockerApp/apps/DockerApp.jar"]
+# --sun-misc-unsafe-memory-access=allow silences protobuf's UnsafeUtil deprecation warning on JDK 25.
+# The netty System.loadLibrary warning is silenced via the JAR's Enable-Native-Access manifest entry.
+CMD ["java", "--sun-misc-unsafe-memory-access=allow", "-jar", "/opt/DockerApp/apps/DockerApp.jar"]

--- a/platform-sdk/swirlds-cli/pcli.sh
+++ b/platform-sdk/swirlds-cli/pcli.sh
@@ -148,6 +148,12 @@ fi
 # Pass banner flag to Java program (disabled by default, enabled with --banner/-B)
 JVM_ARGS+=("-Dpcli.showBanner=${SHOW_BANNER}")
 
+# Silence JDK 25 warnings: netty's System::loadLibrary restricted-method warning
+# (--enable-native-access) and protobuf's sun.misc.Unsafe::arrayBaseOffset deprecation
+# (--sun-misc-unsafe-memory-access). Required because pcli launches via -cp, not -jar,
+# so manifest-based mitigations do not apply.
+JVM_ARGS+=("--enable-native-access=ALL-UNNAMED" "--sun-misc-unsafe-memory-access=allow")
+
 # Run the CLI
 java "${JVM_ARGS[@]}" -cp "${JVM_CLASSPATH}" $MAIN_CLASS_NAME "${PROGRAM_ARGS[@]}"
 EXIT_CODE=$?


### PR DESCRIPTION
**Description**:

Apply the JDK 25 warning mitigations from #25199 to the rest of the consensus node. Same approach as yahcli:

- Add `Enable-Native-Access: ALL-UNNAMED` to every executable JAR manifest (silences netty's `System::loadLibrary` restricted-method warning when launched via `java -jar`): hedera-app, SuiteRunner, rcdiff, sloth/otter DockerApp test-fixtures.
- Add `--sun-misc-unsafe-memory-access=allow` to every CN launcher / Docker entrypoint (silences protobuf's `sun.misc.Unsafe::arrayBaseOffset` deprecation; no manifest equivalent).
- For `-cp`-based launchers (production/local/jrs entrypoints, `start-services.sh`, `pcli.sh`) also add `--enable-native-access=ALL-UNNAMED` since the manifest attribute does not apply when not using `-jar`.

**Related issue(s)**:

Fixes #25239

**Notes for reviewer**:

Verified locally on JDK 25 by rebuilding the affected JARs and inspecting `META-INF/MANIFEST.MF` — `Enable-Native-Access: ALL-UNNAMED` is present in `app-*.jar`, `SuiteRunner.jar`, sloth and otter test-fixtures JARs. All patched shell scripts pass `bash -n`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)