### PR TITLE
chore: (0.75) Update Mainnet throttles for CryptoGetAccountBalanceQuery

### DIFF
--- a/hedera-node/configuration/mainnet/upgrade/throttles.json
+++ b/hedera-node/configuration/mainnet/upgrade/throttles.json
@@ -205,7 +205,7 @@
       "throttleGroups": [
         {
           "opsPerSec": 0,
-          "milliOpsPerSec": 40000000,
+          "milliOpsPerSec": 20000000,
           "operations": [
             "CryptoGetAccountBalance"
           ]


### PR DESCRIPTION
**Description**:
This pull request makes a targeted adjustment to the throttling configuration for the mainnet. Specifically, it reduces the allowed rate for the `CryptoGetAccountBalance` operation.

- Reduced the `milliOpsPerSec` value for the `CryptoGetAccountBalance` operation from 40,000,000 to 20,000,000 in `hedera-node/configuration/mainnet/upgrade/throttles.json`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
