### PR TITLE
feat: 25370 Add continuity check to `apply-blocks` command

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -28,7 +28,10 @@ import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
@@ -134,6 +137,7 @@ public class BlockStreamRecoveryWorkflow {
                         getPlatformContext().getFileSystemManager());
 
         stateLifecycleManager.initWithState(StateUtils.getDefaultState());
+        validateNoMissingBlocks(blockStreamDirectory);
         final var blocks = BlockStreamAccess.readBlocks(blockStreamDirectory, false);
         final BlockStreamRecoveryWorkflow workflow = new BlockStreamRecoveryWorkflow(
                 stateLifecycleManager, targetRound, outputPath, expectedHash, roundsPerSecond);
@@ -244,6 +248,58 @@ public class BlockStreamRecoveryWorkflow {
             throw new RuntimeException("Excepted and actual hashes do not match. \n Expected: %s \n Actual: %s "
                     .formatted(expectedRootHash, rootHash));
         }
+    }
+
+    /**
+     * Validates that block files in the given directory form a contiguous sequence with no gaps.
+     * This provides an early, descriptive failure when block files are missing from the directory,
+     * rather than deferring to a cryptic hash mismatch or an unclear round-number error later in
+     * the workflow.
+     *
+     * @param blockStreamDirectory the directory containing block stream files
+     * @throws IOException if an I/O error occurs while listing files
+     * @throws RuntimeException if missing block files are detected
+     */
+    private static void validateNoMissingBlocks(@NonNull final Path blockStreamDirectory) throws IOException {
+        final List<Long> blockNumbers;
+        try (var stream = Files.walk(blockStreamDirectory)) {
+            blockNumbers = stream.filter(p -> BlockStreamAccess.isBlockFile(p, false))
+                    .map(BlockStreamAccess::extractBlockNumber)
+                    .filter(n -> n != -1)
+                    .sorted()
+                    .toList();
+        }
+
+        if (blockNumbers.size() < 2) {
+            return;
+        }
+
+        final List<Long> missingBlocks = new ArrayList<>();
+        for (int i = 1; i < blockNumbers.size(); i++) {
+            final long prev = blockNumbers.get(i - 1);
+            final long curr = blockNumbers.get(i);
+            for (long missing = prev + 1; missing < curr; missing++) {
+                missingBlocks.add(missing);
+            }
+        }
+
+        if (!missingBlocks.isEmpty()) {
+            throw new RuntimeException(("Block stream directory is missing %d block file(s). "
+                            + "First present block = %d, last present block = %d. Missing blocks: %s")
+                    .formatted(
+                            missingBlocks.size(),
+                            blockNumbers.getFirst(),
+                            blockNumbers.getLast(),
+                            missingBlocks.size() <= 20
+                                    ? missingBlocks.toString()
+                                    : missingBlocks.subList(0, 20) + " ... (" + missingBlocks.size() + " total)"));
+        }
+
+        log.info(
+                "Block file contiguity validated: {} block files present, range [{}, {}]",
+                blockNumbers.size(),
+                blockNumbers.getFirst(),
+                blockNumbers.getLast());
     }
 
     /**


### PR DESCRIPTION
**Description**:

When block files are missing from the input directory, the workflow fails late with either a confusing round-number mismatch or a hash mismatch at the end — neither pointing to the root cause.

This adds a `validateNoMissingBlocks` check that runs before any block content is parsed. It walks the directory, extracts block numbers from file names, and verifies the sequence is contiguous. On gaps, it fails immediately listing the missing block numbers.


**Related issue(s)**:

Fixes #25370 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
