### PR TITLE
fix: 25369 Add support of GCP bucket as a source for all the path parameters

### DIFF
--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -3,6 +3,20 @@
 The **Hedera State Validator** is a comprehensive tool for working with the persisted state of Hedera nodes, providing capabilities to validate state integrity, introspect state contents, export state data,
 compact state files, and apply block streams to advance state.
 
+### GCP Support
+
+All commands accept a GCS URI (`gs://...`) as the state directory, eliminating the need to manually download state files. When a GCS path is provided, the tool downloads the state to a local cache directory using the `gcloud storage` CLI.
+
+**Prerequisites:** The `gcloud` CLI must be installed and authenticated with access to the target bucket. See [Google Cloud SDK installation](https://cloud.google.com/sdk/docs/install).
+
+**Caching:** Downloaded state files are cached in a deterministic directory (`./state-validator-cache-<round>/`) in the current working directory. Subsequent runs with the same state path reuse the cached copy without re-downloading.
+
+### Global Options
+
+These options apply to all subcommands:
+
+- `--cleanup-temp` - Delete cached directories created for GCP downloads after execution. Default = `false` (cache is preserved for reuse).
+
 ## Validate
 
 [ValidateCommand](src/main/java/com/hedera/statevalidation/ValidateCommand.java) ensures state integrity and validates that Hedera nodes can start from existing state snapshots.
@@ -19,7 +33,7 @@ java -jar ./validator-.jar {path-to-state-round} validate {group} [{group}...] [
 
 ### Parameters
 
-- `{path-to-state-round}` - Location of the state files (required).
+- `{path-to-state-round}` - Location of the state files (required). Accepts a local path or a GCS URI (e.g. `gs://bucket/node00/round`) (required).
 - `{group}` - Validation group that should be run, multiple groups can be specified, separated by spaces (at least one required). Current supported groups:
   - [`all`](/src/main/java/com/hedera/statevalidation/validator/Validator.java) - Runs all validators.
   - [`internal`](/src/main/java/com/hedera/statevalidation/validator/HashRecordIntegrityValidator.java) - Validates hash record integrity for internal nodes.
@@ -196,7 +210,7 @@ java -jar ./validator-<version>.jar {path-to-state-round} introspect --service-n
 
 ### Parameters
 
-- `{path-to-state-round}` - Location of the state files (required).
+- `{path-to-state-round}` - Location of the state files (required). Accepts a local path or a GCS URI (e.g. `gs://bucket/node00/round`) (required).
 
 ### Options
 
@@ -223,7 +237,7 @@ java -jar ./validator-<version>.jar {path-to-state-round} analyze [--path-to-kv]
 
 ### Parameters
 
-- `{path-to-state-round}` - Location of the state files (required).
+- `{path-to-state-round}` - Location of the state files (required). Accepts a local path or a GCS URI (e.g. `gs://bucket/node00/round`) (required).
 
 ### Options
 
@@ -296,7 +310,7 @@ java -jar [-DmaxObjPerFile=<number>] [-DprettyPrint=true] ./validator-<version>.
 
 ### Parameters
 
-- `{path-to-state-round}` - Location of the state files (required).
+- `{path-to-state-round}` - Location of the state files (required). Accepts a local path or a GCS URI (e.g. `gs://bucket/node00/round`) (required).
 
 ### Options
 
@@ -457,7 +471,7 @@ java -jar ./validator-<version>.jar {path-to-state-round} compact
 
 ### Parameters
 
-- `{path-to-state-round}` - Location of the state files (required).
+- `{path-to-state-round}` - Location of the state files (required). Accepts a local path or a GCS URI (e.g. `gs://bucket/node00/round`) (required).
 
 ## Updating State with a Block Stream
 
@@ -472,20 +486,46 @@ java -jar ./validator-<version>.jar {path-to-state-round} apply-blocks --block-s
  [--rate=<rounds per second>]
 ```
 
+#### Using GCS paths:
+
+Both the state directory and block stream directory accept GCS URIs:
+
+```shell
+java -jar ./validator-<version>.jar gs://bucket/prefix/4971437 apply-blocks \
+ --block-stream-dir=gs://bucket/block-stream/0/1 \
+ --node-id=0 \
+ --target-round=5013136 \
+ --out=./out \
+ --billing-project=my-gcp-project
+```
+
 ### Parameters
 
-- `{path-to-state-round}` - Location of the state files (required).
+- `{path-to-state-round}` - Location of the state files (required). Accepts a local path or a GCS URI (e.g. `gs://bucket/node00/round`).
 
 ### Options
 
-- `--block-stream-dir` (or `-d`) - Location of the block stream files (required).
+- `--block-stream-dir` (or `-d`) - Location of the block stream files (required). Accepts a local path or a GCS URI (`gs://...`). When a GCS path is provided, `--target-round` is required.
 - `--out` (or `-o`) - The location where the resulting snapshot is written. Must not exist prior to invocation. Default = `./out`.
 - `--node-id` (or `-id`) - The ID of the node that is being used to recover the state. This node's keys should be available locally.
-- `--target-round` (or `-t`) - The last round that should be applied to the state, any higher rounds are ignored. If a target round is specified, the command will not apply rounds beyond it, even if additional block files exist.
-- `--expected-hash` (or `-h`) - Expected hash of the resulting state. If specified, the command can validate the hash of the resulting state against it.
+- `--target-round` (or `-t`) - The last round that should be applied to the state, any higher rounds are ignored. Required when `--block-stream-dir` is a GCS path.
+- `--expected-hash` (or `-h`) - Expected hash of the resulting state. If specified, the command validates the hash of the resulting state against it.
 - `--rate` (or `-r`) - Maximum rounds to apply per second (integer, ≥ 1). Controls CPU/IO load independently of state size. For example, `10` means at most 10 rounds/s. Default = unlimited (apply as fast as possible).
+- `--billing-project` (or `-bp`) - GCP billing project for requester-pays buckets. Applies to block stream downloads only.
+- `--download-threads` (or `-dt`) - Number of parallel workers for downloading block files from GCP. Default = `32`.
+
+### GCS Block Stream Download
+
+When `--block-stream-dir` is a GCS path, the tool performs the following steps:
+
+1. **Left boundary**: Reads `BlockStreamInfo.blockNumber` from the loaded state to determine the first block file to download.
+2. **Right boundary**: Uses a scatter-gather binary search over the GCS block files — probes individual `.blk.gz` files, parses `RoundHeader` items, and narrows the range until the block containing the target round is found.
+3. **Download**: Downloads the resolved block range in parallel using batched `gcloud storage cp` invocations.
+4. **Validation**: Verifies all expected files are present and non-empty, with up to 3 retry passes for any missing files.
+   Downloaded block files are cached in a deterministic directory (`./state-validator-blocks-<source-round>-to-<target-round>/`). Subsequent runs with the same state and target round reuse the cached files without re-downloading.
 
 ### Notes:
 
 - The command checks if the block stream contains the next round relative to the initial round to ensure continuity. It fails if the next round is not found.
 - The command also verifies that the corresponding blocks are present. It will fail if a block is missing or if the final round in the stream does not match the target round.
+- When using GCS paths, progress is reported to stdout: state download percentage, block range probing status, and block file download percentage.

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ApplyBlocksCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ApplyBlocksCommand.java
@@ -161,10 +161,11 @@ public class ApplyBlocksCommand extends ParameterizedClass implements Runnable {
         final BinaryState state = (BinaryState) StateUtils.getDefaultState();
         final long leftBlock = BlockRangeResolver.extractLeftBoundary(state);
 
-        // Use a deterministic directory name containing the source round (from the state path)
-        // and the target round, so identical runs reuse cached block files.
+        // Use a deterministic directory name containing the source round, target round, and
+        // a block stream identifier so different block stream sources don't collide.
         final String sourceRound = GcpPathHelper.extractLastPathElement(parent.getRawStateDir());
-        final String cacheName = "state-validator-blocks-" + sourceRound + "-to-" + targetRound;
+        final String streamId = GcpPathHelper.extractLastPathElement(gcpBlockStreamPath);
+        final String cacheName = "state-validator-blocks-" + sourceRound + "-to-" + targetRound + "-s" + streamId;
         final Path tempBlockDir = Path.of(".", cacheName);
         Files.createDirectories(tempBlockDir);
         parent.trackTempDirectory(tempBlockDir);

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ApplyBlocksCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ApplyBlocksCommand.java
@@ -2,9 +2,20 @@
 package com.hedera.statevalidation;
 
 import static com.hedera.statevalidation.blockstream.BlockStreamRecoveryWorkflow.applyBlocks;
+import static com.hedera.statevalidation.gcp.GcpPathHelper.blockFileName;
 
+import com.hedera.statevalidation.gcp.BlockRangeResolver;
+import com.hedera.statevalidation.gcp.GcpPathHelper;
+import com.hedera.statevalidation.util.StateUtils;
+import com.swirlds.state.BinaryState;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.pcli.utility.ParameterizedClass;
 import picocli.CommandLine.Command;
@@ -14,25 +25,37 @@ import picocli.CommandLine.ParentCommand;
 @Command(name = "apply-blocks", description = "Update the state by applying blocks from a block stream.")
 public class ApplyBlocksCommand extends ParameterizedClass implements Runnable {
 
+    private static final Logger log = LogManager.getLogger(ApplyBlocksCommand.class);
+
     @ParentCommand
     private StateOperatorCommand parent;
 
     private Path blockStreamDirectory;
+    private String gcpBlockStreamPath;
     private Path outputPath = Path.of("./out");
     private NodeId selfId;
     public static final long DEFAULT_TARGET_ROUND = Long.MAX_VALUE;
     private long targetRound = DEFAULT_TARGET_ROUND;
     private String expectedHash = "";
     private int roundsPerSecond = Integer.MAX_VALUE;
+    private String billingProject;
+    private int downloadThreads = 32;
 
     private ApplyBlocksCommand() {}
 
     @Option(
             names = {"-d", "--block-stream-dir"},
             required = true,
-            description = "The path to a directory tree containing block stream files.")
-    private void setBlockStreamDirectory(final Path blockStreamDirectory) {
-        this.blockStreamDirectory = pathMustExist(blockStreamDirectory.toAbsolutePath());
+            description = "The path to a directory tree containing block stream files. "
+                    + "Accepts a local path or a GCS URI (gs://...). "
+                    + "When a GCS path is provided, --target-round is required.")
+    private void setBlockStreamDirectory(final String blockStreamDir) {
+        if (GcpPathHelper.isGcpPath(blockStreamDir)) {
+            this.gcpBlockStreamPath = blockStreamDir;
+            // Don't call pathMustExist — the path is remote
+        } else {
+            this.blockStreamDirectory = pathMustExist(Path.of(blockStreamDir).toAbsolutePath());
+        }
     }
 
     @Option(
@@ -56,7 +79,7 @@ public class ApplyBlocksCommand extends ParameterizedClass implements Runnable {
             names = {"-t", "--target-round"},
             defaultValue = "9223372036854775807",
             description = "The last round that should be applied to the state, any higher rounds are ignored. "
-                    + "Default = apply all available rounds")
+                    + "Default = apply all available rounds. Required when --block-stream-dir is a GCS path.")
     private void setTargetRound(final long targetRound) {
         this.targetRound = targetRound;
     }
@@ -78,13 +101,159 @@ public class ApplyBlocksCommand extends ParameterizedClass implements Runnable {
         this.roundsPerSecond = roundsPerSecond;
     }
 
+    @Option(
+            names = {"-bp", "--billing-project"},
+            description = "GCP billing project for requester-pays buckets. "
+                    + "Applies to the block stream directory download.")
+    private void setBillingProject(final String billingProject) {
+        this.billingProject = billingProject;
+    }
+
+    @Option(
+            names = {"-dt", "--download-threads"},
+            defaultValue = "32",
+            description = "Number of parallel workers for downloading block files from GCP. Default = 32.")
+    private void setDownloadThreads(final int downloadThreads) {
+        this.downloadThreads = downloadThreads;
+    }
+
     @Override
     public void run() {
-        parent.initializeStateDir();
+        // Step 1: Resolve and initialize the state directory (handles GCS download if needed)
+        parent.resolveAndGetStateDir();
+
         try {
+            // Step 2: If block stream directory is on GCS, resolve the block range and download
+            if (gcpBlockStreamPath != null) {
+                blockStreamDirectory = resolveGcpBlockStream();
+            }
+
+            // Step 3: Apply blocks using the (now local) block stream directory
             applyBlocks(blockStreamDirectory, selfId, targetRound, outputPath, expectedHash, roundsPerSecond);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Resolves a GCS block stream path by:
+     * <ol>
+     *   <li>Validating that {@code --target-round} is specified (required for GCS)</li>
+     *   <li>Reading {@link com.hedera.hapi.node.state.blockstream.BlockStreamInfo} from the loaded
+     *       state to determine the left block boundary</li>
+     *   <li>Running the scatter-gather binary search to find the right boundary block</li>
+     *   <li>Downloading the resolved block range in parallel to a temp directory</li>
+     * </ol>
+     *
+     * @return the local path to the downloaded block files
+     * @throws IOException if any step fails
+     */
+    private Path resolveGcpBlockStream() throws IOException {
+        // Validate: --target-round is mandatory for GCS paths
+        if (targetRound == DEFAULT_TARGET_ROUND) {
+            throw new IllegalArgumentException(
+                    "--target-round is required when --block-stream-dir is a GCS path (gs://). "
+                            + "Cannot download the entire block stream from GCS.");
+        }
+
+        GcpPathHelper.ensureGcloudAvailable();
+
+        // Read BlockStreamInfo from the state to get the left boundary
+        final BinaryState state = (BinaryState) StateUtils.getDefaultState();
+        final long leftBlock = BlockRangeResolver.extractLeftBoundary(state);
+
+        // Use a deterministic directory name containing the source round (from the state path)
+        // and the target round, so identical runs reuse cached block files.
+        final String sourceRound = GcpPathHelper.extractLastPathElement(parent.getRawStateDir());
+        final String cacheName = "state-validator-blocks-" + sourceRound + "-to-" + targetRound;
+        final Path tempBlockDir = Path.of(".", cacheName);
+        Files.createDirectories(tempBlockDir);
+        parent.trackTempDirectory(tempBlockDir);
+
+        // Resolve the block range (probe files are downloaded into tempBlockDir as a side effect)
+        final BlockRangeResolver resolver = new BlockRangeResolver(gcpBlockStreamPath, billingProject, tempBlockDir);
+        final BlockRangeResolver.BlockRange range = resolver.resolve(leftBlock, targetRound);
+
+        log.info(
+                "Block range resolved: [{}, {}] ({} files). Starting bulk download...",
+                range.leftBlock(),
+                range.rightBlock(),
+                range.fileCount());
+
+        // Clean up probe files outside the resolved range — if left in the directory,
+        // the downstream validator will interpret them as part of the expected block range
+        // and report gaps for the un-downloaded blocks between the range and the probes.
+        cleanUpProbeFiles(tempBlockDir, range.leftBlock(), range.rightBlock());
+
+        // Build the list of file names to download
+        final List<String> fileNames = new ArrayList<>();
+        for (long blockNum = range.leftBlock(); blockNum <= range.rightBlock(); blockNum++) {
+            final String fileName = blockFileName(blockNum);
+            // Skip files already present (from probing or a previous cached run)
+            final Path localFile = tempBlockDir.resolve(fileName);
+            if (localFile.toFile().exists() && localFile.toFile().length() > 0) {
+                continue;
+            }
+            fileNames.add(fileName);
+        }
+
+        final long preCached = range.fileCount() - fileNames.size();
+        if (preCached == range.fileCount()) {
+            System.out.printf("All %d block files already cached locally.%n", range.fileCount());
+            log.info("All {} block files already cached in {}", range.fileCount(), tempBlockDir);
+        } else {
+            log.info("{} files already cached. {} files remaining to download.", preCached, fileNames.size());
+
+            // Bulk download the remaining files
+            GcpPathHelper.downloadFiles(gcpBlockStreamPath, fileNames, tempBlockDir, billingProject, downloadThreads);
+        }
+
+        // Final validation: ensure all files in the range are present and non-empty
+        long missingCount = 0;
+        for (long blockNum = range.leftBlock(); blockNum <= range.rightBlock(); blockNum++) {
+            final Path localFile = tempBlockDir.resolve(blockFileName(blockNum));
+            if (!localFile.toFile().exists() || localFile.toFile().length() == 0) {
+                missingCount++;
+                if (missingCount <= 10) {
+                    log.error("Missing or empty block file after download: {}", localFile.getFileName());
+                }
+            }
+        }
+        if (missingCount > 0) {
+            throw new IOException(missingCount + " block file(s) missing or empty after download. "
+                    + "The block stream may be incomplete in GCS, or downloads failed.");
+        }
+
+        log.info("All {} block files ready in {}", range.fileCount(), tempBlockDir);
+        return tempBlockDir;
+    }
+
+    /**
+     * Removes any {@code .blk.gz} files from the directory whose block number falls outside
+     * the resolved range. These are artifacts from the binary search probing phase.
+     */
+    private static void cleanUpProbeFiles(@NonNull final Path dir, final long leftBlock, final long rightBlock)
+            throws IOException {
+        int removed = 0;
+        try (var stream = Files.list(dir)) {
+            for (final Path file : stream.toList()) {
+                final String name = file.getFileName().toString();
+                if (!name.endsWith(".blk.gz")) {
+                    continue;
+                }
+                try {
+                    final long blockNum = Long.parseLong(name.substring(0, name.indexOf('.')));
+                    if (blockNum < leftBlock || blockNum > rightBlock) {
+                        Files.delete(file);
+                        removed++;
+                    }
+                } catch (NumberFormatException e) {
+                    // Not a standard block file name — leave it alone
+                }
+            }
+        }
+        if (removed > 0) {
+            log.info("Removed {} probe files outside resolved range [{}, {}]", removed, leftBlock, rightBlock);
         }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ApplyBlocksCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ApplyBlocksCommand.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.pcli.utility.ParameterizedClass;
 import picocli.CommandLine.Command;
@@ -25,6 +26,8 @@ import picocli.CommandLine.ParentCommand;
 public class ApplyBlocksCommand extends ParameterizedClass implements Runnable {
 
     private static final Logger log = LogManager.getLogger(ApplyBlocksCommand.class);
+
+    private static final Marker CONSOLE = GcpPathHelper.CONSOLE;
 
     @ParentCommand
     private StateOperatorCommand parent;
@@ -194,7 +197,7 @@ public class ApplyBlocksCommand extends ParameterizedClass implements Runnable {
 
         final long preCached = range.fileCount() - fileNames.size();
         if (preCached == range.fileCount()) {
-            System.out.printf("All %d block files already cached locally.%n", range.fileCount());
+            log.info(CONSOLE, "All {} block files already cached locally.", range.fileCount());
             log.info("All {} block files already cached in {}", range.fileCount(), tempBlockDir);
         } else {
             log.info("{} files already cached. {} files remaining to download.", preCached, fileNames.size());

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ApplyBlocksCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ApplyBlocksCommand.java
@@ -8,7 +8,6 @@ import com.hedera.statevalidation.gcp.BlockRangeResolver;
 import com.hedera.statevalidation.gcp.GcpPathHelper;
 import com.hedera.statevalidation.util.StateUtils;
 import com.swirlds.state.BinaryState;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -180,11 +179,6 @@ public class ApplyBlocksCommand extends ParameterizedClass implements Runnable {
                 range.rightBlock(),
                 range.fileCount());
 
-        // Clean up probe files outside the resolved range — if left in the directory,
-        // the downstream validator will interpret them as part of the expected block range
-        // and report gaps for the un-downloaded blocks between the range and the probes.
-        cleanUpProbeFiles(tempBlockDir, range.leftBlock(), range.rightBlock());
-
         // Build the list of file names to download
         final List<String> fileNames = new ArrayList<>();
         for (long blockNum = range.leftBlock(); blockNum <= range.rightBlock(); blockNum++) {
@@ -226,34 +220,5 @@ public class ApplyBlocksCommand extends ParameterizedClass implements Runnable {
 
         log.info("All {} block files ready in {}", range.fileCount(), tempBlockDir);
         return tempBlockDir;
-    }
-
-    /**
-     * Removes any {@code .blk.gz} files from the directory whose block number falls outside
-     * the resolved range. These are artifacts from the binary search probing phase.
-     */
-    private static void cleanUpProbeFiles(@NonNull final Path dir, final long leftBlock, final long rightBlock)
-            throws IOException {
-        int removed = 0;
-        try (var stream = Files.list(dir)) {
-            for (final Path file : stream.toList()) {
-                final String name = file.getFileName().toString();
-                if (!name.endsWith(".blk.gz")) {
-                    continue;
-                }
-                try {
-                    final long blockNum = Long.parseLong(name.substring(0, name.indexOf('.')));
-                    if (blockNum < leftBlock || blockNum > rightBlock) {
-                        Files.delete(file);
-                        removed++;
-                    }
-                } catch (NumberFormatException e) {
-                    // Not a standard block file name — leave it alone
-                }
-            }
-        }
-        if (removed > 0) {
-            log.info("Removed {} probe files outside resolved range [{}, {}]", removed, leftBlock, rightBlock);
-        }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
@@ -34,6 +34,9 @@ public class StateOperatorCommand implements Runnable {
 
     private static final Logger log = LogManager.getLogger(StateOperatorCommand.class);
 
+    /** Marker file written after a successful GCS download to distinguish complete from partial caches. */
+    private static final String DOWNLOAD_COMPLETE_MARKER = ".download-complete";
+
     @Parameters(index = "0", description = "State directory. Accepts a local path or a GCS URI (gs://...).")
     private String stateDir;
 
@@ -85,14 +88,20 @@ public class StateOperatorCommand implements Runnable {
                 // e.g. gs://bucket/prefix/4994905 → <cacheDir>/4994905/
                 final String lastComponent = GcpPathHelper.extractLastPathElement(stateDir);
                 final Path innerDir = cacheDir.resolve(lastComponent);
+                final Path marker = cacheDir.resolve(DOWNLOAD_COMPLETE_MARKER);
 
-                if (Files.isDirectory(innerDir) && hasContent(innerDir)) {
-                    // Reuse previously downloaded state
+                if (Files.isDirectory(innerDir) && Files.exists(marker)) {
+                    // Reuse previously downloaded state (marker confirms download completed)
                     resolvedStateDir = innerDir.toFile();
                     trackTempDirectory(cacheDir);
                     log.info("Reusing cached state directory: {}", resolvedStateDir.getAbsolutePath());
                     System.out.printf("Reusing cached state directory: %s%n", resolvedStateDir.getAbsolutePath());
                 } else {
+                    // Remove any partial download leftovers before re-downloading
+                    if (Files.isDirectory(cacheDir)) {
+                        log.info("Removing incomplete cache directory: {}", cacheDir);
+                        deleteRecursively(cacheDir);
+                    }
                     Files.createDirectories(cacheDir);
                     trackTempDirectory(cacheDir);
                     log.info("State directory is a GCS path. Downloading {} to {} ...", stateDir, cacheDir);
@@ -101,9 +110,11 @@ public class StateOperatorCommand implements Runnable {
                     if (Files.isDirectory(innerDir)) {
                         resolvedStateDir = innerDir.toFile();
                     } else {
-                        // Fallback in case the directory structure is different than expected
                         resolvedStateDir = cacheDir.toFile();
                     }
+
+                    // Write completion marker so subsequent runs know the download finished
+                    Files.writeString(marker, "");
                 }
                 log.info("State directory resolved to: {}", resolvedStateDir.getAbsolutePath());
             } catch (IOException e) {
@@ -197,28 +208,17 @@ public class StateOperatorCommand implements Runnable {
     }
 
     /**
-     * Derives a deterministic cache directory name from a GCS path.
-     * The last path element is always a round number.
-     * <p>Example: {@code gs://preview-testnet-backup/previewnet-node00/4994905}
-     * → {@code state-validator-cache-4994905}
+     * Derives a deterministic cache directory name from a GCS path. Includes the node name
+     * (second-to-last element) to avoid collisions when different buckets/nodes share the same
+     * round number as the last path element.
+     * <p>Example: {@code gs://bucket/previewnet-node00/4994905}
+     * → {@code state-validator-cache-previewnet-node00-4994905}
+     * <p>If the path has only one element after the bucket, "default" is used as the node name.
      */
     static String gcpPathToCacheDirName(@NonNull final String gcpPath) {
-        return "state-validator-cache-" + GcpPathHelper.extractLastPathElement(gcpPath);
-    }
-
-    /**
-     * Returns {@code true} if the directory exists and contains at least one regular file
-     * (recursively). A quick check to confirm a previous download actually produced content.
-     */
-    private static boolean hasContent(@NonNull final Path dir) {
-        if (!Files.isDirectory(dir)) {
-            return false;
-        }
-        try (var stream = Files.walk(dir)) {
-            return stream.anyMatch(Files::isRegularFile);
-        } catch (IOException e) {
-            return false;
-        }
+        final String nodeName = GcpPathHelper.extractSecondToLastPathElement(gcpPath);
+        final String round = GcpPathHelper.extractLastPathElement(gcpPath);
+        return "state-validator-cache-" + nodeName + "-" + round;
     }
 
     /**

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
@@ -1,11 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.statevalidation;
 
+import com.hedera.statevalidation.gcp.GcpPathHelper;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 @Command(
@@ -26,12 +34,133 @@ public class StateOperatorCommand implements Runnable {
 
     private static final Logger log = LogManager.getLogger(StateOperatorCommand.class);
 
-    @Parameters(index = "0", description = "State directory.")
-    private File stateDir;
+    @Parameters(index = "0", description = "State directory. Accepts a local path or a GCS URI (gs://...).")
+    private String stateDir;
 
-    // shorthand for subcommands
+    @Option(
+            names = {"--cleanup-temp"},
+            defaultValue = "false",
+            description = "Delete temporary directories created for GCP downloads after execution.")
+    private boolean cleanupTemp;
+
+    /**
+     * Tracks all temporary directories created during this execution, so they can optionally be
+     * cleaned up on exit.
+     */
+    private final List<Path> tempDirectories = new ArrayList<>();
+
+    /**
+     * The resolved local state directory. Set after {@link #resolveAndGetStateDir()} is called.
+     * For local paths, this is the original path. For GCS paths, this is the temp directory where
+     * the state was downloaded.
+     */
+    private File resolvedStateDir;
+
+    /**
+     * Resolves the state directory. If the path is a GCS URI ({@code gs://...}), the directory
+     * is downloaded to a temporary local directory first. The resolved local path is then set
+     * as the {@code state.dir} system property for downstream consumers.
+     *
+     * <p>This method must be called by subcommands <b>before</b> accessing the state.
+     *
+     * @throws RuntimeException if GCP download fails or gcloud is not available
+     */
+    void resolveAndGetStateDir() {
+        if (resolvedStateDir != null) {
+            // Already resolved (idempotent)
+            System.setProperty("state.dir", resolvedStateDir.getAbsolutePath());
+            return;
+        }
+
+        if (GcpPathHelper.isGcpPath(stateDir)) {
+            GcpPathHelper.ensureGcloudAvailable();
+            try {
+                // Use a deterministic directory name derived from the GCS path so that
+                // repeated runs reuse an already-downloaded state instead of re-downloading.
+                // The directory is placed in the current working directory (not system /tmp)
+                // to stay on the same filesystem — the validator creates hard links internally.
+                final Path cacheDir = Path.of(".", gcpPathToCacheDirName(stateDir));
+
+                // gcloud storage cp --recursive preserves the last path component of the source,
+                // e.g. gs://bucket/prefix/4994905 → <cacheDir>/4994905/
+                final String lastComponent = GcpPathHelper.extractLastPathElement(stateDir);
+                final Path innerDir = cacheDir.resolve(lastComponent);
+
+                if (Files.isDirectory(innerDir) && hasContent(innerDir)) {
+                    // Reuse previously downloaded state
+                    resolvedStateDir = innerDir.toFile();
+                    trackTempDirectory(cacheDir);
+                    log.info("Reusing cached state directory: {}", resolvedStateDir.getAbsolutePath());
+                    System.out.printf("Reusing cached state directory: %s%n", resolvedStateDir.getAbsolutePath());
+                } else {
+                    Files.createDirectories(cacheDir);
+                    trackTempDirectory(cacheDir);
+                    log.info("State directory is a GCS path. Downloading {} to {} ...", stateDir, cacheDir);
+                    GcpPathHelper.downloadDirectory(stateDir, cacheDir, null);
+
+                    if (Files.isDirectory(innerDir)) {
+                        resolvedStateDir = innerDir.toFile();
+                    } else {
+                        // Fallback in case the directory structure is different than expected
+                        resolvedStateDir = cacheDir.toFile();
+                    }
+                }
+                log.info("State directory resolved to: {}", resolvedStateDir.getAbsolutePath());
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to download state directory from GCS: " + stateDir, e);
+            }
+        } else {
+            resolvedStateDir = new File(stateDir);
+            if (!resolvedStateDir.exists()) {
+                throw new RuntimeException("State directory does not exist: " + stateDir);
+            }
+        }
+
+        System.setProperty("state.dir", resolvedStateDir.getAbsolutePath());
+    }
+
+    /**
+     * @deprecated Use {@link #resolveAndGetStateDir()} instead. Kept for backward compatibility
+     * during the transition period.
+     */
+    @Deprecated
     void initializeStateDir() {
-        System.setProperty("state.dir", stateDir.getAbsolutePath());
+        resolveAndGetStateDir();
+    }
+
+    /**
+     * Returns the resolved state directory. Must be called after {@link #resolveAndGetStateDir()}.
+     *
+     * @throws IllegalStateException if called before resolution
+     */
+    File getStateDir() {
+        if (resolvedStateDir == null) {
+            throw new IllegalStateException("State directory not yet resolved. Call resolveAndGetStateDir() first.");
+        }
+        return resolvedStateDir;
+    }
+
+    /**
+     * Returns the raw state directory string as provided on the command line.
+     * May be a local path or a {@code gs://} URI.
+     */
+    String getRawStateDir() {
+        return stateDir;
+    }
+
+    /**
+     * Registers a temporary directory for tracking and optional cleanup.
+     */
+    void trackTempDirectory(@NonNull final Path tempDir) {
+        tempDirectories.add(tempDir);
+        log.info("Temporary directory created: {}", tempDir);
+    }
+
+    /**
+     * Returns whether temp cleanup is enabled.
+     */
+    boolean isCleanupTemp() {
+        return cleanupTemp;
     }
 
     @Override
@@ -45,15 +174,67 @@ public class StateOperatorCommand implements Runnable {
     public static void main(String[] args) {
         long startTime = System.currentTimeMillis();
         try {
-            int exitCode = new CommandLine(new StateOperatorCommand()).execute(args);
+            final StateOperatorCommand rootCommand = new StateOperatorCommand();
+            int exitCode = new CommandLine(rootCommand).execute(args);
             log.info("Execution time: {} ms.", System.currentTimeMillis() - startTime);
+
+            // Cleanup temp directories if requested
+            if (rootCommand.cleanupTemp && !rootCommand.tempDirectories.isEmpty()) {
+                for (final Path tempDir : rootCommand.tempDirectories) {
+                    try {
+                        deleteRecursively(tempDir);
+                        log.info("Cleaned up temporary directory: {}", tempDir);
+                    } catch (IOException e) {
+                        log.warn("Failed to clean up temporary directory: {}", tempDir, e);
+                    }
+                }
+            }
+
             System.exit(exitCode);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    File getStateDir() {
-        return stateDir;
+    /**
+     * Derives a deterministic cache directory name from a GCS path.
+     * The last path element is always a round number.
+     * <p>Example: {@code gs://preview-testnet-backup/previewnet-node00/4994905}
+     * → {@code state-validator-cache-4994905}
+     */
+    static String gcpPathToCacheDirName(@NonNull final String gcpPath) {
+        return "state-validator-cache-" + GcpPathHelper.extractLastPathElement(gcpPath);
+    }
+
+    /**
+     * Returns {@code true} if the directory exists and contains at least one regular file
+     * (recursively). A quick check to confirm a previous download actually produced content.
+     */
+    private static boolean hasContent(@NonNull final Path dir) {
+        if (!Files.isDirectory(dir)) {
+            return false;
+        }
+        try (var stream = Files.walk(dir)) {
+            return stream.anyMatch(Files::isRegularFile);
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Recursively deletes a directory and all its contents.
+     */
+    private static void deleteRecursively(@NonNull final Path path) throws IOException {
+        if (!Files.exists(path)) {
+            return;
+        }
+        if (Files.isDirectory(path)) {
+            try (var entries = Files.list(path)) {
+                for (Path child : entries.toList()) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        Files.delete(path);
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
@@ -14,6 +14,7 @@ import com.swirlds.state.BinaryState;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -166,6 +167,11 @@ public final class BlockRangeResolver {
             System.out.printf(
                     "  Block range resolved: [%d, %d] (%d files)%n",
                     range.leftBlock(), range.rightBlock(), range.fileCount());
+
+            // Clean up probe files outside the resolved range — if left in the directory,
+            // the downstream consumer will interpret them as part of the expected block range.
+            cleanUpProbeFiles(range);
+
             return range;
         } finally {
             executor.shutdownNow();
@@ -220,7 +226,7 @@ public final class BlockRangeResolver {
 
         // If all probes exist (unlikely), the last available block is at least leftBlock + 2^MAX
         if (firstMiss == -1) {
-            log.warn(
+            log.info(
                     "All exponential probes up to offset {} exist. Last available block is at least {}.",
                     1L << MAX_EXPONENTIAL_POWER,
                     lastHit);
@@ -425,6 +431,40 @@ public final class BlockRangeResolver {
             return maxRound;
         } catch (Exception e) {
             throw new IOException("Failed to parse block file: " + localFile, e);
+        }
+    }
+
+    /**
+     * Removes any {@code .blk.gz} files from the local probe directory whose block number falls
+     * outside the resolved range. These are artifacts from the binary search probing phase.
+     */
+    private void cleanUpProbeFiles(@NonNull final BlockRange range) {
+        try (var stream = Files.list(localProbeDir)) {
+            int removed = 0;
+            for (final Path file : stream.toList()) {
+                final String name = file.getFileName().toString();
+                if (!name.endsWith(".blk.gz")) {
+                    continue;
+                }
+                try {
+                    final long blockNum = Long.parseLong(name.substring(0, name.indexOf('.')));
+                    if (blockNum < range.leftBlock() || blockNum > range.rightBlock()) {
+                        Files.delete(file);
+                        removed++;
+                    }
+                } catch (NumberFormatException e) {
+                    // Not a standard block file name — leave it alone
+                }
+            }
+            if (removed > 0) {
+                log.info(
+                        "Removed {} probe files outside resolved range [{}, {}]",
+                        removed,
+                        range.leftBlock(),
+                        range.rightBlock());
+            }
+        } catch (IOException e) {
+            log.warn("Failed to clean up probe files in {}", localProbeDir, e);
         }
     }
 

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 
 /**
  * Determines the range of block files {@code [leftBlock, rightBlock]} that need to be downloaded
@@ -48,6 +49,8 @@ import org.apache.logging.log4j.Logger;
 public final class BlockRangeResolver {
 
     private static final Logger log = LogManager.getLogger(BlockRangeResolver.class);
+
+    private static final Marker CONSOLE = GcpPathHelper.CONSOLE;
 
     /** The state ID for the BlockStreamInfo singleton. */
     private static final int BLOCK_STREAM_INFO_STATE_ID =
@@ -135,7 +138,7 @@ public final class BlockRangeResolver {
                 leftBlock,
                 targetRound,
                 gcpBlockStreamDir);
-        System.out.printf("Resolving block range (left block: %d, target round: %d) ...%n", leftBlock, targetRound);
+        log.info(CONSOLE, "Resolving block range (left block: {}, target round: {}) ...", leftBlock, targetRound);
 
         // Step 1: Verify the left boundary block exists
         if (!GcpPathHelper.fileExists(blockFileUri(gcpBlockStreamDir, leftBlock), billingProject)) {
@@ -148,13 +151,13 @@ public final class BlockRangeResolver {
         final ExecutorService executor = Executors.newFixedThreadPool(PROBE_THREAD_POOL_SIZE);
         try {
             // Step 2: Find the extent of available blocks (last available block number)
-            System.out.printf("  Probing for last available block ...%n");
+            log.info(CONSOLE, "  Probing for last available block ...");
             final long lastAvailableBlock = findLastAvailableBlock(leftBlock, executor);
             log.info("Last available block in GCS: {}", lastAvailableBlock);
-            System.out.printf("  Last available block: %d%n", lastAvailableBlock);
+            log.info(CONSOLE, "  Last available block: {}", lastAvailableBlock);
 
             // Step 3: Find the block containing the target round via binary search
-            System.out.printf("  Searching for block containing target round %d ...%n", targetRound);
+            log.info(CONSOLE, "  Searching for block containing target round {} ...", targetRound);
             final long rightBlock = findBlockForTargetRound(leftBlock, lastAvailableBlock, targetRound, executor);
             log.info("Block containing target round {}: {}", targetRound, rightBlock);
 
@@ -164,9 +167,12 @@ public final class BlockRangeResolver {
                     range.leftBlock(),
                     range.rightBlock(),
                     range.fileCount());
-            System.out.printf(
-                    "  Block range resolved: [%d, %d] (%d files)%n",
-                    range.leftBlock(), range.rightBlock(), range.fileCount());
+            log.info(
+                    CONSOLE,
+                    "  Block range resolved: [{}, {}] ({} files)",
+                    range.leftBlock(),
+                    range.rightBlock(),
+                    range.fileCount());
 
             // Clean up probe files outside the resolved range — if left in the directory,
             // the downstream consumer will interpret them as part of the expected block range.

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
@@ -359,6 +359,13 @@ public final class BlockRangeResolver {
                     newHi = Math.min(newHi, probe);
                 }
             }
+
+            // If no progress was made (all probes failed), fall back to sequential search
+            if (newLo == lo && newHi == hi) {
+                log.warn("Scatter-gather made no progress in [{}, {}]. Falling back to sequential search.", lo, hi);
+                return sequentialBinarySearchForRound(lo, hi, targetRound, roundCache);
+            }
+
             lo = newLo;
             hi = newHi;
         }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
@@ -1,0 +1,498 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.statevalidation.gcp;
+
+import static com.hedera.statevalidation.gcp.GcpPathHelper.blockFileName;
+import static com.hedera.statevalidation.gcp.GcpPathHelper.blockFileUri;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.state.blockstream.BlockStreamInfo;
+import com.hedera.hapi.platform.state.SingletonType;
+import com.hedera.node.app.hapi.utils.blocks.BlockStreamAccess;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.state.BinaryState;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Determines the range of block files {@code [leftBlock, rightBlock]} that need to be downloaded
+ * from GCS to apply blocks up to a target round.
+ *
+ * <b>Algorithm overview</b>
+ * <br>
+ * <ol>
+ *   <li><b>Left boundary</b>: Read {@link BlockStreamInfo} singleton from the loaded state;
+ *       extract {@code blockNumber + 1}.</li>
+ *   <li><b>Find extent of available blocks</b>: Scatter-gather existence probes at exponentially
+ *       spaced block numbers, then refine the exact last available block.</li>
+ *   <li><b>Find target-round block</b>: Scatter-gather binary search — download candidate
+ *       {@code .blk.gz} files, parse {@code RoundHeader} items, narrow the range until the block
+ *       containing the target round is found.</li>
+ * </ol>
+ *
+ * <p>Probe files are downloaded to the same temp directory that will hold the final bulk download,
+ * so they effectively serve as pre-cached files and are not re-downloaded later.
+ */
+public final class BlockRangeResolver {
+
+    private static final Logger log = LogManager.getLogger(BlockRangeResolver.class);
+
+    /** The state ID for the BlockStreamInfo singleton. */
+    private static final int BLOCK_STREAM_INFO_STATE_ID =
+            SingletonType.BLOCKSTREAMSERVICE_I_BLOCK_STREAM_INFO.protoOrdinal();
+
+    /** Number of parallel probes in a scatter-gather round. */
+    private static final int SCATTER_FACTOR = 8;
+
+    /** Threshold below which we switch from scatter-gather to sequential binary search. */
+    private static final int SEQUENTIAL_THRESHOLD = 1000;
+
+    /** Maximum exponential probe offset (2^20 ≈ 1M blocks). */
+    private static final int MAX_EXPONENTIAL_POWER = 20;
+
+    /** Thread pool for parallel probing operations. */
+    private static final int PROBE_THREAD_POOL_SIZE = 16;
+
+    private final String gcpBlockStreamDir;
+    private final String billingProject;
+    private final Path localProbeDir;
+
+    /**
+     * Result of the block range resolution.
+     *
+     * @param leftBlock  the first block number to download (inclusive)
+     * @param rightBlock the last block number to download (inclusive)
+     */
+    public record BlockRange(long leftBlock, long rightBlock) {
+        public long fileCount() {
+            return rightBlock - leftBlock + 1;
+        }
+    }
+
+    /**
+     * @param gcpBlockStreamDir GCS URI of the block stream directory
+     * @param billingProject    optional billing project for requester-pays buckets
+     * @param localProbeDir     local directory where probe files will be downloaded (also the
+     *                          eventual target for bulk download)
+     */
+    public BlockRangeResolver(
+            @NonNull final String gcpBlockStreamDir,
+            @Nullable final String billingProject,
+            @NonNull final Path localProbeDir) {
+        this.gcpBlockStreamDir = gcpBlockStreamDir;
+        this.billingProject = billingProject;
+        this.localProbeDir = localProbeDir;
+    }
+
+    /**
+     * Reads the {@link BlockStreamInfo} singleton from the given state and returns the block number
+     * that represents the left boundary (i.e. {@code blockNumber + 1}).
+     *
+     * @param state the loaded binary state
+     * @return the first block number that needs to be downloaded
+     * @throws IllegalStateException if the singleton is not found or cannot be parsed
+     */
+    public static long extractLeftBoundary(@NonNull final BinaryState state) {
+        final Bytes raw = state.getSingleton(BLOCK_STREAM_INFO_STATE_ID);
+        if (raw == null) {
+            throw new IllegalStateException(
+                    "BlockStreamInfo singleton not found in state (state ID: " + BLOCK_STREAM_INFO_STATE_ID + ")");
+        }
+        try {
+            final BlockStreamInfo bsi = BlockStreamInfo.PROTOBUF.parse(raw);
+            final long blockNumber = bsi.blockNumber();
+            log.info("BlockStreamInfo.blockNumber = {} → left boundary = {}", blockNumber, blockNumber + 1);
+            return blockNumber + 1;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse BlockStreamInfo singleton", e);
+        }
+    }
+
+    /**
+     * Resolves the full block range that must be downloaded to apply blocks up to
+     * {@code targetRound}.
+     *
+     * @param leftBlock   the first block number to download (from {@link #extractLeftBoundary})
+     * @param targetRound the target round to reach
+     * @return the resolved block range
+     * @throws IOException if probing or downloading fails
+     */
+    public BlockRange resolve(final long leftBlock, final long targetRound) throws IOException {
+        log.info(
+                "Resolving block range: leftBlock={}, targetRound={}, source={}",
+                leftBlock,
+                targetRound,
+                gcpBlockStreamDir);
+        System.out.printf("Resolving block range (left block: %d, target round: %d) ...%n", leftBlock, targetRound);
+
+        // Step 1: Verify the left boundary block exists
+        if (!GcpPathHelper.fileExists(blockFileUri(gcpBlockStreamDir, leftBlock), billingProject)) {
+            throw new IOException("Expected starting block file not found at "
+                    + blockFileUri(gcpBlockStreamDir, leftBlock)
+                    + ". The block stream may be incomplete or the state's BlockStreamInfo is inconsistent.");
+        }
+
+        // Shared executor for all parallel probing operations across phases 2 and 3
+        final ExecutorService executor = Executors.newFixedThreadPool(PROBE_THREAD_POOL_SIZE);
+        try {
+            // Step 2: Find the extent of available blocks (last available block number)
+            System.out.printf("  Probing for last available block ...%n");
+            final long lastAvailableBlock = findLastAvailableBlock(leftBlock, executor);
+            log.info("Last available block in GCS: {}", lastAvailableBlock);
+            System.out.printf("  Last available block: %d%n", lastAvailableBlock);
+
+            // Step 3: Find the block containing the target round via binary search
+            System.out.printf("  Searching for block containing target round %d ...%n", targetRound);
+            final long rightBlock = findBlockForTargetRound(leftBlock, lastAvailableBlock, targetRound, executor);
+            log.info("Block containing target round {}: {}", targetRound, rightBlock);
+
+            final BlockRange range = new BlockRange(leftBlock, rightBlock);
+            log.info(
+                    "Resolved block range: [{}, {}] ({} files)",
+                    range.leftBlock(),
+                    range.rightBlock(),
+                    range.fileCount());
+            System.out.printf(
+                    "  Block range resolved: [%d, %d] (%d files)%n",
+                    range.leftBlock(), range.rightBlock(), range.fileCount());
+            return range;
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    // ========== Phase 2: Find last available block ==========
+
+    /**
+     * Uses scatter-gather exponential probing to find the last block number that exists in GCS.
+     */
+    private long findLastAvailableBlock(final long leftBlock, final ExecutorService executor) {
+        log.info("Finding extent of available blocks starting from {} ...", leftBlock);
+
+        // Phase 2a: Scatter exponential probes to find [lastHit, firstMiss] bracket
+        final List<Long> probeOffsets = new ArrayList<>();
+        for (int power = 0; power <= MAX_EXPONENTIAL_POWER; power++) {
+            probeOffsets.add(1L << power); // 1, 2, 4, 8, ..., 2^20
+        }
+
+        // Check all exponential offsets in parallel
+        final ConcurrentHashMap<Long, Boolean> existenceResults = new ConcurrentHashMap<>();
+        final List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (final long offset : probeOffsets) {
+            final long blockNum = leftBlock + offset;
+            futures.add(CompletableFuture.runAsync(
+                    () -> {
+                        final boolean exists = GcpPathHelper.fileExistsNoRetry(
+                                blockFileUri(gcpBlockStreamDir, blockNum), billingProject);
+                        existenceResults.put(blockNum, exists);
+                        log.debug("Probe block {}: {}", blockNum, exists ? "EXISTS" : "MISSING");
+                    },
+                    executor));
+        }
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        // Find the bracket [lastHit, firstMiss]
+        long lastHit = leftBlock; // We already verified leftBlock exists
+        long firstMiss = -1;
+
+        for (final long offset : probeOffsets) {
+            final long blockNum = leftBlock + offset;
+            final Boolean exists = existenceResults.get(blockNum);
+            if (exists != null && exists) {
+                lastHit = Math.max(lastHit, blockNum);
+            } else {
+                if (firstMiss == -1 || blockNum < firstMiss) {
+                    firstMiss = blockNum;
+                }
+            }
+        }
+
+        // If all probes exist (unlikely), the last available block is at least leftBlock + 2^MAX
+        if (firstMiss == -1) {
+            log.warn(
+                    "All exponential probes up to offset {} exist. Last available block is at least {}.",
+                    1L << MAX_EXPONENTIAL_POWER,
+                    lastHit);
+            return lastHit;
+        }
+
+        // Phase 2b: Refine the exact last available block within [lastHit, firstMiss]
+        return refineLastAvailableBlock(lastHit, firstMiss, executor);
+    }
+
+    /**
+     * Scatter-gather refinement within the bracket to find the exact last existing block.
+     */
+    private long refineLastAvailableBlock(long lo, long hi, final ExecutorService executor) {
+        while (hi - lo > 1) {
+            final long range = hi - lo;
+            if (range <= SEQUENTIAL_THRESHOLD) {
+                // Sequential binary search for small ranges
+                return sequentialBinarySearchExistence(lo, hi);
+            }
+
+            // Scatter probes evenly across the range
+            final List<Long> probes = distributeProbes(lo, hi, SCATTER_FACTOR);
+            final ConcurrentHashMap<Long, Boolean> results = parallelExistenceCheck(probes, executor);
+
+            // Find new bracket
+            long newLo = lo;
+            long newHi = hi;
+            for (final long probe : probes) {
+                final Boolean exists = results.get(probe);
+                if (exists != null && exists) {
+                    newLo = Math.max(newLo, probe);
+                } else {
+                    newHi = Math.min(newHi, probe);
+                }
+            }
+            lo = newLo;
+            hi = newHi;
+        }
+        return lo;
+    }
+
+    /**
+     * Simple sequential binary search for existence within a small range.
+     */
+    private long sequentialBinarySearchExistence(long lo, long hi) {
+        while (hi - lo > 1) {
+            final long mid = lo + (hi - lo) / 2;
+            if (GcpPathHelper.fileExistsNoRetry(blockFileUri(gcpBlockStreamDir, mid), billingProject)) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        return lo;
+    }
+
+    // ========== Phase 3: Find block for target round ==========
+
+    /**
+     * Binary search (scatter-gather for large ranges, sequential for small) to find the block
+     * whose round range includes {@code targetRound}.
+     *
+     * <p>The search downloads candidate block files, parses them to extract the maximum
+     * {@code RoundHeader.roundNumber}, and narrows the range accordingly.</p>
+     */
+    private long findBlockForTargetRound(
+            final long leftBlock, final long lastAvailableBlock, final long targetRound, final ExecutorService executor)
+            throws IOException {
+        log.info(
+                "Searching for block containing target round {} in range [{}, {}]",
+                targetRound,
+                leftBlock,
+                lastAvailableBlock);
+
+        // First, check if the target round is reachable: download the last available block and check
+        final long maxRoundInLastBlock = getMaxRound(lastAvailableBlock);
+        if (maxRoundInLastBlock == -1) {
+            throw new IOException(
+                    "Failed to parse any round headers from the last available block " + lastAvailableBlock);
+        }
+        if (targetRound > maxRoundInLastBlock) {
+            throw new IOException(String.format(
+                    "Target round %d exceeds the last available round %d in block %d at %s",
+                    targetRound, maxRoundInLastBlock, lastAvailableBlock, gcpBlockStreamDir));
+        }
+
+        // Check if the left boundary block already contains the target round
+        final long maxRoundInFirstBlock = getMaxRound(leftBlock);
+        if (maxRoundInFirstBlock >= targetRound) {
+            return leftBlock;
+        }
+
+        // Binary search between leftBlock and lastAvailableBlock
+        long lo = leftBlock;
+        long hi = lastAvailableBlock;
+
+        // Cache of block number → max round (to avoid re-downloading)
+        final ConcurrentHashMap<Long, Long> roundCache = new ConcurrentHashMap<>();
+        roundCache.put(leftBlock, maxRoundInFirstBlock);
+        roundCache.put(lastAvailableBlock, maxRoundInLastBlock);
+
+        while (hi - lo > 1) {
+            final long range = hi - lo;
+
+            if (range <= SEQUENTIAL_THRESHOLD) {
+                return sequentialBinarySearchForRound(lo, hi, targetRound, roundCache);
+            }
+
+            // Scatter-gather: probe SCATTER_FACTOR evenly spaced blocks
+            final List<Long> probes = distributeProbes(lo, hi, SCATTER_FACTOR);
+            log.debug("Scatter-gather round search: probing {} blocks in [{}, {}]", probes.size(), lo, hi);
+
+            final ConcurrentHashMap<Long, Long> probeResults = parallelRoundCheck(probes, executor);
+            roundCache.putAll(probeResults);
+
+            // Find the narrowed bracket
+            long newLo = lo;
+            long newHi = hi;
+            for (final long probe : probes) {
+                final Long maxRound = probeResults.get(probe);
+                if (maxRound == null || maxRound == -1) {
+                    // If we couldn't parse the block, treat it conservatively
+                    continue;
+                }
+                if (maxRound < targetRound) {
+                    newLo = Math.max(newLo, probe);
+                } else {
+                    // This block's max round >= targetRound; it could be the answer or earlier
+                    newHi = Math.min(newHi, probe);
+                }
+            }
+            lo = newLo;
+            hi = newHi;
+        }
+
+        // At this point, hi is the block whose max round >= targetRound
+        return hi;
+    }
+
+    /**
+     * Sequential binary search for the block containing the target round, for small ranges.
+     */
+    private long sequentialBinarySearchForRound(
+            long lo, long hi, final long targetRound, final ConcurrentHashMap<Long, Long> roundCache)
+            throws IOException {
+        while (hi - lo > 1) {
+            final long mid = lo + (hi - lo) / 2;
+            final long maxRound = roundCache.computeIfAbsent(mid, block -> {
+                try {
+                    return getMaxRound(block);
+                } catch (IOException e) {
+                    log.error("Failed to parse block {}", block, e);
+                    return -1L;
+                }
+            });
+
+            if (maxRound == -1) {
+                // If we can't parse, try to narrow from the other side
+                hi = mid;
+            } else if (maxRound < targetRound) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        return hi;
+    }
+
+    // ========== Block parsing ==========
+
+    /**
+     * Downloads a single block file (if not already in the local probe directory),
+     * parses it, and returns the maximum round number found in its {@code RoundHeader} items.
+     *
+     * @param blockNumber the block number to inspect
+     * @return the maximum round number, or {@code -1} if no round headers were found
+     */
+    private long getMaxRound(final long blockNumber) throws IOException {
+        final String fileName = blockFileName(blockNumber);
+        final Path localFile = localProbeDir.resolve(fileName);
+
+        // Download if not already cached locally
+        if (!localFile.toFile().exists() || localFile.toFile().length() == 0) {
+            final String uri = blockFileUri(gcpBlockStreamDir, blockNumber);
+            final boolean ok = GcpPathHelper.downloadFile(uri, localProbeDir, billingProject);
+            if (!ok) {
+                throw new IOException("Failed to download block file: " + uri);
+            }
+        }
+
+        // Parse the block and extract max round
+        try {
+            final Block block = BlockStreamAccess.blockFrom(localFile);
+            long maxRound = -1;
+            for (final BlockItem item : block.items()) {
+                if (item.hasRoundHeader()) {
+                    maxRound = Math.max(maxRound, item.roundHeader().roundNumber());
+                }
+            }
+            log.debug("Block {} → maxRound={}", blockNumber, maxRound);
+            return maxRound;
+        } catch (Exception e) {
+            throw new IOException("Failed to parse block file: " + localFile, e);
+        }
+    }
+
+    // ========== Parallel utilities ==========
+
+    /**
+     * Distributes {@code count} probe points evenly within the open interval {@code (lo, hi)}.
+     */
+    @NonNull
+    private static List<Long> distributeProbes(final long lo, final long hi, final int count) {
+        final long range = hi - lo;
+        if (range <= 1) {
+            return Collections.emptyList();
+        }
+        final List<Long> probes = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            final long probe = lo + (range * i) / (count + 1);
+            if (probe > lo && probe < hi) {
+                probes.add(probe);
+            }
+        }
+        return probes;
+    }
+
+    /**
+     * Checks existence of multiple block files in parallel using the shared executor.
+     */
+    @NonNull
+    private ConcurrentHashMap<Long, Boolean> parallelExistenceCheck(
+            @NonNull final List<Long> blockNumbers, @NonNull final ExecutorService executor) {
+        final ConcurrentHashMap<Long, Boolean> results = new ConcurrentHashMap<>();
+        final List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (final long blockNum : blockNumbers) {
+            futures.add(CompletableFuture.runAsync(
+                    () -> {
+                        results.put(
+                                blockNum,
+                                GcpPathHelper.fileExistsNoRetry(
+                                        blockFileUri(gcpBlockStreamDir, blockNum), billingProject));
+                    },
+                    executor));
+        }
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        return results;
+    }
+
+    /**
+     * Downloads and parses multiple block files in parallel using the shared executor,
+     * returning block → maxRound mappings.
+     */
+    @NonNull
+    private ConcurrentHashMap<Long, Long> parallelRoundCheck(
+            @NonNull final List<Long> blockNumbers, @NonNull final ExecutorService executor) {
+        final ConcurrentHashMap<Long, Long> results = new ConcurrentHashMap<>();
+        final List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (final long blockNum : blockNumbers) {
+            futures.add(CompletableFuture.runAsync(
+                    () -> {
+                        try {
+                            results.put(blockNum, getMaxRound(blockNum));
+                        } catch (IOException e) {
+                            log.warn("Failed to get max round for block {}: {}", blockNum, e.getMessage());
+                            results.put(blockNum, -1L);
+                        }
+                    },
+                    executor));
+        }
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        return results;
+    }
+}

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/GcpPathHelper.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/GcpPathHelper.java
@@ -92,6 +92,24 @@ public final class GcpPathHelper {
         return trimmed.substring(trimmed.lastIndexOf('/') + 1);
     }
 
+    /**
+     * Extracts the second-to-last path element, or {@code "default"} if the path has fewer
+     * than two elements after the scheme. Used for node names in GCS paths.
+     * <p>Example: {@code gs://bucket/previewnet-node00/4994905} → {@code previewnet-node00}
+     */
+    @NonNull
+    public static String extractSecondToLastPathElement(@NonNull final String path) {
+        String trimmed = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+        final int lastSlash = trimmed.lastIndexOf('/');
+        if (lastSlash <= 0) {
+            return "default";
+        }
+        final String parent = trimmed.substring(0, lastSlash);
+        final int secondSlash = parent.lastIndexOf('/');
+        final String element = parent.substring(secondSlash + 1);
+        return element.isEmpty() ? "default" : element;
+    }
+
     // ========== Availability check ==========
 
     /**
@@ -279,8 +297,6 @@ public final class GcpPathHelper {
         try {
             final List<String> cmd = new ArrayList<>();
             cmd.add("xargs");
-            cmd.add("-a");
-            cmd.add(manifestFile.toString());
             cmd.add("-n");
             cmd.add("500");
             cmd.add("-P");
@@ -291,7 +307,7 @@ public final class GcpPathHelper {
             final Thread progressMonitor = startProgressMonitor(
                     "gcp-download-progress", totalFiles, () -> countFilesInDir(localDir, BLOCK_FILE_EXTENSION));
 
-            final int exitCode = executeProcess(cmd, DIRECTORY_DOWNLOAD_TIMEOUT_SECONDS, true);
+            final int exitCode = executeProcess(cmd, DIRECTORY_DOWNLOAD_TIMEOUT_SECONDS, true, manifestFile);
 
             // Stop the progress monitor
             progressMonitor.interrupt();
@@ -509,15 +525,13 @@ public final class GcpPathHelper {
 
                 final List<String> cmd = new ArrayList<>();
                 cmd.add("xargs");
-                cmd.add("-a");
-                cmd.add(manifestFile.toString());
                 cmd.add("-n");
                 cmd.add("500");
                 cmd.add("-P");
                 cmd.add(String.valueOf(Math.max(1, parallelism)));
                 cmd.add(wrapperScript.toString());
 
-                executeProcess(cmd, DIRECTORY_DOWNLOAD_TIMEOUT_SECONDS, true);
+                executeProcess(cmd, DIRECTORY_DOWNLOAD_TIMEOUT_SECONDS, true, manifestFile);
             } finally {
                 Files.deleteIfExists(manifestFile);
                 Files.deleteIfExists(wrapperScript);
@@ -547,9 +561,9 @@ public final class GcpPathHelper {
         sb.append("#!/bin/sh\n");
         sb.append("gcloud storage cp");
         if (billingProject != null && !billingProject.isEmpty()) {
-            sb.append(" --billing-project=").append(billingProject);
+            sb.append(" '--billing-project=").append(billingProject).append("'");
         }
-        sb.append(" \"$@\" ").append(localDir.toAbsolutePath()).append("/\n");
+        sb.append(" \"$@\" '").append(localDir.toAbsolutePath()).append("/'\n");
         return sb.toString();
     }
 
@@ -640,21 +654,47 @@ public final class GcpPathHelper {
      */
     private static int executeProcess(
             @NonNull final List<String> cmd, final long timeoutSeconds, final boolean logOutput) {
+        return executeProcess(cmd, timeoutSeconds, logOutput, null);
+    }
+
+    /**
+     * Executes an external process and returns its exit code, optionally redirecting stdin
+     * from a file (used for portable xargs invocations instead of GNU-only {@code -a}).
+     *
+     * <p>Output is drained in a separate daemon thread so that {@code waitFor(timeout)} can
+     * enforce the timeout even if the process keeps stdout open.
+     */
+    private static int executeProcess(
+            @NonNull final List<String> cmd,
+            final long timeoutSeconds,
+            final boolean logOutput,
+            @Nullable final Path stdinFile) {
         try {
             log.debug("Executing: {}", String.join(" ", cmd));
             final ProcessBuilder pb = new ProcessBuilder(cmd);
             pb.redirectErrorStream(true);
+            if (stdinFile != null) {
+                pb.redirectInput(stdinFile.toFile());
+            }
             final Process process = pb.start();
 
-            // Drain output to prevent blocking
-            try (var reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    if (logOutput) {
-                        log.debug("[gcloud] {}", line);
-                    }
-                }
-            }
+            // Drain output in a daemon thread so waitFor(timeout) is not blocked
+            final Thread drainThread = new Thread(
+                    () -> {
+                        try (var reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                            String line;
+                            while ((line = reader.readLine()) != null) {
+                                if (logOutput) {
+                                    log.debug("[gcloud] {}", line);
+                                }
+                            }
+                        } catch (IOException e) {
+                            // Process was likely destroyed — expected on timeout
+                        }
+                    },
+                    "process-output-drain");
+            drainThread.setDaemon(true);
+            drainThread.start();
 
             final boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
@@ -662,6 +702,10 @@ public final class GcpPathHelper {
                 log.error("Process timed out after {} seconds: {}", timeoutSeconds, String.join(" ", cmd));
                 return -1;
             }
+
+            // Wait briefly for the drain thread to finish reading any remaining output
+            drainThread.join(2000);
+
             return process.exitValue();
         } catch (IOException | InterruptedException e) {
             log.error("Failed to execute process: {}", String.join(" ", cmd), e);

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/GcpPathHelper.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/GcpPathHelper.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 
 /**
  * Utility for downloading files and directories from Google Cloud Storage using the {@code gcloud storage}
@@ -27,6 +29,9 @@ import org.apache.logging.log4j.Logger;
 public final class GcpPathHelper {
 
     private static final Logger log = LogManager.getLogger(GcpPathHelper.class);
+
+    /** Marker for log statements that should be routed to stdout for user-facing progress. */
+    public static final Marker CONSOLE = MarkerManager.getMarker("CONSOLE");
 
     /** Prefix that identifies a GCS URI. */
     private static final String GCS_PREFIX = "gs://";
@@ -210,9 +215,9 @@ public final class GcpPathHelper {
         // Count remote objects first to enable progress reporting
         final int totalObjects = countRemoteObjects(source, billingProject);
         if (totalObjects > 0) {
-            System.out.printf("Downloading state directory from %s (%d objects) ...%n", gcpPath, totalObjects);
+            log.info(CONSOLE, "Downloading state directory from {} ({} objects) ...", gcpPath, totalObjects);
         } else {
-            System.out.printf("Downloading state directory from %s ...%n", gcpPath);
+            log.info(CONSOLE, "Downloading state directory from {} ...", gcpPath);
         }
 
         final long start = System.currentTimeMillis();
@@ -239,7 +244,7 @@ public final class GcpPathHelper {
         }
         final long elapsed = (System.currentTimeMillis() - start) / 1000;
         log.info("State directory download complete in {} seconds: {} -> {}", elapsed, gcpPath, localDir);
-        System.out.printf("State directory download complete in %d seconds.%n", elapsed);
+        log.info(CONSOLE, "State directory download complete in {} seconds.", elapsed);
     }
 
     // ========== Bulk file download ==========
@@ -293,7 +298,7 @@ public final class GcpPathHelper {
         wrapperScript.toFile().setExecutable(true);
 
         final long start = System.currentTimeMillis();
-        System.out.printf("Downloading %d block files from %s ...%n", totalFiles, gcpBaseDir);
+        log.info(CONSOLE, "Downloading {} block files from {} ...", totalFiles, gcpBaseDir);
         try {
             final List<String> cmd = new ArrayList<>();
             cmd.add("xargs");
@@ -327,7 +332,7 @@ public final class GcpPathHelper {
                 if (missing.isEmpty()) {
                     break;
                 }
-                System.out.printf("Retry pass %d: %d missing files...%n", pass, missing.size());
+                log.info(CONSOLE, "Retry pass {}: {} missing files...", pass, missing.size());
                 log.warn("Retry pass {}/{}: {} files missing after download", pass, maxRetryPasses, missing.size());
                 retryMissingFilesBatched(base, missing, localDir, billingProject, parallelism);
             }
@@ -336,7 +341,7 @@ public final class GcpPathHelper {
             validateDownloadedFiles(localDir, BLOCK_FILE_EXTENSION);
 
             final long finalCount = countFilesInDir(localDir, BLOCK_FILE_EXTENSION);
-            System.out.printf("Block file download complete: %d files in %d seconds.%n", finalCount, elapsed);
+            log.info(CONSOLE, "Block file download complete: {} files in {} seconds.", finalCount, elapsed);
 
         } finally {
             Files.deleteIfExists(manifestFile);
@@ -375,7 +380,7 @@ public final class GcpPathHelper {
                             final long count = counter.count();
                             final int percent = (int) (count * 100 / totalFiles);
                             if (percent / 10 > lastReportedPercent / 10) {
-                                System.out.printf("  %d%% (%d/%d)%n", percent, count, totalFiles);
+                                log.info(CONSOLE, "  {}% ({}/{})", percent, count, totalFiles);
                                 lastReportedPercent = percent;
                             }
                         } catch (InterruptedException e) {

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/GcpPathHelper.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/GcpPathHelper.java
@@ -703,6 +703,16 @@ public final class GcpPathHelper {
 
             final boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
             if (!finished) {
+                // Kill all descendant processes first (gcloud, wrapper scripts spawned by xargs).
+                // Without this, destroyForcibly() only kills xargs itself, leaving orphaned gcloud
+                // processes that continue writing into the cache directory after Java has returned.
+                process.descendants().forEach(descendant -> {
+                    log.debug(
+                            "Killing descendant process: pid={}, cmd={}",
+                            descendant.pid(),
+                            descendant.info().commandLine().orElse("unknown"));
+                    descendant.destroyForcibly();
+                });
                 process.destroyForcibly();
                 log.error("Process timed out after {} seconds: {}", timeoutSeconds, String.join(" ", cmd));
                 return -1;

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/GcpPathHelper.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/GcpPathHelper.java
@@ -1,0 +1,674 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.statevalidation.gcp;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Utility for downloading files and directories from Google Cloud Storage using the {@code gcloud storage}
+ * CLI. No GCP SDK dependency is required — authentication and billing are handled by the locally
+ * configured {@code gcloud} tool.
+ *
+ * <p>All public methods that interact with GCS accept an optional {@code billingProject} parameter
+ * for requester-pays buckets.
+ */
+public final class GcpPathHelper {
+
+    private static final Logger log = LogManager.getLogger(GcpPathHelper.class);
+
+    /** Prefix that identifies a GCS URI. */
+    private static final String GCS_PREFIX = "gs://";
+
+    /** Number of digits in a block file name (before the extension). */
+    private static final int BLOCK_NUMBER_DIGITS = 36;
+
+    /** Extension for compressed block files. */
+    private static final String BLOCK_FILE_EXTENSION = ".blk.gz";
+
+    /** Maximum number of retries for transient GCP failures. */
+    private static final int MAX_RETRIES = 3;
+
+    /** Base delay (in milliseconds) for exponential backoff between retries. */
+    private static final long RETRY_BASE_DELAY_MS = 1_000;
+
+    /** Default timeout (in seconds) for a single-file operation. */
+    private static final long SINGLE_FILE_TIMEOUT_SECONDS = 60;
+
+    /** Default timeout (in seconds) for a recursive directory download. */
+    private static final long DIRECTORY_DOWNLOAD_TIMEOUT_SECONDS = 3600;
+
+    private GcpPathHelper() {}
+
+    // ========== Path utilities ==========
+
+    /**
+     * Returns {@code true} if the given path string represents a GCS URI.
+     */
+    public static boolean isGcpPath(@Nullable final String path) {
+        return path != null && path.startsWith(GCS_PREFIX);
+    }
+
+    /**
+     * Converts a block number to the canonical 36-digit zero-padded file name with {@code .blk.gz} extension.
+     * Mirrors {@code FileBlockItemWriter.longToFileName()}.
+     *
+     * @param blockNumber the block number (non-negative)
+     * @return file name, e.g. {@code "000000000000000000000000000000382065.blk.gz"}
+     */
+    @NonNull
+    public static String blockFileName(final long blockNumber) {
+        return String.format("%0" + BLOCK_NUMBER_DIGITS + "d", blockNumber) + BLOCK_FILE_EXTENSION;
+    }
+
+    /**
+     * Builds a full GCS URI for a block file given the base directory and block number.
+     */
+    @NonNull
+    public static String blockFileUri(@NonNull final String gcpBaseDir, final long blockNumber) {
+        final String base = gcpBaseDir.endsWith("/") ? gcpBaseDir : gcpBaseDir + "/";
+        return base + blockFileName(blockNumber);
+    }
+
+    /**
+     * Extracts the last path element from a local path or GCS URI, stripping any trailing slash.
+     * <p>Example: {@code gs://bucket/prefix/4971437} → {@code 4971437},
+     * {@code /local/path/4971437/} → {@code 4971437}.
+     */
+    @NonNull
+    public static String extractLastPathElement(@NonNull final String path) {
+        final String trimmed = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+        return trimmed.substring(trimmed.lastIndexOf('/') + 1);
+    }
+
+    // ========== Availability check ==========
+
+    /**
+     * Verifies that {@code gcloud} is installed and accessible.
+     *
+     * @throws IllegalStateException if {@code gcloud} is not found or returns a non-zero exit code
+     */
+    public static void ensureGcloudAvailable() {
+        try {
+            final ProcessBuilder pb = new ProcessBuilder("gcloud", "--version");
+            pb.redirectErrorStream(true);
+            final Process p = pb.start();
+            // Drain output to avoid blocking
+            try (var reader = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                while (reader.readLine() != null) {
+                    // discard
+                }
+            }
+            final boolean finished = p.waitFor(15, TimeUnit.SECONDS);
+            if (!finished || p.exitValue() != 0) {
+                throw new IllegalStateException("gcloud CLI is not properly configured (exit code: "
+                        + (finished ? p.exitValue() : "timeout") + ")");
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new IllegalStateException(
+                    "gcloud CLI is not installed or not on PATH. "
+                            + "Install it from https://cloud.google.com/sdk/docs/install",
+                    e);
+        }
+    }
+
+    // ========== Single-file operations ==========
+
+    /**
+     * Checks whether a single object exists in GCS without downloading it.
+     * Retries on transient failures.
+     *
+     * @param gcpPath        full GCS URI of the object
+     * @param billingProject optional billing project for requester-pays buckets
+     * @return {@code true} if the object exists
+     */
+    public static boolean fileExists(@NonNull final String gcpPath, @Nullable final String billingProject) {
+        final List<String> cmd = buildLsCommand(gcpPath, billingProject);
+        return executeWithRetry(cmd, SINGLE_FILE_TIMEOUT_SECONDS, false) == 0;
+    }
+
+    /**
+     * Checks whether a single object exists in GCS, <b>without retrying</b>.
+     * Preferred for scatter-gather probing where many "not found" results are expected.
+     *
+     * @param gcpPath        full GCS URI of the object
+     * @param billingProject optional billing project for requester-pays buckets
+     * @return {@code true} if the object exists
+     */
+    public static boolean fileExistsNoRetry(@NonNull final String gcpPath, @Nullable final String billingProject) {
+        final List<String> cmd = buildLsCommand(gcpPath, billingProject);
+        return executeProcess(cmd, SINGLE_FILE_TIMEOUT_SECONDS, false) == 0;
+    }
+
+    /**
+     * Downloads a single file from GCS to a local directory.
+     *
+     * @param gcpPath        full GCS URI of the object
+     * @param localDir       local directory where the file will be saved
+     * @param billingProject optional billing project
+     * @return {@code true} if the download succeeded
+     */
+    public static boolean downloadFile(
+            @NonNull final String gcpPath, @NonNull final Path localDir, @Nullable final String billingProject) {
+        try {
+            Files.createDirectories(localDir);
+        } catch (IOException e) {
+            log.error("Failed to create local directory {}", localDir, e);
+            return false;
+        }
+        final List<String> cmd = buildCommand("cp", gcpPath, localDir.toString() + "/", billingProject);
+        return executeWithRetry(cmd, SINGLE_FILE_TIMEOUT_SECONDS, true) == 0;
+    }
+
+    // ========== Directory download ==========
+
+    /**
+     * Recursively downloads a GCS directory to a local directory.
+     *
+     * @param gcpPath        GCS URI of the directory (e.g. {@code gs://bucket/prefix/})
+     * @param localDir       local target directory
+     * @param billingProject optional billing project
+     * @throws IOException if the download fails
+     */
+    public static void downloadDirectory(
+            @NonNull final String gcpPath, @NonNull final Path localDir, @Nullable final String billingProject)
+            throws IOException {
+        Files.createDirectories(localDir);
+        final String source = gcpPath.endsWith("/") ? gcpPath : gcpPath + "/";
+        final List<String> cmd = buildRecursiveCpCommand(source, localDir.toString() + "/", billingProject);
+        log.info("Downloading state directory from {} to {} ...", gcpPath, localDir);
+
+        // Count remote objects first to enable progress reporting
+        final int totalObjects = countRemoteObjects(source, billingProject);
+        if (totalObjects > 0) {
+            System.out.printf("Downloading state directory from %s (%d objects) ...%n", gcpPath, totalObjects);
+        } else {
+            System.out.printf("Downloading state directory from %s ...%n", gcpPath);
+        }
+
+        final long start = System.currentTimeMillis();
+
+        // Start progress monitor if we know the total
+        final Thread progressMonitor = totalObjects > 0
+                ? startProgressMonitor("gcp-state-download-progress", totalObjects, () -> countFilesRecursive(localDir))
+                : null;
+
+        final int exitCode = executeWithRetry(cmd, DIRECTORY_DOWNLOAD_TIMEOUT_SECONDS, true);
+
+        // Stop the progress monitor
+        if (progressMonitor != null) {
+            progressMonitor.interrupt();
+            try {
+                progressMonitor.join(2000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        if (exitCode != 0) {
+            throw new IOException("Failed to download directory from " + gcpPath + " (exit code: " + exitCode + ")");
+        }
+        final long elapsed = (System.currentTimeMillis() - start) / 1000;
+        log.info("State directory download complete in {} seconds: {} -> {}", elapsed, gcpPath, localDir);
+        System.out.printf("State directory download complete in %d seconds.%n", elapsed);
+    }
+
+    // ========== Bulk file download ==========
+
+    /**
+     * Downloads a list of files from a GCS directory to a local directory using batched parallelism.
+     *
+     * <p>Files are split into {@code parallelism} equal-sized chunks. Each chunk is downloaded
+     * by a separate {@code gcloud storage cp} process, where each process receives up to 500 URIs
+     * as arguments (matching the proven pattern from the download_blockstream.sh script).
+     *
+     * @param gcpBaseDir     base GCS directory URI (without trailing file name)
+     * @param fileNames      list of file names to download
+     * @param localDir       local target directory
+     * @param billingProject optional billing project
+     * @param parallelism    number of parallel download processes
+     * @throws IOException if the download fails or file validation detects problems
+     */
+    public static void downloadFiles(
+            @NonNull final String gcpBaseDir,
+            @NonNull final List<String> fileNames,
+            @NonNull final Path localDir,
+            @Nullable final String billingProject,
+            final int parallelism)
+            throws IOException {
+        if (fileNames.isEmpty()) {
+            return;
+        }
+        Files.createDirectories(localDir);
+        final String base = gcpBaseDir.endsWith("/") ? gcpBaseDir : gcpBaseDir + "/";
+        final int totalFiles = fileNames.size();
+        log.info(
+                "Downloading {} block files from {} to {} using {} parallel workers ...",
+                totalFiles,
+                gcpBaseDir,
+                localDir,
+                parallelism);
+
+        // Build full GCS URIs
+        final List<String> uris = fileNames.stream().map(name -> base + name).collect(Collectors.toList());
+
+        // Write URI list to a temp manifest file
+        final Path manifestFile = Files.createTempFile("gcp-download-manifest-", ".txt");
+        Files.write(manifestFile, uris);
+
+        // Create wrapper script that receives GCS URIs as positional arguments and appends
+        // the local destination directory — needed because xargs inserts args before
+        // the end of the command, but gcloud storage cp expects the destination last.
+        final Path wrapperScript = Files.createTempFile("gcp-download-", ".sh");
+        Files.writeString(wrapperScript, buildDownloadScript(localDir, billingProject));
+        wrapperScript.toFile().setExecutable(true);
+
+        final long start = System.currentTimeMillis();
+        System.out.printf("Downloading %d block files from %s ...%n", totalFiles, gcpBaseDir);
+        try {
+            final List<String> cmd = new ArrayList<>();
+            cmd.add("xargs");
+            cmd.add("-a");
+            cmd.add(manifestFile.toString());
+            cmd.add("-n");
+            cmd.add("500");
+            cmd.add("-P");
+            cmd.add(String.valueOf(Math.max(1, parallelism)));
+            cmd.add(wrapperScript.toString());
+
+            // Start a progress monitor that periodically reports to stdout
+            final Thread progressMonitor = startProgressMonitor(
+                    "gcp-download-progress", totalFiles, () -> countFilesInDir(localDir, BLOCK_FILE_EXTENSION));
+
+            final int exitCode = executeProcess(cmd, DIRECTORY_DOWNLOAD_TIMEOUT_SECONDS, true);
+
+            // Stop the progress monitor
+            progressMonitor.interrupt();
+            try {
+                progressMonitor.join(2000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            final long elapsed = (System.currentTimeMillis() - start) / 1000;
+
+            // Always check for missing files regardless of exit code — xargs can return 0
+            // even when individual gcloud processes silently fail on some files.
+            final int maxRetryPasses = 3;
+            for (int pass = 1; pass <= maxRetryPasses; pass++) {
+                final List<String> missing = findMissingFiles(fileNames, localDir);
+                if (missing.isEmpty()) {
+                    break;
+                }
+                System.out.printf("Retry pass %d: %d missing files...%n", pass, missing.size());
+                log.warn("Retry pass {}/{}: {} files missing after download", pass, maxRetryPasses, missing.size());
+                retryMissingFilesBatched(base, missing, localDir, billingProject, parallelism);
+            }
+
+            // Final validation: check for empty files
+            validateDownloadedFiles(localDir, BLOCK_FILE_EXTENSION);
+
+            final long finalCount = countFilesInDir(localDir, BLOCK_FILE_EXTENSION);
+            System.out.printf("Block file download complete: %d files in %d seconds.%n", finalCount, elapsed);
+
+        } finally {
+            Files.deleteIfExists(manifestFile);
+            Files.deleteIfExists(wrapperScript);
+        }
+    }
+
+    // ========== Progress tracking ==========
+
+    /** Interval between progress reports (in milliseconds). */
+    private static final long PROGRESS_INTERVAL_MS = 5_000;
+
+    /** A counting strategy that may throw {@link IOException}. */
+    @FunctionalInterface
+    private interface FileCounter {
+        long count() throws IOException;
+    }
+
+    /**
+     * Starts a daemon thread that periodically invokes the given counter and prints
+     * progress to stdout. The thread runs until interrupted.
+     *
+     * @param threadName  name for the monitoring thread
+     * @param totalFiles  the expected total file count
+     * @param counter     strategy for counting completed files
+     * @return the monitoring thread (already started)
+     */
+    private static Thread startProgressMonitor(
+            @NonNull final String threadName, final int totalFiles, @NonNull final FileCounter counter) {
+        final Thread monitor = new Thread(
+                () -> {
+                    int lastReportedPercent = -1;
+                    while (!Thread.currentThread().isInterrupted()) {
+                        try {
+                            Thread.sleep(PROGRESS_INTERVAL_MS);
+                            final long count = counter.count();
+                            final int percent = (int) (count * 100 / totalFiles);
+                            if (percent / 10 > lastReportedPercent / 10) {
+                                System.out.printf("  %d%% (%d/%d)%n", percent, count, totalFiles);
+                                lastReportedPercent = percent;
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            break;
+                        } catch (IOException e) {
+                            log.debug("Progress monitor failed to count files", e);
+                        }
+                    }
+                },
+                threadName);
+        monitor.setDaemon(true);
+        monitor.start();
+        return monitor;
+    }
+
+    /**
+     * Counts files with the given extension in the directory (non-recursive).
+     */
+    static long countFilesInDir(@NonNull final Path dir, @NonNull final String extension) throws IOException {
+        if (!Files.isDirectory(dir)) {
+            return 0;
+        }
+        try (Stream<Path> stream = Files.list(dir)) {
+            return stream.filter(p -> p.getFileName().toString().endsWith(extension))
+                    .count();
+        }
+    }
+
+    /**
+     * Counts all regular files recursively under the given directory.
+     */
+    static long countFilesRecursive(@NonNull final Path dir) throws IOException {
+        if (!Files.isDirectory(dir)) {
+            return 0;
+        }
+        try (Stream<Path> stream = Files.walk(dir)) {
+            return stream.filter(Files::isRegularFile).count();
+        }
+    }
+
+    /**
+     * Counts the number of objects in a GCS path using {@code gcloud storage ls --recursive}.
+     * Returns 0 if the count cannot be determined (non-fatal).
+     */
+    private static int countRemoteObjects(@NonNull final String gcpPath, @Nullable final String billingProject) {
+        try {
+            final List<String> cmd = new ArrayList<>();
+            cmd.add("gcloud");
+            cmd.add("storage");
+            cmd.add("ls");
+            cmd.add("--recursive");
+            if (billingProject != null && !billingProject.isEmpty()) {
+                cmd.add("--billing-project=" + billingProject);
+            }
+            cmd.add(gcpPath);
+
+            final ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.redirectErrorStream(true);
+            final Process process = pb.start();
+            int count = 0;
+            try (var reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    // Skip directory markers (lines ending with /) and empty lines
+                    if (!line.isEmpty() && !line.endsWith("/")) {
+                        count++;
+                    }
+                }
+            }
+            final boolean finished = process.waitFor(120, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                return 0;
+            }
+            log.debug("Remote object count for {}: {}", gcpPath, count);
+            return count;
+        } catch (IOException | InterruptedException e) {
+            log.debug("Failed to count remote objects for {}", gcpPath, e);
+            return 0;
+        }
+    }
+
+    /**
+     * Validates that all downloaded files with the given extension are non-empty.
+     *
+     * @throws IOException if any file is empty (likely a partial/failed download)
+     */
+    static void validateDownloadedFiles(@NonNull final Path dir, @NonNull final String extension) throws IOException {
+        try (Stream<Path> stream = Files.list(dir)) {
+            final List<Path> emptyFiles = stream.filter(
+                            p -> p.getFileName().toString().endsWith(extension))
+                    .filter(p -> {
+                        try {
+                            return Files.size(p) == 0;
+                        } catch (IOException e) {
+                            return true;
+                        }
+                    })
+                    .toList();
+            if (!emptyFiles.isEmpty()) {
+                throw new IOException(
+                        "Found " + emptyFiles.size() + " empty block files after download, indicating partial "
+                                + "or failed downloads. First: " + emptyFiles.getFirst());
+            }
+        }
+    }
+
+    // ========== Internal helpers ==========
+
+    /**
+     * Returns the list of file names from the expected set that are missing or empty in the local directory.
+     */
+    private static List<String> findMissingFiles(
+            @NonNull final List<String> expectedFileNames, @NonNull final Path localDir) {
+        final List<String> missing = new ArrayList<>();
+        for (final String name : expectedFileNames) {
+            final Path localFile = localDir.resolve(name);
+            if (!Files.exists(localFile) || fileIsEmpty(localFile)) {
+                missing.add(name);
+            }
+        }
+        return missing;
+    }
+
+    /**
+     * Retries downloading missing files using the same batched xargs approach as the initial download.
+     */
+    private static void retryMissingFilesBatched(
+            @NonNull final String gcpBase,
+            @NonNull final List<String> missingFileNames,
+            @NonNull final Path localDir,
+            @Nullable final String billingProject,
+            final int parallelism) {
+        if (missingFileNames.isEmpty()) {
+            return;
+        }
+        try {
+            final List<String> uris =
+                    missingFileNames.stream().map(name -> gcpBase + name).collect(Collectors.toList());
+            final Path manifestFile = Files.createTempFile("gcp-retry-manifest-", ".txt");
+            final Path wrapperScript = Files.createTempFile("gcp-retry-", ".sh");
+            try {
+                Files.write(manifestFile, uris);
+                Files.writeString(wrapperScript, buildDownloadScript(localDir, billingProject));
+                wrapperScript.toFile().setExecutable(true);
+
+                final List<String> cmd = new ArrayList<>();
+                cmd.add("xargs");
+                cmd.add("-a");
+                cmd.add(manifestFile.toString());
+                cmd.add("-n");
+                cmd.add("500");
+                cmd.add("-P");
+                cmd.add(String.valueOf(Math.max(1, parallelism)));
+                cmd.add(wrapperScript.toString());
+
+                executeProcess(cmd, DIRECTORY_DOWNLOAD_TIMEOUT_SECONDS, true);
+            } finally {
+                Files.deleteIfExists(manifestFile);
+                Files.deleteIfExists(wrapperScript);
+            }
+        } catch (IOException e) {
+            log.error("Retry batch download failed", e);
+        }
+    }
+
+    private static boolean fileIsEmpty(@NonNull final Path path) {
+        try {
+            return Files.size(path) == 0;
+        } catch (IOException e) {
+            return true;
+        }
+    }
+
+    /**
+     * Builds a small shell script that receives GCS URIs as positional arguments
+     * and downloads them to the target directory. This is needed because xargs appends
+     * arguments to the end of the command, but {@code gcloud storage cp} expects the
+     * destination as the last argument.
+     */
+    @NonNull
+    private static String buildDownloadScript(@NonNull final Path localDir, @Nullable final String billingProject) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("#!/bin/sh\n");
+        sb.append("gcloud storage cp");
+        if (billingProject != null && !billingProject.isEmpty()) {
+            sb.append(" --billing-project=").append(billingProject);
+        }
+        sb.append(" \"$@\" ").append(localDir.toAbsolutePath()).append("/\n");
+        return sb.toString();
+    }
+
+    /**
+     * Builds a {@code gcloud storage ls} command for checking object existence.
+     */
+    @NonNull
+    private static List<String> buildLsCommand(@NonNull final String gcpPath, @Nullable final String billingProject) {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add("gcloud");
+        cmd.add("storage");
+        cmd.add("ls");
+        if (billingProject != null && !billingProject.isEmpty()) {
+            cmd.add("--billing-project=" + billingProject);
+        }
+        cmd.add(gcpPath);
+        return cmd;
+    }
+
+    /**
+     * Builds a {@code gcloud storage cp} command with source, destination, and optional billing project.
+     */
+    @NonNull
+    private static List<String> buildCommand(
+            @NonNull final String subCommand,
+            @NonNull final String source,
+            @NonNull final String destination,
+            @Nullable final String billingProject) {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add("gcloud");
+        cmd.add("storage");
+        cmd.add(subCommand);
+        if (billingProject != null && !billingProject.isEmpty()) {
+            cmd.add("--billing-project=" + billingProject);
+        }
+        cmd.add(source);
+        cmd.add(destination);
+        return cmd;
+    }
+
+    /**
+     * Builds a {@code gcloud storage cp --recursive} command.
+     */
+    @NonNull
+    private static List<String> buildRecursiveCpCommand(
+            @NonNull final String source, @NonNull final String destination, @Nullable final String billingProject) {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add("gcloud");
+        cmd.add("storage");
+        cmd.add("cp");
+        cmd.add("--recursive");
+        if (billingProject != null && !billingProject.isEmpty()) {
+            cmd.add("--billing-project=" + billingProject);
+        }
+        cmd.add(source);
+        cmd.add(destination);
+        return cmd;
+    }
+
+    /**
+     * Executes a command with retry logic for transient failures.
+     *
+     * @return the exit code of the last attempt
+     */
+    private static int executeWithRetry(
+            @NonNull final List<String> cmd, final long timeoutSeconds, final boolean logOutput) {
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            final int exitCode = executeProcess(cmd, timeoutSeconds, logOutput);
+            if (exitCode == 0) {
+                return 0;
+            }
+            if (attempt < MAX_RETRIES) {
+                final long delay = RETRY_BASE_DELAY_MS * (1L << (attempt - 1)); // exponential backoff
+                log.debug("Command failed (attempt {}/{}), retrying in {} ms: {}", attempt, MAX_RETRIES, delay, cmd);
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return exitCode;
+                }
+            }
+        }
+        return -1; // all retries exhausted
+    }
+
+    /**
+     * Executes an external process and returns its exit code.
+     */
+    private static int executeProcess(
+            @NonNull final List<String> cmd, final long timeoutSeconds, final boolean logOutput) {
+        try {
+            log.debug("Executing: {}", String.join(" ", cmd));
+            final ProcessBuilder pb = new ProcessBuilder(cmd);
+            pb.redirectErrorStream(true);
+            final Process process = pb.start();
+
+            // Drain output to prevent blocking
+            try (var reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (logOutput) {
+                        log.debug("[gcloud] {}", line);
+                    }
+                }
+            }
+
+            final boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+            if (!finished) {
+                process.destroyForcibly();
+                log.error("Process timed out after {} seconds: {}", timeoutSeconds, String.join(" ", cmd));
+                return -1;
+            }
+            return process.exitValue();
+        } catch (IOException | InterruptedException e) {
+            log.error("Failed to execute process: {}", String.join(" ", cmd), e);
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return -1;
+        }
+    }
+}

--- a/hedera-state-validator/src/main/resources/log4j2.xml
+++ b/hedera-state-validator/src/main/resources/log4j2.xml
@@ -4,6 +4,10 @@
       <Console name="DefaultConsoleAppender" target="SYSTEM_OUT">
           <PatternLayout pattern="%msg%n%throwable"/>
       </Console>
+      <Console name="ConsoleMarkerAppender" target="SYSTEM_OUT">
+          <MarkerFilter marker="CONSOLE" onMatch="ACCEPT" onMismatch="DENY"/>
+          <PatternLayout pattern="%msg%n"/>
+      </Console>
       <Console name="StateAnalysisConsoleAppender" target="SYSTEM_OUT">
           <PatternLayout pattern="%msg%n%throwable"/>
       </Console>
@@ -37,6 +41,7 @@
       </Logger>
       <Root level="DEBUG">
           <AppenderRef ref="FileAppender"/>
+          <AppenderRef ref="ConsoleMarkerAppender"/>
       </Root>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
**Description**:

## Add GCP bucket support to state validator

Enable the state validator to work directly with GCS paths (`gs://...`) for both the state directory and block stream directory, eliminating the need for manual pre-download.

### State directory (all subcommands)
- When a `gs://` path is provided as the positional state dir parameter, it is downloaded recursively to a local cache directory
- Cache is deterministic and reusable across runs (`./state-validator-cache-<round>/`)
- Subsequent runs with the same state path skip the download entirely

### Block stream directory (`apply-blocks` only)
- `--target-round` is required when `--block-stream-dir` is a GCS path
- Reads `BlockStreamInfo.blockNumber` from the loaded state to determine the left block boundary
- Uses scatter-gather binary search to find the block containing the target round — probes individual `.blk.gz` files on GCS and parses `RoundHeader` items
- Downloads the resolved range in parallel using batched `xargs -P N` with `gcloud storage cp`
- Probe files outside the resolved range are cleaned up to prevent the downstream validator from misinterpreting the directory contents
- Cache dir is named `./state-validator-blocks-<source-round>-to-<target-round>/`, fully reusable
- Post-download validation with up to 3 retry passes for missing files

### New CLI options
- `--billing-project` / `-bp` — for requester-pays buckets (block stream)
- `--download-threads` / `-dt` — parallel download workers (default 32)
- `--cleanup-temp` — delete cache directories after execution (default: keep)

### Implementation
- No new SDK dependencies — uses `gcloud storage` CLI
- New files: `GcpPathHelper` (GCS download utilities), `BlockRangeResolver` (block range resolution)
- `stateDir` parameter type changed from `File` to `String`; `initializeStateDir()` renamed to `resolveAndGetStateDir()` (backward-compatible wrapper retained)
- Progress reported to stdout for state download, block range probing, and block file download

**Related issue(s)**:

Fixes #25369 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
