### PR TITLE
fix: 25417: CryptoBench reports stray running threads, deletes its data directory unconditionally

### DIFF
--- a/platform-sdk/swirlds-benchmarks/build.gradle.kts
+++ b/platform-sdk/swirlds-benchmarks/build.gradle.kts
@@ -29,7 +29,6 @@ jmhModuleInfo {
     requires("org.hiero.consensus.model")
     requires("org.hiero.consensus.reconnect")
     requires("org.hiero.consensus.utility")
-    requires("org.hiero.base.utility.test.fixtures")
     requires("jmh.core")
     requires("org.apache.logging.log4j")
     requiresStatic("com.github.spotbugs.annotations")

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 import org.hiero.base.constructable.ConstructableRegistryException;
 import org.hiero.base.crypto.config.CryptoConfig;
 import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
 import org.hiero.consensus.constructable.ConstructableRegistration;
 import org.hiero.consensus.metrics.config.MetricsConfig;
 import org.openjdk.jmh.annotations.Level;
@@ -141,7 +140,7 @@ public abstract class BaseBench {
             benchDir = Files.createDirectories(Path.of(data).resolve(benchmarkName()));
         }
 
-        fileSystemManager = new TestFileSystemManager(benchDir);
+        fileSystemManager = new FileSystemManager(benchDir);
 
         try {
             ConstructableRegistration.registerAllConstructables();

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
@@ -216,6 +216,8 @@ public abstract class BaseBench {
         onTrialTearDown();
 
         BenchmarkMetrics.stop();
+
+        Utils.deleteRecursively(benchDir.resolve("tmp"));
         if (!getBenchmarkConfig().saveDataDirectory()) {
             Utils.deleteRecursively(benchDir);
         }


### PR DESCRIPTION
**Description**:
Use `FileSystemManager` to avoid removing state directory. Tested by running benchmarks and checking directories.

**Related issue(s)**:
Fixes #25417
