### PR TITLE
chore: Update BlockNodeContainer version to v0.34.0-rc1 and impl RSA bootstrap

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SharedNetworkLauncherSessionListener.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SharedNetworkLauncherSessionListener.java
@@ -328,7 +328,7 @@ public class SharedNetworkLauncherSessionListener implements LauncherSessionList
                 // Determine block node mode from system property, default to REAL
                 final BlockNodeMode blockNodeMode = Optional.ofNullable(System.getProperty("hapi.spec.blocknode.mode"))
                         .map(BlockNodeMode::valueOf)
-                        .orElse(BlockNodeMode.SIMULATOR);
+                        .orElse(BlockNodeMode.REAL);
                 log.info(
                         "PR Check Override: blockStream.writerMode={} is set, configuring a Block Node network with mode {}",
                         writerMode,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SharedNetworkLauncherSessionListener.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SharedNetworkLauncherSessionListener.java
@@ -30,6 +30,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,6 +39,8 @@ import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.config.Configurator;
+import org.hiero.consensus.model.node.KeysAndCerts;
+import org.hiero.consensus.model.node.NodeId;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.launcher.LauncherSession;
@@ -330,15 +333,18 @@ public class SharedNetworkLauncherSessionListener implements LauncherSessionList
                         "PR Check Override: blockStream.writerMode={} is set, configuring a Block Node network with mode {}",
                         writerMode,
                         blockNodeMode);
-                BlockNodeNetwork blockNodeNetwork = new BlockNodeNetwork();
+                final SubProcessNetwork subProcessNetwork = (SubProcessNetwork) network;
+                final BlockNodeNetwork blockNodeNetwork = new BlockNodeNetwork();
                 blockNodeNetwork.getBlockNodeModeById().put(0L, blockNodeMode);
                 network.nodes().forEach(node -> {
                     blockNodeNetwork.getBlockNodeIdsBySubProcessNodeId().put(node.getNodeId(), new long[] {0});
                     blockNodeNetwork.getBlockNodePrioritiesBySubProcessNodeId().put(node.getNodeId(), new long[] {0});
                 });
+                if (blockNodeMode == BlockNodeMode.REAL) {
+                    blockNodeNetwork.setRsaBootstrapJson(buildRsaBootstrapJson(subProcessNetwork.getNodeKeys()));
+                }
                 blockNodeNetwork.start();
                 SHARED_BLOCK_NODE_NETWORK.set(blockNodeNetwork);
-                SubProcessNetwork subProcessNetwork = (SubProcessNetwork) network;
                 subProcessNetwork.setBlockNodeMode(blockNodeMode);
                 subProcessNetwork
                         .getPostInitWorkingDirActions()
@@ -348,5 +354,20 @@ public class SharedNetworkLauncherSessionListener implements LauncherSessionList
                         .add(node -> subProcessNetwork.configureBlockNodeCommunicationLogLevel(node, "DEBUG"));
             }
         }
+    }
+
+    public static String buildRsaBootstrapJson(final Map<NodeId, KeysAndCerts> nodeKeys) {
+        final var sb = new StringBuilder("{\"nodeAddress\": [");
+        boolean first = true;
+        for (final Map.Entry<NodeId, KeysAndCerts> entry : nodeKeys.entrySet()) {
+            if (!first) sb.append(", ");
+            first = false;
+            final String hexKey = HexFormat.of()
+                    .formatHex(entry.getValue().sigKeyPair().getPublic().getEncoded());
+            sb.append("{\"nodeId\": ").append(entry.getKey().id());
+            sb.append(", \"RSAPubKey\": \"").append(hexKey).append("\"}");
+        }
+        sb.append("]}");
+        return sb.toString();
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/NetworkTargetingExtension.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/NetworkTargetingExtension.java
@@ -4,6 +4,7 @@ package com.hedera.services.bdd.junit.extensions;
 import static com.hedera.services.bdd.junit.ContextRequirement.FEE_SCHEDULE_OVERRIDES;
 import static com.hedera.services.bdd.junit.ContextRequirement.THROTTLE_OVERRIDES;
 import static com.hedera.services.bdd.junit.SharedNetworkLauncherSessionListener.SharedNetworkExecutionListener.sharedSubProcessNetwork;
+import static com.hedera.services.bdd.junit.SharedNetworkLauncherSessionListener.buildRsaBootstrapJson;
 import static com.hedera.services.bdd.junit.extensions.ExtensionUtils.hapiTestMethodOf;
 import static com.hedera.services.bdd.junit.hedera.embedded.EmbeddedMode.CONCURRENT;
 import static com.hedera.services.bdd.junit.hedera.embedded.EmbeddedMode.REPEATABLE;
@@ -30,6 +31,7 @@ import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.LeakyRepeatableHapiTest;
 import com.hedera.services.bdd.junit.SharedNetworkLauncherSessionListener;
 import com.hedera.services.bdd.junit.TargetEmbeddedMode;
+import com.hedera.services.bdd.junit.hedera.BlockNodeMode;
 import com.hedera.services.bdd.junit.hedera.BlockNodeNetwork;
 import com.hedera.services.bdd.junit.hedera.ExternalPath;
 import com.hedera.services.bdd.junit.hedera.HederaNetwork;
@@ -148,6 +150,11 @@ public class NetworkTargetingExtension implements BeforeEachCallback, AfterEachC
                     }
                 }
 
