### PR TITLE
docs: extract invariants from paper

### DIFF
--- a/platform-sdk/docs/consensus-layer/invariants/INV-001-agreement-atomic-broadcast.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-001-agreement-atomic-broadcast.md
@@ -1,0 +1,51 @@
+---
+id: INV-001
+title: Honest nodes agree on whether a transaction is output
+class: agreement
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §III Definition 1 (Agreement) + §IV Theorem 1 / p. 2
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-001 — Honest nodes agree on whether a transaction is output
+
+## Statement
+If any honest node outputs a transaction T, then every honest node
+eventually outputs T.
+
+## Basis
+This is the Agreement property of atomic broadcast, stated as part
+of Definition 1 in Baird & Luykx 2020, §III / p. 2: "if any
+honest node outputs a transaction, then every honest node outputs
+that transaction." Theorem 1 (§IV / p. 2) establishes that the
+hashgraph protocol satisfies Definition 1 with probability 1.
+Mechanism: every event a node creates eventually propagates to
+every honest node via the gossip protocol (§IV-A), and every
+honest node computes its output from a deterministic function of
+its local hashgraph (§IV-B, §IV-D-3). Two honest nodes therefore
+output the same set of transactions in the long run.
+
+## Change risk
+Any change that allows an honest node to emit a transaction
+without that transaction being in an event reachable by other
+honest nodes via gossip breaks this invariant — for example,
+producing output from local-only events that are excluded from
+gossip-sync, or pruning events from the hashgraph before they
+reach a quorum of honest peers. Equivalently, any change that
+makes the consensus-order computation non-deterministic across
+honest nodes breaks it.
+
+## Notes
+- Theorem 1 bundles Agreement, Total Order, and Liveness; this
+  entry covers Agreement only. The Total Order and Liveness
+  components are captured by INV-002 and INV-003 respectively.
+- `status` is [TBD: confirm enforced in current implementation] —
+  paper-derivedness does not by itself determine whether the
+  current code upholds the property.

--- a/platform-sdk/docs/consensus-layer/invariants/INV-002-total-order-consensus.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-002-total-order-consensus.md
@@ -10,7 +10,7 @@ related:
   heuristics: []
 status: "[TBD: confirm enforced in current implementation]"
 source: Baird & Luykx 2020, §III Definition 1 (Total Order) + §IV Theorem 1 / p. 2
-provenance: paper-extraction-2026-05-20
+provenance: paper-extraction-2026-05-20; cross-refs-updated-2026-05-21
 curated_by: Michael Heinrichs (@netopyr)
 ---
 
@@ -25,12 +25,16 @@ This is the Total Order property of atomic broadcast, stated as
 part of Definition 1 in Baird & Luykx 2020, §III / p. 2 and
 established for the hashgraph protocol by Theorem 1 (§IV / p. 2).
 Mechanism: each honest node computes the consensus order by a
-deterministic function of its local hashgraph (§IV-D-3 / p. 4):
-events are sorted by round-received, then by consensus timestamp,
-then by whitened signature. The monotonicity of every
-deterministic conclusion on the hashgraph (INV-007) ensures that
-once two honest nodes have enough of the hashgraph to compute the
-ith output, they compute the same ith output.
+deterministic function of its local hashgraph (Algorithm 4,
+§IV-D-3 / p. 5): events are sorted by round received, then by
+consensus timestamp, then by whitened signature. The monotonicity
+of the inputs to this computation — round received (INV-015),
+the fame decisions that feed round received (INV-008), and the
+strongly-seeing relation that feeds fame voting (INV-012) —
+ensures that once two honest nodes have enough of the hashgraph
+to compute the ith output, they compute the same ith output. The
+umbrella meta-property (INV-007) covers the design principle
+that licenses these per-component monotonicity claims.
 
 ## Change risk
 Any change that introduces wall-clock, receive-order, or
@@ -44,12 +48,18 @@ hashgraph's frozen ancestor structure.
 
 ## Notes
 - Theorem 1 bundles Agreement, Total Order, and Liveness; this
