### PR TITLE
fix: Record to Block adapters in test-clients and MISC tag fixes

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -173,6 +173,7 @@ import com.hedera.services.bdd.spec.utilops.streams.assertions.BlockStreamAssert
 import com.hedera.services.bdd.spec.utilops.streams.assertions.EventualBlockStreamAssertion;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.EventualRecordStreamAssertion;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.RecordStreamAssertion;
+import com.hedera.services.bdd.spec.utilops.streams.assertions.SelectedBlockItemsAssertion;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.SelectedItemsAssertion;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.TransactionBodyAssertion;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.ValidContractIdsAssertion;
@@ -1742,6 +1743,30 @@ public class UtilVerbs {
         return EventualBlockStreamAssertion.eventuallyAssertingExplicitPass(assertion);
     }
 
+    /**
+     * Returns an op that asserts the block stream eventually contains a pass from the given
+     * assertion within {@code timeout}, opting in to background traffic so blocks keep closing.
+     */
+    public static AbstractEventualStreamAssertion blockStreamMustIncludePassFrom(
+            @NonNull final Function<HapiSpec, BlockStreamAssertion> assertion, @NonNull final Duration timeout) {
+        requireNonNull(assertion);
+        requireNonNull(timeout);
+        return EventualBlockStreamAssertion.eventuallyAssertingExplicitPass(assertion, timeout)
+                .withBackgroundTraffic();
+    }
+
+    /**
+     * Block-stream equivalent of {@link EventualRecordStreamAssertion#eventuallyAssertingExplicitPassWithReplay}:
+     * also replays any existing block files first so genesis-time items (emitted before the
+     * subscription) can still satisfy the assertion.
+     */
+    public static AbstractEventualStreamAssertion blockStreamMustIncludePassWithReplayFrom(
+            @NonNull final Function<HapiSpec, BlockStreamAssertion> assertion, @NonNull final Duration timeout) {
+        requireNonNull(assertion);
+        requireNonNull(timeout);
+        return EventualBlockStreamAssertion.eventuallyAssertingExplicitPassWithReplay(assertion, timeout);
+    }
+
     public static RunnableOp verify(@NonNull final Runnable runnable) {
         return new RunnableOp(runnable);
     }
