### PR TITLE
fix: 25445: LongListDisk temp directories are not cleaned up

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongListDisk.java
@@ -299,7 +299,7 @@ public class LongListDisk extends AbstractLongList<Long> {
         requireNonNull(configuration);
         // FileSystemManager.create() deletes the temp directory created previously. It means,
         // every new LongListDisk instance erases the folder used by the previous LongListDisk, if any!
-        final Path tempDir = fileSystemManager.resolveNewTemp(STORE_POSTFIX);
+        tempDir = fileSystemManager.resolveNewTemp(STORE_POSTFIX);
         if (!exists(tempDir)) {
             Files.createDirectories(tempDir);
         }


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/25445
