### PR TITLE
chore: (0.73) Update mainnet throttles  for `CryptoGetAccountBalance` queries

### DIFF
--- a/hedera-node/configuration/mainnet/upgrade/throttles.json
+++ b/hedera-node/configuration/mainnet/upgrade/throttles.json
@@ -205,7 +205,7 @@
       "throttleGroups": [
         {
           "opsPerSec": 0,
-          "milliOpsPerSec": 40000000,
+          "milliOpsPerSec": 20000000,
           "operations": [
             "CryptoGetAccountBalance"
           ]


### PR DESCRIPTION
## Description

This PR updates the mainnet upgrade throttle configuration for the first phase of deprecating `CryptoGetAccountBalance` queries on Consensus Nodes.

For release `0.73`, the `CryptoGetAccountBalance` query throttle is reduced from `40K TPS` to `20K TPS` by updating `BalanceQueryLimits` from `40,000,000` to `20,000,000` `milliOpsPerSec`.
