### PR TITLE
fix: Fix compilation in HandleWorkflowTest

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -740,8 +740,8 @@ class HandleWorkflowTest {
 
         subject.handleRound(state, round, txns -> {});
 
-        verify(blockRecordManager, never()).writeFreezeBlockWrappedRecordFileBlockHashesToState(state);
-        verify(blockRecordManager, never()).writeFreezeBlockWrappedRecordFileBlockHashesToDisk(state);
+        verify(blockRecordManager, never()).endRound(state);
+        verify(blockRecordManager, never()).closeCurrentRecordFileIfOpen(state);
     }
 
     /**


### PR DESCRIPTION
**Description**:
This pull request updates the `HandleWorkflowTest.java` test to reflect changes in the `blockRecordManager` API. The test now verifies that the correct new methods are not called during a freeze round in blocks mode.

Test updates for block record management:

* Updated the test `freezeRoundSkipsWrappedHashWritesInBlocksMode` to verify that `endRound` and `closeCurrentRecordFileIfOpen` are never called on `blockRecordManager`, replacing the previous checks for `writeFreezeBlockWrappedRecordFileBlockHashesToState` and `writeFreezeBlockWrappedRecordFileBlockHashesToDisk`.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
