### PR TITLE
chore: Fix MATS failure in hapiTestRestart

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/JumpstartFileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/JumpstartFileSuite.java
@@ -61,14 +61,17 @@ class JumpstartFileSuite implements LifecycleTest {
 
         // Mutable map so buildDynamicJumpstartConfig can add jumpstart config properties
         // before the restart reads them
-        final var envOverrides =
-                new HashMap<>(Map.of("hedera.recordStream.writeWrappedRecordFileBlockHashesToDisk", "true"));
+        final var envOverrides = new HashMap<>(Map.of(
+                "hedera.recordStream.writeWrappedRecordFileBlockHashesToDisk",
+                "true",
+                "hedera.recordStream.computeHashesFromWrappedRecordBlocks",
+                "true",
+                "hedera.recordStream.liveWritePrevWrappedRecordHashes",
+                "true"));
 
         return hapiTest(
                 // Any nodes added after genesis will not have a complete wrapped hashes file on disk, so shut them down
                 logIt("Phase 1: Writing wrapped record hashes to disk"),
-                prepareFakeUpgrade(),
-                upgradeToNextConfigVersion(envOverrides),
                 MixedOperations.burstOfTps(5, Duration.ofSeconds(30)),
                 logIt("Phase 2: Restarting with jumpstart config"),
                 prepareFakeUpgrade(),


### PR DESCRIPTION
**Description**:
This pull request updates the environment configuration for the `jumpstartsCorrectLiveWrappedRecordBlockHashes` test in `JumpstartFileSuite.java`. The main change is the addition of two new properties to the `envOverrides` map, enabling additional features related to record stream hash computation and writing in order to fix the failure.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
