### PR TITLE
fix: For selfless events, replace least important parent instead most important

### DIFF
--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreator.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreator.java
@@ -330,14 +330,14 @@ public class TipsetEventCreator implements EventCreator {
                 if (!contains(chosenBestParents, selflessParent)) {
                     // otherwise, replace the least important parent with one we have chosen to reduce selfishness
                     // please note in case of single-parent events, this will replace the only parent
-                    chosenBestParents[chosenBestParents.length - 1] = selflessParent;
+                    chosenBestParents[0] = selflessParent;
                     replacedBestParentForSelfishness = true;
                 }
             }
         }
 
         for (int i = 0; i < chosenBestParents.length; i++) {
-            if (replacedBestParentForSelfishness && i == chosenBestParents.length - 1) {
+            if (replacedBestParentForSelfishness && i == 0) {
                 tipsetMetrics
                         .getPityParentMetric(chosenBestParents[i].getCreatorId())
                         .cycle();


### PR DESCRIPTION
**Description**:
When selfless event selection is activated, in case of multiple-other-parents, the most useful event (with heights weight advancement) was picked by mistake, instead of the least useful one.

Real impact is minimal, as everything still works and with most probably MOP setting we will be picking ALL eligible events anyway, but just for code correctness, this should be fixed.


**Related issue(s)**:

Fixes #25478 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
