### PR TITLE
fix(25454): use parse not parseStrict for block nodes config

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigService.java
@@ -183,7 +183,7 @@ public class BlockNodeConfigService {
             }
 
             final byte[] bytes = Files.readAllBytes(path);
-            connectionInfo = BlockNodeConnectionInfo.JSON.parseStrict(Bytes.wrap(bytes));
+            connectionInfo = BlockNodeConnectionInfo.JSON.parse(Bytes.wrap(bytes));
         } catch (final IOException | ParseException e) {
             logger.warn("Failed to read/parse block node configuration from {}", path, e);
             return;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigServiceTest.java
@@ -306,6 +306,35 @@ class BlockNodeConfigServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
+    void testLoadConfiguration_unknownFieldsIgnored() throws Throwable {
+        // Forward-compat: unknown/removed fields must not fail the parse.
+        writeConfig("""
+                {
+                    "topLevelUnknownField": 42,
+                    "nodes": [
+                        {
+                            "address": "localhost",
+                            "streamingPort": 9999,
+                            "priority": 1,
+                            "futureFieldFromNewerVersion": "ignored"
+                        }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet config = configService.latestConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.versionNumber()).isEqualTo(1L);
+        assertThat(config.configs()).hasSize(1);
+        final BlockNodeConfiguration nodeConfig = config.configs().getFirst();
+        assertThat(nodeConfig.address()).isEqualTo("localhost");
+        assertThat(nodeConfig.streamingPort()).isEqualTo(9999);
+        assertThat(nodeConfig.priority()).isEqualTo(1);
+    }
+
+    @Test
     void testLoadConfiguration_emptyConfigs() throws Throwable {
         // write an empty config file
         writeConfig("""


### PR DESCRIPTION
**Description**:
parseStrict rejects forward-compat fields. parse skips unknowns, still fails on malformed JSON.

**Related issue(s)**:

Fixes #25454

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
