### PR TITLE
ci(workflow-fix): add java version to build release artifact

### DIFF
--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -28,6 +28,14 @@ permissions:
   actions: read
 
 jobs:
+  extract-jdk-version:
+    name: Extract Java Version
+    uses: ./.github/workflows/802-extract-jdk-version.yaml
+    with:
+      ref: ${{ github.ref }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
   prepare-tag-release:
     name: Prepare Release [Tag]
     runs-on: hl-cn-default-lin-sm
@@ -71,6 +79,7 @@ jobs:
     name: Release [Tag]
     uses: ./.github/workflows/node-zxc-build-release-artifact.yaml
     needs:
+      - extract-jdk-version
       - prepare-tag-release
     with:
       version-policy: specified
@@ -79,6 +88,8 @@ jobs:
       release-profile: ${{ needs.prepare-tag-release.outputs.prerelease == 'true' && 'PrereleaseChannel' || 'MavenCentral' }}
       ref: ${{ github.ref }}
       ref-name: ${{ github.ref_name }}
+      java-version: ${{ needs.extract-jdk-version.outputs.jdk-version }}
+      java-distribution: "temurin"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       bucket-name: ${{ secrets.RELEASE_ARTIFACT_BUCKET_NAME }}
@@ -157,6 +168,8 @@ jobs:
   release-branch:
     name: Release [Branch]
     uses: ./.github/workflows/node-zxc-build-release-artifact.yaml
+    needs:
+      - extract-jdk-version
     if: ${{ github.event_name == 'workflow_dispatch' }}
     with:
       version-policy: branch-commit
@@ -165,6 +178,8 @@ jobs:
       ref: ${{ inputs.ref }}
       ref-name: ${{ inputs.ref-name }}
       dry-run-enabled: ${{ inputs.dry-run-enabled }}
+      java-version: ${{ needs.extract-jdk-version.outputs.jdk-version }}
+      java-distribution: "temurin"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       bucket-name: ${{ secrets.RELEASE_ARTIFACT_BUCKET_NAME }}
@@ -182,6 +197,7 @@ jobs:
       jf-docker-registry: ${{ vars.JF_DOCKER_REGISTRY }}
       jf-user-name: ${{ vars.JF_USER_NAME }}
       jf-access-token: ${{ secrets.JF_ACCESS_TOKEN }}
+
 
   deploy-xts-ci-trigger:
     name: Trigger XTS CI Flow

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -198,7 +198,6 @@ jobs:
       jf-user-name: ${{ vars.JF_USER_NAME }}
       jf-access-token: ${{ secrets.JF_ACCESS_TOKEN }}
 
-
   deploy-xts-ci-trigger:
     name: Trigger XTS CI Flow
     runs-on: hl-cn-default-lin-sm

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -45,15 +45,15 @@ on:
         type: boolean
         required: false
         default: false
+      java-version:
+        description: "Java JDK Version:"
+        type: string
+        required: false
       java-distribution:
         description: "Java JDK Distribution:"
         type: string
         required: false
         default: "temurin"
-      java-version:
-        description: "Java JDK Version:"
-        type: string
-        required: false
       gradle-version:
         description: "Gradle Version:"
         type: string


### PR DESCRIPTION
**Description**:

Pass down the java version from `extract-java-version` workflow to `build release artifact`. The default value was removed, causing the error we see in #25604.

**Related Issue(s)**:

Fixes #25604
