### PR TITLE
ci(workflow-fix): change secrets.GH_ACCESS_TOKEN to secrets.GITHUB_TOKEN in some places

### DIFF
--- a/.github/workflows/200-user-adhoc-solo-tests.yaml
+++ b/.github/workflows/200-user-adhoc-solo-tests.yaml
@@ -65,7 +65,7 @@ jobs:
         with:
           checkout: "true"
           checkout-ref: "${{ inputs.ref }}"
-          checkout-token: "${{ github.token }}"
+          checkout-token: "${{ secrets.GITHUB_TOKEN }}"
           checkout-fetch-depth: "0"
           setup-java: "true"
           java-version: "25.0.2"

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -63,7 +63,7 @@ jobs:
         with:
           checkout: "true"
           checkout-ref: ${{ github.sha }}
-          checkout-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          checkout-token: ${{ secrets.GITHUB_TOKEN }}
           checkout-fetch-depth: "0"
 
       - name: Resolve Workflow Reference

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
         with:
           checkout: "true"
-          checkout-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          checkout-token: ${{ secrets.GITHUB_TOKEN }}
           checkout-fetch-depth: "0"
 
       - name: Classify Changed Files
@@ -117,7 +117,8 @@ jobs:
         uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
         with:
           checkout: "true"
-          checkout-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          checkout-ref: ${{ github.event.pull_request.head.sha }}
+          checkout-token: ${{ secrets.GITHUB_TOKEN }}
           checkout-fetch-depth: "0"
 
       - name: Report Summary

--- a/.github/workflows/node-zxcron-release-branching.yaml
+++ b/.github/workflows/node-zxcron-release-branching.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
         with:
           checkout: "true"
-          checkout-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          checkout-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read Trigger Time
         id: time
@@ -85,7 +85,7 @@ jobs:
         uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
         with:
           checkout: "true"
-          checkout-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          checkout-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Branch Creation Check
         id: branch-creation

--- a/.github/workflows/node-zxf-snyk-monitor.yaml
+++ b/.github/workflows/node-zxf-snyk-monitor.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           checkout: "true"
           checkout-fetch-depth: 1
-          checkout-token: "${{ github.token }}"
+          checkout-token: "${{ secrets.GITHUB_TOKEN }}"
           setup-java: "true"
           java-distribution: "temurin"
           java-version: "25.0.2"

--- a/.github/workflows/zxc-block-node-regression.yaml
+++ b/.github/workflows/zxc-block-node-regression.yaml
@@ -55,6 +55,7 @@ jobs:
           checkout: "true"
           checkout-ref: "${{ inputs.ref || '' }}"
           checkout-fetch-depth: 0
+          checkout-token: ${{secrets.GITHUB_TOKEN}}
           setup-java: "true"
           java-distribution: "temurin"
           java-version: "25.0.2"

--- a/.github/workflows/zxc-json-rpc-relay-regression.yaml
+++ b/.github/workflows/zxc-json-rpc-relay-regression.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           checkout: "true"
           checkout-ref: "${{ inputs.ref || '' }}"
-          checkout-token: "${{ secrets.GH_ACCESS_TOKEN }}"
+          checkout-token: "${{ secrets.GITHUB_TOKEN }}"
           checkout-fetch-depth: 0
           setup-java: "true"
           java-distribution: "temurin"

--- a/.github/workflows/zxc-mirror-node-regression.yaml
+++ b/.github/workflows/zxc-mirror-node-regression.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           checkout: "true"
           checkout-ref: "${{ inputs.ref || '' }}"
-          checkout-token: "${{ secrets.GH_ACCESS_TOKEN }}"
+          checkout-token: "${{ secrets.GITHUB_TOKEN }}"
           checkout-fetch-depth: 0
           setup-java: "true"
           java-distribution: "temurin"

--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           checkout: "true"
           checkout-ref: "${{ inputs.ref || '' }}"
-          checkout-token: "${{ secrets.GH_ACCESS_TOKEN }}"
+          checkout-token: "${{ secrets.GITHUB_TOKEN }}"
           checkout-fetch-depth: 0
           setup-java: "true"
           java-distribution: "temurin"

--- a/.github/workflows/zxf-publish-yahcli-image.yaml
+++ b/.github/workflows/zxf-publish-yahcli-image.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           checkout: "true"
           checkout-ref: "${{ inputs.ref || github.ref }}"
-          checkout-token: "${{ github.token }}"
+          checkout-token: "${{ secrets.GITHUB_TOKEN }}"
           setup-java: "true"
           java-distribution: "${{ inputs.java-distribution || 'temurin' }}"
           java-version: "${{ inputs.java-version || '25.0.2' }}"


### PR DESCRIPTION
**Description**:

The [previous PR](https://github.com/hiero-ledger/hiero-consensus-node/pull/25541) to move to initialize-github-job actions mistakenly inserted uses of GH_ACCESS_TOKEN, which is only needed in high security situations.  This PR changes those to the lower security GITHUB_TOKEN.




<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #https://github.com/hiero-ledger/hiero-consensus-node/issues/25570

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
