### PR TITLE
fix: handle `happyPathWithoutReuseForAtomicBatch` flake

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionScenarioBuilder.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionScenarioBuilder.java
@@ -111,8 +111,13 @@ public class TransactionScenarioBuilder implements Scenarios {
 
     @NonNull
     public TransactionInfo txInfoForBatch() {
+        return txInfoForBatch(new TransactionScenarioBuilder().txInfo());
+    }
+
+    @NonNull
+    public TransactionInfo txInfoForBatch(@NonNull final TransactionInfo innerTxInfo) {
         final var innerBody =
-                goodDefaultBody().copyBuilder().batchKey(Key.DEFAULT).build();
+                innerTxInfo.txBody().copyBuilder().batchKey(Key.DEFAULT).build();
         final var innerTxns = List.of(Transaction.newBuilder()
                 .body(innerBody)
                 .signedTransactionBytes(asBytes(
@@ -123,12 +128,7 @@ public class TransactionScenarioBuilder implements Scenarios {
                 .build());
         final var atomicBody = TransactionBody.newBuilder()
                 .nodeAccountID(NODE_1.nodeAccountID())
-                .transactionID(TransactionID.newBuilder()
-                        .accountID(ALICE.accountID())
-                        .transactionValidStart(Timestamp.newBuilder()
-                                .seconds((System.currentTimeMillis() / 1000) - 1)
-                                .build())
-                        .build())
+                .transactionID(innerBody.transactionIDOrThrow()) // outer & inner share an ID deterministically
                 .atomicBatch(AtomicBatchTransactionBody.newBuilder()
                         .transactions(
                                 innerTxns.stream().map(Transaction::bodyBytes).toList()))

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -719,8 +719,10 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             final var payerAccount = ALICE.accountID();
             final var payerKey = ALICE.keyInfo().publicKey();
             final var batchTxInfo = scenario().withPayer(payerAccount).txInfoForBatch();
-            final var innerTxInfo = scenario().withPayer(payerAccount)
-                    .withTransactionValidStart(batchTxInfo.txBody().transactionIDOrThrow().transactionValidStart())
+            final var innerTxInfo = scenario()
+                    .withPayer(payerAccount)
+                    .withTransactionValidStart(
+                            batchTxInfo.txBody().transactionIDOrThrow().transactionValidStart())
                     .txInfo();
             final var txBytes = asByteArray(batchTxInfo.signedTx());
             final Transaction platformTx = createAppPayloadWrapper(txBytes);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -713,17 +713,13 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
         }
 
         @Test
-        @DisplayName("Happy path for atomic batch transaction reusing previous verification results")
+        @DisplayName("Happy path for atomic batch transaction without reusing previous verification results")
         void happyPathWithoutReuseForAtomicBatch(@Mock SignatureVerificationFuture sigFuture) throws Exception {
             // Given a transaction that is perfectly good
             final var payerAccount = ALICE.accountID();
             final var payerKey = ALICE.keyInfo().publicKey();
-            final var batchTxInfo = scenario().withPayer(payerAccount).txInfoForBatch();
-            final var innerTxInfo = scenario()
-                    .withPayer(payerAccount)
-                    .withTransactionValidStart(
-                            batchTxInfo.txBody().transactionIDOrThrow().transactionValidStart())
-                    .txInfo();
+            final var innerTxInfo = scenario().withPayer(payerAccount).txInfo();
+            final var batchTxInfo = scenario().withPayer(payerAccount).txInfoForBatch(innerTxInfo);
             final var txBytes = asByteArray(batchTxInfo.signedTx());
             final Transaction platformTx = createAppPayloadWrapper(txBytes);
             when(sigFuture.get(anyLong(), any())).thenReturn(new SignatureVerificationImpl(payerKey, null, true));

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -719,7 +719,9 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             final var payerAccount = ALICE.accountID();
             final var payerKey = ALICE.keyInfo().publicKey();
             final var batchTxInfo = scenario().withPayer(payerAccount).txInfoForBatch();
-            final var innerTxInfo = scenario().withPayer(payerAccount).txInfo();
+            final var innerTxInfo = scenario().withPayer(payerAccount)
+                    .withTransactionValidStart(batchTxInfo.txBody().transactionIDOrThrow().transactionValidStart())
+                    .txInfo();
             final var txBytes = asByteArray(batchTxInfo.signedTx());
             final Transaction platformTx = createAppPayloadWrapper(txBytes);
             when(sigFuture.get(anyLong(), any())).thenReturn(new SignatureVerificationImpl(payerKey, null, true));


### PR DESCRIPTION
**Description**:

`happyPathWithoutReuseForAtomicBatch` builds `batchTxInfo` and `innerTxInfo` from two separate `scenario()` calls, each deriving its `transactionValidStart` from `System.currentTimeMillis() / 1000` at the moment it's constructed — so whenever a wall-clock second boundary falls between the two calls, their `TransactionIDs` differ and the `verify(deduplicationCache, times(2)).add(batchTxInfo...)` assertion only matches once.

`innerTxInfo`'s `transactionValidStart` is set to the value already captured in `batchTxInfo` via `.withTransactionValidStart(...)`, making the two transaction IDs deterministically equal regardless of when each statement executes.

Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/25423

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
