### PR TITLE
fix(24996): generate signing key for :app:run so node boots past key loading

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -135,11 +135,26 @@ tasks.assemble {
     dependsOn(copyNodeData)
 }
 
+// Generate the signing PEM file expected by EnhancedKeyStoreLoader for the local node.
+// KeysAndCertsGenerator is deterministic per nodeId, so the resulting cert matches the
+// gossipCaCertificate baked into hedera-node/configuration/dev/genesis-network.json.
+val generateNodeKeys =
+    tasks.register<JavaExec>("generateNodeKeys") {
+        description = "Generate the local node's signing key PEM file used by the run task."
+        dependsOn(copyNodeData)
+        workingDir = nodeWorkingDir.get().asFile
+        jvmArgs = listOf("-cp", "data/lib/*:data/apps/*")
+        mainClass.set("org.hiero.consensus.pcli.Pcli")
+        args = listOf("generate-keys", "0", "--path", "data/keys")
+        outputs.file(nodeWorkingDir.get().file("data/keys/s-private-node1.pem"))
+    }
+
 // Create the "run" task for running a Hedera consensus node
 tasks.register<JavaExec>("run") {
     group = "application"
     description = "Run a Hedera consensus node instance."
     dependsOn(tasks.assemble)
+    dependsOn(generateNodeKeys)
     workingDir = nodeWorkingDir.get().asFile
     jvmArgs = listOf("-cp", "data/lib/*:data/apps/*")
     mainClass.set("com.hedera.node.app.ServicesMain")


### PR DESCRIPTION
**Description**:

`./gradlew :app:run` exited at startup with `KEY_LOADING_FAILED` because no signing key was on disk:

```
Reading crypto keys from the files here:   []
Exiting System (KEY_LOADING_FAILED)
```

`hedera-node/data/keys/` only ships scaffolding scripts — no `.pfx`/`.pem`. With nothing to load, `EnhancedKeyStoreLoader.verify()` threw and `CryptoStatic.initNodeSecurity` exited.

Fix: add a `generateNodeKeys` Gradle task that runs `pcli generate-keys 0 --path data/keys` after `copyNodeDataAndConfig` and before `run`. Safe because `KeysAndCertsGenerator.generate(NodeId.of(0))` is deterministic — the regenerated cert matches the `gossipCaCertificate` baked into `configuration/dev/genesis-network.json` byte-for-byte.

**Related issue(s)**:

Fixes #24996

**Notes for reviewer**:

`./gradlew :app:run` now logs:

```
Reading crypto keys from the files here:   [s-public-node1.pem, s-private-node1.pem]
```

and proceeds past the crypto-init phase.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)