### PR TITLE
fix: Synchronize JcaSigner and JcaVerifier sign/verify

### DIFF
--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/JcaSigner.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/JcaSigner.java
@@ -38,8 +38,12 @@ public class JcaSigner implements BytesSigner {
     @Override
     public @NonNull Bytes sign(@NonNull final Bytes data) {
         try {
-            data.updateSignature(signature);
-            return Bytes.wrap(signature.sign());
+            // The JCA Signature object holds mutable state across update()/sign(); guard it so concurrent
+            // callers sharing this signer don't interleave bytes and produce an unverifiable signature.
+            synchronized (signature) {
+                data.updateSignature(signature);
+                return Bytes.wrap(signature.sign());
+            }
         } catch (final SignatureException e) {
             throw new CryptographyException(e);
         }

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/JcaVerifier.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/JcaVerifier.java
@@ -38,8 +38,12 @@ public class JcaVerifier implements BytesSignatureVerifier {
     @Override
     public boolean verify(@NonNull final Bytes data, @NonNull final Bytes signature) {
         try {
-            data.updateSignature(verifier);
-            return signature.verifySignature(verifier);
+            // The JCA Signature object holds mutable state across update()/verify(); guard it so concurrent
+            // callers sharing this verifier don't interleave bytes and produce false negatives.
+            synchronized (verifier) {
+                data.updateSignature(verifier);
+                return signature.verifySignature(verifier);
+            }
         } catch (final SignatureException e) {
             throw new CryptographyException(e);
         }

--- a/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/JcaSignerConcurrencyTest.java
+++ b/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/JcaSignerConcurrencyTest.java
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.base.crypto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.security.KeyPair;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Reproduces the race condition behind the {@code BlockRecordManagerTest#[4] NON_GENESIS, true} flake
+ * (issue #25312): a single {@link org.hiero.base.crypto.internal.JcaSigner} shared across threads
+ * holds one {@link Signature} object whose {@code update}/{@code sign} sequence is not atomic. When
+ * the concurrent record stream producer closes two blocks on the {@code ForkJoinPool} at the same
+ * time, both closures call {@code signer.sign(...)} on the same {@code JcaSigner} and the bytes
+ * accumulated in the shared {@code Signature} interleave, producing an unverifiable signature.
+ *
+ * <p>These tests hammer a shared signer from many threads using unique data per call and assert
+ * that every signature verifies. Without synchronization on the shared {@code Signature}, the
+ * stress test fails within a handful of iterations; with the fix it completes without a single bad
+ * signature.
+ */
+class JcaSignerConcurrencyTest {
+
+    private static final int THREAD_COUNT = 16;
+    private static final int SIGNS_PER_THREAD = 200;
+
+    @ParameterizedTest
+    @EnumSource(
+            value = SigningImplementation.class,
+            names = {"RSA_BC", "RSA_JDK", "ED25519_SUN"})
+    void jcaSignerIsSafeUnderConcurrentSigning(final SigningImplementation implementation) throws Exception {
+        final SecureRandom secureRandom = new SecureRandom();
+        final KeyPair keyPair = SigningFactory.generateKeyPair(implementation.getSigningSchema(), secureRandom);
+        // One signer shared across all threads — the production setup that the race needs.
+        final BytesSigner sharedSigner = SigningFactory.createSigner(implementation, keyPair);
+
+        runStress(implementation, keyPair, sharedSigner);
+    }
+
+    /**
+     * Sanity check: when each thread owns its own signer, no race is possible and the same workload
+     * passes trivially. This guards against the stress test masking a different latent failure.
+     */
+    @Test
+    void perThreadSignerHasNoRace() throws Exception {
+        final SigningImplementation implementation = SigningImplementation.RSA_BC;
+        final SecureRandom secureRandom = new SecureRandom();
+        final KeyPair keyPair = SigningFactory.generateKeyPair(implementation.getSigningSchema(), secureRandom);
+
+        runStress(implementation, keyPair, null /* perThreadSigner */);
+    }
+
+    /**
+     * Drive {@link THREAD_COUNT} threads to sign {@link SIGNS_PER_THREAD} unique payloads each.
+     * If {@code sharedSigner} is {@code null}, each thread builds its own signer (no sharing). Every
+     * resulting signature is verified against the exact payload that produced it; any mismatch is
+     * reported as a failure.
+     */
+    private static void runStress(
+            final SigningImplementation implementation, final KeyPair keyPair, final BytesSigner sharedSigner)
+            throws Exception {
+        // readyGate: workers signal "I'm at the start line"; main waits for all of them.
+        // startGate: main releases all workers at once to maximize update()/sign() overlap.
+        final CountDownLatch readyGate = new CountDownLatch(THREAD_COUNT);
+        final CountDownLatch startGate = new CountDownLatch(1);
+        final ConcurrentLinkedQueue<String> failures = new ConcurrentLinkedQueue<>();
+
+        // try-with-resources guarantees pool.close() on exit; explicit shutdownNow() on failure paths
+        // keeps that close() from blocking on workers still parked at the start gate.
+        try (final ExecutorService pool = Executors.newFixedThreadPool(THREAD_COUNT)) {
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                final int threadId = t;
+                pool.submit(() -> {
+                    final BytesSigner signer =
+                            sharedSigner != null ? sharedSigner : SigningFactory.createSigner(implementation, keyPair);
+                    try {
+                        // Each thread brings its own verifier — the verifier code path is also stateful
+                        // and we don't want to conflate it with the signer race we're hunting.
+                        final Signature verifier = Signature.getInstance(
+                                implementation.getSigningSchema().getSigningAlgorithm(), implementation.getProvider());
+                        verifier.initVerify(keyPair.getPublic());
+                        final MessageDigest digest = MessageDigest.getInstance("SHA-384");
+
+                        readyGate.countDown();
+                        startGate.await();
+
+                        for (int i = 0; i < SIGNS_PER_THREAD; i++) {
+                            // Unique 48-byte payload per (thread, iteration), mirroring the SHA-384 hash
+                            // the record stream signs.
+                            final byte[] raw = (threadId + ":" + i).getBytes();
+                            digest.reset();
+                            final Bytes payload = Bytes.wrap(digest.digest(raw));
+
+                            final Bytes signature = signer.sign(payload);
+
+                            payload.updateSignature(verifier);
+                            final boolean ok = signature.verifySignature(verifier);
+                            if (!ok) {
+                                failures.add("thread=" + threadId + " iter=" + i + " payloadHex=" + payload.toHex());
+                            }
+                        }
+                    } catch (final Exception e) {
+                        failures.add("thread=" + threadId + " exception=" + e);
+                    }
+                });
+            }
+
+            if (!readyGate.await(30, TimeUnit.SECONDS)) {
+                pool.shutdownNow();
+                fail("Worker threads did not reach the start gate in time for " + implementation);
+            }
+            startGate.countDown();
+
+            pool.shutdown();
+            if (!pool.awaitTermination(2, TimeUnit.MINUTES)) {
+                pool.shutdownNow();
+                fail("Stress workload did not finish in time for " + implementation);
+            }
+        }
+
+        final List<String> failureList = List.copyOf(failures);
+        assertEquals(
+                List.of(),
+                failureList,
+                "Concurrent signing produced unverifiable signatures with " + implementation
+                        + ". First few failures: "
+                        + failureList.subList(0, Math.min(5, failureList.size())));
+    }
+}

--- a/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/JcaVerifierConcurrencyTest.java
+++ b/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/JcaVerifierConcurrencyTest.java
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.base.crypto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.security.KeyPair;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Companion to {@link JcaSignerConcurrencyTest}: proves that
+ * {@link org.hiero.base.crypto.internal.JcaVerifier} is also safe to share across threads.
+ *
+ * <p>The verifier holds a single {@link java.security.Signature} object whose
+ * {@code update}/{@code verify} pair is non-atomic, structurally identical to the bug in the signer
+ * that produced issue #25312. Production callers (event intake, RSA hints context) defensively wrap
+ * verifiers in {@code ThreadLocal} maps to avoid this race; this test pins down the contract so
+ * callers no longer need that workaround.
+ *
+ * <p>Each thread signs unique payloads with its own private signer (a fresh {@code JcaSigner} per
+ * thread, so the signing side is uncontested) and then verifies them against a single shared
+ * {@code JcaVerifier}. Any false negative — or thrown exception from corrupted internal state — is
+ * recorded as a failure.
+ */
+class JcaVerifierConcurrencyTest {
+
+    private static final int THREAD_COUNT = 16;
+    private static final int VERIFICATIONS_PER_THREAD = 200;
+
+    @ParameterizedTest
+    @EnumSource(
+            value = SigningImplementation.class,
+            names = {"RSA_BC", "RSA_JDK", "ED25519_SUN"})
+    void jcaVerifierIsSafeUnderConcurrentVerification(final SigningImplementation implementation) throws Exception {
+        final SecureRandom secureRandom = new SecureRandom();
+        final KeyPair keyPair = SigningFactory.generateKeyPair(implementation.getSigningSchema(), secureRandom);
+        // One verifier shared across all threads — the setup the bug needs.
+        final BytesSignatureVerifier sharedVerifier =
+                SigningFactory.createVerifier(implementation, keyPair.getPublic());
+
+        runStress(implementation, keyPair, sharedVerifier);
+    }
+
+    /**
+     * Sanity check: per-thread verifier (current production pattern) — must always pass and guards
+     * against the stress test masking unrelated failures.
+     */
+    @Test
+    void perThreadVerifierHasNoRace() throws Exception {
+        final SigningImplementation implementation = SigningImplementation.RSA_BC;
+        final SecureRandom secureRandom = new SecureRandom();
+        final KeyPair keyPair = SigningFactory.generateKeyPair(implementation.getSigningSchema(), secureRandom);
+
+        runStress(implementation, keyPair, null /* perThreadVerifier */);
+    }
+
+    /**
+     * Pre-signs all payloads up front (single-threaded), then has {@link #THREAD_COUNT} threads
+     * verify them concurrently against either a shared or per-thread verifier. Each thread checks
+     * that every verify() returns {@code true}; any {@code false} or thrown exception is recorded.
+     */
+    private static void runStress(
+            final SigningImplementation implementation,
+            final KeyPair keyPair,
+            final BytesSignatureVerifier sharedVerifier)
+            throws Exception {
+
+        // Pre-sign every payload single-threaded so the verify side is the only thing under test.
+        final BytesSigner signer = SigningFactory.createSigner(implementation, keyPair);
+        final List<List<SignedPayload>> perThreadWork = new ArrayList<>(THREAD_COUNT);
+        final MessageDigest digest = MessageDigest.getInstance("SHA-384");
+        for (int t = 0; t < THREAD_COUNT; t++) {
+            final List<SignedPayload> work = new ArrayList<>(VERIFICATIONS_PER_THREAD);
+            for (int i = 0; i < VERIFICATIONS_PER_THREAD; i++) {
+                digest.reset();
+                final Bytes payload = Bytes.wrap(digest.digest((t + ":" + i).getBytes()));
+                final Bytes signature = signer.sign(payload);
+                work.add(new SignedPayload(payload, signature));
+            }
+            perThreadWork.add(work);
+        }
+
+        // readyGate: workers signal "I'm at the start line"; main waits for all of them.
+        // startGate: main releases all workers at once to maximize update()/verify() overlap.
+        final CountDownLatch readyGate = new CountDownLatch(THREAD_COUNT);
+        final CountDownLatch startGate = new CountDownLatch(1);
+        final ConcurrentLinkedQueue<String> failures = new ConcurrentLinkedQueue<>();
+
+        // try-with-resources guarantees pool.close() on exit; explicit shutdownNow() on failure paths
+        // keeps that close() from blocking on workers still parked at the start gate.
+        try (final ExecutorService pool = Executors.newFixedThreadPool(THREAD_COUNT)) {
+            for (int t = 0; t < THREAD_COUNT; t++) {
+                final int threadId = t;
+                pool.submit(() -> {
+                    final BytesSignatureVerifier verifier = sharedVerifier != null
+                            ? sharedVerifier
+                            : SigningFactory.createVerifier(implementation, keyPair.getPublic());
+                    final List<SignedPayload> work = perThreadWork.get(threadId);
+                    try {
+                        readyGate.countDown();
+                        startGate.await();
+
+                        for (int i = 0; i < work.size(); i++) {
+                            final SignedPayload sp = work.get(i);
+                            final boolean ok = verifier.verify(sp.payload(), sp.signature());
+                            if (!ok) {
+                                failures.add("thread=" + threadId + " iter=" + i + " payloadHex="
+                                        + sp.payload().toHex());
+                            }
+                        }
+                    } catch (final Exception e) {
+                        failures.add("thread=" + threadId + " exception=" + e);
+                    }
+                });
+            }
+
+            if (!readyGate.await(30, TimeUnit.SECONDS)) {
+                pool.shutdownNow();
+                fail("Worker threads did not reach the start gate in time for " + implementation);
+            }
+            startGate.countDown();
+
+            pool.shutdown();
+            if (!pool.awaitTermination(2, TimeUnit.MINUTES)) {
+                pool.shutdownNow();
+                fail("Stress workload did not finish in time for " + implementation);
+            }
+        }
+
+        final List<String> failureList = List.copyOf(failures);
+        assertEquals(
+                List.of(),
+                failureList,
+                "Concurrent verification produced false negatives or exceptions with " + implementation
+                        + ". First few failures: "
+                        + failureList.subList(0, Math.min(5, failureList.size())));
+    }
+
+    private record SignedPayload(Bytes payload, Bytes signature) {}
+}


### PR DESCRIPTION
## Root cause

`JcaSigner` and `JcaVerifier` each hold a single `java.security.Signature` instance whose `update()` + `sign()` / `verifySignature()` pair is non-atomic. When two threads invoke `sign()` (or `verify()`) on the same instance, they interleave the bytes being accumulated in the shared `Signature`, producing:

- corrupt signatures that fail verification (`false` from `verify`), and
- on the BouncyCastle path, `ArrayIndexOutOfBoundsException` from corrupted internal state.

The race became reachable in the record stream after PR #25234 (`feat: Align record files with signed states`) split close-N and create-N+1 into separate executor stages in `StreamFileProducerConcurrent`:

- `finishCurrentBlock()` now sets `currentRecordFileWriter = null` and launches close-N async on `ForkJoinPool.commonPool()`.
- The next `switchBlocks()` sees `currentRecordFileWriter == null` and starts create-N+1 directly from `lastRecordHashingResult`, with **no dependency on close-N**.
- Close-N and close-N+1 can therefore run in parallel on the pool, both calling `signer.sign(…)` twice (file hash + metadata hash) on the shared `RecordTestData.SIGNER`. With a typical interleaving the file signature happens to come out clean while the metadata signature is corrupted - exactly the failure shape observed in the issue trace.

## Fix

Wrap the `update`/`sign` and `update`/`verify` pairs in `synchronized (signature)` / `synchronized (verifier)`. The lock is the shared mutable `Signature` field itself, so the scope is minimal and aligned with what is actually unsafe.
Two parallel stress suites deterministically reproduce the race and prove the fix.

Fixes #25312