@@ -1815,6 +1840,21 @@ public class UtilVerbs {
         requireNonNull(validator);
         requireNonNull(test);
         return spec -> new SelectedItemsAssertion(n, spec, test, validator);
+    }
+
+    /**
+     * Block-stream analog of {@link #selectedItems}. Translates each incoming {@link
+     * com.hedera.hapi.block.stream.Block} back to {@link RecordStreamItem}s so the existing
+     * predicate and {@link VisibleItemsValidator} APIs can be reused under
+     * {@code streamMode=BLOCKS} without re-implementing per-test selection logic.
+     */
+    public static Function<HapiSpec, BlockStreamAssertion> selectedBlockItems(
+            @NonNull final VisibleItemsValidator validator,
+            final int n,
+            @NonNull final BiPredicate<HapiSpec, RecordStreamItem> test) {
+        requireNonNull(validator);
+        requireNonNull(test);
+        return spec -> new SelectedBlockItemsAssertion(n, spec, test, validator);
     }
 
     public static Function<HapiSpec, RecordStreamAssertion> visibleNonSyntheticItems(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/SidecarValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/SidecarValidationOp.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.utilops.streams;
 
+import static com.hedera.node.config.types.StreamMode.BLOCKS;
+import static com.hedera.services.bdd.junit.hedera.ExternalPath.BLOCK_STREAMS_DIR;
 import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -21,8 +23,20 @@ public class SidecarValidationOp extends UtilOp {
     @Override
     protected boolean submitOp(@NonNull final HapiSpec spec) throws Throwable {
         final var streamsLoc = spec.recordStreamsLoc(byNodeId(0));
-        spec.setSidecarWatcher(new SidecarWatcher(streamsLoc));
-        log.info("Watching for sidecar files at {}", streamsLoc);
+        final var network = spec.targetNetworkOrThrow();
+        // Pick exactly one sidecar source based on the current stream mode so we never
+        // see the same logical sidecar from both legacy files and block-translation:
+        //   BLOCKS  -> block stream only (no V6 sidecar files are written)
+        //   RECORDS / BOTH -> legacy V6 sidecar files only (the canonical source there)
+        final var streamMode = spec.startupProperties().getStreamMode("blockStream.streamMode");
+        if (streamMode == BLOCKS) {
+            final var blockStreamLoc = network.getRequiredNode(byNodeId(0)).getExternalPath(BLOCK_STREAMS_DIR);
+            spec.setSidecarWatcher(new SidecarWatcher(streamsLoc, blockStreamLoc, network.shard(), network.realm()));
+            log.info("Watching for block-derived sidecars at {} (streamMode=BLOCKS)", blockStreamLoc);
+        } else {
+            spec.setSidecarWatcher(new SidecarWatcher(streamsLoc));
+            log.info("Watching for V6 sidecar files at {} (streamMode={})", streamsLoc, streamMode);
+        }
         return false;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/EventualBlockStreamAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/EventualBlockStreamAssertion.java
@@ -11,6 +11,7 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.function.Function;
 
 public class EventualBlockStreamAssertion extends AbstractEventualStreamAssertion {
@@ -18,6 +19,10 @@ public class EventualBlockStreamAssertion extends AbstractEventualStreamAssertio
      * The factory for the assertion to be tested.
      */
     private final Function<HapiSpec, BlockStreamAssertion> assertionFactory;
+
+    private final boolean replayExistingFiles;
+    private boolean needsBackgroundTraffic = false;
+
     /**
      * Once this op is submitted, the assertion to be tested.
      */
@@ -32,7 +37,7 @@ public class EventualBlockStreamAssertion extends AbstractEventualStreamAssertio
      */
     public static EventualBlockStreamAssertion eventuallyAssertingNoFailures(
             @NonNull final Function<HapiSpec, BlockStreamAssertion> assertionFactory) {
-        return new EventualBlockStreamAssertion(assertionFactory, true);
+        return new EventualBlockStreamAssertion(assertionFactory, true, false);
     }
 
     /**
@@ -43,19 +48,56 @@ public class EventualBlockStreamAssertion extends AbstractEventualStreamAssertio
      */
     public static EventualBlockStreamAssertion eventuallyAssertingExplicitPass(
             @NonNull final Function<HapiSpec, BlockStreamAssertion> assertionFactory) {
-        return new EventualBlockStreamAssertion(assertionFactory, false);
+        return new EventualBlockStreamAssertion(assertionFactory, false, false);
+    }
+
+    /**
+     * Returns an {@link EventualBlockStreamAssertion} that will pass only if the given assertion explicitly
+     * passes within the given timeout.
+     */
+    public static EventualBlockStreamAssertion eventuallyAssertingExplicitPass(
+            @NonNull final Function<HapiSpec, BlockStreamAssertion> assertionFactory, @NonNull final Duration timeout) {
+        return new EventualBlockStreamAssertion(assertionFactory, false, timeout, false);
+    }
+
+    /**
+     * Returns an {@link EventualBlockStreamAssertion} that will pass only if the given assertion explicitly
+     * passes within the given timeout, after first replaying any existing block files. Mirrors the
+     * record-stream variant for genesis-time tests that need to see items emitted at network startup.
+     */
+    public static EventualBlockStreamAssertion eventuallyAssertingExplicitPassWithReplay(
+            @NonNull final Function<HapiSpec, BlockStreamAssertion> assertionFactory, @NonNull final Duration timeout) {
+        return new EventualBlockStreamAssertion(assertionFactory, false, timeout, true).withBackgroundTraffic();
     }
 
     private EventualBlockStreamAssertion(
             @NonNull final Function<HapiSpec, BlockStreamAssertion> assertionFactory,
-            final boolean hasPassedIfNothingFailed) {
+            final boolean hasPassedIfNothingFailed,
+            final boolean replayExistingFiles) {
         super(hasPassedIfNothingFailed);
         this.assertionFactory = requireNonNull(assertionFactory);
+        this.replayExistingFiles = replayExistingFiles;
+    }
+
+    private EventualBlockStreamAssertion(
+            @NonNull final Function<HapiSpec, BlockStreamAssertion> assertionFactory,
+            final boolean hasPassedIfNothingFailed,
+            @NonNull final Duration timeout,
+            final boolean replayExistingFiles) {
+        super(hasPassedIfNothingFailed, timeout);
+        this.assertionFactory = requireNonNull(assertionFactory);
+        this.replayExistingFiles = replayExistingFiles;
     }
 
     @Override
     public boolean needsBackgroundTraffic() {
-        return false;
+        return needsBackgroundTraffic;
+    }
+
+    /** Opts this assertion into background traffic so blocks keep closing while it waits. */
+    public EventualBlockStreamAssertion withBackgroundTraffic() {
+        this.needsBackgroundTraffic = true;
+        return this;
     }
 
     @Override
@@ -63,6 +105,11 @@ public class EventualBlockStreamAssertion extends AbstractEventualStreamAssertio
         requireNonNull(spec);
         assertion = requireNonNull(assertionFactory.apply(spec));
         unsubscribe = STREAM_FILE_ACCESS.subscribe(blockStreamLocFor(spec), new StreamDataListener() {
+            @Override
+            public boolean replayExistingFiles() {
+                return replayExistingFiles;
+            }
+
             @Override
             public void onNewBlock(@NonNull final Block block) {
                 requireNonNull(block);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/SelectedBlockItemsAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/SelectedBlockItemsAssertion.java
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.spec.utilops.streams.assertions;
+
+import static com.hedera.node.app.hapi.utils.CommonPbjConverters.pbjToProto;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.node.app.hapi.utils.forensics.RecordStreamEntry;
+import com.hedera.node.app.state.SingleTransactionRecord;
+import com.hedera.services.bdd.junit.support.translators.BlockTransactionalUnitTranslator;
+import com.hedera.services.bdd.junit.support.translators.RoleFreeBlockUnitSplit;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.stream.proto.RecordStreamItem;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiPredicate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Block-stream analog of {@link SelectedItemsAssertion}.
+ *
+ * <p>Translates each incoming {@link Block} back to record-stream items via
+ * {@link BlockTransactionalUnitTranslator}, then applies the same
+ * {@link BiPredicate}-and-{@link VisibleItemsValidator} pattern as the
+ * record-stream variant. This lets existing selectors written against
+ * {@link RecordStreamItem} (e.g. {@code TxnUtils::isSysFileUpdate}) be reused
+ * unchanged when running under {@code streamMode=BLOCKS}.
+ */
+public class SelectedBlockItemsAssertion implements BlockStreamAssertion {
+    private static final Logger log = LogManager.getLogger(SelectedBlockItemsAssertion.class);
+
+    private final int expectedCount;
+    private final HapiSpec spec;
+    private final BiPredicate<HapiSpec, RecordStreamItem> test;
+    private final VisibleItemsValidator validator;
+    private final List<RecordStreamEntry> selectedEntries = new ArrayList<>();
+
+    // One translator per assertion: BaseTranslator carries alias and nonce state
+    // that must persist across blocks for translation to remain consistent.
+    private final BlockTransactionalUnitTranslator translator;
+    private final RoleFreeBlockUnitSplit split = new RoleFreeBlockUnitSplit();
+    private boolean foundGenesis = false;
+
+    public SelectedBlockItemsAssertion(
+            final int expectedCount,
+            @NonNull final HapiSpec spec,
+            @NonNull final BiPredicate<HapiSpec, RecordStreamItem> test,
+            @NonNull final VisibleItemsValidator validator) {
+        this.expectedCount = expectedCount;
+        this.spec = requireNonNull(spec);
+        this.test = requireNonNull(test);
+        this.validator = requireNonNull(validator);
+        final var network = spec.targetNetworkOrThrow();
+        this.translator = new BlockTransactionalUnitTranslator(network.shard(), network.realm());
+    }
+
+    @Override
+    public boolean test(@NonNull final Block block) throws AssertionError {
+        requireNonNull(block);
+        // Genesis must be scanned before any translation so receipts/aliases match what the
+        // record stream would have produced.
+        if (!foundGenesis) {
+            foundGenesis = translator.scanBlockForGenesis(block);
+        }
+        for (final var unit : split.split(block)) {
+            final List<SingleTransactionRecord> translated;
+            try {
+                translated = translator.translate(unit.withBatchTransactionParts());
+            } catch (final RuntimeException e) {
+                // Translation issues for individual units shouldn't fail the whole assertion;
+                // keep going so the selector still has a chance to find its matches.
+                log.warn("Block-to-record translation failed for a unit; skipping", e);
+                continue;
+            }
+            for (final var record : translated) {
+                final var item = toItem(record);
+                if (test.test(spec, item)) {
+                    selectedEntries.add(RecordStreamEntry.from(item));
+                    if (selectedEntries.size() == expectedCount) {
+                        runValidator();
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private void runValidator() {
+        try {
+            validator.assertValid(
+                    spec,
+                    Map.of(
+                            SelectedItemsAssertion.SELECTED_ITEMS_KEY,
+                            new VisibleItems(new AtomicInteger(), selectedEntries)));
+        } catch (final Throwable t) {
+            if (t instanceof AssertionError ae) {
+                throw ae;
+            }
+            throw new AssertionError("Unhandled exception in validator", t);
+        }
+    }
+
+    private static RecordStreamItem toItem(@NonNull final SingleTransactionRecord record) {
+        // PBJ source types are fully qualified to disambiguate from the already-imported
+        // proto types of the same simple name.
+        return RecordStreamItem.newBuilder()
+                .setTransaction(pbjToProto(
+                        record.transaction(), com.hedera.hapi.node.base.Transaction.class, Transaction.class))
+                .setRecord(pbjToProto(
+                        record.transactionRecord(),
+                        com.hedera.hapi.node.transaction.TransactionRecord.class,
+                        TransactionRecord.class))
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "SelectedBlockItems{matched=" + selectedEntries.size() + "/" + expectedCount + "}";
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/traceability/SidecarWatcher.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/verification/traceability/SidecarWatcher.java
@@ -1,17 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.verification.traceability;
 
+import static com.hedera.node.app.hapi.utils.CommonPbjConverters.pbjToProto;
 import static com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils.guaranteedExtantDir;
 import static com.hedera.services.bdd.junit.support.StreamFileAccess.STREAM_FILE_ACCESS;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.triggerAndCloseAtLeastOneFileIfNotInterrupted;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.hapi.block.stream.Block;
 import com.hedera.services.bdd.junit.support.StreamDataListener;
 import com.hedera.services.bdd.junit.support.StreamFileAccess;
+import com.hedera.services.bdd.junit.support.translators.BlockTransactionalUnitTranslator;
+import com.hedera.services.bdd.junit.support.translators.RoleFreeBlockUnitSplit;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.stream.proto.TransactionSidecarRecord;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
@@ -24,13 +29,16 @@ import java.util.Queue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
 /**
  * A class that simultaneously,
  * <ol>
- *     <li>Listens for the actual sidecars written at the given location via
- *     the {@link StreamFileAccess#STREAM_FILE_ACCESS} utility; and,</li>
+ *     <li>Listens for the actual sidecars from one source — either the legacy V6 sidecar files
+ *     via {@link StreamFileAccess#STREAM_FILE_ACCESS}, or synthesised from the block stream
+ *     when the four-arg constructor is given a block-stream path; and,</li>
  *     <li>Registers expected sidecars.</li>
  * </ol>
  * When a client has registered all its expectations with a {@link SidecarWatcher}
@@ -45,6 +53,8 @@ import org.junit.jupiter.api.Assertions;
 // string literals should not be duplicated
 @SuppressWarnings("java:S1192")
 public class SidecarWatcher {
+    private static final Logger log = LogManager.getLogger(SidecarWatcher.class);
+
     /**
      * The watcher is event-driven (sidecars arrive after a sidecar marker file is noticed).
      * In CI, marker creation/visibility can lag just enough that immediate unsubscribe can race
@@ -55,7 +65,21 @@ public class SidecarWatcher {
     private static final int FINAL_DRAIN_ATTEMPTS = 3;
 
     private final Path streamFilesPath;
+    /**
+     * Handle to the record-stream listener subscription. Set to a no-op when the watcher is in
+     * block-stream-only mode (see the 4-arg constructor).
+     */
     private final Runnable unsubscribe;
+
+    /**
+     * Handle to the block-stream listener subscription, present only when the watcher was
+     * constructed in block-stream-only mode. When set, each new block is translated back into
+     * V6-shape {@link TransactionSidecarRecord}s and pumped through the same drain pipeline as the
+     * legacy on-disk sidecars.
+     */
+    @Nullable
+    private final Runnable unsubscribeBlocks;
+
     private final Queue<ExpectedSidecar> expectedSidecars = new LinkedBlockingDeque<>();
     private final Queue<TransactionSidecarRecord> actualSidecars = new LinkedBlockingDeque<>();
     private final HashSet<TransactionSidecarRecord> seenActualSidecars = new HashSet<>();
@@ -69,11 +93,87 @@ public class SidecarWatcher {
     private record ConstructionDetails(String creatingThread, String stackTrace) {}
 
     public SidecarWatcher(@NonNull final Path path) {
+        // shard/realm are unused on this overload — only consulted when blockStreamPath != null.
+        this(path, null, 0L, 0L);
+    }
+
+    /**
+     * Constructs a watcher that picks exactly one source for actual sidecars:
+     * <ul>
+     *     <li>If {@code blockStreamPath} is non-null, sidecars are synthesised from each new block
+     *         under that path via {@link BlockTransactionalUnitTranslator} (this is the path used
+     *         under {@code streamMode=BLOCKS}, where no V6 sidecar files are written).</li>
+     *     <li>Otherwise the watcher subscribes to the legacy V6 sidecar files at {@code path}
+     *         (this is the path used under {@code streamMode=RECORDS} or {@code BOTH}).</li>
+     * </ul>
+     * Picking exactly one source avoids the double-delivery race that would otherwise be possible
+     * under {@code BOTH} when a block-derived sidecar differs byte-for-byte from its on-disk twin.
+     * The legacy {@code path} is always retained (so {@link #drainUnseenSidecarsFromDisk()} has a
+     * directory to scan during the final cleanup pass) even when the block-stream source is used.
+     */
+    public SidecarWatcher(
+            @NonNull final Path path, @Nullable final Path blockStreamPath, final long shard, final long realm) {
         this.streamFilesPath = guaranteedExtantDir(path);
-        this.unsubscribe = STREAM_FILE_ACCESS.subscribe(streamFilesPath, new StreamDataListener() {
+        if (blockStreamPath != null) {
+            // Block-stream-only mode: skip the record-stream listener entirely; the legacy dir is
+            // empty under streamMode=BLOCKS so it would deliver nothing anyway.
+            this.unsubscribe = () -> {};
+            this.unsubscribeBlocks = subscribeBlocks(blockStreamPath, shard, realm);
+        } else {
+            // Legacy mode: V6 sidecar files are the only source.
+            this.unsubscribe = STREAM_FILE_ACCESS.subscribe(streamFilesPath, new StreamDataListener() {
+                @Override
+                public void onNewSidecar(@NonNull final TransactionSidecarRecord sidecar) {
+                    enqueueActualSidecar(sidecar);
+                }
+            });
+            this.unsubscribeBlocks = null;
+        }
+    }
+
+    private Runnable subscribeBlocks(@NonNull final Path blockStreamPath, final long shard, final long realm) {
+        // One translator/split owned by this subscription so alias and nonce state persist
+        // across blocks (BaseTranslator is stateful).
+        final var translator = new BlockTransactionalUnitTranslator(shard, realm);
+        final var split = new RoleFreeBlockUnitSplit();
+        // Single-element array used as a mutable boolean captured by the listener lambda.
+        final boolean[] foundGenesis = {false};
+        return STREAM_FILE_ACCESS.subscribe(guaranteedExtantDir(blockStreamPath), new StreamDataListener() {
+            // Replay so genesis sidecars (emitted before this subscription) are still picked up.
             @Override
-            public void onNewSidecar(@NonNull final TransactionSidecarRecord sidecar) {
-                enqueueActualSidecar(sidecar);
+            public boolean replayExistingFiles() {
+                return true;
+            }
+
+            @Override
+            public void onNewBlock(@NonNull final Block block) {
+                try {
+                    if (!foundGenesis[0]) {
+                        foundGenesis[0] = translator.scanBlockForGenesis(block);
+                    }
+                    for (final var unit : split.split(block)) {
+                        for (final var record : translator.translate(unit.withBatchTransactionParts())) {
+                            for (final var pbjSidecar : record.transactionSidecarRecords()) {
+                                // Fully qualified to disambiguate from the already-imported
+                                // proto type of the same simple name.
+                                final var protoSidecar = pbjToProto(
+                                        pbjSidecar,
+                                        com.hedera.hapi.streams.TransactionSidecarRecord.class,
+                                        TransactionSidecarRecord.class);
+                                enqueueActualSidecar(protoSidecar);
+                            }
+                        }
+                    }
+                } catch (final RuntimeException e) {
+                    // Don't propagate: a single bad unit shouldn't kill the watcher; the
+                    // expectations-vs-actual diff at the end will surface any real miss.
+                    log.warn("Failed to translate block to sidecars; continuing", e);
+                }
+            }
+
+            @Override
+            public String name() {
+                return "SidecarWatcher#blockStreamPump";
             }
         });
     }
@@ -95,10 +195,14 @@ public class SidecarWatcher {
     }
 
     /**
-     * Ensures that the sidecar watcher is unsubscribed.
+     * Ensures that the sidecar watcher is unsubscribed from both the record stream and (if
+     * configured) the block stream.
      */
     public void ensureUnsubscribed() {
         unsubscribe.run();
+        if (unsubscribeBlocks != null) {
+            unsubscribeBlocks.run();
+        }
     }
 
     /**
@@ -136,6 +240,9 @@ public class SidecarWatcher {
 
         // Stop listening for any more actual sidecars, then drain anything already queued.
         unsubscribe.run();
+        if (unsubscribeBlocks != null) {
+            unsubscribeBlocks.run();
+        }
         drainUnseenSidecarsFromDisk();
         drainActualSidecars();
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/LeakyContractTestsSuite.java
@@ -837,7 +837,6 @@ public class LeakyContractTestsSuite {
     @LeakyEmbeddedHapiTest(reason = NEEDS_STATE_ACCESS)
     final Stream<DynamicTest> bytecodeSidecarExternalizedEvenWithInlineInitcode() {
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
                 sidecarValidation(),
                 contractCreate("CreateTrivial")
                         .via("inlineCreation")
@@ -878,7 +877,6 @@ public class LeakyContractTestsSuite {
         final var evmAddressOfChildContract = new AtomicReference<BytesValue>();
 
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
                 sidecarValidation(),
                 overriding("contracts.evm.version", "v0.34"),
                 newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1299/UpdateNodeAccountTestSubprocess.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1299/UpdateNodeAccountTestSubprocess.java
@@ -16,7 +16,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeUpdate;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.generateX509Certificates;
@@ -64,25 +63,23 @@ public class UpdateNodeAccountTestSubprocess {
             final AtomicReference<AccountID> newAccountId = new AtomicReference<>();
             final AtomicReference<AccountID> oldNodeAccountId = new AtomicReference<>();
             final String nodeToUpdate = "3";
-            final Path recordsDir = workingDirFor(Long.parseLong(nodeToUpdate), null)
+            final Path blocksDir = workingDirFor(Long.parseLong(nodeToUpdate), null)
                     .resolve("data")
-                    .resolve("recordStreams");
+                    .resolve("blockStreams");
 
             return hapiTest(
-                    overriding("blockStream.streamMode", "BOTH"),
                     cryptoCreate("newAccount").exposingCreatedIdTo(newAccountId::set),
                     // account 6 is the node account of node 3
                     getAccountInfo("6").exposingIdTo(oldNodeAccountId::set),
                     nodeUpdate(nodeToUpdate).accountId("newAccount").signedByPayerAnd("newAccount"),
-                    // create a transaction after the update so record files are generated
+                    // create a transaction after the update so block files are generated
                     cryptoCreate("foo"),
-                    // assert record paths
+                    // assert block paths
                     withOpContext((spec, log) -> {
-                        final var oldRecordPath =
-                                recordsDir.resolve("record" + asAccountString(oldNodeAccountId.get()));
-                        final var newRecordPath = recordsDir.resolve("record" + asAccountString(newAccountId.get()));
-                        assertTrue(oldRecordPath.toFile().exists());
-                        assertFalse(newRecordPath.toFile().exists());
+                        final var oldBlockPath = blocksDir.resolve("block-" + asAccountString(oldNodeAccountId.get()));
+                        final var newBlockPath = blocksDir.resolve("block-" + asAccountString(newAccountId.get()));
+                        assertTrue(oldBlockPath.toFile().exists());
+                        assertFalse(newBlockPath.toFile().exists());
                     }));
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip993/SystemFileExportsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip993/SystemFileExportsTest.java
@@ -24,6 +24,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.simulatePostUpgradeTransaction;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.allVisibleItems;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockStreamMustIncludePassFrom;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockStreamMustIncludePassWithReplayFrom;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doWithStartupConfig;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
@@ -32,8 +34,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.nOps;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.recordStreamMustIncludeNoFailuresFrom;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.recordStreamMustIncludePassFrom;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.selectedItems;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.selectedBlockItems;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
@@ -41,7 +42,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilNextBlock;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.writeToNodeWorkingDirs;
 import static com.hedera.services.bdd.spec.utilops.grouping.GroupingVerbs.getSystemFiles;
-import static com.hedera.services.bdd.spec.utilops.streams.assertions.EventualRecordStreamAssertion.eventuallyAssertingExplicitPassWithReplay;
 import static com.hedera.services.bdd.spec.utilops.streams.assertions.SelectedItemsAssertion.SELECTED_ITEMS_KEY;
 import static com.hedera.services.bdd.spec.utilops.streams.assertions.VisibleItemsAssertion.ALL_TX_IDS;
 import static com.hedera.services.bdd.suites.HapiSuite.APP_PROPERTIES;
@@ -126,8 +126,9 @@ public class SystemFileExportsTest {
         };
         final AtomicReference<Map<Long, X509Certificate>> gossipCertificates = new AtomicReference<>();
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
-                recordStreamMustIncludePassFrom(selectedItems(
+                // Translate the block stream back to records so this spec works under streamMode=BLOCKS,
+                // where no legacy record stream is written.
+                blockStreamMustIncludePassFrom(selectedBlockItems(
                         nodeDetailsExportValidator(grpcCertHashes, gossipCertificates),
                         1,
                         sysFileUpdateTo("files.nodeDetails"))),
@@ -156,8 +157,8 @@ public class SystemFileExportsTest {
         };
         final AtomicReference<Map<Long, X509Certificate>> gossipCertificates = new AtomicReference<>();
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
-                recordStreamMustIncludePassFrom(selectedItems(
+                // Use block-stream-translated items so the assertion succeeds under streamMode=BLOCKS.
+                blockStreamMustIncludePassFrom(selectedBlockItems(
                         addressBookExportValidator("files.addressBook", grpcCertHashes), 2, TxnUtils::isSysFileUpdate)),
                 given(() -> gossipCertificates.set(generateCertificates(CLASSIC_HAPI_TEST_NETWORK_SIZE))),
                 // This is the genesis transaction
@@ -183,8 +184,7 @@ public class SystemFileExportsTest {
         final var upgradeFeeSchedules =
                 CurrentAndNextFeeSchedule.parseFrom(SYS_FILE_SERDES.get(111L).toRawFile(feeSchedulesJson, null));
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
-                recordStreamMustIncludePassFrom(selectedItems(
+                blockStreamMustIncludePassFrom(selectedBlockItems(
                         sysFileExportValidator(
                                 "files.feeSchedules", upgradeFeeSchedules, SystemFileExportsTest::parseFeeSchedule),
                         3,
@@ -223,8 +223,7 @@ public class SystemFileExportsTest {
         final var upgradeThrottleDefs =
                 ThrottleDefinitions.parseFrom(SYS_FILE_SERDES.get(123L).toRawFile(throttlesJson, null));
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
-                recordStreamMustIncludePassFrom(selectedItems(
+                blockStreamMustIncludePassFrom(selectedBlockItems(
                         sysFileExportValidator(
                                 "files.throttleDefinitions",
                                 upgradeThrottleDefs,
@@ -260,8 +259,7 @@ public class SystemFileExportsTest {
         final var upgradePropOverrides =
                 ServicesConfigurationList.parseFrom(SYS_FILE_SERDES.get(121L).toRawFile(overrideProperties, null));
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
-                recordStreamMustIncludePassFrom(selectedItems(
+                blockStreamMustIncludePassFrom(selectedBlockItems(
                         sysFileExportValidator(
                                 "files.networkProperties",
                                 upgradePropOverrides,
@@ -294,8 +292,7 @@ public class SystemFileExportsTest {
     @GenesisHapiTest
     final Stream<DynamicTest> syntheticPropertyOverridesUpdateCanBeEmptyFile() {
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
-                recordStreamMustIncludePassFrom(selectedItems(
+                blockStreamMustIncludePassFrom(selectedBlockItems(
                         sysFileExportValidator(
                                 "files.networkProperties",
                                 ServicesConfigurationList.getDefaultInstance(),
@@ -331,8 +328,7 @@ public class SystemFileExportsTest {
         final var upgradePermissionOverrides =
                 ServicesConfigurationList.parseFrom(SYS_FILE_SERDES.get(122L).toRawFile(overridePermissions, null));
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
-                recordStreamMustIncludePassFrom(selectedItems(
+                blockStreamMustIncludePassFrom(selectedBlockItems(
                         sysFileExportValidator(
                                 "files.hapiPermissions",
                                 upgradePermissionOverrides,
@@ -367,8 +363,7 @@ public class SystemFileExportsTest {
     @GenesisHapiTest
     final Stream<DynamicTest> syntheticNodeAdminKeysUpdateHappensAtUpgradeBoundary() {
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
-                recordStreamMustIncludePassFrom(selectedItems(
+                blockStreamMustIncludePassFrom(selectedBlockItems(
                         nodeUpdatesValidator(),
                         // Our node admin key file will contain two override keys
                         2,
@@ -419,10 +414,11 @@ public class SystemFileExportsTest {
     final Stream<DynamicTest> syntheticFileCreationsMatchQueriesAndNodeStakeUpdate() {
         final AtomicReference<Map<FileID, Bytes>> preGenesisContents = new AtomicReference<>();
         return hapiTest(
-                overriding("blockStream.streamMode", "BOTH"),
                 getSystemFiles(preGenesisContents::set),
-                eventuallyAssertingExplicitPassWithReplay(
-                        selectedItems(
+                // Replay existing block files so we can still see synthetic file creations
+                // emitted at network startup, before this assertion subscribed.
+                blockStreamMustIncludePassWithReplayFrom(
+                        selectedBlockItems(
                                 validatorFor(preGenesisContents),
                                 19,
                                 (ignore, item) -> item.getRecord().getReceipt().hasFileID()


### PR DESCRIPTION
**Description**:
Enables pre-existing assertions to work with BLOCKS streaming mode, patches MISC tag tests.

Fixes #
