### PR TITLE
fix: Disable broadcast in gossip

### DIFF
--- a/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/BroadcastConfig.java
+++ b/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/BroadcastConfig.java
@@ -21,7 +21,7 @@ import java.time.Duration;
  */
 @ConfigData("broadcast")
 public record BroadcastConfig(
-        @ConfigProperty(defaultValue = "true") boolean enableBroadcast,
+        @ConfigProperty(defaultValue = "false") boolean enableBroadcast,
         @ConfigProperty(defaultValue = "900ms") Duration disablePingThreshold,
         @ConfigProperty(defaultValue = "200") int throttleOutputQueueThreshold,
         @ConfigProperty(defaultValue = "30s") Duration pauseOnLag,


### PR DESCRIPTION
**Description**:
Disable broadcast due to suspicion of causing socket timeout exceptions.

**Related issue(s)**:

Fixes #25421 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
