### PR TITLE
feat: cleanup/improve MerkelDB tests

### DIFF
--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/file/FileSystemManager.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/file/FileSystemManager.java
@@ -78,6 +78,14 @@ public class FileSystemManager {
     }
 
     /**
+     * @return path to temporary directory used as root for all directories created by {@link #resolveNewTemp()} methods.
+     */
+    @NonNull
+    public Path getTempPath() {
+        return tempPath;
+    }
+
+    /**
      * Resolve a path relative to the {@code rootPath} of this file system manager.
      *
      * @param relativePath the path to resolve against the root directory

--- a/platform-sdk/base-utility/src/testFixtures/java/org/hiero/base/utility/test/fixtures/file/AbstractFileManagerAwareTest.java
+++ b/platform-sdk/base-utility/src/testFixtures/java/org/hiero/base/utility/test/fixtures/file/AbstractFileManagerAwareTest.java
@@ -1,10 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.utility.test.fixtures.file;
 
+import java.nio.file.Path;
 import org.hiero.base.file.FileSystemManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.io.TempDir;
-
-import java.nio.file.Path;
 
 /**
  * Base class for tests that want to use {@link FileSystemManager}.

--- a/platform-sdk/base-utility/src/testFixtures/java/org/hiero/base/utility/test/fixtures/file/AbstractFileManagerAwareTest.java
+++ b/platform-sdk/base-utility/src/testFixtures/java/org/hiero/base/utility/test/fixtures/file/AbstractFileManagerAwareTest.java
@@ -1,0 +1,21 @@
+package org.hiero.base.utility.test.fixtures.file;
+
+import org.hiero.base.file.FileSystemManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+/**
+ * Base class for tests that want to use {@link FileSystemManager}.
+ * {@link #fileSystemManager} uses {@link TempDir} created by JUnit.
+ */
+public abstract class AbstractFileManagerAwareTest {
+
+    protected static FileSystemManager fileSystemManager;
+
+    @BeforeAll
+    static void setupFileSystemManager(@TempDir Path fsmTempDir) {
+        fileSystemManager = new FileSystemManager(fsmTempDir);
+    }
+}

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -507,6 +507,11 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                 this.hashChunkHeight);
     }
 
+    @NonNull
+    public MerkleDbPaths getDbPaths() {
+        return dbPaths;
+    }
+
     private void rebuildHashChunks(
             final Configuration config,
             final FileSystemManager fileSystemManager,

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSourceBuilder.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSourceBuilder.java
@@ -28,6 +28,8 @@ import org.hiero.base.file.FileSystemManager;
  */
 public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
 
+    public static final String FOLDER_SUFFIX = "merkledb-";
+
     /** Platform configuration */
     private final Configuration configuration;
 
@@ -62,7 +64,7 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
     }
 
     private Path newDataSourceDir(final String label) {
-        return fileSystemManager.resolveNewTemp("merkledb-" + label);
+        return fileSystemManager.resolveNewTemp(FOLDER_SUFFIX + label);
     }
 
     private Path snapshotDataDir(final Path snapshotDir, final String label) {
@@ -94,7 +96,7 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
     }
 
     @NonNull
