### PR TITLE
refactor: refactor: Move RosterHistory creation logic to ReadableRosterStore

### DIFF
--- a/platform-sdk/consensus-roster/src/main/java/org/hiero/consensus/roster/ReadableRosterStore.java
+++ b/platform-sdk/consensus-roster/src/main/java/org/hiero/consensus/roster/ReadableRosterStore.java
@@ -9,7 +9,10 @@ import com.hedera.hapi.node.state.roster.RoundRosterPair;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Read-only implementation for accessing rosters states.
@@ -97,4 +100,19 @@ public interface ReadableRosterStore {
      * @return true if the transplant updates are in progress
      */
     boolean isTransplantInProgress();
+
+    /**
+     * Creates a {@link RosterHistory} from the rosters accessible through this store.
+     *
+     * @return the roster history
+     */
+    @NonNull
+    default RosterHistory createRosterHistory() {
+        final List<RoundRosterPair> pairs = getRosterHistory();
+        final Map<Bytes, Roster> map = new HashMap<>();
+        for (final RoundRosterPair pair : pairs) {
+            map.put(pair.activeRosterHash(), Objects.requireNonNull(get(pair.activeRosterHash())));
+        }
+        return new RosterHistory(pairs, map);
+    }
 }

--- a/platform-sdk/consensus-roster/src/main/java/org/hiero/consensus/roster/RosterStateUtils.java
+++ b/platform-sdk/consensus-roster/src/main/java/org/hiero/consensus/roster/RosterStateUtils.java
@@ -2,16 +2,10 @@
 package org.hiero.consensus.roster;
 
 import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RoundRosterPair;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.State;
 import com.swirlds.state.spi.CommittableWritableStates;
 import com.swirlds.state.spi.WritableStates;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 
 /**
  * A utility class for roster operations that depend on the State API.
@@ -28,14 +22,8 @@ public final class RosterStateUtils {
      */
     @NonNull
     public static RosterHistory createRosterHistory(@NonNull final State state) {
-        final ReadableRosterStore rosterStore =
-                new ReadableRosterStoreImpl(state.getReadableStates(RosterStateId.SERVICE_NAME));
-        final List<RoundRosterPair> roundRosterPairs = rosterStore.getRosterHistory();
-        final Map<Bytes, Roster> rosterMap = new HashMap<>();
-        for (final RoundRosterPair pair : roundRosterPairs) {
-            rosterMap.put(pair.activeRosterHash(), Objects.requireNonNull(rosterStore.get(pair.activeRosterHash())));
-        }
-        return new RosterHistory(roundRosterPairs, rosterMap);
+        return new ReadableRosterStoreImpl(state.getReadableStates(RosterStateId.SERVICE_NAME))
+                .createRosterHistory();
     }
 
     /**


### PR DESCRIPTION
**Description**:
This PR moves the `createRosterHistory()` functionality from `RosterStateUtils` into `ReadableRosterStore`.
- Add `createRosterHistory()` instance method to `ReadableRosterStore` and its implementation.
- Update `RosterStateUtils` to delegate history creation to the store.
- Remove redundant transformation logic from utility classes to improve encapsulation.
- Clean up imports and leverage `ReadableRosterStoreImpl` for state-to-domain mapping.

**Related issue(s)**:
Fixes #22689 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
