### PR TITLE
chore: Only log when a slow or stalled BN connection is detected

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -141,8 +141,7 @@ public class BlockNodeConnectionManager {
     private static final long MASK_UPDATED_CONFIG = 1 << 1;
     private static final long MASK_BUFFER_ACTION_STAGE = 1 << 2;
     private static final long MASK_HIGHER_PRIORITY_CONNECTION = 1 << 3;
-    private static final long MASK_STALLED_CONNECTION = 1 << 4;
-    private static final long MASK_AUTO_RESET = 1 << 5;
+    private static final long MASK_AUTO_RESET = 1 << 4;
 
     /**
      * A record that holds a candidate node configuration along with the block number it wants to stream.
@@ -629,6 +628,9 @@ public class BlockNodeConnectionManager {
 
         final Instant now = Instant.now();
         final BlockNodeStreamingConnection activeConnection = activeConnectionRef.get();
+
+        checkActiveConnectionStalled(now, activeConnection);
+
         CloseReason closeReason = CloseReason.UNKNOWN;
         NodeSelectionCriteria criteria = new AnyCriteria();
         long changes = NO_CHANGES;
@@ -649,10 +651,6 @@ public class BlockNodeConnectionManager {
             criteria =
                     new MinimumPriorityCriteria(activeConnection.configuration().priority() - 1);
             closeReason = CloseReason.HIGHER_PRIORITY_FOUND;
-        }
-        if (isActiveConnectionStalled(now, activeConnection)) {
-            changes |= MASK_STALLED_CONNECTION;
-            closeReason = CloseReason.CONNECTION_STALLED;
         }
         if (isActiveConnectionAutoReset(now, activeConnection)) {
             changes |= MASK_AUTO_RESET;
@@ -705,9 +703,6 @@ public class BlockNodeConnectionManager {
         }
         if ((changes & MASK_HIGHER_PRIORITY_CONNECTION) != 0) {
             sb.append(" higher-priority-connection-found");
-        }
-        if ((changes & MASK_STALLED_CONNECTION) != 0) {
-            sb.append(" stalled-active-connection");
         }
         if ((changes & MASK_AUTO_RESET) != 0) {
             sb.append(" auto-reset-active-connection");
@@ -866,12 +861,11 @@ public class BlockNodeConnectionManager {
      *
      * @param now timestamp used compare against the last heartbeat of the connection
      * @param activeConnection the connection to check if stalled
-     * @return true if the connection is stalled, else false
      */
-    private boolean isActiveConnectionStalled(
+    private void checkActiveConnectionStalled(
             @NonNull final Instant now, @Nullable final BlockNodeStreamingConnection activeConnection) {
         if (activeConnection == null) {
-            return false;
+            return;
         }
 
         final long stalledConnectionThresholdMillis = bncConfig().connectionStallThresholdMillis();
@@ -882,17 +876,13 @@ public class BlockNodeConnectionManager {
             final long deltaMillis = now.toEpochMilli() - lastHeartbeatTimestamp;
             if (deltaMillis >= stalledConnectionThresholdMillis) {
                 logger.warn(
-                        "{} Active connection is marked as being stalled (lastHeartbeat: {}, thresholdMillis: {}, deltaMillis: {}); closing connection",
+                        "{} Active connection is slow/stalled (lastHeartbeat: {}, threshold: {}ms, observed: {}ms)",
                         activeConnection,
                         lastHeartbeatTimestamp,
                         stalledConnectionThresholdMillis,
                         deltaMillis);
-                activeConnection.close(CloseReason.CONNECTION_STALLED, true);
-                return true;
             }
         }
-
-        return false;
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnection.java
@@ -796,7 +796,17 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
         final long durationMicros = calculateDurationMicros(startNanos.get(), endNanos.get());
         blockStreamMetrics.recordRequestLatency(durationMicros);
 
-        if (logger.isTraceEnabled() && request instanceof BlockRequest) {
+        final long durationMillis = TimeUnit.MICROSECONDS.toMillis(durationMicros);
+        final long slowThresholdMillis = bncConfig().slowRequestThresholdMillis();
+
+        if (durationMillis > slowThresholdMillis) {
+            logger.warn(
+                    "{} Slow request detected (threshold: {}ms, observed: {}ms, requestSize: {}B)",
+                    connectionContext(correlationId),
+                    slowThresholdMillis,
+                    durationMillis,
+                    request.streamRequest().protobufSize());
+        } else if (logger.isTraceEnabled() && request instanceof BlockRequest) {
             logger.trace(
                     "{} Request successfully sent (duration: {}μs)", connectionContext(correlationId), durationMicros);
         }
@@ -828,7 +838,7 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
                 }
             }
         }
-        // spotles:on
+        // spotless:on
 
         return true;
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/CloseReason.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/CloseReason.java
@@ -29,10 +29,6 @@ public enum CloseReason {
      */
     CONNECTION_ERROR(CoolDownType.BASIC),
     /**
-     * The connection was closed because it was determined to be stalled.
-     */
-    CONNECTION_STALLED(CoolDownType.BASIC),
-    /**
      * The connection was closed due to receiving an end stream response AND as a result the associated block node is
      * considered degraded because several end stream responses have been received in a short period of time.
      */

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerLoggingTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerLoggingTest.java
@@ -49,6 +49,7 @@ class BlockNodeConnectionManagerLoggingTest extends BlockNodeCommunicationTestBa
     private static final VarHandle blockNodesHandle;
 
     private static final MethodHandle updateConnectionIfNeededHandle;
+    private static final MethodHandle checkActiveConnectionStalledHandle;
 
     static {
         try {
@@ -62,12 +63,18 @@ class BlockNodeConnectionManagerLoggingTest extends BlockNodeCommunicationTestBa
             final Method updateConnectionIfNeeded = cls.getDeclaredMethod("updateConnectionIfNeeded");
             updateConnectionIfNeeded.setAccessible(true);
             updateConnectionIfNeededHandle = lookup.unreflect(updateConnectionIfNeeded);
+
+            final Method checkActiveConnectionStalled = cls.getDeclaredMethod(
+                    "checkActiveConnectionStalled", Instant.class, BlockNodeStreamingConnection.class);
+            checkActiveConnectionStalled.setAccessible(true);
+            checkActiveConnectionStalledHandle = lookup.unreflect(checkActiveConnectionStalled);
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     private static final long NODE_ID = 0;
+    private static final long STALLED_CONNECTION_THRESHOLD_MILLIS = 500;
 
     private BlockNodeConnectionManager connectionManager;
     private LogCaptor logCaptor;
@@ -90,7 +97,8 @@ class BlockNodeConnectionManagerLoggingTest extends BlockNodeCommunicationTestBa
         configProvider = createConfigProvider(createDefaultConfigProvider()
                 .withValue(
                         "blockNode.blockNodeConnectionFileDir",
-                        tempDir.toAbsolutePath().toString()));
+                        tempDir.toAbsolutePath().toString())
+                .withValue("blockNode.connectionStallThresholdMillis", STALLED_CONNECTION_THRESHOLD_MILLIS));
 
         bufferService = mock(BlockBufferService.class);
         metrics = mock(BlockStreamMetrics.class);
@@ -221,6 +229,44 @@ class BlockNodeConnectionManagerLoggingTest extends BlockNodeCommunicationTestBa
         assertLogOccurrence(infoLogs, "Selecting a new block node is deferred due to global cool down until", 1);
     }
 
+    @Test
+    void testCheckActiveConnectionStalled_true() throws Throwable {
+        final Instant now = Instant.now();
+        final BlockNodeStreamingConnection activeConnection = mock(BlockNodeStreamingConnection.class);
+        final StreamingConnectionStatistics stats = mock(StreamingConnectionStatistics.class);
+        final long lastHeartbeat =
+                now.minusMillis(STALLED_CONNECTION_THRESHOLD_MILLIS + 10).toEpochMilli();
+        when(activeConnection.connectionStatistics()).thenReturn(stats);
+        when(stats.lastHeartbeatMillis()).thenReturn(lastHeartbeat);
+
+        invoke_checkActiveConnectionStalled(now, activeConnection);
+
+        final List<String> warnLogs = logCaptor.warnLogs();
+        assertThat(warnLogs).hasSize(1);
+        assertLogOccurrence(
+                warnLogs,
+                "Active connection is slow/stalled (lastHeartbeat: " + lastHeartbeat + ", threshold: "
+                        + STALLED_CONNECTION_THRESHOLD_MILLIS + "ms, observed: "
+                        + (STALLED_CONNECTION_THRESHOLD_MILLIS + 10) + "ms)",
+                1);
+    }
+
+    @Test
+    void testCheckActiveConnectionStalled_false() throws Throwable {
+        final Instant now = Instant.now();
+        final BlockNodeStreamingConnection activeConnection = mock(BlockNodeStreamingConnection.class);
+        final StreamingConnectionStatistics stats = mock(StreamingConnectionStatistics.class);
+        final long lastHeartbeat =
+                now.minusMillis(STALLED_CONNECTION_THRESHOLD_MILLIS - 10).toEpochMilli();
+        when(activeConnection.connectionStatistics()).thenReturn(stats);
+        when(stats.lastHeartbeatMillis()).thenReturn(lastHeartbeat);
+
+        invoke_checkActiveConnectionStalled(now, activeConnection);
+
+        final List<String> warnLogs = logCaptor.warnLogs();
+        assertThat(warnLogs).isEmpty();
+    }
+
     // Utilities
 
     void assertLogOccurrence(final List<String> logLines, final String expectedMessage, final int numExpected) {
@@ -240,6 +286,11 @@ class BlockNodeConnectionManagerLoggingTest extends BlockNodeCommunicationTestBa
 
     void invoke_updateConnectionIfNeeded() throws Throwable {
         updateConnectionIfNeededHandle.invoke(connectionManager);
+    }
+
+    void invoke_checkActiveConnectionStalled(final Instant now, final BlockNodeStreamingConnection activeConnection)
+            throws Throwable {
+        checkActiveConnectionStalledHandle.invoke(connectionManager, now, activeConnection);
     }
 
     @SuppressWarnings("unchecked")

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -76,7 +76,6 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
     private static final VarHandle connectionMonitorThreadRefHandle;
 
     private static final MethodHandle isActiveConnectionAutoResetHandle;
-    private static final MethodHandle isActiveConnectionStalledHandle;
     private static final MethodHandle isHigherPriorityNodeAvailableHandle;
     private static final MethodHandle isBufferUnhealthyHandle;
     private static final MethodHandle isConfigUpdatedHandle;
@@ -108,11 +107,6 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
                     "isActiveConnectionAutoReset", Instant.class, BlockNodeStreamingConnection.class);
             isActiveConnectionAutoReset.setAccessible(true);
             isActiveConnectionAutoResetHandle = lookup.unreflect(isActiveConnectionAutoReset);
-
-            final Method isActiveConnectionStalled = cls.getDeclaredMethod(
-                    "isActiveConnectionStalled", Instant.class, BlockNodeStreamingConnection.class);
-            isActiveConnectionStalled.setAccessible(true);
-            isActiveConnectionStalledHandle = lookup.unreflect(isActiveConnectionStalled);
 
             final Method isHigherPriorityNodeAvailable =
                     cls.getDeclaredMethod("isHigherPriorityNodeAvailable", BlockNodeStreamingConnection.class);
@@ -246,49 +240,6 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
 
         verify(activeConnection).autoResetTimestamp();
         verify(activeConnection).closeAtBlockBoundary(CloseReason.PERIODIC_RESET);
-        verifyNoMoreInteractions(activeConnection);
-    }
-
-    @Test
-    void testIsActiveConnectionStalled_nullConnection() throws Throwable {
-        final boolean isStalled = invoke_isActiveConnectionStalled(Instant.now(), null);
-        assertThat(isStalled).isFalse();
-    }
-
-    @Test
-    void testIsActiveConnectionStalled_false() throws Throwable {
-        final Instant now = Instant.now();
-        final BlockNodeStreamingConnection activeConnection = mock(BlockNodeStreamingConnection.class);
-        final StreamingConnectionStatistics connStats = mock(StreamingConnectionStatistics.class);
-        when(activeConnection.connectionStatistics()).thenReturn(connStats);
-        // stalled connections are based on the heartbeat timestamp, so if we set the last heartbeat to near now
-        // the connection will not be marked as stalled
-        when(connStats.lastHeartbeatMillis()).thenReturn(now.toEpochMilli());
-
-        final boolean isStalled = invoke_isActiveConnectionStalled(now, activeConnection);
-
-        assertThat(isStalled).isFalse();
-
-        verify(activeConnection).connectionStatistics();
-        verifyNoMoreInteractions(activeConnection);
-    }
-
-    @Test
-    void testIsActiveConnectionStalled_true() throws Throwable {
-        final Instant now = Instant.now();
-        final BlockNodeStreamingConnection activeConnection = mock(BlockNodeStreamingConnection.class);
-        final StreamingConnectionStatistics connStats = mock(StreamingConnectionStatistics.class);
-        // stalled connections are based on the heartbeat timestamp, so set the last heartbeat to far in the past
-        // to trigger a stall detection
-        when(connStats.lastHeartbeatMillis()).thenReturn(now.minusSeconds(1).toEpochMilli());
-        when(activeConnection.connectionStatistics()).thenReturn(connStats);
-
-        final boolean isStalled = invoke_isActiveConnectionStalled(now, activeConnection);
-
-        assertThat(isStalled).isTrue();
-
-        verify(activeConnection).connectionStatistics();
-        verify(activeConnection).close(CloseReason.CONNECTION_STALLED, true);
         verifyNoMoreInteractions(activeConnection);
     }
 
