### PR TITLE
chore: evm.UseBonnevilleEVM=true

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -163,5 +163,5 @@ public record ContractsConfig(
         @ConfigProperty(value = "metrics.smartContract.secondary.enabled", defaultValue = "true") @NetworkProperty
         boolean metricsSmartContractSecondaryEnabled,
 
-        @ConfigProperty(value = "evm.UseBonnevilleEVM", defaultValue = "false") @NetworkProperty
+        @ConfigProperty(value = "evm.UseBonnevilleEVM", defaultValue = "true") @NetworkProperty
         boolean useBonnevilleEVM) {}


### PR DESCRIPTION
**Description**:
`BonnevilleEVM` tests for comparison with https://github.com/hiero-ledger/hiero-consensus-node/pull/25559

**Related issue(s)**:
- https://github.com/hiero-ledger/hiero-consensus-node/issues/25500

**Notes for reviewer**:
- HAPI testing with `contracts.evm.UseBonnevilleEVM` enabled

| Suite | Job / Result | Failures / Notes |
|---|---|---|
| **Misc** | ✅ `hapiTestMisc` | |
| | ✅ `hapiTestMiscEmbedded` | |
| | ❌ `hapiTestMiscRepeatable` — 65 failing | • Expected SUCCESS, was REJECTED_BY_ACCOUNT_ALLOWANCE_HOOK (LambdaplexCoreOrderTypesTest, LambdaplexMixedOrderTypesTest, LambdaplexStopOrderTypesTest)<br>• Wrong # of (non-staking) child records |
| **Smart Contracts & ISS** | ❌ `hapiTestSmartContract` — 5 failing | • ValidContractIdsAssertion: action is missing result (output, error, or revertReason)<br>• Expected SUCCESS, was INVALID_TRANSACTION_BODY (ContractCallSuite — callToNonExtantEvmAddressUsesTargetedAddress, hscsEvm010ReceiverMustSignContractTx, hollowCreationFailsCleanly, callToNonExtantLongZeroAddressUsesTargetedAddress, repeatedCreate2FailsWithInterpretableActionSidecars) |
| | ❌ `hapiTestSmartContractSerial` — 7 failing | • Expected SUCCESS, was INVALID_TRANSACTION_BODY (ScheduleDeleteTest — 3 tests)<br>• opsDuration failures: value 0.0 not in expected range \<100.0, 150.0\> (3 tests)<br>• TraceabilitySuite.assertSidecars() failed |
| | ✅ `hapiTestIss` | |
| **Restart** | ❌ `hapiTestRestart` — 1 failing | • Invalid signature in proof (start round #2246) — BlockProof block=157, TssSignedBlockProof signature validation failed |
