### PR TITLE
fix(history): use isCompleted in ProofControllerImpl constructor gate

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/ProofControllerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/ProofControllerImpl.java
@@ -155,7 +155,7 @@ public class ProofControllerImpl implements ProofController {
         this.historyService = requireNonNull(historyService);
         this.schnorrKeyPair = requireNonNull(schnorrKeyPair);
         votes.forEach((nodeId, vote) -> incorporateVote(nodeId, vote, tssConfig));
-        if (!construction.hasTargetProof()) {
+        if (!isCompleted(construction, tssConfig)) {
             final var cutoffTime = construction.hasGracePeriodEndTime()
                     ? asInstant(construction.gracePeriodEndTimeOrThrow())
                     : Instant.MAX;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/ProofControllerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/ProofControllerImplTest.java
@@ -238,6 +238,116 @@ class ProofControllerImplTest {
     }
 
     @Test
+    void constructorInitializesProverWhenWrapsEnabledOnNonWrapsExtensibleTargetProof() {
+        // Regression: when wrapsEnabled flips false -> true after an upgrade, an existing
+        // target proof saved before WRAPS was enabled is no longer "completed" per
+        // HistoryService.isCompleted, but the constructor previously only checked
+        // construction.hasTargetProof() and so skipped createProver(). The fix widens
+        // that gate to !isCompleted(construction, tssConfig) so the conversion path has
+        // a prover to drive.
+        construction = HistoryProofConstruction.newBuilder()
+                .constructionId(CONSTRUCTION_ID)
+                .targetProof(aValidProof())
+                .build();
+        given(tssConfig.wrapsEnabled()).willReturn(true);
+        given(proverFactory.create(
+                        eq(SELF_ID),
+                        eq(tssConfig),
+                        eq(keyPair),
+                        any(),
+                        eq(weights),
+                        any(),
+                        any(),
+                        eq(historyLibrary),
+                        eq(submissions)))
+                .willReturn(prover);
+
+        subject = new ProofControllerImpl(
+                SELF_ID,
+                keyPair,
+                construction,
+                weights,
+                executor,
+                submissions,
+                machine,
+                keyPublications,
+                wrapsMessagePublications,
+                existingVotes,
+                historyService,
+                historyLibrary,
+                proverFactory,
+                null,
+                historyProofMetrics,
+                tssConfig);
+
+        verify(proverFactory)
+                .create(
+                        eq(SELF_ID),
+                        eq(tssConfig),
+                        eq(keyPair),
+                        any(),
+                        eq(weights),
+                        any(),
+                        any(),
+                        eq(historyLibrary),
+                        eq(submissions));
+    }
+
+    @Test
+    void advanceConstructionDrivesProverWhenConvertingNonWrapsExtensibleTargetProof() {
+        // Regression: with a target proof that is not WRAPS-extensible and wrapsEnabled=true,
+        // isStillInProgress returns true (because isCompleted=false), advanceConstruction
+        // falls through to the prover-driven branch, and the prover must not be null.
+        construction = HistoryProofConstruction.newBuilder()
+                .constructionId(CONSTRUCTION_ID)
+                .targetProof(aValidProof())
+                .build();
+        given(tssConfig.wrapsEnabled()).willReturn(true);
+        given(writableHistoryStore.getLedgerId()).willReturn(Bytes.EMPTY);
+        given(proverFactory.create(
+                        eq(SELF_ID),
+                        eq(tssConfig),
+                        eq(keyPair),
+                        any(),
+                        eq(weights),
+                        any(),
+                        any(),
+                        eq(historyLibrary),
+                        eq(submissions)))
+                .willReturn(prover);
+
+        final var completedProof = recursiveProof("compressed", "uncompressed");
+        given(prover.advance(any(), any(), any(), any(), eq(tssConfig), any()))
+                .willReturn(new HistoryProver.Outcome.Completed(completedProof));
+        given(writableHistoryStore.completeProof(eq(CONSTRUCTION_ID), eq(completedProof)))
+                .willReturn(construction);
+
+        subject = new ProofControllerImpl(
+                SELF_ID,
+                keyPair,
+                construction,
+                weights,
+                executor,
+                submissions,
+                machine,
+                keyPublications,
+                wrapsMessagePublications,
+                existingVotes,
+                historyService,
+                historyLibrary,
+                proverFactory,
+                null,
+                historyProofMetrics,
+                tssConfig);
+
+        subject.advanceConstruction(
+                Instant.EPOCH.plusSeconds(1), METADATA, writableHistoryStore, true, tssConfig);
+
+        verify(prover).advance(any(), any(), any(), any(), eq(tssConfig), any());
+        verify(writableHistoryStore).completeProof(eq(CONSTRUCTION_ID), eq(completedProof));
+    }
+
+    @Test
     void advanceConstructionPublishesKeyWhenMetadataMissingAndActive() {
         given(weights.targetIncludes(SELF_ID)).willReturn(true);
 


### PR DESCRIPTION
## Summary

`ProofControllerImpl`'s constructor used `!construction.hasTargetProof()` to decide whether to call `createProver(tssConfig)`. That predicate is narrower than `HistoryService.isCompleted(construction, tssConfig)`, which is used by `isStillInProgress` — and therefore by `advanceConstruction`'s own early-return gate.

The mismatch breaks the WRAPS-conversion path. When a network whose construction #1 completed *before* WRAPS was enabled is upgraded with `tss.wrapsEnabled` flipped from `false` to `true`:

- The existing target proof is set but `isWrapsExtensible(targetProof) == false`.
- `HistoryService.isCompleted(construction, tssConfig)` returns `false` (the proof must be converted to a WRAPS-extensible one), so `isStillInProgress` returns `true`.
- But the constructor's narrower `!hasTargetProof()` gate already evaluated `false` and **skipped** `createProver`, leaving `prover` null.
- Every consensus round then NPEs at `requireNonNull(prover).advance(...)` in `advanceConstruction:232`, surfacing as repeated `Possibly CATASTROPHIC failure trying to reconcile TSS state` ERROR lines in `hgcaa.log`.

The conversion path is otherwise wired up correctly:
- [`incorporateVote:396`](https://github.com/hiero-ledger/hiero-consensus-node/blob/main/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/ProofControllerImpl.java#L396) explicitly accepts votes when \`wrapsEnabled != isWrapsExtensible(targetProof)\` — i.e. exactly this conversion case.
- [`finishProof:436-437`](https://github.com/hiero-ledger/hiero-consensus-node/blob/main/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/ProofControllerImpl.java#L436) clears the votes map with the comment \`// In case we'll vote again on a conversion to a WRAPS proof\`.

So the runtime *expects* a non-null `prover` for this case; the bug was purely that the constructor skipped initializing it.

## Fix

Widen the constructor's gate to `!isCompleted(construction, tssConfig)` so it agrees with `isStillInProgress`:

```diff
-        if (!construction.hasTargetProof()) {
+        if (!isCompleted(construction, tssConfig)) {
```

The static import for `isCompleted` was already present.

## Why this is safe

The behavioral delta is bounded to exactly one case:

| Construction state at boot | Old gate (`!hasTargetProof`) | New gate (`!isCompleted`) | Behavior change? |
|---|---|---|---|
| No target proof yet | true → prover created | true → prover created | none |
| Target proof + `wrapsEnabled=false` | false → no prover | `isCompleted=true`, false → no prover | none |
| Target proof + `wrapsEnabled=true` + `isWrapsExtensible=true` | false → no prover | `isCompleted=true`, false → no prover | none |
| Target proof + `wrapsEnabled=true` + `isWrapsExtensible=false` | false → no prover (then NPE) | `isCompleted=false`, true → **prover created** | the fix |

In the newly-entered branch the constructor:
1. Re-processes `keyPublications` via `maybeUpdateForProofKey` (idempotent `targetProofKeys` map update).
2. Calls `createProver(tssConfig)` (the same call `retryIfRecoverableFailure` uses elsewhere to reassign the prover).
3. Replays prior `wrapsMessagePublications` via `replayWrapsSigningMessage` (idempotent recovery into the new prover).

None of these touch `WritableHistoryStore`; only local controller state.

## Tests

Two new regression tests in `ProofControllerImplTest`:

- `constructorInitializesProverWhenWrapsEnabledOnNonWrapsExtensibleTargetProof` — constructs a `ProofControllerImpl` with `hasTargetProof=true`, `isWrapsExtensible=false`, `wrapsEnabled=true`; asserts `proverFactory.create(...)` is invoked.
- `advanceConstructionDrivesProverWhenConvertingNonWrapsExtensibleTargetProof` — same construction, then calls `advanceConstruction(...)` and asserts the full conversion-vote flow runs (no NPE, prover advances, `WritableHistoryStore.completeProof` is called with the new WRAPS-extensible proof).

Both tests fail on the old gate (`requireNonNull(prover)` NPEs at `ProofControllerImpl.java:232`) and pass on the new. Full `:app:test` against `*.history.impl.*` passes (133/133).

## Test plan

- [ ] CI green on `:app:test` (`com.hedera.node.app.history.impl.*` in particular).
- [ ] Reproducible empirically: deploy a network with `tss.hintsEnabled=true`/`tss.historyEnabled=true`/`tss.wrapsEnabled=false`, let construction #1 complete; perform an upgrade flipping `wrapsEnabled=true`; verify no `Possibly CATASTROPHIC failure trying to reconcile TSS state` lines appear in `hgcaa.log` and that the WRAPS conversion advances to `History proof constructed (#1, WRAPS-extensible? true)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)