+                final boolean hasRealBlockNode =
+                        Arrays.stream(annotation.blockNodeConfigs()).anyMatch(c -> c.mode() == BlockNodeMode.REAL);
+                if (hasRealBlockNode) {
+                    targetBlockNodeNetwork.setRsaBootstrapJson(buildRsaBootstrapJson(targetNetwork.getNodeKeys()));
+                }
                 targetBlockNodeNetwork.start();
                 SHARED_BLOCK_NODE_NETWORK.set(targetBlockNodeNetwork);
                 targetNetwork.start();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/BlockNodeNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/BlockNodeNetwork.java
@@ -42,6 +42,8 @@ public class BlockNodeNetwork {
     private final Map<Long, long[]> blockNodePrioritiesBySubProcessNodeId = new HashMap<>();
     private final Map<Long, long[]> blockNodeIdsBySubProcessNodeId = new HashMap<>();
 
+    private String rsaBootstrapJson;
+
     public static final int BLOCK_NODE_LOCAL_PORT = 40840;
     private static final int MAX_START_ATTEMPTS = 4;
     private static final long CONTAINER_START_BACKOFF_MS = 1000L;
@@ -225,7 +227,7 @@ public class BlockNodeNetwork {
             final int port = findAvailablePort();
             BlockNodeContainer container = null;
             try {
-                container = new BlockNodeContainer(id, port);
+                container = new BlockNodeContainer(id, port, rsaBootstrapJson);
                 container.start();
                 blockNodeContainerById.put(id, container);
                 logger.info("Started real block node container {} @ {}", id, container);
@@ -376,5 +378,13 @@ public class BlockNodeNetwork {
 
     public Map<Long, Boolean> getBlockNodeHighLatencyById() {
         return blockNodeHighLatencyById;
+    }
+
+    public void setRsaBootstrapJson(@NonNull final String rsaBootstrapJson) {
+        this.rsaBootstrapJson = rsaBootstrapJson;
+    }
+
+    public String getRsaBootstrapJson() {
+        return rsaBootstrapJson;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
@@ -172,27 +172,29 @@ public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
      * from its default {@code app.state.rsaBootstrapFilePath} without any config override.
      */
     private static Path prepareStateDir(final String rsaBootstrapJson) {
-        final Path scopeRoot = WorkingDirUtils.workingDirFor(0, null).getParent();
-        final Path stateDir;
-        if (scopeRoot == null) {
-            stateDir = Path.of("build", "block-node", BLOCK_NODE_VERSION, "node")
-                    .toAbsolutePath()
-                    .normalize();
-        } else {
-            stateDir = scopeRoot
-                    .resolve("block-node")
-                    .resolve(BLOCK_NODE_VERSION)
-                    .resolve("node")
-                    .toAbsolutePath()
-                    .normalize();
+        synchronized (PLUGINS_LOCK) {
+            final Path scopeRoot = WorkingDirUtils.workingDirFor(0, null).getParent();
+            final Path stateDir;
+            if (scopeRoot == null) {
+                stateDir = Path.of("build", "block-node", BLOCK_NODE_VERSION, "node")
+                        .toAbsolutePath()
+                        .normalize();
+            } else {
+                stateDir = scopeRoot
+                        .resolve("block-node")
+                        .resolve(BLOCK_NODE_VERSION)
+                        .resolve("node")
+                        .toAbsolutePath()
+                        .normalize();
+            }
+            try {
+                Files.createDirectories(stateDir);
+                Files.writeString(stateDir.resolve(RSA_BOOTSTRAP_FILE_NAME), rsaBootstrapJson);
+            } catch (final IOException e) {
+                throw new RuntimeException("Failed to write RSA bootstrap file to " + stateDir, e);
+            }
+            return stateDir;
         }
-        try {
-            Files.createDirectories(stateDir);
-            Files.writeString(stateDir.resolve(RSA_BOOTSTRAP_FILE_NAME), rsaBootstrapJson);
-        } catch (final IOException e) {
-            throw new RuntimeException("Failed to write RSA bootstrap file to " + stateDir, e);
-        }
-        return stateDir;
     }
 
     private static void downloadIfMissing(final HttpClient client, final String url, final Path destination)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/containers/BlockNodeContainer.java
@@ -26,13 +26,14 @@ import org.testcontainers.utility.DockerImageName;
  * A test container for running a block node server instance.
  */
 public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
-    private static final String BLOCK_NODE_VERSION = "0.30.2";
+    private static final String BLOCK_NODE_VERSION = "0.34.0-rc1";
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("ghcr.io/hiero-ledger/hiero-block-node:" + BLOCK_NODE_VERSION);
     private static final int GRPC_PORT = 40840;
-    private static final int HEALTH_PORT = 16007;
     private static final String MAVEN_CENTRAL_BASE_URL = "https://repo1.maven.org/maven2";
     private static final String HIER0_BLOCK_NODE_GROUP_PATH = "org/hiero/block-node";
+    private static final String STATE_DIR_IN_CONTAINER = "/opt/hiero/block-node/node";
+    private static final String RSA_BOOTSTRAP_FILE_NAME = "rsa-bootstrap-roster.json";
     private static final Object PLUGINS_LOCK = new Object();
     private static final List<String> REQUIRED_PLUGIN_ARTIFACTS = List.of(
             "facility-messaging",
@@ -50,19 +51,19 @@ public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
                     MAVEN_CENTRAL_BASE_URL
                             + "/com/github/spotbugs/spotbugs-annotations/4.9.8/spotbugs-annotations-4.9.8.jar"),
             Map.entry("disruptor-4.0.0.jar", MAVEN_CENTRAL_BASE_URL + "/com/lmax/disruptor/4.0.0/disruptor-4.0.0.jar"),
-            // Transitive deps of the verification plugin (new in 0.29.0)
+            // Transitive deps of the verification plugin
             Map.entry(
-                    "hedera-cryptography-wraps-3.6.0.jar",
+                    "hedera-cryptography-wraps-3.8.1.jar",
                     MAVEN_CENTRAL_BASE_URL
-                            + "/com/hedera/cryptography/hedera-cryptography-wraps/3.6.0/hedera-cryptography-wraps-3.6.0.jar"),
+                            + "/com/hedera/cryptography/hedera-cryptography-wraps/3.8.1/hedera-cryptography-wraps-3.8.1.jar"),
             Map.entry(
-                    "hedera-cryptography-hints-3.6.0.jar",
+                    "hedera-cryptography-hints-3.8.1.jar",
                     MAVEN_CENTRAL_BASE_URL
-                            + "/com/hedera/cryptography/hedera-cryptography-hints/3.6.0/hedera-cryptography-hints-3.6.0.jar"),
+                            + "/com/hedera/cryptography/hedera-cryptography-hints/3.8.1/hedera-cryptography-hints-3.8.1.jar"),
             Map.entry(
-                    "hedera-common-nativesupport-3.6.0.jar",
+                    "hedera-common-nativesupport-3.8.1.jar",
                     MAVEN_CENTRAL_BASE_URL
-                            + "/com/hedera/common/hedera-common-nativesupport/3.6.0/hedera-common-nativesupport-3.6.0.jar"),
+                            + "/com/hedera/common/hedera-common-nativesupport/3.8.1/hedera-common-nativesupport-3.8.1.jar"),
             Map.entry(
                     "antlr4-runtime-4.13.2.jar",
                     MAVEN_CENTRAL_BASE_URL + "/org/antlr/antlr4-runtime/4.13.2/antlr4-runtime-4.13.2.jar"));
@@ -70,32 +71,42 @@ public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
 
     /**
      * Creates a new block node container with the default image.
+     *
      * @param blockNodeId the id of the block node
      * @param port the internal port of the block node container to expose
+     * @param rsaBootstrapJson JSON content for the RSA bootstrap roster file, or {@code null} to skip
      */
-    public BlockNodeContainer(final long blockNodeId, final int port) {
-        this(DEFAULT_IMAGE_NAME, blockNodeId, port);
+    public BlockNodeContainer(final long blockNodeId, final int port, final String rsaBootstrapJson) {
+        this(DEFAULT_IMAGE_NAME, blockNodeId, port, rsaBootstrapJson);
     }
 
     /**
      * Creates a new block node container with the specified image.
      *
      * @param dockerImageName the docker image to use
+     * @param rsaBootstrapJson JSON content for the RSA bootstrap roster file, or {@code null} to skip
      */
-    private BlockNodeContainer(DockerImageName dockerImageName, final long blockNodeId, final int port) {
+    private BlockNodeContainer(
+            DockerImageName dockerImageName, final long blockNodeId, final int port, final String rsaBootstrapJson) {
         super(dockerImageName);
 
         final Path pluginsDir = ensurePluginsAvailable();
         this.withFileSystemBind(pluginsDir.toString(), pluginsDirInContainer(), BindMode.READ_ONLY);
 
+        if (rsaBootstrapJson != null) {
+            final Path stateDir = prepareStateDir(rsaBootstrapJson);
+            this.withFileSystemBind(stateDir.toString(), STATE_DIR_IN_CONTAINER, BindMode.READ_WRITE);
+        }
+
         // Expose the gRPC port for block node communication
         this.addFixedExposedPort(port, GRPC_PORT);
-        // Also expose the health check port
-        this.addExposedPort(HEALTH_PORT);
         this.withNetworkAliases("block-node-" + blockNodeId)
                 .withEnv("VERSION", BLOCK_NODE_VERSION)
-                // Use HTTP health check on the health port to verify the service is ready
-                .waitingFor(Wait.forHttp("/-/healthy").forPort(HEALTH_PORT).withStartupTimeout(Duration.ofMinutes(2)));
+                // The health endpoint is served on the same HTTP/2 port as gRPC (40840), which is
+                // incompatible with testcontainers' HTTP/1.1 wait strategy. Use a log-message check
+                // instead; BlockNodeNetwork.awaitGrpcReadiness() provides the gRPC-level confirmation.
+                .waitingFor(Wait.forLogMessage(".*Started BlockNode Server.*", 1)
+                        .withStartupTimeout(Duration.ofMinutes(2)));
     }
 
     private static String pluginsDirInContainer() {
@@ -153,6 +164,35 @@ public class BlockNodeContainer extends GenericContainer<BlockNodeContainer> {
                 .resolve("plugins")
                 .toAbsolutePath()
                 .normalize();
+    }
+
+    /**
+     * Writes the RSA bootstrap JSON to the block node state directory and returns the directory path.
+     * The file is written as {@value RSA_BOOTSTRAP_FILE_NAME} so the block node app picks it up
+     * from its default {@code app.state.rsaBootstrapFilePath} without any config override.
+     */
+    private static Path prepareStateDir(final String rsaBootstrapJson) {
+        final Path scopeRoot = WorkingDirUtils.workingDirFor(0, null).getParent();
+        final Path stateDir;
+        if (scopeRoot == null) {
+            stateDir = Path.of("build", "block-node", BLOCK_NODE_VERSION, "node")
+                    .toAbsolutePath()
+                    .normalize();
+        } else {
+            stateDir = scopeRoot
+                    .resolve("block-node")
+                    .resolve(BLOCK_NODE_VERSION)
+                    .resolve("node")
+                    .toAbsolutePath()
+                    .normalize();
+        }
+        try {
+            Files.createDirectories(stateDir);
+            Files.writeString(stateDir.resolve(RSA_BOOTSTRAP_FILE_NAME), rsaBootstrapJson);
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to write RSA bootstrap file to " + stateDir, e);
+        }
+        return stateDir;
     }
 
     private static void downloadIfMissing(final HttpClient client, final String url, final Path destination)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/simulator/BlockNodeController.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/simulator/BlockNodeController.java
@@ -22,6 +22,7 @@ import org.hiero.block.api.PublishStreamResponse.EndOfStream;
  */
 public class BlockNodeController {
     private static final Logger log = LogManager.getLogger(BlockNodeController.class);
+    private static BlockNodeNetwork blockNodeNetwork;
     private static Map<Long, SimulatedBlockNodeServer> simulatedBlockNodes = new HashMap<>();
     private static Map<Long, BlockNodeContainer> blockNodeContainers = new HashMap<>();
     // Store the ports of shutdown block nodes for restart
@@ -35,6 +36,7 @@ public class BlockNodeController {
      * @param network the SubProcessNetwork containing simulated block nodes
      */
     public BlockNodeController(@NonNull final BlockNodeNetwork network) {
+        blockNodeNetwork = network;
         simulatedBlockNodes = network.getSimulatedBlockNodeById();
         if (simulatedBlockNodes.isEmpty()) {
             log.warn("No simulated block nodes found in the network. Make sure BlockNodeMode.SIMULATOR is set.");
@@ -504,7 +506,7 @@ public class BlockNodeController {
                 blockNodeContainer = blockNodeContainers.get(nodeIndex);
                 blockNodeContainer.resume();
             } else {
-                blockNodeContainer = new BlockNodeContainer(nodeIndex, port);
+                blockNodeContainer = new BlockNodeContainer(nodeIndex, port, blockNodeNetwork.getRsaBootstrapJson());
                 blockNodeContainer.start();
             }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
@@ -881,4 +881,8 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
     public Map<Long, List<String>> getApplicationPropertyOverrides() {
         return applicationPropertyOverrides;
     }
+
+    public Map<NodeId, KeysAndCerts> getNodeKeys() {
+        return nodeKeys;
+    }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
@@ -53,7 +53,9 @@ public class BlockNodeBackPressureSuite {
                             "blockStream.streamMode",
                             "BLOCKS",
                             "blockStream.writerMode",
-                            "FILE_AND_GRPC"
+                            "FILE_AND_GRPC",
+                            "blockStream.streamWrappedRecordBlocks",
+                            "false"
                         })
             })
     @Order(1)
@@ -88,7 +90,9 @@ public class BlockNodeBackPressureSuite {
                             "blockStream.streamMode",
                             "BLOCKS",
                             "blockStream.writerMode",
-                            "FILE_AND_GRPC"
+                            "FILE_AND_GRPC",
+                            "blockStream.streamWrappedRecordBlocks",
+                            "false"
                         })
             })
     @Order(2)
@@ -135,36 +139,56 @@ public class BlockNodeBackPressureSuite {
                         blockNodeIds = {0},
                         blockNodePriorities = {0},
                         applicationPropertiesOverrides = {
-                            "blockStream.buffer.maxBlocks", "5",
-                            "blockStream.streamMode", "BLOCKS",
-                            "blockStream.writerMode", "GRPC"
+                            "blockStream.buffer.maxBlocks",
+                            "5",
+                            "blockStream.streamMode",
+                            "BLOCKS",
+                            "blockStream.writerMode",
+                            "GRPC",
+                            "blockStream.streamWrappedRecordBlocks",
+                            "false"
                         }),
                 @SubProcessNodeConfig(
                         nodeId = 1,
                         blockNodeIds = {1},
                         blockNodePriorities = {0},
                         applicationPropertiesOverrides = {
-                            "blockStream.buffer.maxBlocks", "5",
-                            "blockStream.streamMode", "BLOCKS",
-                            "blockStream.writerMode", "GRPC"
+                            "blockStream.buffer.maxBlocks",
+                            "5",
+                            "blockStream.streamMode",
+                            "BLOCKS",
+                            "blockStream.writerMode",
+                            "GRPC",
+                            "blockStream.streamWrappedRecordBlocks",
+                            "false"
                         }),
                 @SubProcessNodeConfig(
                         nodeId = 2,
                         blockNodeIds = {2},
                         blockNodePriorities = {0},
                         applicationPropertiesOverrides = {
-                            "blockStream.buffer.maxBlocks", "5",
-                            "blockStream.streamMode", "BLOCKS",
-                            "blockStream.writerMode", "GRPC"
+                            "blockStream.buffer.maxBlocks",
+                            "5",
+                            "blockStream.streamMode",
+                            "BLOCKS",
+                            "blockStream.writerMode",
+                            "GRPC",
+                            "blockStream.streamWrappedRecordBlocks",
+                            "false"
                         }),
                 @SubProcessNodeConfig(
                         nodeId = 3,
                         blockNodeIds = {3},
                         blockNodePriorities = {0},
                         applicationPropertiesOverrides = {
-                            "blockStream.buffer.maxBlocks", "5",
-                            "blockStream.streamMode", "BLOCKS",
-                            "blockStream.writerMode", "GRPC"
+                            "blockStream.buffer.maxBlocks",
+                            "5",
+                            "blockStream.streamMode",
+                            "BLOCKS",
+                            "blockStream.writerMode",
+                            "GRPC",
+                            "blockStream.streamWrappedRecordBlocks",
+                            "false"
                         })
             })
     @Order(3)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -177,7 +177,9 @@ public class BlockNodeSuite {
                             "blockStream.writerMode",
                             "FILE_AND_GRPC",
                             "blockNode.forcedSwitchRescheduleDelay",
-                            "30s"
+                            "30s",
+                            "blockStream.streamWrappedRecordBlocks",
+                            "false"
                         })
             })
     @Order(3)
