### PR TITLE
ci(workflow-fix): explictly declare java 25.0.2

### DIFF
--- a/.github/workflows/050-user-memory-profile-ctrl.yaml
+++ b/.github/workflows/050-user-memory-profile-ctrl.yaml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Install tools
         run: |

--- a/.github/workflows/200-user-adhoc-solo-tests.yaml
+++ b/.github/workflows/200-user-adhoc-solo-tests.yaml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -211,7 +211,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Setup NodeJS
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/700-flow-copilot-setup-steps.yaml
+++ b/.github/workflows/700-flow-copilot-setup-steps.yaml
@@ -29,7 +29,7 @@ jobs:
           checkout-fetch-depth: "1"
           checkout-token: "${{ secrets.GITHUB_TOKEN }}"
           setup-java: "true"
-          java-version: "25"
+          java-version: "25.0.2"
           java-distribution: "temurin"
           setup-gradle: "true"
           gradle-cache-read-only: "false"

--- a/.github/workflows/flow-artifact-determinism.yaml
+++ b/.github/workflows/flow-artifact-determinism.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
 
 defaults:
   run:
@@ -57,7 +57,7 @@ jobs:
     with:
       ref: ${{ needs.commit-info.outputs.sha }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
     secrets:
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
       gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
@@ -70,7 +70,7 @@ jobs:
     with:
       ref: ${{ needs.commit-info.outputs.sha }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}

--- a/.github/workflows/flow-dry-run-mats-suite.yaml
+++ b/.github/workflows/flow-dry-run-mats-suite.yaml
@@ -86,7 +86,7 @@ jobs:
       enable-snyk-scan: "${{ inputs.enable-snyk-scan || 'false' }}"
       enable-gradle-determinism: "${{ inputs.enable-gradle-determinism || 'false' }}"
       enable-docker-determinism: "${{ inputs.enable-docker-determinism || 'false' }}"
-      java-version: "25"
+      java-version: "25.0.2"
       java-distribution: "temurin"
       custom-job-label: "${{ inputs.custom-job-label || 'MATS (dry-run):' }}"
     secrets:

--- a/.github/workflows/flow-increment-next-main-release.yaml
+++ b/.github/workflows/flow-increment-next-main-release.yaml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: "temurin"
-          java-version: "25"
+          java-version: "25.0.2"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -39,7 +39,7 @@ jobs:
       enable-snyk-scan: "true"
       enable-gradle-determinism: "true"
       enable-docker-determinism: "true"
-      java-version: "25"
+      java-version: "25.0.2"
       java-distribution: "temurin"
       custom-job-label: "MATS (main):"
     secrets:

--- a/.github/workflows/node-flow-deploy-adhoc-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-adhoc-artifact.yaml
@@ -18,7 +18,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       java-distribution:
         description: "Java JDK Distribution:"
         type: string
@@ -44,7 +44,7 @@ jobs:
       trigger-env-deploy: none
       release-profile: AdhocCommit
       dry-run-enabled: ${{ github.event.inputs.dry-run-enabled == 'true' }}
-      java-version: ${{ github.event.inputs.java-version || '25' }}
+      java-version: ${{ github.event.inputs.java-version || '25.0.2' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
       gradle-version: ${{ github.event.inputs.gradle-version || 'wrapper' }}
       ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -70,7 +70,7 @@ jobs:
       enable-hapi-tests-state-throttling: ${{ needs.detect-change-type.outputs.enable-tests }}
       enable-otter-tests: ${{ needs.detect-change-type.outputs.enable-tests }}
       enable-snyk-scan: ${{ needs.detect-change-type.outputs.enable-tests }}
-      java-version: "25"
+      java-version: "25.0.2"
       java-distribution: "temurin"
       custom-job-label: "Standard"
     secrets:

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -54,7 +54,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       gradle-version:
         description: "Gradle Version:"
         type: string

--- a/.github/workflows/node-zxcron-release-branching.yaml
+++ b/.github/workflows/node-zxcron-release-branching.yaml
@@ -215,7 +215,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Install Semantic Version Tools
         run: |

--- a/.github/workflows/node-zxf-snyk-monitor.yaml
+++ b/.github/workflows/node-zxf-snyk-monitor.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0

--- a/.github/workflows/zxc-block-node-regression.yaml
+++ b/.github/workflows/zxc-block-node-regression.yaml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       # Set up the node environment
       # Version 20.18.0 is the recommended version for solo.

--- a/.github/workflows/zxc-build-publish-state-validator.yaml
+++ b/.github/workflows/zxc-build-publish-state-validator.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: "25"
+          java-version: "25.0.2"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0

--- a/.github/workflows/zxc-compile-and-spotless-check.yaml
+++ b/.github/workflows/zxc-compile-and-spotless-check.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-dependency-module-check.yaml
+++ b/.github/workflows/zxc-dependency-module-check.yaml
@@ -16,7 +16,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-execute-hammer-tests.yaml
+++ b/.github/workflows/zxc-execute-hammer-tests.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-execute-hapi-tests.yaml
+++ b/.github/workflows/zxc-execute-hapi-tests.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-execute-integration-tests.yaml
+++ b/.github/workflows/zxc-execute-integration-tests.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-execute-otter-tests.yaml
+++ b/.github/workflows/zxc-execute-otter-tests.yaml
@@ -32,7 +32,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-execute-performance-test.yaml
+++ b/.github/workflows/zxc-execute-performance-test.yaml
@@ -180,7 +180,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/.github/workflows/zxc-execute-timing-sensitive-tests.yaml
+++ b/.github/workflows/zxc-execute-timing-sensitive-tests.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-execute-unit-tests.yaml
+++ b/.github/workflows/zxc-execute-unit-tests.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-jrs-regression.yaml
+++ b/.github/workflows/zxc-jrs-regression.yaml
@@ -67,7 +67,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       gradle-version:
         description: "Gradle Version:"
         type: string

--- a/.github/workflows/zxc-json-rpc-relay-regression.yaml
+++ b/.github/workflows/zxc-json-rpc-relay-regression.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       # Set up the node environment
       - name: Setup NodeJS Environment

--- a/.github/workflows/zxc-mats-tests.yaml
+++ b/.github/workflows/zxc-mats-tests.yaml
@@ -82,7 +82,7 @@ on:
         description: "Java JDK Version"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       java-distribution:
         description: "Java JDK Distribution"
         type: string
@@ -159,7 +159,7 @@ jobs:
     needs:
       - commit-info
     with:
-      java-version: "25"
+      java-version: "25.0.2"
       java-distribution: "temurin"
       ref: ${{ needs.commit-info.outputs.sha }}
     secrets:
@@ -190,7 +190,7 @@ jobs:
       - compile-and-spotless
     with:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
     secrets:
       access-token: ${{ secrets.access-token }}
@@ -208,7 +208,7 @@ jobs:
       - compile-and-spotless
     with:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
       enable-network-log-capture: "true"
     secrets:
@@ -225,7 +225,7 @@ jobs:
       - compile-and-spotless
     with:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
       enable-hapi-tests-misc: "${{ inputs.enable-hapi-tests == 'true' }}"
       enable-hapi-tests-misc-records-crypto-and-serial: "${{ inputs.enable-hapi-tests == 'true' || inputs.enable-hapi-tests-misc-records-crypto-and-serial == 'true' }}"
@@ -250,7 +250,7 @@ jobs:
     uses: ./.github/workflows/zxc-execute-otter-tests.yaml
     with:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
       enable-fast-otter-tests: ${{ inputs.enable-otter-tests == 'true' }}
       enable-network-log-capture: true
@@ -268,7 +268,7 @@ jobs:
     uses: ./.github/workflows/zxc-snyk-scan.yaml
     with:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
     secrets:
       access-token: ${{ secrets.access-token }}
@@ -285,7 +285,7 @@ jobs:
     uses: ./.github/workflows/zxc-verify-gradle-build-determinism.yaml
     with:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
     secrets:
       github-token: ${{ secrets.access-token }}
@@ -301,7 +301,7 @@ jobs:
     uses: ./.github/workflows/zxc-verify-docker-build-determinism.yaml
     with:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
-      java-version: ${{ inputs.java-version || '25' }}
+      java-version: ${{ inputs.java-version || '25.0.2' }}
       java-distribution: ${{ inputs.java-distribution || 'temurin' }}
     secrets:
       github-token: ${{ secrets.access-token }}

--- a/.github/workflows/zxc-merge-queue-performance-test.yaml
+++ b/.github/workflows/zxc-merge-queue-performance-test.yaml
@@ -185,7 +185,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4.4.0

--- a/.github/workflows/zxc-mirror-node-regression.yaml
+++ b/.github/workflows/zxc-mirror-node-regression.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1

--- a/.github/workflows/zxc-single-day-longevity-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-test.yaml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -189,7 +189,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
@@ -763,7 +763,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
@@ -942,7 +942,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/.github/workflows/zxc-snyk-scan.yaml
+++ b/.github/workflows/zxc-snyk-scan.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       node-version:
         description: "NodeJS Version:"
         type: string

--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -102,7 +102,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 25.0.2
 
       # Set up the node environment
       # Version 20.18.0 is the recommended version for solo.

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
 
     secrets:
       github-token:

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -17,7 +17,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
 
     secrets:
       github-token:

--- a/.github/workflows/zxc-xts-tests.yaml
+++ b/.github/workflows/zxc-xts-tests.yaml
@@ -160,7 +160,7 @@ jobs:
     needs:
       - commit-info
     with:
-      java-version: "25"
+      java-version: "25.0.2"
       java-distribution: "temurin"
       ref: ${{ needs.commit-info.outputs.sha }}
     secrets:

--- a/.github/workflows/zxf-publish-yahcli-image.yaml
+++ b/.github/workflows/zxf-publish-yahcli-image.yaml
@@ -24,7 +24,7 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
-        default: "25"
+        default: "25.0.2"
       gradle-version:
         description: "Gradle Version:"
         type: string
@@ -70,7 +70,7 @@ jobs:
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: ${{ inputs.java-distribution || 'temurin' }}
-          java-version: ${{ inputs.java-version || '25' }}
+          java-version: ${{ inputs.java-version || '25.0.2' }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0


### PR DESCRIPTION
**Description**:
This pull request updates the Java JDK version used across all GitHub Actions workflow files from version 25 to version 25.0.2. This ensures that all CI/CD jobs and workflows are using a specific patch release, improving build consistency and reducing ambiguity around the Java environment.

**Workflow configuration updates:**

* All references to the Java version in `actions/setup-java` steps are updated from `25` to `25.0.2` in various workflow files, including those for user memory profiling, solo tests, flow setup, release branching, and more. [[1]](diffhunk://#diff-f7028128bfafabd177f65ac53e01785cb03b844e241d5c5ff4657f61c2b55ea1L123-R123) [[2]](diffhunk://#diff-18e6e9d175d0db30e342a66f43e08a278420b82f7e102639bf02676a694b8b8dL87-R87) [[3]](diffhunk://#diff-18e6e9d175d0db30e342a66f43e08a278420b82f7e102639bf02676a694b8b8dL214-R214) [[4]](diffhunk://#diff-aa639497542a8c8bb4903ddc0afa206310ad4ae6477ec3bc03e0a54a453bef6cL32-R32) [[5]](diffhunk://#diff-c5183cca6f208c543cb966b0a1a8ca65b41a024a1500f28f175163777c879028L218-R218) [[6]](diffhunk://#diff-eec2689bca56a16310f9d90995ccd8a0713b489299ae6fd21ba2bafc07dedd4fL32-R32) [[7]](diffhunk://#diff-303f1c5fceb02f3688d2a8a47f686d350e3ef9cc5b634ffcf49f5b92c5d5f265L146-R146) [[8]](diffhunk://#diff-862a11b8cfe3020a02933deb53aa5f660765b1a9f05684f927474568ab129006L64-R64) [[9]](diffhunk://#diff-25c7ef90034c67aaa0b403b13d6181c139315ad8a537adf122debe6b1f931c76L45-R45) [[10]](diffhunk://#diff-21f6c71c0b73a50fb45b390a8c9c8a7ea4eee8080b08b175726d8c3df3ed2254L89-R89) [[11]](diffhunk://#diff-1f2aadd308cdf2a372f92e553fda2bfaae9bdc475d477c6a2fa2b181ef346fb0L42-R42) [[12]](diffhunk://#diff-a6f62cfa1aa6ad418695a8605010fc057f95b777f8aa6859c24391dd7940d6bdL73-R73)

* All workflow input defaults and job variables for the Java version are updated to `"25.0.2"` instead of `"25"` in reusable workflows and composite actions. [[1]](diffhunk://#diff-b1807573e6d897f28bb26228078cb9c90183cc56186bcf069fd2590c1e25e445L20-R20) [[2]](diffhunk://#diff-b1807573e6d897f28bb26228078cb9c90183cc56186bcf069fd2590c1e25e445L60-R60) [[3]](diffhunk://#diff-b1807573e6d897f28bb26228078cb9c90183cc56186bcf069fd2590c1e25e445L73-R73) [[4]](diffhunk://#diff-28edb182027cf663bf7e403257652c15d6394a6a91a2ded6551b92ce91c09534L21-R21) [[5]](diffhunk://#diff-28edb182027cf663bf7e403257652c15d6394a6a91a2ded6551b92ce91c09534L47-R47) F907dedfL17R17, [[6]](diffhunk://#diff-61b9e70748811f07dfad182de08559e67018d8f21e3f0f53096061e24ecd169dL20-R20) [[7]](diffhunk://#diff-785e34e558b8346c21f7f3a1fe6aa5b44dc8137e9eaa961b3837464c29dbee86L19-R19) [[8]](diffhunk://#diff-3871c05a5e388bc9aadef3c50bc08e2b0639cbbf6d58fcc288726915750172adL20-R20) [[9]](diffhunk://#diff-b80dff3a4020704d0693267b50948584e8bf5bfe1c2eb20668fc63afcaee963bL20-R20) [[10]](diffhunk://#diff-a8b10cab00d5d38ff06131eea0905cbbbb9d2bd14257184b9f92cf3296af3376L20-R20) [[11]](diffhunk://#diff-e83359651b7a0f9fedfafe8de2b1d59b6b29c2fb0a463ef504c1d384364c3c5cL35-R35)

No other functional or logic changes are included; this is a version bump for improved clarity and reproducibility.

**Related issue(s)**:

Fixes #25492 (Part 1 in comments)

**Testing**:

MATS Dry Run in work [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/26044359575)

