### PR TITLE
chore: pectra evm.UseBonnevilleEVM=true

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -166,5 +166,5 @@ public record ContractsConfig(
         @ConfigProperty(value = "metrics.smartContract.secondary.enabled", defaultValue = "true") @NetworkProperty
         boolean metricsSmartContractSecondaryEnabled,
 
-        @ConfigProperty(value = "evm.UseBonnevilleEVM", defaultValue = "false") @NetworkProperty
+        @ConfigProperty(value = "evm.UseBonnevilleEVM", defaultValue = "true") @NetworkProperty
         boolean useBonnevilleEVM) {}


### PR DESCRIPTION
**Description**:
`BonnevilleEVM` tests for comparison with https://github.com/hiero-ledger/hiero-consensus-node/pull/25559

**Related issue(s)**:
- https://github.com/hiero-ledger/hiero-consensus-node/issues/25500

**Notes for reviewer**:
- HAPI testing with `contracts.evm.UseBonnevilleEVM` enabled

| Suite | Job / Result | Failures / Notes |
|---|---|---|
| **Token & Time Consuming** | ✅ `hapiTestToken` | |
| | ✅ `hapiTestTokenSerial` | |
| | ❌ `hapiTestTimeConsuming` — 34 failing | • Expected SUCCESS, was INVALID_TRANSACTION_BODY<br>• Expected CONTRACT_REVERT_EXECUTED, was INVALID_TRANSACTION_BODY<br>• Expected MAX_GAS_LIMIT_EXCEEDED, was SUCCESS |
| | ✅ `hapiTestTimeConsumingSerial` | |
| **Smart Contracts & ISS** | ❌ `hapiTestSmartContract` — 52 failing | • ValidContractIdsAssertion: action is missing result (output, error, or revertReason)<br>• Expected SUCCESS, was INSUFFICIENT_GAS<br>• Expected SUCCESS, was CONTRACT_REVERT_EXECUTED<br>• Expected SUCCESS, was INVALID_TRANSACTION_BODY<br>• Expected SUCCESS, was INNER_TRANSACTION_FAILED<br>• Expected INVALID_CONTRACT_ID, was INVALID_TRANSACTION_BODY<br>• Expected MAX_CHILD_RECORDS_EXCEEDED, was INVALID_TRANSACTION_BODY<br>• Expected CONTRACT_REVERT_EXECUTED, was INVALID_TRANSACTION_BODY<br>• Bad balance! Expected change from 'initialBalance' to be \<-1 ± 0\>, was \<0\><br>• Found 2 problems in log file (ConcurrentSubprocessValidationTest) |
| | ❌ `hapiTestSmartContractSerial` — 16 failing | • Expected SUCCESS, was INVALID_TRANSACTION_BODY<br>• Expected SUCCESS, was CONTRACT_REVERT_EXECUTED<br>• Expected CONTRACT_REVERT_EXECUTED, was INVALID_TRANSACTION_BODY<br>• Expected SUCCESS, was REJECTED_BY_ACCOUNT_ALLOWANCE_HOOK<br>• opsDuration failures: 3 tests (exceed, revert, halt)<br>• 10 differences found between generated and translated records |
| | ✅ `hapiTestIss` | |
| **Misc** | ✅ `hapiTestMisc` | |
| | ❌ `hapiTestMiscEmbedded` — 15 failing | • Expected SUCCESS, was CONTRACT_REVERT_EXECUTED<br>• Expected SUCCESS, was INVALID_TRANSACTION_BODY<br>• Expected CONTRACT_REVERT_EXECUTED, was INVALID_TRANSACTION_BODY<br>• Expected MAX_CHILD_RECORDS_EXCEEDED, was INVALID_TRANSACTION_BODY |
| | ❌ `hapiTestMiscRepeatable` — 19 failing | • Expected SUCCESS, was INVALID_TRANSACTION_BODY<br>• Expected CONTRACT_REVERT_EXECUTED, was INVALID_TRANSACTION_BODY |
| **Misc Records, Crypto & Misc Serial** | ✅ `hapiTestMiscRecords` | |
| | ✅ `hapiTestMiscRecordsSerial` | |
| | ❌ `hapiTestCrypto` — 9 failing | • Wrong balance! expected \<1\> but was \<0\><br>• Expected SUCCESS, was CONTRACT_REVERT_EXECUTED<br>• Expected SUCCESS, was INVALID_TRANSACTION_BODY |
| | ✅ `hapiTestCryptoEmbedded` | |
| | ✅ `hapiTestCryptoSerial` | |
| | ✅ `hapiTestMiscSerial` | |
| **Atomic Batch** | ❌ `hapiTestAtomicBatch` — 3 failing | • Expected SUCCESS, was INNER_TRANSACTION_FAILED |
| | ❌ `hapiTestAtomicBatchSerial` — 6 failing | • Expected SUCCESS, was CONTRACT_REVERT_EXECUTED |
| | ❌ `hapiTestAtomicBatchEmbedded` — 9 failing | • Expected SUCCESS, was INNER_TRANSACTION_FAILED<br>• Expected CONTRACT_REVERT_EXECUTED, was INVALID_TRANSACTION_BODY<br>• Expected MAX_CHILD_RECORDS_EXCEEDED, was INVALID_TRANSACTION_BODY |
| **Unit Tests** | ❌ `Unit Tests` — 6 failing | • `Hip1195EnabledTest.nftTransferWithTokenRedirectHook` — 3 runs failed<br>• `Hip1195EnabledTest.transferWorksFromOwnerOfTheHook` — 3 runs failed |