@@ -229,13 +231,22 @@ public class BlockNodeSuite {
                         blockNodeIds = {0},
                         blockNodePriorities = {0},
                         applicationPropertiesOverrides = {
-                            "blockStream.streamMode", "BLOCKS",
-                            "blockStream.writerMode", "FILE_AND_GRPC",
-                            "blockStream.buffer.maxBlocks", "60",
-                            "blockStream.buffer.isBufferPersistenceEnabled", "true",
-                            "blockStream.blockPeriod", BLOCK_PERIOD_SECONDS + "s",
-                            "blockNode.streamResetPeriod", "20s",
-                            "blockNode.streamResetPeriodJitter", "0s",
+                            "blockStream.streamMode",
+                            "BLOCKS",
+                            "blockStream.writerMode",
+                            "FILE_AND_GRPC",
+                            "blockStream.buffer.maxBlocks",
+                            "60",
+                            "blockStream.buffer.isBufferPersistenceEnabled",
+                            "true",
+                            "blockStream.blockPeriod",
+                            BLOCK_PERIOD_SECONDS + "s",
+                            "blockNode.streamResetPeriod",
+                            "20s",
+                            "blockNode.streamResetPeriodJitter",
+                            "0s",
+                            "blockStream.streamWrappedRecordBlocks",
+                            "false"
                         })
             })
     @Order(4)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/WrbStreamingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/WrbStreamingSuite.java
