### PR TITLE
chore: (0.74) Update Mainnet throttles for `CryptoGetAccountBalanceQuery`

### DIFF
--- a/hedera-node/configuration/mainnet/upgrade/throttles.json
+++ b/hedera-node/configuration/mainnet/upgrade/throttles.json
@@ -205,7 +205,7 @@
       "throttleGroups": [
         {
           "opsPerSec": 0,
-          "milliOpsPerSec": 20000000,
+          "milliOpsPerSec": 40000000,
           "operations": [
             "CryptoGetAccountBalance"
           ]


### PR DESCRIPTION
This reverts commit c74381393c6c37b1dc0a5a9217e2a969531f72dc to revert throttles of `GetAccountBalanceQuery`
