### PR TITLE
refactor: move EventStreamReport into the swirlds-cli module

### DIFF
--- a/platform-sdk/swirlds-cli/build.gradle.kts
+++ b/platform-sdk/swirlds-cli/build.gradle.kts
@@ -13,6 +13,8 @@ testModuleInfo {
     requires("org.hiero.consensus.hashgraph.impl.test.fixtures")
     requires("org.hiero.consensus.roster.test.fixtures")
     requires("org.hiero.consensus.utility.test.fixtures")
+    requires("org.hiero.base.utility.test.fixtures")
+    requires("org.hiero.consensus.event.stream.test.fixtures")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/EventStreamInfoCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/EventStreamInfoCommand.java
@@ -4,9 +4,6 @@ package org.hiero.consensus.pcli;
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.platform.util.BootstrapUtils.setupConstructableRegistry;
 
-import com.swirlds.platform.event.report.EventStreamMultiNodeReport;
-import com.swirlds.platform.event.report.EventStreamReport;
-import com.swirlds.platform.event.report.EventStreamScanner;
 import com.swirlds.platform.recovery.internal.EventStreamLowerBound;
 import com.swirlds.platform.recovery.internal.EventStreamRoundLowerBound;
 import com.swirlds.platform.recovery.internal.EventStreamTimestampLowerBound;
@@ -25,6 +22,9 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hiero.consensus.pcli.report.EventStreamMultiNodeReport;
+import org.hiero.consensus.pcli.report.EventStreamReport;
+import org.hiero.consensus.pcli.report.EventStreamScanner;
 import picocli.CommandLine;
 
 @CommandLine.Command(

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/EventStreamInfo.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/EventStreamInfo.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.event.report;
+package org.hiero.consensus.pcli.report;
 
 import java.time.Instant;
 import org.hiero.consensus.model.event.CesEvent;
@@ -11,6 +11,8 @@ import org.hiero.consensus.model.event.CesEvent;
  * 		the timestamp at the start of the period reported
  * @param end
  * 		the timestamp at the end of the period reported
+ * @param roundCount
+ * 		the number of rounds in this period
  * @param eventCount
  * 		the number of events in this period
  * @param applicationTransactionCount
@@ -18,7 +20,7 @@ import org.hiero.consensus.model.event.CesEvent;
  * @param fileCount
  * 		the number of files in this period
  * @param byteCount
- * 		the byte count of
+ * 		the byte count of the period
  * @param firstEvent
  * 		the first event in the time period
  * @param lastEvent

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/EventStreamMultiNodeReport.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/EventStreamMultiNodeReport.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.event.report;
+package org.hiero.consensus.pcli.report;
 
 import static com.swirlds.base.formatting.TextEffect.BRIGHT_RED;
 import static com.swirlds.base.formatting.TextEffect.BRIGHT_YELLOW;

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/EventStreamReport.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/EventStreamReport.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.event.report;
+package org.hiero.consensus.pcli.report;
 
 import static com.swirlds.base.formatting.StringFormattingUtils.commaSeparatedNumber;
 import static com.swirlds.base.formatting.TextEffect.BRIGHT_CYAN;

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/EventStreamScanner.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/EventStreamScanner.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.event.report;
+package org.hiero.consensus.pcli.report;
 
 import static com.swirlds.base.formatting.StringFormattingUtils.commaSeparatedNumber;
 import static com.swirlds.base.formatting.TextEffect.BRIGHT_RED;

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/RoundRunningHash.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/report/RoundRunningHash.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.event.report;
+package org.hiero.consensus.pcli.report;
 
 import org.hiero.base.crypto.Hash;
 

--- a/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/report/EventStreamReportingToolTest.java
+++ b/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/report/EventStreamReportingToolTest.java
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.report;
+package org.hiero.consensus.pcli.report;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
-import com.swirlds.platform.event.report.EventStreamReport;
-import com.swirlds.platform.event.report.EventStreamScanner;
 import com.swirlds.platform.recovery.internal.EventStreamRoundLowerBound;
 import com.swirlds.platform.recovery.internal.EventStreamTimestampLowerBound;
 import com.swirlds.platform.test.fixtures.simulated.RandomSigner;

--- a/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
@@ -26,7 +26,6 @@ module com.swirlds.platform.core {
     exports com.swirlds.platform.config;
     exports com.swirlds.platform.config.legacy;
     exports com.swirlds.platform.crypto;
-    exports com.swirlds.platform.event.report;
     exports com.swirlds.platform.eventhandling;
     exports com.swirlds.platform.health;
     exports com.swirlds.platform.health.clock;


### PR DESCRIPTION
Description

Move `EventStreamReport` and related reporting utilities from `swirlds-platform-core` into the `swirlds-cli` module as part of the platform modularization effort.

Changes :- 

1. Move reporting classes into `org.hiero.consensus.pcli.report`
2. Update package declarations and imports
3. Update `EventStreamInfoCommand` to use the new package location
4. Move `EventStreamReportingToolTest` into the `swirlds-cli` test package
5. Remove the obsolete `com.swirlds.platform.event.report` export from `swirlds-platform-core`
6. Add required test fixture dependencies to `swirlds-cli`

Related issue(s) :- 

Fixes #25188

Notes for reviewer :- 

I cleaned up the PR to keep it focused strictly on the module move.  
Previously introduced unrelated formatting/helper changes were reverted so the diff now only contains package relocation and required integration updates.

Build verification is currently limited by the repository’s Java 25 requirement from the updated `pbj-compiler` dependency, while the available local runtime is Java 21....