### PR TITLE
ci(workflow-fix): update cancelled HAPI test processing in MATS

### DIFF
--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -989,7 +989,7 @@ jobs:
       - hapi-tests-restart
       - hapi-tests-bn-comms
       - hapi-tests-state-throttling
-    if: ${{ !cancelled() && always() }} # always run unless cancelled
+    if: ${{ always() }}
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
     steps:
@@ -1028,11 +1028,18 @@ jobs:
           failure_mode="none"
 
           for i in "${!job_statuses[@]}"; do
-            if [[ "${job_statuses[$i]}" == "failure" ]]; then
-              mode="${job_failure_modes[$i]}"
+            status="${job_statuses[$i]}"
+            mode="${job_failure_modes[$i]}"
+            if [[ "${status}" == "failure" ]]; then
               if [[ "${failure_mode}" == "none" ]]; then
                 failure_mode="${mode}"
               elif [[ "${mode}" == "workflow" ]]; then
+                failure_mode="workflow"
+              fi
+            elif [[ "${status}" == "cancelled" ]]; then
+              # A cancelled job signals an infrastructure/runner issue, not a test bug.
+              # Default to workflow so report-status routes to the environment channel.
+              if [[ "${failure_mode}" != "workflow" ]]; then
                 failure_mode="workflow"
               fi
             fi

--- a/.github/workflows/zxc-mats-tests.yaml
+++ b/.github/workflows/zxc-mats-tests.yaml
@@ -325,7 +325,7 @@ jobs:
       - mats-snyk-scan
       - mats-gradle-determinism
       - mats-docker-determinism
-    if: ${{ !cancelled() && always() }} # always run unless cancelled
+    if: ${{ always() }}
     steps:
       - name: Initialize GitHub Job
         uses: pandaswhocode/initialize-github-job@d93cd457947758129c6d93e09f89ad528119960f # v1.0.8
@@ -389,6 +389,17 @@ jobs:
                 failed_tests="$name"
               else
                 failed_tests="$failed_tests, $name"
+              fi
+            elif [[ "$status" == "cancelled" ]]; then
+              # A cancelled job signals an infrastructure/runner issue, not a test bug.
+              # Default to workflow so report-status routes to the environment channel.
+              if [[ "${failure_mode}" != "workflow" ]]; then
+                failure_mode="workflow"
+              fi
+              if [[ -z "$failed_tests" ]]; then
+                failed_tests="$name (cancelled)"
+              else
+                failed_tests="$failed_tests, $name (cancelled)"
               fi
             fi
           done


### PR DESCRIPTION
**Description**:
This pull request updates the workflow logic for both HAPI and MATS test jobs in GitHub Actions to better handle job cancellation scenarios. The main improvements ensure that cancelled jobs are treated as infrastructure or runner issues (not test bugs), and the reporting logic is updated accordingly.

**Workflow logic improvements:**

* The conditional for running summary/reporting jobs is changed to always run, regardless of cancellation, by removing the `!cancelled()` check and relying solely on `always()`. (`.github/workflows/zxc-execute-hapi-tests.yaml`, `.github/workflows/zxc-mats-tests.yaml`) [[1]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL992-R992) [[2]](diffhunk://#diff-6ead8440dd8e7b048efa5745d75500006f97146fd8f26c133fb6d8ec46f68584L328-R328)

**Failure mode and reporting enhancements:**

* In both workflows, the shell scripts that aggregate job statuses now explicitly handle the `cancelled` status: cancelled jobs set the `failure_mode` to `workflow` (to indicate infrastructure issues), and in the MATS workflow, cancelled jobs are also listed in the failed tests summary with a `(cancelled)` label. (`.github/workflows/zxc-execute-hapi-tests.yaml`, `.github/workflows/zxc-mats-tests.yaml`) [[1]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL1031-R1044) [[2]](diffhunk://#diff-6ead8440dd8e7b048efa5745d75500006f97146fd8f26c133fb6d8ec46f68584R393-R403)

**Related issue(s)**:

Fixes #25400 
