### PR TITLE
fix: flaky ethereum suites

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumSuite.java
@@ -47,7 +47,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createLargeFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.restoreDefault;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
@@ -499,7 +498,7 @@ public class EthereumSuite {
                 }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.evm.ethTransaction.zeroHapiFees.enabled"})
     final Stream<DynamicTest> etx031InvalidNonceEthereumTxFailsAndChargesRelayer() {
         final var relayerSnapshot = "relayer";
         final var senderSnapshot = "sender";
@@ -1332,7 +1331,7 @@ public class EthereumSuite {
                                 new byte[32])));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.throttle.throttleByGas", "contracts.maxGasPerTransaction"})
     final Stream<DynamicTest> ethereumTransactionRespectsMaxGasPerTransaction() {
         return hapiTest(
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -1350,9 +1349,7 @@ public class EthereumSuite {
                         .gasLimit(16_000_000L)
                         .sending(1)
                         .hasKnownStatus(MAX_GAS_LIMIT_EXCEEDED),
-                getAliasedAccountInfo(SECP_256K1_SOURCE_KEY).has(accountWith().nonce(0L)),
-                restoreDefault("contracts.maxGasPerTransaction"),
-                restoreDefault("contracts.throttle.throttleByGas"));
+                getAliasedAccountInfo(SECP_256K1_SOURCE_KEY).has(accountWith().nonce(0L)));
     }
 
     // Legacy `v` byte values that are neither EIP-155 protected (v >= 35, derived from

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/batch/AtomicEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/batch/AtomicEthereumSuite.java
@@ -104,6 +104,7 @@ import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts;
 import com.hedera.services.bdd.spec.keys.SigControl;
@@ -218,7 +219,7 @@ class AtomicEthereumSuite {
                         .hasPriority(recordWith().transfers(includingDeduction("HAPI fees", RELAYER))));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.evm.ethTransaction.zeroHapiFees.enabled"})
     final Stream<DynamicTest> baseRelayerCostAsExpected() {
         return hapiTest(
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -590,7 +591,7 @@ class AtomicEthereumSuite {
                 }));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"contracts.evm.ethTransaction.zeroHapiFees.enabled"})
     final Stream<DynamicTest> etx031InvalidNonceEthereumTxFailsAndChargesRelayer() {
         final var relayerSnapshot = "relayer";
         final var senderSnapshot = "sender";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractCreateSuite.java
@@ -395,7 +395,6 @@ class AtomicContractCreateSuite {
     }
 
     @LeakyHapiTest(overrides = {"contracts.maxGasPerSec"})
-    @HapiTest
     final Stream<DynamicTest> rejectsNegativeGas() {
         return hapiTest(
                 uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),


### PR DESCRIPTION
**Description**:
Tests that override shared network configuration (`contracts.maxGasPerTransaction`, `contracts.throttle.throttleByGas`, `contracts.evm.ethTransaction.zeroHapiFees.enabled`) were using `@HapiTest` (read lock) instead of `@LeakyHapiTest` (write lock). This allowed concurrent tests to restore or modify the overridden properties mid-test, causing intermittent failures.

- `EthereumSuite`: switched 2 methods to `@LeakyHapiTest`, removed now-redundant manual `restoreDefault()` calls
- `AtomicEthereumSuite`: switched 2 methods to `@LeakyHapiTest`
- `AtomicContractCreateSuite`: removed redundant `@HapiTest` that conflicted with existing `@LeakyHapiTest`
**Related issue(s)**:

Fixes #25150 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
