### PR TITLE
fix: 25365 Added missing `PathsConfig`

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ConfigUtils.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ConfigUtils.java
@@ -49,6 +49,7 @@ import com.swirlds.platform.builder.ModulesConfig;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
 import org.hiero.base.crypto.config.CryptoConfig;
 import org.hiero.consensus.config.BasicConfig;
+import org.hiero.consensus.config.PathsConfig;
 import org.hiero.consensus.metrics.config.MetricsConfig;
 import org.hiero.consensus.pces.config.PcesConfig;
 import org.hiero.consensus.state.config.StateConfig;
@@ -121,6 +122,7 @@ public final class ConfigUtils {
                 .withConfigDataType(BlockRecordStreamConfig.class)
                 .withConfigDataType(BlockStreamJumpstartConfig.class)
                 .withConfigDataType(ModulesConfig.class)
+                .withConfigDataType(PathsConfig.class)
                 .withSource(new SimpleConfigSource().withValue("merkleDb.usePbj", false))
                 .withSource(new SimpleConfigSource().withValue("merkleDb.minNumberOfFilesInCompaction", 2))
                 .withSource(new SimpleConfigSource().withValue("merkleDb.maxFileChannelsPerFileReader", FILE_CHANNELS))


### PR DESCRIPTION
**Description**:

This PR adds registration of missing `PathsConfig` to `ConfigUtils`. 

**Related issue(s)**:

Fixes #25365 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
