### PR TITLE
build: improve reuse of HAPI test results on CI

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.hiero.gradle.environment.EnvAccess
 
 plugins {
     id("org.hiero.gradle.module.application")
@@ -295,7 +296,7 @@ tasks {
 tasks.register<Test>("testSubprocess") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    outputs.upToDateWhen { false } // Don't skip execution of hapi test tasks
+    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
 
     // Isolate each subtask's working directory so logs are not overwritten
     val subtaskName =
@@ -432,7 +433,7 @@ tasks.register<Test>("testSubprocess") {
 tasks.register<Test>("testSubprocessConcurrent") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    outputs.upToDateWhen { false } // Don't skip execution of hapi test tasks
+    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
 
     // Isolate each subtask's working directory so logs are not overwritten
     val subtaskName =
@@ -574,7 +575,7 @@ tasks.register<Test>("testSubprocessConcurrent") {
 tasks.register<Test>("testRemote") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    outputs.upToDateWhen { false } // Don't skip execution of hapi test tasks
+    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
 
     // Isolate each subtask's working directory so logs are not overwritten
     val subtaskName =
@@ -675,7 +676,7 @@ tasks {
 tasks.register<Test>("testEmbedded") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    outputs.upToDateWhen { false } // Don't skip execution of hapi test tasks
+    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
 
     // Isolate each subtask's working directory so logs are not overwritten
     val subtaskName =
@@ -742,7 +743,7 @@ tasks {
 tasks.register<Test>("testRepeatable") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
     classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
-    outputs.upToDateWhen { false } // Don't skip execution of hapi test tasks
+    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
 
     // Isolate each subtask's working directory so logs are not overwritten
     val subtaskName =

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 description = "Hedera Services Test Clients for End to End Tests (EET)"
 
 // Detect available resources and scale JVM settings accordingly
-class TestResourceArgumentsProvider() : CommandLineArgumentProvider {
+class TestResourceArgumentsProvider : CommandLineArgumentProvider {
     override fun asArguments(): Iterable<String> {
         val logger =
             org.slf4j.LoggerFactory.getLogger(TestResourceArgumentsProvider::class.java) as Logger

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -9,48 +9,68 @@ plugins {
 description = "Hedera Services Test Clients for End to End Tests (EET)"
 
 // Detect available resources and scale JVM settings accordingly
-val availableCpus = Runtime.getRuntime().availableProcessors()
-val totalMemoryGib: Double =
-    try {
-        val osName = System.getProperty("os.name", "").lowercase()
-        if (osName.contains("linux")) {
-            // Try cgroup limit first (container-aware), fall back to /proc/meminfo
-            val cgroupV2 = File("/sys/fs/cgroup/memory.max")
-            val cgroupV1 = File("/sys/fs/cgroup/memory/memory.limit_in_bytes")
-            val cgroupBytes: Long? =
-                when {
-                    cgroupV2.exists() -> cgroupV2.readText().trim().toLongOrNull()
-                    cgroupV1.exists() -> cgroupV1.readText().trim().toLongOrNull()
-                    else -> null
+class TestResourceArgumentsProvider() : CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> {
+        val logger =
+            org.slf4j.LoggerFactory.getLogger(TestResourceArgumentsProvider::class.java) as Logger
+        val availableCpus = Runtime.getRuntime().availableProcessors()
+        val totalMemoryGib: Double =
+            try {
+                val osName = System.getProperty("os.name", "").lowercase()
+                if (osName.contains("linux")) {
+                    // Try cgroup limit first (container-aware), fall back to /proc/meminfo
+                    val cgroupV2 = File("/sys/fs/cgroup/memory.max")
+                    val cgroupV1 = File("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+                    val cgroupBytes: Long? =
+                        when {
+                            cgroupV2.exists() -> cgroupV2.readText().trim().toLongOrNull()
+                            cgroupV1.exists() -> cgroupV1.readText().trim().toLongOrNull()
+                            else -> null
+                        }
+                    if (cgroupBytes != null && cgroupBytes < Long.MAX_VALUE / 2) {
+                        cgroupBytes / 1024.0 / 1024.0 / 1024.0
+                    } else {
+                        val memLine =
+                            File("/proc/meminfo").readLines().first { line ->
+                                line.startsWith("MemTotal")
+                            }
+                        memLine.split("\\s+".toRegex())[1].toLong() / 1024.0 / 1024.0
+                    }
+                } else {
+                    // macOS/other: use Gradle JVM max memory as a proxy, fallback to 16 GiB
+                    // This is the Gradle daemon's max heap, not physical RAM, but provides a
+                    // reasonable lower bound for scaling test settings
+                    Runtime.getRuntime().maxMemory() / 1024.0 / 1024.0 / 1024.0
                 }
-            if (cgroupBytes != null && cgroupBytes < Long.MAX_VALUE / 2) {
-                cgroupBytes / 1024.0 / 1024.0 / 1024.0
-            } else {
-                val memLine =
-                    File("/proc/meminfo").readLines().first { line -> line.startsWith("MemTotal") }
-                memLine.split("\\s+".toRegex())[1].toLong() / 1024.0 / 1024.0
+            } catch (_: Exception) {
+                16.0
             }
-        } else {
-            // macOS/other: use Gradle JVM max memory as a proxy, fallback to 16 GiB
-            // This is the Gradle daemon's max heap, not physical RAM, but provides a
-            // reasonable lower bound for scaling test settings
-            Runtime.getRuntime().maxMemory() / 1024.0 / 1024.0 / 1024.0
-        }
-    } catch (_: Exception) {
-        16.0
-    }
-// Use all available processors but cap at 8 to avoid excessive thread contention
-val testProcessorCount = availableCpus.coerceAtMost(8)
-// Parallelism is set per-task based on actual node count (see testSubprocessConcurrent below)
-// Reserve ~half of total memory for the test client JVM, leave the rest for forked node JVMs and OS
-val testClientHeapGib = (totalMemoryGib / 2).toInt().coerceIn(4, 8)
-val testMaxHeap = "${testClientHeapGib}g"
-// Pass remaining memory pool to ProcessUtils, which divides by actual node count at runtime
-val nodePoolMib = ((totalMemoryGib - testClientHeapGib) * 1024 * 0.8).toInt().coerceAtLeast(2048)
 
-logger.lifecycle(
-    "Test resource detection: cpus=$availableCpus, totalMem=${String.format("%.1f", totalMemoryGib)}GiB -> processorCount=$testProcessorCount, clientHeap=$testMaxHeap, nodePool=${nodePoolMib}m"
-)
+        // Use all available processors but cap at 8 to avoid excessive thread contention
+        val testProcessorCount = availableCpus.coerceAtMost(8)
+        // Parallelism is set per-task based on actual node count (see testSubprocessConcurrent
+        // below)
+        // Reserve ~half of total memory for the test client JVM, leave the rest for forked node
+        // JVMs and OS
+        val testClientHeapGib = (totalMemoryGib / 2).toInt().coerceIn(4, 8)
+        val testMaxHeap = "${testClientHeapGib}g"
+        // Pass remaining memory pool to ProcessUtils, which divides by actual node count at runtime
+        val nodePoolMib =
+            ((totalMemoryGib - testClientHeapGib) * 1024 * 0.8).toInt().coerceAtLeast(2048)
+
+        logger.lifecycle(
+            "Test resource detection: cpus=$availableCpus, totalMem=${String.format("%.1f", totalMemoryGib)}GiB -> processorCount=$testProcessorCount, clientHeap=$testMaxHeap, nodePool=${nodePoolMib}m"
+        )
+
+        return listOf(
+            // Scale heap and processor count to match available resources
+            "-Xmx$testMaxHeap",
+            "-XX:ActiveProcessorCount=$testProcessorCount",
+            // Limit forked node JVM heap to avoid overcommitting container/runner memory
+            "-Dhapi.spec.node.poolMib=$nodePoolMib",
+        )
+    }
+}
 
 mainModuleInfo {
     runtimeOnly("org.junit.jupiter.engine")
@@ -103,8 +123,7 @@ tasks.test {
     systemProperty("hapi.spec.embedded.mode", "per-class")
 
     // Scale heap and processor count to match available resources
-    maxHeapSize = testMaxHeap
-    jvmArgs("-XX:ActiveProcessorCount=$testProcessorCount")
+    jvmArgumentProviders.add(TestResourceArgumentsProvider())
 }
 
 val miscTags =
@@ -397,14 +416,11 @@ tasks.register<Test>("testSubprocess") {
         "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
     )
 
-    // Scale heap and processor count to match available resources
-    maxHeapSize = testMaxHeap
-    // Limit forked node JVM heap to avoid overcommitting container/runner memory
-    systemProperty("hapi.spec.node.poolMib", "$nodePoolMib")
+    jvmArgumentProviders.add(TestResourceArgumentsProvider())
+
     // Fix testcontainers module system access to commons libraries
     // testcontainers 2.0.2 is a named module but doesn't declare its module-info dependencies
     jvmArgs(
-        "-XX:ActiveProcessorCount=$testProcessorCount",
         "--add-reads=org.testcontainers=org.apache.commons.lang3",
         "--add-reads=org.testcontainers=org.apache.commons.compress",
         "--add-reads=org.testcontainers=org.apache.commons.io",
@@ -543,14 +559,10 @@ tasks.register<Test>("testSubprocessConcurrent") {
         "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
     )
 
-    // Scale heap and processor count to match available resources
-    maxHeapSize = testMaxHeap
-    // Limit forked node JVM heap to avoid overcommitting container/runner memory
-    systemProperty("hapi.spec.node.poolMib", "$nodePoolMib")
+    jvmArgumentProviders.add(TestResourceArgumentsProvider())
     // Fix testcontainers module system access to commons libraries
     // testcontainers 2.0.2 is a named module but doesn't declare its module-info dependencies
     jvmArgs(
-        "-XX:ActiveProcessorCount=$testProcessorCount",
         "--add-reads=org.testcontainers=org.apache.commons.lang3",
         "--add-reads=org.testcontainers=org.apache.commons.compress",
         "--add-reads=org.testcontainers=org.apache.commons.io",
@@ -628,9 +640,7 @@ tasks.register<Test>("testRemote") {
         "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
     )
 
-    // Scale heap and processor count to match available resources
-    maxHeapSize = testMaxHeap
-    jvmArgs("-XX:ActiveProcessorCount=$testProcessorCount")
+    jvmArgumentProviders.add(TestResourceArgumentsProvider())
     maxParallelForks = 1
 }
 
@@ -714,8 +724,7 @@ tasks.register<Test>("testEmbedded") {
     }
 
     // Scale heap and processor count to match available resources
-    maxHeapSize = testMaxHeap
-    jvmArgs("-XX:ActiveProcessorCount=$testProcessorCount")
+    jvmArgumentProviders.add(TestResourceArgumentsProvider())
 }
 
 val repeatableBaseTags = mapOf("hapiTestMiscRepeatable" to "REPEATABLE&!CRYPTO")
@@ -766,9 +775,7 @@ tasks.register<Test>("testRepeatable") {
     // Tell our launcher to target a repeatable embedded network
     systemProperty("hapi.spec.embedded.mode", "repeatable")
 
-    // Scale heap and processor count to match available resources
-    maxHeapSize = testMaxHeap
-    jvmArgs("-XX:ActiveProcessorCount=$testProcessorCount")
+    jvmArgumentProviders.add(TestResourceArgumentsProvider())
 
     // Pass a system property "KEY=VALUE" to the test JVM via "-PsysProp.KEY=VALUE"
     project.properties


### PR DESCRIPTION
- Clarify `UP-TO-DATE` and `FROM-CACHE` reuse of HAPI test results
  - Local build: never reuse - expressed by `if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")`
     - Refines solution from #24668
  - CI build: allow `UP-TO-DATE` and `FROM-CACHE` - e.g if only a test in another project is modified, HAPI test results from previous CI are reused.
- Move resource calculation into `CommandLineArgumentProvider` 
   - Machine resource details are no longer part of cache key
   - Log message no longer printed on build invocations that do not run HAPI tests