### PR TITLE
chore: (0.76) Update Mainnet throttles for CryptoGetAccountBalanceQuery

### DIFF
--- a/hedera-node/configuration/mainnet/upgrade/throttles.json
+++ b/hedera-node/configuration/mainnet/upgrade/throttles.json
@@ -205,7 +205,7 @@
       "throttleGroups": [
         {
           "opsPerSec": 0,
-          "milliOpsPerSec": 40000000,
+          "milliOpsPerSec": 10000000,
           "operations": [
             "CryptoGetAccountBalance"
           ]


### PR DESCRIPTION
**Description**:
This pull request makes a configuration adjustment to the throttling settings for the mainnet. The change reduces the allowed rate for a specific operation to help manage system load.

- Throttle configuration update:
  * In `hedera-node/configuration/mainnet/upgrade/throttles.json`, reduced the `milliOpsPerSec` value for the `CryptoGetAccountBalance` operation from 40,000,000 to 10,000,000.

**Related issue(s)**:

Fixes #25587 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
