### PR TITLE
fix: 25412: (0.74) MerkleDb directory leak in temp

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -1201,10 +1201,18 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
     public VirtualDataSource detachAsDataSourceCopy() {
         return pipeline.pausePipelineAndRun("detach", () -> {
             final Path snapshotPath = dataSourceBuilder.snapshot(null, dataSource);
-            VirtualDataSource dataSourceCopy = dataSourceBuilder.build(getLabel(), snapshotPath, true, false);
-
-            flush(cache.snapshot(), metadata, dataSourceCopy);
-            return dataSourceCopy;
+            try {
+                VirtualDataSource dataSourceCopy = dataSourceBuilder.build(getLabel(), snapshotPath, true, false);
+                flush(cache.snapshot(), metadata, dataSourceCopy);
+                return dataSourceCopy;
+            } finally {
+                try {
+                    // Delete the snapshot directory
+                    FileUtils.deleteDirectory(snapshotPath);
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Unable to delete snapshot directory", e);
+                }
+            }
         });
     }
 
@@ -1217,10 +1225,20 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
     public RecordAccessor detach() {
         return pipeline.pausePipelineAndRun("detach", () -> {
             final Path snapshotPath = dataSourceSnapshot();
-            final VirtualDataSource dataSourceCopy = dataSourceBuilder.build(getLabel(), snapshotPath, false, false);
-            final VirtualNodeCache cacheSnapshot = cache.snapshot();
-            final int hashChunkHeight = dataSource.getHashChunkHeight();
-            return new RecordAccessor(metadata.copy(), hashChunkHeight, cacheSnapshot, dataSourceCopy);
+            try {
+                final VirtualDataSource dataSourceCopy =
+                        dataSourceBuilder.build(getLabel(), snapshotPath, false, false);
+                final VirtualNodeCache cacheSnapshot = cache.snapshot();
+                final int hashChunkHeight = dataSource.getHashChunkHeight();
+                return new RecordAccessor(metadata.copy(), hashChunkHeight, cacheSnapshot, dataSourceCopy);
+            } finally {
+                try {
+                    // Delete the snapshot directory
+                    FileUtils.deleteDirectory(snapshotPath);
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Unable to delete snapshot directory", e);
+                }
+            }
         });
     }
 


### PR DESCRIPTION
Fix summary: direct backport of https://github.com/hiero-ledger/hiero-consensus-node/pull/25409 to the `release/0.74` branch.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/25412
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
