### PR TITLE
fix(25239): silence JVM warnings in Solo Latitude JAVA_OPTS

### DIFF
--- a/.github/workflows/support/citr/init-containers-values7.yaml
+++ b/.github/workflows/support/citr/init-containers-values7.yaml
@@ -129,7 +129,7 @@ defaults:
         memory: 256Gi
     extraEnv:
       - name: JAVA_OPTS
-        value: "-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:ZAllocationSpikeTolerance=2 -XX:ConcGCThreads=14 -XX:ZMarkStackSpaceLimit=16g -XX:MaxDirectMemorySize=64g -XX:MetaspaceSize=100M -XX:+ZGenerational -Xlog:gc*:gc.log --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true"
+        value: "-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:ZAllocationSpikeTolerance=2 -XX:ConcGCThreads=14 -XX:ZMarkStackSpaceLimit=16g -XX:MaxDirectMemorySize=64g -XX:MetaspaceSize=100M -XX:+ZGenerational -Xlog:gc*:gc.log --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --enable-native-access=ALL-UNNAMED --sun-misc-unsafe-memory-access=allow -Dio.netty.tryReflectionSetAccessible=true"
       - name: JAVA_HEAP_MIN
         value: "32g"
       - name: JAVA_HEAP_MAX


### PR DESCRIPTION
**Description**:

Follow-up to #25287. Reviewer flagged one more entrypoint that was missed: Solo-on-Latitude reads `JAVA_OPTS` from `.github/workflows/support/citr/init-containers-values7.yaml`. Apply the same two flags PR #25287 added to other `-cp` launchers:

- `--enable-native-access=ALL-UNNAMED` — silences netty `System::loadLibrary` restricted-method warning
- `--sun-misc-unsafe-memory-access=allow` — silences protobuf `sun.misc.Unsafe::arrayBaseOffset` deprecation

**Related issue(s)**:

Refs #25239, #25287

**Notes for reviewer**:

Surfaced by @alex-kuzmin-hg in https://github.com/hiero-ledger/hiero-consensus-node/pull/25287#issuecomment-4435178799. Flag ordering matches `hedera-node/docker/start-services.sh` from #25287.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)