### PR TITLE
chore: Remove blockStream.enableStateProofs config

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -28,7 +28,6 @@ import static org.hiero.consensus.platformstate.PlatformStateUtils.creationSeman
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.BlockProof;
-import com.hedera.hapi.block.stream.MerklePath;
 import com.hedera.hapi.block.stream.MerkleSiblingHash;
 import com.hedera.hapi.block.stream.StateProof;
 import com.hedera.hapi.block.stream.TssSignedBlockProof;
@@ -874,30 +873,17 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             } else {
                 // This is a pending block whose block number precedes the signed block number, so we construct an
                 // indirect state proof
-                if (configProvider
-                        .getConfiguration()
-                        .getConfigData(BlockStreamConfig.class)
-                        .enableStateProofs()) {
-                    final var stateProof = BlockStateProofGenerator.generateStateProof(
-                            currentPendingBlock,
-                            blockNumber,
-                            effectiveSignature,
-                            signedBlock.blockTimestamp(),
-                            // Pass the remaining pending blocks, but don't remove them from the queue
-                            pendingBlocks.stream());
-                    proof = currentPendingBlock.proofBuilder().blockStateProof(stateProof);
+                final var stateProof = BlockStateProofGenerator.generateStateProof(
+                        currentPendingBlock,
+                        blockNumber,
+                        effectiveSignature,
+                        signedBlock.blockTimestamp(),
+                        // Pass the remaining pending blocks, but don't remove them from the queue
+                        pendingBlocks.stream());
+                proof = currentPendingBlock.proofBuilder().blockStateProof(stateProof);
 
-                    if (log.isDebugEnabled()) {
-                        logStateProof(effectiveSignature, currentPendingBlock, blockNumber, stateProof);
-                    }
-                } else {
-                    // (FUTURE) Once state proofs are enabled, this placeholder proof can be removed
-                    proof = currentPendingBlock
-                            .proofBuilder()
-                            .blockStateProof(StateProof.newBuilder()
-                                    .paths(MerklePath.newBuilder().build())
-                                    .signedBlockProof(latestSignedBlockProof)
-                                    .build());
+                if (log.isDebugEnabled()) {
+                    logStateProof(effectiveSignature, currentPendingBlock, blockNumber, stateProof);
                 }
 
                 // Update the metrics

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
@@ -57,9 +57,6 @@ public record BlockStreamConfig(
         @ConfigProperty(defaultValue = "500000000") @NodeProperty
         int maxReadBytesSize,
 
-        @ConfigProperty(defaultValue = "false") @NetworkProperty
-        boolean enableStateProofs,
-
         @ConfigProperty(defaultValue = "4096") @Min(512) @NetworkProperty
         int blockFileBufferOuterSizeKb,
 

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/BlockStreamConfigTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/BlockStreamConfigTest.java
@@ -47,7 +47,6 @@ class BlockStreamConfigTest {
                 Duration.ofSeconds(1),
                 512,
                 500_000_000,
-                false,
                 4096,
                 1024,
                 256,

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -183,23 +183,23 @@ val prCheckStartPorts =
 val prCheckPropOverrides =
     mapOf(
         "hapiTestAdhoc" to
-            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=true,tss.forceMockSignatures=false,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=true,tss.forceMockSignatures=false,block.stateproof.verification.enabled=true",
         "hapiTestToken" to "hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestCrypto" to
-            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=false,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
+            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=false,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestCryptoSerial" to
-            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=false,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+            "tss.hintsEnabled=true,tss.historyEnabled=true,tss.wrapsEnabled=false,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,block.stateproof.verification.enabled=true",
         "hapiTestSmartContract" to
             "tss.historyEnabled=false,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestSmartContractSerial" to "tss.historyEnabled=false",
         "hapiTestRestart" to
-            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5,platform.wiring.healthLogThreshold=5s",
+            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.forceMockSignatures=false,blockStream.blockPeriod=1s,quiescence.enabled=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5,platform.wiring.healthLogThreshold=5s",
         "hapiTestWrapsDownload" to
-            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.initialCrsParties=16,blockStream.blockPeriod=1s,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,tss.wrapsProvingKeyDownloadEnabled=true,tss.wrapsProvingKeyPath=testfiles/valid-wraps-proving-key.tar.gz,tss.wrapsProvingKeyHash=da83f3ae5eaa8575f5bedf583de2826ccfa5bff80bd6f58a54b0bf7e934e98919b5bcdaa074b3ae248f161317b87a22a",
+            "tss.hintsEnabled=true,tss.forceHandoffs=true,tss.initialCrsParties=16,blockStream.blockPeriod=1s,quiescence.enabled=true,block.stateproof.verification.enabled=true,tss.wrapsProvingKeyDownloadEnabled=true,tss.wrapsProvingKeyPath=testfiles/valid-wraps-proving-key.tar.gz,tss.wrapsProvingKeyHash=da83f3ae5eaa8575f5bedf583de2826ccfa5bff80bd6f58a54b0bf7e934e98919b5bcdaa074b3ae248f161317b87a22a",
         "hapiTestMisc" to
-            "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
+            "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestMiscSerial" to
-            "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+            "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,block.stateproof.verification.enabled=true",
         "hapiTestTimeConsuming" to
             "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestWraps" to
@@ -216,14 +216,13 @@ val prCheckPropOverrides =
         "hapiTestTimeConsumingSerial" to "nodes.nodeRewardsEnabled=false,quiescence.enabled=true",
         "hapiTestStateThrottling" to "nodes.nodeRewardsEnabled=false,quiescence.enabled=true",
         "hapiTestMiscRecords" to
-            "blockStream.streamMode=RECORDS,nodes.nodeRewardsEnabled=false,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
+            "blockStream.streamMode=RECORDS,nodes.nodeRewardsEnabled=false,quiescence.enabled=true,block.stateproof.verification.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestMiscRecordsSerial" to
-            "blockStream.streamMode=RECORDS,nodes.nodeRewardsEnabled=false,quiescence.enabled=true,blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+            "blockStream.streamMode=RECORDS,nodes.nodeRewardsEnabled=false,quiescence.enabled=true,block.stateproof.verification.enabled=true",
         "hapiTestSimpleFees" to
             "fees.simpleFeesEnabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestSimpleFeesSerial" to "fees.simpleFeesEnabled=true",
-        "hapiTestNDReconnect" to
-            "blockStream.enableStateProofs=true,block.stateproof.verification.enabled=true",
+        "hapiTestNDReconnect" to "block.stateproof.verification.enabled=true",
         "hapiTestAtomicBatch" to
             "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestAtomicBatchSerial" to "nodes.nodeRewardsEnabled=false,quiescence.enabled=true",

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSoftwareUpgradeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSoftwareUpgradeSuite.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Tag;
 @OrderedInIsolation
 public class BlockNodeSoftwareUpgradeSuite implements LifecycleTest {
 
-    // Reenable TSS feature flags, after BNs are capable of verifying StateProofs
     @HapiTest
     @HapiBlockNode(
             networkSize = 4,
@@ -46,8 +45,7 @@ public class BlockNodeSoftwareUpgradeSuite implements LifecycleTest {
                             "BLOCKS",
                             "blockStream.writerMode",
                             "GRPC",
-                            /*"blockStream.enableStateProofs",
-                            "true",
+                            /*
                             "tss.hintsEnabled",
                             "true",
                             "tss.historyEnabled",
@@ -70,8 +68,7 @@ public class BlockNodeSoftwareUpgradeSuite implements LifecycleTest {
                             "BLOCKS",
                             "blockStream.writerMode",
                             "GRPC",
-                            /*"blockStream.enableStateProofs",
-                            "true",
+                            /*
                             "tss.hintsEnabled",
                             "true",
                             "tss.historyEnabled",
@@ -94,8 +91,7 @@ public class BlockNodeSoftwareUpgradeSuite implements LifecycleTest {
                             "BLOCKS",
                             "blockStream.writerMode",
                             "GRPC",
-                            /*"blockStream.enableStateProofs",
-                            "true",
+                            /*
                             "tss.hintsEnabled",
                             "true",
                             "tss.historyEnabled",
@@ -118,8 +114,7 @@ public class BlockNodeSoftwareUpgradeSuite implements LifecycleTest {
                             "BLOCKS",
                             "blockStream.writerMode",
                             "GRPC",
-                            /*"blockStream.enableStateProofs",
-                            "true",
+                            /*
                             "tss.hintsEnabled",
                             "true",
                             "tss.historyEnabled",


### PR DESCRIPTION
**Description**:
This pull request removes the now-unused `enableStateProofs` configuration property from the codebase and cleans up related logic and test overrides. This simplifies the configuration for block streaming and state proofs, ensuring that state proof generation is always enabled and eliminating dead code and unnecessary toggles.

Configuration and code cleanup:

* Removed the `enableStateProofs` property from the `BlockStreamConfig` configuration record, making state proof generation always enabled.
* Removed conditional checks and placeholder logic for `enableStateProofs` in `BlockStreamManagerImpl`, as state proof generation no longer depends on this flag. [[1]](diffhunk://#diff-c343aa21ae9a8fadca2c6ec0d324953669907c2872e0574c30fc8c6c20e18adcL877-L880) [[2]](diffhunk://#diff-c343aa21ae9a8fadca2c6ec0d324953669907c2872e0574c30fc8c6c20e18adcL893-L901)

Test and build configuration updates:

* Removed all occurrences of `blockStream.enableStateProofs` from test property overrides in `build.gradle.kts` to reflect the removal of the config flag.
* Updated test suite setup in `BlockNodeSoftwareUpgradeSuite.java` to comment out any references to `blockStream.enableStateProofs`, aligning with the new always-on behavior.

Other:

* Removed the unused import of `MerklePath` from `BlockStreamManagerImpl.java`.

**Related issue(s)**:

Fixes #25360 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