-    private VirtualDataSource buildNewDataSource(
+    private MerkleDbDataSource buildNewDataSource(
             final String label, final boolean compactionEnabled, final boolean offlineUse) {
         if (initialCapacity <= 0) {
             throw new IllegalArgumentException("Initial map capacity not set");
@@ -151,7 +153,7 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
      * this method throws an IO exception.
      */
     @NonNull
-    private VirtualDataSource restoreDataSource(
+    private MerkleDbDataSource restoreDataSource(
             final String label,
             @NonNull final Path snapshotDir,
             final boolean compactionEnabled,

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/CompactionInterruptTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/CompactionInterruptTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.files.DataFileCompactor;
-import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
+import com.swirlds.merkledb.test.fixtures.AbstractMerkelDbTest;
 import com.swirlds.merkledb.test.fixtures.TestType;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -26,11 +26,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -45,17 +41,10 @@ import org.junit.jupiter.params.provider.ValueSource;
  * limited to coordinator-level state: {@code compactionEnabled}, {@code compactorsByName},
  * executor queue, and per-store {@code isCompactionRunning()} checks.
  */
-class CompactionInterruptTest {
+class CompactionInterruptTest extends AbstractMerkelDbTest {
 
     /** This needs to be big enough so that the snapshot is slow enough that we can do a merge at the same time */
     private static final int COUNT = 2_000_000;
-
-    /**
-     * Temporary directory provided by JUnit
-     */
-    @SuppressWarnings("unused")
-    @TempDir
-    Path tmpFileDir;
 
     /*
      * RUN THE TEST IN A BACKGROUND THREAD. We do this so that we can kill the thread at the end of
@@ -72,15 +61,8 @@ class CompactionInterruptTest {
      * quiescent state quickly.
      */
     boolean startMergeThenInterruptImpl() throws IOException, InterruptedException {
-        final Path storeDir = tmpFileDir.resolve("startMergeThenInterruptImpl");
-        final FileSystemManager fileSystemManager = new TestFileSystemManager(tmpFileDir);
-        final String tableName = "mergeThenInterrupt";
-        final MerkleDbDataSource dataSource = TestType.variable_variable
-                .dataType()
-                .createDataSource(CONFIGURATION, fileSystemManager, storeDir, tableName, COUNT, false, false);
-        final MerkleDbCompactionCoordinator coordinator = dataSource.getCompactionCoordinator();
-
-        try {
+        createAndApplyDataSource(COUNT, dataSource -> {
+            final MerkleDbCompactionCoordinator coordinator = dataSource.getCompactionCoordinator();
             // Create data in batches so that files accumulate content worth compacting
             createData(dataSource);
             coordinator.enableBackgroundCompaction();
@@ -93,9 +75,8 @@ class CompactionInterruptTest {
             // wait a small-time for merging to start
             MILLISECONDS.sleep(20);
             stopCompactionAndVerifyItsStopped(coordinator, compactingExecutor, initialCompletedTaskCount);
-        } finally {
-            dataSource.close();
-        }
+        });
+
         return true;
     }
 
@@ -119,45 +100,42 @@ class CompactionInterruptTest {
      * snapshot or compaction.
      */
     boolean startMergeWhileSnapshottingThenInterruptImpl(int delayMs) throws IOException, InterruptedException {
-        final Path storeDir = tmpFileDir.resolve("startMergeWhileSnapshottingThenInterruptImpl");
-        final String tableName = "mergeWhileSnapshotting";
-        final MerkleDbDataSource dataSource = TestType.variable_variable
-                .dataType()
-                .createDataSource(CONFIGURATION, null, storeDir, tableName, COUNT, false, false);
-        final MerkleDbCompactionCoordinator coordinator = dataSource.getCompactionCoordinator();
+        createAndApplyDataSource(COUNT, dataSource -> {
+            final MerkleDbCompactionCoordinator coordinator = dataSource.getCompactionCoordinator();
 
-        final ExecutorService exec = Executors.newCachedThreadPool();
-        try {
-            // Create data in batches so that files accumulate content worth compacting
-            createData(dataSource);
-            coordinator.enableBackgroundCompaction();
+            final ExecutorService exec = Executors.newCachedThreadPool();
+            try {
+                // Create data in batches so that files accumulate content worth compacting
+                createData(dataSource);
+                coordinator.enableBackgroundCompaction();
 
-            // Start a snapshot in the background
-            final Path snapshotDir = tmpFileDir.resolve("startMergeWhileSnapshottingThenInterruptImplSnapshot");
-            exec.submit(() -> {
-                dataSource.snapshot(snapshotDir);
-                return null;
-            });
+                // Start a snapshot in the background
+                final Path snapshotDir =
+                        fileSystemManager.resolveNewTemp("startMergeWhileSnapshottingThenInterruptImplSnapshot");
+                exec.submit(() -> {
+                    dataSource.snapshot(snapshotDir);
+                    return null;
+                });
 
-            final ThreadPoolExecutor compactingExecutor =
-                    (ThreadPoolExecutor) MerkleDbCompactionCoordinator.getCompactionExecutor(
-                            CONFIGURATION.getConfigData(MerkleDbConfig.class));
-            final long initialCompletedTaskCount = compactingExecutor.getTaskCount();
-            final long initTaskCount = compactingExecutor.getTaskCount();
-            triggerScansAndSubmitCompaction(dataSource, coordinator);
+                final ThreadPoolExecutor compactingExecutor =
+                        (ThreadPoolExecutor) MerkleDbCompactionCoordinator.getCompactionExecutor(
+                                CONFIGURATION.getConfigData(MerkleDbConfig.class));
+                final long initialCompletedTaskCount = compactingExecutor.getTaskCount();
+                final long initTaskCount = compactingExecutor.getTaskCount();
+                triggerScansAndSubmitCompaction(dataSource, coordinator);
 
-            assertEventuallyTrue(
-                    () -> compactingExecutor.getTaskCount() >= initTaskCount + 3L,
-                    Duration.ofSeconds(2),
-                    "Unexpected number of tasks " + compactingExecutor.getTaskCount());
-            // wait a small-time for merging to start (or don't wait at all)
-            Thread.sleep(delayMs);
-            stopCompactionAndVerifyItsStopped(coordinator, compactingExecutor, initialCompletedTaskCount);
-        } finally {
-            exec.shutdown();
-            assertTrue(exec.awaitTermination(10, TimeUnit.SECONDS), "Should not timeout");
-            dataSource.close();
-        }
+                assertEventuallyTrue(
+                        () -> compactingExecutor.getTaskCount() >= initTaskCount + 3L,
+                        Duration.ofSeconds(2),
+                        "Unexpected number of tasks " + compactingExecutor.getTaskCount());
+                // wait a small-time for merging to start (or don't wait at all)
+                Thread.sleep(delayMs);
+                stopCompactionAndVerifyItsStopped(coordinator, compactingExecutor, initialCompletedTaskCount);
+            } finally {
+                exec.shutdown();
+                assertTrue(exec.awaitTermination(10, TimeUnit.SECONDS), "Should not timeout");
+            }
+        });
         return true;
     }
 
@@ -241,10 +219,5 @@ class CompactionInterruptTest {
                     Stream.empty(),
                     false);
         }
-    }
-
-    @AfterAll
-    static void tearDown() {
-        MerkleDbTestUtils.assertAllDatabasesClosed();
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/DataSourceValidatorTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/DataSourceValidatorTest.java
@@ -5,91 +5,55 @@ import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createHashChu
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.swirlds.merkledb.test.fixtures.AbstractMerkelDbTest;
 import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
 import com.swirlds.merkledb.test.fixtures.TestType;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.file.FileUtils;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-class DataSourceValidatorTest {
+class DataSourceValidatorTest extends AbstractMerkelDbTest {
 
-    @TempDir
-    private Path tempDir;
-
-    @TempDir
-    private Path fileSystemManagerTempDir;
-
-    private FileSystemManager fileSystemManager;
-    private int count;
-
-    @BeforeEach
-    public void setUp() throws IOException {
-        count = 10_000;
-        MerkleDbTestUtils.assertAllDatabasesClosed();
-        if (Files.exists(tempDir)) {
-            FileUtils.deleteDirectory(tempDir);
-        }
-        fileSystemManager = new TestFileSystemManager(fileSystemManagerTempDir);
-    }
+    private static final int count = 10_000;
 
     @Test
     void testValidateValidDataSource() throws IOException {
-        MerkleDbDataSourceTest.createAndApplyDataSource(
-                fileSystemManager,
-                tempDir,
-                "createAndCheckInternalNodeHashes",
-                TestType.long_fixed,
-                count,
-                dataSource -> {
-                    // check db count
-                    MerkleDbTestUtils.assertSomeDatabasesStillOpen(1L);
+        createAndApplyDataSource(count, dataSource -> {
+            // check db count
+            MerkleDbTestUtils.assertSomeDatabasesStillOpen(1L);
 
-                    final var validator = new DataSourceValidator(dataSource);
-                    // create some node hashes
-                    dataSource.saveRecords(
-                            count - 1,
-                            count * 2L - 2,
-                            createHashChunkStream((int) (count * 2L - 2), dataSource.getHashChunkHeight()),
-                            IntStream.range(count - 1, count * 2 - 1)
-                                    .mapToObj(
-                                            i -> TestType.long_fixed.dataType().createVirtualLeafRecord(i)),
-                            Stream.empty(),
-                            false);
+            final var validator = new DataSourceValidator(dataSource);
+            // create some node hashes
+            dataSource.saveRecords(
+                    count - 1,
+                    count * 2L - 2,
+                    createHashChunkStream((int) (count * 2L - 2), dataSource.getHashChunkHeight()),
+                    IntStream.range(count - 1, count * 2 - 1)
+                            .mapToObj(i -> TestType.long_fixed.dataType().createVirtualLeafRecord(i)),
+                    Stream.empty(),
+                    false);
 
-                    assertTrue(validator.validate());
-                });
+            assertTrue(validator.validate());
+        });
     }
 
     @Test
     void testValidateInvalidDataSource() throws IOException {
-        MerkleDbDataSourceTest.createAndApplyDataSource(
-                fileSystemManager,
-                tempDir,
-                "createAndCheckInternalNodeHashes",
-                TestType.long_fixed,
-                count,
-                dataSource -> {
-                    // check db count
-                    MerkleDbTestUtils.assertSomeDatabasesStillOpen(1L);
-                    final var validator = new DataSourceValidator(dataSource);
-                    // create some node hashes
-                    dataSource.saveRecords(
-                            count - 1,
-                            count * 2L - 2,
-                            createHashChunkStream(count * 2 - 2, dataSource.getHashChunkHeight()),
-                            // leaves are missing
-                            Stream.empty(),
-                            Stream.empty(),
-                            false);
-                    assertFalse(validator.validate());
-                });
+        createAndApplyDataSource(count, dataSource -> {
+            // check db count
+            MerkleDbTestUtils.assertSomeDatabasesStillOpen(1L);
+            final var validator = new DataSourceValidator(dataSource);
+            // create some node hashes
+            dataSource.saveRecords(
+                    count - 1,
+                    count * 2L - 2,
+                    createHashChunkStream(count * 2 - 2, dataSource.getHashChunkHeight()),
+                    // leaves are missing
+                    Stream.empty(),
+                    Stream.empty(),
+                    false);
+            assertFalse(validator.validate());
+        });
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/KeyRangeTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/KeyRangeTest.java
@@ -41,7 +41,7 @@ class KeyRangeTest {
         final var keyRange1 = new KeyRange(10, 20);
         final var keyRange2 = new KeyRange(10, 20);
         assertEquals(keyRange1, keyRange2, "Keys should be equal");
-        assertNotEquals(keyRange1, new KeyRange(9, 19), "Keys should not be equal");
+        assertNotEquals(new KeyRange(9, 19), keyRange1, "Keys should not be equal");
     }
 
     @Test

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -2,6 +2,8 @@
 package com.swirlds.merkledb;
 
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertAllDatabasesClosed;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createDataSource;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -13,37 +15,27 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.hiero.base.constructable.ConstructableRegistryException;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.hiero.consensus.constructable.ConstructableRegistration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class MerkleDbBuilderTest {
+class MerkleDbBuilderTest extends AbstractFileManagerAwareTest {
 
     private static final long INITIAL_SIZE = 1_000_000;
-
-    private static FileSystemManager fileSystemManager;
-
-    @TempDir
-    static Path tempDir;
 
     @BeforeAll
     static void setup() throws ConstructableRegistryException {
         ConstructableRegistration.registerAllConstructables();
-        fileSystemManager = new TestFileSystemManager(tempDir);
     }
 
     @AfterEach
     public void afterCheckNoDbLeftOpen() {
-        // check db count
-        assertEquals(0, MerkleDbDataSource.getCountOfOpenDatabases(), "Expected no open dbs");
+        assertAllDatabasesClosed();
     }
 
     final MerkleDbDataSourceBuilder createDefaultBuilder() {
@@ -51,21 +43,14 @@ class MerkleDbBuilderTest {
     }
 
     @ParameterizedTest
-    @CsvSource({"100", "1000000"})
+    @ValueSource(ints = {100, 1000000})
     @DisplayName("Test table config is passed to data source")
-    public void testTableConfig(final long initialCapacity) throws IOException {
-        final MerkleDbDataSourceBuilder builder =
-                new MerkleDbDataSourceBuilder(CONFIGURATION, fileSystemManager, initialCapacity);
-        VirtualDataSource dataSource = null;
+    public void testTableConfig(final int initialCapacity) throws IOException {
+        final MerkleDbDataSource dataSource = createDataSource(fileSystemManager, initialCapacity, false, false);
         try {
-            dataSource = builder.build("test1", null, false, false);
-            assertInstanceOf(MerkleDbDataSource.class, dataSource);
-            MerkleDbDataSource merkleDbDataSource = (MerkleDbDataSource) dataSource;
-            assertEquals(initialCapacity, merkleDbDataSource.getInitialCapacity());
+            assertEquals(initialCapacity, dataSource.getInitialCapacity());
         } finally {
-            if (dataSource != null) {
-                dataSource.close();
-            }
+            dataSource.close();
         }
     }
 
@@ -73,13 +58,9 @@ class MerkleDbBuilderTest {
     @ValueSource(booleans = {true, false})
     @DisplayName("Test compaction flag is passed to data source")
     public void testCompactionConfig(final boolean compactionEnabled) throws IOException {
-        final MerkleDbDataSourceBuilder builder = new MerkleDbDataSourceBuilder(CONFIGURATION, fileSystemManager, 1024);
-        VirtualDataSource dataSource = null;
+        MerkleDbDataSource dataSource = createDataSource(fileSystemManager, 1024, compactionEnabled, false);
         try {
-            dataSource = builder.build("test2", null, compactionEnabled, false);
-            assertInstanceOf(MerkleDbDataSource.class, dataSource);
-            MerkleDbDataSource merkleDbDataSource = (MerkleDbDataSource) dataSource;
-            assertEquals(compactionEnabled, merkleDbDataSource.isCompactionEnabled());
+            assertEquals(compactionEnabled, dataSource.isCompactionEnabled());
         } finally {
             dataSource.close();
         }
@@ -87,49 +68,34 @@ class MerkleDbBuilderTest {
 
     @Test
     void testSnapshot() throws IOException {
-        final MerkleDbDataSourceBuilder builder = new MerkleDbDataSourceBuilder(CONFIGURATION, fileSystemManager, 1024);
-        VirtualDataSource dataSource = null;
+        final String label = "testSnapshot";
+        final MerkleDbDataSourceBuilder builder = createDefaultBuilder();
+        VirtualDataSource dataSource = builder.build("testSnapshot", null, false, false);
         try {
-            final String label = "testSnapshot";
-            dataSource = builder.build(label, null, false, false);
-            final Path tmpDir = fileSystemManager.resolveNewTemp("snapshot");
-            Files.createDirectories(tmpDir);
-            builder.snapshot(tmpDir, dataSource);
-            assertTrue(Files.isDirectory(tmpDir.resolve("data").resolve(label)));
+            final Path snapshotDir = builder.snapshot(null, dataSource);
+            assertTrue(Files.isDirectory(snapshotDir.resolve("data").resolve(label)));
         } finally {
-            if (dataSource != null) {
-                dataSource.close();
-            }
+            dataSource.close();
         }
     }
 
     @Test
     void testSnapshotRestore() throws IOException {
-        final MerkleDbDataSourceBuilder builder =
-                new MerkleDbDataSourceBuilder(CONFIGURATION, fileSystemManager, 10_000);
-        VirtualDataSource dataSource = null;
+        final String label = "testSnapshotRestore";
+        final MerkleDbDataSourceBuilder builder = createDefaultBuilder();
+        VirtualDataSource dataSource = builder.build(label, null, false, false);
         try {
-            final String label = "testSnapshotRestore";
-            dataSource = builder.build(label, null, false, false);
-            final Path tmpDir = fileSystemManager.resolveNewTemp("snapshot");
-            Files.createDirectories(tmpDir);
-            builder.snapshot(tmpDir, dataSource);
-            assertTrue(Files.isDirectory(tmpDir.resolve("data").resolve(label)));
-            VirtualDataSource restored = null;
+            final Path snapshotDir = builder.snapshot(null, dataSource);
+            assertTrue(Files.isDirectory(snapshotDir.resolve("data").resolve(label)));
+            VirtualDataSource restored = builder.build(label, snapshotDir, false, false);
             try {
-                restored = builder.build(label, tmpDir, false, false);
                 assertNotNull(restored);
                 assertInstanceOf(MerkleDbDataSource.class, restored);
-                final MerkleDbDataSource merkleDbRestored = (MerkleDbDataSource) restored;
             } finally {
-                if (restored != null) {
-                    restored.close();
-                }
+                restored.close();
             }
         } finally {
-            if (dataSource != null) {
-                dataSource.close();
-            }
+            dataSource.close();
         }
     }
 
@@ -149,13 +115,8 @@ class MerkleDbBuilderTest {
         final VirtualDataSource copy = dsBuilder.build("vm", snapshotPath, true, false);
 
         try {
-            final Path snapshotDir = fileSystemManager.resolveNewTemp("snapshot");
-            Files.createDirectories(snapshotDir);
-            dsBuilder.snapshot(snapshotDir, copy);
-
-            final Path oldSnapshotDir = fileSystemManager.resolveNewTemp("oldSnapshot");
-            Files.createDirectories(oldSnapshotDir);
-            assertDoesNotThrow(() -> dsBuilder.snapshot(oldSnapshotDir, original));
+            dsBuilder.snapshot(null, copy);
+            assertDoesNotThrow(() -> dsBuilder.snapshot(null, original));
         } finally {
             original.close();
             copy.close();

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
@@ -273,9 +273,7 @@ class MerkleDbCompactionCoordinatorTest {
         coordinator.submitCompactionTasks(ID_TO_HASH_CHUNK, () -> compactor, config);
         assertTrue(taskStarted.await(1, TimeUnit.SECONDS), "Compaction didn't start");
 
-        coordinator.pauseCompactionAndRun(() -> {
-            verify(compactor).pauseCompaction();
-        });
+        coordinator.pauseCompactionAndRun(() -> verify(compactor).pauseCompaction());
         verify(compactor).resumeCompaction();
 
         releaseTask.countDown();
@@ -451,7 +449,6 @@ class MerkleDbCompactionCoordinatorTest {
 
         final List<List<DataFileReader>> allCompactedGroups = new ArrayList<>();
         final CountDownLatch allTasksDone = new CountDownLatch(2); // garbage + consolidation
-        final AtomicInteger compactorCalls = new AtomicInteger();
         final DataFileCompactor compactor = mock(DataFileCompactor.class);
         when(compactor.compactSingleLevel(anyList(), anyInt())).thenAnswer(invocation -> {
             synchronized (allCompactedGroups) {
@@ -693,7 +690,6 @@ class MerkleDbCompactionCoordinatorTest {
 
         publishScanStats(ID_TO_HASH_CHUNK, buildStats(new StatsEntry(file, 20)));
 
-        final CountDownLatch taskDone = new CountDownLatch(1);
         final DataFileCompactor compactor = mock(DataFileCompactor.class);
         when(compactor.compactSingleLevel(anyList(), anyInt())).thenAnswer(_ -> {
             throw new IOException("simulated failure");

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceMetricsTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceMetricsTest.java
@@ -2,66 +2,56 @@
 package com.swirlds.merkledb;
 
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertAllDatabasesClosed;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertDatabaseFolderDeleted;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertSomeDatabasesStillOpen;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createDataSource;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createHashChunkStream;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createMetrics;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.getMetric;
 import static com.swirlds.merkledb.test.fixtures.TestType.long_fixed;
-import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.swirlds.merkledb.config.MerkleDbConfig;
-import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
-import com.swirlds.merkledb.test.fixtures.TestType;
 import com.swirlds.metrics.api.Metric;
 import com.swirlds.metrics.api.Metrics;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-class MerkleDbDataSourceMetricsTest {
+class MerkleDbDataSourceMetricsTest extends AbstractFileManagerAwareTest {
 
-    public static final String TABLE_NAME = "test";
     // default number of longs per chunk
     private static final int COUNT = 1_048_576;
 
-    @TempDir
-    static Path tempDir;
-
-    private static FileSystemManager fileSystemManager;
-    private static Path testDirectory;
     private MerkleDbDataSource dataSource;
     private Metrics metrics;
 
-    @BeforeAll
-    static void setup() throws Exception {
-        fileSystemManager = new TestFileSystemManager(tempDir);
-        testDirectory = fileSystemManager.resolveNewTemp("MerkleDbDataSourceMetricsTest");
-    }
-
     @BeforeEach
-    public void beforeEach() throws IOException {
+    public void beforeEach() {
         // check db count
-        MerkleDbTestUtils.assertAllDatabasesClosed();
+        assertAllDatabasesClosed();
         // create db
-        dataSource = createDataSource(fileSystemManager, testDirectory, TABLE_NAME, long_fixed, COUNT * 10);
+        dataSource = createDataSource(fileSystemManager, COUNT * 10, false, false);
 
         metrics = createMetrics();
         dataSource.registerMetrics(metrics);
 
         // check db count
-        MerkleDbTestUtils.assertSomeDatabasesStillOpen(1L);
+        assertSomeDatabasesStillOpen(1L);
+    }
+
+    @AfterEach
+    public void afterEach() throws IOException {
+        dataSource.close();
+        assertAllDatabasesClosed();
+        assertDatabaseFolderDeleted(dataSource);
     }
 
     @Tag(TestComponentTags.VMAP)
@@ -82,7 +72,7 @@ class MerkleDbDataSourceMetricsTest {
 
         // one 8 MB memory chunk; this value may need to be adjusted if the default chunk height
         // is changed
-        assertMetricValue("ds_offheap_hashesIndexMb_" + TABLE_NAME, 8);
+        assertMetricValue("ds_offheap_hashesIndexMb_" + dataSource.getTableName(), 8);
         assertNoMemoryForLeafAndKeyToPathLists();
 
         // create more internal nodes
@@ -96,8 +86,8 @@ class MerkleDbDataSourceMetricsTest {
 
         // one 8 MB memory chunk
         final int expectedHashesIndexSize = 8;
-        assertMetricValue("ds_offheap_hashesIndexMb_" + TABLE_NAME, expectedHashesIndexSize);
-        assertMetricValue("ds_offheap_dataSourceMb_" + TABLE_NAME, expectedHashesIndexSize);
+        assertMetricValue("ds_offheap_hashesIndexMb_" + dataSource.getTableName(), expectedHashesIndexSize);
+        assertMetricValue("ds_offheap_dataSourceMb_" + dataSource.getTableName(), expectedHashesIndexSize);
         assertNoMemoryForLeafAndKeyToPathLists();
     }
 
@@ -119,9 +109,9 @@ class MerkleDbDataSourceMetricsTest {
                 false);
 
         // only one 8 MB memory is reserved despite the fact that leaves reside in [COUNT, COUNT * 2] interval
-        assertMetricValue("ds_offheap_leavesIndexMb_" + TABLE_NAME, 8);
-        assertMetricValue("ds_offheap_objectKeyBucketsIndexMb_" + TABLE_NAME, 8);
-        assertMetricValue("ds_offheap_dataSourceMb_" + TABLE_NAME, 16);
+        assertMetricValue("ds_offheap_leavesIndexMb_" + dataSource.getTableName(), 8);
+        assertMetricValue("ds_offheap_objectKeyBucketsIndexMb_" + dataSource.getTableName(), 8);
+        assertMetricValue("ds_offheap_dataSourceMb_" + dataSource.getTableName(), 16);
         assertNoMemoryForInternalList();
 
         final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
@@ -136,9 +126,9 @@ class MerkleDbDataSourceMetricsTest {
                 false);
 
         // reserved additional memory chunk for a value that didn't fit into the previous chunk
-        assertMetricValue("ds_offheap_leavesIndexMb_" + TABLE_NAME, 16);
-        assertMetricValue("ds_offheap_objectKeyBucketsIndexMb_" + TABLE_NAME, 8);
-        assertMetricValue("ds_offheap_dataSourceMb_" + TABLE_NAME, 24);
+        assertMetricValue("ds_offheap_leavesIndexMb_" + dataSource.getTableName(), 16);
+        assertMetricValue("ds_offheap_objectKeyBucketsIndexMb_" + dataSource.getTableName(), 8);
+        assertMetricValue("ds_offheap_dataSourceMb_" + dataSource.getTableName(), 24);
         assertNoMemoryForInternalList();
 
         dataSource.saveRecords(
@@ -152,34 +142,23 @@ class MerkleDbDataSourceMetricsTest {
                 false);
 
         // shrink the list by one chunk
-        assertMetricValue("ds_offheap_leavesIndexMb_" + TABLE_NAME, 8);
+        assertMetricValue("ds_offheap_leavesIndexMb_" + dataSource.getTableName(), 8);
 
-        assertMetricValue("ds_offheap_objectKeyBucketsIndexMb_" + TABLE_NAME, 8);
-        assertMetricValue("ds_offheap_dataSourceMb_" + TABLE_NAME, 16);
+        assertMetricValue("ds_offheap_objectKeyBucketsIndexMb_" + dataSource.getTableName(), 8);
+        assertMetricValue("ds_offheap_dataSourceMb_" + dataSource.getTableName(), 16);
         assertNoMemoryForInternalList();
-    }
-
-    @AfterEach
-    public void afterEach() throws IOException {
-        dataSource.close();
-        MerkleDbTestUtils.assertAllDatabasesClosed();
-        // check the database was deleted
-        assertEventuallyFalse(
-                () -> Files.exists(testDirectory.resolve(TABLE_NAME)),
-                Duration.ofSeconds(1),
-                "Database should have been deleted by closeAndDelete()");
     }
 
     // =================================================================================================================
     // Helper Methods
 
     private void assertNoMemoryForInternalList() {
-        assertMetricValue("ds_offheap_hashesIndexMb_" + TABLE_NAME, 0);
+        assertMetricValue("ds_offheap_hashesIndexMb_" + dataSource.getTableName(), 0);
     }
 
     private void assertNoMemoryForLeafAndKeyToPathLists() {
-        assertMetricValue("ds_offheap_leavesIndexMb_" + TABLE_NAME, 0);
-        assertMetricValue("ds_offheap_objectKeyBucketsIndexMb_" + TABLE_NAME, 0);
+        assertMetricValue("ds_offheap_leavesIndexMb_" + dataSource.getTableName(), 0);
+        assertMetricValue("ds_offheap_objectKeyBucketsIndexMb_" + dataSource.getTableName(), 0);
     }
 
     private void assertMetricValue(final String metricPattern, final int expectedValue) {
@@ -187,16 +166,5 @@ class MerkleDbDataSourceMetricsTest {
         assertEquals(
                 expectedValue,
                 Integer.valueOf(metric.get(Metric.ValueType.VALUE).toString()));
-    }
-
-    public static MerkleDbDataSource createDataSource(
-            final FileSystemManager fileSystemManager,
-            final Path testDirectory,
-            final String name,
-            final TestType testType,
-            final int size)
-            throws IOException {
-        return testType.dataType()
-                .createDataSource(CONFIGURATION, fileSystemManager, testDirectory, name, size, false, false);
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
@@ -3,12 +3,14 @@ package com.swirlds.merkledb;
 
 import static com.swirlds.merkledb.MerkleDbDataSourceTest.assertLeaf;
 import static com.swirlds.merkledb.files.DataFileCommon.deleteDirectoryAndContents;
-import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertAllDatabasesClosed;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.checkDirectMemoryIsCleanedUpToLessThanBaseUsage;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createDataSource;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createHashChunkStream;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.getDirectMemoryUsedBytes;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.getMetric;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.hash;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.restoreDataSource;
 import static com.swirlds.metrics.api.Metric.ValueType.VALUE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,14 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.swirlds.base.units.UnitConstants;
 import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
 import com.swirlds.merkledb.test.fixtures.TestType;
 import com.swirlds.metrics.api.Metric;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.test.fixtures.VirtualMapTestUtils;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -36,30 +36,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.hiero.base.constructable.ConstructableRegistryException;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
-import org.junit.jupiter.api.BeforeAll;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class MerkleDbDataSourceSnapshotMergeTest {
+class MerkleDbDataSourceSnapshotMergeTest extends AbstractFileManagerAwareTest {
 
     private static final int COUNT = 20_000;
     private static final int COUNT2 = 30_000;
-
-    private static FileSystemManager fileSystemManager;
-
-    @TempDir
-    static Path tempDir;
-
-    @BeforeAll
-    static void setup() throws ConstructableRegistryException {
-        fileSystemManager = new TestFileSystemManager(tempDir);
-    }
 
     /*
      * RUN THE TEST IN A BACKGROUND THREAD. We do this so that we can kill the thread at the end of the test which will
@@ -80,23 +66,14 @@ class MerkleDbDataSourceSnapshotMergeTest {
         future.get(10, TimeUnit.MINUTES);
         executorService.shutdown();
         // check we did not leak direct memory now that the thread is shut down so thread locals should be released.
-        assertTrue(
-                checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart),
-                "Direct Memory used is more than base usage even after 20 gc() calls. At start was "
-                        + (directMemoryUsedAtStart * UnitConstants.BYTES_TO_MEBIBYTES) + "MB and is now "
-                        + (getDirectMemoryUsedBytes() * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB");
+        checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart);
         // check db count
-        assertEquals(0, MerkleDbDataSource.getCountOfOpenDatabases(), "Expected no open dbs");
+        assertAllDatabasesClosed();
     }
 
     void createMergeSnapshotReadBackImpl(final TestType testType, final boolean preferDiskBasedIndexes)
             throws IOException, InterruptedException {
-        final Path storeDir = Files.createTempDirectory("createMergeSnapshotReadBackImpl");
-        final String tableName = "mergeSnapshotReadBack";
-        final MerkleDbDataSource dataSource = testType.dataType()
-                .createDataSource(
-                        CONFIGURATION, fileSystemManager, storeDir, tableName, COUNT, false, preferDiskBasedIndexes);
+        final MerkleDbDataSource dataSource = createDataSource(fileSystemManager, COUNT, false, preferDiskBasedIndexes);
         final ExecutorService exec = Executors.newCachedThreadPool();
         try {
             // create some internal and leaf nodes in batches
@@ -104,7 +81,7 @@ class MerkleDbDataSourceSnapshotMergeTest {
             // check all data
             checkData(COUNT, testType, dataSource);
             // create snapshot and test creating a second snapshot in another thread causes exception
-            final Path snapshotDir = Files.createTempDirectory("createMergeSnapshotReadBackImplSnapshot");
+            final Path snapshotDir = fileSystemManager.resolveNewTemp();
             final CountDownLatch countDownLatch = new CountDownLatch(3);
             exec.submit(() -> {
                 // do a good snapshot
@@ -157,7 +134,7 @@ class MerkleDbDataSourceSnapshotMergeTest {
             checkData(COUNT2, testType, dataSource);
             // load snapshot and check data
             final MerkleDbDataSource snapshotDataSource =
-                    testType.dataType().getDataSource(fileSystemManager, snapshotDir, tableName, false);
+                    restoreDataSource(fileSystemManager, snapshotDir, dataSource.getTableName(), false);
             checkData(COUNT, testType, snapshotDataSource);
             // validate all data in the snapshot
             final DataSourceValidator dataSourceValidator = new DataSourceValidator(snapshotDataSource);
@@ -242,7 +219,6 @@ class MerkleDbDataSourceSnapshotMergeTest {
         } finally {
             // cleanup
             dataSource.close();
-            deleteDirectoryAndContents(storeDir);
             exec.shutdown();
         }
     }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
@@ -2,14 +2,10 @@
 package com.swirlds.merkledb;
 
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
-import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.checkDirectMemoryIsCleanedUpToLessThanBaseUsage;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createHashChunkStream;
-import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.getDirectMemoryUsedBytes;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.hash;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.shuffle;
 import static com.swirlds.virtualmap.datasource.VirtualDataSource.INVALID_PATH;
-import static org.hiero.base.utility.test.fixtures.RandomUtils.nextInt;
-import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyFalse;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -21,8 +17,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.base.function.CheckedConsumer;
-import com.swirlds.base.units.UnitConstants;
 import com.swirlds.common.io.config.TemporaryFileConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
@@ -31,6 +25,7 @@ import com.swirlds.merkledb.collections.HashListByteBuffer;
 import com.swirlds.merkledb.collections.LongListSegment;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.files.MemoryIndexDiskKeyValueStore;
+import com.swirlds.merkledb.test.fixtures.AbstractMerkelDbTest;
 import com.swirlds.merkledb.test.fixtures.ExampleByteArrayVirtualValue;
 import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
 import com.swirlds.merkledb.test.fixtures.TestType;
@@ -45,7 +40,6 @@ import com.swirlds.virtualmap.test.fixtures.VirtualMapTestUtils;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -57,74 +51,26 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.hiero.base.crypto.Hash;
-import org.hiero.base.file.FileSystemManager;
 import org.hiero.base.file.FileUtils;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-class MerkleDbDataSourceTest {
+class MerkleDbDataSourceTest extends AbstractMerkelDbTest {
 
     private static final Random RANDOM = new Random(1234);
-
-    @TempDir
-    Path tempDir;
-
-    private FileSystemManager fileSystemManager;
-    private Path testDirectory;
-
-    /**
-     * Keep track of initial direct memory used already, so we can check if we leak over and above
-     * what we started with
-     */
-    private long directMemoryUsedAtStart;
-
-    @BeforeEach
-    void initializeDirectMemoryAtStart() {
-        directMemoryUsedAtStart = getDirectMemoryUsedBytes();
-    }
-
-    @BeforeEach
-    void setupDatabaseDir() {
-        fileSystemManager = new TestFileSystemManager(tempDir);
-        testDirectory = fileSystemManager.resolveNewTemp("MerkleDbDataSourceTest");
-    }
-
-    @AfterEach
-    void checkDirectMemoryForLeaks() {
-        // check all memory is freed after DB is closed
-        assertTrue(
-                checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart),
-                "Direct Memory used is more than base usage even after 20 gc() calls. At start was "
-                        + (directMemoryUsedAtStart * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB and is now "
-                        + (getDirectMemoryUsedBytes() * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB");
-    }
 
     // =================================================================================================================
     // Tests
 
-    @ParameterizedTest
-    @EnumSource(TestType.class)
-    void createAndCheckInternalNodeHashes(final TestType testType) throws IOException {
-
-        final String tableName = "createAndCheckInternalNodeHashes";
-        // check db count
-        MerkleDbTestUtils.assertAllDatabasesClosed();
+    @Test
+    void createAndCheckInternalNodeHashes() throws IOException {
         // create db
         final int count = 10_000;
         final int firstLeafPath = count - 1;
         final int lastLeafPath = firstLeafPath * 2;
-        createAndApplyDataSource(fileSystemManager, testDirectory, tableName, testType, count, dataSource -> {
-            // check db count
-            MerkleDbTestUtils.assertSomeDatabasesStillOpen(1L);
-
+        createAndApplyDataSource(count, dataSource -> {
             final int hashChunkHeight = dataSource.getHashChunkHeight();
 
             // create some node hashes
@@ -153,50 +99,23 @@ class MerkleDbDataSourceTest {
                     "loadHashChunk should throw IAE on invalid chunk ID");
             assertEquals(
                     "Hash chunk ID (-1) is not valid", e.getMessage(), "Detail message should capture the failure");
-
-            // close data source
-            dataSource.close();
-            // check db count
-            MerkleDbTestUtils.assertAllDatabasesClosed();
-            // check the database was deleted
-            assertEventuallyFalse(
-                    () -> Files.exists(testDirectory.resolve(tableName)),
-                    Duration.ofSeconds(1),
-                    "Database should have been deleted by close()");
         });
     }
 
     @Test
     void throwsOnNonPositiveInitialCapacity() {
         // 0 initial capacity
-        assertThrows(IllegalStateException.class, () -> TestType.variable_variable
-                .dataType()
-                .createDataSource(
-                        CONFIGURATION,
-                        fileSystemManager,
-                        testDirectory.resolve("badInitialCapacityZero" + nextInt()),
-                        "badInitialZero",
-                        0,
-                        false,
-                        false));
+        assertThrows(IllegalArgumentException.class, () -> createDataSource(0, false, false)
+                .close());
         // negative initial capacity
-        assertThrows(IllegalStateException.class, () -> TestType.variable_variable
-                .dataType()
-                .createDataSource(
-                        CONFIGURATION,
-                        fileSystemManager,
-                        testDirectory.resolve("badInitialCapacityNegative" + nextInt()),
-                        "badInitialNeg",
-                        -1,
-                        false,
-                        false));
+        assertThrows(IllegalArgumentException.class, () -> createDataSource(-1, false, false)
+                .close());
     }
 
-    @ParameterizedTest
-    @EnumSource(TestType.class)
-    void testRandomHashUpdates(final TestType testType) throws IOException {
+    @Test
+    void testRandomHashUpdates() throws IOException {
         final int testSize = 2000;
-        createAndApplyDataSource(fileSystemManager, testDirectory, "test2", testType, testSize, dataSource -> {
+        createAndApplyDataSource(testSize, dataSource -> {
             final int chunkHeight = dataSource.getHashChunkHeight();
             // create some node hashes
             dataSource.saveRecords(
@@ -243,7 +162,7 @@ class MerkleDbDataSourceTest {
         final int count = 10_000;
         final int firstLeafPath = count - 1;
         final int lastLeafPath = firstLeafPath * 2;
-        createAndApplyDataSource(fileSystemManager, testDirectory, "test3", testType, count, dataSource -> {
+        createAndApplyDataSource(count, dataSource -> {
             // create some leaves
             dataSource.saveRecords(
                     firstLeafPath,
@@ -273,64 +192,61 @@ class MerkleDbDataSourceTest {
 
     @ParameterizedTest
     @EnumSource(TestType.class)
-    void updateLeaves(final TestType testType) throws IOException, InterruptedException {
+    void updateLeaves(final TestType testType) throws IOException {
         final int firstLeafPath = 499;
         final int lastLeafPath = 998;
 
-        createAndApplyDataSource(
-                fileSystemManager, testDirectory, "test4", testType, lastLeafPath - firstLeafPath + 1, dataSource -> {
-                    // create some leaves
-                    dataSource.saveRecords(
-                            firstLeafPath,
-                            lastLeafPath,
-                            createHashChunkStream(firstLeafPath, lastLeafPath, i -> i, dataSource.getHashChunkHeight()),
-                            IntStream.range(firstLeafPath, lastLeafPath + 1)
-                                    .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
-                            Stream.empty(),
-                            false);
-                    // check all the leaf data
+        createAndApplyDataSource(lastLeafPath - firstLeafPath + 1, dataSource -> {
+            // create some leaves
+            dataSource.saveRecords(
+                    firstLeafPath,
+                    lastLeafPath,
+                    createHashChunkStream(firstLeafPath, lastLeafPath, i -> i, dataSource.getHashChunkHeight()),
                     IntStream.range(firstLeafPath, lastLeafPath + 1)
-                            .forEach(i -> assertLeaf(testType, dataSource, i, i));
-                    // update all to i+10,000 in a random order
-                    final int[] randomInts = shuffle(
-                            RANDOM,
-                            IntStream.range(firstLeafPath, lastLeafPath + 1).toArray());
-                    dataSource.saveRecords(
-                            firstLeafPath,
-                            lastLeafPath,
-                            Stream.empty(),
-                            Arrays.stream(randomInts)
-                                    .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i, i, i + 10_000))
-                                    .sorted(Comparator.comparingLong(VirtualLeafBytes::path)),
-                            Stream.empty(),
-                            false);
-                    assertEquals(
-                            testType.dataType().createVirtualLeafRecord(100, 100, 100 + 10_000),
-                            testType.dataType().createVirtualLeafRecord(100, 100, 100 + 10_000),
-                            "same call to createVirtualLeafRecord returns different results");
-                    // check all the leaf data
-                    IntStream.range(firstLeafPath, lastLeafPath + 1)
-                            .forEach(i -> assertLeaf(testType, dataSource, i, i, i, i + 10_000));
-                    // delete a couple leaves
-                    dataSource.saveRecords(
-                            firstLeafPath,
-                            lastLeafPath,
-                            Stream.empty(),
-                            Stream.empty(),
-                            IntStream.range(firstLeafPath + 10, firstLeafPath + 20 + 1)
-                                    .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
-                            false);
-                    // check deleted items are no longer there
-                    for (int i = (firstLeafPath + 10); i < (firstLeafPath + 20 + 1); i++) {
-                        final Bytes key = testType.dataType().createVirtualLongKey(i);
-                        assertEqualsAndPrint(null, dataSource.loadLeafRecord(key));
-                    }
-                    // check all remaining leaf data
-                    IntStream.range(firstLeafPath, firstLeafPath + 10)
-                            .forEach(i -> assertLeaf(testType, dataSource, i, i, i, i + 10_000));
-                    IntStream.range(firstLeafPath + 21, lastLeafPath + 1)
-                            .forEach(i -> assertLeaf(testType, dataSource, i, i, i, i + 10_000));
-                });
+                            .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
+                    Stream.empty(),
+                    false);
+            // check all the leaf data
+            IntStream.range(firstLeafPath, lastLeafPath + 1).forEach(i -> assertLeaf(testType, dataSource, i, i));
+            // update all to i+10,000 in a random order
+            final int[] randomInts = shuffle(
+                    RANDOM, IntStream.range(firstLeafPath, lastLeafPath + 1).toArray());
+            dataSource.saveRecords(
+                    firstLeafPath,
+                    lastLeafPath,
+                    Stream.empty(),
+                    Arrays.stream(randomInts)
+                            .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i, i, i + 10_000))
+                            .sorted(Comparator.comparingLong(VirtualLeafBytes::path)),
+                    Stream.empty(),
+                    false);
+            assertEquals(
+                    testType.dataType().createVirtualLeafRecord(100, 100, 100 + 10_000),
+                    testType.dataType().createVirtualLeafRecord(100, 100, 100 + 10_000),
+                    "same call to createVirtualLeafRecord returns different results");
+            // check all the leaf data
+            IntStream.range(firstLeafPath, lastLeafPath + 1)
+                    .forEach(i -> assertLeaf(testType, dataSource, i, i, i, i + 10_000));
+            // delete a couple leaves
+            dataSource.saveRecords(
+                    firstLeafPath,
+                    lastLeafPath,
+                    Stream.empty(),
+                    Stream.empty(),
+                    IntStream.range(firstLeafPath + 10, firstLeafPath + 20 + 1)
+                            .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
+                    false);
+            // check deleted items are no longer there
+            for (int i = (firstLeafPath + 10); i < (firstLeafPath + 20 + 1); i++) {
+                final Bytes key = testType.dataType().createVirtualLongKey(i);
+                assertEqualsAndPrint(null, dataSource.loadLeafRecord(key));
+            }
+            // check all remaining leaf data
+            IntStream.range(firstLeafPath, firstLeafPath + 10)
+                    .forEach(i -> assertLeaf(testType, dataSource, i, i, i, i + 10_000));
+            IntStream.range(firstLeafPath + 21, lastLeafPath + 1)
+                    .forEach(i -> assertLeaf(testType, dataSource, i, i, i, i + 10_000));
+        });
     }
 
     @ParameterizedTest
@@ -339,49 +255,48 @@ class MerkleDbDataSourceTest {
         final int incFirstLeafPath = 499;
         final int exclLastLeafPath = 998;
 
-        createAndApplyDataSource(
-                fileSystemManager, testDirectory, "test5", testType, exclLastLeafPath - 1, dataSource -> {
-                    // create some leaves
-                    dataSource.saveRecords(
-                            incFirstLeafPath,
-                            exclLastLeafPath,
-                            createHashChunkStream(
-                                    incFirstLeafPath, exclLastLeafPath - 1, i -> i, dataSource.getHashChunkHeight()),
-                            IntStream.range(incFirstLeafPath, exclLastLeafPath)
-                                    .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
-                            Stream.empty(),
-                            false);
-                    // check 500 and 800
-                    assertLeaf(testType, dataSource, 500, 500);
-                    assertLeaf(testType, dataSource, 800, 800);
-                    // move a leaf from 500 to 750, under new API there is no move as such, so we just write leaf 500
-                    // at path 750
+        createAndApplyDataSource(exclLastLeafPath - 1, dataSource -> {
+            // create some leaves
+            dataSource.saveRecords(
+                    incFirstLeafPath,
+                    exclLastLeafPath,
+                    createHashChunkStream(
+                            incFirstLeafPath, exclLastLeafPath - 1, i -> i, dataSource.getHashChunkHeight()),
+                    IntStream.range(incFirstLeafPath, exclLastLeafPath)
+                            .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
+                    Stream.empty(),
+                    false);
+            // check 500 and 800
+            assertLeaf(testType, dataSource, 500, 500);
+            assertLeaf(testType, dataSource, 800, 800);
+            // move a leaf from 500 to 750, under new API there is no move as such, so we just write leaf 500
+            // at path 750
 
-                    final VirtualLeafBytes vlr500 =
-                            testType.dataType().createVirtualLeafRecord(500).withPath(750);
-                    dataSource.saveRecords(
-                            incFirstLeafPath,
-                            exclLastLeafPath,
-                            createHashChunkStream(750, 750, i -> 500, dataSource.getHashChunkHeight()),
-                            Stream.of(vlr500),
-                            Stream.empty(),
-                            false);
+            final VirtualLeafBytes vlr500 =
+                    testType.dataType().createVirtualLeafRecord(500).withPath(750);
+            dataSource.saveRecords(
+                    incFirstLeafPath,
+                    exclLastLeafPath,
+                    createHashChunkStream(750, 750, i -> 500, dataSource.getHashChunkHeight()),
+                    Stream.of(vlr500),
+                    Stream.empty(),
+                    false);
 
-                    // check 750 now has 500's data
-                    assertLeaf(testType, dataSource, 700, 700);
-                    assertEquals(
-                            testType.dataType().createVirtualLeafRecord(500, 500, 500),
-                            dataSource.loadLeafRecord(500),
-                            "creating/loading same LeafRecord gives different results");
-                    assertLeaf(testType, dataSource, 750, 500);
-                });
+            // check 750 now has 500's data
+            assertLeaf(testType, dataSource, 700, 700);
+            assertEquals(
+                    testType.dataType().createVirtualLeafRecord(500, 500, 500),
+                    dataSource.loadLeafRecord(500),
+                    "creating/loading same LeafRecord gives different results");
+            assertLeaf(testType, dataSource, 750, 500);
+        });
     }
 
     @ParameterizedTest
     @EnumSource(TestType.class)
     void createAndDeleteAllLeaves(final TestType testType) throws IOException {
         final int count = 1000;
-        createAndApplyDataSource(fileSystemManager, testDirectory, "test3", testType, count, dataSource -> {
+        createAndApplyDataSource(count, dataSource -> {
             // create some leaves
             dataSource.saveRecords(
                     count - 1,
@@ -415,7 +330,7 @@ class MerkleDbDataSourceTest {
 
     @Test
     void preservesInterruptStatusWhenInterruptedSavingRecords() throws IOException {
-        createAndApplyDataSource(fileSystemManager, testDirectory, "test6", TestType.long_fixed, 1000, dataSource -> {
+        createAndApplyDataSource(1000, dataSource -> {
             final CountDownLatch savingThreadStarted = new CountDownLatch(1);
             final InterruptRememberingThread savingThread = slowRecordSavingThread(dataSource, savingThreadStarted);
             savingThread.start();
@@ -442,10 +357,9 @@ class MerkleDbDataSourceTest {
     void createCloseSnapshotCheckDelete(final TestType testType) throws IOException {
         final int count = 10_000;
         final String tableName = "testDB";
-        final Path originalDbPath = testDirectory.resolve("merkledb-" + testType);
-        // array to hold the snapshot path
-        final Path[] snapshotDbPathRef = new Path[1];
-        createAndApplyDataSource(fileSystemManager, originalDbPath, tableName, testType, count, dataSource -> {
+        final Path snapshotDir = fileSystemManager.resolveNewTemp("merkledb-" + testType + "_SNAPSHOT");
+
+        createAndApplyDataSource(tableName, count, dataSource -> {
             // create some leaves
             dataSource.saveRecords(
                     count - 1,
@@ -458,39 +372,20 @@ class MerkleDbDataSourceTest {
             // check all the leaf data
             IntStream.range(count - 1, count * 2 - 1).forEach(i -> assertLeaf(testType, dataSource, i, i));
             // create a snapshot
-            snapshotDbPathRef[0] = testDirectory.resolve("merkledb-" + testType + "_SNAPSHOT");
-            dataSource.snapshot(snapshotDbPathRef[0]);
-            // close data source
-            dataSource.close();
-            // check directory is deleted on close
-            assertFalse(Files.exists(originalDbPath), "Data source dir should be deleted");
-            assertTrue(Files.exists(snapshotDbPathRef[0]), "Snapshot dir [" + snapshotDbPathRef[0] + "] should exist");
+
+            dataSource.snapshot(snapshotDir);
         });
 
+        assertTrue(Files.exists(snapshotDir), "Snapshot dir [" + snapshotDir + "] should exist");
+
         // reopen data source and check
-        final MerkleDbDataSource dataSource2 =
-                testType.dataType().getDataSource(fileSystemManager, snapshotDbPathRef[0], tableName, false);
+        final MerkleDbDataSource dataSource2 = restoreDataSource(snapshotDir, tableName, false);
         try {
             // check all the leaf data
             IntStream.range(count - 1, count * 2 - 1).forEach(i -> assertLeaf(testType, dataSource2, i, i));
         } finally {
             // close data source
             dataSource2.close();
-        }
-        // check db count
-        MerkleDbTestUtils.assertAllDatabasesClosed();
-    }
-
-    boolean directMemoryUsageByDataFileIteratorWorkaroundApplied = false;
-
-    // When the first DataFileIterator is initialized, it allocates 16Mb direct byte buffer internally.
-    // Since we have direct memory usage checks after each test case, it's reported as a memory leak.
-    // A workaround is to reset memory usage value right after the first usage of iterator. No need to
-    // do it before each test run, it's enough to do just once
-    void reinitializeDirectMemoryUsage() {
-        if (!directMemoryUsageByDataFileIteratorWorkaroundApplied) {
-            initializeDirectMemoryAtStart();
-            directMemoryUsageByDataFileIteratorWorkaroundApplied = true;
         }
     }
 
@@ -499,70 +394,62 @@ class MerkleDbDataSourceTest {
     void snapshotRestoreIndex(final TestType testType) throws IOException {
         final int count = 1000;
         final String tableName = "vm";
-        final Path originalDbPath = testDirectory.resolve("merkledb-snapshotRestoreIndex-" + testType);
         final int[] deltas = {-10, 0, 10};
+        final Path snapshotDir =
+                fileSystemManager.resolveNewTemp("merkledb-snapshotRestoreIndex-" + testType + "_SNAPSHOT");
+
         for (int delta : deltas) {
-            createAndApplyDataSource(
-                    fileSystemManager, originalDbPath, tableName, testType, count + Math.abs(delta), dataSource -> {
-                        // create some records
-                        dataSource.saveRecords(
-                                count - 1,
-                                count * 2 - 2,
-                                createHashChunkStream(0, count * 2 - 2, i -> i + 1, dataSource.getHashChunkHeight()),
-                                IntStream.range(count - 1, count * 2 - 1)
-                                        .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
-                                Stream.empty(),
-                                false);
-                        if (delta != 0) {
-                            // create some more, current leaf path range shifted by delta
-                            dataSource.saveRecords(
-                                    count - 1 + delta,
-                                    count * 2 - 2 + 2 * delta,
-                                    createHashChunkStream(
-                                            1, count * 2 - 2 + 2 * delta, i -> i + 1, dataSource.getHashChunkHeight()),
-                                    IntStream.range(count - 1 + delta, count * 2 - 1 + 2 * delta)
-                                            .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
-                                    Stream.empty(),
-                                    false);
-                        }
-                        // create a snapshot
-                        final Path snapshotDbPath =
-                                testDirectory.resolve("merkledb-snapshotRestoreIndex-" + testType + "_SNAPSHOT");
-                        dataSource.snapshot(snapshotDbPath);
-                        // close data source
-                        dataSource.close();
+            createAndApplyDataSource(tableName, count + Math.abs(delta), dataSource -> {
+                // create some records
+                dataSource.saveRecords(
+                        count - 1,
+                        count * 2 - 2,
+                        createHashChunkStream(0, count * 2 - 2, i -> i + 1, dataSource.getHashChunkHeight()),
+                        IntStream.range(count - 1, count * 2 - 1)
+                                .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
+                        Stream.empty(),
+                        false);
+                if (delta != 0) {
+                    // create some more, current leaf path range shifted by delta
+                    dataSource.saveRecords(
+                            count - 1 + delta,
+                            count * 2 - 2 + 2 * delta,
+                            createHashChunkStream(
+                                    1, count * 2 - 2 + 2 * delta, i -> i + 1, dataSource.getHashChunkHeight()),
+                            IntStream.range(count - 1 + delta, count * 2 - 1 + 2 * delta)
+                                    .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i)),
+                            Stream.empty(),
+                            false);
+                }
+                // create a snapshot
 
-                        final MerkleDbPaths snapshotPaths = new MerkleDbPaths(snapshotDbPath);
-                        // Delete all indices
-                        Files.delete(snapshotPaths.pathToDiskLocationLeafNodesFile);
-                        Files.delete(snapshotPaths.idToDiskLocationHashChunksFile);
-                        // There is no way to use MerkleDbPaths to get bucket index file path
-                        Files.deleteIfExists(snapshotPaths.keyToPathDirectory.resolve(tableName + "_bucket_index.ll"));
+                dataSource.snapshot(snapshotDir);
+            });
 
-                        final MerkleDbDataSource snapshotDataSource =
-                                testType.dataType().getDataSource(fileSystemManager, snapshotDbPath, tableName, false);
-                        reinitializeDirectMemoryUsage();
-                        // Check hashes
-                        IntStream.range(1, count * 2 - 1 + 2 * delta)
-                                .forEach(i -> assertHash(snapshotDataSource, i, i + 1));
-                        assertNullHash(snapshotDataSource, count * 2 + 2 * delta);
-                        // Check leaves
-                        IntStream.range(0, count - 2 + delta).forEach(i -> assertNullLeaf(snapshotDataSource, i));
-                        IntStream.range(count - 1 + delta, count * 2 - 1 + 2 * delta)
-                                .forEach(i -> assertLeaf(testType, snapshotDataSource, i, i, i + 1, i));
-                        assertNullLeaf(snapshotDataSource, count * 2 + 2 * delta);
-                        // close data source
-                        snapshotDataSource.close();
+            final MerkleDbPaths snapshotPaths = new MerkleDbPaths(snapshotDir);
+            // Delete all indices
+            Files.delete(snapshotPaths.pathToDiskLocationLeafNodesFile);
+            Files.delete(snapshotPaths.idToDiskLocationHashChunksFile);
+            // There is no way to use MerkleDbPaths to get bucket index file path
+            Files.deleteIfExists(snapshotPaths.keyToPathDirectory.resolve(tableName + "_bucket_index.ll"));
 
-                        // check db count
-                        MerkleDbTestUtils.assertAllDatabasesClosed();
-                    });
+            final MerkleDbDataSource snapshotDataSource = restoreDataSource(snapshotDir, tableName, false);
+            // Check hashes
+            IntStream.range(1, count * 2 - 1 + 2 * delta).forEach(i -> assertHash(snapshotDataSource, i, i + 1));
+            assertNullHash(snapshotDataSource, count * 2 + 2 * delta);
+            // Check leaves
+            IntStream.range(0, count - 2 + delta).forEach(i -> assertNullLeaf(snapshotDataSource, i));
+            IntStream.range(count - 1 + delta, count * 2 - 1 + 2 * delta)
+                    .forEach(i -> assertLeaf(testType, snapshotDataSource, i, i, i + 1, i));
+            assertNullLeaf(snapshotDataSource, count * 2 + 2 * delta);
+            // close data source
+            snapshotDataSource.close();
         }
     }
 
     @Test
     void preservesInterruptStatusWhenInterruptedClosing() throws IOException {
-        createAndApplyDataSource(fileSystemManager, testDirectory, "test8", TestType.long_fixed, 1001, dataSource -> {
+        createAndApplyDataSource(1001, dataSource -> {
             /* Keep an executor busy */
             final CountDownLatch savingThreadStarted = new CountDownLatch(1);
             final InterruptRememberingThread savingThread = slowRecordSavingThread(dataSource, savingThreadStarted);
@@ -595,19 +482,14 @@ class MerkleDbDataSourceTest {
     @Test
     void canConstructStandardStoreWithMergingDisabled() {
         assertDoesNotThrow(
-                () -> TestType.long_fixed
-                        .dataType()
-                        .createDataSource(CONFIGURATION, fileSystemManager, testDirectory, "testDB", 1000, false, false)
-                        .close(),
+                () -> createDataSource(1000, false, false).close(),
                 "Should be possible to instantiate data source with merging disabled");
-        // check db count
-        MerkleDbTestUtils.assertAllDatabasesClosed();
     }
 
     @Test
     void skipKeyToPathCompactionWhenResizeNeeded() throws IOException {
         // spotless:off
-        createAndApplyDataSource(fileSystemManager, testDirectory, "skipKeyToPathCompactionWhenResizeNeeded", TestType.long_fixed, 1, dataSource -> {
+        createAndApplyDataSource(1, dataSource -> {
             final MerkleDbCompactionCoordinator coordinator = dataSource.getCompactionCoordinator();
             coordinator.stopAndDisableBackgroundCompaction();
 
@@ -638,10 +520,7 @@ class MerkleDbDataSourceTest {
     @ParameterizedTest
     @EnumSource(TestType.class)
     void dirtyDeletedLeavesBetweenFlushesOnReconnect(final TestType testType) throws IOException {
-        final String tableName = "vm";
-        final Path originalDbPath =
-                testDirectory.resolve("merkledb-dirtyDeletedLeavesBetweenFlushesOnReconnect-" + testType);
-        createAndApplyDataSource(fileSystemManager, originalDbPath, tableName, testType, 100, dataSource -> {
+        createAndApplyDataSource(100, dataSource -> {
             final List<Bytes> keys = new ArrayList<>(31);
             for (int i = 0; i < 31; i++) {
                 keys.add(testType.dataType().createVirtualLongKey(i));
@@ -747,10 +626,8 @@ class MerkleDbDataSourceTest {
         final int size = 300_000;
         final long firstLeafPath = size - 1;
         final long lastLeafPath = 2 * size - 2;
-        final TestType testType = TestType.long_fixed;
-        final Path originalDbPath = testDirectory.resolve("migrateHashesToChunks");
-        createAndApplyDataSource(fileSystemManager, originalDbPath, dbName, testType, size, dataSource -> {
-            final Path snapshotDbPath = testDirectory.resolve("migrateHashesToChunks-snapshot");
+        createAndApplyDataSource(dbName, size, dataSource -> {
+            final Path snapshotDbPath = fileSystemManager.resolveNewTemp("migrateHashesToChunks-snapshot");
             // MerkleDbDataSource.snapshot() builds a snapshot in a new format with hash chunks.
             // Let's hack the snapshot so it looks like the old format, so hash migration can
             // be tested
@@ -777,7 +654,7 @@ class MerkleDbDataSourceTest {
                 hashStoreRam.writeToFile(snapshotPaths.hashStoreRamFile);
             }
             if (hashesRamToDiskThreshold <= lastLeafPath) {
-                final Path tmpDir = testDirectory.resolve("migrateHashesToChunks-tmp");
+                final Path tmpDir = fileSystemManager.resolveNewTemp("migrateHashesToChunks-tmp");
                 final LongListSegment hashStoreDiskIndex = new LongListSegment(1024, 2 * size, 1024);
                 final MemoryIndexDiskKeyValueStore hashStoreDisk = new MemoryIndexDiskKeyValueStore(
                         CONFIGURATION.getConfigData(MerkleDbConfig.class),
@@ -799,8 +676,7 @@ class MerkleDbDataSourceTest {
             }
 
             // Restore
-            final MerkleDbDataSource snapshot = testType.dataType()
-                    .createDataSource(CONFIGURATION, fileSystemManager, snapshotDbPath, dbName, size, false, false);
+            final MerkleDbDataSource snapshot = restoreDataSource(snapshotDbPath, dbName, false);
             // Check all hashes are migrated successfully
             try {
                 for (long i = firstLeafPath; i <= lastLeafPath; i++) {
@@ -819,10 +695,9 @@ class MerkleDbDataSourceTest {
     void testRebuildHDHMIndex() throws Exception {
         final String label = "testRebuildHDHMIndex";
         final TestType testType = TestType.variable_variable;
-        final Path originalDbPath = testDirectory.resolve("merkledb-testRebuildHDHMIndex-" + testType);
-        final Path snapshotDbPath1 = testDirectory.resolve("merkledb-testRebuildHDHMIndex_SNAPSHOT1");
-        final Path snapshotDbPath2 = testDirectory.resolve("merkledb-testRebuildHDHMIndex_SNAPSHOT2");
-        createAndApplyDataSource(fileSystemManager, originalDbPath, label, testType, 100, dataSource -> {
+        final Path snapshotDbPath1 = fileSystemManager.resolveNewTemp("merkledb-testRebuildHDHMIndex_SNAPSHOT1");
+        final Path snapshotDbPath2 = fileSystemManager.resolveNewTemp("merkledb-testRebuildHDHMIndex_SNAPSHOT2");
+        createAndApplyDataSource(label, 100, dataSource -> {
             // Flush 1: leaf path range is [8,16]
             dataSource.saveRecords(
                     8,
@@ -844,9 +719,9 @@ class MerkleDbDataSourceTest {
             // Create snapshots
             dataSource.snapshot(snapshotDbPath1);
             dataSource.snapshot(snapshotDbPath2);
-            // close data source
-            dataSource.close();
         });
+
+        final Bytes staleKey = testType.dataType().createVirtualLongKey(8);
 
         // Load snapshot 1 with empty tablesToRepairHdhm config. It's expected to contain a stale key
         final Configuration config1 = ConfigurationBuilder.create()
@@ -855,12 +730,13 @@ class MerkleDbDataSourceTest {
                 .withConfigDataType(TemporaryFileConfig.class)
                 .withSource(new SimpleConfigSource("merkleDb.tablesToRepairHdhm", ""))
                 .build();
-        final MerkleDbDataSource snapshotDataSource1 =
-                new MerkleDbDataSource(snapshotDbPath1, config1, fileSystemManager, label, false, false);
-        IntStream.range(9, 19).forEach(i -> assertLeaf(testType, snapshotDataSource1, i, i, 2 * i, 3 * i));
-        final Bytes staleKey = testType.dataType().createVirtualLongKey(8);
-        assertEquals(8, snapshotDataSource1.findKey(staleKey));
-        snapshotDataSource1.close();
+        final MerkleDbDataSource snapshotDataSource1 = restoreDataSource(config1, snapshotDbPath1, label, false);
+        try {
+            IntStream.range(9, 19).forEach(i -> assertLeaf(testType, snapshotDataSource1, i, i, 2 * i, 3 * i));
+            assertEquals(8, snapshotDataSource1.findKey(staleKey));
+        } finally {
+            snapshotDataSource1.close();
+        }
 
         // Now load snapshot 2, but with HDHM bucket index rebuilt. There must be no stale keys there
         final Configuration config2 = ConfigurationBuilder.create()
@@ -868,11 +744,13 @@ class MerkleDbDataSourceTest {
                 .withConfigDataType(VirtualMapConfig.class)
                 .withSource(new SimpleConfigSource("merkleDb.tablesToRepairHdhm", label))
                 .build();
-        final MerkleDbDataSource snapshotDataSource2 =
-                new MerkleDbDataSource(snapshotDbPath2, config2, fileSystemManager, label, false, false);
-        IntStream.range(9, 19).forEach(i -> assertLeaf(testType, snapshotDataSource2, i, i, 2 * i, 3 * i));
-        assertEquals(-1, snapshotDataSource2.findKey(staleKey));
-        snapshotDataSource2.close();
+        final MerkleDbDataSource snapshotDataSource2 = restoreDataSource(config2, snapshotDbPath2, label, false);
+        try {
+            IntStream.range(9, 19).forEach(i -> assertLeaf(testType, snapshotDataSource2, i, i, 2 * i, 3 * i));
+            assertEquals(-1, snapshotDataSource2.findKey(staleKey));
+        } finally {
+            snapshotDataSource2.close();
+        }
     }
 
     @Test
@@ -881,8 +759,8 @@ class MerkleDbDataSourceTest {
         // for the copy correctly
         final String label = "copyStatisticsTest";
         final TestType testType = TestType.variable_variable;
-        final Metrics metrics = testType.getMetrics();
-        createAndApplyDataSource(fileSystemManager, testDirectory, label, testType, 16, dataSource -> {
+        final Metrics metrics = MerkleDbTestUtils.createMetrics();
+        createAndApplyDataSource(label, 16, dataSource -> {
             dataSource.registerMetrics(metrics);
             assertEquals(
                     1L,
@@ -905,9 +783,7 @@ class MerkleDbDataSourceTest {
             assertEquals(1L, sourceCounter.get());
             final Path copyPath = fileSystemManager.resolveNewTemp("copyStatisticsTest");
             dataSource.snapshot(copyPath);
-            final MerkleDbDataSource copy =
-                    testType.dataType().getDataSource(fileSystemManager, copyPath, dataSource.getTableName(), true);
-            reinitializeDirectMemoryUsage();
+            final MerkleDbDataSource copy = restoreDataSource(copyPath, dataSource.getTableName(), true);
             try {
                 assertEquals(
                         2L, metrics.getMetric("merkle_db", "merkledb_count").get(ValueType.VALUE));
@@ -926,82 +802,60 @@ class MerkleDbDataSourceTest {
 
     @ParameterizedTest
     @EnumSource(TestType.class)
-    void closeWhileFlushingTest(final TestType testType) throws IOException, InterruptedException {
-        final Path dbPath = testDirectory.resolve("merkledb-closeWhileFlushingTest-" + testType);
-        final MerkleDbDataSource dataSource = testType.dataType()
-                .createDataSource(CONFIGURATION, fileSystemManager, dbPath, "vm", 1000, false, false);
-
-        final int count = 20;
-        final List<Bytes> keys = new ArrayList<>(count);
-        for (int i = 0; i < count; i++) {
-            keys.add(testType.dataType().createVirtualLongKey(i));
-        }
-        final List<ExampleByteArrayVirtualValue> values = new ArrayList<>(count);
-        for (int i = 0; i < count; i++) {
-            values.add(testType.dataType().createVirtualValue(i + 1));
-        }
-
-        final CountDownLatch updateStarted = new CountDownLatch(1);
-        final Thread closeThread = new Thread(() -> {
-            try {
-                updateStarted.await();
-                Thread.sleep(new Random().nextInt(100));
-                dataSource.close();
-            } catch (Exception z) {
-                // Print and ignore
-                z.printStackTrace(System.err);
+    void closeWhileFlushingTest(final TestType testType) throws IOException {
+        createAndApplyDataSource(1000, dataSource -> {
+            final int count = 20;
+            final List<Bytes> keys = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                keys.add(testType.dataType().createVirtualLongKey(i));
             }
+            final List<ExampleByteArrayVirtualValue> values = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                values.add(testType.dataType().createVirtualValue(i + 1));
+            }
+
+            final CountDownLatch updateStarted = new CountDownLatch(1);
+            final Thread closeThread = new Thread(() -> {
+                try {
+                    updateStarted.await();
+                    Thread.sleep(new Random().nextInt(100));
+                    dataSource.close();
+                } catch (Exception z) {
+                    // Print and ignore
+                    z.printStackTrace(System.err);
+                }
+            });
+            closeThread.start();
+
+            updateStarted.countDown();
+            for (int i = 1; i < 10; i++) {
+                final int k = i;
+                try {
+                    dataSource.saveRecords(
+                            count - 1,
+                            2 * count - 2,
+                            createHashChunkStream(k, k + count - 1, t -> t + 1, dataSource.getHashChunkHeight()),
+                            IntStream.range(count - 1, count)
+                                    .mapToObj(j -> new VirtualLeafBytes(
+                                            k + j,
+                                            keys.get(k),
+                                            values.get((k + j) % count),
+                                            testType.dataType().getCodec())),
+                            Stream.empty(),
+                            true);
+                } catch (Exception z) {
+                    // Print and ignore
+                    z.printStackTrace(System.err);
+                    break;
+                }
+            }
+
+            closeThread.join();
         });
-        closeThread.start();
-
-        updateStarted.countDown();
-        for (int i = 1; i < 10; i++) {
-            final int k = i;
-            try {
-                dataSource.saveRecords(
-                        count - 1,
-                        2 * count - 2,
-                        createHashChunkStream(k, k + count - 1, t -> t + 1, dataSource.getHashChunkHeight()),
-                        IntStream.range(count - 1, count)
-                                .mapToObj(j -> new VirtualLeafBytes(
-                                        k + j,
-                                        keys.get(k),
-                                        values.get((k + j) % count),
-                                        testType.dataType().getCodec())),
-                        Stream.empty(),
-                        true);
-            } catch (Exception z) {
-                // Print and ignore
-                z.printStackTrace(System.err);
-                break;
-            }
-        }
-
-        closeThread.join();
     }
 
     // =================================================================================================================
     // Helper Methods
-
-    public static void createAndApplyDataSource(
-            final FileSystemManager fileSystemManager,
-            final Path testDirectory,
-            final String name,
-            final TestType testType,
-            final int size,
-            CheckedConsumer<MerkleDbDataSource, Exception> dataSourceConsumer)
-            throws IOException {
-        final MerkleDbDataSource dataSource = testType.dataType()
-                .createDataSource(CONFIGURATION, fileSystemManager, testDirectory, name, size, false, false);
-        try {
-            dataSourceConsumer.accept(dataSource);
-        } catch (Throwable e) {
-            fail(e);
-        } finally {
-            dataSource.close();
-        }
-        MerkleDbTestUtils.assertAllDatabasesClosed();
-    }
 
     public static void assertHash(final MerkleDbDataSource dataSource, final long path, final int i) {
         final int hashChunkHeight = dataSource.getHashChunkHeight();

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/VirtualMapSerializationTests.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/VirtualMapSerializationTests.java
@@ -22,27 +22,20 @@ import java.util.Random;
 import java.util.stream.Stream;
 import org.hiero.base.constructable.ConstructableRegistryException;
 import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.hiero.consensus.constructable.ConstructableRegistration;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("VirtualMap Serialization Test")
-class VirtualMapSerializationTests {
-
-    @TempDir
-    static Path tempDir;
-
-    private static FileSystemManager fileSystemManager;
+class VirtualMapSerializationTests extends AbstractFileManagerAwareTest {
 
     @BeforeAll
     static void setUp() throws ConstructableRegistryException {
         ConstructableRegistration.registerAllConstructables();
-        fileSystemManager = new TestFileSystemManager(tempDir);
     }
 
     /**
@@ -126,7 +119,6 @@ class VirtualMapSerializationTests {
     /**
      * Test serialization of a map. Does not release any resources created by caller.
      */
-    @SuppressWarnings("resource")
     private void testMapSerialization(final VirtualMap map) throws IOException {
 
         final Path savedStateDirectory = fileSystemManager.resolveNewTemp("saved-state");

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkledb.collections;
 
-import static com.swirlds.base.units.UnitConstants.BYTES_TO_MEBIBYTES;
 import static com.swirlds.merkledb.collections.AbstractLongList.FILE_HEADER_SIZE_V3;
 import static com.swirlds.merkledb.collections.LongList.IMPERMISSIBLE_VALUE;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
@@ -26,6 +25,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.SimpleConfigSource;
 import com.swirlds.merkledb.config.MerkleDbConfig;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -41,10 +41,8 @@ import java.util.function.LongConsumer;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.hiero.base.utility.test.fixtures.io.ResourceLoader;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -58,7 +56,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
+abstract class AbstractLongListTest<T extends AbstractLongList<?>> extends AbstractFileManagerAwareTest {
 
     // Constants (used in ordered and some of the other tests)
 
@@ -75,16 +73,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
     // Variables used in ordered tests
 
     private static AbstractLongList<?> longList;
-
-    @TempDir
-    static Path fsmTempDir;
-
-    protected static FileSystemManager fileSystemManager;
-
-    @BeforeAll
-    static void setupFileSystemManager() {
-        fileSystemManager = new TestFileSystemManager(fsmTempDir);
-    }
 
     /**
      * Keep track of initial direct memory used already, so we can check if we leek over and above what we started with
@@ -219,12 +207,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
         // Also skip for LongListSegment — FFM arena allocations are not tracked by the
         // direct memory BufferPoolMXBean; they are verified separately below.
         if (!(longList instanceof LongListDisk) && !(longList instanceof LongListSegment)) {
-            assertTrue(
-                    checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart),
-                    "Direct Memory used is more than base usage even after 20 gc() calls. At start was "
-                            + (directMemoryUsedAtStart * BYTES_TO_MEBIBYTES) + "MB and is now "
-                            + (getDirectMemoryUsedBytes() * BYTES_TO_MEBIBYTES)
-                            + "MB");
+            checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart);
         }
         // For LongListSegment: Arena.close() is deterministic — no GC dependency. If
         // AbstractLongList.close() called closeChunk for every chunk (which it does via
@@ -256,24 +239,25 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
         }
     }
 
-    @SuppressWarnings("resource")
     @Test
     void testConstructorValidatesArgs() {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> createLongList(1, -1, 0),
+                () -> createLongList(1, -1, 0).close(),
                 "Should not be able to create with a negative maxLongs");
         assertThrows(
                 IllegalArgumentException.class,
-                () -> createLongList(Integer.MAX_VALUE, 1000, 0),
+                () -> createLongList(Integer.MAX_VALUE, 1000, 0).close(),
                 "Should not be able to create with a more longs per chunk than maxLongs");
         assertThrows(
                 IllegalArgumentException.class,
-                () -> createLongList((Integer.MAX_VALUE / 8) + 1, Integer.MAX_VALUE, 0),
+                () -> createLongList((Integer.MAX_VALUE / 8) + 1, Integer.MAX_VALUE, 0)
+                        .close(),
                 "Check that IllegalArgumentException of num longs per chuck is too big");
         assertThrows(
                 IllegalArgumentException.class,
-                () -> createLongList(Integer.MAX_VALUE - 1, Integer.MAX_VALUE, 0),
+                () -> createLongList(Integer.MAX_VALUE - 1, Integer.MAX_VALUE, 0)
+                        .close(),
                 "Check that IllegalArgumentException of num longs per chuck is too big");
     }
 
@@ -315,17 +299,13 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
      */
     @Test
     void testCloseAndRecreateLongListMultipleTimes(@TempDir final Path tempDir) throws IOException {
-        final Path file = tempDir.resolve("testCloseAndRecreateLongListMultipleTimes.ll");
-        if (Files.exists(file)) {
-            Files.delete(file);
-        }
-
+        Path file;
         try (final LongList longList = createLongList(NUM_LONGS_PER_CHUNK, MAX_LONGS, 0)) {
             longList.updateValidRange(0, SAMPLE_SIZE);
             for (int i = 0; i <= SAMPLE_SIZE; i++) {
                 longList.put(i, i + 100);
             }
-            longList.writeToFile(file);
+            file = writeLongListToFileAndVerify(longList, "testCloseAndRecreateLongListMultipleTimes.ll", tempDir);
             assertTrue(Files.exists(file), "The file should exist after writing with the first list");
         }
 
@@ -344,10 +324,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
 
     @Test
     void testLoadDifferentChunkSize(@TempDir final Path tempDir) throws IOException {
-        final Path file = tempDir.resolve("testLoadDifferentChunkSize.ll");
-        if (Files.exists(file)) {
-            Files.delete(file);
-        }
+        final Path file;
         final long CAPACITY = 1000;
         final int GAP = 50;
         try (final LongList longList = createLongList(100, CAPACITY, 0)) {
@@ -355,8 +332,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
             for (int i = GAP; i <= CAPACITY - GAP; i++) {
                 longList.put(i, i * 2L);
             }
-            longList.writeToFile(file);
-            assertTrue(Files.exists(file), "The file should exist after writing with the first list");
+            file = writeLongListToFileAndVerify(longList, "testLoadDifferentChunkSize.ll", tempDir);
         }
         try (final LongList longList = createLongList(file, 200, CAPACITY, 0)) {
             assertEquals(GAP, longList.getMinValidIndex());
@@ -369,18 +345,14 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
 
     @Test
     void testLoadIncreasedCapacity(@TempDir final Path tempDir) throws IOException {
-        final Path file = tempDir.resolve("testLoadIncreasedCapacity.ll");
-        if (Files.exists(file)) {
-            Files.delete(file);
-        }
+        final Path file;
         final long CAPACITY = 1000;
         try (final LongList longList = createLongList(100, CAPACITY, 0)) {
             longList.updateValidRange(0, CAPACITY - 1);
             for (int i = 0; i < CAPACITY; i++) {
                 longList.put(i, i * 2L + 1);
             }
-            longList.writeToFile(file);
-            assertTrue(Files.exists(file), "The file should exist after writing with the first list");
+            file = writeLongListToFileAndVerify(longList, "testLoadIncreasedCapacity.ll", tempDir);
         }
         try (final LongList longList = createLongList(file, 100, CAPACITY + 100, 0)) {
             assertEquals(0, longList.getMinValidIndex());
@@ -396,20 +368,17 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
 
     @Test
     void testLoadDecreasedCapacity(@TempDir final Path tempDir) throws IOException {
-        final Path file = tempDir.resolve("testLoadDecreasedCapacity.ll");
-        if (Files.exists(file)) {
-            Files.delete(file);
-        }
+        final Path file;
         final long CAPACITY = 1000;
         try (final LongList longList = createLongList(100, CAPACITY, 0)) {
             longList.updateValidRange(0, CAPACITY - 1);
             for (int i = 0; i < CAPACITY; i++) {
                 longList.put(i, i * 2L + 1);
             }
-            longList.writeToFile(file);
-            assertTrue(Files.exists(file), "The file should exist after writing with the first list");
+            file = writeLongListToFileAndVerify(longList, "testLoadDecreasedCapacity.ll", tempDir);
         }
-        assertThrows(IllegalArgumentException.class, () -> createLongList(file, 100, CAPACITY - 100, 0));
+        assertThrows(IllegalArgumentException.class, () -> createLongList(file, 100, CAPACITY - 100, 0)
+                .close());
     }
 
     // SAMPLE_SIZE should be 10K for this test
@@ -596,59 +565,47 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
     }
 
     @Test
-    void testRestoreUpdateSnapshot() throws IOException {
+    void testRestoreUpdateSnapshot(@TempDir Path testDir) throws IOException {
         try (final LongList longList = createLongList(100, MAX_LONGS, 0)) {
             longList.updateValidRange(0, 50);
             longList.put(2, 1002);
-            final Path tmpDir = Files.createTempDirectory("testRestoreUpdateSnapshot");
-            final Path tmpFile = tmpDir.resolve("snapshot");
-            longList.writeToFile(tmpFile);
-            try (final LongList restored = createLongList(tmpFile, 100, MAX_LONGS, 0)) {
+            final Path snapshot1 = testDir.resolve("snapshot1");
+            longList.writeToFile(snapshot1);
+            try (final LongList restored = createLongList(snapshot1, 100, MAX_LONGS, 0)) {
                 restored.updateValidRange(0, 50);
                 assertEquals(3, restored.size());
                 assertEquals(1002, restored.get(2));
                 restored.put(3, 1003);
-                final Path tmpDir2 = Files.createTempDirectory("testRestoreUpdateSnapshot");
-                final Path tmpFile2 = tmpDir2.resolve("snapshot");
-                restored.writeToFile(tmpFile2);
-                try (final LongList restored2 = createLongList(tmpFile2, 100, MAX_LONGS, 0)) {
+                final Path snapshot2 = testDir.resolve("snapshot2");
+                restored.writeToFile(snapshot2);
+                try (final LongList restored2 = createLongList(snapshot2, 100, MAX_LONGS, 0)) {
                     restored2.updateValidRange(0, 50);
                     assertEquals(4, restored2.size());
                     assertEquals(1002, restored2.get(2));
                     assertEquals(1003, restored2.get(3));
-                } finally {
-                    Files.delete(tmpFile2);
-                    Files.delete(tmpDir2);
                 }
-            } finally {
-                Files.delete(tmpFile);
-                Files.delete(tmpDir);
             }
         }
     }
 
     @Test
     @DisplayName("Regression test for hiero-ledger/hiero-consensus-node/issues/18235")
-    void testSnapshotHalfEmptyChunks() throws IOException {
+    void testSnapshotHalfEmptyChunks(@TempDir Path testDir) throws IOException {
         try (final LongList longList = createLongList(200, 10000, 0)) {
             longList.updateValidRange(500, 1100);
             longList.put(599, 1599); // chunk 2
             longList.put(1050, 2050); // chunk 5
             longList.put(900, 1900); // chunk 4
             longList.put(700, 1700); // chunk 3
-            final Path tmpDir = Files.createTempDirectory("testSnapshotHalfEmptyChunks");
-            final Path tmpFile = tmpDir.resolve("snapshot");
-            longList.writeToFile(tmpFile);
-            try (final LongList restored = createLongList(tmpFile, 200, 10000, 0)) {
+            final Path snapshot = testDir.resolve("snapshot");
+            longList.writeToFile(snapshot);
+            try (final LongList restored = createLongList(snapshot, 200, 10000, 0)) {
                 assertEquals(1700, restored.get(700));
                 assertEquals(2050, restored.get(1050));
                 assertEquals(1900, restored.get(900));
                 assertEquals(1599, restored.get(599));
                 // Make sure chunk 3 doesn't have any values carried over from chunk 2
                 assertEquals(0, restored.get(799));
-            } finally {
-                Files.delete(tmpFile);
-                Files.delete(tmpDir);
             }
         }
     }
@@ -661,11 +618,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 list.put(i, i + 1000);
             }
             final AtomicInteger counter = new AtomicInteger(0);
-            list.forEach(
-                    (l, v) -> {
-                        counter.incrementAndGet();
-                    },
-                    () -> counter.get() < 42);
+            list.forEach((l, v) -> counter.incrementAndGet(), () -> counter.get() < 42);
             assertEquals(42, counter.get());
         }
     }
@@ -678,11 +631,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 list.put(i, i + 1000);
             }
             final AtomicInteger counter = new AtomicInteger(0);
-            list.forEach(
-                    (l, v) -> {
-                        counter.incrementAndGet();
-                    },
-                    null);
+            list.forEach((l, v) -> counter.incrementAndGet(), null);
             assertEquals(100, counter.get());
         }
     }
@@ -695,6 +644,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
      * {@code createInstance} is the function that constructs a new {@link AbstractLongList}.
      */
     public record LongListWriterFactory(String name, Supplier<AbstractLongList<?>> createInstance) {
+        @NonNull
         @Override
         public String toString() {
             return name;
@@ -708,6 +658,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
      * and longsPerChunk/capacity/reservedBufferSize encoded as a long array.
      */
     public record LongListReaderFactory(String name, BiFunction<Path, List<Long>, AbstractLongList<?>> createFromFile) {
+        @NonNull
         @Override
         public String toString() {
             return name;
@@ -718,22 +669,22 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
      * Factories (named suppliers) for creating different {@link AbstractLongList} implementations
      * with test configuration.
      */
-    static LongListWriterFactory heapWriterFactory = new LongListWriterFactory(
+    static final LongListWriterFactory heapWriterFactory = new LongListWriterFactory(
             LongListHeap.class.getSimpleName(), () -> new LongListHeap(NUM_LONGS_PER_CHUNK, MAX_LONGS, 0));
 
-    static LongListWriterFactory offHeapWriterFactory = new LongListWriterFactory(
+    static final LongListWriterFactory offHeapWriterFactory = new LongListWriterFactory(
             LongListOffHeap.class.getSimpleName(), () -> new LongListOffHeap(NUM_LONGS_PER_CHUNK, MAX_LONGS, 0));
-    static LongListWriterFactory diskWriterFactory = new LongListWriterFactory(
+    static final LongListWriterFactory diskWriterFactory = new LongListWriterFactory(
             LongListDisk.class.getSimpleName(),
             () -> new LongListDisk(NUM_LONGS_PER_CHUNK, MAX_LONGS, 0, CONFIGURATION, fileSystemManager));
-    static LongListWriterFactory segmentWriterFactory = new LongListWriterFactory(
+    static final LongListWriterFactory segmentWriterFactory = new LongListWriterFactory(
             LongListSegment.class.getSimpleName(), () -> new LongListSegment(NUM_LONGS_PER_CHUNK, MAX_LONGS, 0));
 
     /**
      * Factories (named BiFunctions) for reconstructing different {@link AbstractLongList}
      * implementations from files.
      */
-    static LongListReaderFactory heapReaderFactory =
+    static final LongListReaderFactory heapReaderFactory =
             new LongListReaderFactory(LongListHeap.class.getSimpleName(), (file, a) -> {
                 try {
                     return new LongListHeap(file, (int) a.get(0).longValue(), a.get(1), a.get(2), CONFIGURATION);
@@ -742,7 +693,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 }
             });
 
-    static LongListReaderFactory offHeapReaderFactory =
+    static final LongListReaderFactory offHeapReaderFactory =
             new LongListReaderFactory(LongListOffHeap.class.getSimpleName(), (file, a) -> {
                 try {
                     return new LongListOffHeap(file, (int) a.get(0).longValue(), a.get(1), a.get(2), CONFIGURATION);
@@ -750,7 +701,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                     throw new RuntimeException(e);
                 }
             });
-    static LongListReaderFactory diskReaderFactory =
+    static final LongListReaderFactory diskReaderFactory =
             new LongListReaderFactory(LongListDisk.class.getSimpleName(), (file, a) -> {
                 try {
                     return new LongListDisk(
@@ -759,7 +710,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                     throw new RuntimeException(e);
                 }
             });
-    static LongListReaderFactory segmentReaderFactory =
+    static final LongListReaderFactory segmentReaderFactory =
             new LongListReaderFactory(LongListSegment.class.getSimpleName(), (file, a) -> {
                 try {
                     return new LongListSegment(file, (int) a.get(0).longValue(), a.get(1), a.get(2), CONFIGURATION);
@@ -809,8 +760,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 // Validate the reconstructed list's attributes
                 assertEquals(writerList.capacity(), readerList.capacity(), "Capacity mismatch in reconstructed list.");
                 assertEquals(writerList.size(), readerList.size(), "Size mismatch in reconstructed list.");
-            } finally {
-                Files.delete(longListFile);
             }
         }
     }
@@ -842,8 +791,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 assertEquals(0, readerList.size(), "An empty list should have size 0");
                 assertEquals(-1, readerList.getMinValidIndex(), "For an empty list, minValidIndex should be -1");
                 assertEquals(-1, readerList.getMaxValidIndex(), "For an empty list, maxValidIndex should be -1");
-            } finally {
-                Files.delete(longListFile);
             }
         }
     }
@@ -877,11 +824,8 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
 
                 // Verify that writing the read list to a new file doesn't cause exceptions
                 assertDoesNotThrow(() -> {
-                    final Path longListFile2 = writeLongListToFileAndVerify(readerList, TEMP_FILE_NAME_2, tempDir);
-                    Files.delete(longListFile2);
+                    writeLongListToFileAndVerify(readerList, TEMP_FILE_NAME_2, tempDir);
                 });
-            } finally {
-                Files.delete(longListFile);
             }
         }
     }
@@ -915,9 +859,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                     .apply(longListFile, List.of(1024L * 1024, Integer.MAX_VALUE + 100L, 256L * 1024))) {
                 // Validate that the large index is correctly reconstructed
                 assertEquals(1, readerList.get(bigIndex), "Value mismatch for the large index after reconstruction.");
-            } finally {
-                // Clean up the temporary file
-                Files.delete(longListFile);
             }
         }
     }
@@ -966,9 +907,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                             readerList.get(i),
                             "Mismatch in data for index " + i + " between writer and reader lists.");
                 }
-            } finally {
-                // Clean up the temporary file
-                Files.delete(longListFile);
             }
         }
     }
@@ -1017,9 +955,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                             readerList.get(i),
                             "Mismatch in data for index " + i + " between writer and reader lists.");
                 }
-            } finally {
-                // Clean up the temporary file
-                Files.delete(longListFile);
             }
         }
     }
@@ -1138,7 +1073,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
             checkData(writerList);
 
             // Update the minimum valid index to exclude the lower half of the list
-            //noinspection UnnecessaryLocalVariable
             int newMinValidIndex = HALF_SAMPLE_SIZE;
             writerList.updateValidRange(newMinValidIndex, MAX_VALID_INDEX);
 
@@ -1207,9 +1141,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                     // Validate the refilled list
                     checkData(zeroMinValidIndexList);
                 }
-            } finally {
-                // Clean up temporary files
-                Files.deleteIfExists(longListFile);
             }
         }
     }
@@ -1276,9 +1207,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 for (int i = startIndex; i <= endIndex; i++) {
                     assertEquals(i + 100, readerList.get(i), "Mismatch in value for index " + i);
                 }
-            } finally {
-                // Clean up the temporary file
-                Files.deleteIfExists(longListFile);
             }
         }
     }
@@ -1344,9 +1272,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                             readerList.get(i),
                             "Unexpected value in a loaded readerList, index=" + i);
                 }
-            } finally {
-                // Clean up the temporary file after the test
-                Files.deleteIfExists(longListFile);
             }
         }
     }
@@ -1389,9 +1314,6 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                             readerList.get(i),
                             "Unexpected value in a loaded readerList, index=" + i);
                 }
-            } finally {
-                // Clean up the temporary file after the test
-                Files.deleteIfExists(longListFile);
             }
         }
     }
@@ -1474,10 +1396,7 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
             throws IOException {
         final Path file = tempDir.resolve(fileName);
 
-        if (Files.exists(file)) {
-            Files.delete(file);
-        }
-
+        Files.deleteIfExists(file);
         longList.writeToFile(file);
 
         assertTrue(

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/HashListByteBufferTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/HashListByteBufferTest.java
@@ -12,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.base.units.UnitConstants;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.SimpleConfigSource;
@@ -76,12 +75,7 @@ class HashListByteBufferTest {
     @AfterEach
     void checkDirectMemoryForLeeks() {
         // check all memory is freed after DB is closed
-        assertTrue(
-                checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart),
-                "Direct Memory used is more than base usage even after 20 gc() calls. At start was "
-                        + (directMemoryUsedAtStart * UnitConstants.BYTES_TO_MEBIBYTES) + "MB and is now "
-                        + (getDirectMemoryUsedBytes() * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB");
+        checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart);
     }
 
     // ------------------------------------------------------
@@ -104,7 +98,7 @@ class HashListByteBufferTest {
     void createInstanceWithNegativeCapacityThrows(final boolean offHeap) {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> createHashList(10, -1, offHeap),
+                () -> createHashList(10, -1, offHeap).close(),
                 "Negative max hashes shouldn't be allowed");
     }
 
@@ -112,7 +106,8 @@ class HashListByteBufferTest {
     @ValueSource(booleans = {true, false})
     @DisplayName("Creating an instance with a zero for capacity is fine")
     void createInstanceWithZeroCapacityIsOk(final boolean offHeap) {
-        assertDoesNotThrow(() -> createHashList(10, 0, offHeap), "Should be legal to create a permanently empty list");
+        assertDoesNotThrow(
+                () -> createHashList(10, 0, offHeap).close(), "Should be legal to create a permanently empty list");
     }
 
     // ------------------------------------------------------
@@ -122,7 +117,7 @@ class HashListByteBufferTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Check for out of bounds conditions on get")
-    void badIndexOnGetThrows(final boolean offHeap) throws Exception {
+    void badIndexOnGetThrows(final boolean offHeap) {
         try (final HashList hashList = createHashList(10, 100, offHeap)) {
             // Negative is no good
             assertThrows(IndexOutOfBoundsException.class, () -> hashList.get(-1), "Negative indices should be illegal");
@@ -157,7 +152,7 @@ class HashListByteBufferTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @DisplayName("Check for out of bounds conditions on put")
-    void badIndexOnPutThrows(final boolean offHeap) throws IOException {
+    void badIndexOnPutThrows(final boolean offHeap) {
         try (final HashList hashList = createHashList(10, 1000, offHeap)) {
             final Hash hash = hash(123);
             // Negative is no good
@@ -233,7 +228,7 @@ class HashListByteBufferTest {
     @ParameterizedTest
     @MethodSource("provideLargeHashLists")
     @DisplayName("Randomly set hashes across the entire hash list space from multiple threads with no collisions")
-    void putRandomlyAcrossAll(final HashList hashList) throws IOException {
+    void putRandomlyAcrossAll(final HashList hashList) {
         // Write from multiple threads concurrently, but not to the same indexes
         IntStream.range(0, LARGE_MAX_HASHES).parallel().forEach(index -> {
             final Hash hash = hash(index);
@@ -383,8 +378,10 @@ class HashListByteBufferTest {
             assertEquals(hashCount, hashList.size(), "Unexpected size: " + hashList.size());
             hashList.writeToFile(file);
             assertTrue(Files.exists(file));
-            assertThrows(IllegalArgumentException.class, () -> createHashList(file, 10, hashCount + 1, true));
-            assertThrows(IllegalArgumentException.class, () -> createHashList(file, 10, hashCount - 1, true));
+            assertThrows(IllegalArgumentException.class, () -> createHashList(file, 10, hashCount + 1, true)
+                    .close());
+            assertThrows(IllegalArgumentException.class, () -> createHashList(file, 10, hashCount - 1, true)
+                    .close());
         }
     }
 
@@ -445,7 +442,8 @@ class HashListByteBufferTest {
     void restoreFromV1CapacityNotEnough() throws Exception {
         // v1 hash list: buffer size = 48 hashes, max hashes = 1024, num hashes = 800
         final Path file = ResourceLoader.getFile("test_data/HashList_48_1024_800_v1.hl");
-        assertThrows(IllegalArgumentException.class, () -> createHashList(file, 48, 799, true));
+        assertThrows(IllegalArgumentException.class, () -> createHashList(file, 48, 799, true)
+                .close());
     }
 
     @Test
@@ -475,8 +473,6 @@ class HashListByteBufferTest {
                     assertEquals(hash(i), hashList2.get(i), "Unexpected value for hashList2.get(" + i + ")");
                 }
             }
-            // delete file as we are done with it
-            Files.delete(file);
         }
     }
 

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArrayTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/ImmutableIndexedObjectListUsingArrayTest.java
@@ -188,15 +188,5 @@ class ImmutableIndexedObjectListUsingArrayTest {
     }
 
     /** Testing implementation of IndexedObject */
-    static class TestIndexedObject implements IndexedObject {
-        public final int index;
-
-        public TestIndexedObject(int index) {
-            this.index = index;
-        }
-
-        public int getIndex() {
-            return index;
-        }
-    }
+    record TestIndexedObject(int getIndex) implements IndexedObject {}
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/LongListAdHocTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/LongListAdHocTest.java
@@ -8,15 +8,11 @@ import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
-import org.junit.jupiter.api.BeforeAll;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -26,39 +22,32 @@ import org.junit.jupiter.params.provider.MethodSource;
  * {@link AbstractLongListTest}, but still warrant individual coverage for bug fixes or
  * concurrency concerns.
  */
-class LongListAdHocTest {
-
-    @TempDir
-    static Path tempDir;
-
-    private static FileSystemManager fileSystemManager;
-
-    @BeforeAll
-    static void setup() {
-        fileSystemManager = new TestFileSystemManager(tempDir);
-    }
+class LongListAdHocTest extends AbstractFileManagerAwareTest {
 
     @ParameterizedTest
     @MethodSource("provideLongLists")
     void test4089(final AbstractLongList<?> list) {
-        list.updateValidRange(0, list.capacity() - 1);
-        // Issue #4089: ArrayIndexOutOfBoundsException from VirtualMap.put()
-        final long maxLongs = list.capacity();
-        final int defaultValue = -1;
-        final AtomicBoolean done = new AtomicBoolean();
+        try (list) {
+            list.updateValidRange(0, list.capacity() - 1);
+            // Issue #4089: ArrayIndexOutOfBoundsException from VirtualMap.put()
+            final long maxLongs = list.capacity();
+            final int defaultValue = -1;
+            final AtomicBoolean done = new AtomicBoolean();
 
-        IntStream.range(0, 2).parallel().forEach(thread -> {
-            if (thread == 0) {
-                // Getter
-                while (!done.get()) {
-                    assertEquals(defaultValue, list.get(maxLongs - 2, defaultValue), "Value should be whats expected.");
+            IntStream.range(0, 2).parallel().forEach(thread -> {
+                if (thread == 0) {
+                    // Getter
+                    while (!done.get()) {
+                        assertEquals(
+                                defaultValue, list.get(maxLongs - 2, defaultValue), "Value should be whats expected.");
+                    }
+                } else {
+                    // Putter
+                    list.put(maxLongs - 1, 1);
+                    done.set(true);
                 }
-            } else {
-                // Putter
-                list.put(maxLongs - 1, 1);
-                done.set(true);
-            }
-        });
+            });
+        }
     }
 
     static Stream<LongList> provideLongLists() {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/LongListDiskConcurrentChunkRecyclingTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/LongListDiskConcurrentChunkRecyclingTest.java
@@ -3,9 +3,9 @@ package com.swirlds.merkledb.collections;
 
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CyclicBarrier;
@@ -17,14 +17,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Tests that verify {@link LongListDisk} correctly handles concurrent reads
@@ -44,7 +41,7 @@ import org.junit.jupiter.api.io.TempDir;
  * because a reader can grab a chunk file-offset that is freed and reused for
  * a different index range between the offset lookup and the file read.
  */
-class LongListDiskConcurrentChunkRecyclingTest {
+class LongListDiskConcurrentChunkRecyclingTest extends AbstractFileManagerAwareTest {
 
     /**
      * Small chunk size to maximize the number of chunk boundaries and therefore
@@ -72,16 +69,6 @@ class LongListDiskConcurrentChunkRecyclingTest {
 
     /** Number of concurrent reader threads. */
     private static final int READER_THREADS = 4;
-
-    @TempDir
-    static Path tempDir;
-
-    private static FileSystemManager fileSystemManager;
-
-    @BeforeAll
-    static void setupFileSystemManager() {
-        fileSystemManager = new TestFileSystemManager(tempDir);
-    }
 
     private LongListDisk list;
 
@@ -163,9 +150,8 @@ class LongListDiskConcurrentChunkRecyclingTest {
         list.updateValidRange(newMin, CAPACITY - 1);
 
         // Write into indices beyond the initial range — these should reuse freed chunk offsets
-        final int extendedStart = initialCount;
         final int extendedEnd = initialCount + LONGS_PER_CHUNK * 3;
-        for (int i = extendedStart; i < extendedEnd; i++) {
+        for (int i = initialCount; i < extendedEnd; i++) {
             list.put(i, i + VALUE_MAGIC);
         }
 
@@ -174,7 +160,7 @@ class LongListDiskConcurrentChunkRecyclingTest {
             assertEquals(i + VALUE_MAGIC, list.get(i, 0), "Surviving index " + i + " should retain its value");
         }
         // Verify new values in recycled chunks
-        for (int i = extendedStart; i < extendedEnd; i++) {
+        for (int i = initialCount; i < extendedEnd; i++) {
             assertEquals(
                     i + VALUE_MAGIC,
                     list.get(i, 0),
@@ -527,12 +513,12 @@ class LongListDiskConcurrentChunkRecyclingTest {
 
         // Wrong expected → no change
         boolean changed = list.putIfEqual(42, 999, 200);
-        assertEquals(false, changed);
+        assertFalse(changed);
         assertEquals(100, list.get(42, 0));
 
         // Correct expected → swap
         changed = list.putIfEqual(42, 100, 200);
-        assertEquals(true, changed);
+        assertTrue(changed);
         assertEquals(200, list.get(42, 0));
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/LongListValidRangeTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/LongListValidRangeTest.java
@@ -12,39 +12,35 @@ import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
-import java.nio.file.Path;
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class LongListValidRangeTest {
+class LongListValidRangeTest extends AbstractFileManagerAwareTest {
 
     public static final int MAX_LONGS = 1000;
 
-    @TempDir
-    static Path tempDir;
-
-    private static FileSystemManager fileSystemManager;
-
-    @BeforeAll
-    static void setupFileSystemManager() {
-        fileSystemManager = new TestFileSystemManager(tempDir);
-    }
-
     private AbstractLongList<?> list;
+
+    @AfterEach
+    public void cleanUp() {
+        if (list != null) {
+            list.close();
+            if (list instanceof LongListDisk) {
+                ((LongListDisk) list).resetTransferBuffer();
+            }
+        }
+    }
 
     @Tag(TestComponentTags.VMAP)
     @ParameterizedTest
@@ -785,15 +781,5 @@ class LongListValidRangeTest {
 
     private long maxValidIndex() {
         return list.getMaxValidIndex();
-    }
-
-    @AfterEach
-    public void cleanUp() {
-        if (list != null) {
-            list.close();
-            if (list instanceof LongListDisk) {
-                ((LongListDisk) list).resetTransferBuffer();
-            }
-        }
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
@@ -8,7 +8,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.test.fixtures.ExampleFixedValue;
 import com.swirlds.merkledb.test.fixtures.ExampleLongKey;
-import com.swirlds.merkledb.test.fixtures.TestType;
+import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.VirtualMap;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
@@ -30,12 +30,11 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 /**
  * This is a regression test for swirlds/swirlds-platform/issues/6151, but
@@ -45,17 +44,11 @@ import org.junit.jupiter.api.io.TempDir;
  * disk. Right after a flush is started, the last map is released, which triggers virtual
  * pipeline shutdown. The test then makes sure the flush completes without exceptions.
  */
-public class CloseFlushTest {
-
-    @TempDir
-    static Path tempDir;
-
-    private static FileSystemManager fileSystemManager;
+public class CloseFlushTest extends AbstractFileManagerAwareTest {
 
     @BeforeAll
-    public static void setup() throws IOException {
+    public static void setup() {
         Configurator.setRootLevel(Level.WARN);
-        fileSystemManager = new TestFileSystemManager(tempDir);
     }
 
     @AfterAll
@@ -71,10 +64,8 @@ public class CloseFlushTest {
         final Path tmpFileDir = fileSystemManager.resolveNewTemp();
         Files.createDirectories(tmpFileDir);
         for (int j = 0; j < 100; j++) {
-            final Path storeDir = tmpFileDir.resolve("closeFlushTest-" + j);
-            final VirtualDataSource dataSource = TestType.long_fixed
-                    .dataType()
-                    .createDataSource(CONFIGURATION, fileSystemManager, storeDir, "closeFlushTest", count, false, true);
+            final VirtualDataSource dataSource = MerkleDbTestUtils.createDataSource(
+                    CONFIGURATION, fileSystemManager, "closeFlushTest", count, false, true);
             // Create a custom data source builder, which creates a custom data source to capture
             // all exceptions happened in saveRecords()
             final VirtualDataSourceBuilder builder =
@@ -118,13 +109,8 @@ public class CloseFlushTest {
 
     public static class CustomDataSourceBuilder extends MerkleDbDataSourceBuilder {
 
-        private VirtualDataSource delegate = null;
-        private AtomicReference<Exception> exceptionSink = null;
-
-        // Provided for deserialization
-        public CustomDataSourceBuilder() {
-            super(CONFIGURATION, fileSystemManager);
-        }
+        private final VirtualDataSource delegate;
+        private final AtomicReference<Exception> exceptionSink;
 
         public CustomDataSourceBuilder(
                 final VirtualDataSource delegate,

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@SuppressWarnings("unused")
 class DataFileCollectionCompactionTest {
 
     // Would be nice to add a test to make sure files get deleted

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
-import com.swirlds.base.units.UnitConstants;
 import com.swirlds.logging.test.fixtures.MockAppender;
 import com.swirlds.merkledb.KeyRange;
 import com.swirlds.merkledb.collections.CASableLongIndex;
@@ -62,14 +61,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mockito;
 
-@SuppressWarnings("SameParameterValue")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DataFileCollectionTest {
 
     private static final MerkleDbConfig MERKLE_DB_CONFIG = CONFIGURATION.getConfigData(MerkleDbConfig.class);
 
     /** Temporary directory provided by JUnit */
-    @SuppressWarnings("unused")
     @TempDir
     static Path tempFileDir;
 
@@ -131,16 +128,11 @@ class DataFileCollectionTest {
             }
             // put in 1000 items
             for (int i = count; i < count + 100; i++) {
-                long[] dataValue;
-                switch (testType) {
-                    default:
-                    case fixed:
-                        dataValue = new long[] {i, i + 10_000};
-                        break;
-                    case variable:
-                        dataValue = getVariableSizeDataForI(i, 10_000);
-                        break;
-                }
+                long[] dataValue =
+                        switch (testType) {
+                            case variable -> getVariableSizeDataForI(i, 10_000);
+                            default -> new long[] {i, i + 10_000};
+                        };
                 // store in file
                 storedOffsets.put(i, storeDataItem(fileCollection, dataValue));
             }
@@ -449,16 +441,11 @@ class DataFileCollectionTest {
         fileCollection.startWriting();
         // put in 1000 items
         for (int i = 0; i < 50; i++) {
-            long[] dataValue;
-            switch (testType) {
-                default:
-                case fixed:
-                    dataValue = new long[] {i, i + 100_000};
-                    break;
-                case variable:
-                    dataValue = getVariableSizeDataForI(i, 100_000);
-                    break;
-            }
+            long[] dataValue =
+                    switch (testType) {
+                        case variable -> getVariableSizeDataForI(i, 100_000);
+                        default -> new long[] {i, i + 100_000};
+                    };
             // store in file
             storedOffsets.put(i, storeDataItem(fileCollection, dataValue));
         }
@@ -680,16 +667,11 @@ class DataFileCollectionTest {
             fileCollection.startWriting();
             // put in 1000 items
             for (int i = count; i < count + 100; i++) {
-                long[] dataValue;
-                switch (testType) {
-                    default:
-                    case fixed:
-                        dataValue = new long[] {i, i + 10_000};
-                        break;
-                    case variable:
-                        dataValue = getVariableSizeDataForI(i, 10_000);
-                        break;
-                }
+                long[] dataValue =
+                        switch (testType) {
+                            case variable -> getVariableSizeDataForI(i, 10_000);
+                            default -> new long[] {i, i + 10_000};
+                        };
                 // store in file
                 storedOffsets.put(i, storeDataItem(fileCollection, dataValue));
             }
@@ -775,13 +757,7 @@ class DataFileCollectionTest {
     @AfterEach
     void checkDirectMemoryUsage() {
         // check all memory is freed after DB is closed
-        assertTrue(
-                checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart),
-                "Direct Memory used is more than base usage even after 20 gc() calls. At start was "
-                        + (directMemoryUsedAtStart * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB and is now "
-                        + (getDirectMemoryUsedBytes() * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB");
+        checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart);
     }
 
     private static class LoadedDataCallbackImpl implements DataFileCollection.LoadedDataCallback {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCompactorSingleLevelTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCompactorSingleLevelTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkledb.files;
 
-import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,7 +8,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.swirlds.merkledb.collections.CASableLongIndex;
-import com.swirlds.merkledb.config.MerkleDbConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -21,17 +19,15 @@ import org.junit.jupiter.api.Test;
 class DataFileCompactorSingleLevelTest {
 
     private DataFileCollection dataFileCollection;
-    private CASableLongIndex index;
     private TestDataFileCompactor compactor;
 
     @BeforeEach
     void setUp() {
         dataFileCollection = mock(DataFileCollection.class);
-        index = mock(CASableLongIndex.class);
+        CASableLongIndex index = mock(CASableLongIndex.class);
         when(dataFileCollection.getAllCompletedFiles()).thenReturn(List.of());
 
-        final MerkleDbConfig config = CONFIGURATION.getConfigData(MerkleDbConfig.class);
-        compactor = new TestDataFileCompactor(config, dataFileCollection, index);
+        compactor = new TestDataFileCompactor(dataFileCollection, index);
     }
 
     @Test
@@ -89,10 +85,7 @@ class DataFileCompactorSingleLevelTest {
         private List<DataFileReader> capturedFiles = List.of();
         private int capturedTargetLevel = -1;
 
-        private TestDataFileCompactor(
-                final MerkleDbConfig config,
-                final DataFileCollection dataFileCollection,
-                final CASableLongIndex index) {
+        private TestDataFileCompactor(final DataFileCollection dataFileCollection, final CASableLongIndex index) {
             super(dataFileCollection, index, null, null, null, null);
         }
 

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileLowLevelTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileLowLevelTest.java
@@ -31,12 +31,10 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-@SuppressWarnings("SameParameterValue")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DataFileLowLevelTest {
 
     /** Temporary directory provided by JUnit */
-    @SuppressWarnings("unused")
     @TempDir
     static Path tempFileDir;
 
@@ -125,16 +123,11 @@ class DataFileLowLevelTest {
                 "test_" + testType.name(), tempFileDir, DATA_FILE_INDEX, TEST_START, INITIAL_COMPACTION_LEVEL);
         LongArrayList listOfDataItemLocations = new LongArrayList(ITEMS_SIZE);
         for (int i = 0; i < ITEMS_SIZE; i++) {
-            long[] dataValue;
-            switch (testType) {
-                default:
-                case fixed:
-                    dataValue = new long[] {i, i + 10_000};
-                    break;
-                case variable:
-                    dataValue = getVariableSizeDataForI(i);
-                    break;
-            }
+            long[] dataValue =
+                    switch (testType) {
+                        case variable -> getVariableSizeDataForI(i);
+                        default -> new long[] {i, i + 10_000};
+                    };
 
             listOfDataItemLocations.add(storeDataItem(writer, dataValue));
         }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileReaderCloseTest.java
@@ -11,15 +11,12 @@ import com.swirlds.merkledb.collections.LongListSegment;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import java.io.IOException;
 import java.nio.channels.ClosedByInterruptException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,23 +25,16 @@ import org.junit.jupiter.api.io.TempDir;
 
 class DataFileReaderCloseTest {
 
-    @TempDir
-    static Path tempDir;
-
-    private static FileSystemManager fileSystemManager;
     private static DataFileCollection collection;
 
     @BeforeAll
-    static void setup() throws IOException {
-        fileSystemManager = new TestFileSystemManager(tempDir);
-        final Path dir = fileSystemManager.resolveNewTemp("readerIsOpenTest");
-        Files.createDirectories(dir);
+    static void setup(@TempDir Path tempDir) throws IOException {
         final MerkleDbConfig dbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
-        collection = new DataFileCollection(dbConfig, dir, "store", null);
+        collection = new DataFileCollection(dbConfig, tempDir, "store", null);
     }
 
     @AfterAll
-    static void teardown() throws IOException {
+    static void tearDown() throws IOException {
         collection.close();
     }
 
@@ -66,7 +56,6 @@ class DataFileReaderCloseTest {
                                 },
                                 2 * Long.BYTES));
             }
-            //noinspection resource
             collection.endWriting();
             final AtomicBoolean readingThreadStarted = new AtomicBoolean(false);
             final AtomicReference<IOException> exceptionOccurred = new AtomicReference<>();
@@ -107,49 +96,40 @@ class DataFileReaderCloseTest {
     }
 
     @Test
-    void readWhileFinishWritingTest() throws IOException {
-        final Path tmpDir = fileSystemManager.resolveNewTemp("readWhileFinishWritingTest");
-        Files.createDirectories(tmpDir);
+    void readWhileFinishWritingTest(@TempDir Path testDir) throws IOException {
         final MerkleDbConfig dbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
         final int COUNT = 100;
         for (int i = 0; i < COUNT; i++) {
-            Path filePath = null;
             final int fi = i;
-            try {
-                final DataFileWriter writer =
-                        new DataFileWriter("test", tmpDir, i, Instant.now(), INITIAL_COMPACTION_LEVEL);
-                filePath = writer.getPath();
-                final DataFileMetadata metadata = writer.getMetadata();
-                final LongList index = new LongListOffHeap(COUNT / 10, COUNT, COUNT / 10);
-                index.updateValidRange(0, i);
-                index.put(
-                        0,
-                        writer.storeDataItem(
-                                o -> {
-                                    o.writeLong(fi);
-                                    o.writeLong(fi * 2 + 1);
-                                },
-                                2 * Long.BYTES));
-                final DataFileReader reader = new DataFileReader(dbConfig, filePath, metadata);
-                // Check the item in parallel to finish writing
-                IntStream.of(0, 1).parallel().forEach(t -> {
-                    try {
-                        if (t == 1) {
-                            writer.close();
-                        } else {
-                            final BufferedData itemBytes = reader.readDataItem(index.get(0));
-                            Assertions.assertEquals(fi, itemBytes.readLong());
-                            Assertions.assertEquals(fi * 2 + 1, itemBytes.readLong());
-                        }
-                    } catch (final IOException e) {
-                        throw new RuntimeException(e);
+            final DataFileWriter writer =
+                    new DataFileWriter("test", testDir, i, Instant.now(), INITIAL_COMPACTION_LEVEL);
+            Path filePath = writer.getPath();
+            final DataFileMetadata metadata = writer.getMetadata();
+            final LongList index = new LongListOffHeap(COUNT / 10, COUNT, COUNT / 10);
+            index.updateValidRange(0, i);
+            index.put(
+                    0,
+                    writer.storeDataItem(
+                            o -> {
+                                o.writeLong(fi);
+                                o.writeLong(fi * 2 + 1);
+                            },
+                            2 * Long.BYTES));
+            final DataFileReader reader = new DataFileReader(dbConfig, filePath, metadata);
+            // Check the item in parallel to finish writing
+            IntStream.of(0, 1).parallel().forEach(t -> {
+                try {
+                    if (t == 1) {
+                        writer.close();
+                    } else {
+                        final BufferedData itemBytes = reader.readDataItem(index.get(0));
+                        Assertions.assertEquals(fi, itemBytes.readLong());
+                        Assertions.assertEquals(fi * 2 + 1, itemBytes.readLong());
                     }
-                });
-            } finally {
-                if (filePath != null) {
-                    Files.delete(filePath);
+                } catch (final IOException e) {
+                    throw new RuntimeException(e);
                 }
-            }
+            });
         }
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileReaderTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileReaderTest.java
@@ -5,12 +5,14 @@ import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.swirlds.merkledb.config.MerkleDbConfig;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class DataFileReaderTest {
 
@@ -18,19 +20,17 @@ class DataFileReaderTest {
 
     private final DataFileMetadata dataFileMetadata = new DataFileMetadata(0, Instant.now(), 0, 0);
 
-    private File file;
     private DataFileReader dataFileReader;
 
     @BeforeEach
-    void setUp() throws IOException {
-        file = File.createTempFile("file-reader", "test");
-        dataFileReader = new DataFileReader(dbConfig, file.toPath(), dataFileMetadata);
+    void setUp(@TempDir Path tmpDir) throws IOException {
+        Path readerFile = Files.createFile(tmpDir.resolve("file-reader"));
+        dataFileReader = new DataFileReader(dbConfig, readerFile, dataFileMetadata);
     }
 
     @AfterEach
     public void tearDown() throws IOException {
         dataFileReader.close();
-        file.deleteOnExit();
     }
 
     @Test

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileWriterTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileWriterTest.java
@@ -22,9 +22,11 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -36,10 +38,14 @@ class DataFileWriterTest {
     private Path dataFilePath;
 
     @BeforeEach
-    public void setUp() throws Exception {
-        final Path dataFileDir = Files.createTempDirectory("dataFileWriterTest");
-        dataFileWriter = new DataFileWriter("test", dataFileDir, 1, Instant.now(), 1, BUFFER_SIZE, BUFFER_SIZE * 16384);
+    void setUp(@TempDir Path tempDir) throws Exception {
+        dataFileWriter = new DataFileWriter("test", tempDir, 1, Instant.now(), 1, BUFFER_SIZE, BUFFER_SIZE * 16384);
         dataFilePath = dataFileWriter.getPath();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        dataFileWriter.close();
     }
 
     @Test

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/MemoryIndexDiskKeyValueStoreTest.java
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkledb.files;
 
-import static com.swirlds.merkledb.files.DataFileCommon.deleteDirectoryAndContents;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
-import com.swirlds.base.units.UnitConstants;
 import com.swirlds.merkledb.collections.LongListOffHeap;
 import com.swirlds.merkledb.collections.LongListSegment;
 import com.swirlds.merkledb.config.MerkleDbConfig;
@@ -33,7 +31,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 class MemoryIndexDiskKeyValueStoreTest {
 
     /** Temporary directory provided by JUnit */
-    @SuppressWarnings("unused")
     @TempDir
     Path testDirectory;
 
@@ -127,8 +124,8 @@ class MemoryIndexDiskKeyValueStoreTest {
             store.put(
                     i,
                     o -> {
-                        for (int k = 0; k < dataValue.length; k++) {
-                            o.writeLong(dataValue[k]);
+                        for (long l : dataValue) {
+                            o.writeLong(l);
                         }
                     },
                     dataValue.length * Long.BYTES);
@@ -157,13 +154,7 @@ class MemoryIndexDiskKeyValueStoreTest {
         future.get(10, TimeUnit.MINUTES);
         executorService.shutdown();
         // check all memory is freed after DB is closed
-        assertTrue(
-                checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart),
-                "Direct Memory used is more than base usage even after 20 gc() calls. At start was "
-                        + (directMemoryUsedAtStart * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB and is now "
-                        + (getDirectMemoryUsedBytes() * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB");
+        checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart);
     }
 
     void createDataAndCheckImpl(final FilesTestType testType) throws Exception {
@@ -289,7 +280,5 @@ class MemoryIndexDiskKeyValueStoreTest {
         // clean up and delete files
         store.close();
         index.close();
-        deleteDirectoryAndContents(tempDir);
-        deleteDirectoryAndContents(tempSnapshotDir);
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/BucketTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/BucketTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-@SuppressWarnings({"RedundantCast", "unchecked", "rawtypes"})
 class BucketTest {
 
     private enum KeyType {
@@ -36,26 +35,27 @@ class BucketTest {
         }
     }
 
-    @ParameterizedTest
-    @EnumSource(KeyType.class)
-    void canSetAndGetBucketIndex(KeyType keyType) {
-        final Bucket subject = new Bucket();
-        final int pretendIndex = 123;
-        subject.setBucketIndex(pretendIndex);
-        assertEquals(pretendIndex, subject.getBucketIndex(), "Should be able to get the set index");
+    @Test
+    void canSetAndGetBucketIndex() throws IOException {
+        try (Bucket subject = new Bucket()) {
+            final int pretendIndex = 123;
+            subject.setBucketIndex(pretendIndex);
+            assertEquals(pretendIndex, subject.getBucketIndex(), "Should be able to get the set index");
+        }
     }
 
     @ParameterizedTest
     @EnumSource(KeyType.class)
     void returnsNotFoundValueFromEmptyBucket(KeyType keyType) throws IOException {
-        final Bucket subject = new Bucket();
-        final long notFoundValue = 123;
-        final Bytes missingKey = keyType.keyConstructor.apply(321L);
+        try (Bucket subject = new Bucket()) {
+            final long notFoundValue = 123;
+            final Bytes missingKey = keyType.keyConstructor.apply(321L);
 
-        assertEquals(
-                notFoundValue,
-                subject.findValue(missingKey.hashCode(), missingKey, notFoundValue),
-                "Should not find a value in an empty bucket");
+            assertEquals(
+                    notFoundValue,
+                    subject.findValue(missingKey.hashCode(), missingKey, notFoundValue),
+                    "Should not find a value in an empty bucket");
+        }
     }
 
     @ParameterizedTest
@@ -179,94 +179,107 @@ class BucketTest {
         for (int i = 0; i < testKeys.length; i++) {
             testKeys[i] = keyType.keyConstructor.apply((long) (i + 10));
         }
-        // create a bucket
-        final Bucket bucket = new Bucket();
-        assertEquals(0, bucket.getBucketEntryCount(), "Check we start with empty bucket");
-        // insert keys and check
-        for (int i = 0; i < testKeys.length; i++) {
-            final Bytes key = testKeys[i];
-            bucket.putValue(key, key.hashCode(), keyType.getKeyAsLong(key) + 100);
-            assertEquals(i + 1, bucket.getBucketEntryCount(), "Check we have correct count");
-            // check that all keys added so far are there
-            for (int j = 0; j <= i; j++) {
-                checkKey(keyType, bucket, testKeys[j]);
+
+        try (final Bucket bucket = new Bucket()) {
+            assertEquals(0, bucket.getBucketEntryCount(), "Check we start with empty bucket");
+            // insert keys and check
+            for (int i = 0; i < testKeys.length; i++) {
+                final Bytes key = testKeys[i];
+                bucket.putValue(key, key.hashCode(), keyType.getKeyAsLong(key) + 100);
+                assertEquals(i + 1, bucket.getBucketEntryCount(), "Check we have correct count");
+                // check that all keys added so far are there
+                for (int j = 0; j <= i; j++) {
+                    checkKey(keyType, bucket, testKeys[j]);
+                }
+            }
+            assertEquals(testKeys.length, bucket.getBucketEntryCount(), "Check we have correct count");
+            // get raw bytes first to compare to
+            final int size = bucket.sizeInBytes();
+            final byte[] goodBytes = new byte[size];
+            final BufferedData bucketData = BufferedData.wrap(goodBytes);
+            bucket.writeTo(bucketData);
+            final String goodBytesStr = Arrays.toString(goodBytes);
+            // now test write to buffer
+            final BufferedData bbuf = BufferedData.allocate(size);
+            bucket.writeTo(bbuf);
+            bbuf.flip();
+            assertEquals(
+                    goodBytesStr,
+                    Arrays.toString(bbuf.getBytes(0, bbuf.length()).toByteArray()),
+                    "Expect bytes to match");
+
+            // create new bucket with good bytes and check it is the same
+            try (final Bucket bucket2 = new Bucket()) {
+                bucket2.readFrom(BufferedData.wrap(goodBytes));
+                assertEquals(bucket.toString(), bucket2.toString(), "Expect bucket toStrings to match");
+            }
+
+            // test clear
+            try (final Bucket bucket3 = new Bucket()) {
+                bucket.clear();
+                assertEquals(bucket3.toString(), bucket.toString(), "Expect bucket toStrings to match");
             }
         }
-        assertEquals(testKeys.length, bucket.getBucketEntryCount(), "Check we have correct count");
-        // get raw bytes first to compare to
-        final int size = bucket.sizeInBytes();
-        final byte[] goodBytes = new byte[size];
-        final BufferedData bucketData = BufferedData.wrap(goodBytes);
-        bucket.writeTo(bucketData);
-        final String goodBytesStr = Arrays.toString(goodBytes);
-        // now test write to buffer
-        final BufferedData bbuf = BufferedData.allocate(size);
-        bucket.writeTo(bbuf);
-        bbuf.flip();
-        assertEquals(
-                goodBytesStr, Arrays.toString(bbuf.getBytes(0, bbuf.length()).toByteArray()), "Expect bytes to match");
-
-        // create new bucket with good bytes and check it is the same
-        final Bucket bucket2 = new Bucket();
-        bucket2.readFrom(BufferedData.wrap(goodBytes));
-        assertEquals(bucket.toString(), bucket2.toString(), "Expect bucket toStrings to match");
-
-        // test clear
-        final Bucket bucket3 = new Bucket();
-        bucket.clear();
-        assertEquals(bucket3.toString(), bucket.toString(), "Expect bucket toStrings to match");
     }
 
     @Test
-    void toStringAsExpectedForBucket() {
-        final Bucket bucket = new Bucket();
+    void toStringAsExpectedForBucket() throws IOException {
+        try (final Bucket bucket = new Bucket()) {
+            final String emptyBucketRepr = "Bucket{bucketIndex=0, entryCount=0, size=5}";
+            assertEquals(emptyBucketRepr, bucket.toString(), "Empty bucket should represent as expected");
 
-        final String emptyBucketRepr = "Bucket{bucketIndex=0, entryCount=0, size=5}";
-        assertEquals(emptyBucketRepr, bucket.toString(), "Empty bucket should represent as expected");
+            final String bucketWithIndex0Repr = "Bucket{bucketIndex=0, entryCount=0, size=5}";
+            bucket.setBucketIndex(0);
+            assertEquals(bucketWithIndex0Repr, bucket.toString(), "Empty bucket should represent as expected");
 
-        final String bucketWithIndex0Repr = "Bucket{bucketIndex=0, entryCount=0, size=5}";
-        bucket.setBucketIndex(0);
-        assertEquals(bucketWithIndex0Repr, bucket.toString(), "Empty bucket should represent as expected");
+            final String bucketWithIndex1Repr = "Bucket{bucketIndex=1, entryCount=0, size=5}";
+            bucket.setBucketIndex(1);
+            assertEquals(bucketWithIndex1Repr, bucket.toString(), "Empty bucket should represent as expected");
 
-        final String bucketWithIndex1Repr = "Bucket{bucketIndex=1, entryCount=0, size=5}";
-        bucket.setBucketIndex(1);
-        assertEquals(bucketWithIndex1Repr, bucket.toString(), "Empty bucket should represent as expected");
-
-        final Bytes key = ExampleLongKey.longToKey(2056);
-        bucket.putValue(key, key.hashCode(), 5124);
-        bucket.setBucketIndex(0);
-        final String nonEmptyBucketRepr = "Bucket{bucketIndex=0, entryCount=1, size=31}";
-        assertEquals(nonEmptyBucketRepr, bucket.toString(), "Non-empty bucket represent as expected");
+            final Bytes key = ExampleLongKey.longToKey(2056);
+            bucket.putValue(key, key.hashCode(), 5124);
+            bucket.setBucketIndex(0);
+            final String nonEmptyBucketRepr = "Bucket{bucketIndex=0, entryCount=1, size=31}";
+            assertEquals(nonEmptyBucketRepr, bucket.toString(), "Non-empty bucket represent as expected");
+        }
     }
 
     @ParameterizedTest
     @EnumSource(KeyType.class)
     void emptyParsedBucketToBucketIndexZero(final KeyType keyType) throws IOException {
-        final Bucket inBucket = new ParsedBucket();
+        final BufferedData buf;
         final Bytes key1 = keyType.keyConstructor.apply(1L);
         final Bytes key2 = keyType.keyConstructor.apply(2L);
-        inBucket.setBucketIndex(0);
-        inBucket.putValue(key1, key1.hashCode(), 2);
-        inBucket.putValue(key2, key2.hashCode(), 1);
-        final BufferedData buf = BufferedData.allocate(inBucket.sizeInBytes());
-        inBucket.writeTo(buf);
-        buf.reset();
-        final Bucket outBucket = new Bucket();
-        outBucket.readFrom(buf);
-        outBucket.putValue(key1, key1.hashCode(), INVALID_VALUE);
-        outBucket.putValue(key2, key2.hashCode(), INVALID_VALUE);
-        assertDoesNotThrow(outBucket::getBucketIndex);
-        assertDoesNotThrow(outBucket::getBucketEntryCount);
-        assertEquals(0, outBucket.getBucketEntryCount());
-        assertEquals(0, outBucket.getBucketIndex());
+
+        try (final Bucket inBucket = new ParsedBucket()) {
+
+            inBucket.setBucketIndex(0);
+            inBucket.putValue(key1, key1.hashCode(), 2);
+            inBucket.putValue(key2, key2.hashCode(), 1);
+            buf = BufferedData.allocate(inBucket.sizeInBytes());
+            inBucket.writeTo(buf);
+            buf.reset();
+        }
+
+        try (final Bucket outBucket = new Bucket()) {
+            outBucket.readFrom(buf);
+            outBucket.putValue(key1, key1.hashCode(), INVALID_VALUE);
+            outBucket.putValue(key2, key2.hashCode(), INVALID_VALUE);
+            assertDoesNotThrow(outBucket::getBucketIndex);
+            assertDoesNotThrow(outBucket::getBucketEntryCount);
+            assertEquals(0, outBucket.getBucketEntryCount());
+            assertEquals(0, outBucket.getBucketIndex());
+        }
     }
 
     @ParameterizedTest
     @EnumSource(KeyType.class)
-    void parsedBucketPutIfEqual(final KeyType keyType) {
+    void parsedBucketPutIfEqual(final KeyType keyType) throws IOException {
         final Bytes key1 = keyType.keyConstructor.apply(1L);
-        final Bucket bucket = new ParsedBucket();
-        assertDoesNotThrow(() -> bucket.putValue(key1, key1.hashCode(), INVALID_VALUE, 1));
+
+        try (final Bucket bucket = new ParsedBucket()) {
+            assertDoesNotThrow(() -> bucket.putValue(key1, key1.hashCode(), INVALID_VALUE, 1));
+        }
     }
 
     @Test

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
@@ -24,36 +24,26 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
-import org.junit.jupiter.api.BeforeEach;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@SuppressWarnings({"SameParameterValue"})
-class HalfDiskHashMapTest {
-
-    /** Temporary directory provided by JUnit */
-    @SuppressWarnings("unused")
-    @TempDir
-    Path tempDirPath;
-
-    private FileSystemManager fileSystemManager;
-
-    @BeforeEach
-    void setupFileSystemManager() {
-        fileSystemManager = new TestFileSystemManager(tempDirPath);
-    }
+class HalfDiskHashMapTest extends AbstractFileManagerAwareTest {
 
     // =================================================================================================================
     // Helper Methods
     private HalfDiskHashMap createNewTempMap(final String name, final long count) throws IOException {
         // create map
         HalfDiskHashMap map = new HalfDiskHashMap(
-                CONFIGURATION, fileSystemManager, count, tempDirPath.resolve(name), "HalfDiskHashMapTest", null, false);
+                CONFIGURATION,
+                fileSystemManager,
+                count,
+                fileSystemManager.resolve(name),
+                "HalfDiskHashMapTest",
+                null,
+                false);
         map.printStats();
         return map;
     }
@@ -62,7 +52,7 @@ class HalfDiskHashMapTest {
         final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
         final LongList index = new LongListHeap(count, CONFIGURATION);
         return new MemoryIndexDiskKeyValueStore(
-                merkleDbConfig, tempDirPath.resolve(name + "_kv"), "HalfDiskHashMapTestKV", null, null, index);
+                merkleDbConfig, fileSystemManager.resolve(name + "_kv"), "HalfDiskHashMapTestKV", null, null, index);
     }
 
     private static void createSomeData(
@@ -105,7 +95,7 @@ class HalfDiskHashMapTest {
     @ParameterizedTest
     @EnumSource(FilesTestType.class)
     void createDataAndCheck(FilesTestType testType) throws Exception {
-        final Path tempSnapshotDir = tempDirPath.resolve("DataFileTestSnapshot_" + testType.name());
+        final Path tempSnapshotDir = fileSystemManager.resolve("DataFileTestSnapshot_" + testType.name());
         final int count = 10_000;
         // create map
         try (HalfDiskHashMap map = createNewTempMap("createDataAndCheck", count)) {
@@ -286,7 +276,7 @@ class HalfDiskHashMapTest {
     @ParameterizedTest
     @ValueSource(longs = {100, 1000, 2000, 1_000_000, 1_000_000_000})
     void testDefaultNumOfBuckets(final long count) throws Exception {
-        try (HalfDiskHashMap map = createNewTempMap("testDefaultNumOfBuckets", count)) {
+        try (HalfDiskHashMap map = createNewTempMap("testDefaultNumOfBuckets" + count, count)) {
             assertEquals(calcExpectedNumOfBuckets(count), map.getNumOfBuckets());
         }
     }
@@ -609,11 +599,11 @@ class HalfDiskHashMapTest {
                 config,
                 fileSystemManager,
                 100,
-                tempDirPath.resolve("test"),
+                fileSystemManager.resolve("test"),
                 "testResizeRespectsBucketIndexCapacity",
                 null,
                 false);
-        try {
+        try (hdhm) {
             final LongList bucketIndex = hdhm.getBucketIndexToBucketLocation();
             // 500 / 32 / 0.7, rounded up -> 32
             assertEquals(32, bucketIndex.capacity());
@@ -633,8 +623,6 @@ class HalfDiskHashMapTest {
             // And again. This time resizeIfNeeded() should stay at 32 buckets to respect bucket index capacity
             hdhm.resizeIfNeeded(800, 1600);
             assertEquals(32, hdhm.getNumOfBuckets());
-        } finally {
-            hdhm.close();
         }
     }
 

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPoolTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPoolTest.java
@@ -5,6 +5,6 @@ final class ReusableBucketPoolTest extends ReusableBucketPoolTestBase {
 
     @Override
     protected ReusableBucketPool createPool(final int size) {
-        return new ReusableBucketPool(size, pool -> new Bucket(pool));
+        return new ReusableBucketPool(size, Bucket::new);
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPoolTestBase.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/ReusableBucketPoolTestBase.java
@@ -27,7 +27,7 @@ abstract class ReusableBucketPoolTestBase {
     }
 
     @AfterEach
-    void resore() {
+    void restore() {
         Assertions.assertNull(error.get(), () -> {
             final StringWriter sw = new StringWriter();
             error.get().printStackTrace(new PrintWriter(sw));

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/ReusableParsedBucketPoolTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/ReusableParsedBucketPoolTest.java
@@ -5,6 +5,6 @@ final class ReusableParsedBucketPoolTest extends ReusableBucketPoolTestBase {
 
     @Override
     protected ReusableBucketPool createPool(final int size) {
-        return new ReusableBucketPool(size, pool -> new ParsedBucket(pool));
+        return new ReusableBucketPool(size, ParsedBucket::new);
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/utilities/MerkleDBFileUtilsTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/utilities/MerkleDBFileUtilsTest.java
@@ -528,7 +528,7 @@ class MerkleDBFileUtilsTest {
         }
 
         @Override
-        public long read(final ByteBuffer[] dsts, final int offset, final int length) throws IOException {
+        public long read(final ByteBuffer[] dsts, final int offset, final int length) {
             throw new NotImplementedException();
         }
 
@@ -543,7 +543,7 @@ class MerkleDBFileUtilsTest {
         }
 
         @Override
-        public long write(final ByteBuffer[] srcs, final int offset, final int length) throws IOException {
+        public long write(final ByteBuffer[] srcs, final int offset, final int length) {
             throw new NotImplementedException();
         }
 
@@ -618,7 +618,7 @@ class MerkleDBFileUtilsTest {
         }
 
         @Override
-        public MappedByteBuffer map(final MapMode mode, final long position, final long size) throws IOException {
+        public MappedByteBuffer map(final MapMode mode, final long position, final long size) {
             throw new NotImplementedException();
         }
 

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/AbstractMerkelDbTest.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/AbstractMerkelDbTest.java
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.merkledb.test.fixtures;
+
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertAllDatabasesClosed;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertDatabaseFolderDeleted;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.checkDirectMemoryIsCleanedUpToLessThanBaseUsage;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.getDirectMemoryUsedBytes;
+import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.swirlds.base.function.CheckedConsumer;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.merkledb.MerkleDbDataSource;
+import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+import org.hiero.base.constructable.ConstructableRegistryException;
+import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
+import org.hiero.consensus.constructable.ConstructableRegistration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class AbstractMerkelDbTest extends AbstractFileManagerAwareTest {
+
+    /**
+     * Keep track of initial direct memory used already, so we can check if we leak over and above
+     * what we started with
+     */
+    private long directMemoryUsedAtStart;
+
+    @BeforeAll
+    static void registerAllConstructables() throws ConstructableRegistryException {
+        ConstructableRegistration.registerAllConstructables();
+    }
+
+    @BeforeEach
+    void initializeDirectMemoryAtStart() {
+        directMemoryUsedAtStart = getDirectMemoryUsedBytes();
+    }
+
+    @AfterEach
+    void verifyNoDatabases() {
+        checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart);
+        assertAllDatabasesClosed();
+        assertDatabaseFolders(0);
+    }
+
+    protected void assertDatabaseFolders(int count) {
+        final Path tempPath = fileSystemManager.getTempPath();
+        final long actualCount;
+        try (final Stream<Path> entries = Files.list(tempPath)) {
+            actualCount = entries.filter(Files::isDirectory)
+                    .filter(p -> p.getFileName().toString().contains(MerkleDbDataSourceBuilder.FOLDER_SUFFIX))
+                    .count();
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to list temp directory: " + tempPath, e);
+        }
+        assertEquals(count, actualCount, "Wrong number of database folders found.");
+    }
+
+    protected MerkleDbDataSource restoreDataSource(
+            final Configuration configuration, final Path dbPath, final String name, final boolean compactionEnabled)
+            throws IOException {
+        return new MerkleDbDataSource(dbPath, configuration, fileSystemManager, name, compactionEnabled, false);
+    }
+
+    protected MerkleDbDataSource restoreDataSource(
+            final Path dbPath, final String name, final boolean compactionEnabled) throws IOException {
+        return restoreDataSource(CONFIGURATION, dbPath, name, compactionEnabled);
+    }
+
+    protected MerkleDbDataSource createDataSource(
+            final long size, final boolean compactionEnabled, boolean preferDiskBasedIndexes) {
+        return createDataSource("test", size, compactionEnabled, preferDiskBasedIndexes);
+    }
+
+    protected MerkleDbDataSource createDataSource(
+            final String name, final long size, final boolean compactionEnabled, boolean preferDiskBasedIndexes) {
+        MerkleDbDataSourceBuilder dataSourceBuilder =
+                new MerkleDbDataSourceBuilder(CONFIGURATION, fileSystemManager, size);
+        return (MerkleDbDataSource) dataSourceBuilder.build(name, null, compactionEnabled, preferDiskBasedIndexes);
+    }
+
+    protected void createAndApplyDataSource(
+            final int size, CheckedConsumer<MerkleDbDataSource, Exception> dataSourceConsumer) throws IOException {
+        createAndApplyDataSource("test", size, dataSourceConsumer);
+    }
+
+    protected void createAndApplyDataSource(
+            String tableName, final int size, CheckedConsumer<MerkleDbDataSource, Exception> dataSourceConsumer)
+            throws IOException {
+        long openedDatabasesBefore = MerkleDbDataSource.getCountOfOpenDatabases();
+        final MerkleDbDataSource dataSource = createDataSource(tableName, size, false, false);
+        try {
+            dataSourceConsumer.accept(dataSource);
+        } catch (Throwable e) {
+            fail("Failed to test MerkleDbDataSource", e);
+        } finally {
+            dataSource.close();
+            assertEventuallyEquals(
+                    openedDatabasesBefore,
+                    MerkleDbDataSource::getCountOfOpenDatabases,
+                    Duration.of(3, ChronoUnit.SECONDS),
+                    "Expected " + openedDatabasesBefore + " open databases.");
+            assertDatabaseFolderDeleted(dataSource);
+        }
+    }
+}

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleFixedValue.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleFixedValue.java
@@ -7,7 +7,6 @@ import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.util.Random;
 
 public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
@@ -87,18 +86,17 @@ public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
                 boolean strictMode,
                 boolean parseUnknownFields,
                 int maxDepth,
-                int maxSize)
-                throws ParseException {
+                int maxSize) {
             return new ExampleFixedValue(in);
         }
 
         @Override
-        public void write(@NonNull ExampleFixedValue value, @NonNull WritableSequentialData out) throws IOException {
+        public void write(@NonNull ExampleFixedValue value, @NonNull WritableSequentialData out) {
             value.writeTo(out);
         }
 
         @Override
-        public int measure(@NonNull ReadableSequentialData in) throws ParseException {
+        public int measure(@NonNull ReadableSequentialData in) {
             throw new UnsupportedOperationException("ExampleFixedValueCodec.measure() not implemented");
         }
 

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleVariableValue.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleVariableValue.java
@@ -5,10 +5,7 @@ import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Random;
 
 public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
@@ -25,18 +22,8 @@ public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
         RANDOM.nextBytes(RANDOM_DATA);
     }
 
-    private int id;
-    private byte[] data;
-
-    public static Bytes intToValue(final int v) {
-        return intToValue(v, RANDOM_DATA, 0, 256 + (v % 768));
-    }
-
-    public static Bytes intToValue(final int v, final byte[] data, final int off, final int len) {
-        final byte[] bytes = new byte[Integer.BYTES + len];
-        ByteBuffer.wrap(bytes).putInt(v).put(data, off, len);
-        return Bytes.wrap(bytes);
-    }
+    private final int id;
+    private final byte[] data;
 
     public ExampleVariableValue() {
         this.id = 0;
@@ -47,12 +34,6 @@ public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
         this.id = id;
         data = new byte[256 + (id % 768)];
         System.arraycopy(RANDOM_DATA, 0, data, 0, data.length);
-    }
-
-    public ExampleVariableValue(final int id, final byte[] data) {
-        this.id = id;
-        this.data = new byte[data.length];
-        System.arraycopy(data, 0, this.data, 0, data.length);
     }
 
     public ExampleVariableValue(final ReadableSequentialData in) {
@@ -102,7 +83,7 @@ public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
         }
 
         @Override
-        public void write(@NonNull ExampleVariableValue value, @NonNull WritableSequentialData out) throws IOException {
+        public void write(@NonNull ExampleVariableValue value, @NonNull WritableSequentialData out) {
             value.writeTo(out);
         }
 

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/MerkleDbTestUtils.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/MerkleDbTestUtils.java
@@ -3,17 +3,17 @@ package com.swirlds.merkledb.test.fixtures;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import com.sun.management.HotSpotDiagnosticMXBean;
 import com.swirlds.base.units.UnitConstants;
 import com.swirlds.common.io.config.TemporaryFileConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDbDataSource;
+import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.metrics.api.Metric;
 import com.swirlds.metrics.api.Metrics;
@@ -21,21 +21,13 @@ import com.swirlds.virtualmap.config.VirtualMapConfig;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualHashChunk;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintStream;
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ManagementFactory;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.LongBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -49,18 +41,18 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import javax.management.MBeanServer;
 import org.hiero.base.crypto.DigestType;
 import org.hiero.base.crypto.Hash;
-import org.hiero.base.crypto.HashBuilder;
+import org.hiero.base.file.FileSystemManager;
 import org.hiero.consensus.config.PathsConfig;
 import org.hiero.consensus.metrics.config.MetricsConfig;
 import org.hiero.consensus.metrics.platform.DefaultPlatformMetrics;
 import org.hiero.consensus.metrics.platform.MetricKeyRegistry;
 import org.hiero.consensus.metrics.platform.PlatformMetricsFactoryImpl;
 
-@SuppressWarnings("unused")
 public class MerkleDbTestUtils {
+
+    public static final String DEFAULT_TABLE_NAME = "testTable";
 
     /**
      * The amount of direct memory used by JVM and caches. This needs to be big enough to allow for
@@ -95,27 +87,8 @@ public class MerkleDbTestUtils {
         executorService.shutdown();
         // Check we did not leak direct memory now that the thread is shut down so thread locals
         // should be released
-        assertTrue(
-                checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart),
-                "Direct Memory used is more than base usage even after 20 gc() calls. At start was "
-                        + (directMemoryUsedAtStart * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB and is now "
-                        + (getDirectMemoryUsedBytes() * UnitConstants.BYTES_TO_MEBIBYTES)
-                        + "MB");
-        // check db count
-        assertEquals(0, MerkleDbDataSource.getCountOfOpenDatabases(), "Expected no open dbs");
-    }
-
-    /** Dump the Java heap to a file in current working directory */
-    public static void dumpHeap() throws IOException {
-        final MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-        final HotSpotDiagnosticMXBean mxBean = ManagementFactory.newPlatformMXBeanProxy(
-                server, "com.sun.management:type=HotSpotDiagnostic", HotSpotDiagnosticMXBean.class);
-        final String filePath = Path.of("heapdump-" + System.currentTimeMillis() + ".hprof")
-                .toAbsolutePath()
-                .toString();
-        mxBean.dumpHeap(filePath, true);
-        System.out.println("Dumped heap to " + filePath);
+        checkDirectMemoryIsCleanedUpToLessThanBaseUsage(directMemoryUsedAtStart);
+        assertAllDatabasesClosed();
     }
 
     /**
@@ -128,12 +101,11 @@ public class MerkleDbTestUtils {
      *
      * @param directMemoryBytesBefore The number of bytes of direct memory allocated before test was
      *     started
-     * @return True if more than base usage of direct memory is being used after 20 gc() calls.
      */
-    public static boolean checkDirectMemoryIsCleanedUpToLessThanBaseUsage(final long directMemoryBytesBefore) {
+    public static void checkDirectMemoryIsCleanedUpToLessThanBaseUsage(final long directMemoryBytesBefore) {
         final long limit = directMemoryBytesBefore + DIRECT_MEMORY_BASE_USAGE;
         if (getDirectMemoryUsedBytes() < limit) {
-            return true;
+            return;
         }
         for (int i = 0; i < 5 && getDirectMemoryUsedBytes() > limit; i++) {
             System.gc();
@@ -143,7 +115,13 @@ public class MerkleDbTestUtils {
                 throw new RuntimeException(e);
             }
         }
-        return getDirectMemoryUsedBytes() < limit;
+
+        assertTrue(
+                getDirectMemoryUsedBytes() < limit,
+                "Direct Memory used is more than base usage even after 5 gc() calls. At start was "
+                        + (directMemoryBytesBefore * UnitConstants.BYTES_TO_MEBIBYTES) + "MB and is now "
+                        + (getDirectMemoryUsedBytes() * UnitConstants.BYTES_TO_MEBIBYTES)
+                        + "MB");
     }
 
     private static final BufferPoolMXBean DIRECT_MEMORY_POOL;
@@ -194,57 +172,6 @@ public class MerkleDbTestUtils {
     }
 
     /**
-     * Creates a hash of the status of all files in a directory, that is their names, sizes and
-     * modification dates. This is useful to be able to check if any modifications have happened on
-     * a directory.
-     *
-     * @param dir The directory to scan and hash
-     * @return null if directory doesn't exist or hash of status of contents
-     */
-    public static Hash hashDirectoryContentsStatus(final Path dir) {
-        if (Files.exists(dir) && Files.isDirectory(dir)) {
-            final HashBuilder hashBuilder = new HashBuilder(DigestType.SHA_384);
-            try (final Stream<Path> filesStream = Files.walk(dir)) {
-                filesStream.forEach(filePath -> {
-                    try {
-                        hashBuilder.update(filePath.getFileName().toString().getBytes());
-                        final BasicFileAttributes fileAttributes =
-                                Files.readAttributes(filePath, BasicFileAttributes.class);
-                        hashBuilder.update(fileAttributes.lastModifiedTime().toMillis());
-                        hashBuilder.update(Files.size(filePath));
-                    } catch (final IOException e) {
-                        e.printStackTrace();
-                    }
-                });
-            } catch (final Exception e) {
-                System.err.println("Failed to hash directory [" + dir.toFile().getAbsolutePath() + "]");
-                e.printStackTrace();
-            }
-            return hashBuilder.build();
-        } else {
-            return null;
-        }
-    }
-
-    public static String toLongsString(final Hash hash) {
-        final LongBuffer longBuf = ByteBuffer.wrap(hash.copyToByteArray())
-                .order(ByteOrder.BIG_ENDIAN)
-                .asLongBuffer();
-        final long[] array = new long[longBuf.remaining()];
-        longBuf.get(array);
-        return Arrays.toString(array);
-    }
-
-    public static String toLongsString(final ByteBuffer buf) {
-        buf.rewind();
-        final LongBuffer longBuf = buf.asLongBuffer();
-        final long[] array = new long[longBuf.remaining()];
-        longBuf.get(array);
-        buf.rewind();
-        return Arrays.toString(array);
-    }
-
-    /**
      * Creates a hash containing an int repeated 6 times as longs.
      *
      * @return hash with digest an array of 6 longs determined by the given value
@@ -257,36 +184,6 @@ public class MerkleDbTestUtils {
             System.arraycopy(hardCoded, 0, digest, i * 6 + 4, 4);
         }
         return new Hash(digest, DigestType.SHA_384);
-    }
-
-    public static void hexDump(final PrintStream out, final Path file) throws IOException {
-        final InputStream is = new FileInputStream(file.toFile());
-        int i = 0;
-
-        while (is.available() > 0) {
-            final StringBuilder sb1 = new StringBuilder();
-            final StringBuilder sb2 = new StringBuilder("   ");
-            out.printf("%04X  ", i * 16);
-            for (int j = 0; j < 16; j++) {
-                if (is.available() > 0) {
-                    final int value = is.read();
-                    sb1.append(String.format("%02X ", value));
-                    if (!Character.isISOControl(value)) {
-                        sb2.append((char) value);
-                    } else {
-                        sb2.append(".");
-                    }
-                } else {
-                    for (; j < 16; j++) {
-                        sb1.append("   ");
-                    }
-                }
-            }
-            out.print(sb1);
-            out.println(sb2);
-            i++;
-        }
-        is.close();
     }
 
     /** Code from method java.util.Collections.shuffle(); */
@@ -307,16 +204,6 @@ public class MerkleDbTestUtils {
         array[j] = temp;
     }
 
-    public static String randomString(final int length, final Random random) {
-        final int leftLimit = 48; // numeral '0'
-        final int rightLimit = 122; // letter 'z'
-        return random.ints(leftLimit, rightLimit + 1)
-                .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
-                .limit(length)
-                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-                .toString();
-    }
-
     public static byte[] randomUtf8Bytes(final int n) {
         final byte[] data = new byte[n];
         int i = 0;
@@ -326,20 +213,6 @@ public class MerkleDbTestUtils {
             i += rnd.length;
         }
         return data;
-    }
-
-    /** Do a standard "ls -lh" on a directory or file and print results to System.out. */
-    public static void ls(final Path dir) {
-        System.out.println("=== " + dir + " ======================================================");
-        try {
-            final ProcessBuilder pb =
-                    new ProcessBuilder("ls", "-Rlh", dir.toAbsolutePath().toString());
-            pb.inheritIO();
-            pb.start().waitFor();
-        } catch (final IOException | InterruptedException e) {
-            e.printStackTrace();
-        }
-        System.out.println("===================================================================");
     }
 
     public static Metrics createMetrics() {
@@ -381,11 +254,48 @@ public class MerkleDbTestUtils {
         return metric.orElse(null);
     }
 
+    public static MerkleDbDataSource createDataSource(
+            final FileSystemManager fileSystemManager,
+            final long size,
+            final boolean compactionEnabled,
+            boolean preferDiskBasedIndexes) {
+        return createDataSource(
+                CONFIGURATION, fileSystemManager, DEFAULT_TABLE_NAME, size, compactionEnabled, preferDiskBasedIndexes);
+    }
+
+    public static MerkleDbDataSource createDataSource(
+            final Configuration configuration,
+            final FileSystemManager fileSystemManager,
+            final String name,
+            final long size,
+            final boolean compactionEnabled,
+            boolean preferDiskBasedIndexes) {
+        MerkleDbDataSourceBuilder dataSourceBuilder =
+                new MerkleDbDataSourceBuilder(configuration, fileSystemManager, size);
+        return (MerkleDbDataSource) dataSourceBuilder.build(name, null, compactionEnabled, preferDiskBasedIndexes);
+    }
+
+    public static MerkleDbDataSource restoreDataSource(
+            final FileSystemManager fileSystemManager,
+            final Path dbPath,
+            final String name,
+            final boolean compactionEnabled)
+            throws IOException {
+        return new MerkleDbDataSource(dbPath, CONFIGURATION, fileSystemManager, name, compactionEnabled, false);
+    }
+
     /**
      * Asserts that all databases are closed within a certain time frame.
      */
     public static void assertAllDatabasesClosed() {
         assertSomeDatabasesStillOpen(0L);
+    }
+
+    public static void assertDatabaseFolderDeleted(MerkleDbDataSource dataSource) {
+        assertEventuallyFalse(
+                () -> Files.exists(dataSource.getDbPaths().storageDir.resolve(dataSource.getTableName())),
+                Duration.ofSeconds(1),
+                "Database should have been deleted");
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/TestType.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/TestType.java
@@ -1,28 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkledb.test.fixtures;
 
-import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.config.api.Configuration;
-import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDbDataSource;
-import com.swirlds.merkledb.MerkleDbStatistics;
-import com.swirlds.merkledb.config.MerkleDbConfig;
-import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.concurrent.ScheduledExecutorService;
-import org.hiero.base.file.FileSystemManager;
-import org.hiero.consensus.metrics.config.MetricsConfig;
-import org.hiero.consensus.metrics.platform.DefaultPlatformMetrics;
-import org.hiero.consensus.metrics.platform.MetricKeyRegistry;
-import org.hiero.consensus.metrics.platform.PlatformMetricsFactoryImpl;
 
 /**
  * Supports parameterized testing of {@link MerkleDbDataSource} with
@@ -33,51 +15,23 @@ import org.hiero.consensus.metrics.platform.PlatformMetricsFactoryImpl;
 public enum TestType {
 
     /** Parameterizes a test with fixed-size key and fixed-size data. */
-    long_fixed(true),
+    long_fixed,
     /** Parameterizes a test with fixed-size key and variable-size data. */
-    long_variable(false),
+    long_variable,
     /** Parameterizes a test with fixed-size complex key and fixed-size data. */
-    longLong_fixed(true),
+    longLong_fixed,
     /** Parameterizes a test with fixed-size complex key and variable-size data. */
-    longLong_variable(false),
+    longLong_variable,
     /** Parameterizes a test with variable-size key and fixed-size data. */
-    variable_fixed(false),
+    variable_fixed,
     /** Parameterizes a test with variable-size key and variable-size data. */
-    variable_variable(false);
-
-    public final boolean fixedSize;
-
-    private Metrics metrics = null;
-
-    TestType(boolean fixedSize) {
-        this.fixedSize = fixedSize;
-    }
+    variable_variable;
 
     public DataTypeConfig dataType() {
         return new DataTypeConfig(this);
     }
 
-    public Metrics getMetrics() {
-        if (metrics == null) {
-            final Configuration CONFIGURATION = new TestConfigBuilder().getOrCreateConfig();
-            MetricsConfig metricsConfig = CONFIGURATION.getConfigData(MetricsConfig.class);
-
-            final MetricKeyRegistry registry = mock(MetricKeyRegistry.class);
-            when(registry.register(any(), any(), any())).thenReturn(true);
-            metrics = new DefaultPlatformMetrics(
-                    null,
-                    registry,
-                    mock(ScheduledExecutorService.class),
-                    new PlatformMetricsFactoryImpl(metricsConfig),
-                    metricsConfig);
-            MerkleDbStatistics statistics =
-                    new MerkleDbStatistics(CONFIGURATION.getConfigData(MerkleDbConfig.class), "test");
-            statistics.registerMetrics(metrics);
-        }
-        return metrics;
-    }
-
-    public class DataTypeConfig {
+    public static class DataTypeConfig {
 
         private final TestType testType;
 
@@ -86,84 +40,25 @@ public enum TestType {
         }
 
         public Bytes createVirtualLongKey(final int i) {
-            switch (testType) {
-                default:
-                case long_fixed:
-                case long_variable:
-                    return ExampleLongKey.longToKey(i);
-                case longLong_fixed:
-                case longLong_variable:
-                    return ExampleLongLongKey.longToKey(i);
-                case variable_fixed:
-                case variable_variable:
-                    return ExampleVariableKey.longToKey(i);
-            }
+            return switch (testType) {
+                case longLong_fixed, longLong_variable -> ExampleLongLongKey.longToKey(i);
+                case variable_fixed, variable_variable -> ExampleVariableKey.longToKey(i);
+                default -> ExampleLongKey.longToKey(i);
+            };
         }
 
         public ExampleByteArrayVirtualValue createVirtualValue(final int i) {
-            switch (testType) {
-                default:
-                case long_fixed:
-                case longLong_fixed:
-                case variable_fixed:
-                    return new ExampleFixedValue(i);
-                case long_variable:
-                case longLong_variable:
-                case variable_variable:
-                    return new ExampleVariableValue(i);
-            }
+            return switch (testType) {
+                case long_variable, longLong_variable, variable_variable -> new ExampleVariableValue(i);
+                default -> new ExampleFixedValue(i);
+            };
         }
 
         public Codec<? extends ExampleByteArrayVirtualValue> getCodec() {
             return switch (testType) {
-                case long_fixed -> ExampleFixedValue.CODEC;
-                case longLong_fixed -> ExampleFixedValue.CODEC;
-                case variable_fixed -> ExampleFixedValue.CODEC;
-                case long_variable -> ExampleVariableValue.CODEC;
-                case longLong_variable -> ExampleVariableValue.CODEC;
-                case variable_variable -> ExampleVariableValue.CODEC;
+                case long_fixed, longLong_fixed, variable_fixed -> ExampleFixedValue.CODEC;
+                case long_variable, longLong_variable, variable_variable -> ExampleVariableValue.CODEC;
             };
-        }
-
-        /**
-         * Get the file size for a file created in DataFileLowLevelTest.createFile test. Values here are measured values
-         * from a known good test run.
-         */
-        public long getDataFileLowLevelTestFileSize() {
-            switch (testType) {
-                default:
-                case long_fixed:
-                case long_variable:
-                case longLong_fixed:
-                case longLong_variable:
-                case variable_fixed:
-                case variable_variable:
-                    return 24576L;
-            }
-        }
-
-        public MerkleDbDataSource createDataSource(
-                final Configuration configuration,
-                final FileSystemManager fileSystemManager,
-                final Path dbPath,
-                final String name,
-                final int size,
-                final boolean enableMerging,
-                boolean preferDiskBasedIndexes)
-                throws IOException {
-            MerkleDbDataSource dataSource = new MerkleDbDataSource(
-                    dbPath, configuration, fileSystemManager, name, size, enableMerging, preferDiskBasedIndexes);
-            dataSource.registerMetrics(getMetrics());
-            return dataSource;
-        }
-
-        public MerkleDbDataSource getDataSource(
-                final FileSystemManager fileSystemManager,
-                final Path dbPath,
-                final String name,
-                final boolean enableMerging)
-                throws IOException {
-            return new MerkleDbDataSource(dbPath, CONFIGURATION, fileSystemManager, name, enableMerging, false);
         }
 
         @SuppressWarnings("rawtypes")
@@ -173,22 +68,17 @@ public enum TestType {
 
         @SuppressWarnings("rawtypes")
         public VirtualLeafBytes createVirtualLeafRecord(final long path, final int i, final int valueIndex) {
-            switch (testType) {
-                default:
-                case long_fixed:
-                case longLong_fixed:
-                case variable_fixed:
-                    return new VirtualLeafBytes<>(
-                            path, createVirtualLongKey(i), new ExampleFixedValue(valueIndex), ExampleFixedValue.CODEC);
-                case long_variable:
-                case longLong_variable:
-                case variable_variable:
-                    return new VirtualLeafBytes<>(
+            return switch (testType) {
+                case long_variable, longLong_variable, variable_variable ->
+                    new VirtualLeafBytes<>(
                             path,
                             createVirtualLongKey(i),
                             new ExampleVariableValue(valueIndex),
                             ExampleVariableValue.CODEC);
-            }
+                default ->
+                    new VirtualLeafBytes<>(
+                            path, createVirtualLongKey(i), new ExampleFixedValue(valueIndex), ExampleFixedValue.CODEC);
+            };
         }
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/files/FilesTestType.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/files/FilesTestType.java
@@ -21,12 +21,9 @@ public enum FilesTestType {
     variable;
 
     public Bytes createVirtualLongKey(final int i) {
-        switch (this) {
-            case fixed:
-            default:
-                return ExampleLongKey.longToKey(i);
-            case variable:
-                return ExampleVariableKey.longToKey(i);
-        }
+        return switch (this) {
+            case variable -> ExampleVariableKey.longToKey(i);
+            default -> ExampleLongKey.longToKey(i);
+        };
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/module-info.java
@@ -4,16 +4,16 @@ module com.swirlds.merkledb.test.fixtures {
     exports com.swirlds.merkledb.test.fixtures.files;
 
     requires transitive com.hedera.pbj.runtime;
+    requires transitive com.swirlds.base;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;
     requires transitive com.swirlds.virtualmap;
     requires transitive org.hiero.base.crypto;
+    requires transitive org.hiero.base.utility.test.fixtures;
     requires transitive org.hiero.base.utility;
-    requires com.swirlds.base;
     requires com.swirlds.common;
     requires com.swirlds.config.extensions.test.fixtures;
     requires com.swirlds.merkledb;
-    requires org.hiero.base.utility.test.fixtures;
     requires org.hiero.consensus.metrics;
     requires org.hiero.consensus.model;
     requires org.hiero.consensus.utility;

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/module-info.java
@@ -18,7 +18,9 @@ module com.swirlds.merkledb.test.fixtures {
     requires org.hiero.consensus.model;
     requires org.hiero.consensus.utility;
     requires java.management;
-    requires jdk.management;
     requires org.junit.jupiter.api;
     requires org.mockito;
+
+    opens com.swirlds.merkledb.test.fixtures to
+            org.junit.platform.commons;
 }


### PR DESCRIPTION
**Description**:
- Use `@TempDir `from Junit
- Improve `MerkleDbTestUtils.checkDirectMemoryIsCleanedUpToLessThanBaseUsage()`
- Add abstract test classes
- Other minor improvements

**Related issue(s)**: #24773
