### PR TITLE
chore: Add record file running hash validator

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/RunningHashChainValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/RunningHashChainValidator.java
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.junit.support.validators;
+
+import com.hedera.services.bdd.junit.support.RecordStreamValidator;
+import com.hedera.services.stream.proto.RecordStreamFile;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+
+public class RunningHashChainValidator implements RecordStreamValidator {
+    @Override
+    public void validateFiles(final List<RecordStreamFile> files) {
+        RecordStreamFile previous = null;
+        for (final var file : files) {
+            if (previous != null) {
+                Assertions.assertEquals(
+                        previous.getEndObjectRunningHash(),
+                        file.getStartObjectRunningHash(),
+                        String.format(
+                                "Block %d startObjectRunningHash does not match endObjectRunningHash of preceding block %d",
+                                file.getBlockNumber(), previous.getBlockNumber()));
+            }
+            previous = file;
+        }
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
@@ -32,6 +32,7 @@ import com.hedera.services.bdd.junit.support.StreamFileAccess;
 import com.hedera.services.bdd.junit.support.validators.BalanceReconciliationValidator;
 import com.hedera.services.bdd.junit.support.validators.BlockNoValidator;
 import com.hedera.services.bdd.junit.support.validators.ExpiryRecordsValidator;
+import com.hedera.services.bdd.junit.support.validators.RunningHashChainValidator;
 import com.hedera.services.bdd.junit.support.validators.TokenReconciliationValidator;
 import com.hedera.services.bdd.junit.support.validators.TransactionBodyValidator;
 import com.hedera.services.bdd.junit.support.validators.WrappedRecordHashesByRecordFilesValidator;
@@ -103,7 +104,8 @@ public class StreamValidationOp extends UtilOp implements LifecycleTest {
                 new TransactionBodyValidator(),
                 new ExpiryRecordsValidator(),
                 new BalanceReconciliationValidator(),
-                new TokenReconciliationValidator());
+                new TokenReconciliationValidator(),
+                new RunningHashChainValidator());
     }
 
     @Override


### PR DESCRIPTION
**Description**:
This pull request introduces a new validator to ensure the integrity of running hashes in the record stream files, and integrates it into the stream validation operation. The main changes focus on improving the robustness of the test suite by verifying that the `startObjectRunningHash` of each block matches the `endObjectRunningHash` of the preceding block.

**New Validator Implementation:**

* Added `RunningHashChainValidator` to the `com.hedera.services.bdd.junit.support.validators` package, which checks that each record stream file's starting running hash matches the previous file's ending running hash.

**Integration into Stream Validation:**

* Imported `RunningHashChainValidator` in `StreamValidationOp.java` and included it in the list of validators used by default in the `StreamValidationOp` constructor.

**Related issue(s)**:

Fixes #25367

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
