### PR TITLE
chore: Create v0.75.0 BlockRecordSchema with migration

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordService.java
@@ -11,7 +11,7 @@ import com.hedera.hapi.node.state.blockrecords.RunningHashes;
 import com.hedera.node.app.records.impl.BlockRecordManagerImpl;
 import com.hedera.node.app.records.schemas.V0490BlockRecordSchema;
 import com.hedera.node.app.records.schemas.V0560BlockRecordSchema;
-import com.hedera.node.app.records.schemas.V0740BlockRecordSchema;
+import com.hedera.node.app.records.schemas.V0750BlockRecordSchema;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.lifecycle.SchemaRegistry;
@@ -68,7 +68,7 @@ public final class BlockRecordService implements Service {
     public void registerSchemas(@NonNull final SchemaRegistry registry) {
         registry.register(new V0490BlockRecordSchema());
         registry.register(new V0560BlockRecordSchema());
-        registry.register(new V0740BlockRecordSchema());
+        registry.register(new V0750BlockRecordSchema());
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
@@ -2,6 +2,7 @@
 package com.hedera.node.app.records.schemas;
 
 import static com.hedera.hapi.util.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
+import static com.hedera.node.app.records.BlockRecordService.EPOCH;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCKS_STATE_ID;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING_HASHES_STATE_ID;
 
@@ -20,21 +21,27 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Migration schema that initializes jumpstart wrapped-record voting metadata once during the 0.74.0 upgrade.
+ * Migration schema that initializes jumpstart wrapped-record voting metadata during an upgrade if the jumpstart data is present.
  * It also makes the existing block record info and running hashes available as shared values for the upcoming
  * jumpstart cutover (if applicable).
+ * <p>
+ * Also contains a migrate method that increments the last block number and sets the first consensus time of the current block to the epoch timestamp.
+ * This is necessary because the mechanism for which record files close is changing in release 0.75, and the BlockInfo singleton
+ * needs to represent the last closed block number, which would be the freeze block number which would previously have been updated
+ * when handling the next user transaction after an upgrade.
  */
-public class V0740BlockRecordSchema extends Schema<SemanticVersion> {
-    private static final Logger log = LogManager.getLogger(V0740BlockRecordSchema.class);
+public class V0750BlockRecordSchema extends Schema<SemanticVersion> {
+    private static final Logger log = LogManager.getLogger(V0750BlockRecordSchema.class);
 
     private static final SemanticVersion VERSION =
-            SemanticVersion.newBuilder().major(0).minor(74).patch(0).build();
+            SemanticVersion.newBuilder().major(0).minor(75).patch(0).build();
+
     public static final int DEADLINE_BLOCK_NUMBER_BUFFER = 10;
 
     private static final String SHARED_BLOCK_RECORD_INFO = "SHARED_BLOCK_RECORD_INFO";
     private static final String SHARED_RUNNING_HASHES = "SHARED_RUNNING_HASHES";
 
-    public V0740BlockRecordSchema() {
+    public V0750BlockRecordSchema() {
         super(VERSION, SEMANTIC_VERSION_COMPARATOR);
     }
 
@@ -88,5 +95,20 @@ public class V0740BlockRecordSchema extends Schema<SemanticVersion> {
 
     private static boolean hasJumpstartData(@NonNull MigrationContext ctx) {
         return ctx.appConfig().getConfigData(BlockStreamJumpstartConfig.class).blockNum() > 0;
+    }
+
+    @Override
+    public void migrate(@NonNull final MigrationContext ctx) {
+        if (!ctx.isGenesis()) {
+            final var blockInfoSingleton = ctx.newStates().<BlockInfo>getSingleton(BLOCKS_STATE_ID);
+            final var existingBlockInfo = blockInfoSingleton.get();
+            log.info("Migrating BlockInfo singleton with lastBlockNumber " + (existingBlockInfo.lastBlockNumber() + 1)
+                    + " and firstConsTimeOfCurrentBlock to EPOCH");
+            blockInfoSingleton.put(existingBlockInfo
+                    .copyBuilder()
+                    .lastBlockNumber(existingBlockInfo.lastBlockNumber() + 1)
+                    .firstConsTimeOfCurrentBlock(EPOCH)
+                    .build());
+        }
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.Logger;
 public class V0750BlockRecordSchema extends Schema<SemanticVersion> {
     private static final Logger log = LogManager.getLogger(V0750BlockRecordSchema.class);
 
-    private static final SemanticVersion VERSION =g
+    private static final SemanticVersion VERSION =
             SemanticVersion.newBuilder().major(0).minor(75).patch(0).build();
 
     public static final int DEADLINE_BLOCK_NUMBER_BUFFER = 10;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
@@ -102,6 +102,10 @@ public class V0750BlockRecordSchema extends Schema<SemanticVersion> {
         if (!ctx.isGenesis()) {
             final var blockInfoSingleton = ctx.newStates().<BlockInfo>getSingleton(BLOCKS_STATE_ID);
             final var existingBlockInfo = blockInfoSingleton.get();
+            if (existingBlockInfo == null) {
+                log.info("Skipping BlockInfo migration because BlockInfo singleton does not exist");
+                return;
+            }
             log.info("Migrating BlockInfo singleton with lastBlockNumber " + (existingBlockInfo.lastBlockNumber() + 1)
                     + " and firstConsTimeOfCurrentBlock to EPOCH");
             blockInfoSingleton.put(existingBlockInfo

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
@@ -33,7 +33,7 @@ import org.apache.logging.log4j.Logger;
 public class V0750BlockRecordSchema extends Schema<SemanticVersion> {
     private static final Logger log = LogManager.getLogger(V0750BlockRecordSchema.class);
 
-    private static final SemanticVersion VERSION =
+    private static final SemanticVersion VERSION =g
             SemanticVersion.newBuilder().major(0).minor(75).patch(0).build();
 
     public static final int DEADLINE_BLOCK_NUMBER_BUFFER = 10;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -867,7 +867,10 @@ public class HandleWorkflow {
                 parentTxn.stack().commitTransaction(parentTxn.baseBuilder());
             } else {
                 final var dispatch = parentTxnFactory.createDispatch(parentTxn, exchangeRateManager.exchangeRates());
-                stakePeriodChanges.advanceTimeTo(parentTxn, true);
+                if (parentTxn.functionality() != HederaFunctionality.HINTS_PARTIAL_SIGNATURE
+                        && parentTxn.functionality() != HederaFunctionality.MIGRATION_ROOT_HASH_VOTE) {
+                    stakePeriodChanges.advanceTimeTo(parentTxn, true);
+                }
                 logPreDispatch(parentTxn);
                 final var hollowAccountCompletionsDetails =
                         hollowAccountCompletions.completeHollowAccounts(parentTxn, dispatch);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -27,6 +27,7 @@ import com.hedera.hapi.block.stream.input.EventHeader;
 import com.hedera.hapi.block.stream.input.ParentEventReference;
 import com.hedera.hapi.block.stream.input.RoundHeader;
 import com.hedera.hapi.block.stream.output.StateChanges;
+import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.hapi.node.state.history.ProofKey;
@@ -626,12 +627,16 @@ public class HandleWorkflow {
                 parentTxnFactory.createTopLevelTxn(state, creator, txn, consensusNow, shortCircuitCallback);
         if (topLevelTxn == null) {
             return false;
-        } else if (streamMode != BLOCKS && startsNewRecordFile) {
+        }
+        final var functionality = topLevelTxn.functionality();
+        final boolean isNodeSubmittedTransaction = functionality == HederaFunctionality.HINTS_PARTIAL_SIGNATURE
+                || functionality == HederaFunctionality.MIGRATION_ROOT_HASH_VOTE;
+        if (streamMode != BLOCKS && startsNewRecordFile && !isNodeSubmittedTransaction) {
             blockRecordManager.startUserTransaction(consensusNow, state);
         }
 
         final var handleOutput = executeSubmittedParent(topLevelTxn, eventBirthRound, state);
-        if (streamMode != BLOCKS) {
+        if (streamMode != BLOCKS && !isNodeSubmittedTransaction) {
             final var records = ((LegacyListRecordSource) handleOutput.recordSourceOrThrow()).precomputedRecords();
             blockRecordManager.endUserTransaction(records.stream(), state);
         }
@@ -644,7 +649,9 @@ public class HandleWorkflow {
         opWorkflowMetrics.updateDuration(topLevelTxn.functionality(), (int) (System.nanoTime() - handleStart));
         congestionMetrics.updateMultiplier(topLevelTxn.txnInfo(), topLevelTxn.readableStoreFactory());
 
-        executeScheduledTransactions(state, topLevelTxn.consensusNow(), topLevelTxn.creatorInfo());
+        if (!isNodeSubmittedTransaction) {
+            executeScheduledTransactions(state, topLevelTxn.consensusNow(), topLevelTxn.creatorInfo());
+        }
 
         return true;
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchemaTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
@@ -35,7 +36,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class V0740BlockRecordSchemaTest {
+class V0750BlockRecordSchemaTest {
     @Mock
     private MigrationContext ctx;
 
@@ -63,11 +64,11 @@ class V0740BlockRecordSchemaTest {
     @Mock
     private WritableSingletonState<BlockInfo> blockInfoState;
 
-    private final V0740BlockRecordSchema subject = new V0740BlockRecordSchema();
+    private final V0750BlockRecordSchema subject = new V0750BlockRecordSchema();
 
     @Test
-    void versionIsV0740() {
-        assertEquals(new SemanticVersion(0, 74, 0, "", ""), subject.getVersion());
+    void versionIsV0750() {
+        assertEquals(new SemanticVersion(0, 75, 0, "", ""), subject.getVersion());
     }
 
     @Test
@@ -233,6 +234,38 @@ class V0740BlockRecordSchemaTest {
         subject.restart(ctx);
 
         verify(ctx, never()).sharedValues();
+    }
+
+    @Test
+    void migrateIsNoopOnGenesis() {
+        given(ctx.isGenesis()).willReturn(true);
+
+        subject.migrate(ctx);
+
+        verify(ctx, never()).newStates();
+        verifyNoInteractions(writableStates, blockInfoState);
+    }
+
+    @Test
+    void migrateIncrementsLastBlockNumberAndSetsFirstConsTimeToEpoch() {
+        final var nonEpochTime = new Timestamp(1_000_000L, 0);
+        final var initialBlockInfo = baseBlockInfo()
+                .copyBuilder()
+                .firstConsTimeOfCurrentBlock(nonEpochTime)
+                .build();
+        given(ctx.isGenesis()).willReturn(false);
+        given(ctx.newStates()).willReturn(writableStates);
+        given(writableStates.<BlockInfo>getSingleton(BLOCKS_STATE_ID)).willReturn(blockInfoState);
+        given(blockInfoState.get()).willReturn(initialBlockInfo);
+
+        subject.migrate(ctx);
+
+        verify(blockInfoState)
+                .put(initialBlockInfo
+                        .copyBuilder()
+                        .lastBlockNumber(initialBlockInfo.lastBlockNumber() + 1)
+                        .firstConsTimeOfCurrentBlock(EPOCH)
+                        .build());
     }
 
     private void givenRestartPreconditions() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/BlockTransactionalUnitTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/BlockTransactionalUnitTranslator.java
@@ -121,8 +121,8 @@ import org.apache.logging.log4j.Logger;
 public class BlockTransactionalUnitTranslator {
     private static final Logger log = LogManager.getLogger(BlockTransactionalUnitTranslator.class);
 
-    private static final Set<HederaFunctionality> RECORD_STREAM_ABSENT_FUNCTIONALITIES = EnumSet.of(
-            STATE_SIGNATURE_TRANSACTION, HINTS_PARTIAL_SIGNATURE, MIGRATION_ROOT_HASH_VOTE);
+    private static final Set<HederaFunctionality> RECORD_STREAM_ABSENT_FUNCTIONALITIES =
+            EnumSet.of(STATE_SIGNATURE_TRANSACTION, HINTS_PARTIAL_SIGNATURE, MIGRATION_ROOT_HASH_VOTE);
 
     /**
      * The base translator used to create the {@link SingleTransactionRecord}s.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/BlockTransactionalUnitTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/BlockTransactionalUnitTranslator.java
@@ -107,9 +107,11 @@ import com.hedera.services.bdd.junit.support.translators.inputs.BlockTransaction
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -118,6 +120,9 @@ import org.apache.logging.log4j.Logger;
  */
 public class BlockTransactionalUnitTranslator {
     private static final Logger log = LogManager.getLogger(BlockTransactionalUnitTranslator.class);
+
+    private static final Set<HederaFunctionality> RECORD_STREAM_ABSENT_FUNCTIONALITIES = EnumSet.of(
+            STATE_SIGNATURE_TRANSACTION, HINTS_PARTIAL_SIGNATURE, MIGRATION_ROOT_HASH_VOTE);
 
     /**
      * The base translator used to create the {@link SingleTransactionRecord}s.
@@ -252,7 +257,7 @@ public class BlockTransactionalUnitTranslator {
                 if (hookMetadata != null && blockTransactionParts.isHookCall()) {
                     executingHookId = hookMetadata.execHookIds().removeFirst();
                 }
-                if (blockTransactionParts.functionality() != STATE_SIGNATURE_TRANSACTION
+                if (!RECORD_STREAM_ABSENT_FUNCTIONALITIES.contains(blockTransactionParts.functionality())
                         && blockTransactionParts.hasResult()
                         && blockTransactionParts.transactionParts() != null) {
                     final var translation = translator.translate(


### PR DESCRIPTION
**Description**:
This pull request implements a migration for the block record schema to support the 0.75.0 release, updates the workflow to handle new node-submitted transaction types correctly, and ensures that test coverage and translation logic are up to date. The changes focus on schema migration, workflow logic for special transaction types, and test/client updates.

**Schema Migration and Versioning:**

* The `V0740BlockRecordSchema` has been renamed and updated to `V0750BlockRecordSchema`, with the version incremented to 0.75.0. The migration logic now increments the last block number and sets the first consensus time of the current block to the epoch timestamp during the upgrade, to support changes in how record files are opened/closed in 0.75.0.

**Workflow Logic for Node-Submitted Transactions:**

* Updates in `HandleWorkflow` ensure that node-submitted transactions (specifically `HINTS_PARTIAL_SIGNATURE` and `MIGRATION_ROOT_HASH_VOTE`) are handled differently: they do not start or end user transactions for block record management, do not execute scheduled transactions, and do not advance stake period time.

**Testing and Validation:**

* The test class has been renamed to `V0750BlockRecordSchemaTest` and updated to match the new schema version. Tests have been added to verify that the migration is a no-op on genesis and that it correctly increments the block number and sets the consensus time during migration.

**Test Client and Translation Logic:**

* The `BlockTransactionalUnitTranslator` now uses an `EnumSet` to group functionalities that should not produce record stream entries, including the new node-submitted transaction types, and updates the translation logic accordingly.

**Related issue(s)**:

Fixes #25489 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