-  entry covers Total Order only. Agreement is INV-001, Liveness is
-  INV-003.
-- The event-level consensus-position finality stated in Theorem 1
-  ("Each transaction ... will eventually be assigned the same
-  consensus position in the total order of events by each honest
-  node") is the conjunction of this invariant with INV-007
-  (monotonicity of the consensus-order function); it is therefore
-  not catalogued as a separate entry.
+  entry covers Total Order only. Agreement is INV-001, Liveness
+  is INV-003.
+- This entry absorbs consensus-order monotonicity from the
+  umbrella meta-property INV-007: the event-level
+  consensus-position finality stated in Theorem 1 ("Each
+  transaction ... will eventually be assigned the same consensus
+  position in the total order of events by each honest node") is
+  encoded here in the Basis as the "once two honest nodes have
+  enough of the hashgraph to compute the ith output, they
+  compute the same ith output" mechanism. The other components
+  that feed this computation are catalogued separately: INV-015
+  (round received), INV-008 (fame finality, which also absorbs
+  fame monotonicity), INV-012 (strongly-seeing monotonicity),
+  INV-010 (ancestry monotonicity).
 - `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-002-total-order-consensus.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-002-total-order-consensus.md
@@ -1,0 +1,55 @@
+---
+id: INV-002
+title: Honest nodes agree on the order of every consensus output
+class: ordering
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §III Definition 1 (Total Order) + §IV Theorem 1 / p. 2
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-002 — Honest nodes agree on the order of every consensus output
+
+## Statement
+For all i > 0, if T is the ith output of one honest node and T′
+is the ith output of another honest node, then T = T′.
+
+## Basis
+This is the Total Order property of atomic broadcast, stated as
+part of Definition 1 in Baird & Luykx 2020, §III / p. 2 and
+established for the hashgraph protocol by Theorem 1 (§IV / p. 2).
+Mechanism: each honest node computes the consensus order by a
+deterministic function of its local hashgraph (§IV-D-3 / p. 4):
+events are sorted by round-received, then by consensus timestamp,
+then by whitened signature. The monotonicity of every
+deterministic conclusion on the hashgraph (INV-007) ensures that
+once two honest nodes have enough of the hashgraph to compute the
+ith output, they compute the same ith output.
+
+## Change risk
+Any change that introduces wall-clock, receive-order, or
+node-local randomness into the consensus-order computation breaks
+this invariant. Replacing the deterministic tiebreak (whitened
+signature) with a non-deterministic one — for example, sort by
+local arrival time — would also break it. Any change to the
+round-received or consensus-timestamp derivation must preserve
+the property that the computation depends only on the local
+hashgraph's frozen ancestor structure.
+
+## Notes
+- Theorem 1 bundles Agreement, Total Order, and Liveness; this
+  entry covers Total Order only. Agreement is INV-001, Liveness is
+  INV-003.
+- The event-level consensus-position finality stated in Theorem 1
+  ("Each transaction ... will eventually be assigned the same
+  consensus position in the total order of events by each honest
+  node") is the conjunction of this invariant with INV-007
+  (monotonicity of the consensus-order function); it is therefore
+  not catalogued as a separate entry.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-003-liveness-eventual-output.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-003-liveness-eventual-output.md
@@ -1,0 +1,56 @@
+---
+id: INV-003
+title: Every transaction submitted to an honest node is eventually output by every honest node
+class: liveness
+topics: [hashgraph, gossip]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §III Definition 1 (Liveness) + §IV Theorem 1 / p. 2
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-003 — Every transaction submitted to an honest node is eventually output by every honest node
+
+## Statement
+If a transaction is input to an honest node, then every honest
+node eventually outputs that transaction, with probability 1.
+
+## Basis
+This is the Liveness property of atomic broadcast, stated as part
+of Definition 1 in Baird & Luykx 2020, §III / p. 2 ("if a
+transaction is input to an honest node, then it is eventually
+output by every honest node") and established for the hashgraph
+protocol by Theorem 1 (§IV / p. 2, with the probability-1
+qualifier). Mechanism, given the §III network assumption that
+messages between honest nodes succeed if repeatedly retried:
+gossip propagates every event to every honest node (§IV-A); fame
+decisions on every witness terminate with probability 1 thanks to
+the coin-round mechanism (INV-009, §IV-D-2); findOrder then
+assigns each event a round-received, and the event — along with
+its transactions — enters the consensus output stream.
+
+## Change risk
+Any change that lets transactions get stuck somewhere in the
+pipeline — gossip-sync that fails to retry, a fame election that
+can stall without termination, a findOrder step that can leave
+events without a round-received — breaks this invariant. The
+probability-1 qualifier depends on the coin-round mechanism (or
+an equivalent randomisation) being preserved; removing coin
+rounds in favour of a purely deterministic election scheme would
+make liveness conditional on adversarial scheduling and thus
+violate this invariant under arbitrary asynchrony.
+
+## Notes
+- Theorem 1 bundles Agreement, Total Order, and Liveness; this
+  entry covers Liveness only. Agreement is INV-001, Total Order is
+  INV-002.
+- `topics` includes `gossip` because gossip is the propagation
+  mechanism on which the liveness property load-bears. The
+  property itself is hashgraph-level (it ranges over consensus
+  outputs).
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-004-consistent-hashgraphs.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-004-consistent-hashgraphs.md
@@ -10,7 +10,7 @@ related:
   heuristics: []
 status: "[TBD: confirm enforced in current implementation]"
 source: Baird & Luykx 2020, §IV-A / p. 3
-provenance: paper-extraction-2026-05-20
+provenance: paper-extraction-2026-05-20; cross-refs-updated-2026-05-21
 curated_by: Michael Heinrichs (@netopyr)
 ---
 
@@ -49,4 +49,12 @@ votes on different nodes, and consensus order diverges.
 - Sits downstream of INV-005 (event authenticity): without
   authenticated, parent-resolvable events the hash-chain rigidity
   argument collapses.
+- Sibling to INV-010 (ancestry monotonicity). INV-004 establishes
+  that two honest nodes holding the same event hold the same
+  ancestor sub-DAG (cross-node identity); INV-010 establishes
+  that within a single node, once the ancestry relation is
+  concluded for a pair, it does not flip (intra-node
+  monotonicity). Together they ensure the ancestor predicate is
+  the same function on every honest node and that it is monotone
+  on each.
 - `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-004-consistent-hashgraphs.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-004-consistent-hashgraphs.md
@@ -1,0 +1,52 @@
+---
+id: INV-004
+title: Honest hashgraphs share identical ancestor sub-DAGs for any shared event
+class: agreement
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-A / p. 3
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-004 — Honest hashgraphs share identical ancestor sub-DAGs for any shared event
+
+## Statement
+For any event x present in two honest nodes' hashgraphs, both
+hashgraphs contain the same set of ancestors of x and the same
+parent edges among those ancestors.
+
+## Basis
+Each event is a tuple containing the hashes of its two parents, a
+transaction list, a timestamp, and a signature over the whole
+tuple (Baird & Luykx 2020, §IV-A / p. 3). Because cryptographic
+hashes are collision-resistant, the parent-of edges of any event
+are determined by the event itself; the ancestor sub-DAG of x is
+reconstructible from x's hash chain alone. Honest nodes only
+accept events with valid signatures and resolvable parent hashes
+(INV-005). Two honest nodes that both hold x therefore necessarily
+hold the same ancestor sub-DAG. The paper states this directly:
+"any two nodes have consistent hashgraphs: for any event x
+contained in hashgraphs A and B, both A and B contain the same set
+of ancestors for x, with the same parent edges between those
+ancestors."
+
+## Change risk
+Any change that lets an honest node admit a divergent view of x's
+parents — for example, treating an event as valid before all of
+its ancestors are verified, accepting events with unresolved
+parent hashes, or relaxing signature checks on parent references —
+breaks this invariant. The downstream effect cascades: virtual
+voting (which is defined on ancestor relations) produces different
+votes on different nodes, and consensus order diverges.
+
+## Notes
+- Sits downstream of INV-005 (event authenticity): without
+  authenticated, parent-resolvable events the hash-chain rigidity
+  argument collapses.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-005-event-authenticity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-005-event-authenticity.md
@@ -1,0 +1,55 @@
+---
+id: INV-005
+title: Every event in an honest hashgraph is creator-signed and parent-resolvable
+class: integrity
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-A / p. 3
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-005 — Every event in an honest hashgraph is creator-signed and parent-resolvable
+
+## Statement
+Every event held by an honest node carries a signature that
+verifies against its claimed creator's public key, and every
+parent hash referenced by that event resolves to an event already
+present in the same honest node's hashgraph.
+
+## Basis
+The paper specifies (Baird & Luykx 2020, §IV-A / p. 3): "Nodes
+only accept events that have a valid signature and contain valid
+hashes referring to events they already have." This is a
+protocol-level acceptance rule on correct nodes; any correct
+implementation upholds it. The resulting property — that honest
+hashgraphs contain only creator-authenticated, parent-resolvable
+events — is what makes the consistent-hashgraphs property
+(INV-004) sound: the hash-chain rigidity argument depends on
+parent references being verifiable against locally held events.
+
+## Change risk
+Any change that admits an event before its signature is verified,
+or before its parent hashes are matched against locally held
+events, breaks this invariant. Forged or orphan events in an
+honest hashgraph corrupt ancestor relations (and thus INV-004) and
+therefore corrupt every conclusion downstream of ancestor
+relations: seeing, strongly-seeing (INV-006), fame (INV-008), and
+consensus order (INV-002).
+
+## Notes
+- This entry sits on the invariant / protocol-rule boundary. The
+  paper states event acceptance as a node-behaviour requirement;
+  this entry frames the resulting property of honest hashgraphs as
+  the invariant. The framing is the invariant-shaped reading. If
+  the catalog convention later prefers to keep such properties as
+  preconditions of INV-004, fold this into INV-004's Basis.
+- `topics` is `[hashgraph]`. Once `architecture/topics/event-intake.md`
+  is a load-bearing reference for event acceptance, consider also
+  tagging `event-intake`. [TBD: confirm secondary topic.]
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-006-strongly-seeing-fork-resolution.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-006-strongly-seeing-fork-resolution.md
@@ -10,7 +10,7 @@ related:
   heuristics: []
 status: "[TBD: confirm enforced in current implementation]"
 source: Baird & Luykx 2020, §IV-C / p. 3
-provenance: paper-extraction-2026-05-20
+provenance: paper-extraction-2026-05-20; cross-refs-updated-2026-05-21
 curated_by: Michael Heinrichs (@netopyr)
 ---
 
@@ -48,4 +48,10 @@ diverge, and consensus splits.
 - Depends on the >2n/3 honest assumption from the §III threat
   model. The property is a protocol guarantee given that
   assumption; weakening the assumption is out of scope.
+- Sibling to INV-012 (strongly-seeing monotonicity). This entry
+  constrains strongly-seeing across forks (no event strongly sees
+  both branches); INV-012 constrains strongly-seeing across time
+  (the conclusion never flips as the hashgraph grows). Together
+  they pin down strongly-seeing as both unambiguous on
+  fork-shaped inputs and permanent once concluded.
 - `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-006-strongly-seeing-fork-resolution.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-006-strongly-seeing-fork-resolution.md
@@ -1,0 +1,51 @@
+---
+id: INV-006
+title: No event can strongly see both branches of a fork
+class: safety
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-C / p. 3
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-006 — No event can strongly see both branches of a fork
+
+## Statement
+For any pair of events y and z that form a fork (same creator,
+neither an ancestor of the other), no event x can strongly see
+both y and z.
+
+## Basis
+Strong seeing requires that x can see more than 2n/3 events by
+distinct nodes, each of which can see the target (Baird & Luykx
+2020, §IV-C / p. 3). If x strongly saw both y and z, the two
+strong-seeing witness sets would overlap in more than n/3 distinct
+nodes. Since fewer than n/3 nodes are malicious (§III / p. 2), at
+least one honest node sits in the overlap. But an honest node
+cannot see both branches of a fork by the same creator — seeing
+excludes paths that pass through a creator's fork. The two
+strong-seeings therefore cannot coexist. The paper states the
+conclusion directly: "If y and z are on different branches of a
+fork, then x can strongly see either y or z, but not both."
+
+## Change risk
+Any change that weakens the strong-seeing threshold below the
+>2n/3 / >n/3 overlap argument — for example, lowering the
+distinct-node count required for strong-seeing, or letting events
+authored by the same forking creator count toward the threshold —
+breaks this invariant. The downstream effect: an attacker who
+forks an event can make different honest nodes strongly see
+different branches, virtual voting diverges, fame decisions
+diverge, and consensus splits.
+
+## Notes
+- Depends on the >2n/3 honest assumption from the §III threat
+  model. The property is a protocol guarantee given that
+  assumption; weakening the assumption is out of scope.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-007-hashgraph-conclusion-monotonicity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-007-hashgraph-conclusion-monotonicity.md
@@ -1,0 +1,65 @@
+---
+id: INV-007
+title: Deterministic conclusions on the hashgraph are monotone and eventually agreed
+class: determinism
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-B + §IV-C end / p. 3
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-007 — Deterministic conclusions on the hashgraph are monotone and eventually agreed
+
+## Statement
+Every deterministic function of the local hashgraph used by the
+protocol (ancestry, seeing, strongly seeing, fame of a witness,
+round received, consensus order) is monotone: at any moment a node
+either has no conclusion (undecided) or has a conclusion that will
+never change as its local hashgraph grows, and every honest node
+eventually reaches the same conclusion.
+
+## Basis
+The paper states the design constraint in §IV-B (p. 3): "the
+algorithm must be designed so that a conclusion based on a
+deterministic function of the hashgraph at one moment will not
+change as the hashgraph grows." Ancestry is given as the canonical
+example: at any moment a node either does not yet have enough
+hashgraph to conclude whether D1 is an ancestor of C6, or it has
+concluded yes and that conclusion never reverses. §IV-C end (p. 3)
+promotes the ancestry example to every deterministic conclusion
+used by the protocol: "All components of the hashgraph consensus
+algorithm have mathematical proofs that they have this consistency
+property." Mechanism: the hashgraph only grows — events are added,
+never removed — and every protocol conclusion is defined over the
+ancestor sub-DAG of an event, which is itself frozen the moment
+the event is known (INV-004).
+
+## Change risk
+The invariant breaks if the protocol introduces a deterministic
+conclusion that depends on something other than the immutable
+ancestor sub-DAG — for instance, a conclusion that depends on
+wall-clock arrival order, on which events have been received but
+not yet integrated, or on the sync order with peers. Any such
+conclusion can flip as the local hashgraph grows or as scheduling
+changes, and the monotonicity argument collapses. The downstream
+effect: virtual votes flip retroactively, fame decisions
+un-decide, and consensus order is no longer well-defined.
+
+## Notes
+- The paper states this as a single meta-property covering every
+  component of the algorithm. This entry preserves that framing.
+  An alternative is to split into per-conclusion invariants
+  (ancestry, seeing, strongly-seeing, fame, consensus-order
+  monotonicity); the paper does not state them separately, and the
+  merged form is the closer-to-source choice.
+- Load-bearing for INV-002 (total order), INV-006 (strongly-seeing
+  fork resolution), and INV-008 (fame finality), each of which
+  cites monotonicity as the mechanism that prevents flip-flopping
+  conclusions.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-007-hashgraph-conclusion-monotonicity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-007-hashgraph-conclusion-monotonicity.md
@@ -1,6 +1,6 @@
 ---
 id: INV-007
-title: Deterministic conclusions on the hashgraph are monotone and eventually agreed
+title: Every deterministic conclusion on the hashgraph is monotone and eventually agreed
 class: determinism
 topics: [hashgraph]
 related:
@@ -10,56 +10,73 @@ related:
   heuristics: []
 status: "[TBD: confirm enforced in current implementation]"
 source: Baird & Luykx 2020, §IV-B + §IV-C end / p. 3
-provenance: paper-extraction-2026-05-20
+provenance: paper-extraction-2026-05-20; reframed-as-umbrella-2026-05-21
 curated_by: Michael Heinrichs (@netopyr)
 ---
 
-# INV-007 — Deterministic conclusions on the hashgraph are monotone and eventually agreed
+# INV-007 — Every deterministic conclusion on the hashgraph is monotone and eventually agreed
 
 ## Statement
-Every deterministic function of the local hashgraph used by the
-protocol (ancestry, seeing, strongly seeing, fame of a witness,
-round received, consensus order) is monotone: at any moment a node
-either has no conclusion (undecided) or has a conclusion that will
-never change as its local hashgraph grows, and every honest node
-eventually reaches the same conclusion.
+Every deterministic conclusion that the protocol derives from
+the local hashgraph is monotone: at any moment an honest node
+either has no conclusion (it has not yet received enough of the
+hashgraph) or has a conclusion that never changes as its
+hashgraph grows, and every honest node eventually reaches the
+same conclusion.
 
 ## Basis
-The paper states the design constraint in §IV-B (p. 3): "the
-algorithm must be designed so that a conclusion based on a
-deterministic function of the hashgraph at one moment will not
-change as the hashgraph grows." Ancestry is given as the canonical
-example: at any moment a node either does not yet have enough
-hashgraph to conclude whether D1 is an ancestor of C6, or it has
-concluded yes and that conclusion never reverses. §IV-C end (p. 3)
-promotes the ancestry example to every deterministic conclusion
-used by the protocol: "All components of the hashgraph consensus
-algorithm have mathematical proofs that they have this consistency
-property." Mechanism: the hashgraph only grows — events are added,
-never removed — and every protocol conclusion is defined over the
-ancestor sub-DAG of an event, which is itself frozen the moment
-the event is known (INV-004).
+The paper states the design constraint in Baird & Luykx 2020,
+§IV-B / p. 3: "the algorithm must be designed so that a
+conclusion based on a deterministic function of the hashgraph at
+one moment will not change as the hashgraph grows." The §IV-C
+end sentence (p. 3) promotes this from a design constraint into
+a verified property of every component: "All components of the
+hashgraph consensus algorithm have mathematical proofs that they
+have this consistency property." Mechanism: the hashgraph only
+grows — events are added, never removed — and every protocol
+conclusion is defined over the ancestor sub-DAG of an event,
+which is itself frozen the moment the event is known (INV-004,
+INV-005).
 
 ## Change risk
-The invariant breaks if the protocol introduces a deterministic
-conclusion that depends on something other than the immutable
-ancestor sub-DAG — for instance, a conclusion that depends on
-wall-clock arrival order, on which events have been received but
-not yet integrated, or on the sync order with peers. Any such
-conclusion can flip as the local hashgraph grows or as scheduling
-changes, and the monotonicity argument collapses. The downstream
-effect: virtual votes flip retroactively, fame decisions
-un-decide, and consensus order is no longer well-defined.
+The meta-property breaks if the protocol introduces a
+deterministic conclusion that depends on something other than the
+immutable ancestor sub-DAG — for instance, a conclusion that
+depends on wall-clock arrival order, on which events have been
+received but not yet integrated, on the sync order with peers,
+or on global state outside the ancestor sub-DAG. Any such
+conclusion can flip as the local hashgraph grows or as
+scheduling changes, and the monotonicity argument collapses for
+that conclusion and for everything downstream of it. New
+protocol features that add a deterministic step must demonstrate
+that the step reduces to the ancestor sub-DAG.
 
 ## Notes
-- The paper states this as a single meta-property covering every
-  component of the algorithm. This entry preserves that framing.
-  An alternative is to split into per-conclusion invariants
-  (ancestry, seeing, strongly-seeing, fame, consensus-order
-  monotonicity); the paper does not state them separately, and the
-  merged form is the closer-to-source choice.
-- Load-bearing for INV-002 (total order), INV-006 (strongly-seeing
-  fork resolution), and INV-008 (fame finality), each of which
-  cites monotonicity as the mechanism that prevents flip-flopping
-  conclusions.
+- This is the umbrella entry for the deterministic-conclusion
+  meta-property. The per-component instantiations of monotonicity
+  live in dedicated entries:
+  - INV-010 — ancestry
+  - INV-011 — seeing
+  - INV-012 — strongly-seeing
+  - INV-013 — round assignment
+  - INV-014 — witness status
+  - INV-015 — round received
+  Two further components are absorbed into the entries that
+  state them rather than carrying their own splits: fame
+  monotonicity is encoded directly in INV-008 (a fame decision,
+  once made, never changes), and consensus-order monotonicity is
+  encoded directly in INV-002 (once two honest nodes have enough
+  hashgraph to compute the ith output, they compute the same
+  ith output).
+- This entry was originally a single bundled monotonicity claim
+  (paper-extraction-2026-05-20). It was reframed as the umbrella
+  on 2026-05-21 when the per-component splits (INV-010 through
+  INV-015) were created, prioritising downstream catalog
+  usability — search by concern — over preserving the paper's
+  bundling.
+- The reframed Statement covers any future deterministic
+  conclusion the protocol may add. If a new conclusion is added
+  that does not yet have its own entry, this umbrella is the
+  catalogued home for the monotonicity claim until a split is
+  warranted.
 - `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-008-fame-decision-finality.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-008-fame-decision-finality.md
@@ -10,7 +10,7 @@ related:
   heuristics: []
 status: "[TBD: confirm enforced in current implementation]"
 source: Baird & Luykx 2020, §IV-D-2 / p. 4
-provenance: paper-extraction-2026-05-20
+provenance: paper-extraction-2026-05-20; cross-refs-updated-2026-05-21
 curated_by: Michael Heinrichs (@netopyr)
 ---
 
@@ -23,18 +23,26 @@ decision is reached by every honest node, and no subsequent vote
 in any later round can flip it.
 
 ## Basis
-The paper specifies the decision rule in §IV-D-2 (p. 4): "If more
-than 2n/3 witnesses agree on whether x is famous then the
-community has decided, and the election is over." The decision
-itself is the value of a deterministic function of the local
-hashgraph — the tally of votes over strongly-seen previous-round
-witnesses — so it inherits monotonicity from INV-007: once
-non-undecided, it cannot change. Across honest nodes, the >2n/3
-threshold combined with the strongly-seeing fork-resolution
-property (INV-006) prevents an attacker from manufacturing two
-disagreeing >2n/3 majorities: any two >2n/3 sets overlap in more
-than n/3 nodes, and the overlap includes at least one honest node
-whose vote is the same regardless of which observer looks at it.
+The paper specifies the decision rule in Baird & Luykx 2020,
+§IV-D-2 / p. 4: "If more than 2n/3 witnesses agree on whether x
+is famous then the community has decided, and the election is
+over." The decision itself is the value of a deterministic
+function of the local hashgraph — the tally of votes over
+strongly-seen previous-round witnesses — and that strongly-seen
+relation is monotone (INV-012), so the tally cannot subsequently
+lose votes; once it crosses the >2n/3 threshold it stays crossed.
+Across honest nodes, the >2n/3 threshold combined with the
+strongly-seeing fork-resolution property (INV-006) prevents an
+attacker from manufacturing two disagreeing >2n/3 majorities: any
+two >2n/3 sets overlap in more than n/3 nodes, and the overlap
+includes at least one honest node whose vote is the same
+regardless of which observer looks at it.
+
+This entry absorbs the fame component of the deterministic-
+conclusion meta-property (INV-007): fame monotonicity — once a
+fame value transitions from undecided to decided, it never
+changes — is encoded directly in this entry's Statement rather
+than carrying a separate split.
 
 ## Change risk
 Any change that lets the same witness x receive two different
@@ -44,10 +52,17 @@ on something other than strongly-seen previous-round witnesses,
 or by introducing non-determinism into the vote computation —
 breaks this invariant. A flipped fame decision changes which
 events have a round-received r and therefore retroactively
-changes the consensus order, violating INV-002.
+changes the consensus order, violating INV-015 and INV-002.
 
 ## Notes
-- Depends on INV-006 (strongly-seeing fork resolution) and INV-007
-  (conclusion monotonicity) for its proof. A weakening of either
-  weakens this invariant.
+- Depends on INV-006 (strongly-seeing fork resolution) and
+  INV-012 (strongly-seeing monotonicity) for its proof. A
+  weakening of either weakens this invariant.
+- Absorbs fame monotonicity from the umbrella meta-property
+  INV-007 — this entry catalogues both the cross-node finality
+  and the intra-node monotonicity of fame decisions in a single
+  Statement, so no separate fame-monotonicity split exists.
+- Load-bearing for INV-015 (round received depends on fame being
+  decided for all witnesses in rounds ≤ r) and indirectly for
+  INV-002 (consensus order sorts by round received).
 - `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-008-fame-decision-finality.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-008-fame-decision-finality.md
@@ -1,0 +1,53 @@
+---
+id: INV-008
+title: A fame decision, once made, never changes and is the same on every honest node
+class: safety
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-D-2 / p. 4
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-008 — A fame decision, once made, never changes and is the same on every honest node
+
+## Statement
+Once more than 2n/3 witnesses in some round agree on whether a
+given witness x is famous, the decision is fixed: the same
+decision is reached by every honest node, and no subsequent vote
+in any later round can flip it.
+
+## Basis
+The paper specifies the decision rule in §IV-D-2 (p. 4): "If more
+than 2n/3 witnesses agree on whether x is famous then the
+community has decided, and the election is over." The decision
+itself is the value of a deterministic function of the local
+hashgraph — the tally of votes over strongly-seen previous-round
+witnesses — so it inherits monotonicity from INV-007: once
+non-undecided, it cannot change. Across honest nodes, the >2n/3
+threshold combined with the strongly-seeing fork-resolution
+property (INV-006) prevents an attacker from manufacturing two
+disagreeing >2n/3 majorities: any two >2n/3 sets overlap in more
+than n/3 nodes, and the overlap includes at least one honest node
+whose vote is the same regardless of which observer looks at it.
+
+## Change risk
+Any change that lets the same witness x receive two different
+fame decisions on different honest nodes — for example, by
+reducing the decision threshold below >2n/3, by basing the tally
+on something other than strongly-seen previous-round witnesses,
+or by introducing non-determinism into the vote computation —
+breaks this invariant. A flipped fame decision changes which
+events have a round-received r and therefore retroactively
+changes the consensus order, violating INV-002.
+
+## Notes
+- Depends on INV-006 (strongly-seeing fork resolution) and INV-007
+  (conclusion monotonicity) for its proof. A weakening of either
+  weakens this invariant.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-009-fame-decision-termination.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-009-fame-decision-termination.md
@@ -1,0 +1,53 @@
+---
+id: INV-009
+title: Fame is decided for every witness with probability 1
+class: liveness
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-D-2 / p. 4
+provenance: paper-extraction-2026-05-20
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-009 — Fame is decided for every witness with probability 1
+
+## Statement
+For every witness, the fame election eventually terminates with a
+decided value, with probability 1.
+
+## Basis
+The paper specifies the termination argument in §IV-D-2 (p. 4).
+In normal rounds, witnesses vote by majority of the strongly-seen
+witnesses of the previous round; in periodic coin rounds,
+witnesses vote pseudorandomly (the middle bit of their signature)
+unless they already strongly see a >2n/3 supermajority. The
+pseudorandom vote means an adversary controlling message timing
+cannot keep votes carefully split forever — each coin round gives
+an independent chance of crossing the >2n/3 threshold, so the
+probability of remaining undecided after k coin rounds tends to
+zero. The paper states the conclusion directly: "there is still a
+chance that the community will randomly cross the 2n/3 threshold,
+and so agreement is eventually reached, with probability one."
+
+## Change risk
+Any change that removes coin rounds, replaces the pseudorandom
+coin with a deterministic tiebreak, or otherwise lets an
+adversary indefinitely split the vote breaks this invariant.
+Without termination, no round can be considered complete, no
+events ever receive a round-received, findOrder never produces
+output, and the system-wide liveness property (INV-003)
+collapses.
+
+## Notes
+- Load-bearing for INV-003: the probability-1 qualifier on
+  liveness is exactly the qualifier this invariant supplies.
+- The paper notes a coin round is unlikely to occur in practice
+  "because convergence is fast when the honest nodes are allowed
+  to communicate freely" — but the invariant covers the worst
+  case, where the adversary controls scheduling.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-010-ancestry-monotonicity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-010-ancestry-monotonicity.md
@@ -1,0 +1,70 @@
+---
+id: INV-010
+title: Ancestry is monotone and eventually agreed
+class: determinism
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-B + §IV-C end / p. 3
+provenance: split-from-INV-007 against §IV-C-end meta-claim + §IV-B definition of ancestry; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-010 — Ancestry is monotone and eventually agreed
+
+## Statement
+Whether one event is an ancestor of another is a monotone
+deterministic conclusion: at any moment an honest node either has
+no conclusion (it has not yet received enough of the hashgraph)
+or has a conclusion that never changes as its hashgraph grows,
+and every honest node eventually reaches the same conclusion.
+
+## Basis
+The paper directly names ancestry as the canonical example of
+this property in Baird & Luykx 2020, §IV-B / p. 3: "ancestry is
+an example of a deterministic function of a hashgraph that at
+any given moment either gives no conclusion at all, or it makes a
+conclusion that will never change, and all nodes eventually come
+to that same conclusion." The worked example given immediately
+before (a node concluding that D1 is an ancestor of C6, and a
+peer that has D1 but not yet C6 having no conclusion until C6
+arrives with all of its ancestors) illustrates the mechanism:
+once a node accepts an event via gossip, it has received all of
+that event's ancestors (INV-005), and the ancestor sub-DAG is
+determined by the event's hash chain. The §IV-C end meta-claim
+("All components of the hashgraph consensus algorithm have
+mathematical proofs that they have this consistency property")
+confirms the property is permanent rather than merely
+illustrative.
+
+## Change risk
+Any change that lets the ancestry relation between two events in
+an honest node's hashgraph change as the hashgraph grows breaks
+this invariant. Mechanisms: accepting an event before all of its
+ancestors are verified to be present (then later rediscovering
+parent edges); deriving ancestry from receive order or sync
+metadata rather than from the event's parent hash references;
+mutating already-received events. Any such change makes ancestry
+a function of mutable state rather than the frozen sub-DAG, and
+every downstream conclusion (seeing, strongly-seeing, round,
+fame, consensus order) inherits the flip-flopping.
+
+## Notes
+- One of six per-component instantiations of the deterministic-
+  conclusion meta-property catalogued under INV-007 (the
+  umbrella). The other five are INV-011 (seeing), INV-012
+  (strongly-seeing), INV-013 (round), INV-014 (witness status),
+  INV-015 (round received). Two further components — fame and
+  consensus order — are absorbed into INV-008 and INV-002
+  respectively.
+- Sibling to INV-004 (which establishes cross-node identity of
+  the ancestor sub-DAG; this entry establishes intra-node
+  monotonicity of the ancestry predicate).
+- Load-bearing for INV-011 (seeing is defined on the ancestor
+  sub-DAG and on the absence of forks in y's ancestors) and
+  indirectly for every conclusion downstream of seeing.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-011-seeing-monotonicity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-011-seeing-monotonicity.md
@@ -1,0 +1,57 @@
+---
+id: INV-011
+title: Seeing is monotone and eventually agreed
+class: determinism
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-C + §IV-C end / p. 3
+provenance: split-from-INV-007 against §IV-C-end meta-claim + §IV-C definition of seeing; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-011 — Seeing is monotone and eventually agreed
+
+## Statement
+Whether one event sees another (descendant relation with paths
+through forks by y's creator excluded) is a monotone
+deterministic conclusion: once an honest node concludes that x
+sees y, the conclusion never reverses as its hashgraph grows,
+and every honest node eventually reaches the same conclusion.
+
+## Basis
+Seeing is defined in Baird & Luykx 2020, §IV-C / p. 3: "the
+event x sees y if x is a descendant of y, and y's ancestors do
+not include a fork by y's creator." Both clauses are functions
+of frozen sub-DAGs: descendant is the inverse of ancestor, whose
+monotonicity is INV-010; and "y's ancestors do not include a
+fork by y's creator" is a predicate over y's ancestor sub-DAG,
+which is frozen by INV-004. The §IV-C end meta-claim ("All
+components of the hashgraph consensus algorithm have mathematical
+proofs that they have this consistency property") licenses the
+monotonicity property for seeing as one of those components.
+
+## Change risk
+Any change that lets the seeing predicate flip as the local
+hashgraph grows breaks this invariant. Mechanisms: deriving the
+"no fork in y's ancestors" check from a global view rather than
+y's ancestor sub-DAG (a later-arriving fork by y's creator,
+outside y's ancestors, then retroactively changes whether x sees
+y); admitting events that mutate parent edges (then ancestry,
+and thus seeing, are no longer frozen); evaluating seeing
+against a dynamic set of forks rather than what is present in
+y's frozen ancestors. Strongly-seeing (INV-012) is a direct
+consumer and inherits any breakage here.
+
+## Notes
+- Depends on INV-010 (ancestry monotonicity) and INV-004
+  (consistent hashgraphs).
+- Load-bearing for INV-012 (strongly-seeing is defined as a
+  quorum over events that each see y).
+- One of six per-component instantiations of the deterministic-
+  conclusion meta-property catalogued under INV-007.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-012-strongly-seeing-monotonicity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-012-strongly-seeing-monotonicity.md
@@ -1,0 +1,63 @@
+---
+id: INV-012
+title: Strongly-seeing is monotone and eventually agreed
+class: determinism
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, §IV-C + §IV-C end / p. 3
+provenance: split-from-INV-007 against §IV-C-end meta-claim + §IV-C definition of strongly-seeing; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-012 — Strongly-seeing is monotone and eventually agreed
+
+## Statement
+Whether one event strongly sees another is a monotone
+deterministic conclusion: once an honest node concludes that x
+strongly sees y, the conclusion never reverses as its hashgraph
+grows, and every honest node eventually reaches the same
+conclusion.
+
+## Basis
+The paper directly names this property in Baird & Luykx 2020,
+§IV-C / p. 3: "strongly seeing is an example of a conclusion
+that is a deterministic function of a hashgraph that is
+guaranteed to eventually be reached by all nodes no matter what
+order they receive the hashgraph." Strongly-seeing is defined in
+the same section: "the event x strongly sees y if x can see more
+than 2n/3 events by different nodes, each of which can see y."
+Both the membership of the witness set (events that see y, by
+INV-011) and x's seeing of those events (INV-011 again) are
+monotone, so the quorum threshold is crossed once and stays
+crossed. The §IV-C end meta-claim provides the broader license
+covering this and the other deterministic conclusions.
+
+## Change risk
+Any change that lets the strongly-seeing predicate flip as the
+local hashgraph grows breaks this invariant. Mechanisms:
+lowering or making variable the >2n/3 distinct-node threshold
+(a later threshold change un-decides previous conclusions);
+deriving the witness set from a global or mutable view rather
+than from x's frozen ancestor sub-DAG; allowing events authored
+by a forking creator to count toward the distinct-node quorum
+(this also interacts with INV-006). Downstream effects: round
+assignment (INV-013), fame voting (INV-008), and consensus order
+(INV-002) all inherit any flip-flopping here.
+
+## Notes
+- Depends on INV-011 (seeing monotonicity).
+- Sibling to INV-006 (anti-fork property of the same operation:
+  INV-006 says no event can strongly see both branches of a
+  fork; INV-012 says the conclusion does not flip over time).
+- Load-bearing for INV-013 (round assignment uses
+  strongly-sees-prior-round-witnesses), INV-008 (fame voting
+  tallies over strongly-seen previous-round witnesses), and
+  INV-002 (consensus order via INV-013 → INV-015).
+- One of six per-component instantiations of the deterministic-
+  conclusion meta-property catalogued under INV-007.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-013-round-monotonicity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-013-round-monotonicity.md
@@ -1,0 +1,57 @@
+---
+id: INV-013
+title: An event's round assignment is monotone and eventually agreed
+class: determinism
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, Algorithm 2 (divideRounds), §IV-D-1 / p. 4 + §IV-C end / p. 3
+provenance: split-from-INV-007 against §IV-C-end meta-claim + Algorithm 2 definition of x.round; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-013 — An event's round assignment is monotone and eventually agreed
+
+## Statement
+The round assigned to an event (`x.round`) is a monotone
+deterministic conclusion: once an honest node computes
+`x.round`, the value never changes as its hashgraph grows, and
+every honest node eventually computes the same value.
+
+## Basis
+`x.round` is computed by `divideRounds` (Baird & Luykx 2020,
+Algorithm 2, §IV-D-1 / p. 4): the parent-round maximum `r` is
+taken (or 1 if x has no parents), and `x.round` becomes `r + 1`
+if x strongly sees more than 2n/3 round-`r` witnesses, else `r`.
+Every input to this computation is a monotone function of the
+frozen ancestor sub-DAG: parent rounds are themselves `x.round`
+values on x's parents (recursive monotonicity, anchored at the
+parentless base case), and the strongly-seeing predicate is
+monotone by INV-012. The §IV-C end meta-claim ("All components
+of the hashgraph consensus algorithm have mathematical proofs
+that they have this consistency property") licenses round
+assignment as one of those components.
+
+## Change risk
+Any change that lets `x.round` change after first being computed
+breaks this invariant. Mechanisms: making the round-`r` witness
+set depend on what x has subsequently received rather than what
+is in x's ancestor sub-DAG; changing the strongly-sees threshold
+or the witness-identity rule after the fact; allowing a parent's
+round to be recomputed and propagated; lazily evaluating
+`x.round` against a moving hashgraph state rather than committing
+on first computation. Downstream effects: witness status
+(INV-014), fame elections (INV-008, which range over witnesses),
+and round received (INV-015) all read from `x.round`.
+
+## Notes
+- Depends on INV-012 (strongly-seeing monotonicity).
+- Load-bearing for INV-014 (witness status is a function of
+  round) and indirectly for INV-008 and INV-015.
+- One of six per-component instantiations of the deterministic-
+  conclusion meta-property catalogued under INV-007.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-014-witness-status-monotonicity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-014-witness-status-monotonicity.md
@@ -1,0 +1,57 @@
+---
+id: INV-014
+title: An event's witness status is monotone and eventually agreed
+class: determinism
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, Algorithm 2 (divideRounds), §IV-D-1 / p. 4 + §IV-C end / p. 3
+provenance: split-from-INV-007 against §IV-C-end meta-claim + Algorithm 2 definition of x.witness; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-014 — An event's witness status is monotone and eventually agreed
+
+## Statement
+Whether an event is a witness (`x.witness`) is a monotone
+deterministic conclusion: once an honest node computes
+`x.witness`, the value never changes as its hashgraph grows,
+and every honest node eventually computes the same value.
+
+## Basis
+`x.witness` is computed by `divideRounds` (Baird & Luykx 2020,
+Algorithm 2, §IV-D-1 / p. 4) as `(x has no self parent) or
+(x.round > x.selfParent.round)`. Both inputs are monotone: x's
+parent structure is fixed by its hash chain (INV-004, INV-005),
+so the "has no self parent" check has a fixed answer the moment
+x is known; and `x.round` and `x.selfParent.round` are monotone
+by INV-013. A conclusion built from monotone inputs by a fixed
+boolean predicate is itself monotone. The §IV-C end meta-claim
+provides the broader license.
+
+## Change risk
+Any change that lets `x.witness` flip after first being
+determined breaks this invariant. Mechanisms: redefining witness
+in terms of post-derivation values (for example, a "is this
+still the first event of its creator in this round" check that
+re-evaluates as more events arrive); mutating `x.round` or
+`x.selfParent.round` (which would also break INV-013); allowing
+witness status to depend on neighbour-round events outside x's
+ancestor sub-DAG; computing witness lazily against a moving
+hashgraph state rather than committing on first computation.
+Downstream effects: fame elections (INV-008) are defined over
+witnesses, and findOrder (INV-015) reads witness status to
+identify famous-witness sets.
+
+## Notes
+- Depends on INV-013 (round monotonicity).
+- Load-bearing for INV-008 (fame elections range over witnesses)
+  and INV-015 (round received depends on famous-witness sets,
+  which are determined by witness status plus fame).
+- One of six per-component instantiations of the deterministic-
+  conclusion meta-property catalogued under INV-007.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-015-round-received-monotonicity.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-015-round-received-monotonicity.md
@@ -1,0 +1,61 @@
+---
+id: INV-015
+title: An event's round received is monotone and eventually agreed
+class: determinism
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, Algorithm 4 (findOrder), §IV-D-3 / p. 5 + §IV-C end / p. 3
+provenance: split-from-INV-007 against §IV-C-end meta-claim + Algorithm 4 definition of x.roundReceived; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-015 — An event's round received is monotone and eventually agreed
+
+## Statement
+An event's round received (`x.roundReceived`) is a monotone
+deterministic conclusion: once an honest node assigns
+`x.roundReceived`, the value never changes as its hashgraph
+grows, and every honest node eventually assigns the same value.
+
+## Basis
+`x.roundReceived` is defined by `findOrder` (Baird & Luykx 2020,
+Algorithm 4, §IV-D-3 / p. 5) as the first round `r` such that
+there is no witness in or before round `r` whose fame is
+undecided, and x is an ancestor of every round-`r` unique famous
+witness — with the property not holding for any earlier round.
+Every input is monotone: fame decisions are final once made
+(INV-008), witness status is monotone (INV-014), and the
+ancestor predicate is monotone (INV-010). The "no earlier round
+satisfies the condition" clause is itself monotone, because
+adding events to the hashgraph can only move fame from undecided
+to decided (never the reverse, by INV-008), so an earlier round
+that did not qualify at the time `r` was chosen cannot
+retroactively qualify. The §IV-C end meta-claim provides the
+broader license.
+
+## Change risk
+Any change that lets `x.roundReceived` change after first being
+assigned breaks this invariant. Mechanisms: allowing fame to be
+re-decided (would also break INV-008); changing the unique-
+famous-witness selection rule retroactively; allowing the
+ancestor predicate to flip (would also break INV-010); choosing
+`r` from a non-deterministic search order; lazily evaluating
+`x.roundReceived` against a moving hashgraph state rather than
+committing on first assignment. The consensus-order computation
+(INV-002) sorts events first by round received, so any breakage
+here propagates immediately to total order.
+
+## Notes
+- Depends on INV-008 (fame decision finality), INV-014
+  (witness-status monotonicity), and INV-010 (ancestry
+  monotonicity).
+- Load-bearing for INV-002 (consensus order sorts first by round
+  received).
+- One of six per-component instantiations of the deterministic-
+  conclusion meta-property catalogued under INV-007.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-016-round-respects-ancestry.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-016-round-respects-ancestry.md
@@ -1,0 +1,60 @@
+---
+id: INV-016
+title: An event's round is at least as large as every ancestor's round
+class: safety
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, Algorithm 2 (divideRounds), §IV-D-1 / p. 4
+provenance: algorithmic-consequences-extraction against Algorithm 2 (divideRounds) §IV-D-1; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-016 — An event's round is at least as large as every ancestor's round
+
+## Statement
+For any event x and any ancestor a of x in an honest node's
+hashgraph, `x.round ≥ a.round`.
+
+## Basis
+Algorithm 2 (divideRounds, Baird & Luykx 2020, §IV-D-1 / p. 4)
+computes `x.round` as follows: `r ← max round of parents of x`
+(or 1 if x has no parents), and then `x.round ← r + 1` if x
+strongly sees more than 2n/3 round-`r` witnesses, else
+`x.round ← r`. Either branch yields `x.round ≥ r`, i.e.,
+`x.round ≥` every parent's round. Applying this fact along
+parent edges by transitive closure gives `x.round ≥` every
+ancestor's round. The paper does not state this property
+explicitly; the algorithm forces it in one inference step.
+
+## Change risk
+Any change that lets an event's round drop below an ancestor's
+round breaks this invariant. Mechanisms: redefining `r` as
+something other than the maximum of parent rounds (a min, an
+average, or a value derived from non-parent inputs); allowing
+`x.round` to be assigned independently of parents (for example,
+from creation timestamp or sync arrival order); allowing parent
+edges to be added to an event after its round is computed in a
+way that does not trigger recomputation. Downstream effects:
+round-along-ancestry feeds every consensus stage that ranges
+over rounds — the witness predicate (which compares against the
+self-parent's round), fame elections (which vote across rounds),
+round-received determination, and consensus output ordering.
+
+## Notes
+- Structural counterpart to INV-013. INV-013 is *temporal*
+  monotonicity: once `x.round` is computed for one event, it
+  doesn't change. INV-016 is *structural* monotonicity: the
+  function `event → round` respects the partial order of the
+  DAG. Both can be violated independently; together they pin
+  down round assignment as a stable function of frozen ancestry.
+- Load-bearing for INV-017 (witness uniqueness uses parent-edge
+  round monotonicity along the self-parent chain) and implicitly
+  for findOrder's ancestor condition (`x.roundReceived = r`
+  requires x to be an ancestor of every round-r unique famous
+  witness, which combined with INV-016 yields `x.round ≤ r`).
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-017-witness-uniqueness-per-round.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-017-witness-uniqueness-per-round.md
@@ -1,0 +1,68 @@
+---
+id: INV-017
+title: At most one witness per round on any single self-parent chain
+class: safety
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, Algorithm 2 (divideRounds), §IV-D-1 / p. 4
+provenance: algorithmic-consequences-extraction against Algorithm 2 (divideRounds) §IV-D-1; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-017 — At most one witness per round on any single self-parent chain
+
+## Statement
+Along any single self-parent chain in an honest node's
+hashgraph, at most one event per round has `x.witness = TRUE`.
+Equivalently, for any honest non-forking creator, at most one of
+that creator's events per round is a witness.
+
+## Basis
+Algorithm 2 (divideRounds, Baird & Luykx 2020, §IV-D-1 / p. 4)
+computes `x.witness ← (x has no self parent) OR (x.round >
+x.selfParent.round)`. Walk a self-parent chain `e₁ ← e₂ ← e₃
+← …`, where each `eᵢ₊₁` has `eᵢ` as its self-parent. The
+self-parent is by definition a parent, so parent-edge round
+monotonicity (INV-016) gives `eᵢ.round ≤ eᵢ₊₁.round`: the chain
+carries a non-decreasing integer sequence of rounds. The witness
+predicate makes `eᵢ₊₁.witness` depend on `eᵢ₊₁.round >
+eᵢ.round` — a *strict* increase. Strict increases on a
+non-decreasing integer sequence are unique per integer value,
+so each round number can host at most one witness on the chain.
+
+## Change risk
+Any change that lets multiple events at the same round on a
+single self-parent chain become witnesses breaks this invariant.
+Mechanisms: weakening the witness predicate from `x.round >
+x.selfParent.round` to `x.round ≥ x.selfParent.round`; allowing
+the predicate to consult inputs other than the self-parent;
+recomputing witness status against a moving hashgraph state in
+a way that flips the result (which also breaks INV-014);
+allowing the "no self-parent" branch to fire for events that do
+have a self-parent. Downstream effects: per-round
+famous-witness sets used in Algorithm 4 would no longer
+correspond to one event per (creator, round) along an honest
+chain, and "unique famous witness" — central to round-received
+determination — would lose its single-event grounding for
+honest creators.
+
+## Notes
+- A forking creator can have multiple self-parent chains; this
+  invariant bounds witnesses per chain, not per (creator, round)
+  globally. The "unique" in "unique famous witness" (Algorithm 4,
+  §IV-D-3 / p. 5) is the consensus-level mechanism that handles
+  the multiple-chains case.
+- Depends on INV-016 (parent-edge round monotonicity used in the
+  inference).
+- Structural counterpart to INV-014 (which is *temporal*
+  monotonicity of the `x.witness` flag — once decided, doesn't
+  flip — not a cap on count). Both can be violated independently.
+- Load-bearing indirectly for INV-008 and INV-015, which both
+  range over witnesses; a violation here would change which
+  events are subjects of fame elections.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-018-roundreceived-presupposes-fame-finality.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-018-roundreceived-presupposes-fame-finality.md
@@ -1,0 +1,69 @@
+---
+id: INV-018
+title: A round-received r implies fame is decided for every witness in rounds ≤ r
+class: ordering
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, Algorithm 4 (findOrder), §IV-D-3 / p. 5
+provenance: algorithmic-consequences-extraction against Algorithm 4 (findOrder) §IV-D-3; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-018 — A round-received r implies fame is decided for every witness in rounds ≤ r
+
+## Statement
+If an honest node has assigned `x.roundReceived = r` for some
+event x, then for every witness y in that node's hashgraph with
+`y.round ≤ r`, `y.famous` is decided (i.e., not UNDECIDED).
+
+## Basis
+Algorithm 4 (findOrder, Baird & Luykx 2020, §IV-D-3 / p. 5)
+assigns `x.roundReceived ← r` only when, among other
+conditions, "there is no event y in or before round r that has
+`y.witness = TRUE` and `y.famous = UNDECIDED`". The
+fame-decidedness clause is a precondition for the assignment;
+whenever the assignment fires, the precondition held at that
+moment. INV-008 (fame finality) then keeps the fame decisions
+stable for all subsequent moments, so the universally-quantified
+fame-decidedness still holds for witnesses in rounds ≤ r at any
+later time.
+
+## Change risk
+Any change that lets `x.roundReceived` be set while some witness
+in rounds ≤ r still has undecided fame breaks this invariant.
+Mechanisms: optimistically assigning round-received based on the
+ancestor condition alone (skipping the fame-decided check); using
+a relaxed "fame decided for round r only" precondition that
+omits earlier rounds; processing rounds out of order in a way
+that lets findOrder run before decideFame has converged for a
+relevant prior round; pipelining findOrder with decideFame in a
+way that breaks the Algorithm 1 sequencing (`divideRounds` →
+`decideFame` → `findOrder`). Downstream effects: the consensus
+order sorts first by round-received (INV-002); a round-received
+assigned without fame finality could subsequently shift if a
+prior witness's fame is later decided in a way the optimistic
+assignment didn't anticipate, retroactively changing which
+events qualify for round r and corrupting total order.
+
+## Notes
+- Captures the design rule that orders the three consensus
+  stages as data dependencies, not just as a pipeline: round
+  assignment (Algorithm 2) must complete before fame decision
+  (Algorithm 3), which must complete before round-received
+  (Algorithm 4). Algorithm 1 mirrors this as a control-flow
+  pipeline; INV-018 records it as a property of the *state*
+  that findOrder is allowed to commit.
+- Depends on INV-008 (fame finality) for the "still holds after
+  assignment" half of the argument: the precondition holds at
+  the moment of assignment by Algorithm 4 directly, and it
+  continues to hold thereafter because fame is final.
+- Load-bearing for INV-015 (round-received monotonicity), which
+  presupposes the fame inputs to findOrder are themselves
+  monotone, and indirectly for INV-002 (consensus order sorts
+  by round-received).
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/INV-019-fame-decided-only-for-witnesses.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-019-fame-decided-only-for-witnesses.md
@@ -1,0 +1,63 @@
+---
+id: INV-019
+title: Only witnesses can have a decided fame value
+class: integrity
+topics: [hashgraph]
+related:
+  rules: []
+  decisions: []
+  scenarios: []
+  heuristics: []
+status: "[TBD: confirm enforced in current implementation]"
+source: Baird & Luykx 2020, Algorithm 3 (decideFame), §IV-D-2 / p. 4
+provenance: algorithmic-consequences-extraction against Algorithm 3 (decideFame) §IV-D-2; 2026-05-21
+curated_by: Michael Heinrichs (@netopyr)
+---
+
+# INV-019 — Only witnesses can have a decided fame value
+
+## Statement
+For any event x in an honest node's hashgraph, if `x.famous ≠
+UNDECIDED` then `x.witness = TRUE`. Equivalently, non-witnesses
+always have `x.famous = UNDECIDED`.
+
+## Basis
+Algorithm 3 (decideFame, Baird & Luykx 2020, §IV-D-2 / p. 4)
+initialises `x.famous ← UNDECIDED` for every event in its outer
+loop. The only subsequent write to `x.famous` occurs inside the
+inner loop, guarded by `if x.witness and y.witness and y.round
+> x.round then …` — the only assignment site is `x.famous ← v`
+inside this conditional. Any decided value of `x.famous` must
+therefore have come from this assignment, which fires only when
+`x.witness = TRUE`. Contrapositively, a non-witness x is
+written only by the outer-loop initialisation and retains
+`UNDECIDED` permanently.
+
+## Change risk
+Any change that lets fame be assigned to non-witness events
+breaks this invariant. Mechanisms: dropping the `x.witness`
+guard from the inner conditional; introducing additional
+fame-assignment sites elsewhere in the protocol (for example,
+an "early decision" path or a post-hoc reconciliation step);
+initialising fame to something other than UNDECIDED in a branch
+that does not reset it for non-witnesses; redefining `x.witness`
+*after* fame has already been written (which also breaks
+INV-014). Downstream effects: Algorithm 4 reads "round r unique
+famous witness" when computing round-received; if non-witnesses
+can be famous, the unique-famous-witness set could contain
+events that aren't witnesses, breaking the round-received and
+consensus-timestamp computations.
+
+## Notes
+- Distinct from INV-008. INV-008 states fame *finality* for
+  witnesses (decisions are stable once made); INV-019 states the
+  *domain* of fame decisions (decisions exist only for
+  witnesses). Both constrain the same `x.famous` field but on
+  orthogonal axes — finality on the time axis, domain on the
+  event-type axis.
+- A typing constraint on the `famous` field: its domain of
+  decision is exactly the witnesses.
+- Load-bearing for the interpretation of "unique famous witness"
+  in Algorithm 4, which presumes that every famous event is in
+  fact a witness whose `x.round` is well-defined.
+- `status` is [TBD: confirm enforced in current implementation].

--- a/platform-sdk/docs/consensus-layer/invariants/README.md
+++ b/platform-sdk/docs/consensus-layer/invariants/README.md
@@ -33,9 +33,23 @@ marks a known correctness gap, not a stale entry.
 | INV-004 | Honest hashgraphs share identical ancestor sub-DAGs for any shared event | agreement | hashgraph | [TBD] |
 | INV-005 | Every event in an honest hashgraph is creator-signed and parent-resolvable | integrity | hashgraph | [TBD] |
 | INV-006 | No event can strongly see both branches of a fork | safety | hashgraph | [TBD] |
-| INV-007 | Deterministic conclusions on the hashgraph are monotone and eventually agreed | determinism | hashgraph | [TBD] |
+| INV-007 | Every deterministic conclusion on the hashgraph is monotone and eventually agreed | determinism | hashgraph | [TBD] |
 | INV-008 | A fame decision, once made, never changes and is the same on every honest node | safety | hashgraph | [TBD] |
 | INV-009 | Fame is decided for every witness with probability 1 | liveness | hashgraph | [TBD] |
+| INV-010 | Ancestry is monotone and eventually agreed | determinism | hashgraph | [TBD] |
+| INV-011 | Seeing is monotone and eventually agreed | determinism | hashgraph | [TBD] |
+| INV-012 | Strongly-seeing is monotone and eventually agreed | determinism | hashgraph | [TBD] |
+| INV-013 | An event's round assignment is monotone and eventually agreed | determinism | hashgraph | [TBD] |
+| INV-014 | An event's witness status is monotone and eventually agreed | determinism | hashgraph | [TBD] |
+| INV-015 | An event's round received is monotone and eventually agreed | determinism | hashgraph | [TBD] |
+
+INV-007 is the umbrella entry for the deterministic-conclusion meta-property
+named in the paper's §IV-C end. INV-010 through INV-015 are the per-component
+instantiations of that property. Two further components — fame and consensus
+order — are absorbed into INV-008 and INV-002 respectively rather than
+carrying their own splits, because the cross-node finality of each is already
+the entry's primary claim and the intra-node monotonicity follows from the
+same mechanism.
 
 <!--
 Row convention, one line per entry, kept in INV-NNN order:

--- a/platform-sdk/docs/consensus-layer/invariants/README.md
+++ b/platform-sdk/docs/consensus-layer/invariants/README.md
@@ -42,6 +42,10 @@ marks a known correctness gap, not a stale entry.
 | INV-013 | An event's round assignment is monotone and eventually agreed | determinism | hashgraph | [TBD] |
 | INV-014 | An event's witness status is monotone and eventually agreed | determinism | hashgraph | [TBD] |
 | INV-015 | An event's round received is monotone and eventually agreed | determinism | hashgraph | [TBD] |
+| INV-016 | An event's round is at least as large as every ancestor's round | safety | hashgraph | [TBD] |
+| INV-017 | At most one witness per round on any single self-parent chain | safety | hashgraph | [TBD] |
+| INV-018 | A round-received r implies fame is decided for every witness in rounds ≤ r | ordering | hashgraph | [TBD] |
+| INV-019 | Only witnesses can have a decided fame value | integrity | hashgraph | [TBD] |
 
 INV-007 is the umbrella entry for the deterministic-conclusion meta-property
 named in the paper's §IV-C end. INV-010 through INV-015 are the per-component
@@ -51,7 +55,21 @@ carrying their own splits, because the cross-node finality of each is already
 the entry's primary claim and the intra-node monotonicity follows from the
 same mechanism.
 
+INV-016 through INV-019 are structural one-step consequences of Algorithms 2,
+3, and 4 — properties the algorithms force directly without going through the
+monotonicity umbrella. They complement the INV-010–INV-015 family: where
+those entries say *the value of a derived field is stable over time*, the
+INV-016–INV-019 entries say *the relations between fields, or between a
+field and the DAG, are constrained by the algorithm's structure*. In
+particular, INV-016 (round respects ancestry) and INV-013 (round stable over
+time) together pin down the round function as a stable map that respects the
+DAG partial order; INV-017 (witness count per chain) and INV-014 (witness
+flag stable over time) together pin down the witness set on a chain;
+INV-018 records the data dependency between fame finality and round-received
+that Algorithm 1's sequencing makes a control-flow rule; INV-019 records
+the typing constraint that fame decisions live only on witnesses.
+
 <!--
 Row convention, one line per entry, kept in INV-NNN order:
-| INV-NNN | Title from entry frontmatter | class | topic-slug[, topic-slug] | enforced\|proposed\|divergent |
+| INV-NNN | Title from entry frontmatter | class | topic-slug[, topic-slug] | enforced|proposed|divergent |
 -->

--- a/platform-sdk/docs/consensus-layer/invariants/README.md
+++ b/platform-sdk/docs/consensus-layer/invariants/README.md
@@ -25,9 +25,17 @@ marks a known correctness gap, not a stale entry.
 
 ## Index
 
-|     ID     | Title | Class | Topics | Status |
-|------------|-------|-------|--------|--------|
-| _none yet_ |       |       |        |        |
+| ID | Title | Class | Topics | Status |
+|----|-------|-------|--------|--------|
+| INV-001 | Honest nodes agree on whether a transaction is output | agreement | hashgraph | [TBD] |
+| INV-002 | Honest nodes agree on the order of every consensus output | ordering | hashgraph | [TBD] |
+| INV-003 | Every transaction submitted to an honest node is eventually output by every honest node | liveness | hashgraph, gossip | [TBD] |
+| INV-004 | Honest hashgraphs share identical ancestor sub-DAGs for any shared event | agreement | hashgraph | [TBD] |
+| INV-005 | Every event in an honest hashgraph is creator-signed and parent-resolvable | integrity | hashgraph | [TBD] |
+| INV-006 | No event can strongly see both branches of a fork | safety | hashgraph | [TBD] |
+| INV-007 | Deterministic conclusions on the hashgraph are monotone and eventually agreed | determinism | hashgraph | [TBD] |
+| INV-008 | A fame decision, once made, never changes and is the same on every honest node | safety | hashgraph | [TBD] |
+| INV-009 | Fame is decided for every witness with probability 1 | liveness | hashgraph | [TBD] |
 
 <!--
 Row convention, one line per entry, kept in INV-NNN order:


### PR DESCRIPTION
**Description**:

This PR adds invariants that were extracted from the Hashgraph paper

**Related issue(s)**:

Fixes #25352 