@@ -1599,66 +1550,6 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testUpdateConnectionIfNeeded_activeConnectionStalledOnly() throws Throwable {
-        // set active connection that is stalled
-        final BlockNodeConfiguration existingActiveNodeConfig = newBlockNodeConfig("localhost", 1234, 1);
-        final BlockNodeStreamingConnection existingActiveConnection = mock(BlockNodeStreamingConnection.class);
-        when(existingActiveConnection.configuration()).thenReturn(existingActiveNodeConfig);
-        // set the last heartbeat to be in the distant past to trigger the stall check
-        final StreamingConnectionStatistics existingConnStats = mock(StreamingConnectionStatistics.class);
-        when(existingActiveConnection.connectionStatistics()).thenReturn(existingConnStats);
-        when(existingConnStats.lastHeartbeatMillis())
-                .thenReturn(Instant.now().minusSeconds(2).toEpochMilli());
-        when(existingActiveConnection.autoResetTimestamp())
-                .thenReturn(Instant.now().plusSeconds(90));
-        final BlockNode existingActiveNode = mock(BlockNode.class);
-        lenient().when(existingActiveNode.configuration()).thenReturn(existingActiveNodeConfig);
-        when(existingActiveNode.isStreamingCandidate()).thenReturn(false);
-        activeConnectionRef().set(existingActiveConnection);
-        // mark the buffer as healthy
-        when(bufferService.latestBufferStatus()).thenReturn(new BlockBufferStatus(Instant.now(), 0.0D, false));
-        // add another block node to switch to
-        final BlockNodeConfiguration otherNodeConfig = newBlockNodeConfig("localhost", 2345, 1);
-        final BlockNode otherNode = mock(BlockNode.class);
-        when(otherNode.configuration()).thenReturn(otherNodeConfig);
-        when(otherNode.isStreamingCandidate()).thenReturn(true);
-        final Future<Object> otherNodeFuture = mock(Future.class);
-        when(otherNodeFuture.state()).thenReturn(State.SUCCESS);
-        when(otherNodeFuture.resultNow()).thenReturn(new BlockNodeStatus(true, 10, 12));
-        when(blockingIoExecutor.invokeAll(anyCollection(), anyLong(), any(TimeUnit.class)))
-                .thenReturn(List.of(otherNodeFuture));
-        // set the latest config as the current config
-        final VersionedBlockNodeConfigurationSet configSet =
-                new VersionedBlockNodeConfigurationSet(1, List.of(existingActiveNodeConfig, otherNodeConfig));
-        activeConfigRef().set(configSet);
-        when(blockNodeConfigService.latestConfiguration()).thenReturn(configSet);
-        // other setup
-        when(bufferService.getEarliestAvailableBlockNumber()).thenReturn(10L);
-        when(bufferService.getLastBlockNumberProduced()).thenReturn(20L);
-
-        blockNodes().put(existingActiveNodeConfig.streamingEndpoint(), existingActiveNode);
-        blockNodes().put(otherNodeConfig.streamingEndpoint(), otherNode);
-
-        final BlockNodeStreamingConnection newActiveConnection;
-        try (final MockedConstruction<BlockNodeStreamingConnection> mockConnection =
-                mockConstruction(BlockNodeStreamingConnection.class)) {
-            invoke_updateConnectionIfNeeded();
-
-            // one connection should have been created
-            final List<BlockNodeStreamingConnection> createdConnections = mockConnection.constructed();
-            assertThat(createdConnections).hasSize(1);
-
-            newActiveConnection = createdConnections.getFirst();
-        }
-
-        assertThat(activeConnectionRef()).doesNotHaveNullValue().hasValue(newActiveConnection);
-        verify(newActiveConnection).initialize();
-        verify(newActiveConnection).updateConnectionState(ConnectionState.ACTIVE);
-        verify(existingActiveConnection).closeAtBlockBoundary(CloseReason.CONNECTION_STALLED);
-        verify(metrics).recordActiveConnectionCount(anyLong());
-    }
-
-    @Test
     void testUpdateConnectionIfNeeded_activeConnectionAutoResetOnly() throws Throwable {
         // set active connection that is ready for auto reset
         final BlockNodeConfiguration nodeConfig = newBlockNodeConfig("localhost", 1234, 1);
@@ -1875,11 +1766,6 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
 
     boolean invoke_isHigherPriorityNodeAvailable(final BlockNodeStreamingConnection activeConnection) throws Throwable {
         return (boolean) isHigherPriorityNodeAvailableHandle.invoke(connectionManager, activeConnection);
-    }
-
-    boolean invoke_isActiveConnectionStalled(final Instant now, final BlockNodeStreamingConnection activeConnection)
-            throws Throwable {
-        return (boolean) isActiveConnectionStalledHandle.invoke(connectionManager, now, activeConnection);
     }
 
     boolean invoke_isActiveConnectionAutoReset(final Instant now, final BlockNodeStreamingConnection activeConnection)

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionLoggingTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionLoggingTest.java
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl.streaming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.hedera.node.app.blocks.impl.streaming.BlockNodeStreamingConnection.BlockEndRequest;
+import com.hedera.node.app.blocks.impl.streaming.BlockNodeStreamingConnection.StreamRequest;
+import com.hedera.node.app.blocks.impl.streaming.config.BlockNodeConfiguration;
+import com.hedera.node.app.metrics.BlockStreamMetrics;
+import com.hedera.node.app.spi.fixtures.util.LogCaptor;
+import com.hedera.node.config.ConfigProvider;
+import com.hedera.pbj.runtime.grpc.Pipeline;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.logging.log4j.LogManager;
+import org.hiero.block.api.BlockEnd;
+import org.hiero.block.api.BlockStreamPublishServiceInterface.BlockStreamPublishServiceClient;
+import org.hiero.block.api.PublishStreamRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlockNodeStreamingConnectionLoggingTest extends BlockNodeCommunicationTestBase {
+
+    private static final VarHandle connectionStateHandle;
+
+    private static final MethodHandle sendRequestHandle;
+
+    static {
+        try {
+            final Lookup lookup = MethodHandles.lookup();
+
+            connectionStateHandle = MethodHandles.privateLookupIn(AbstractBlockNodeConnection.class, lookup)
+                    .findVarHandle(AbstractBlockNodeConnection.class, "stateRef", AtomicReference.class);
+
+            final Method sendRequest =
+                    BlockNodeStreamingConnection.class.getDeclaredMethod("sendRequest", StreamRequest.class);
+            sendRequest.setAccessible(true);
+            sendRequestHandle = lookup.unreflect(sendRequest);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final long SLOW_REQ_THRESHOLD_MILLIS = 200;
+
+    private BlockNodeStreamingConnection connection;
+    private LogCaptor logCaptor;
+
+    ExecutorService blockingIoExecutor;
+    private Pipeline<?> requestPipeline;
+
+    @BeforeEach
+    void beforeEach() {
+        final ConfigProvider configProvider = createConfigProvider(createDefaultConfigProvider()
+                .withValue("blockNode.slowRequestThresholdMillis", SLOW_REQ_THRESHOLD_MILLIS));
+        final BlockNode blockNode = mock(BlockNode.class);
+        final BlockNodeConfiguration bnConfig = newBlockNodeConfig("localhost", 8080, 1);
+        when(blockNode.configuration()).thenReturn(bnConfig);
+        final BlockNodeConnectionManager connectionManager = mock(BlockNodeConnectionManager.class);
+        final BlockBufferService bufferService = mock(BlockBufferService.class);
+        final BlockStreamMetrics metrics = mock(BlockStreamMetrics.class);
+        blockingIoExecutor = Executors.newSingleThreadExecutor();
+        final BlockNodeClientFactory clientFactory = mock(BlockNodeClientFactory.class);
+        requestPipeline = mock(Pipeline.class);
+
+        final BlockStreamPublishServiceClient client = mock(BlockStreamPublishServiceClient.class);
+        when(clientFactory.createStreamingClient(any(BlockNodeConfiguration.class), any(Duration.class), anyString()))
+                .thenReturn(client);
+        when(client.publishBlockStream(any(Pipeline.class))).thenReturn(requestPipeline);
+
+        connection = new BlockNodeStreamingConnection(
+                configProvider,
+                blockNode,
+                connectionManager,
+                bufferService,
+                metrics,
+                blockingIoExecutor,
+                null,
+                clientFactory,
+                0L);
+
+        logCaptor = new LogCaptor(LogManager.getLogger(BlockNodeStreamingConnection.class));
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (blockingIoExecutor != null) {
+            blockingIoExecutor.shutdownNow();
+        }
+
+        logCaptor.stopCapture();
+    }
+
+    @Test
+    void testSlowConnectionWarning() throws Throwable {
+        connection.initialize();
+        connectionState().set(ConnectionState.ACTIVE);
+
+        doAnswer(inv -> {
+                    try {
+                        Thread.sleep(SLOW_REQ_THRESHOLD_MILLIS + 100);
+                    } catch (final InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    return null;
+                })
+                .when(requestPipeline)
+                .onNext(any());
+
+        final PublishStreamRequest psr = PublishStreamRequest.newBuilder()
+                .endOfBlock(BlockEnd.newBuilder().blockNumber(1))
+                .build();
+        final StreamRequest request = new BlockEndRequest(psr, 1, 2);
+
+        invoke_sendRequest(request);
+
+        final List<String> warnLogs = logCaptor.warnLogs();
+        assertLogOccurrence(
+                warnLogs, "Slow request detected (threshold: " + SLOW_REQ_THRESHOLD_MILLIS + "ms, observed: ", 1);
+    }
+
+    // Utilities
+
+    @SuppressWarnings("unchecked")
+    private AtomicReference<ConnectionState> connectionState() {
+        return (AtomicReference<ConnectionState>) connectionStateHandle.get(connection);
+    }
+
+    private boolean invoke_sendRequest(final StreamRequest request) throws Throwable {
+        return (boolean) sendRequestHandle.invoke(connection, request);
+    }
+
+    void assertLogOccurrence(final List<String> logLines, final String expectedMessage, final int numExpected) {
+        int numFound = 0;
+        for (final String logLine : logLines) {
+            if (logLine.contains(expectedMessage)) {
+                ++numFound;
+            }
+        }
+
+        assertThat(numFound)
+                .overridingErrorMessage(
+                        "Expected to find message '%s' %d times, but only found %d",
+                        expectedMessage, numExpected, numFound)
+                .isEqualTo(numExpected);
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionTest.java
@@ -931,9 +931,9 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
     void testClose() {
         activateConnection();
 
-        connection.close(CloseReason.CONNECTION_STALLED, true);
+        connection.close(CloseReason.CONFIG_UPDATE, true);
 
-        assertThat(connection.closeReason()).isEqualTo(CloseReason.CONNECTION_STALLED);
+        assertThat(connection.closeReason()).isEqualTo(CloseReason.CONFIG_UPDATE);
         assertThat(connection.currentState()).isEqualTo(ConnectionState.CLOSED);
 
         // verifications for sending EndStream.RESET
@@ -941,7 +941,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         verify(metrics).recordRequestLatency(anyLong());
         verify(metrics).recordRequestEndStreamSent(EndStream.Code.RESET);
         // remaining verifications
-        verify(metrics).recordConnectionClosed(CloseReason.CONNECTION_STALLED);
+        verify(metrics).recordConnectionClosed(CloseReason.CONFIG_UPDATE);
         verify(requestPipeline).onComplete();
         verify(bufferService).getEarliestAvailableBlockNumber();
         verify(bufferService).getHighestAckedBlockNumber();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeTest.java
@@ -158,7 +158,7 @@ class BlockNodeTest extends BlockNodeCommunicationTestBase {
                 Instant.parse("2026-04-02T11:00:00.000Z"),
                 Instant.parse("2026-04-02T11:00:01.000Z"),
                 Instant.parse("2026-04-02T11:00:05.000Z"),
-                CloseReason.CONNECTION_STALLED,
+                CloseReason.CONNECTION_ERROR,
                 conn2Stats);
         final ConnectionId conn3Id = new ConnectionId(NODE_ID, ConnectionType.BLOCK_STREAMING, 3);
         final StreamingConnectionStatistics conn3Stats = newStatsBuilder()
@@ -185,7 +185,7 @@ class BlockNodeTest extends BlockNodeCommunicationTestBase {
                 Block Node (host: localhost, port: 1234, priority: 1, isStreamingCandidate: false, coolDownTimestamp: 2026-04-02T18:00:15Z, activeConnections: 1)
                   Connection History
                     N0-STR3 => created: 2026-04-02T12:00:00Z, activated: 2026-04-02T12:00:01Z, closed: *, duration: *, closeReason: *, numBlocksSent: 44*, lastBlockSent: 93*, numBlocksAcked: 43*, lastBlockAcked: 92*, reqSendAttempts: 100*, reqSendSuccesses: 100*, lastHeartbeat: 20000*
-                    N0-STR2 => created: 2026-04-02T11:00:00Z, activated: 2026-04-02T11:00:01Z, closed: 2026-04-02T11:00:05Z, duration: PT4S, closeReason: CONNECTION_STALLED, numBlocksSent: 3, lastBlockSent: 9, numBlocksAcked: 3, lastBlockAcked: 9, reqSendAttempts: 5, reqSendSuccesses: 4, lastHeartbeat: 15000
+                    N0-STR2 => created: 2026-04-02T11:00:00Z, activated: 2026-04-02T11:00:01Z, closed: 2026-04-02T11:00:05Z, duration: PT4S, closeReason: CONNECTION_ERROR, numBlocksSent: 3, lastBlockSent: 9, numBlocksAcked: 3, lastBlockAcked: 9, reqSendAttempts: 5, reqSendSuccesses: 4, lastHeartbeat: 15000
                     N0-STR1 => created: 2026-04-02T10:00:00Z, activated: 2026-04-02T10:00:01Z, closed: 2026-04-02T10:00:05Z, duration: PT4S, closeReason: CONFIG_UPDATE, numBlocksSent: 10, lastBlockSent: 10, numBlocksAcked: 10, lastBlockAcked: 10, reqSendAttempts: 25, reqSendSuccesses: 25, lastHeartbeat: 10000""";
 
         final StringBuilder sb = new StringBuilder();

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockNodeConnectionConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockNodeConnectionConfig.java
@@ -40,6 +40,7 @@ import java.time.Duration;
  *                                    via {@link BlockBufferConfig#maxBlocks()}) a block node can be behind before the node is placed in a basic cool down
  * @param numBlocksBehindHighThreshold number of blocks (as a percentage - 0.0 to 100.0 - of the max number of blocks allowed in the buffer
  *                                     via {@link BlockBufferConfig#maxBlocks()}) a block node can be behind before the node is placed in an extended cool down
+ * @param slowRequestThresholdMillis amount of time (in milliseconds) a request will take to send before it is considered slow (should be less than {@link #pipelineOperationTimeout()}
  */
 // spotless:off
 @ConfigData("blockNode")
@@ -63,12 +64,13 @@ public record BlockNodeConnectionConfig(
         @ConfigProperty(defaultValue = "1s") @NodeProperty Duration blockNodeStatusTimeout,
         @ConfigProperty(defaultValue = "131072000") @Min(1) @NodeProperty long defaultMessageHardLimitBytes,
         @ConfigProperty(defaultValue = "200") @Min(1) @NetworkProperty int connectionMonitorCheckIntervalMillis,
-        @ConfigProperty(defaultValue = "250") @Min(10) @NetworkProperty int connectionStallThresholdMillis,
+        @ConfigProperty(defaultValue = "500") @Min(10) @NetworkProperty int connectionStallThresholdMillis,
         @ConfigProperty(defaultValue = "10") @Min(0) @NetworkProperty int globalCoolDownSeconds,
         @ConfigProperty(defaultValue = "15") @Min(0) @NetworkProperty int basicNodeCoolDownSeconds,
         @ConfigProperty(defaultValue = "30") @Min(0) @NetworkProperty int extendedNodeCoolDownSeconds,
         @ConfigProperty(defaultValue = "2000") @Min(10) @NetworkProperty long wantedBlockExpirationMillis,
         @ConfigProperty(defaultValue = "20.0") @Min(0) @NetworkProperty double numBlocksBehindLowThreshold,
-        @ConfigProperty(defaultValue = "35.0") @Min(0) @NetworkProperty double numBlocksBehindHighThreshold) {
+        @ConfigProperty(defaultValue = "35.0") @Min(0) @NetworkProperty double numBlocksBehindHighThreshold,
+        @ConfigProperty(defaultValue = "250") @Min(1) @NetworkProperty long slowRequestThresholdMillis) {
 }
 // spotless:on


### PR DESCRIPTION
**Description**:
Instead of closing connections when a stalled connection is detected, only log a warning message. Additionally, when a slow request occurred, also log it.

**Related issue(s)**:

Fixes #25487 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