@@ -47,7 +47,7 @@ public class WrbStreamingSuite {
                             "blockStream.streamMode", "BOTH",
                             // writerMode=FILE is the production WRB topology (preview blocks to
                             // disk, only WRBs over gRPC); see #24775.
-                            "blockStream.writerMode", "FILE",
+                            "blockStream.writerMode", "FILE_AND_GRPC",
                             "blockStream.streamWrappedRecordBlocks", "true",
                             "hedera.recordStream.liveWritePrevWrappedRecordHashes", "true",
                             // Forces votingBlockNumInitialized() so WRB emission fires without


### PR DESCRIPTION
**Description**:
This pull request enhances the block node container infrastructure to support RSA bootstrap roster injection for real block node modes, updates dependencies, and improves container startup logic. The changes ensure that when running in "REAL" block node mode, the system generates and mounts an RSA bootstrap JSON file containing node public keys, which is then used by the block node application at startup. Additionally, the block node container version and related dependencies are updated, and health check logic is improved for compatibility with the latest block node server.

**Block Node RSA Bootstrap Roster Support**
- Added logic to generate an RSA bootstrap JSON file from node public keys and inject it into the block node container when running in REAL mode. This is handled via the new `buildRsaBootstrapJson` method and updates to the container startup process.

**Dependency and Version Updates**
- Upgraded the block node container version to `0.34.0-rc1` and updated several transitive dependencies to their latest versions (`hedera-cryptography-wraps`, `hedera-cryptography-hints`, and `hedera-common-nativesupport`) for compatibility and bug fixes.

**Container Startup and Health Check Improvements**
- Modified the container's health check mechanism to use a log-message-based wait strategy instead of HTTP, due to changes in the block node's health endpoint protocol. Also removed the now-unused health port exposure.

**API and Codebase Enhancements**
- Extended the `BlockNodeNetwork` and `SubProcessNetwork` classes with new getter/setter methods for RSA bootstrap JSON and node keys, respectively, to facilitate the new injection logic.
- Updated constructors and usages of `BlockNodeContainer` to accept the RSA bootstrap JSON parameter and ensure correct file mounting.

**Related issue(s)**:

Fixes #25506 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
