### PR TITLE
feat: 25535 Add progress reporting to validation commands

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -17,6 +17,7 @@ import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.statevalidation.util.ProgressReporter;
 import com.hedera.statevalidation.util.StateUtils;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.platform.state.snapshot.SignedStateFileWriter;
@@ -160,6 +161,13 @@ public class BlockStreamRecoveryWorkflow {
                 ? new RateLimiter(platformContext.getTime(), roundsPerSecond)
                 : null;
 
+        // Progress reporting: percentage-based when targetRound is known, count-based otherwise
+        final boolean bounded = targetRound != DEFAULT_TARGET_ROUND;
+        final ProgressReporter progress = bounded
+                ? new ProgressReporter("Block stream recovery", targetRound - initRound)
+                : new ProgressReporter("Block stream recovery", 1); // unbounded fallback
+
+
         blocks.forEach(block -> {
             for (final BlockItem item : block.items()) {
                 // if the first block item belongs to the round after the first round to apply, we can't proceed
@@ -197,6 +205,11 @@ public class BlockStreamRecoveryWorkflow {
                         // requestAndTrigger() always succeeds .
                         rateLimit(rateLimiter);
                         currentRound.incrementAndGet();
+                        if (bounded) {
+                            progress.advance(1);
+                        } else {
+                            progress.advanceUnbounded(1);
+                        }
                     }
                 }
 

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -167,7 +167,6 @@ public class BlockStreamRecoveryWorkflow {
                 ? new ProgressReporter("Block stream recovery", targetRound - initRound)
                 : new ProgressReporter("Block stream recovery", 1); // unbounded fallback
 
-
         blocks.forEach(block -> {
             for (final BlockItem item : block.items()) {
                 // if the first block item belongs to the round after the first round to apply, we can't proceed

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ProgressReporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ProgressReporter.java
@@ -4,7 +4,6 @@ package com.hedera.statevalidation.util;
 import static com.hedera.statevalidation.gcp.GcpPathHelper.CONSOLE;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -30,12 +29,13 @@ public class ProgressReporter {
     private final String label;
     private final long total;
     private final AtomicLong completed = new AtomicLong();
-    private final AtomicInteger lastReportedDecile = new AtomicInteger(0);
 
     /**
      * Interval for unbounded progress reporting: log every N units.
      */
-    private static final long UNBOUNDED_LOG_INTERVAL = 1000;
+    private static final long DEFAULT_UNBOUNDED_LOG_INTERVAL = 1000;
+
+    private final long unboundedLogInterval;
 
     /**
      * Creates a bounded progress reporter.
@@ -44,8 +44,20 @@ public class ProgressReporter {
      * @param total the total amount of work; must be positive
      */
     public ProgressReporter(@NonNull final String label, final long total) {
+        this(label, total, DEFAULT_UNBOUNDED_LOG_INTERVAL);
+    }
+
+    /**
+     * Creates a bounded progress reporter.
+     *
+     * @param label the label printed before each percentage (e.g. "Pipeline", "Block stream recovery")
+     * @param total the total amount of work; must be positive
+     * @param unboundedLogInterval the interval for unbounded progress reporting
+     */
+    public ProgressReporter(String label, long total, long unboundedLogInterval) {
         this.label = label;
         this.total = total;
+        this.unboundedLogInterval = unboundedLogInterval;
     }
 
     /**
@@ -56,30 +68,25 @@ public class ProgressReporter {
      */
     public void advance(final long delta) {
         final long current = completed.addAndGet(delta);
-        final int decile = (int) Math.min(current * 10 / total, 10);
-        int prev = lastReportedDecile.get();
-        // Report every 10% decile that was crossed since the last report
-        while (decile > prev) {
-            if (lastReportedDecile.compareAndSet(prev, decile)) {
-                for (int d = prev + 1; d <= decile; d++) {
-                    log.info(CONSOLE, "{}: {}%", label, d * 10);
-                }
-                break;
-            }
-            prev = lastReportedDecile.get();
+        final long prev = current - delta;
+        final int prevDecile = (int) (prev * 10 / total);
+        final int currentDecile = (int) Math.min(current * 10 / total, 10);
+        for (int d = prevDecile + 1; d <= currentDecile; d++) {
+            log.info(CONSOLE, "{}: {}%", label, d * 10);
         }
     }
 
     /**
      * Advances an unbounded counter (total unknown). Logs the current count
-     * every {@value UNBOUNDED_LOG_INTERVAL} units.
+     * every {@link #unboundedLogInterval} units.
      *
      * @param delta the amount of work completed
      */
     public void advanceUnbounded(final long delta) {
-        final long prev = completed.get();
         final long current = completed.addAndGet(delta);
-        if (current / UNBOUNDED_LOG_INTERVAL > prev / UNBOUNDED_LOG_INTERVAL) {
+        final long prev = current - delta;
+
+        if (current / unboundedLogInterval > prev / unboundedLogInterval) {
             log.info(CONSOLE, "{}: {} processed", label, current);
         }
     }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ProgressReporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ProgressReporter.java
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.statevalidation.util;
+
+import static com.hedera.statevalidation.gcp.GcpPathHelper.CONSOLE;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Thread-safe progress reporter that logs percentage milestones to stdout via the
+ * {@code CONSOLE} log4j marker. Reports at every 10% boundary: {@code 10%...20%...100%}.
+ *
+ * <p>Typical usage:
+ * <pre>{@code
+ *   ProgressReporter progress = new ProgressReporter("Pipeline", totalBytes);
+ *   // from any thread:
+ *   progress.advance(bytesProcessed);
+ * }</pre>
+ *
+ * <p>When the total is not known upfront (e.g. unbounded stream), use {@link #advanceUnbounded(long)}
+ * to periodically log the current count without percentage.
+ */
+public class ProgressReporter {
+
+    private static final Logger log = LogManager.getLogger(ProgressReporter.class);
+
+    private final String label;
+    private final long total;
+    private final AtomicLong completed = new AtomicLong();
+    private final AtomicInteger lastReportedDecile = new AtomicInteger(0);
+
+    /**
+     * Interval for unbounded progress reporting: log every N units.
+     */
+    private static final long UNBOUNDED_LOG_INTERVAL = 1000;
+
+    /**
+     * Creates a bounded progress reporter.
+     *
+     * @param label the label printed before each percentage (e.g. "Pipeline", "Block stream recovery")
+     * @param total the total amount of work; must be positive
+     */
+    public ProgressReporter(@NonNull final String label, final long total) {
+        this.label = label;
+        this.total = total;
+    }
+
+    /**
+     * Advances progress by {@code delta} units. If a new 10% boundary is crossed,
+     * logs the milestone to stdout.
+     *
+     * @param delta the amount of work completed (must be non-negative)
+     */
+    public void advance(final long delta) {
+        final long current = completed.addAndGet(delta);
+        final int decile = (int) Math.min(current * 10 / total, 10);
+        int prev = lastReportedDecile.get();
+        // Report every 10% decile that was crossed since the last report
+        while (decile > prev) {
+            if (lastReportedDecile.compareAndSet(prev, decile)) {
+                for (int d = prev + 1; d <= decile; d++) {
+                    log.info(CONSOLE, "{}: {}%", label, d * 10);
+                }
+                break;
+            }
+            prev = lastReportedDecile.get();
+        }
+    }
+
+    /**
+     * Advances an unbounded counter (total unknown). Logs the current count
+     * every {@value UNBOUNDED_LOG_INTERVAL} units.
+     *
+     * @param delta the amount of work completed
+     */
+    public void advanceUnbounded(final long delta) {
+        final long prev = completed.get();
+        final long current = completed.addAndGet(delta);
+        if (current / UNBOUNDED_LOG_INTERVAL > prev / UNBOUNDED_LOG_INTERVAL) {
+            log.info(CONSOLE, "{}: {} processed", label, current);
+        }
+    }
+}

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/pipeline/ValidationPipelineExecutor.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/pipeline/ValidationPipelineExecutor.java
@@ -7,6 +7,7 @@ import static com.swirlds.base.units.UnitConstants.MEBIBYTES_TO_BYTES;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.statevalidation.util.ProgressReporter;
 import com.hedera.statevalidation.validator.Validator;
 import com.hedera.statevalidation.validator.listener.ValidationListener;
 import com.hedera.statevalidation.validator.model.DataStats;
@@ -168,6 +169,12 @@ public final class ValidationPipelineExecutor {
                 // Sort segments: largest segments first (better thread utilization)
                 readSegments.sort((a, b) -> Long.compare(b.endByte() - b.startByte(), a.endByte() - a.startByte()));
 
+                // Progress tracking: total bytes across all segments is known upfront
+                final long totalBytes = readSegments.stream()
+                                        .mapToLong(s -> s.endByte() - s.startByte())
+                                                .sum();
+               final ProgressReporter progress = new ProgressReporter("Pipeline validation", totalBytes);
+
                 // Initialize data structures for processing
                 dataStats = new DataStats();
                 totalBoundarySearchTime = new AtomicLong(0L);
@@ -186,6 +193,7 @@ public final class ValidationPipelineExecutor {
                 for (final ReadSegment segment : readSegments) {
                     ioFutures.add(ioPool.submit(() -> {
                         readFileSegment(segment.reader(), segment.type(), segment.startByte(), segment.endByte());
+                        progress.advance(segment.endByte() - segment.startByte());
                         return null;
                     }));
                 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/pipeline/ValidationPipelineExecutor.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/pipeline/ValidationPipelineExecutor.java
@@ -171,9 +171,9 @@ public final class ValidationPipelineExecutor {
 
                 // Progress tracking: total bytes across all segments is known upfront
                 final long totalBytes = readSegments.stream()
-                                        .mapToLong(s -> s.endByte() - s.startByte())
-                                                .sum();
-               final ProgressReporter progress = new ProgressReporter("Pipeline validation", totalBytes);
+                        .mapToLong(s -> s.endByte() - s.startByte())
+                        .sum();
+                final ProgressReporter progress = new ProgressReporter("Pipeline validation", totalBytes);
 
                 // Initialize data structures for processing
                 dataStats = new DataStats();


### PR DESCRIPTION
Print percentage progress (`10%...20%...100%`) to stdout via the `CONSOLE` log4j marker during long-running validations.

**Changes:**
- `ProgressReporter` — thread-safe utility that logs at 10% decile boundaries. Supports bounded (percentage) and unbounded (count-based) modes.
- `ValidationPipelineExecutor` — tracks bytes read across completed IO segments vs total segment bytes.
- `BlockStreamRecoveryWorkflow` — tracks rounds applied vs `targetRound - initRound` when target is set; falls back to periodic count logging when unbounded.

**Related issue(s)**:

Fixes #25535 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
