### PR TITLE
feat: 25299 : Relax state validator to accept `VirtualMapState` snapshots

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/StateUtils.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/StateUtils.java
@@ -6,7 +6,6 @@ import static com.hedera.statevalidation.util.ConfigUtils.getConfiguration;
 import static com.hedera.statevalidation.util.ConfigUtils.resetConfiguration;
 import static com.hedera.statevalidation.util.PlatformContextHelper.getPlatformContext;
 import static com.hedera.statevalidation.util.PlatformContextHelper.resetPlatformContext;
-import static com.swirlds.platform.state.snapshot.SignedStateFileReader.readState;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.creationSoftwareVersionOf;
 
 import com.hedera.hapi.node.base.SemanticVersion;
@@ -58,6 +57,7 @@ import com.hedera.pbj.runtime.OneOf;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
+import com.swirlds.platform.state.snapshot.SignedStateFileReader;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.state.State;
 import com.swirlds.state.StateLifecycleManager;
@@ -185,16 +185,19 @@ public final class StateUtils {
                             platformContext.getTime(),
                             platformContext.getConfiguration());
 
-            final DeserializedSignedState dss =
-                    readState(Path.of(ConfigUtils.STATE_DIR).toAbsolutePath(), platformContext, stateLifecycleManager);
-            originalStateHashes.put(key, dss.originalHash());
+            // Load the snapshot: the manager wraps the VirtualMap in a VirtualMapStateImpl, initializes itself,
+            // and returns the hash of the original immutable snapshot as stored on disk.
+            final Hash originalHash = stateLifecycleManager.loadSnapshot(
+                    Path.of(ConfigUtils.STATE_DIR).toAbsolutePath());
+            originalStateHashes.put(key, originalHash);
 
             // The mutable state is already available via the stateLifecycleManager after readState()
             final VirtualMapState state = stateLifecycleManager.getMutableState();
             states.put(key, state);
-            serviceRegistry.register(new RosterServiceImpl(roster -> true, (r, b) -> {}, () -> {
+            serviceRegistry.register(new RosterServiceImpl(_ -> true, (_, _) -> {}, () -> {
                 throw new UnsupportedOperationException("No startup networks available");
             }));
+            SignedStateFileReader.registerServiceStates(state);
             initServiceMigrator(state, platformContext, serviceRegistry);
             state.getRoot().getDataSource().stopAndDisableBackgroundCompaction();
         } catch (Exception e) {
@@ -292,7 +295,7 @@ public final class StateUtils {
         final SemanticVersion version = creationSoftwareVersionOf(state);
         // previousVersion and currentVersion are the same!
         serviceMigrator.doMigrations(
-                (VirtualMapState) state,
+                state,
                 servicesRegistry,
                 version,
                 version,


### PR DESCRIPTION
**Summary:**

Replaces the signed state deserialization path with direct snapshot loading via `StateLifecycleManager.loadSnapshot()`. The state validator no longer requires a fully signed snapshot — a plain `VirtualMapState` file is sufficient.

**What changed:**

- Swapped `readState()` → `stateLifecycleManager.loadSnapshot()`, returning the original hash directly.
- Added explicit `SignedStateFileReader.registerServiceStates(state)` call after loading.
- Removed unnecessary `(VirtualMapState)` cast in `doMigrations()`.
- Cleaned up unused lambda parameter names.

**Why:**

The validator only needs the merkle tree data, not the signatures. Requiring signed snapshots was an unnecessary constraint that limited where the tool could be used.

Fixes #25299 