### PR TITLE
feat: improve async streams for reconnect.

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/lag/BenchmarkSlowAsyncOutputStream.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/lag/BenchmarkSlowAsyncOutputStream.java
@@ -46,7 +46,12 @@ public class BenchmarkSlowAsyncOutputStream extends AsyncOutputStream {
             final long delayNetworkMicroseconds,
             final double delayNetworkFuzzRangePercent,
             @NonNull final ReconnectConfig reconnectConfig) {
-        super(out, workGroup, reconnectConfig);
+        super(
+                out,
+                workGroup,
+                reconnectConfig.asyncStreamBufferSize(),
+                reconnectConfig.asyncOutputStreamFlush(),
+                reconnectConfig.asyncStreamTimeout());
 
         // Note that we use randomSeed and -randomSeed for the two fuzzers
         // to ensure that they don't end up returning the exact same
@@ -65,7 +70,7 @@ public class BenchmarkSlowAsyncOutputStream extends AsyncOutputStream {
      * simulating slow disk reads.
      */
     @Override
-    public void sendAsync(@NonNull final byte[] messageBytes) throws InterruptedException {
+    public void sendAsync(@NonNull final byte @NonNull [] messageBytes) throws InterruptedException {
         sleepMicros(delayStorageMicrosecondsFuzzer.next());
         super.sendAsync(messageBytes);
     }
@@ -77,7 +82,7 @@ public class BenchmarkSlowAsyncOutputStream extends AsyncOutputStream {
      * simulating slow network I/O.
      */
     @Override
-    protected void writeMessage(@NonNull final byte[] messageBytes) throws IOException {
+    protected void writeMessage(@NonNull final byte @NonNull [] messageBytes) throws IOException {
         sleepMicros(delayNetworkMicrosecondsFuzzer.next());
         super.writeMessage(messageBytes);
     }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeReceiveTask.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeReceiveTask.java
@@ -79,7 +79,7 @@ public class LearnerPullVirtualTreeReceiveTask {
     private void run() {
         try {
             while (!Thread.currentThread().isInterrupted()) {
-                final byte[] responseBytes = in.readOrWait(YieldStrategy.SPIN);
+                final byte[] responseBytes = in.readOrWait(YieldStrategy.SLEEP);
                 if (responseBytes == null) {
                     break;
                 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeReceiveTask.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeReceiveTask.java
@@ -7,6 +7,7 @@ import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.swirlds.virtualmap.internal.Path;
 import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
 import com.swirlds.virtualmap.sync.streams.AsyncInputStream;
+import com.swirlds.virtualmap.sync.streams.YieldStrategy;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.logging.log4j.LogManager;
@@ -78,13 +79,9 @@ public class LearnerPullVirtualTreeReceiveTask {
     private void run() {
         try {
             while (!Thread.currentThread().isInterrupted()) {
-                final byte[] responseBytes = in.readAnticipatedMessage();
+                final byte[] responseBytes = in.readOrWait(YieldStrategy.SPIN);
                 if (responseBytes == null) {
-                    if (!in.isAlive()) {
-                        break;
-                    }
-                    Thread.sleep(0, 1);
-                    continue;
+                    break;
                 }
                 final PullVirtualTreeResponse response =
                         PullVirtualTreeResponse.parseFrom(BufferedData.wrap(responseBytes));

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeView.java
@@ -170,7 +170,7 @@ public final class LearnerPullVirtualTreeView implements LearnerTreeView {
         mapStats.incrementTransfersFromLearner();
 
         // wait for response
-        final byte[] rootResponseBytes = in.readOrWait(YieldStrategy.SPIN);
+        final byte[] rootResponseBytes = in.readOrWait(YieldStrategy.PARK);
         if (rootResponseBytes == null) {
             throw new MerkleSynchronizationException("Stream closed before root node response was received");
         }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/LearnerPullVirtualTreeView.java
@@ -13,6 +13,7 @@ import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
 import com.swirlds.virtualmap.sync.stats.ReconnectMapStats;
 import com.swirlds.virtualmap.sync.streams.AsyncInputStream;
 import com.swirlds.virtualmap.sync.streams.AsyncOutputStream;
+import com.swirlds.virtualmap.sync.streams.YieldStrategy;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.Objects;
@@ -120,7 +121,12 @@ public final class LearnerPullVirtualTreeView implements LearnerTreeView {
         // any parallel tasks. The root response carries the teacher's first/last leaf path range,
         // which must be known before the traversal order can be started and before any parallel
         // send tasks can generate meaningful non-root requests.
-        exchangeRootNode(in, out);
+        try {
+            exchangeRootNode(in, out);
+        } catch (Exception e) {
+            workGroup.handleError(e);
+            throw e; // rethrow
+        }
 
         final AtomicLong expectedResponses = new AtomicLong(0);
         // FUTURE WORK: configurable number of tasks
@@ -164,8 +170,7 @@ public final class LearnerPullVirtualTreeView implements LearnerTreeView {
         mapStats.incrementTransfersFromLearner();
 
         // wait for response
-        final byte[] rootResponseBytes =
-                in.readAnticipatedMessageSync(reconnectConfig.pullLearnerRootResponseTimeout());
+        final byte[] rootResponseBytes = in.readOrWait(YieldStrategy.SPIN);
         if (rootResponseBytes == null) {
             throw new MerkleSynchronizationException("Stream closed before root node response was received");
         }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/TeacherPullVirtualTreeReceiveTask.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/TeacherPullVirtualTreeReceiveTask.java
@@ -11,6 +11,7 @@ import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import com.swirlds.virtualmap.internal.Path;
 import com.swirlds.virtualmap.sync.streams.AsyncInputStream;
 import com.swirlds.virtualmap.sync.streams.AsyncOutputStream;
+import com.swirlds.virtualmap.sync.streams.YieldStrategy;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
@@ -105,13 +106,9 @@ public class TeacherPullVirtualTreeReceiveTask {
             final long start = System.currentTimeMillis();
             while (!Thread.currentThread().isInterrupted()) {
                 rateLimit();
-                final byte[] requestBytes = in.readAnticipatedMessage();
+                final byte[] requestBytes = in.readOrWait(YieldStrategy.SLEEP);
                 if (requestBytes == null) {
-                    if (!in.isAlive()) {
-                        break;
-                    }
-                    Thread.sleep(0, 1);
-                    continue;
+                    break;
                 }
                 final PullVirtualTreeRequest request =
                         PullVirtualTreeRequest.parseFrom(BufferedData.wrap(requestBytes));

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/TeacherPullVirtualTreeView.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/TeacherPullVirtualTreeView.java
@@ -15,6 +15,7 @@ import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
 import com.swirlds.virtualmap.sync.TeacherTreeView;
 import com.swirlds.virtualmap.sync.streams.AsyncInputStream;
 import com.swirlds.virtualmap.sync.streams.AsyncOutputStream;
+import com.swirlds.virtualmap.sync.streams.YieldStrategy;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
@@ -65,7 +66,12 @@ public final class TeacherPullVirtualTreeView implements TeacherTreeView {
         // any parallel tasks. The root response carries the teacher's first/last leaf path range.
         // Once sent, the learner will start sending non-root requests, which the parallel tasks
         // will process. This guarantees no task races for the first message on the stream.
-        exchangeRootNode(in, out);
+        try {
+            exchangeRootNode(in, out);
+        } catch (Exception e) {
+            workGroup.handleError(e);
+            throw e; // rethrow
+        }
 
         // FUTURE work: pool size config
         final int teacherTasks = 16;
@@ -88,7 +94,7 @@ public final class TeacherPullVirtualTreeView implements TeacherTreeView {
      * @throws MerkleSynchronizationException if the exchange fails, times out, or is interrupted
      */
     private void exchangeRootNode(final AsyncInputStream in, final AsyncOutputStream out) {
-        final byte[] rootRequestBytes = in.readAnticipatedMessageSync();
+        final byte[] rootRequestBytes = in.readOrWait(YieldStrategy.PARK);
         if (rootRequestBytes == null) {
             throw new MerkleSynchronizationException("Stream closed before root node request was received");
         }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/LearningSynchronizer.java
@@ -91,8 +91,8 @@ public class LearningSynchronizer {
      * @throws InterruptedException if the current thread is interrupted
      */
     private void receiveTree() throws InterruptedException {
-        final AsyncInputStream in =
-                new AsyncInputStream(inputStream, workGroup, reconnectConfig.asyncStreamBufferSize());
+        final AsyncInputStream in = new AsyncInputStream(
+                inputStream, workGroup, reconnectConfig.asyncStreamBufferSize(), reconnectConfig.asyncStreamTimeout());
         in.start();
         final AsyncOutputStream out = buildOutputStream(workGroup, outputStream, reconnectConfig);
         out.start();

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/LearningSynchronizer.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/LearningSynchronizer.java
@@ -91,7 +91,8 @@ public class LearningSynchronizer {
      * @throws InterruptedException if the current thread is interrupted
      */
     private void receiveTree() throws InterruptedException {
-        final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, reconnectConfig);
+        final AsyncInputStream in =
+                new AsyncInputStream(inputStream, workGroup, reconnectConfig.asyncStreamBufferSize());
         in.start();
         final AsyncOutputStream out = buildOutputStream(workGroup, outputStream, reconnectConfig);
         out.start();
@@ -109,7 +110,6 @@ public class LearningSynchronizer {
         }
 
         if (interruptException != null || workGroup.hasExceptions()) {
-            in.abort();
             if (interruptException != null) {
                 throw interruptException;
             }
@@ -136,6 +136,11 @@ public class LearningSynchronizer {
             @NonNull final StandardWorkGroup workGroup,
             @NonNull final DataOutputStream out,
             @NonNull final ReconnectConfig reconnectConfig) {
-        return new AsyncOutputStream(out, workGroup, reconnectConfig);
+        return new AsyncOutputStream(
+                out,
+                workGroup,
+                reconnectConfig.asyncStreamBufferSize(),
+                reconnectConfig.asyncOutputStreamFlush(),
+                reconnectConfig.asyncStreamTimeout());
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/TeachingSynchronizer.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/TeachingSynchronizer.java
@@ -87,7 +87,8 @@ public class TeachingSynchronizer {
      * Perform reconnect in the role of the teacher.
      */
     public void synchronize() throws InterruptedException {
-        final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, reconnectConfig);
+        final AsyncInputStream in =
+                new AsyncInputStream(inputStream, workGroup, reconnectConfig.asyncStreamBufferSize());
         in.start();
         final AsyncOutputStream out = buildOutputStream(workGroup, outputStream, reconnectConfig);
         out.start();
@@ -105,7 +106,6 @@ public class TeachingSynchronizer {
         }
 
         if ((interruptException != null) || workGroup.hasExceptions()) {
-            in.abort();
             if (interruptException != null) {
                 throw interruptException;
             }
@@ -130,6 +130,11 @@ public class TeachingSynchronizer {
             @NonNull final StandardWorkGroup workGroup,
             @NonNull final DataOutputStream out,
             @NonNull final ReconnectConfig reconnectConfig) {
-        return new AsyncOutputStream(out, workGroup, reconnectConfig);
+        return new AsyncOutputStream(
+                out,
+                workGroup,
+                reconnectConfig.asyncStreamBufferSize(),
+                reconnectConfig.asyncOutputStreamFlush(),
+                reconnectConfig.asyncStreamTimeout());
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/TeachingSynchronizer.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/TeachingSynchronizer.java
@@ -87,8 +87,8 @@ public class TeachingSynchronizer {
      * Perform reconnect in the role of the teacher.
      */
     public void synchronize() throws InterruptedException {
-        final AsyncInputStream in =
-                new AsyncInputStream(inputStream, workGroup, reconnectConfig.asyncStreamBufferSize());
+        final AsyncInputStream in = new AsyncInputStream(
+                inputStream, workGroup, reconnectConfig.asyncStreamBufferSize(), reconnectConfig.asyncStreamTimeout());
         in.start();
         final AsyncOutputStream out = buildOutputStream(workGroup, outputStream, reconnectConfig);
         out.start();

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncInputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncInputStream.java
@@ -211,7 +211,7 @@ public class AsyncInputStream {
             }
             if (!isAlive()) {
                 // Drain race: the producer may have enqueued one final message
-                // between our last poll and flipping alive=false in its finally.
+                // between our last poll and the background reader transitioning to done as it exits.
                 return readOrNull();
             }
             if (Thread.currentThread().isInterrupted()) {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncInputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncInputStream.java
@@ -8,17 +8,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
-import org.hiero.consensus.reconnect.config.ReconnectConfig;
 
 /**
  * <p>
@@ -28,13 +24,22 @@ import org.hiero.consensus.reconnect.config.ReconnectConfig;
  * <p>
  * A background thread continuously reads messages from the underlying {@link DataInputStream}
  * and enqueues them as raw {@code byte[]} arrays. Consumers retrieve messages via
- * {@link #readAnticipatedMessage()} (non-blocking) or {@link #readAnticipatedMessageSync()}
- * (blocking with timeout). Callers are responsible for parsing the raw bytes into domain objects.
+ * {@link #readOrWait(YieldStrategy)}, which blocks (with the caller-chosen yield strategy)
+ * until a message is available or the stream is permanently done. There is no timeout for readers,
+ * because this class intended to be used with socket input stream, which should have a timeout.
  * </p>
  *
  * <p>
- * This object is not thread safe. Only one thread should attempt to read messages at any point
- * in time.
+ * This object is thread safe. Multiple consumers may call {@link #readOrWait(YieldStrategy)} in parallel.
+ * </p>
+ *
+ * <p>
+ * Lifecycle is tracked by {@link Status}: {@link Status#NOT_STARTED} → {@link Status#RUNNING} (set by a successful
+ * {@link #start()}) → {@link Status#DONE} (set by the background thread when it exits — normal EOF marker, I/O error,
+ * or interrupt). Shutdown is driven by either an {@link IOException} (EOF marker, socket timeout, etc.) on the stream
+ * or by an interrupt delivered through {@link StandardWorkGroup} (e.g. {@code handleError} → {@code shutdownNow}). An
+ * I/O error is reported through the work group rather than the status, so {@link Status#DONE} does not distinguish
+ * clean shutdown from a failure — callers that care should consult {@link StandardWorkGroup#hasExceptions()}.
  * </p>
  */
 public class AsyncInputStream {
@@ -43,52 +48,75 @@ public class AsyncInputStream {
 
     private static final String THREAD_NAME = "async-input-stream";
 
+    // maximum message size in bytes - 8mb
+    public static final int MAX_MESSAGE_SIZE = 8 * 1024 * 1024;
+
+    /** Lifecycle states of the background reader thread. Transitions are monotonic. */
+    public enum Status {
+        /** {@link #start()} has not been called yet. */
+        NOT_STARTED,
+        /** The background reader thread is running and may be enqueuing messages. */
+        RUNNING,
+        /** The background reader thread has exited (clean EOF, I/O error, or interrupt). */
+        DONE
+    }
+
     private final DataInputStream inputStream;
 
     private final Queue<byte[]> inputQueue = new ConcurrentLinkedQueue<>();
 
-    // Checking queue size on every received message may be expensive. Instead, track the
-    // size manually using an atomic
+    // Tracking queue size with an atomic avoids the O(n) walk that
+    // ConcurrentLinkedQueue.size() performs on every enqueue.
     private final AtomicInteger inputQueueSize = new AtomicInteger(0);
 
-    private final Duration pollTimeout;
-
-    /**
-     * Becomes 0 when the input thread is finished.
-     */
-    private final CountDownLatch finishedLatch;
-
-    private final AtomicBoolean alive = new AtomicBoolean(true);
+    // Single writer per transition: start() sets RUNNING under sync; the background
+    // thread sets DONE on exit. Volatile is sufficient for visibility.
+    private volatile Status status = Status.NOT_STARTED;
 
     private final StandardWorkGroup workGroup;
 
-    private final int sharedQueueSizeThreshold;
+    private final int queueSizeThreshold;
 
     /**
      * Create a new async input stream.
      *
      * @param inputStream the base stream to read from
      * @param workGroup the work group that is managing this stream's thread
-     * @param reconnectConfig the configuration to use
+     * @param queueSizeThreshold max size of the queue for reader thread backpressure
      */
     public AsyncInputStream(
             @NonNull final DataInputStream inputStream,
             @NonNull final StandardWorkGroup workGroup,
-            @NonNull final ReconnectConfig reconnectConfig) {
-        Objects.requireNonNull(reconnectConfig, "reconnectConfig must not be null");
-
+            final int queueSizeThreshold) {
         this.inputStream = Objects.requireNonNull(inputStream, "inputStream must not be null");
         this.workGroup = Objects.requireNonNull(workGroup, "workGroup must not be null");
-        this.finishedLatch = new CountDownLatch(1);
-        this.pollTimeout = reconnectConfig.asyncStreamTimeout();
-        this.sharedQueueSizeThreshold = reconnectConfig.asyncStreamBufferSize();
+
+        if (queueSizeThreshold <= 0) {
+            throw new IllegalArgumentException("queueSizeThreshold must be greater than 0");
+        }
+        this.queueSizeThreshold = queueSizeThreshold;
     }
 
     /**
      * Start the background thread that reads from the input stream and populates the internal queue.
+     * This method can be called only once.
+     *
+     * @throws IllegalStateException if background thread is already started or terminated
+     * @throws MerkleSynchronizationException if background thread cannot be submitted for execution
      */
-    public void start() {
-        workGroup.execute(THREAD_NAME, this::run);
+    public synchronized void start() {
+        if (status != Status.NOT_STARTED) {
+            throw new IllegalStateException("Stream status has already been set: " + status);
+        }
+        status = Status.RUNNING;
+
+        try {
+            workGroup.execute(THREAD_NAME, this::run);
+        } catch (Exception e) {
+            status = Status.DONE;
+            workGroup.handleError(e); // terminate other tasks that already running
+            throw new MerkleSynchronizationException("Background reading thread cannot be submitted for execution", e);
+        }
     }
 
     /**
@@ -96,20 +124,25 @@ public class AsyncInputStream {
      * enqueues them. A negative length value serves as a termination marker.
      */
     private void run() {
-        logger.debug(RECONNECT.getMarker(), Thread.currentThread().getName() + " run");
+        logger.debug(RECONNECT.getMarker(), "Background reader thread started");
+
         try {
             while (!Thread.currentThread().isInterrupted()) {
                 final int len = inputStream.readInt();
                 if (len < 0) {
                     logger.info(RECONNECT.getMarker(), "Async input stream is done");
-                    alive.set(false);
-                    break;
+                    return;
+                } else if (len > MAX_MESSAGE_SIZE) {
+                    throw new MerkleSynchronizationException(
+                            "Message size exceeds maximum size of " + MAX_MESSAGE_SIZE);
                 }
+
                 final byte[] messageBytes = new byte[len];
                 inputStream.readFully(messageBytes, 0, len);
                 inputQueue.add(messageBytes);
-                if (inputQueueSize.incrementAndGet() > sharedQueueSizeThreshold) {
-                    while (inputQueueSize.get() > sharedQueueSizeThreshold
+
+                if (inputQueueSize.incrementAndGet() >= queueSizeThreshold) {
+                    while (inputQueueSize.get() >= queueSizeThreshold
                             && !Thread.currentThread().isInterrupted()) {
                         Thread.onSpinWait();
                     }
@@ -119,94 +152,72 @@ public class AsyncInputStream {
             logger.warn(RECONNECT.getMarker(), "Async input stream failed due to I/O error", e);
             workGroup.handleError(e);
         } finally {
-            finishedLatch.countDown();
+            status = Status.DONE;
+            logger.debug(RECONNECT.getMarker(), "Background reader thread stopped");
         }
-        logger.debug(RECONNECT.getMarker(), Thread.currentThread().getName() + " done");
     }
 
     /**
-     * Returns {@code true} if the background reader thread has not yet encountered the termination
-     * marker or an error.
-     *
-     * @return whether the stream is still alive
+     * Returns {@code true} while the background reader thread is running.
+     * Even if background reader is not alive, consumers may still try to read queued messages
+     * until {@link #readOrWait(YieldStrategy)} doesn't return {@code null}.
      */
     public boolean isAlive() {
-        return alive.get();
+        return status == Status.RUNNING;
     }
 
     /**
-     * Read the next raw message bytes from the queue (non-blocking).
+     * @return current lifecycle status of the background reader thread. Visible for tests.
+     */
+    Status getStatus() {
+        return status;
+    }
+
+    /**
+     * @return current input queue size
+     */
+    int getInputQueueSize() {
+        return inputQueueSize.get();
+    }
+
+    /**
+     * Non-blocking poll of the internal queue.
      *
-     * @return the message bytes, or {@code null} if no message is available
+     * @return the next message bytes, or {@code null} if the queue is empty
      */
     @Nullable
-    public byte[] readAnticipatedMessage() {
-        final byte[] itemBytes = inputQueue.poll();
-        if (itemBytes != null) {
+    private byte[] readOrNull() {
+        final byte[] msg = inputQueue.poll();
+        if (msg != null) {
             inputQueueSize.decrementAndGet();
         }
-        return itemBytes;
+        return msg;
     }
 
     /**
-     * Read the next raw message bytes from the queue, blocking until one is available or the
-     * configured stream timeout expires.
+     * Read the next raw message bytes from the queue, waiting with the given yield strategy until
+     * a message is available, the background reader has finished and drained, or the calling
+     * thread is interrupted.
      *
-     * @return the message bytes, or {@code null} if the stream is no longer alive
-     * @throws MerkleSynchronizationException if the operation times out
+     * @param yield how the calling thread should wait between polls
+     * @return the next message bytes, or {@code null} if the caller was interrupted or the stream is permanently done and no messages available in the queue
      */
     @Nullable
-    public byte[] readAnticipatedMessageSync() {
-        return readAnticipatedMessageSync(pollTimeout);
-    }
-
-    /**
-     * Read the next raw message bytes from the queue, blocking until one is available or the
-     * given timeout expires.
-     *
-     * @param timeout the maximum time to wait for a message
-     * @return the message bytes, or {@code null} if the stream is no longer alive
-     * @throws MerkleSynchronizationException if the operation times out or is interrupted
-     */
-    @Nullable
-    public byte[] readAnticipatedMessageSync(@NonNull final Duration timeout) {
-        byte[] message = readAnticipatedMessage();
-        if (message != null) {
-            return message;
-        }
-        final long start = System.currentTimeMillis();
-        final Thread currentThread = Thread.currentThread();
+    public byte[] readOrWait(@NonNull final YieldStrategy yield) {
         while (true) {
-            message = readAnticipatedMessage();
-            if (message != null) {
-                return message;
+            final byte[] msg = readOrNull();
+            if (msg != null) {
+                return msg;
             }
             if (!isAlive()) {
+                // Drain race: the producer may have enqueued one final message
+                // between our last poll and flipping alive=false in its finally.
+                return readOrNull();
+            }
+            if (Thread.currentThread().isInterrupted()) {
                 return null;
             }
-            final long now = System.currentTimeMillis();
-            if (currentThread.isInterrupted() || (now - start > timeout.toMillis())) {
-                break;
-            }
-        }
-        if (currentThread.isInterrupted()) {
-            throw new MerkleSynchronizationException("Interrupted while waiting for data");
-        } else {
-            throw new MerkleSynchronizationException("Timed out waiting for data");
-        }
-    }
-
-    /**
-     * Signals the background reader to stop and waits for it to finish. This method should be
-     * called when the consumer decides to stop reading from the stream, for example after
-     * encountering an exception.
-     */
-    public void abort() {
-        alive.set(false);
-        try {
-            finishedLatch.await();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            yield.yield();
         }
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncInputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncInputStream.java
@@ -8,10 +8,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
@@ -49,7 +51,7 @@ public class AsyncInputStream {
     private static final String THREAD_NAME = "async-input-stream";
 
     // maximum message size in bytes - 8mb
-    public static final int MAX_MESSAGE_SIZE = 8 * 1024 * 1024;
+    static final int MAX_MESSAGE_SIZE = 8 * 1024 * 1024;
 
     /** Lifecycle states of the background reader thread. Transitions are monotonic. */
     public enum Status {
@@ -69,32 +71,43 @@ public class AsyncInputStream {
     // ConcurrentLinkedQueue.size() performs on every enqueue.
     private final AtomicInteger inputQueueSize = new AtomicInteger(0);
 
-    // Single writer per transition: start() sets RUNNING under sync; the background
-    // thread sets DONE on exit. Volatile is sufficient for visibility.
-    private volatile Status status = Status.NOT_STARTED;
+    // Single writer per transition: start() sets RUNNING atomically; the background
+    // thread sets DONE on exit.
+    private final AtomicReference<Status> status = new AtomicReference<>(Status.NOT_STARTED);
 
     private final StandardWorkGroup workGroup;
 
     private final int queueSizeThreshold;
 
+    private final long timeoutNanos;
+
     /**
      * Create a new async input stream.
      *
-     * @param inputStream the base stream to read from
-     * @param workGroup the work group that is managing this stream's thread
-     * @param queueSizeThreshold max size of the queue for reader thread backpressure
+     * @param inputStream           the base stream to read from
+     * @param workGroup             the work group that is managing this stream's thread
+     * @param queueSizeThreshold    max size of the queue for reader thread backpressure
+     * @param timeout               maximum time {@link #readOrWait(YieldStrategy)} will wait when the buffer is full;
+     *                              must be non-null and positive
      */
     public AsyncInputStream(
             @NonNull final DataInputStream inputStream,
             @NonNull final StandardWorkGroup workGroup,
-            final int queueSizeThreshold) {
+            final int queueSizeThreshold,
+            @NonNull final Duration timeout) {
         this.inputStream = Objects.requireNonNull(inputStream, "inputStream must not be null");
         this.workGroup = Objects.requireNonNull(workGroup, "workGroup must not be null");
+        Objects.requireNonNull(timeout, "timeout must not be null");
 
         if (queueSizeThreshold <= 0) {
             throw new IllegalArgumentException("queueSizeThreshold must be greater than 0");
         }
+        if (!timeout.isPositive()) {
+            throw new IllegalArgumentException("timeout must be positive");
+        }
+
         this.queueSizeThreshold = queueSizeThreshold;
+        this.timeoutNanos = timeout.toNanos();
     }
 
     /**
@@ -104,16 +117,15 @@ public class AsyncInputStream {
      * @throws IllegalStateException if background thread is already started or terminated
      * @throws MerkleSynchronizationException if background thread cannot be submitted for execution
      */
-    public synchronized void start() {
-        if (status != Status.NOT_STARTED) {
-            throw new IllegalStateException("Stream status has already been set: " + status);
+    public void start() {
+        if (!status.compareAndSet(Status.NOT_STARTED, Status.RUNNING)) {
+            throw new IllegalStateException("Stream status has already been set: " + status.get());
         }
-        status = Status.RUNNING;
 
         try {
             workGroup.execute(THREAD_NAME, this::run);
         } catch (Exception e) {
-            status = Status.DONE;
+            status.set(Status.DONE);
             workGroup.handleError(e); // terminate other tasks that already running
             throw new MerkleSynchronizationException("Background reading thread cannot be submitted for execution", e);
         }
@@ -152,31 +164,22 @@ public class AsyncInputStream {
             logger.warn(RECONNECT.getMarker(), "Async input stream failed due to I/O error", e);
             workGroup.handleError(e);
         } finally {
-            status = Status.DONE;
+            status.set(Status.DONE);
             logger.debug(RECONNECT.getMarker(), "Background reader thread stopped");
         }
-    }
-
-    /**
-     * Returns {@code true} while the background reader thread is running.
-     * Even if background reader is not alive, consumers may still try to read queued messages
-     * until {@link #readOrWait(YieldStrategy)} doesn't return {@code null}.
-     */
-    public boolean isAlive() {
-        return status == Status.RUNNING;
     }
 
     /**
      * @return current lifecycle status of the background reader thread. Visible for tests.
      */
     Status getStatus() {
-        return status;
+        return status.get();
     }
 
     /**
      * @return current input queue size
      */
-    int getInputQueueSize() {
+    int getQueueSize() {
         return inputQueueSize.get();
     }
 
@@ -201,23 +204,26 @@ public class AsyncInputStream {
      *
      * @param yield how the calling thread should wait between polls
      * @return the next message bytes, or {@code null} if the caller was interrupted or the stream is permanently done and no messages available in the queue
+     * @throws MerkleSynchronizationException if timeout on waiting for the message when buffer is empty
      */
     @Nullable
     public byte[] readOrWait(@NonNull final YieldStrategy yield) {
-        while (true) {
+        final long start = System.nanoTime();
+        while (!Thread.currentThread().isInterrupted()) {
             final byte[] msg = readOrNull();
             if (msg != null) {
                 return msg;
             }
-            if (!isAlive()) {
+            if (status.get() != Status.RUNNING) {
                 // Drain race: the producer may have enqueued one final message
                 // between our last poll and the background reader transitioning to done as it exits.
                 return readOrNull();
             }
-            if (Thread.currentThread().isInterrupted()) {
-                return null;
-            }
             yield.yield();
+            if (System.nanoTime() - start > timeoutNanos) {
+                throw new MerkleSynchronizationException("Timed out waiting for message from the input stream");
+            }
         }
+        return null;
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStream.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
@@ -68,20 +69,19 @@ public class AsyncOutputStream {
     private final DataOutputStream outputStream;
 
     /** Bounded buffer providing backpressure for {@link #sendAsync(byte[])}. */
-    private final BlockingQueue<byte[]> streamQueue;
+    private final BlockingQueue<byte[]> outputQueue;
 
     /** Maximum time the background thread waits for a new message before flushing buffered data. */
     private final Duration flushInterval;
 
     /** Maximum time {@link #sendAsync(byte[])} will wait when the buffer is full. */
-    private final Duration timeout;
+    private final long timeoutNanos;
 
     private final StandardWorkGroup workGroup;
 
-    // Single writer per transition: start() sets RUNNING under sync; done() sets FINISHING under
-    // sync (guarded — no-op unless RUNNING); the background thread sets DONE on exit.
-    // Volatile is sufficient for visibility.
-    private volatile Status status = Status.NOT_STARTED;
+    // Single writer per transition: start() sets RUNNING atomically; done() sets FINISHING atomically
+    // (guarded — no-op unless RUNNING); the background thread sets DONE on exit.
+    private final AtomicReference<Status> status = new AtomicReference<>(Status.NOT_STARTED);
 
     /**
      * Constructs a new instance.
@@ -108,16 +108,16 @@ public class AsyncOutputStream {
         if (bufferSize <= 0) {
             throw new IllegalArgumentException("bufferSize must be greater than 0");
         }
-        if (flushInterval.isNegative() || flushInterval.isZero()) {
+        if (!flushInterval.isPositive()) {
             throw new IllegalArgumentException("flushInterval must be positive");
         }
-        if (timeout.isNegative() || timeout.isZero()) {
+        if (!timeout.isPositive()) {
             throw new IllegalArgumentException("timeout must be positive");
         }
 
-        this.streamQueue = new LinkedBlockingQueue<>(bufferSize);
+        this.outputQueue = new LinkedBlockingQueue<>(bufferSize);
         this.flushInterval = flushInterval;
-        this.timeout = timeout;
+        this.timeoutNanos = timeout.toNanos();
     }
 
     /**
@@ -126,16 +126,15 @@ public class AsyncOutputStream {
      * @throws IllegalStateException          if the stream has already been started or terminated
      * @throws MerkleSynchronizationException if the background thread cannot be submitted for execution
      */
-    public synchronized void start() {
-        if (status != Status.NOT_STARTED) {
-            throw new IllegalStateException("Stream status has already been set: " + status);
+    public void start() {
+        if (!status.compareAndSet(Status.NOT_STARTED, Status.RUNNING)) {
+            throw new IllegalStateException("Stream status has already been set: " + status.get());
         }
-        status = Status.RUNNING;
 
         try {
             workGroup.execute(THREAD_NAME, this::run);
         } catch (Exception e) {
-            status = Status.DONE;
+            status.set(Status.DONE);
             workGroup.handleError(e); // terminate other tasks that already running
             throw new MerkleSynchronizationException("Background writing thread cannot be submitted for execution", e);
         }
@@ -149,10 +148,8 @@ public class AsyncOutputStream {
      * <p>Calls made before {@link #start()} or after the stream has reached {@link Status#FINISHING}
      * or {@link Status#DONE} are silent no-ops.
      */
-    public synchronized void done() {
-        if (status == Status.RUNNING) {
-            status = Status.FINISHING;
-        }
+    public void done() {
+        status.compareAndSet(Status.RUNNING, Status.FINISHING);
     }
 
     /**
@@ -166,28 +163,27 @@ public class AsyncOutputStream {
      * @throws MerkleSynchronizationException if the enqueue timed out because the buffer stayed full
      */
     public void sendAsync(@NonNull final byte[] messageBytes) throws InterruptedException {
-        if (status != Status.RUNNING) {
+        if (status.get() != Status.RUNNING) {
             throw new IllegalStateException("Stream is not running: " + status);
         }
-        final boolean success = streamQueue.offer(messageBytes, timeout.toNanos(), TimeUnit.NANOSECONDS);
+        final boolean success = outputQueue.offer(messageBytes, timeoutNanos, TimeUnit.NANOSECONDS);
         if (!success) {
             throw new MerkleSynchronizationException("Timed out waiting to send data");
         }
     }
 
     /**
-     * Returns {@code true} while the background writer thread is running, which includes both
-     * {@link Status#RUNNING} (accepting new work) and {@link Status#FINISHING} (draining).
-     */
-    public boolean isAlive() {
-        return status == Status.RUNNING || status == Status.FINISHING;
-    }
-
-    /**
      * @return current lifecycle status of the background writer thread. Visible for tests.
      */
     Status getStatus() {
-        return status;
+        return status.get();
+    }
+
+    /**
+     * @return current output queue size
+     */
+    int getQueueSize() {
+        return outputQueue.size();
     }
 
     /**
@@ -203,8 +199,8 @@ public class AsyncOutputStream {
         long lastFlushNanos = System.nanoTime();
         boolean dirty = false;
         try {
-            while (status == Status.RUNNING && !Thread.currentThread().isInterrupted()) {
-                final byte[] msg = streamQueue.poll(flushIntervalNanos, TimeUnit.NANOSECONDS);
+            while (status.get() == Status.RUNNING && !Thread.currentThread().isInterrupted()) {
+                final byte[] msg = outputQueue.poll(flushIntervalNanos, TimeUnit.NANOSECONDS);
                 if (msg != null) {
                     writeMessage(msg);
                     dirty = true;
@@ -218,7 +214,7 @@ public class AsyncOutputStream {
 
             // Drain any remaining queued messages submitted before done() was called.
             byte[] msg;
-            while ((msg = streamQueue.poll()) != null) {
+            while ((msg = outputQueue.poll()) != null) {
                 writeMessage(msg);
             }
 
@@ -232,7 +228,7 @@ public class AsyncOutputStream {
             logger.warn(RECONNECT.getMarker(), "Async output stream failed due to I/O error", e);
             workGroup.handleError(e);
         } finally {
-            status = Status.DONE;
+            status.set(Status.DONE);
             logger.debug(RECONNECT.getMarker(), "Background writer thread stopped");
         }
     }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStream.java
@@ -3,7 +3,6 @@ package com.swirlds.virtualmap.sync.streams;
 
 import static com.swirlds.logging.legacy.LogMarker.RECONNECT;
 
-import com.swirlds.base.time.StopWatch;
 import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.DataOutputStream;
@@ -13,183 +12,235 @@ import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
-import org.hiero.consensus.reconnect.config.ReconnectConfig;
 
 /**
  * <p>
- * Allows a thread to asynchronously send data over a stream.
+ * Allows producer threads to asynchronously send length-prefixed byte array messages over a stream.
  * </p>
  *
  * <p>
- * Only one type of message is allowed to be sent using an instance of this class. Originally this class was capable of
- * supporting arbitrary message types, but there was a significant memory footprint optimization that was made possible
- * by switching to single message type.
+ * A background thread continuously dequeues messages from an internal bounded buffer and writes
+ * length-prefixed frames to the underlying {@link DataOutputStream}. Producers enqueue messages with
+ * {@link #sendAsync(byte[])} (which blocks up to {@code timeout} when the buffer is full) and signal
+ * end-of-stream by calling {@link #done()}. After {@link #done()}, the background thread drains any
+ * remaining queued messages, writes a {@code -1} termination marker, flushes, and exits.
  * </p>
  *
  * <p>
- * This object is not thread safe. Only one thread should attempt to send data over this stream at any point in time.
+ * This object is thread safe. Multiple producers may call {@link #sendAsync(byte[])} in parallel and
+ * messages enqueued by a single producer are written to the stream in submission order. Ordering
+ * across producers is not guaranteed beyond what the underlying {@link BlockingQueue} provides.
+ * </p>
+ *
+ * <p>
+ * Lifecycle is tracked by {@link Status}: {@link Status#NOT_STARTED} → {@link Status#RUNNING} (set by
+ * {@link #start()}) → {@link Status#FINISHING} (set by {@link #done()}, while the background thread
+ * is still draining) → {@link Status#DONE} (set by the background thread when it exits — drain
+ * complete or I/O error). {@link #done()} only signals; observers wait for actual termination via the
+ * {@link StandardWorkGroup}. {@link #sendAsync(byte[])} only accepts new work while the status is
+ * {@link Status#RUNNING}; any call during {@link Status#FINISHING} or after fails with
+ * {@link IllegalStateException}. An I/O error is reported through the work group rather than the
+ * status, so {@link Status#DONE} does not distinguish clean shutdown from a failure — callers that
+ * care should consult {@link StandardWorkGroup#hasExceptions()}.
  * </p>
  */
 public class AsyncOutputStream {
 
     private static final Logger logger = LogManager.getLogger(AsyncOutputStream.class);
 
-    /**
-     * The stream which all data is written to.
-     */
+    private static final String THREAD_NAME = "async-output-stream";
+
+    /** Lifecycle states of the background writer thread. Transitions are monotonic. */
+    public enum Status {
+        /** {@link #start()} has not been called yet. */
+        NOT_STARTED,
+        /** The background writer thread is running and {@link #sendAsync(byte[])} accepts new work. */
+        RUNNING,
+        /** {@link #done()} has been called; the background thread is draining the queue before exit. */
+        FINISHING,
+        /** The background writer thread has exited (drain complete, I/O error, or interrupt). */
+        DONE
+    }
+
     private final DataOutputStream outputStream;
 
-    /**
-     * A queue that needs to be written to the output stream.
-     */
+    /** Bounded buffer providing backpressure for {@link #sendAsync(byte[])}. */
     private final BlockingQueue<byte[]> streamQueue;
 
-    /**
-     * The time that has elapsed since the last flush was attempted.
-     */
-    private final StopWatch timeSinceLastFlush;
-
-    /**
-     * The maximum amount of time that is permitted to pass without a flush being attempted.
-     */
+    /** Maximum time the background thread waits for a new message before flushing buffered data. */
     private final Duration flushInterval;
 
-    /**
-     * The number of messages that have been written to the stream but have not yet been flushed
-     */
-    private int bufferedMessageCount;
-
-    /**
-     * The maximum amount of time to wait when writing a message.
-     */
+    /** Maximum time {@link #sendAsync(byte[])} will wait when the buffer is full. */
     private final Duration timeout;
 
     private final StandardWorkGroup workGroup;
 
-    /**
-     * A condition to check whether it's time to terminate this output stream.
-     */
-    private final AtomicBoolean isDone = new AtomicBoolean(false);
+    // Single writer per transition: start() sets RUNNING under sync; done() sets FINISHING under
+    // sync (guarded — no-op unless RUNNING); the background thread sets DONE on exit.
+    // Volatile is sufficient for visibility.
+    private volatile Status status = Status.NOT_STARTED;
 
     /**
-     * Constructs a new instance using the given underlying {@link DataOutputStream} and
-     * {@link StandardWorkGroup}.
+     * Constructs a new instance.
      *
-     * @param outputStream the outputStream to which all objects are written
-     * @param workGroup    the work group that should be used to execute this thread
-     * @param config       the reconnect configuration
+     * @param outputStream  the stream all serialized messages are written to
+     * @param workGroup     the work group that executes the background writer thread
+     * @param bufferSize    capacity of the internal queue; must be {@code > 0}
+     * @param flushInterval maximum time the background thread waits for a new message before flushing
+     *                      buffered data; must be non-null and positive
+     * @param timeout       maximum time {@link #sendAsync(byte[])} will wait when the buffer is full;
+     *                      must be non-null and positive
      */
     public AsyncOutputStream(
             @NonNull final DataOutputStream outputStream,
             @NonNull final StandardWorkGroup workGroup,
-            @NonNull final ReconnectConfig config) {
-        Objects.requireNonNull(config, "config must not be null");
-
+            final int bufferSize,
+            @NonNull final Duration flushInterval,
+            @NonNull final Duration timeout) {
         this.outputStream = Objects.requireNonNull(outputStream, "outputStream must not be null");
         this.workGroup = Objects.requireNonNull(workGroup, "workGroup must not be null");
-        this.streamQueue = new LinkedBlockingQueue<>(config.asyncStreamBufferSize());
-        this.timeSinceLastFlush = new StopWatch();
-        this.timeSinceLastFlush.start();
-        this.flushInterval = config.asyncOutputStreamFlush();
-        this.timeout = config.asyncStreamTimeout();
-    }
+        Objects.requireNonNull(flushInterval, "flushInterval must not be null");
+        Objects.requireNonNull(timeout, "timeout must not be null");
 
-    /**
-     * Start the thread that writes to the stream.
-     */
-    public void start() {
-        workGroup.execute("async-output-stream", this::run);
-    }
-
-    /**
-     * Background thread loop. Drains the message queue, writes length-prefixed messages to the
-     * underlying stream, and flushes periodically. On termination, writes a {@code -1} marker.
-     */
-    public void run() {
-        logger.debug(RECONNECT.getMarker(), Thread.currentThread().getName() + " run");
-        try {
-            while ((!isDone.get() || !streamQueue.isEmpty())
-                    && !Thread.currentThread().isInterrupted()) {
-                flushIfRequired();
-                boolean workDone = handleQueuedMessages();
-                if (!workDone) {
-                    workDone = flush();
-                    if (!workDone) {
-                        Thread.onSpinWait();
-                    }
-                }
-            }
-            // Handle remaining queued messages
-            boolean wasNotEmpty = true;
-            while (wasNotEmpty) {
-                wasNotEmpty = handleQueuedMessages();
-            }
-            flush();
-            try {
-                logger.info(RECONNECT.getMarker(), Thread.currentThread().getName() + " closing stream");
-                // Send reconnect termination marker
-                outputStream.writeInt(-1);
-                outputStream.flush();
-            } catch (final IOException e) {
-                throw new MerkleSynchronizationException(e);
-            }
-        } catch (final Exception e) {
-            workGroup.handleError(e);
+        if (bufferSize <= 0) {
+            throw new IllegalArgumentException("bufferSize must be greater than 0");
         }
-        logger.debug(RECONNECT.getMarker(), Thread.currentThread().getName() + " done");
+        if (flushInterval.isNegative() || flushInterval.isZero()) {
+            throw new IllegalArgumentException("flushInterval must be positive");
+        }
+        if (timeout.isNegative() || timeout.isZero()) {
+            throw new IllegalArgumentException("timeout must be positive");
+        }
+
+        this.streamQueue = new LinkedBlockingQueue<>(bufferSize);
+        this.flushInterval = flushInterval;
+        this.timeout = timeout;
     }
 
     /**
-     * Send a pre-serialized message asynchronously. Messages are guaranteed to be delivered
-     * in the order sent.
+     * Start the background writer thread. This method can be called only once.
      *
-     * This method can be overridden to simulate disk write delays. Note that the caller thread will be delayed.
+     * @throws IllegalStateException          if the stream has already been started or terminated
+     * @throws MerkleSynchronizationException if the background thread cannot be submitted for execution
+     */
+    public synchronized void start() {
+        if (status != Status.NOT_STARTED) {
+            throw new IllegalStateException("Stream status has already been set: " + status);
+        }
+        status = Status.RUNNING;
+
+        try {
+            workGroup.execute(THREAD_NAME, this::run);
+        } catch (Exception e) {
+            status = Status.DONE;
+            workGroup.handleError(e); // terminate other tasks that already running
+            throw new MerkleSynchronizationException("Background writing thread cannot be submitted for execution", e);
+        }
+    }
+
+    /**
+     * Signal that no more messages will be sent. The background thread drains any remaining queued
+     * messages, writes a {@code -1} termination marker, flushes, and exits. This method only signals;
+     * observers wait for actual termination via {@link StandardWorkGroup#waitForTermination()}.
+     *
+     * <p>Calls made before {@link #start()} or after the stream has reached {@link Status#FINISHING}
+     * or {@link Status#DONE} are silent no-ops.
+     */
+    public synchronized void done() {
+        if (status == Status.RUNNING) {
+            status = Status.FINISHING;
+        }
+    }
+
+    /**
+     * Send a pre-serialized message asynchronously. Messages from a single producer are written to
+     * the underlying stream in submission order; ordering across producers is not guaranteed. When
+     * the internal buffer is full this call blocks for up to {@code timeout} and then throws.
      *
      * @param messageBytes the serialized message bytes
-     * @throws InterruptedException if interrupted while waiting to enqueue
+     * @throws InterruptedException           if the caller is interrupted while waiting to enqueue
+     * @throws IllegalStateException          if the stream is not in {@link Status#RUNNING}
+     * @throws MerkleSynchronizationException if the enqueue timed out because the buffer stayed full
      */
     public void sendAsync(@NonNull final byte[] messageBytes) throws InterruptedException {
+        if (status != Status.RUNNING) {
+            throw new IllegalStateException("Stream is not running: " + status);
+        }
         final boolean success = streamQueue.offer(messageBytes, timeout.toMillis(), TimeUnit.MILLISECONDS);
         if (!success) {
-            try {
-                outputStream.close();
-            } catch (final IOException e) {
-                throw new MerkleSynchronizationException("Unable to close stream", e);
-            }
             throw new MerkleSynchronizationException("Timed out waiting to send data");
         }
     }
 
     /**
-     * Send the next message if possible.
-     *
-     * @return true if a message was sent.
+     * Returns {@code true} while the background writer thread is running, which includes both
+     * {@link Status#RUNNING} (accepting new work) and {@link Status#FINISHING} (draining).
      */
-    private boolean handleQueuedMessages() {
-        byte[] item = streamQueue.poll();
-        if (item == null) {
-            return false;
-        }
-        try {
-            do {
-                writeMessage(item);
-                bufferedMessageCount += 1;
-                item = streamQueue.poll();
-            } while (item != null);
-        } catch (final IOException e) {
-            throw new MerkleSynchronizationException(e);
-        }
-        return true;
+    public boolean isAlive() {
+        return status == Status.RUNNING || status == Status.FINISHING;
     }
 
     /**
-     * Writes a single length-prefixed message to the underlying output stream. Called on
-     * the <b>writer thread</b> for each dequeued message. This method is helpful for testing
-     * when it comes to simulation of network latency.
+     * @return current lifecycle status of the background writer thread. Visible for tests.
+     */
+    Status getStatus() {
+        return status;
+    }
+
+    /**
+     * Background thread loop. Waits up to {@code flushInterval} for the next message, writes it as
+     * a length-prefixed frame, and flushes when {@code flushInterval} has elapsed since the last
+     * flush with buffered data pending. The wall-clock check is independent of the poll timeout, so
+     * a continuously-populated queue still gets periodic flushes. On shutdown, drains remaining
+     * messages, writes a {@code -1} termination marker, and flushes.
+     */
+    private void run() {
+        logger.debug(RECONNECT.getMarker(), "Background writer thread started");
+        final long flushIntervalNanos = flushInterval.toNanos();
+        long lastFlushNanos = System.nanoTime();
+        boolean dirty = false;
+        try {
+            while (status == Status.RUNNING && !Thread.currentThread().isInterrupted()) {
+                final byte[] msg = streamQueue.poll(flushIntervalNanos, TimeUnit.NANOSECONDS);
+                if (msg != null) {
+                    writeMessage(msg);
+                    dirty = true;
+                }
+                if (dirty && (System.nanoTime() - lastFlushNanos) >= flushIntervalNanos) {
+                    outputStream.flush();
+                    dirty = false;
+                    lastFlushNanos = System.nanoTime();
+                }
+            }
+
+            // Drain any remaining queued messages submitted before done() was called.
+            byte[] msg;
+            while ((msg = streamQueue.poll()) != null) {
+                writeMessage(msg);
+            }
+
+            // Termination marker
+            outputStream.writeInt(-1);
+            outputStream.flush();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logger.debug(RECONNECT.getMarker(), "Background writer thread interrupted");
+        } catch (final IOException e) {
+            logger.warn(RECONNECT.getMarker(), "Async output stream failed due to I/O error", e);
+            workGroup.handleError(e);
+        } finally {
+            status = Status.DONE;
+            logger.debug(RECONNECT.getMarker(), "Background writer thread stopped");
+        }
+    }
+
+    /**
+     * Writes a single length-prefixed message to the underlying output stream. Called on the
+     * <b>writer thread</b> for each dequeued message. Exposed as {@code protected} so test doubles
+     * (e.g. simulated network latency) can override per-message behavior.
      *
      * @param messageBytes the serialized message bytes
      * @throws IOException if writing to the stream fails
@@ -197,43 +248,5 @@ public class AsyncOutputStream {
     protected void writeMessage(@NonNull final byte[] messageBytes) throws IOException {
         outputStream.writeInt(messageBytes.length);
         outputStream.write(messageBytes);
-    }
-
-    /**
-     * Flushes the underlying output stream if any messages have been written since the last flush.
-     *
-     * @return {@code true} if a flush was performed
-     */
-    private boolean flush() {
-        timeSinceLastFlush.reset();
-        timeSinceLastFlush.start();
-        if (bufferedMessageCount > 0) {
-            try {
-                outputStream.flush();
-            } catch (final IOException e) {
-                throw new MerkleSynchronizationException(e);
-            }
-            bufferedMessageCount = 0;
-            return true;
-        }
-        return false;
-    }
-
-    /**
-     * Flush the stream if necessary.
-     */
-    private void flushIfRequired() {
-        if (timeSinceLastFlush.getElapsedTimeNano() > flushInterval.toNanos()) {
-            flush();
-        }
-    }
-
-    /**
-     * Marks this async output stream as done. All messages currently enqueued are processed,
-     * then the thread behind this object is exited. In the end, the stream sends a reconnect
-     * termination marker to the underlying output stream.
-     */
-    public void done() {
-        isDone.set(true);
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStream.java
@@ -169,7 +169,7 @@ public class AsyncOutputStream {
         if (status != Status.RUNNING) {
             throw new IllegalStateException("Stream is not running: " + status);
         }
-        final boolean success = streamQueue.offer(messageBytes, timeout.toMillis(), TimeUnit.MILLISECONDS);
+        final boolean success = streamQueue.offer(messageBytes, timeout.toNanos(), TimeUnit.NANOSECONDS);
         if (!success) {
             throw new MerkleSynchronizationException("Timed out waiting to send data");
         }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/YieldStrategy.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/YieldStrategy.java
@@ -4,7 +4,7 @@ package com.swirlds.virtualmap.sync.streams;
 import java.util.concurrent.locks.LockSupport;
 
 /**
- * Strategy to be used yield current thread while waiting for some data or resource.
+ * Strategy to be used to yield the current thread while waiting for some data or resource.
  *
  * <ul>
  *   <li>{@link #SPIN} — calls {@link Thread#onSpinWait()}, yielding a CPU hint without relinquishing

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/YieldStrategy.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/sync/streams/YieldStrategy.java
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.virtualmap.sync.streams;
+
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Strategy to be used yield current thread while waiting for some data or resource.
+ *
+ * <ul>
+ *   <li>{@link #SPIN} — calls {@link Thread#onSpinWait()}, yielding a CPU hint without relinquishing
+ *       the OS thread. Lowest latency, highest CPU burn.</li>
+ *   <li>{@link #PARK} — calls {@link LockSupport#parkNanos(long) LockSupport.parkNanos(1)},
+ *       briefly suspending the thread. Good balance between latency and CPU usage.</li>
+ *   <li>{@link #SLEEP} — calls {@link Thread#sleep(long, int) Thread.sleep(0, 1)}, relinquishing
+ *       the OS thread for the minimum quanta. Lowest CPU burn, highest latency.</li>
+ * </ul>
+ */
+public enum YieldStrategy {
+
+    /**
+     * CPU spin hint — no OS-level yielding. Best for latency-sensitive consumers with a fast producer.
+     */
+    SPIN {
+        @Override
+        public void yield() {
+            Thread.onSpinWait();
+        }
+    },
+
+    /**
+     * Park the thread for 1 nanosecond via {@link LockSupport}. Does not throw
+     * {@link InterruptedException}; interrupt status is preserved by the JVM.
+     */
+    PARK {
+        @Override
+        public void yield() {
+            LockSupport.parkNanos(1L);
+        }
+    },
+
+    /**
+     * Sleep for the minimum OS quanta (0 ms + 1 ns). On interrupt, the thread's interrupt flag
+     * is restored so the caller's interrupt check fires on the next iteration.
+     */
+    SLEEP {
+        @Override
+        public void yield() {
+            try {
+                Thread.sleep(0, 1);
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    };
+
+    /**
+     * Relinquish CPU control according to this strategy.
+     */
+    public abstract void yield();
+}

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncInputStreamTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncInputStreamTest.java
@@ -3,391 +3,661 @@ package com.swirlds.virtualmap.sync.streams;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyEquals;
+import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyFalse;
 import static org.hiero.consensus.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
-import com.swirlds.config.api.Configuration;
-import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
 import com.swirlds.virtualmap.test.fixtures.sync.BlockingInputStream;
-import com.swirlds.virtualmap.test.fixtures.sync.BlockingOutputStream;
 import com.swirlds.virtualmap.test.fixtures.sync.PairedStreams;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.hiero.base.concurrent.ThrowingRunnable;
 import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
-import org.hiero.consensus.concurrent.framework.config.ThreadConfiguration;
 import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
-import org.hiero.consensus.reconnect.config.ReconnectConfig;
-import org.hiero.consensus.reconnect.config.ReconnectConfig_;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-@DisplayName("Async Stream Test")
+@Tag(TestComponentTags.RECONNECT)
 class AsyncInputStreamTest {
 
-    private final Configuration configuration = new TestConfigBuilder()
-            .withConfigDataType(ReconnectConfig.class)
-            .withValue(ReconnectConfig_.ASYNC_STREAM_BUFFER_SIZE, 100)
-            .withValue(ReconnectConfig_.ASYNC_OUTPUT_STREAM_FLUSH, "50ms")
-            .getOrCreateConfig();
-    private final ReconnectConfig reconnectConfig = configuration.getConfigData(ReconnectConfig.class);
+    /** Default queue size threshold used by tests that don't care about backpressure boundaries. */
+    private static final int DEFAULT_QUEUE_SIZE = 100;
 
-    /** Serialize a long value into a byte array. */
-    private static byte[] serializeLong(final long value) {
-        final byte[] bytes = new byte[Long.BYTES];
-        BufferedData.wrap(bytes).writeLong(value);
-        return bytes;
+    /**
+     * Tests to validate constructor, basic properties and methods without starting background thread
+     */
+    @Nested
+    class BasicsWithoutStart {
+
+        @Test
+        @DisplayName("Constructor rejects null inputStream")
+        @SuppressWarnings("DataFlowIssue")
+        void constructorRejectsNullInputStream() {
+            assertThrows(
+                    NullPointerException.class,
+                    () -> new AsyncInputStream(null, mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE));
+        }
+
+        @Test
+        @DisplayName("Constructor rejects null workGroup")
+        @SuppressWarnings("DataFlowIssue")
+        void constructorRejectsNullWorkGroup() {
+            assertThrows(
+                    NullPointerException.class,
+                    () -> new AsyncInputStream(mock(DataInputStream.class), null, DEFAULT_QUEUE_SIZE));
+        }
+
+        @ParameterizedTest
+        @DisplayName("Constructor rejects non-positive queueSizeThreshold")
+        @ValueSource(ints = {-1, 0})
+        void constructorRejectsBadThreshold(int queueSizeThreshold) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new AsyncInputStream(
+                            mock(DataInputStream.class), mock(StandardWorkGroup.class), queueSizeThreshold));
+        }
+
+        @Test
+        @DisplayName("Not alive and queue is empty before start")
+        void notAliveAndEmptyBeforeStart() {
+            final AsyncInputStream in = new AsyncInputStream(
+                    mock(DataInputStream.class), mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE);
+
+            assertEquals(AsyncInputStream.Status.NOT_STARTED, in.getStatus(), "status should be NOT_STARTED");
+            assertFalse(in.isAlive(), "isAlive must be false before start()");
+            assertEquals(0, in.getInputQueueSize(), "queue size should be empty");
+        }
+
+        @ParameterizedTest
+        @EnumSource(YieldStrategy.class)
+        @DisplayName("readOrWait returns null on a stream that was never started")
+        void readOrWaitReturnNullAndOnNotStartedStream(final YieldStrategy yieldStrategy) {
+            final AsyncInputStream in = new AsyncInputStream(
+                    mock(DataInputStream.class), mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE);
+            assertNull(in.readOrWait(yieldStrategy), "Queue is empty and stream is not alive to return any message");
+        }
     }
 
-    /** Parse a long value from raw message bytes. */
+    /**
+     * Tests to validate normal work with single thread and no exceptions
+     */
+    @Nested
+    class SingleThreadBasics {
+
+        /**
+         * Create and start input stream reading data from predefined bytes array.
+         *
+         * @param data predefined data
+         * @param consumerTest test consuming async input stream - must read all messages
+         */
+        private void createStreamAndTest(final byte[] data, final Consumer<AsyncInputStream> consumerTest) {
+            // provided data must have a termination marker in the end
+            assertEquals(-1, data[data.length - 1], "test data doesn't have a termination marker");
+
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
+            final AsyncInputStream in = new AsyncInputStream(
+                    new DataInputStream(new ByteArrayInputStream(data)), workGroup, DEFAULT_QUEUE_SIZE);
+            in.start();
+
+            testAndAwaitTermination(workGroup, () -> {
+                // wait for background thread should read all the data
+                assertEventuallyFalse(
+                        in::isAlive,
+                        Duration.ofSeconds(3),
+                        "Stream should not be alive after termination marker is read");
+                assertEquals(AsyncInputStream.Status.DONE, in.getStatus(), "status should be DONE after termination");
+
+                consumerTest.accept(in);
+
+                assertNull(in.readOrWait(YieldStrategy.SPIN), "Stream should be drained after all messages");
+            });
+
+            // verify not able to start after termination
+            assertThrows(IllegalStateException.class, in::start, "Should have thrown an exception");
+        }
+
+        @Test
+        @DisplayName("No messages correct behavior")
+        void emptyData() throws IOException {
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final DataOutputStream dataOut = new DataOutputStream(byteOut);
+            dataOut.writeInt(-1); // termination
+            dataOut.flush();
+
+            createStreamAndTest(
+                    byteOut.toByteArray(),
+                    in -> assertEquals(0, in.getInputQueueSize(), "Input queue size should be empty"));
+        }
+
+        @ParameterizedTest
+        @EnumSource(YieldStrategy.class)
+        @DisplayName("Less than queue size messages decoded in order under each YieldStrategy")
+        void lessMessagesThanQueueSize(final YieldStrategy yield) throws IOException {
+            final int count = DEFAULT_QUEUE_SIZE - 1;
+
+            createStreamAndTest(encodeLongs(count), in -> {
+                assertEquals(count, in.getInputQueueSize(), "Input queue size should match number of messages");
+
+                for (int i = 0; i < count; i++) {
+                    final byte[] msg = in.readOrWait(yield);
+                    assertNotNull(msg, "Message " + i + " should be available");
+                    assertEquals(i, parseLong(msg), "Message " + i + " value should match");
+                }
+            });
+        }
+
+        @ParameterizedTest
+        @EnumSource(YieldStrategy.class)
+        @DisplayName("More than queue size messages decoded in order under each YieldStrategy")
+        void moreMessagesThanQueueSize(final YieldStrategy yield) throws IOException {
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
+            final AsyncInputStream in = new AsyncInputStream(
+                    new DataInputStream(new ByteArrayInputStream(encodeLongs(DEFAULT_QUEUE_SIZE))),
+                    workGroup,
+                    DEFAULT_QUEUE_SIZE);
+            in.start();
+
+            testAndAwaitTermination(workGroup, () -> {
+                assertEventuallyEquals(
+                        DEFAULT_QUEUE_SIZE,
+                        in::getInputQueueSize,
+                        Duration.ofSeconds(3),
+                        "Background message queue should fill up");
+                assertTrue(
+                        in.isAlive(),
+                        "Stream should be alive since termination marker is not yer read due to full queue");
+
+                // reading only one message should unblock background thread to read termination marker
+                int i = 0;
+                byte[] msg = in.readOrWait(yield);
+                assertNotNull(msg, "Message " + i + " should be available");
+                assertEquals(i, parseLong(msg), "Message " + i + " value should match");
+
+                assertEventuallyFalse(
+                        in::isAlive,
+                        Duration.ofSeconds(3),
+                        "Stream should not be alive after termination marker is read");
+
+                // drain all other messages and verify
+                i++;
+                for (; i < DEFAULT_QUEUE_SIZE; i++) {
+                    msg = in.readOrWait(yield);
+                    assertNotNull(msg, "Message " + i + " should be available");
+                    assertEquals(i, parseLong(msg), "Message " + i + " value should match");
+                }
+
+                assertNull(in.readOrWait(YieldStrategy.SPIN), "Stream should be drained after all messages");
+            });
+        }
+
+        @Test
+        @DisplayName("Zero-length payload round-trips as an empty byte array")
+        void zeroLengthPayloadRoundTrips() throws IOException {
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final DataOutputStream dataOut = new DataOutputStream(byteOut);
+            dataOut.writeInt(0); // empty payload
+            dataOut.writeInt(-1); // termination
+            dataOut.flush();
+
+            createStreamAndTest(byteOut.toByteArray(), in -> {
+                final byte[] msg = in.readOrWait(YieldStrategy.SPIN);
+                assertNotNull(msg, "Zero-length payload should still produce a (non-null) byte array");
+                assertEquals(0, msg.length, "Payload should be empty");
+            });
+        }
+
+        @Test
+        @DisplayName("Large message (1 MiB) round-trips byte-exact")
+        void largeMessageRoundTrip() throws IOException {
+            final byte[] payload = new byte[1 << 20]; // 1 MiB
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] = (byte) (i & 0xFF);
+            }
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final DataOutputStream dataOut = new DataOutputStream(byteOut);
+            dataOut.writeInt(payload.length);
+            dataOut.write(payload);
+            dataOut.writeInt(-1);
+            dataOut.flush();
+
+            createStreamAndTest(byteOut.toByteArray(), in -> {
+                final byte[] received = in.readOrWait(YieldStrategy.PARK);
+                assertNotNull(received, "Large message should arrive");
+                assertEquals(payload.length, received.length, "Large message length must match");
+                assertArrayEquals(payload, received, "Large message bytes must round-trip exactly");
+            });
+        }
+    }
+
+    /**
+     * Tests to validate exception handling and propagation.
+     */
+    @Nested
+    class Exceptions {
+
+        @Test
+        @DisplayName("Second start throws an exception")
+        void secondStartThrowsAnException() {
+            final StandardWorkGroup workGroup = mock(StandardWorkGroup.class);
+            final DataInputStream inputStream = mock(DataInputStream.class);
+            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+
+            in.start();
+
+            assertTrue(in.isAlive(), "Stream should be alive");
+            assertEquals(AsyncInputStream.Status.RUNNING, in.getStatus(), "status should be RUNNING after start");
+            assertThrows(IllegalStateException.class, in::start, "Second start should throw an exception");
+
+            verify(workGroup, times(1)).execute(eq("async-input-stream"), any(Runnable.class));
+            verifyNoMoreInteractions(workGroup);
+            verifyNoInteractions(inputStream);
+        }
+
+        @Test
+        @DisplayName("Background thread failed to submit")
+        void backgroundReadThreadFailsToBeSubmitted() {
+            final RuntimeException cause = new RuntimeException();
+            final StandardWorkGroup workGroup = mock(StandardWorkGroup.class);
+            final DataInputStream inputStream = mock(DataInputStream.class);
+
+            doThrow(cause).when(workGroup).execute(eq("async-input-stream"), any(Runnable.class));
+
+            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+            assertThrows(MerkleSynchronizationException.class, in::start, "Should have thrown an exception");
+            assertFalse(in.isAlive(), "Stream should be alive");
+            assertEquals(AsyncInputStream.Status.DONE, in.getStatus(), "status should be DONE after failed start");
+
+            verify(workGroup, times(1)).execute(eq("async-input-stream"), any(Runnable.class));
+            verify(workGroup, times(1)).handleError(cause);
+            verifyNoMoreInteractions(workGroup);
+            verifyNoInteractions(inputStream);
+        }
+
+        @Test
+        @DisplayName("Too big message read causes exception")
+        void tooBigMessageReadThrowsException() throws InterruptedException, IOException {
+            final byte[] payload = new byte[AsyncInputStream.MAX_MESSAGE_SIZE + 1];
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] = (byte) (i & 0xFF);
+            }
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final DataOutputStream dataOut = new DataOutputStream(byteOut);
+            dataOut.writeInt(payload.length);
+            dataOut.write(payload);
+            dataOut.writeInt(-1);
+            dataOut.flush();
+
+            final ExceptionCapture exceptionCapture = new ExceptionCapture();
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "test", null, exceptionCapture);
+            final DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
+            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+
+            in.start();
+            workGroup.waitForTermination();
+
+            assertFalse(in.isAlive(), "Stream should not be alive");
+            assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
+            assertEquals(1, exceptionCapture.getExceptions().size());
+            assertInstanceOf(
+                    ExecutionException.class, exceptionCapture.getExceptions().peek());
+            assertTrue(
+                    exceptionCapture.getExceptions().peek().getMessage().contains("Message size exceeds maximum size"));
+
+            // verify not able to start after error
+            assertThrows(IllegalStateException.class, in::start, "Should have thrown an exception");
+        }
+
+        @Test
+        @DisplayName("EOFexception is propagated to work group")
+        void eofExceptionIsPropagatedToWorkGroup() throws InterruptedException {
+            final ExceptionCapture exceptionCapture = new ExceptionCapture();
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "test", null, exceptionCapture);
+            final DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(new byte[0]));
+            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+
+            in.start();
+            workGroup.waitForTermination();
+
+            assertFalse(in.isAlive(), "Stream should not be alive");
+            assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
+            assertEquals(1, exceptionCapture.getExceptions().size());
+            assertInstanceOf(
+                    EOFException.class, exceptionCapture.getExceptions().peek());
+
+            // verify not able to start after error
+            assertThrows(IllegalStateException.class, in::start, "Should have thrown an exception");
+        }
+
+        @Test
+        @DisplayName("IOException is propagated to work group")
+        void ioExceptionIsPropagatedToWorkGroup() throws InterruptedException, IOException {
+            final String error = "broken stream";
+            final ExceptionCapture exceptionCapture = new ExceptionCapture();
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "test", null, exceptionCapture);
+
+            final DataInputStream inputStream = mock(DataInputStream.class);
+            when(inputStream.readInt()).thenThrow(new IOException(error));
+
+            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+
+            in.start();
+            workGroup.waitForTermination();
+
+            assertFalse(in.isAlive(), "Stream should not be alive");
+            assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
+            assertEquals(1, exceptionCapture.getExceptions().size());
+            assertInstanceOf(IOException.class, exceptionCapture.getExceptions().peek());
+            assertEquals(error, exceptionCapture.getExceptions().peek().getMessage());
+        }
+
+        @Test
+        @DisplayName("Socket SO_TIMEOUT propagates SocketTimeoutException to the work group")
+        void socketTimeoutPropagatesError() throws IOException {
+            final ExceptionCapture exceptionCapture = new ExceptionCapture();
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "socket-timeout", null, exceptionCapture);
+
+            try (final PairedStreams streams = new PairedStreams()) {
+                streams.setLearnerTimeout(100); // 100 ms read timeout
+
+                final AsyncInputStream in =
+                        new AsyncInputStream(streams.getLearnerInput(), workGroup, DEFAULT_QUEUE_SIZE);
+                in.start();
+                // Teacher never writes anything - learner's readInt() will throw SocketTimeoutException.
+
+                testAndAwaitTermination(
+                        workGroup,
+                        () -> assertEventuallyFalse(in::isAlive, Duration.ofSeconds(5), "Stream should not be alive"));
+
+                assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
+                assertEquals(1, exceptionCapture.getExceptions().size());
+                assertInstanceOf(
+                        SocketTimeoutException.class,
+                        exceptionCapture.getExceptions().peek());
+            }
+        }
+
+        @Test
+        @DisplayName("Truncated wire frame propagates an IOException to the work group")
+        void truncatedFramePropagatesError() throws IOException {
+            final ExceptionCapture exceptionCapture = new ExceptionCapture();
+
+            final PairedStreams streams = new PairedStreams();
+            try {
+                final StandardWorkGroup workGroup =
+                        new StandardWorkGroup(getStaticThreadManager(), "truncated-frame", null, exceptionCapture);
+                final AsyncInputStream in =
+                        new AsyncInputStream(streams.getLearnerInput(), workGroup, DEFAULT_QUEUE_SIZE);
+                in.start();
+
+                // Write length=10 but only 3 bytes of payload, then drop the connection.
+                final DataOutputStream teacherOut = streams.getTeacherOutput();
+                teacherOut.writeInt(10);
+                teacherOut.write(new byte[] {1, 2, 3});
+                teacherOut.flush();
+                streams.disconnectTeacher();
+
+                testAndAwaitTermination(
+                        workGroup,
+                        () -> assertEventuallyFalse(in::isAlive, Duration.ofSeconds(5), "Stream should not be alive"));
+
+                assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
+                assertEquals(1, exceptionCapture.getExceptions().size());
+                assertInstanceOf(
+                        IOException.class, exceptionCapture.getExceptions().peek());
+            } finally {
+                closeIgnoringIoException(streams);
+            }
+        }
+    }
+
+    /**
+     * Tests for concurrent consumption, blocking, interruption.
+     */
+    @Nested
+    class Concurrent {
+
+        @Test
+        @DisplayName("Concurrent starts throws an exception")
+        void concurrentStartsThrowsAnException() throws InterruptedException {
+            final StandardWorkGroup workGroup = mock(StandardWorkGroup.class);
+            final DataInputStream inputStream = mock(DataInputStream.class);
+            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+
+            final int threadsCount = 10;
+            final AtomicInteger exceptionsCount = new AtomicInteger();
+            final CyclicBarrier barrier = new CyclicBarrier(threadsCount);
+            final CountDownLatch doneLatch = new CountDownLatch(threadsCount);
+
+            for (int i = 0; i < threadsCount; i++) {
+                new Thread(() -> {
+                            try {
+                                barrier.await();
+                                in.start();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new RuntimeException("Interrupted", e);
+                            } catch (BrokenBarrierException e) {
+                                throw new RuntimeException(e);
+                            } catch (IllegalStateException e) {
+                                exceptionsCount.incrementAndGet();
+                            } finally {
+                                doneLatch.countDown();
+                            }
+                        })
+                        .start();
+            }
+
+            if (!doneLatch.await(1, TimeUnit.SECONDS)) {
+                throw new AssertionError("No all threads starting stream finished");
+            }
+            assertEquals(
+                    threadsCount - 1,
+                    exceptionsCount.get(),
+                    "Only one thread can start, others should throw an exception");
+            verify(workGroup, times(1)).execute(eq("async-input-stream"), any(Runnable.class));
+            verifyNoMoreInteractions(workGroup);
+            verifyNoInteractions(inputStream);
+        }
+
+        @ParameterizedTest
+        @EnumSource(YieldStrategy.class)
+        @DisplayName("readOrWait returns null when the calling thread is interrupted")
+        void readOrWaitReturnsNullOnInterrupt(final YieldStrategy yieldStrategy) throws IOException {
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "interrupted", null);
+            // Lock the underlying stream so the reader thread blocks inside readInt() and alive
+            // stays true - this forces readOrWait to exit via the interrupt branch, not !alive.
+            final BlockingInputStream blockingIn = new BlockingInputStream(new ByteArrayInputStream(encodeLongs(1)));
+            blockingIn.lock();
+            final AsyncInputStream in =
+                    new AsyncInputStream(new DataInputStream(blockingIn), workGroup, DEFAULT_QUEUE_SIZE);
+            in.start();
+
+            testAndAwaitTermination(workGroup, () -> {
+                assertTrue(in.isAlive(), "Reader thread should be alive");
+
+                final CountDownLatch startLatch = new CountDownLatch(1);
+                final byte[][] result = new byte[1][];
+                final Thread caller = new Thread(() -> {
+                    startLatch.countDown();
+                    result[0] = in.readOrWait(yieldStrategy);
+                });
+                caller.setDaemon(true);
+                caller.start();
+
+                assertTrue(startLatch.await(3, TimeUnit.SECONDS), "Consumer thread should be started");
+                // Give the caller a moment to enter the spin loop, then interrupt it from outside.
+                MILLISECONDS.sleep(50);
+                caller.interrupt(); // interrupt waiting for a message
+                caller.join(2_000);
+
+                assertFalse(caller.isAlive(), "Caller thread should exit after interrupt");
+                assertNull(result[0], "readOrWait should return null when the caller is interrupted");
+
+                // Unblock so the reader thread can finish and the work group can terminate.
+                blockingIn.unlock();
+            });
+        }
+
+        @ParameterizedTest
+        @EnumSource(YieldStrategy.class)
+        @DisplayName("Concurrent read messages")
+        void concurrentReadMessages(final YieldStrategy yieldStrategy) throws IOException {
+            final int threadsCount = 10;
+            final int messageCount = DEFAULT_QUEUE_SIZE * threadsCount;
+
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
+            final AsyncInputStream in = new AsyncInputStream(
+                    new DataInputStream(new ByteArrayInputStream(encodeLongs(messageCount))),
+                    workGroup,
+                    DEFAULT_QUEUE_SIZE);
+            in.start();
+
+            final CyclicBarrier barrier = new CyclicBarrier(threadsCount);
+            final CountDownLatch doneLatch = new CountDownLatch(threadsCount);
+            final Thread[] threads = new Thread[threadsCount];
+            final ConcurrentLinkedQueue<Long> received = new ConcurrentLinkedQueue<>();
+
+            testAndAwaitTermination(workGroup, () -> {
+                for (int i = 0; i < threadsCount; i++) {
+                    Thread thread = new Thread(() -> {
+                        try {
+                            barrier.await();
+                            while (true) {
+                                final byte[] msg = in.readOrWait(yieldStrategy);
+                                if (msg == null) {
+                                    return;
+                                }
+                                received.add(parseLong(msg));
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException("Interrupted", e);
+                        } catch (BrokenBarrierException e) {
+                            throw new RuntimeException(e);
+                        } finally {
+                            doneLatch.countDown();
+                        }
+                    });
+                    thread.setDaemon(true);
+                    thread.start();
+                    threads[i] = thread;
+                }
+
+                if (!doneLatch.await(3, TimeUnit.SECONDS)) {
+                    throw new AssertionError("Not all consumer threads finished");
+                }
+            });
+
+            assertEquals(messageCount, received.size(), "Every message should have been delivered exactly once");
+            final Set<Long> distinct = new HashSet<>(received);
+            assertEquals(messageCount, distinct.size(), "No duplicate deliveries across consumers");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
     private static long parseLong(final byte[] bytes) {
         return BufferedData.wrap(bytes).readLong();
     }
 
-    @Test
-    @Tag(TestComponentTags.RECONNECT)
-    @DisplayName("Basic Operation")
-    void basicOperation() throws IOException, InterruptedException {
-        try (final PairedStreams streams = new PairedStreams()) {
-            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
-
-            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, reconnectConfig);
-            final AsyncOutputStream out = new AsyncOutputStream(streams.getLearnerOutput(), workGroup, reconnectConfig);
-
-            in.start();
-            out.start();
-
-            final int count = 100;
-
-            for (int i = 0; i < count; i++) {
-                out.sendAsync(serializeLong(i));
-                final byte[] message = in.readAnticipatedMessageSync();
-                assertNotNull(message);
-                assertEquals(i, parseLong(message), "message should match the value that was serialized");
-            }
-
-            out.done();
-            workGroup.waitForTermination();
-        }
-    }
-
-    @Test
-    @Tag(TestComponentTags.RECONNECT)
-    @DisplayName("Pre-Anticipation")
-    void preAnticipation() throws IOException, InterruptedException {
-        try (final PairedStreams streams = new PairedStreams()) {
-            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
-
-            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, reconnectConfig);
-            final AsyncOutputStream out = new AsyncOutputStream(streams.getLearnerOutput(), workGroup, reconnectConfig);
-
-            in.start();
-            out.start();
-
-            final int count = 100;
-
-            for (int i = 0; i < count; i++) {
-                out.sendAsync(serializeLong(i));
-                final byte[] message = in.readAnticipatedMessageSync();
-                assertNotNull(message);
-                assertEquals(i, parseLong(message), "message should match the value that was serialized");
-            }
-
-            out.done();
-            workGroup.waitForTermination();
-        }
-    }
-
-    @Test
-    @Tag(TestComponentTags.RECONNECT)
-    @DisplayName("Max Output Queue Size")
-    void maxOutputQueueSize() throws InterruptedException, IOException {
-
-        final int bufferSize = 100;
-        final int count = 1_000;
-
-        final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
-
-        final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-        final BlockingOutputStream blockingOut = new BlockingOutputStream(byteOut);
-
-        // Block all bytes from this stream, data can only sit in async stream buffer
-        blockingOut.lock();
-
-        final AsyncOutputStream out =
-                new AsyncOutputStream(new DataOutputStream(blockingOut), workGroup, reconnectConfig);
-
-        out.start();
-
-        final AtomicInteger messagesSent = new AtomicInteger(0);
-        final Thread outputThread = new ThreadConfiguration(getStaticThreadManager())
-                .setRunnable(() -> {
-                    for (int i = 0; i < count; i++) {
-                        try {
-                            out.sendAsync(serializeLong(i));
-                            messagesSent.getAndIncrement();
-                        } catch (final InterruptedException ex) {
-                            Thread.currentThread().interrupt();
-                            ex.printStackTrace(System.err);
-                            break;
-                        }
-                    }
-                })
-                .setThreadName("output-thread")
-                .build();
-        outputThread.start();
-
-        // Sender will send until the sender buffer is full.
-        MILLISECONDS.sleep(100);
-
-        final int messageCount = messagesSent.get();
-        // The buffer will fill up, and one or more messages will be held by the sending thread (which is
-        // blocked), up to double buffer size
-        assertTrue(messageCount >= bufferSize + 1, "incorrect message count");
-        assertTrue(messageCount <= 2 * bufferSize, "incorrect message count");
-
-        // Unblock the buffer, allowing remaining messages to be sent
-        blockingOut.unlock();
-
-        assertEventuallyEquals(count, messagesSent::get, Duration.ofSeconds(5), "all messages should have been sent");
-
-        out.done();
-
-        workGroup.waitForTermination();
-
-        // Sanity check, make sure all the messages were written to the stream
-        final byte[] bytes = byteOut.toByteArray();
-        final DataInputStream dataIn = new DataInputStream(new ByteArrayInputStream(bytes));
-        for (int i = 0; i < count; i++) {
-            assertEquals(Long.BYTES, dataIn.readInt(), "message length should be Long.BYTES");
-            assertEquals(i, dataIn.readLong(), "deserialized value should match expected value");
-        }
-    }
-
-    @Test
-    @Tag(TestComponentTags.RECONNECT)
-    @DisplayName("Max Input Queue Size")
-    void maxInputQueueSize() throws IOException, InterruptedException {
-
-        final int bufferSize = 100;
-        final int count = 1_000;
-        final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
-
-        // Write messages in the async stream wire format: int32 length prefix + message bytes
+    /** Writes {@code count} long-valued messages followed by the termination marker. */
+    private static byte[] encodeLongs(final int count) throws IOException {
         final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
         final DataOutputStream dataOut = new DataOutputStream(byteOut);
         for (int i = 0; i < count; i++) {
             dataOut.writeInt(Long.BYTES);
             dataOut.writeLong(i);
         }
-        // Write the termination marker
-        dataOut.writeInt(-1);
+        dataOut.writeInt(-1); // termination marker
         dataOut.flush();
-        MILLISECONDS.sleep(100);
-        final byte[] data = byteOut.toByteArray();
-
-        final BlockingInputStream blockingIn = new BlockingInputStream(new ByteArrayInputStream(data));
-
-        final AsyncInputStream in = new AsyncInputStream(new DataInputStream(blockingIn), workGroup, reconnectConfig);
-        in.start();
-
-        // Give the stream some time to accept as much data as it wants. Stream will stop accepting when queue fills up.
-        MILLISECONDS.sleep(100);
-
-        // Lock the stream, preventing further reads
-        blockingIn.lock();
-
-        final AtomicInteger messagesReceived = new AtomicInteger(0);
-        final Thread inputThread = new ThreadConfiguration(getStaticThreadManager())
-                .setRunnable(() -> {
-                    for (int i = 0; i < count; i++) {
-                        final byte[] message = in.readAnticipatedMessageSync();
-                        assertNotNull(message);
-                        assertEquals(i, parseLong(message), "value does not match expected");
-                        messagesReceived.getAndIncrement();
-                    }
-                })
-                .setThreadName("output-thread")
-                .build();
-        inputThread.start();
-
-        // Let the input thread read from the buffer
-        MILLISECONDS.sleep(100);
-
-        // The number of messages should equal the buffer size
-        // plus one message that was blocked from entering the buffer
-        assertEquals(bufferSize + 1, messagesReceived.get(), "incorrect number of messages received");
-
-        // Unblock the stream, remainder of messages should be read
-        blockingIn.unlock();
-
-        assertEventuallyEquals(count, messagesReceived::get, Duration.ofSeconds(5), "all messages should be read");
-
-        workGroup.waitForTermination();
+        return byteOut.toByteArray();
     }
 
     /**
-     * This test verifies that a bug that once existed in AsyncInputStream has been fixed. This bug could cause the
-     * stream to deadlock during an abort.
+     * After an intentional disconnect, {@link PairedStreams#close()} can throw because flushing a
+     * buffered stream over a closed socket fails. Swallow that expected failure during cleanup.
      */
-    @Test()
-    @Tag(TestComponentTags.MERKLE)
-    @DisplayName("AsyncInputStream Deadlock")
-    void asyncInputStreamAbortDeadlock() throws InterruptedException {
-        try (final PairedStreams pairedStreams = new PairedStreams()) {
-
-            final StandardWorkGroup workGroup =
-                    new StandardWorkGroup(getStaticThreadManager(), "input-stream-abort-deadlock", null);
-
-            final AsyncOutputStream teacherOut =
-                    new AsyncOutputStream(pairedStreams.getTeacherOutput(), workGroup, reconnectConfig);
-
-            final AsyncInputStream learnerIn =
-                    new AsyncInputStream(pairedStreams.getLearnerInput(), workGroup, reconnectConfig);
-
-            final Runnable reader = () -> {
-                try {
-                    final byte[] bytes = learnerIn.readAnticipatedMessageSync();
-                    // Force an error to simulate deserialization failure
-                    throw new RuntimeException("Intentional deserialization failure");
-                } catch (final Exception e) {
-                    workGroup.handleError(e);
-                }
-            };
-            workGroup.execute(reader);
-
-            learnerIn.start();
-            teacherOut.start();
-
-            // Send a dummy message to trigger the reader
-            teacherOut.sendAsync(serializeLong(42));
-            Thread.sleep(100);
-
-            workGroup.waitForTermination();
-            assertTrue(workGroup.hasExceptions(), "work group is expected to have an exception");
-
-            final Thread abortThread = new Thread(learnerIn::abort);
-
-            abortThread.start();
-            abortThread.join(1_000);
-            if (abortThread.isAlive()) {
-                abortThread.interrupt();
-                fail("abort should have finished");
-            }
-
-            abortThread.join();
-
-        } catch (final IOException e) {
-            e.printStackTrace(System.err);
-            fail("exception encountered", e);
+    private static void closeIgnoringIoException(final PairedStreams streams) {
+        try {
+            streams.close();
+        } catch (final IOException ignored) {
+            // expected after disconnectTeacher() / disconnectLearner()
         }
     }
 
-    @Test
-    @Tag(TestComponentTags.RECONNECT)
-    @DisplayName("readAnticipatedMessage returns null when queue is empty")
-    void readReturnsNullWhenEmpty() throws IOException {
-        try (final PairedStreams streams = new PairedStreams()) {
-            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
-            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, reconnectConfig);
-            // Don't start the background reader — queue stays empty
-            final byte[] msg = in.readAnticipatedMessage();
-            assertNull(msg, "Should return null when no messages are queued");
+    private static void testAndAwaitTermination(StandardWorkGroup workGroup, ThrowingRunnable test) {
+        try {
+            test.run();
+            workGroup.waitForTermination();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted", ex);
+        } catch (Exception ex) {
+            workGroup.handleError(ex); // cancel all submitted tasks in case of any error inside test (like assertion)
+            throw new RuntimeException(ex);
+        } catch (Throwable ex) {
+            workGroup.handleError(ex); // cancel all submitted tasks in case of any error inside test (like assertion)
         }
     }
 
-    @Test
-    @Tag(TestComponentTags.RECONNECT)
-    @DisplayName("isAlive returns false after termination marker is received")
-    void isAliveAfterTermination() throws IOException, InterruptedException {
-        try (final PairedStreams streams = new PairedStreams()) {
-            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
+    private static class ExceptionCapture implements Function<Throwable, Boolean> {
 
-            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, reconnectConfig);
-            final AsyncOutputStream out = new AsyncOutputStream(streams.getLearnerOutput(), workGroup, reconnectConfig);
+        private final ConcurrentLinkedQueue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
 
-            in.start();
-            out.start();
-
-            out.sendAsync(serializeLong(1));
-            out.done();
-
-            workGroup.waitForTermination();
-
-            // Drain the queue
-            in.readAnticipatedMessage();
-
-            assertFalse(in.isAlive(), "Stream should not be alive after termination marker is received");
+        @Override
+        public Boolean apply(Throwable throwable) {
+            exceptions.add(throwable);
+            return true;
         }
-    }
 
-    @Test
-    @Tag(TestComponentTags.RECONNECT)
-    @DisplayName("Empty byte array message round-trips")
-    void emptyMessage() throws IOException, InterruptedException {
-        try (final PairedStreams streams = new PairedStreams()) {
-            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
-
-            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, reconnectConfig);
-            final AsyncOutputStream out = new AsyncOutputStream(streams.getLearnerOutput(), workGroup, reconnectConfig);
-
-            in.start();
-            out.start();
-
-            out.sendAsync(new byte[0]);
-            out.done();
-
-            workGroup.waitForTermination();
-
-            final byte[] result = in.readAnticipatedMessage();
-            assertNotNull(result);
-            assertEquals(0, result.length, "Empty message should have zero bytes");
-        }
-    }
-
-    @Test
-    @Tag(TestComponentTags.RECONNECT)
-    @DisplayName("Messages of different sizes are correctly delimited")
-    void parserReceivesBoundedData() throws IOException, InterruptedException {
-        try (final PairedStreams streams = new PairedStreams()) {
-            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
-
-            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, reconnectConfig);
-            final AsyncOutputStream out = new AsyncOutputStream(streams.getLearnerOutput(), workGroup, reconnectConfig);
-
-            in.start();
-            out.start();
-
-            // Send two messages of different sizes
-            final byte[] small = new byte[] {1, 2, 3};
-            final byte[] large = new byte[] {10, 20, 30, 40, 50};
-            out.sendAsync(small);
-            out.sendAsync(large);
-            out.done();
-
-            workGroup.waitForTermination();
-
-            // First message should have exactly 3 bytes
-            final byte[] read1 = in.readAnticipatedMessage();
-            assertNotNull(read1);
-            assertArrayEquals(small, read1);
-
-            // Second message should have exactly 5 bytes
-            final byte[] read2 = in.readAnticipatedMessage();
-            assertNotNull(read2);
-            assertArrayEquals(large, read2);
+        public ConcurrentLinkedQueue<Throwable> getExceptions() {
+            return exceptions;
         }
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncInputStreamTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncInputStreamTest.java
@@ -3,7 +3,6 @@ package com.swirlds.virtualmap.sync.streams;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyEquals;
-import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyFalse;
 import static org.hiero.consensus.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,14 +25,12 @@ import static org.mockito.Mockito.when;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
 import com.swirlds.virtualmap.test.fixtures.sync.BlockingInputStream;
-import com.swirlds.virtualmap.test.fixtures.sync.PairedStreams;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
@@ -61,6 +58,8 @@ class AsyncInputStreamTest {
     /** Default queue size threshold used by tests that don't care about backpressure boundaries. */
     private static final int DEFAULT_QUEUE_SIZE = 100;
 
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
     /**
      * Tests to validate constructor, basic properties and methods without starting background thread
      */
@@ -73,7 +72,8 @@ class AsyncInputStreamTest {
         void constructorRejectsNullInputStream() {
             assertThrows(
                     NullPointerException.class,
-                    () -> new AsyncInputStream(null, mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE));
+                    () -> new AsyncInputStream(
+                            null, mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT));
         }
 
         @Test
@@ -82,7 +82,7 @@ class AsyncInputStreamTest {
         void constructorRejectsNullWorkGroup() {
             assertThrows(
                     NullPointerException.class,
-                    () -> new AsyncInputStream(mock(DataInputStream.class), null, DEFAULT_QUEUE_SIZE));
+                    () -> new AsyncInputStream(mock(DataInputStream.class), null, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT));
         }
 
         @ParameterizedTest
@@ -92,26 +92,51 @@ class AsyncInputStreamTest {
             assertThrows(
                     IllegalArgumentException.class,
                     () -> new AsyncInputStream(
-                            mock(DataInputStream.class), mock(StandardWorkGroup.class), queueSizeThreshold));
+                            mock(DataInputStream.class),
+                            mock(StandardWorkGroup.class),
+                            queueSizeThreshold,
+                            DEFAULT_TIMEOUT));
         }
 
         @Test
-        @DisplayName("Not alive and queue is empty before start")
-        void notAliveAndEmptyBeforeStart() {
+        @DisplayName("Constructor rejects null timeout")
+        @SuppressWarnings("DataFlowIssue")
+        void constructorRejectsNullTimeout() {
+            assertThrows(
+                    NullPointerException.class,
+                    () -> new AsyncInputStream(
+                            mock(DataInputStream.class), mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE, null));
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = {-1L, 0L})
+        @DisplayName("Constructor rejects non-positive timeout")
+        void constructorRejectsBadTimeout(long timeoutMs) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new AsyncInputStream(
+                            mock(DataInputStream.class),
+                            mock(StandardWorkGroup.class),
+                            DEFAULT_QUEUE_SIZE,
+                            Duration.ofMillis(timeoutMs)));
+        }
+
+        @Test
+        @DisplayName("Status is NOT_STARTED and queue is empty before start")
+        void notStartedAndEmptyBeforeStart() {
             final AsyncInputStream in = new AsyncInputStream(
-                    mock(DataInputStream.class), mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE);
+                    mock(DataInputStream.class), mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
 
             assertEquals(AsyncInputStream.Status.NOT_STARTED, in.getStatus(), "status should be NOT_STARTED");
-            assertFalse(in.isAlive(), "isAlive must be false before start()");
-            assertEquals(0, in.getInputQueueSize(), "queue size should be empty");
+            assertEquals(0, in.getQueueSize(), "queue size should be empty");
         }
 
         @ParameterizedTest
         @EnumSource(YieldStrategy.class)
-        @DisplayName("readOrWait returns null on a stream that was never started")
-        void readOrWaitReturnNullAndOnNotStartedStream(final YieldStrategy yieldStrategy) {
+        @DisplayName("read returns null on a stream that was never started")
+        void readReturnsNullOnNotStartedStream(final YieldStrategy yieldStrategy) {
             final AsyncInputStream in = new AsyncInputStream(
-                    mock(DataInputStream.class), mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE);
+                    mock(DataInputStream.class), mock(StandardWorkGroup.class), DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
             assertNull(in.readOrWait(yieldStrategy), "Queue is empty and stream is not alive to return any message");
         }
     }
@@ -126,25 +151,35 @@ class AsyncInputStreamTest {
          * Create and start input stream reading data from predefined bytes array.
          *
          * @param data predefined data
-         * @param consumerTest test consuming async input stream - must read all messages
+         * @param beforeDone test consuming async input stream to run before waiting for background thread to be done
+         * @param afterDone test consuming async input stream to run after background stream is done - must read all messages
          */
-        private void createStreamAndTest(final byte[] data, final Consumer<AsyncInputStream> consumerTest) {
+        private void createStreamAndTest(
+                final byte[] data,
+                final Consumer<AsyncInputStream> beforeDone,
+                final Consumer<AsyncInputStream> afterDone) {
             final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
             final AsyncInputStream in = new AsyncInputStream(
-                    new DataInputStream(new ByteArrayInputStream(data)), workGroup, DEFAULT_QUEUE_SIZE);
+                    new DataInputStream(new ByteArrayInputStream(data)),
+                    workGroup,
+                    DEFAULT_QUEUE_SIZE,
+                    DEFAULT_TIMEOUT);
             in.start();
 
             testAndAwaitTermination(workGroup, () -> {
-                // wait for background thread should read all the data
-                assertEventuallyFalse(
-                        in::isAlive,
+                beforeDone.accept(in);
+
+                // wait for background thread read all the data
+                assertEventuallyEquals(
+                        AsyncInputStream.Status.DONE,
+                        in::getStatus,
                         Duration.ofSeconds(3),
                         "Stream should not be alive after termination marker is read");
-                assertEquals(AsyncInputStream.Status.DONE, in.getStatus(), "status should be DONE after termination");
 
-                consumerTest.accept(in);
+                afterDone.accept(in);
 
                 assertNull(in.readOrWait(YieldStrategy.SPIN), "Stream should be drained after all messages");
+                assertEquals(0, in.getQueueSize(), "buffer size should be empty");
             });
 
             // verify not able to start after termination
@@ -159,9 +194,7 @@ class AsyncInputStreamTest {
             dataOut.writeInt(-1); // termination
             dataOut.flush();
 
-            createStreamAndTest(
-                    byteOut.toByteArray(),
-                    in -> assertEquals(0, in.getInputQueueSize(), "Input queue size should be empty"));
+            createStreamAndTest(byteOut.toByteArray(), _ -> {}, _ -> {});
         }
 
         @ParameterizedTest
@@ -170,8 +203,8 @@ class AsyncInputStreamTest {
         void lessMessagesThanQueueSize(final YieldStrategy yield) throws IOException {
             final int count = DEFAULT_QUEUE_SIZE - 1;
 
-            createStreamAndTest(encodeLongs(count), in -> {
-                assertEquals(count, in.getInputQueueSize(), "Input queue size should match number of messages");
+            createStreamAndTest(encodeLongs(count), _ -> {}, in -> {
+                assertEquals(count, in.getQueueSize(), "Input queue size should match number of messages");
 
                 for (int i = 0; i < count; i++) {
                     final byte[] msg = in.readOrWait(yield);
@@ -183,46 +216,35 @@ class AsyncInputStreamTest {
 
         @ParameterizedTest
         @EnumSource(YieldStrategy.class)
-        @DisplayName("More than queue size messages decoded in order under each YieldStrategy")
-        void moreMessagesThanQueueSize(final YieldStrategy yield) throws IOException {
-            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
-            final AsyncInputStream in = new AsyncInputStream(
-                    new DataInputStream(new ByteArrayInputStream(encodeLongs(DEFAULT_QUEUE_SIZE))),
-                    workGroup,
-                    DEFAULT_QUEUE_SIZE);
-            in.start();
+        @DisplayName("Full queue keep background stream running")
+        void fullQueueKeepsStreamRunning(final YieldStrategy yield) throws IOException {
+            createStreamAndTest(
+                    encodeLongs(DEFAULT_QUEUE_SIZE),
+                    in -> {
+                        assertEventuallyEquals(
+                                DEFAULT_QUEUE_SIZE,
+                                in::getQueueSize,
+                                Duration.ofSeconds(3),
+                                "Background message queue should fill up");
+                        assertEquals(
+                                AsyncInputStream.Status.RUNNING,
+                                in.getStatus(),
+                                "Stream should be alive since termination marker is not yet read due to full queue");
 
-            testAndAwaitTermination(workGroup, () -> {
-                assertEventuallyEquals(
-                        DEFAULT_QUEUE_SIZE,
-                        in::getInputQueueSize,
-                        Duration.ofSeconds(3),
-                        "Background message queue should fill up");
-                assertTrue(
-                        in.isAlive(),
-                        "Stream should be alive since termination marker is not yet read due to full queue");
-
-                // reading only one message should unblock background thread to read termination marker
-                int i = 0;
-                byte[] msg = in.readOrWait(yield);
-                assertNotNull(msg, "Message " + i + " should be available");
-                assertEquals(i, parseLong(msg), "Message " + i + " value should match");
-
-                assertEventuallyFalse(
-                        in::isAlive,
-                        Duration.ofSeconds(3),
-                        "Stream should not be alive after termination marker is read");
-
-                // drain all other messages and verify
-                i++;
-                for (; i < DEFAULT_QUEUE_SIZE; i++) {
-                    msg = in.readOrWait(yield);
-                    assertNotNull(msg, "Message " + i + " should be available");
-                    assertEquals(i, parseLong(msg), "Message " + i + " value should match");
-                }
-
-                assertNull(in.readOrWait(YieldStrategy.SPIN), "Stream should be drained after all messages");
-            });
+                        // reading only one message should unblock background thread to read termination marker
+                        int i = 0;
+                        byte[] msg = in.readOrWait(yield);
+                        assertNotNull(msg, "Message " + i + " should be available");
+                        assertEquals(i, parseLong(msg), "Message " + i + " value should match");
+                    },
+                    in -> {
+                        // drain all other messages and verify
+                        for (int i = 1; i < DEFAULT_QUEUE_SIZE; i++) {
+                            byte[] msg = in.readOrWait(yield);
+                            assertNotNull(msg, "Message " + i + " should be available");
+                            assertEquals(i, parseLong(msg), "Message " + i + " value should match");
+                        }
+                    });
         }
 
         @Test
@@ -234,7 +256,7 @@ class AsyncInputStreamTest {
             dataOut.writeInt(-1); // termination
             dataOut.flush();
 
-            createStreamAndTest(byteOut.toByteArray(), in -> {
+            createStreamAndTest(byteOut.toByteArray(), _ -> {}, in -> {
                 final byte[] msg = in.readOrWait(YieldStrategy.SPIN);
                 assertNotNull(msg, "Zero-length payload should still produce a (non-null) byte array");
                 assertEquals(0, msg.length, "Payload should be empty");
@@ -255,7 +277,7 @@ class AsyncInputStreamTest {
             dataOut.writeInt(-1);
             dataOut.flush();
 
-            createStreamAndTest(byteOut.toByteArray(), in -> {
+            createStreamAndTest(byteOut.toByteArray(), _ -> {}, in -> {
                 final byte[] received = in.readOrWait(YieldStrategy.PARK);
                 assertNotNull(received, "Large message should arrive");
                 assertEquals(payload.length, received.length, "Large message length must match");
@@ -275,11 +297,11 @@ class AsyncInputStreamTest {
         void secondStartThrowsAnException() {
             final StandardWorkGroup workGroup = mock(StandardWorkGroup.class);
             final DataInputStream inputStream = mock(DataInputStream.class);
-            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncInputStream in =
+                    new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
 
             in.start();
 
-            assertTrue(in.isAlive(), "Stream should be alive");
             assertEquals(AsyncInputStream.Status.RUNNING, in.getStatus(), "status should be RUNNING after start");
             assertThrows(IllegalStateException.class, in::start, "Second start should throw an exception");
 
@@ -297,9 +319,9 @@ class AsyncInputStreamTest {
 
             doThrow(cause).when(workGroup).execute(eq("async-input-stream"), any(Runnable.class));
 
-            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncInputStream in =
+                    new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
             assertThrows(MerkleSynchronizationException.class, in::start, "Should have thrown an exception");
-            assertFalse(in.isAlive(), "Stream should be alive");
             assertEquals(AsyncInputStream.Status.DONE, in.getStatus(), "status should be DONE after failed start");
 
             verify(workGroup, times(1)).execute(eq("async-input-stream"), any(Runnable.class));
@@ -326,12 +348,13 @@ class AsyncInputStreamTest {
             final StandardWorkGroup workGroup =
                     new StandardWorkGroup(getStaticThreadManager(), "test", null, exceptionCapture);
             final DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
-            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncInputStream in =
+                    new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
 
             in.start();
             workGroup.waitForTermination();
 
-            assertFalse(in.isAlive(), "Stream should not be alive");
+            assertEquals(AsyncInputStream.Status.DONE, in.getStatus(), "Reader thread should be done");
             assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
             assertEquals(1, exceptionCapture.getExceptions().size());
             assertInstanceOf(
@@ -351,12 +374,13 @@ class AsyncInputStreamTest {
             final StandardWorkGroup workGroup =
                     new StandardWorkGroup(getStaticThreadManager(), "test", null, exceptionCapture);
             final DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(new byte[0]));
-            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncInputStream in =
+                    new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
 
             in.start();
             workGroup.waitForTermination();
 
-            assertFalse(in.isAlive(), "Stream should not be alive");
+            assertEquals(AsyncInputStream.Status.DONE, in.getStatus(), "Reader thread should be done");
             assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
             assertEquals(1, exceptionCapture.getExceptions().size());
             assertInstanceOf(
@@ -377,12 +401,14 @@ class AsyncInputStreamTest {
             final DataInputStream inputStream = mock(DataInputStream.class);
             when(inputStream.readInt()).thenThrow(new IOException(error));
 
-            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncInputStream in =
+                    new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
 
             in.start();
             workGroup.waitForTermination();
 
-            assertFalse(in.isAlive(), "Stream should not be alive");
+            assertEquals(AsyncInputStream.Status.DONE, in.getStatus(), "Reader thread should be done");
+
             assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
             assertEquals(1, exceptionCapture.getExceptions().size());
             assertInstanceOf(IOException.class, exceptionCapture.getExceptions().peek());
@@ -390,63 +416,21 @@ class AsyncInputStreamTest {
         }
 
         @Test
-        @DisplayName("Socket SO_TIMEOUT propagates SocketTimeoutException to the work group")
-        void socketTimeoutPropagatesError() throws IOException {
-            final ExceptionCapture exceptionCapture = new ExceptionCapture();
-            final StandardWorkGroup workGroup =
-                    new StandardWorkGroup(getStaticThreadManager(), "socket-timeout", null, exceptionCapture);
+        @DisplayName("Consumer timeout if no messages are available in stream")
+        void consumerTimeoutOnBlockingStream() throws IOException, InterruptedException {
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "timeout", null);
 
-            try (final PairedStreams streams = new PairedStreams()) {
-                streams.setLearnerTimeout(100); // 100 ms read timeout
+            final BlockingInputStream blockingIn = new BlockingInputStream(new ByteArrayInputStream(encodeLongs(1)));
+            blockingIn.lock();
+            final AsyncInputStream in = new AsyncInputStream(
+                    new DataInputStream(blockingIn), workGroup, DEFAULT_QUEUE_SIZE, Duration.ofMillis(100));
+            in.start();
 
-                final AsyncInputStream in =
-                        new AsyncInputStream(streams.getLearnerInput(), workGroup, DEFAULT_QUEUE_SIZE);
-                in.start();
-                // Teacher never writes anything - learner's readInt() will throw SocketTimeoutException.
+            assertThrows(
+                    MerkleSynchronizationException.class, () -> in.readOrWait(YieldStrategy.PARK), "Should time out");
 
-                testAndAwaitTermination(
-                        workGroup,
-                        () -> assertEventuallyFalse(in::isAlive, Duration.ofSeconds(5), "Stream should not be alive"));
-
-                assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
-                assertEquals(1, exceptionCapture.getExceptions().size());
-                assertInstanceOf(
-                        SocketTimeoutException.class,
-                        exceptionCapture.getExceptions().peek());
-            }
-        }
-
-        @Test
-        @DisplayName("Truncated wire frame propagates an IOException to the work group")
-        void truncatedFramePropagatesError() throws IOException {
-            final ExceptionCapture exceptionCapture = new ExceptionCapture();
-
-            final PairedStreams streams = new PairedStreams();
-            try {
-                final StandardWorkGroup workGroup =
-                        new StandardWorkGroup(getStaticThreadManager(), "truncated-frame", null, exceptionCapture);
-                final AsyncInputStream in =
-                        new AsyncInputStream(streams.getLearnerInput(), workGroup, DEFAULT_QUEUE_SIZE);
-                in.start();
-
-                // Write length=10 but only 3 bytes of payload, then drop the connection.
-                final DataOutputStream teacherOut = streams.getTeacherOutput();
-                teacherOut.writeInt(10);
-                teacherOut.write(new byte[] {1, 2, 3});
-                teacherOut.flush();
-                streams.disconnectTeacher();
-
-                testAndAwaitTermination(
-                        workGroup,
-                        () -> assertEventuallyFalse(in::isAlive, Duration.ofSeconds(5), "Stream should not be alive"));
-
-                assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
-                assertEquals(1, exceptionCapture.getExceptions().size());
-                assertInstanceOf(
-                        IOException.class, exceptionCapture.getExceptions().peek());
-            } finally {
-                closeIgnoringIoException(streams);
-            }
+            blockingIn.unlock();
+            workGroup.waitForTermination();
         }
     }
 
@@ -461,7 +445,8 @@ class AsyncInputStreamTest {
         void concurrentStartsThrowsAnException() throws InterruptedException {
             final StandardWorkGroup workGroup = mock(StandardWorkGroup.class);
             final DataInputStream inputStream = mock(DataInputStream.class);
-            final AsyncInputStream in = new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncInputStream in =
+                    new AsyncInputStream(inputStream, workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
 
             final int threadsCount = 10;
             final AtomicInteger exceptionsCount = new AtomicInteger();
@@ -501,19 +486,19 @@ class AsyncInputStreamTest {
 
         @ParameterizedTest
         @EnumSource(YieldStrategy.class)
-        @DisplayName("readOrWait returns null when the calling thread is interrupted")
-        void readOrWaitReturnsNullOnInterrupt(final YieldStrategy yieldStrategy) throws IOException {
+        @DisplayName("read returns null when the calling thread is interrupted")
+        void readReturnsNullOnInterrupt(final YieldStrategy yieldStrategy) throws IOException {
             final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "interrupted", null);
             // Lock the underlying stream so the reader thread blocks inside readInt() and alive
-            // stays true - this forces readOrWait to exit via the interrupt branch, not !alive.
+            // stays true - this forces read to exit via the interrupt branch, not !alive.
             final BlockingInputStream blockingIn = new BlockingInputStream(new ByteArrayInputStream(encodeLongs(1)));
             blockingIn.lock();
-            final AsyncInputStream in =
-                    new AsyncInputStream(new DataInputStream(blockingIn), workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncInputStream in = new AsyncInputStream(
+                    new DataInputStream(blockingIn), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
             in.start();
 
             testAndAwaitTermination(workGroup, () -> {
-                assertTrue(in.isAlive(), "Reader thread should be alive");
+                assertEquals(AsyncInputStream.Status.RUNNING, in.getStatus(), "Reader thread should be running");
 
                 final CountDownLatch startLatch = new CountDownLatch(1);
                 final byte[][] result = new byte[1][];
@@ -531,7 +516,7 @@ class AsyncInputStreamTest {
                 caller.join(2_000);
 
                 assertFalse(caller.isAlive(), "Caller thread should exit after interrupt");
-                assertNull(result[0], "readOrWait should return null when the caller is interrupted");
+                assertNull(result[0], "read should return null when the caller is interrupted");
 
                 // Unblock so the reader thread can finish and the work group can terminate.
                 blockingIn.unlock();
@@ -549,12 +534,12 @@ class AsyncInputStreamTest {
             final AsyncInputStream in = new AsyncInputStream(
                     new DataInputStream(new ByteArrayInputStream(encodeLongs(messageCount))),
                     workGroup,
-                    DEFAULT_QUEUE_SIZE);
+                    DEFAULT_QUEUE_SIZE,
+                    DEFAULT_TIMEOUT);
             in.start();
 
             final CyclicBarrier barrier = new CyclicBarrier(threadsCount);
             final CountDownLatch doneLatch = new CountDownLatch(threadsCount);
-            final Thread[] threads = new Thread[threadsCount];
             final ConcurrentLinkedQueue<Long> received = new ConcurrentLinkedQueue<>();
 
             testAndAwaitTermination(workGroup, () -> {
@@ -580,7 +565,6 @@ class AsyncInputStreamTest {
                     });
                     thread.setDaemon(true);
                     thread.start();
-                    threads[i] = thread;
                 }
 
                 if (!doneLatch.await(3, TimeUnit.SECONDS)) {
@@ -613,18 +597,6 @@ class AsyncInputStreamTest {
         dataOut.writeInt(-1); // termination marker
         dataOut.flush();
         return byteOut.toByteArray();
-    }
-
-    /**
-     * After an intentional disconnect, {@link PairedStreams#close()} can throw because flushing a
-     * buffered stream over a closed socket fails. Swallow that expected failure during cleanup.
-     */
-    private static void closeIgnoringIoException(final PairedStreams streams) {
-        try {
-            streams.close();
-        } catch (final IOException ignored) {
-            // expected after disconnectTeacher() / disconnectLearner()
-        }
     }
 
     private static void testAndAwaitTermination(StandardWorkGroup workGroup, ThrowingRunnable test) {

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncInputStreamTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncInputStreamTest.java
@@ -41,11 +41,9 @@ import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import org.hiero.base.concurrent.ThrowingRunnable;
 import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
 import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
@@ -131,9 +129,6 @@ class AsyncInputStreamTest {
          * @param consumerTest test consuming async input stream - must read all messages
          */
         private void createStreamAndTest(final byte[] data, final Consumer<AsyncInputStream> consumerTest) {
-            // provided data must have a termination marker in the end
-            assertEquals(-1, data[data.length - 1], "test data doesn't have a termination marker");
-
             final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "test", null);
             final AsyncInputStream in = new AsyncInputStream(
                     new DataInputStream(new ByteArrayInputStream(data)), workGroup, DEFAULT_QUEUE_SIZE);
@@ -205,7 +200,7 @@ class AsyncInputStreamTest {
                         "Background message queue should fill up");
                 assertTrue(
                         in.isAlive(),
-                        "Stream should be alive since termination marker is not yer read due to full queue");
+                        "Stream should be alive since termination marker is not yet read due to full queue");
 
                 // reading only one message should unblock background thread to read termination marker
                 int i = 0;
@@ -340,7 +335,8 @@ class AsyncInputStreamTest {
             assertTrue(workGroup.hasExceptions(), "Work group should have an exception");
             assertEquals(1, exceptionCapture.getExceptions().size());
             assertInstanceOf(
-                    ExecutionException.class, exceptionCapture.getExceptions().peek());
+                    MerkleSynchronizationException.class,
+                    exceptionCapture.getExceptions().peek());
             assertTrue(
                     exceptionCapture.getExceptions().peek().getMessage().contains("Message size exceeds maximum size"));
 
@@ -643,21 +639,7 @@ class AsyncInputStreamTest {
             throw new RuntimeException(ex);
         } catch (Throwable ex) {
             workGroup.handleError(ex); // cancel all submitted tasks in case of any error inside test (like assertion)
-        }
-    }
-
-    private static class ExceptionCapture implements Function<Throwable, Boolean> {
-
-        private final ConcurrentLinkedQueue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
-
-        @Override
-        public Boolean apply(Throwable throwable) {
-            exceptions.add(throwable);
-            return true;
-        }
-
-        public ConcurrentLinkedQueue<Throwable> getExceptions() {
-            return exceptions;
+            throw ex;
         }
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStreamTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStreamTest.java
@@ -34,10 +34,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -566,8 +564,8 @@ class AsyncOutputStreamTest {
             workGroup.waitForTermination();
 
             assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
-            assertEquals(1, exceptionCapture.exceptions.size());
-            assertInstanceOf(IOException.class, exceptionCapture.exceptions.peek());
+            assertEquals(1, exceptionCapture.getExceptions().size());
+            assertInstanceOf(IOException.class, exceptionCapture.getExceptions().peek());
         }
     }
 
@@ -801,22 +799,7 @@ class AsyncOutputStreamTest {
             throw new RuntimeException(ex);
         } catch (Throwable ex) {
             workGroup.handleError(ex);
-        }
-    }
-
-    private static class ExceptionCapture implements java.util.function.Function<Throwable, Boolean> {
-
-        final ConcurrentLinkedQueue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
-
-        @Override
-        public Boolean apply(final Throwable throwable) {
-            // StandardWorkGroup may wrap user exceptions in ExecutionException; unwrap for assertions.
-            if (throwable instanceof ExecutionException && throwable.getCause() != null) {
-                exceptions.add(throwable.getCause());
-            } else {
-                exceptions.add(throwable);
-            }
-            return true;
+            throw ex;
         }
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStreamTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStreamTest.java
@@ -1,0 +1,822 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.virtualmap.sync.streams;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyEquals;
+import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyTrue;
+import static org.hiero.consensus.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
+import com.swirlds.virtualmap.test.fixtures.sync.BlockingOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.base.concurrent.ThrowingRunnable;
+import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
+import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Tag(TestComponentTags.RECONNECT)
+class AsyncOutputStreamTest {
+
+    private static final int DEFAULT_BUFFER_SIZE = 100;
+    private static final Duration DEFAULT_FLUSH_INTERVAL = Duration.ofMillis(50);
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+    /**
+     * Tests to validate constructor, basic properties and methods without starting background thread.
+     */
+    @Nested
+    class BasicsWithoutStart {
+
+        @Test
+        @DisplayName("Constructor rejects null outputStream")
+        @SuppressWarnings("DataFlowIssue")
+        void constructorRejectsNullOutputStream() {
+            assertThrows(
+                    NullPointerException.class,
+                    () -> new AsyncOutputStream(
+                            null,
+                            mock(StandardWorkGroup.class),
+                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_FLUSH_INTERVAL,
+                            DEFAULT_TIMEOUT));
+        }
+
+        @Test
+        @DisplayName("Constructor rejects null workGroup")
+        @SuppressWarnings("DataFlowIssue")
+        void constructorRejectsNullWorkGroup() {
+            assertThrows(
+                    NullPointerException.class,
+                    () -> new AsyncOutputStream(
+                            mock(DataOutputStream.class),
+                            null,
+                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_FLUSH_INTERVAL,
+                            DEFAULT_TIMEOUT));
+        }
+
+        @Test
+        @DisplayName("Constructor rejects null flushInterval")
+        @SuppressWarnings("DataFlowIssue")
+        void constructorRejectsNullFlushInterval() {
+            assertThrows(
+                    NullPointerException.class,
+                    () -> new AsyncOutputStream(
+                            mock(DataOutputStream.class),
+                            mock(StandardWorkGroup.class),
+                            DEFAULT_BUFFER_SIZE,
+                            null,
+                            DEFAULT_TIMEOUT));
+        }
+
+        @Test
+        @DisplayName("Constructor rejects null timeout")
+        @SuppressWarnings("DataFlowIssue")
+        void constructorRejectsNullTimeout() {
+            assertThrows(
+                    NullPointerException.class,
+                    () -> new AsyncOutputStream(
+                            mock(DataOutputStream.class),
+                            mock(StandardWorkGroup.class),
+                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_FLUSH_INTERVAL,
+                            null));
+        }
+
+        @ParameterizedTest
+        @DisplayName("Constructor rejects non-positive bufferSize")
+        @ValueSource(ints = {-1, 0})
+        void constructorRejectsBadBufferSize(int bufferSize) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new AsyncOutputStream(
+                            mock(DataOutputStream.class),
+                            mock(StandardWorkGroup.class),
+                            bufferSize,
+                            DEFAULT_FLUSH_INTERVAL,
+                            DEFAULT_TIMEOUT));
+        }
+
+        @Test
+        @DisplayName("Constructor rejects non-positive flushInterval")
+        void constructorRejectsBadFlushInterval() {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new AsyncOutputStream(
+                            mock(DataOutputStream.class),
+                            mock(StandardWorkGroup.class),
+                            DEFAULT_BUFFER_SIZE,
+                            Duration.ZERO,
+                            DEFAULT_TIMEOUT));
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new AsyncOutputStream(
+                            mock(DataOutputStream.class),
+                            mock(StandardWorkGroup.class),
+                            DEFAULT_BUFFER_SIZE,
+                            Duration.ofMillis(-1),
+                            DEFAULT_TIMEOUT));
+        }
+
+        @Test
+        @DisplayName("Constructor rejects non-positive timeout")
+        void constructorRejectsBadTimeout() {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new AsyncOutputStream(
+                            mock(DataOutputStream.class),
+                            mock(StandardWorkGroup.class),
+                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_FLUSH_INTERVAL,
+                            Duration.ZERO));
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new AsyncOutputStream(
+                            mock(DataOutputStream.class),
+                            mock(StandardWorkGroup.class),
+                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_FLUSH_INTERVAL,
+                            Duration.ofMillis(-1)));
+        }
+
+        @Test
+        @DisplayName("Status is NOT_STARTED and isAlive is false before start")
+        void notAliveBeforeStart() {
+            final AsyncOutputStream out = newOut(mock(DataOutputStream.class), mock(StandardWorkGroup.class));
+            assertEquals(AsyncOutputStream.Status.NOT_STARTED, out.getStatus());
+            assertFalse(out.isAlive(), "isAlive must be false before start()");
+        }
+
+        @Test
+        @DisplayName("sendAsync before start throws IllegalStateException")
+        void sendAsyncBeforeStartThrows() {
+            final AsyncOutputStream out = newOut(mock(DataOutputStream.class), mock(StandardWorkGroup.class));
+            assertThrows(IllegalStateException.class, () -> out.sendAsync(serializeLong(1)));
+        }
+
+        @Test
+        @DisplayName("done() before start is a no-op")
+        void doneBeforeStartIsNoOp() {
+            final AsyncOutputStream out = newOut(mock(DataOutputStream.class), mock(StandardWorkGroup.class));
+            out.done(); // should not throw
+            assertEquals(AsyncOutputStream.Status.NOT_STARTED, out.getStatus());
+        }
+    }
+
+    /**
+     * Tests to validate normal work with single thread and no exceptions.
+     */
+    @Nested
+    class SingleThreadBasics {
+
+        @Test
+        @DisplayName("done() with no messages writes only the termination marker")
+        void doneWithNoMessagesWritesOnlyMarker() throws IOException {
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "no-msgs", null);
+            final AsyncOutputStream out = newOut(new DataOutputStream(byteOut), workGroup);
+            out.start();
+            assertEquals(AsyncOutputStream.Status.RUNNING, out.getStatus());
+
+            testAndAwaitTermination(workGroup, out::done);
+
+            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
+            assertFalse(out.isAlive(), "Stream should not be alive after termination");
+
+            verifyOrderedMessages(0, byteOut.toByteArray());
+        }
+
+        @Test
+        @DisplayName("Less than buffer size messages drain in order followed by -1")
+        void lessMessagesThanBuffer() throws IOException {
+            final int count = DEFAULT_BUFFER_SIZE - 1;
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "drain-less", null);
+            final AsyncOutputStream out = newOut(new DataOutputStream(byteOut), workGroup);
+            out.start();
+
+            testAndAwaitTermination(workGroup, () -> {
+                for (int i = 0; i < count; i++) {
+                    out.sendAsync(serializeLong(i));
+                }
+                out.done();
+            });
+
+            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
+            verifyOrderedMessages(count, byteOut.toByteArray());
+        }
+
+        @Test
+        @DisplayName("More than buffer size messages — backpressure works, all messages delivered")
+        void moreMessagesThanBuffer() throws IOException, InterruptedException {
+            final int bufferSize = 16;
+            final int count = bufferSize * 100;
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final BlockingOutputStream blockingOut = new BlockingOutputStream(byteOut);
+            blockingOut.lock();
+
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "drain-more", null);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    new DataOutputStream(blockingOut), workGroup, bufferSize, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
+            out.start();
+
+            final AtomicInteger messagesSent = new AtomicInteger(0);
+            final Thread producer = new Thread(() -> {
+                for (int i = 0; i < count; i++) {
+                    try {
+                        out.sendAsync(serializeLong(i));
+                        messagesSent.incrementAndGet();
+                    } catch (final InterruptedException ex) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            });
+            producer.setDaemon(true);
+            producer.start();
+
+            // Producer must be blocked by backpressure: at most buffer + one in-flight.
+            MILLISECONDS.sleep(150);
+            final int snapshot = messagesSent.get();
+            assertTrue(producer.isAlive(), "Producer thread should be alive");
+            // one message polled from queue and blocked on writing to output while bufferSize messages sit in the queue
+            assertEquals(bufferSize + 1, snapshot, "producer should be blocked by backpressure");
+
+            // Release the writer; all messages should drain.
+            blockingOut.unlock();
+            assertEventuallyEquals(count, messagesSent::get, Duration.ofSeconds(5), "all messages should be sent");
+
+            testAndAwaitTermination(workGroup, out::done);
+            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
+
+            verifyOrderedMessages(count, byteOut.toByteArray());
+        }
+
+        @Test
+        @DisplayName("Zero-length payload round-trips as an empty length-prefixed frame")
+        void zeroLengthPayloadRoundTrips() throws IOException {
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "zero-len", null);
+            final AsyncOutputStream out = newOut(new DataOutputStream(byteOut), workGroup);
+            out.start();
+
+            testAndAwaitTermination(workGroup, () -> {
+                out.sendAsync(new byte[0]);
+                out.done();
+            });
+
+            final DataInputStream dataIn = new DataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
+            assertEquals(0, dataIn.readInt(), "zero-length frame header should be present");
+            assertEquals(-1, dataIn.readInt(), "termination marker should follow");
+        }
+
+        @Test
+        @DisplayName("Large message (1 MiB) round-trips byte-exact")
+        void largeMessageRoundTrip() throws IOException {
+            final byte[] payload = new byte[1 << 20];
+            for (int i = 0; i < payload.length; i++) {
+                payload[i] = (byte) (i & 0xFF);
+            }
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "large-msg", null);
+            final AsyncOutputStream out = newOut(new DataOutputStream(byteOut), workGroup);
+            out.start();
+
+            testAndAwaitTermination(workGroup, () -> {
+                out.sendAsync(payload);
+                out.done();
+            });
+
+            final DataInputStream dataIn = new DataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
+            assertEquals(payload.length, dataIn.readInt(), "length header should match");
+            final byte[] received = new byte[payload.length];
+            dataIn.readFully(received);
+            for (int i = 0; i < payload.length; i++) {
+                assertEquals(payload[i], received[i], "byte " + i + " must round-trip exactly");
+            }
+            assertEquals(-1, dataIn.readInt(), "termination marker should follow");
+        }
+
+        @Test
+        @DisplayName("Buffered writes are flushed within flushInterval without further sends")
+        void flushIntervalTriggersFlush() {
+            final AtomicInteger flushCount = new AtomicInteger();
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final OutputStream flushCounter = new OutputStream() {
+                @Override
+                public void write(final int b) {
+                    byteOut.write(b);
+                }
+
+                @Override
+                public void write(final byte[] b, final int off, final int len) {
+                    byteOut.write(b, off, len);
+                }
+
+                @Override
+                public void flush() {
+                    flushCount.incrementAndGet();
+                }
+            };
+            final Duration flushInterval = Duration.ofMillis(50);
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "flush-tick", null);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    new DataOutputStream(flushCounter), workGroup, DEFAULT_BUFFER_SIZE, flushInterval, DEFAULT_TIMEOUT);
+            out.start();
+
+            testAndAwaitTermination(workGroup, () -> {
+                out.sendAsync(serializeLong(42));
+                // Wait long enough for the writer to wake from poll() and flush at least once.
+                assertEventuallyTrue(
+                        () -> flushCount.get() >= 1,
+                        Duration.ofSeconds(2),
+                        "writer should flush within a few flushInterval cycles");
+
+                out.done();
+            });
+        }
+
+        @Test
+        @DisplayName("Periodic flush still fires when the queue is continuously populated")
+        void flushHappensUnderSustainedLoad() {
+            // Each underlying byte write sleeps briefly, so writeMessage takes longer than the
+            // flushInterval. With a constantly populated queue, poll() always returns immediately,
+            // so flushing must be driven by the wall-clock time-since-last-flush check, not by
+            // the poll timeout. Without that check, only the final shutdown flush would fire.
+            final AtomicInteger flushCount = new AtomicInteger();
+            final OutputStream slowOut = new OutputStream() {
+                @Override
+                public void write(final int b) {
+                    sleepUninterruptibly(2);
+                }
+
+                @Override
+                public void write(final byte[] b, final int off, final int len) {
+                    sleepUninterruptibly(2);
+                }
+
+                @Override
+                public void flush() {
+                    flushCount.incrementAndGet();
+                }
+            };
+            final Duration flushInterval = Duration.ofMillis(5);
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "flush-busy", null);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    new DataOutputStream(slowOut), workGroup, DEFAULT_BUFFER_SIZE, flushInterval, DEFAULT_TIMEOUT);
+            out.start();
+
+            testAndAwaitTermination(workGroup, () -> {
+                // Keep sending so the queue is never empty for the writer.
+                final int count = 50;
+                for (int i = 0; i < count; i++) {
+                    out.sendAsync(serializeLong(i));
+                }
+
+                // Expect periodic flushes during the run — at minimum more than the single final flush.
+                assertEventuallyTrue(
+                        () -> flushCount.get() >= 3,
+                        Duration.ofSeconds(5),
+                        "writer should flush periodically under sustained load, observed " + flushCount.get());
+
+                out.done();
+            });
+        }
+    }
+
+    /**
+     * Tests to validate exception handling and propagation.
+     */
+    @Nested
+    class Exceptions {
+
+        @Test
+        @DisplayName("Second start throws an exception")
+        void secondStartThrowsAnException() {
+            final StandardWorkGroup workGroup = mock(StandardWorkGroup.class);
+            final DataOutputStream outputStream = mock(DataOutputStream.class);
+            final AsyncOutputStream out = newOut(outputStream, workGroup);
+
+            out.start();
+            assertTrue(out.isAlive(), "Stream should be alive");
+
+            assertThrows(IllegalStateException.class, out::start, "Second start should throw an exception");
+
+            verify(workGroup, times(1)).execute(eq("async-output-stream"), any(Runnable.class));
+            verifyNoMoreInteractions(workGroup);
+        }
+
+        @Test
+        @DisplayName("Background thread failed to submit")
+        void backgroundWriteThreadFailsToBeSubmitted() {
+            final RuntimeException cause = new RuntimeException();
+            final StandardWorkGroup workGroup = mock(StandardWorkGroup.class);
+            final DataOutputStream outputStream = mock(DataOutputStream.class);
+
+            doThrow(cause).when(workGroup).execute(eq("async-output-stream"), any(Runnable.class));
+
+            final AsyncOutputStream out = newOut(outputStream, workGroup);
+            assertThrows(MerkleSynchronizationException.class, out::start);
+            assertFalse(out.isAlive(), "Stream should not be alive");
+            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
+
+            verify(workGroup, times(1)).execute(eq("async-output-stream"), any(Runnable.class));
+            verify(workGroup, times(1)).handleError(cause);
+            verifyNoMoreInteractions(workGroup);
+        }
+
+        @Test
+        @DisplayName("sendAsync after done() is rejected (status is FINISHING/DONE)")
+        void sendAsyncAfterDoneIsRejected() throws InterruptedException {
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final BlockingOutputStream blockingOut = new BlockingOutputStream(byteOut);
+            // Hold the writer in the middle of a write so we can observe FINISHING.
+            blockingOut.lock();
+
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "send-after-done", null);
+            final AsyncOutputStream out = newOut(new DataOutputStream(blockingOut), workGroup);
+            out.start();
+
+            out.sendAsync(serializeLong(1));
+            // Give the writer thread a chance to dequeue and block on the locked stream.
+            MILLISECONDS.sleep(50);
+
+            out.done();
+            assertEquals(
+                    AsyncOutputStream.Status.FINISHING,
+                    out.getStatus(),
+                    "done() should flip status to FINISHING while writer is still draining");
+            assertTrue(out.isAlive(), "isAlive should still be true during FINISHING");
+
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> out.sendAsync(serializeLong(2)),
+                    "sendAsync during FINISHING must be rejected");
+
+            blockingOut.unlock();
+            workGroup.waitForTermination();
+            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
+            assertFalse(out.isAlive());
+
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> out.sendAsync(serializeLong(3)),
+                    "sendAsync after DONE must also be rejected");
+        }
+
+        @Test
+        @DisplayName("sendAsync times out with MerkleSynchronizationException when buffer stays full")
+        void sendAsyncTimesOutWhenQueueFull() throws InterruptedException {
+            final int bufferSize = 5;
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final BlockingOutputStream blockingOut = new BlockingOutputStream(byteOut);
+            blockingOut.lock();
+
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "queue-timeout", null);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    new DataOutputStream(blockingOut),
+                    workGroup,
+                    bufferSize,
+                    Duration.ofMillis(10),
+                    Duration.ofMillis(100));
+            out.start();
+
+            int sent = 0;
+            MerkleSynchronizationException caught = null;
+            try {
+                for (int i = 0; i < bufferSize * 3; i++) {
+                    out.sendAsync(serializeLong(i));
+                    sent++;
+                }
+            } catch (final MerkleSynchronizationException e) {
+                caught = e;
+            }
+
+            assertNotNull(caught, "sendAsync should have timed out once the buffer filled up");
+            assertTrue(
+                    caught.getMessage().contains("Timed out waiting to send data"),
+                    "exception message should mention the timeout, was: " + caught.getMessage());
+            assertTrue(sent >= bufferSize, "expected at least bufferSize sends to succeed before the timeout");
+
+            blockingOut.unlock();
+            out.done();
+            workGroup.waitForTermination();
+        }
+
+        @Test
+        @DisplayName("Writer I/O error is forwarded to the work group")
+        void writerIoErrorPropagatesToWorkGroup() throws InterruptedException {
+            final OutputStream brokenOut = new OutputStream() {
+                @Override
+                public void write(final int b) throws IOException {
+                    throw new IOException("simulated write failure");
+                }
+            };
+            final ExceptionCapture exceptionCapture = new ExceptionCapture();
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "writer-io-error", null, exceptionCapture);
+            final AsyncOutputStream out = newOut(new DataOutputStream(brokenOut), workGroup);
+            out.start();
+            out.sendAsync(serializeLong(1));
+
+            assertEventuallyTrue(
+                    workGroup::hasExceptions,
+                    Duration.ofSeconds(5),
+                    "work group should record the writer's IOException");
+
+            out.done();
+            workGroup.waitForTermination();
+
+            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
+            assertEquals(1, exceptionCapture.exceptions.size());
+            assertInstanceOf(IOException.class, exceptionCapture.exceptions.peek());
+        }
+    }
+
+    /**
+     * Tests for concurrent usage from multiple producer threads.
+     */
+    @Nested
+    class Concurrent {
+
+        @Test
+        @DisplayName("Concurrent starts: only one succeeds")
+        void concurrentStartsThrowsAnException() throws InterruptedException {
+            final StandardWorkGroup workGroup = mock(StandardWorkGroup.class);
+            final DataOutputStream outputStream = mock(DataOutputStream.class);
+            final AsyncOutputStream out = newOut(outputStream, workGroup);
+
+            final int threadsCount = 10;
+            final AtomicInteger exceptionsCount = new AtomicInteger();
+            final CyclicBarrier barrier = new CyclicBarrier(threadsCount);
+            final CountDownLatch doneLatch = new CountDownLatch(threadsCount);
+
+            for (int i = 0; i < threadsCount; i++) {
+                new Thread(() -> {
+                            try {
+                                barrier.await();
+                                out.start();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                throw new RuntimeException("Interrupted", e);
+                            } catch (BrokenBarrierException e) {
+                                throw new RuntimeException(e);
+                            } catch (IllegalStateException e) {
+                                exceptionsCount.incrementAndGet();
+                            } finally {
+                                doneLatch.countDown();
+                            }
+                        })
+                        .start();
+            }
+
+            if (!doneLatch.await(2, TimeUnit.SECONDS)) {
+                throw new AssertionError("Not all starter threads finished");
+            }
+            assertEquals(threadsCount - 1, exceptionsCount.get(), "Only one thread can start, others should throw");
+            verify(workGroup, times(1)).execute(eq("async-output-stream"), any(Runnable.class));
+            verifyNoMoreInteractions(workGroup);
+        }
+
+        @Test
+        @DisplayName("Concurrent sendAsync from many producers preserves per-producer order")
+        void concurrentSendPreservesPerProducerOrder() throws IOException {
+            final int producers = 8;
+            final int perProducer = 200;
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "concurrent-send", null);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    new DataOutputStream(byteOut),
+                    workGroup,
+                    DEFAULT_BUFFER_SIZE,
+                    DEFAULT_FLUSH_INTERVAL,
+                    DEFAULT_TIMEOUT);
+            out.start();
+
+            final CyclicBarrier barrier = new CyclicBarrier(producers);
+            final CountDownLatch doneLatch = new CountDownLatch(producers);
+
+            for (int p = 0; p < producers; p++) {
+                final int producerId = p;
+                final Thread t = new Thread(() -> {
+                    try {
+                        barrier.await();
+                        for (int seq = 0; seq < perProducer; seq++) {
+                            out.sendAsync(encodeProducerMsg(producerId, seq));
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted", e);
+                    } catch (BrokenBarrierException e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        doneLatch.countDown();
+                    }
+                });
+                t.setDaemon(true);
+                t.start();
+            }
+
+            testAndAwaitTermination(workGroup, () -> {
+                if (!doneLatch.await(5, TimeUnit.SECONDS)) {
+                    throw new AssertionError("Not all producer threads finished");
+                }
+                out.done();
+            });
+
+            final Map<Integer, List<Integer>> perProducerSeqs = new HashMap<>();
+            final DataInputStream dataIn = new DataInputStream(new ByteArrayInputStream(byteOut.toByteArray()));
+            int total = 0;
+            while (true) {
+                final int len = dataIn.readInt();
+                if (len < 0) {
+                    break;
+                }
+                assertEquals(Long.BYTES, len, "every framed message should be a long");
+                final long combined = dataIn.readLong();
+                final int producerId = (int) (combined >>> 32);
+                final int seq = (int) combined;
+                perProducerSeqs
+                        .computeIfAbsent(producerId, k -> new ArrayList<>())
+                        .add(seq);
+                total++;
+            }
+            assertEquals(producers * perProducer, total, "every message should have been written");
+
+            for (int p = 0; p < producers; p++) {
+                final List<Integer> seqs = perProducerSeqs.get(p);
+                assertNotNull(seqs, "producer " + p + " should have at least one message");
+                assertEquals(perProducer, seqs.size(), "producer " + p + " should have all its messages");
+                for (int i = 0; i < seqs.size(); i++) {
+                    assertEquals(
+                            i, seqs.get(i).intValue(), "producer " + p + " message at index " + i + " out of order");
+                }
+            }
+        }
+
+        @Test
+        @DisplayName("sendAsync interrupted while waiting on a full buffer throws InterruptedException")
+        void sendAsyncInterruptedOnFullBuffer() throws InterruptedException {
+            final int bufferSize = 2;
+            final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+            final BlockingOutputStream blockingOut = new BlockingOutputStream(byteOut);
+            blockingOut.lock();
+
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "send-interrupt", null);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    new DataOutputStream(blockingOut),
+                    workGroup,
+                    bufferSize,
+                    DEFAULT_FLUSH_INTERVAL,
+                    Duration.ofSeconds(60));
+            out.start();
+
+            // Let the writer pick up the first message and block on the locked stream.
+            out.sendAsync(serializeLong(0));
+            MILLISECONDS.sleep(50);
+            // Fill the buffer.
+            out.sendAsync(serializeLong(1));
+            out.sendAsync(serializeLong(2));
+
+            final AtomicReference<Object> outcome = new AtomicReference<>();
+            final CountDownLatch startedLatch = new CountDownLatch(1);
+            final Thread caller = new Thread(() -> {
+                startedLatch.countDown();
+                try {
+                    out.sendAsync(serializeLong(3));
+                    outcome.set("unexpected-success");
+                } catch (final InterruptedException e) {
+                    outcome.set(e);
+                    Thread.currentThread().interrupt();
+                } catch (final Throwable t) {
+                    outcome.set(t);
+                }
+            });
+            caller.setDaemon(true);
+            caller.start();
+
+            assertTrue(startedLatch.await(2, TimeUnit.SECONDS), "caller thread should have started");
+            // Give the caller a moment to enter offer(timeout).
+            MILLISECONDS.sleep(50);
+            caller.interrupt();
+            caller.join(2_000);
+
+            assertFalse(caller.isAlive(), "caller thread should exit after interrupt");
+            assertInstanceOf(
+                    InterruptedException.class,
+                    outcome.get(),
+                    "sendAsync should throw InterruptedException, got: " + outcome.get());
+
+            // Cleanup: unblock writer, signal done, drain.
+            blockingOut.unlock();
+            out.done();
+            workGroup.waitForTermination();
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static AsyncOutputStream newOut(final DataOutputStream out, final StandardWorkGroup workGroup) {
+        return new AsyncOutputStream(out, workGroup, DEFAULT_BUFFER_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
+    }
+
+    private void verifyOrderedMessages(int messagesCount, byte[] data) throws IOException {
+        final DataInputStream dataIn = new DataInputStream(new ByteArrayInputStream(data));
+        for (int i = 0; i < messagesCount; i++) {
+            assertEquals(Long.BYTES, dataIn.readInt(), "message length should be Long.BYTES");
+            assertEquals(i, dataIn.readLong(), "messages should be drained in send order");
+        }
+        assertEquals(-1, dataIn.readInt(), "termination marker should follow all messages");
+        assertEquals(0, dataIn.available(), "no bytes after the termination marker");
+    }
+
+    private static byte[] serializeLong(final long value) {
+        final byte[] bytes = new byte[Long.BYTES];
+        BufferedData.wrap(bytes).writeLong(value);
+        return bytes;
+    }
+
+    private static byte[] encodeProducerMsg(final int producerId, final int seq) {
+        return serializeLong(((long) producerId << 32) | (seq & 0xFFFFFFFFL));
+    }
+
+    private static void sleepUninterruptibly(final long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static void testAndAwaitTermination(final StandardWorkGroup workGroup, final ThrowingRunnable test) {
+        try {
+            test.run();
+            workGroup.waitForTermination();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted", ex);
+        } catch (Exception ex) {
+            workGroup.handleError(ex); // cancel submitted tasks if the test body threw
+            throw new RuntimeException(ex);
+        } catch (Throwable ex) {
+            workGroup.handleError(ex);
+        }
+    }
+
+    private static class ExceptionCapture implements java.util.function.Function<Throwable, Boolean> {
+
+        final ConcurrentLinkedQueue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
+
+        @Override
+        public Boolean apply(final Throwable throwable) {
+            // StandardWorkGroup may wrap user exceptions in ExecutionException; unwrap for assertions.
+            if (throwable instanceof ExecutionException && throwable.getCause() != null) {
+                exceptions.add(throwable.getCause());
+            } else {
+                exceptions.add(throwable);
+            }
+            return true;
+        }
+    }
+}

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStreamTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/AsyncOutputStreamTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 @Tag(TestComponentTags.RECONNECT)
 class AsyncOutputStreamTest {
 
-    private static final int DEFAULT_BUFFER_SIZE = 100;
+    private static final int DEFAULT_QUEUE_SIZE = 100;
     private static final Duration DEFAULT_FLUSH_INTERVAL = Duration.ofMillis(50);
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
 
@@ -71,7 +71,7 @@ class AsyncOutputStreamTest {
                     () -> new AsyncOutputStream(
                             null,
                             mock(StandardWorkGroup.class),
-                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_QUEUE_SIZE,
                             DEFAULT_FLUSH_INTERVAL,
                             DEFAULT_TIMEOUT));
         }
@@ -85,7 +85,7 @@ class AsyncOutputStreamTest {
                     () -> new AsyncOutputStream(
                             mock(DataOutputStream.class),
                             null,
-                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_QUEUE_SIZE,
                             DEFAULT_FLUSH_INTERVAL,
                             DEFAULT_TIMEOUT));
         }
@@ -99,7 +99,7 @@ class AsyncOutputStreamTest {
                     () -> new AsyncOutputStream(
                             mock(DataOutputStream.class),
                             mock(StandardWorkGroup.class),
-                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_QUEUE_SIZE,
                             null,
                             DEFAULT_TIMEOUT));
         }
@@ -113,14 +113,14 @@ class AsyncOutputStreamTest {
                     () -> new AsyncOutputStream(
                             mock(DataOutputStream.class),
                             mock(StandardWorkGroup.class),
-                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_QUEUE_SIZE,
                             DEFAULT_FLUSH_INTERVAL,
                             null));
         }
 
         @ParameterizedTest
-        @DisplayName("Constructor rejects non-positive bufferSize")
         @ValueSource(ints = {-1, 0})
+        @DisplayName("Constructor rejects non-positive bufferSize")
         void constructorRejectsBadBufferSize(int bufferSize) {
             assertThrows(
                     IllegalArgumentException.class,
@@ -132,54 +132,40 @@ class AsyncOutputStreamTest {
                             DEFAULT_TIMEOUT));
         }
 
-        @Test
+        @ParameterizedTest
+        @ValueSource(ints = {-1, 0})
         @DisplayName("Constructor rejects non-positive flushInterval")
-        void constructorRejectsBadFlushInterval() {
+        void constructorRejectsBadFlushInterval(int flushIntervalMs) {
             assertThrows(
                     IllegalArgumentException.class,
                     () -> new AsyncOutputStream(
                             mock(DataOutputStream.class),
                             mock(StandardWorkGroup.class),
-                            DEFAULT_BUFFER_SIZE,
-                            Duration.ZERO,
-                            DEFAULT_TIMEOUT));
-            assertThrows(
-                    IllegalArgumentException.class,
-                    () -> new AsyncOutputStream(
-                            mock(DataOutputStream.class),
-                            mock(StandardWorkGroup.class),
-                            DEFAULT_BUFFER_SIZE,
-                            Duration.ofMillis(-1),
+                            DEFAULT_QUEUE_SIZE,
+                            Duration.ofMillis(flushIntervalMs),
                             DEFAULT_TIMEOUT));
         }
 
-        @Test
+        @ParameterizedTest
+        @ValueSource(longs = {-1L, 0L})
         @DisplayName("Constructor rejects non-positive timeout")
-        void constructorRejectsBadTimeout() {
+        void constructorRejectsBadTimeout(long timeoutMs) {
             assertThrows(
                     IllegalArgumentException.class,
                     () -> new AsyncOutputStream(
                             mock(DataOutputStream.class),
                             mock(StandardWorkGroup.class),
-                            DEFAULT_BUFFER_SIZE,
+                            DEFAULT_QUEUE_SIZE,
                             DEFAULT_FLUSH_INTERVAL,
-                            Duration.ZERO));
-            assertThrows(
-                    IllegalArgumentException.class,
-                    () -> new AsyncOutputStream(
-                            mock(DataOutputStream.class),
-                            mock(StandardWorkGroup.class),
-                            DEFAULT_BUFFER_SIZE,
-                            DEFAULT_FLUSH_INTERVAL,
-                            Duration.ofMillis(-1)));
+                            Duration.ofMillis(timeoutMs)));
         }
 
         @Test
-        @DisplayName("Status is NOT_STARTED and isAlive is false before start")
-        void notAliveBeforeStart() {
+        @DisplayName("Status is NOT_STARTED and queue is empty before start")
+        void notStartedAndEmptyBeforeStart() {
             final AsyncOutputStream out = newOut(mock(DataOutputStream.class), mock(StandardWorkGroup.class));
             assertEquals(AsyncOutputStream.Status.NOT_STARTED, out.getStatus());
-            assertFalse(out.isAlive(), "isAlive must be false before start()");
+            assertEquals(0, out.getQueueSize(), "queue size should be empty");
         }
 
         @Test
@@ -216,15 +202,14 @@ class AsyncOutputStreamTest {
             testAndAwaitTermination(workGroup, out::done);
 
             assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
-            assertFalse(out.isAlive(), "Stream should not be alive after termination");
 
             verifyOrderedMessages(0, byteOut.toByteArray());
         }
 
         @Test
-        @DisplayName("Less than buffer size messages drain in order followed by -1")
-        void lessMessagesThanBuffer() throws IOException {
-            final int count = DEFAULT_BUFFER_SIZE - 1;
+        @DisplayName("Less than queue size messages drain in order followed by -1")
+        void lessMessagesThanQueueSize() throws IOException {
+            final int count = DEFAULT_QUEUE_SIZE - 1;
             final ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
             final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "drain-less", null);
             final AsyncOutputStream out = newOut(new DataOutputStream(byteOut), workGroup);
@@ -270,7 +255,7 @@ class AsyncOutputStreamTest {
             producer.setDaemon(true);
             producer.start();
 
-            // Producer must be blocked by backpressure: at most buffer + one in-flight.
+            // Producer must be blocked by backpressure: at most queue size + one in-flight.
             MILLISECONDS.sleep(150);
             final int snapshot = messagesSent.get();
             assertTrue(producer.isAlive(), "Producer thread should be alive");
@@ -356,7 +341,7 @@ class AsyncOutputStreamTest {
             final Duration flushInterval = Duration.ofMillis(50);
             final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "flush-tick", null);
             final AsyncOutputStream out = new AsyncOutputStream(
-                    new DataOutputStream(flushCounter), workGroup, DEFAULT_BUFFER_SIZE, flushInterval, DEFAULT_TIMEOUT);
+                    new DataOutputStream(flushCounter), workGroup, DEFAULT_QUEUE_SIZE, flushInterval, DEFAULT_TIMEOUT);
             out.start();
 
             testAndAwaitTermination(workGroup, () -> {
@@ -364,7 +349,7 @@ class AsyncOutputStreamTest {
                 // Wait long enough for the writer to wake from poll() and flush at least once.
                 assertEventuallyTrue(
                         () -> flushCount.get() >= 1,
-                        Duration.ofSeconds(2),
+                        flushInterval.plus(Duration.ofMillis(100)),
                         "writer should flush within a few flushInterval cycles");
 
                 out.done();
@@ -398,7 +383,7 @@ class AsyncOutputStreamTest {
             final Duration flushInterval = Duration.ofMillis(5);
             final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "flush-busy", null);
             final AsyncOutputStream out = new AsyncOutputStream(
-                    new DataOutputStream(slowOut), workGroup, DEFAULT_BUFFER_SIZE, flushInterval, DEFAULT_TIMEOUT);
+                    new DataOutputStream(slowOut), workGroup, DEFAULT_QUEUE_SIZE, flushInterval, DEFAULT_TIMEOUT);
             out.start();
 
             testAndAwaitTermination(workGroup, () -> {
@@ -433,7 +418,7 @@ class AsyncOutputStreamTest {
             final AsyncOutputStream out = newOut(outputStream, workGroup);
 
             out.start();
-            assertTrue(out.isAlive(), "Stream should be alive");
+            assertEquals(AsyncOutputStream.Status.RUNNING, out.getStatus(), "Stream should be running");
 
             assertThrows(IllegalStateException.class, out::start, "Second start should throw an exception");
 
@@ -452,8 +437,7 @@ class AsyncOutputStreamTest {
 
             final AsyncOutputStream out = newOut(outputStream, workGroup);
             assertThrows(MerkleSynchronizationException.class, out::start);
-            assertFalse(out.isAlive(), "Stream should not be alive");
-            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
+            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus(), "Stream should be done");
 
             verify(workGroup, times(1)).execute(eq("async-output-stream"), any(Runnable.class));
             verify(workGroup, times(1)).handleError(cause);
@@ -482,7 +466,6 @@ class AsyncOutputStreamTest {
                     AsyncOutputStream.Status.FINISHING,
                     out.getStatus(),
                     "done() should flip status to FINISHING while writer is still draining");
-            assertTrue(out.isAlive(), "isAlive should still be true during FINISHING");
 
             assertThrows(
                     IllegalStateException.class,
@@ -492,7 +475,6 @@ class AsyncOutputStreamTest {
             blockingOut.unlock();
             workGroup.waitForTermination();
             assertEquals(AsyncOutputStream.Status.DONE, out.getStatus());
-            assertFalse(out.isAlive());
 
             assertThrows(
                     IllegalStateException.class,
@@ -537,6 +519,7 @@ class AsyncOutputStreamTest {
             blockingOut.unlock();
             out.done();
             workGroup.waitForTermination();
+            assertEquals(AsyncOutputStream.Status.DONE, out.getStatus(), "Stream should not be alive");
         }
 
         @Test
@@ -625,7 +608,7 @@ class AsyncOutputStreamTest {
             final AsyncOutputStream out = new AsyncOutputStream(
                     new DataOutputStream(byteOut),
                     workGroup,
-                    DEFAULT_BUFFER_SIZE,
+                    DEFAULT_QUEUE_SIZE,
                     DEFAULT_FLUSH_INTERVAL,
                     DEFAULT_TIMEOUT);
             out.start();
@@ -756,7 +739,7 @@ class AsyncOutputStreamTest {
     // ---------------------------------------------------------------------
 
     private static AsyncOutputStream newOut(final DataOutputStream out, final StandardWorkGroup workGroup) {
-        return new AsyncOutputStream(out, workGroup, DEFAULT_BUFFER_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
+        return new AsyncOutputStream(out, workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
     }
 
     private void verifyOrderedMessages(int messagesCount, byte[] data) throws IOException {

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/ExceptionCapture.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/ExceptionCapture.java
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.virtualmap.sync.streams;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+
+public class ExceptionCapture implements Function<Throwable, Boolean> {
+
+    private final ConcurrentLinkedQueue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
+
+    @Override
+    public Boolean apply(final Throwable throwable) {
+        // StandardWorkGroup may wrap user exceptions in ExecutionException; unwrap for assertions.
+        if (throwable instanceof ExecutionException && throwable.getCause() != null) {
+            exceptions.add(throwable.getCause());
+        } else {
+            exceptions.add(throwable);
+        }
+        return true;
+    }
+
+    public ConcurrentLinkedQueue<Throwable> getExceptions() {
+        return exceptions;
+    }
+}

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/PairedAsyncStreamsTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/PairedAsyncStreamsTest.java
@@ -1,23 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.virtualmap.sync.streams;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyTrue;
 import static org.hiero.consensus.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
-import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
 import com.swirlds.virtualmap.test.fixtures.sync.PairedStreams;
+import java.io.EOFException;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.hiero.base.concurrent.ThrowingRunnable;
 import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
 import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * End-to-end tests that exercise {@link AsyncInputStream} and {@link AsyncOutputStream} together
@@ -33,6 +39,8 @@ class PairedAsyncStreamsTest {
 
     private static final int DEFAULT_QUEUE_SIZE = 100;
     private static final Duration DEFAULT_FLUSH_INTERVAL = Duration.ofMillis(50);
+    // Generous safety timeout used for the production knobs (readOrWait / sendAsync) that are
+    // expected to never fire in a healthy test run. Matches AsyncOutputStreamTest.DEFAULT_TIMEOUT.
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
 
     @Test
@@ -41,94 +49,133 @@ class PairedAsyncStreamsTest {
         try (final PairedStreams streams = new PairedStreams()) {
             final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "basic", null);
 
-            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, DEFAULT_QUEUE_SIZE);
-            final AsyncOutputStream out = new AsyncOutputStream(
+            final AsyncInputStream teacherIn =
+                    new AsyncInputStream(streams.getTeacherInput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
+            final AsyncOutputStream learnerOut = new AsyncOutputStream(
                     streams.getLearnerOutput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
 
-            in.start();
-            out.start();
+            teacherIn.start();
+            learnerOut.start();
 
             final int count = 100;
-            for (int i = 0; i < count; i++) {
-                out.sendAsync(serializeLong(i));
-                final byte[] message = in.readOrWait(YieldStrategy.SPIN);
-                assertNotNull(message);
-                assertEquals(i, parseLong(message), "message should match the value that was serialized");
-            }
 
-            out.done();
+            OutcomeRunnable learnerRunnable = new OutcomeRunnable(() -> {
+                for (int i = 0; i < count; i++) {
+                    learnerOut.sendAsync(serializeLong(i));
+                }
+                learnerOut.done();
+            });
+            workGroup.execute("learner-sender", learnerRunnable);
+
+            final AtomicInteger messagesRead = new AtomicInteger();
+            OutcomeRunnable teacherRunnable = new OutcomeRunnable(() -> {
+                while (!Thread.currentThread().isInterrupted()) {
+                    final byte[] message = teacherIn.readOrWait(YieldStrategy.SPIN);
+                    if (message == null) {
+                        break;
+                    }
+                    assertNotNull(message);
+                    assertEquals(
+                            messagesRead.getAndIncrement(),
+                            parseLong(message),
+                            "message should match the value that was serialized");
+                }
+            });
+            workGroup.execute("teacher-receiver", teacherRunnable);
+
             workGroup.waitForTermination();
+
+            learnerRunnable.verifySuccess("learner task");
+            teacherRunnable.verifySuccess("teacher task");
+            assertEquals(count, messagesRead.get(), "messages should be read");
         }
     }
 
     @Test
-    @DisplayName("Teacher disconnect mid-stream propagates error to work group")
-    void teacherDisconnectMidStream() throws IOException, InterruptedException {
+    @DisplayName("Learner disconnect mid-stream propagates error to work group")
+    void learnerDisconnectMidStream() throws IOException, InterruptedException {
+        ExceptionCapture exceptionCapture = new ExceptionCapture();
         final PairedStreams streams = new PairedStreams();
         try {
             final StandardWorkGroup workGroup =
-                    new StandardWorkGroup(getStaticThreadManager(), "teacher-disconnect", null);
+                    new StandardWorkGroup(getStaticThreadManager(), "teacher-disconnect", null, exceptionCapture);
 
-            final AsyncInputStream in = new AsyncInputStream(streams.getLearnerInput(), workGroup, DEFAULT_QUEUE_SIZE);
-            final AsyncOutputStream out = new AsyncOutputStream(
-                    streams.getTeacherOutput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
+            final AsyncInputStream teacherIn =
+                    new AsyncInputStream(streams.getTeacherInput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
+            final AsyncOutputStream learnerOut = new AsyncOutputStream(
+                    streams.getLearnerOutput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
 
-            in.start();
-            out.start();
+            teacherIn.start();
+            learnerOut.start();
 
-            // Send one message so the writer flushes through the socket, then pull the plug
-            // on the teacher side. The learner-side reader will see EOF/SocketException.
-            out.sendAsync(serializeLong(1));
-            MILLISECONDS.sleep(50);
-            streams.disconnectTeacher();
+            // Teacher task signals when the first message has been observed so the main thread
+            // can disconnect the learner only after the round-trip is complete — avoids the
+            // timing-based race of sleeping for "long enough" to assume a flush happened.
+            final CountDownLatch firstReceived = new CountDownLatch(1);
+            OutcomeRunnable teacherRunnable = new OutcomeRunnable(() -> {
+                final byte[] first = teacherIn.readOrWait(YieldStrategy.PARK);
+                assertNotNull(first, "first message should arrive before disconnect");
+                firstReceived.countDown();
+                // second read blocks until the work group interrupts the task after EOF
+                teacherIn.readOrWait(YieldStrategy.PARK);
+            });
+            workGroup.execute("teacher-task", teacherRunnable);
 
-            assertEventuallyTrue(
-                    workGroup::hasExceptions,
-                    Duration.ofSeconds(5),
-                    "Work group should record an exception after teacher disconnect");
+            learnerOut.sendAsync(serializeLong(1));
+            assertTrue(
+                    firstReceived.await(5, TimeUnit.SECONDS), "teacher should observe first message before disconnect");
+
+            streams.disconnectLearner();
+            workGroup.waitForTermination();
+
+            assertEquals(AsyncInputStream.Status.DONE, teacherIn.getStatus(), "input stream should be closed");
+            assertEquals(AsyncOutputStream.Status.DONE, learnerOut.getStatus(), "output stream should be closed");
+            teacherRunnable.verifyInterrupted("teacher task");
+            assertTrue(workGroup.hasExceptions(), "Work group should record an exception after teacher disconnect");
+            assertEquals(1, exceptionCapture.getExceptions().size(), "one exception should be captured");
+            assertInstanceOf(
+                    EOFException.class, exceptionCapture.getExceptions().peek(), "EOFException should be captured");
         } finally {
             closeIgnoringIoException(streams);
         }
     }
 
     @Test
-    @DisplayName("Learner disconnect mid-stream propagates error to work group")
-    void learnerDisconnectMidStream() throws IOException {
+    @Timeout(value = 30, unit = TimeUnit.SECONDS)
+    @DisplayName("Teacher disconnect mid-stream propagates error to work group")
+    void teacherDisconnectMidStream() throws IOException, InterruptedException {
         final PairedStreams streams = new PairedStreams();
         try {
             final StandardWorkGroup workGroup =
                     new StandardWorkGroup(getStaticThreadManager(), "learner-disconnect", null);
 
-            final AsyncInputStream in = new AsyncInputStream(streams.getLearnerInput(), workGroup, DEFAULT_QUEUE_SIZE);
-            final AsyncOutputStream out = new AsyncOutputStream(
-                    streams.getTeacherOutput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
+            final AsyncInputStream teacherIn =
+                    new AsyncInputStream(streams.getTeacherInput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
+            final AsyncOutputStream learnerOut = new AsyncOutputStream(
+                    streams.getLearnerOutput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
 
-            in.start();
-            out.start();
+            teacherIn.start();
+            learnerOut.start();
 
-            // Close the learner socket so the teacher's write/flush fails with an IOException.
+            // Close the teacher socket so the learner's write/flush fails with an IOException.
             // Keep pumping messages on a background thread until the work group records the error
             // — the OS may buffer the first few writes before reporting the broken pipe.
-            streams.disconnectLearner();
+            streams.disconnectTeacher();
 
-            final Thread sender = new Thread(() -> {
-                for (int i = 0; i < 10_000 && !workGroup.hasExceptions(); i++) {
-                    try {
-                        out.sendAsync(serializeLong(i));
-                    } catch (final InterruptedException
-                            | MerkleSynchronizationException
-                            | IllegalStateException ignored) {
-                        break;
-                    }
+            OutcomeRunnable learnerRunnable = new OutcomeRunnable(() -> {
+                for (int i = 0; i < 10_000 && !Thread.currentThread().isInterrupted(); i++) {
+                    learnerOut.sendAsync(serializeLong(i));
                 }
             });
-            sender.setDaemon(true);
-            sender.start();
+            workGroup.execute(learnerRunnable);
 
-            assertEventuallyTrue(
-                    workGroup::hasExceptions,
-                    Duration.ofSeconds(5),
-                    "Work group should record an exception after learner disconnect");
+            workGroup.waitForTermination();
+
+            assertEquals(AsyncInputStream.Status.DONE, teacherIn.getStatus(), "input stream should be closed");
+            assertEquals(AsyncOutputStream.Status.DONE, learnerOut.getStatus(), "output stream should be closed");
+            learnerRunnable.verifyNotSuccess("learner task");
+
+            assertTrue(workGroup.hasExceptions(), "Work group should record an exception after teacher disconnect");
         } finally {
             closeIgnoringIoException(streams);
         }
@@ -136,7 +183,7 @@ class PairedAsyncStreamsTest {
 
     @Test
     @DisplayName("Producer outpaces a slow consumer: all messages arrive in order, done() terminates")
-    void slowConsumerBackpressuresProducer() throws IOException, InterruptedException {
+    void slowConsumerBackpressureProducer() throws IOException, InterruptedException {
         try (final PairedStreams streams = new PairedStreams()) {
             final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "slow-consumer", null);
 
@@ -144,7 +191,8 @@ class PairedAsyncStreamsTest {
             // backpressure blocks the producer instead of throwing while the consumer catches up.
             final int bufferSize = 8;
             final int count = 1000;
-            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, bufferSize);
+            final AsyncInputStream in =
+                    new AsyncInputStream(streams.getTeacherInput(), workGroup, bufferSize, DEFAULT_TIMEOUT);
             final AsyncOutputStream out = new AsyncOutputStream(
                     streams.getLearnerOutput(), workGroup, bufferSize, DEFAULT_FLUSH_INTERVAL, Duration.ofSeconds(30));
 
@@ -186,6 +234,42 @@ class PairedAsyncStreamsTest {
         }
     }
 
+    @Test
+    @Timeout(value = 5, unit = TimeUnit.SECONDS)
+    @DisplayName("Socket SO_TIMEOUT on the input side surfaces as SocketTimeoutException to the work group")
+    void socketTimeoutOnBackgroundReadPropagatesToWorkGroup() throws IOException, InterruptedException {
+        final PairedStreams streams = new PairedStreams();
+        try {
+            final ExceptionCapture exceptionCapture = new ExceptionCapture();
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "socket-timeout", null, exceptionCapture);
+
+            // Short SO_TIMEOUT on the teacher socket; the learner never writes anything so the
+            // background reader's readInt() will block on the socket until SO_TIMEOUT fires and
+            // throws SocketTimeoutException (a subclass of IOException) into AsyncInputStream.run().
+            streams.setTeacherTimeout(100);
+
+            final AsyncInputStream teacherIn =
+                    new AsyncInputStream(streams.getTeacherInput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_TIMEOUT);
+            teacherIn.start();
+
+            workGroup.waitForTermination();
+
+            assertEquals(
+                    AsyncInputStream.Status.DONE,
+                    teacherIn.getStatus(),
+                    "background reader should exit after socket timeout");
+            assertTrue(workGroup.hasExceptions(), "work group should record the SocketTimeoutException");
+            assertEquals(1, exceptionCapture.getExceptions().size(), "exactly one exception expected");
+            assertInstanceOf(
+                    SocketTimeoutException.class,
+                    exceptionCapture.getExceptions().peek(),
+                    "the recorded exception should be SocketTimeoutException");
+        } finally {
+            closeIgnoringIoException(streams);
+        }
+    }
+
     // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
@@ -210,6 +294,45 @@ class PairedAsyncStreamsTest {
             streams.close();
         } catch (final IOException ignored) {
             // expected after disconnectTeacher() / disconnectLearner()
+        }
+    }
+
+    private static class OutcomeRunnable implements Runnable {
+
+        private final ThrowingRunnable delegate;
+        private Exception exception;
+
+        OutcomeRunnable(ThrowingRunnable delegate) {
+            this.delegate = delegate;
+        }
+
+        public void verifySuccess(String context) {
+            assertNull(exception, "Runnable should have been successfully finished for " + context);
+        }
+
+        public void verifyNotSuccess(String context) {
+            assertNotNull(exception, "Runnable should have been interrupted or have error for " + context);
+        }
+
+        public void verifyInterrupted(String context) {
+            assertInstanceOf(
+                    InterruptedException.class, exception, "Runnable should have been interrupted for " + context);
+        }
+
+        public void verifyError(Class<? extends Exception> exClass, String context) {
+            assertInstanceOf(exClass, exception, "Runnable should have been interrupted for " + context);
+        }
+
+        @Override
+        public void run() {
+            try {
+                delegate.run();
+                if (Thread.currentThread().isInterrupted()) {
+                    exception = new InterruptedException("Thread has been interrupted");
+                }
+            } catch (Exception ex) {
+                exception = ex;
+            }
         }
     }
 }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/PairedAsyncStreamsTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/sync/streams/PairedAsyncStreamsTest.java
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.virtualmap.sync.streams;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.hiero.base.utility.test.fixtures.assertions.AssertionUtils.assertEventuallyTrue;
+import static org.hiero.consensus.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.swirlds.virtualmap.sync.MerkleSynchronizationException;
+import com.swirlds.virtualmap.test.fixtures.sync.PairedStreams;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
+import org.hiero.consensus.concurrent.pool.StandardWorkGroup;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests that exercise {@link AsyncInputStream} and {@link AsyncOutputStream} together
+ * over a real loopback socket via {@link PairedStreams}. The individual unit tests for each class
+ * already cover constructor validation, framing, backpressure, flushing, error propagation, and
+ * ordering in isolation, so this suite focuses on scenarios that can only be observed when both
+ * background threads are alive on opposite ends of a real socket: a basic round-trip,
+ * asymmetric socket teardown from each side, and producer/consumer speed mismatch across the pair.
+ */
+@Tag(TestComponentTags.RECONNECT)
+@DisplayName("Paired AsyncInputStream / AsyncOutputStream Test")
+class PairedAsyncStreamsTest {
+
+    private static final int DEFAULT_QUEUE_SIZE = 100;
+    private static final Duration DEFAULT_FLUSH_INTERVAL = Duration.ofMillis(50);
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(5);
+
+    @Test
+    @DisplayName("Basic Operation: messages round-trip through the socket and done() terminates cleanly")
+    void basicOperation() throws IOException, InterruptedException {
+        try (final PairedStreams streams = new PairedStreams()) {
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "basic", null);
+
+            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    streams.getLearnerOutput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
+
+            in.start();
+            out.start();
+
+            final int count = 100;
+            for (int i = 0; i < count; i++) {
+                out.sendAsync(serializeLong(i));
+                final byte[] message = in.readOrWait(YieldStrategy.SPIN);
+                assertNotNull(message);
+                assertEquals(i, parseLong(message), "message should match the value that was serialized");
+            }
+
+            out.done();
+            workGroup.waitForTermination();
+        }
+    }
+
+    @Test
+    @DisplayName("Teacher disconnect mid-stream propagates error to work group")
+    void teacherDisconnectMidStream() throws IOException, InterruptedException {
+        final PairedStreams streams = new PairedStreams();
+        try {
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "teacher-disconnect", null);
+
+            final AsyncInputStream in = new AsyncInputStream(streams.getLearnerInput(), workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    streams.getTeacherOutput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
+
+            in.start();
+            out.start();
+
+            // Send one message so the writer flushes through the socket, then pull the plug
+            // on the teacher side. The learner-side reader will see EOF/SocketException.
+            out.sendAsync(serializeLong(1));
+            MILLISECONDS.sleep(50);
+            streams.disconnectTeacher();
+
+            assertEventuallyTrue(
+                    workGroup::hasExceptions,
+                    Duration.ofSeconds(5),
+                    "Work group should record an exception after teacher disconnect");
+        } finally {
+            closeIgnoringIoException(streams);
+        }
+    }
+
+    @Test
+    @DisplayName("Learner disconnect mid-stream propagates error to work group")
+    void learnerDisconnectMidStream() throws IOException {
+        final PairedStreams streams = new PairedStreams();
+        try {
+            final StandardWorkGroup workGroup =
+                    new StandardWorkGroup(getStaticThreadManager(), "learner-disconnect", null);
+
+            final AsyncInputStream in = new AsyncInputStream(streams.getLearnerInput(), workGroup, DEFAULT_QUEUE_SIZE);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    streams.getTeacherOutput(), workGroup, DEFAULT_QUEUE_SIZE, DEFAULT_FLUSH_INTERVAL, DEFAULT_TIMEOUT);
+
+            in.start();
+            out.start();
+
+            // Close the learner socket so the teacher's write/flush fails with an IOException.
+            // Keep pumping messages on a background thread until the work group records the error
+            // — the OS may buffer the first few writes before reporting the broken pipe.
+            streams.disconnectLearner();
+
+            final Thread sender = new Thread(() -> {
+                for (int i = 0; i < 10_000 && !workGroup.hasExceptions(); i++) {
+                    try {
+                        out.sendAsync(serializeLong(i));
+                    } catch (final InterruptedException
+                            | MerkleSynchronizationException
+                            | IllegalStateException ignored) {
+                        break;
+                    }
+                }
+            });
+            sender.setDaemon(true);
+            sender.start();
+
+            assertEventuallyTrue(
+                    workGroup::hasExceptions,
+                    Duration.ofSeconds(5),
+                    "Work group should record an exception after learner disconnect");
+        } finally {
+            closeIgnoringIoException(streams);
+        }
+    }
+
+    @Test
+    @DisplayName("Producer outpaces a slow consumer: all messages arrive in order, done() terminates")
+    void slowConsumerBackpressuresProducer() throws IOException, InterruptedException {
+        try (final PairedStreams streams = new PairedStreams()) {
+            final StandardWorkGroup workGroup = new StandardWorkGroup(getStaticThreadManager(), "slow-consumer", null);
+
+            // Small queue so the producer saturates quickly. Generous sendAsync timeout so
+            // backpressure blocks the producer instead of throwing while the consumer catches up.
+            final int bufferSize = 8;
+            final int count = 1000;
+            final AsyncInputStream in = new AsyncInputStream(streams.getTeacherInput(), workGroup, bufferSize);
+            final AsyncOutputStream out = new AsyncOutputStream(
+                    streams.getLearnerOutput(), workGroup, bufferSize, DEFAULT_FLUSH_INTERVAL, Duration.ofSeconds(30));
+
+            in.start();
+            out.start();
+
+            final AtomicInteger nextExpected = new AtomicInteger(0);
+            final Thread consumer = new Thread(() -> {
+                for (int i = 0; i < count; i++) {
+                    final byte[] msg = in.readOrWait(YieldStrategy.SLEEP);
+                    if (msg == null) {
+                        return;
+                    }
+                    if (parseLong(msg) != i) {
+                        throw new AssertionError("Out of order at index " + i + ", got " + parseLong(msg));
+                    }
+                    nextExpected.set(i + 1);
+                    try {
+                        Thread.sleep(1); // slow the consumer to force the producer to wait
+                    } catch (final InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return;
+                    }
+                }
+            });
+            consumer.setDaemon(true);
+            consumer.start();
+
+            // Producer runs on the test thread; sendAsync will block when the queue saturates.
+            for (int i = 0; i < count; i++) {
+                out.sendAsync(serializeLong(i));
+            }
+
+            out.done();
+            consumer.join(Duration.ofSeconds(30).toMillis());
+            workGroup.waitForTermination();
+
+            assertEquals(count, nextExpected.get(), "All messages should have been received in order");
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static byte[] serializeLong(final long value) {
+        final byte[] bytes = new byte[Long.BYTES];
+        BufferedData.wrap(bytes).writeLong(value);
+        return bytes;
+    }
+
+    private static long parseLong(final byte[] bytes) {
+        return BufferedData.wrap(bytes).readLong();
+    }
+
+    /**
+     * After an intentional asymmetric disconnect, {@link PairedStreams#close()} can throw because
+     * flushing a buffered stream over a closed socket fails. Swallow that expected failure during
+     * cleanup.
+     */
+    private static void closeIgnoringIoException(final PairedStreams streams) {
+        try {
+            streams.close();
+        } catch (final IOException ignored) {
+            // expected after disconnectTeacher() / disconnectLearner()
+        }
+    }
+}

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/BlockingInputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/BlockingInputStream.java
@@ -3,6 +3,7 @@ package com.swirlds.virtualmap.test.fixtures.sync;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -43,7 +44,10 @@ public class BlockingInputStream extends InputStream {
      */
     @Override
     public int read() throws IOException {
-        while (locked.get() && !Thread.currentThread().isInterrupted()) {
+        while (locked.get()) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedIOException();
+            }
             Thread.onSpinWait();
         }
         return in.read();

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/BlockingInputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/BlockingInputStream.java
@@ -43,7 +43,7 @@ public class BlockingInputStream extends InputStream {
      */
     @Override
     public int read() throws IOException {
-        while (locked.get()) {
+        while (locked.get() && !Thread.currentThread().isInterrupted()) {
             Thread.onSpinWait();
         }
         return in.read();

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/BlockingOutputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/BlockingOutputStream.java
@@ -2,6 +2,7 @@
 package com.swirlds.virtualmap.test.fixtures.sync;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -43,7 +44,10 @@ public class BlockingOutputStream extends OutputStream {
      */
     @Override
     public void write(final int b) throws IOException {
-        while (locked.get() && !Thread.currentThread().isInterrupted()) {
+        while (locked.get()) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedIOException();
+            }
             Thread.onSpinWait();
         }
         out.write(b);

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/BlockingOutputStream.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/BlockingOutputStream.java
@@ -43,7 +43,7 @@ public class BlockingOutputStream extends OutputStream {
      */
     @Override
     public void write(final int b) throws IOException {
-        while (locked.get()) {
+        while (locked.get() && !Thread.currentThread().isInterrupted()) {
             Thread.onSpinWait();
         }
         out.write(b);

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/PairedStreams.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/PairedStreams.java
@@ -6,6 +6,8 @@ import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 
@@ -16,20 +18,14 @@ import java.net.Socket;
  */
 public class PairedStreams implements AutoCloseable {
 
-    protected BufferedOutputStream teacherOutputBuffer;
-    protected DataOutputStream teacherOutput;
+    private final Socket teacherSocket;
+    private final Socket learnerSocket;
+    private final ServerSocket server;
 
-    protected BufferedInputStream teacherInputBuffer;
-    protected DataInputStream teacherInput;
-
-    protected BufferedOutputStream learnerOutputBuffer;
-    protected DataOutputStream learnerOutput;
-    protected BufferedInputStream learnerInputBuffer;
-    protected DataInputStream learnerInput;
-
-    protected Socket teacherSocket;
-    protected Socket learnerSocket;
-    protected ServerSocket server;
+    private final DataOutputStream teacherOutput;
+    private final DataInputStream teacherInput;
+    private final DataOutputStream learnerOutput;
+    private final DataInputStream learnerInput;
 
     /**
      * Create a new pair of connected streams over a loopback socket.
@@ -42,16 +38,16 @@ public class PairedStreams implements AutoCloseable {
         teacherSocket = new Socket("127.0.0.1", server.getLocalPort());
         learnerSocket = server.accept();
 
-        teacherOutputBuffer = new BufferedOutputStream(teacherSocket.getOutputStream());
+        OutputStream teacherOutputBuffer = new BufferedOutputStream(teacherSocket.getOutputStream());
         teacherOutput = new DataOutputStream(teacherOutputBuffer);
 
-        teacherInputBuffer = new BufferedInputStream(teacherSocket.getInputStream());
+        InputStream teacherInputBuffer = new BufferedInputStream(teacherSocket.getInputStream());
         teacherInput = new DataInputStream(teacherInputBuffer);
 
-        learnerOutputBuffer = new BufferedOutputStream(learnerSocket.getOutputStream());
+        OutputStream learnerOutputBuffer = new BufferedOutputStream(learnerSocket.getOutputStream());
         learnerOutput = new DataOutputStream(learnerOutputBuffer);
 
-        learnerInputBuffer = new BufferedInputStream(learnerSocket.getInputStream());
+        InputStream learnerInputBuffer = new BufferedInputStream(learnerSocket.getInputStream());
         learnerInput = new DataInputStream(learnerInputBuffer);
     }
 

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/PairedStreams.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/sync/PairedStreams.java
@@ -91,25 +91,92 @@ public class PairedStreams implements AutoCloseable {
         return learnerInput;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Closes all streams and sockets. Closing the outer {@link DataOutputStream}/
+     * {@link DataInputStream} wrappers also closes their underlying buffered streams, so the
+     * buffered layers are not closed redundantly. Any {@link IOException}s encountered are
+     * accumulated; the first is thrown with the rest attached as suppressed exceptions.
+     *
+     * @throws IOException if one or more resources fail to close
+     */
     @Override
-    public void close() {
+    public void close() throws IOException {
+        IOException firstException = null;
+        for (final AutoCloseable resource : new AutoCloseable[] {
+            teacherOutput, teacherInput, learnerOutput, learnerInput, server, teacherSocket, learnerSocket
+        }) {
+            try {
+                resource.close();
+            } catch (IOException e) {
+                if (firstException == null) {
+                    firstException = e;
+                } else {
+                    firstException.addSuppressed(e);
+                }
+            } catch (Exception e) {
+                // AutoCloseable.close() declares Exception; wrap any non-IO surprise
+                if (firstException == null) {
+                    firstException = new IOException("Unexpected error during close", e);
+                } else {
+                    firstException.addSuppressed(e);
+                }
+            }
+        }
+        if (firstException != null) {
+            throw firstException;
+        }
+    }
+
+    /**
+     * Sets the read timeout on the teacher's socket. A blocked read that does not receive data
+     * within {@code timeoutMs} milliseconds will throw a {@link java.net.SocketTimeoutException}.
+     * May be called at any point after construction; takes effect on the next blocking read.
+     *
+     * @param timeoutMs timeout in milliseconds; 0 means wait indefinitely (the default)
+     * @throws java.net.SocketException if the socket option cannot be set
+     */
+    public void setTeacherTimeout(final int timeoutMs) throws java.net.SocketException {
+        teacherSocket.setSoTimeout(timeoutMs);
+    }
+
+    /**
+     * Sets the read timeout on the learner's socket. A blocked read that does not receive data
+     * within {@code timeoutMs} milliseconds will throw a {@link java.net.SocketTimeoutException}.
+     * May be called at any point after construction; takes effect on the next blocking read.
+     *
+     * @param timeoutMs timeout in milliseconds; 0 means wait indefinitely (the default)
+     * @throws java.net.SocketException if the socket option cannot be set
+     */
+    public void setLearnerTimeout(final int timeoutMs) throws java.net.SocketException {
+        learnerSocket.setSoTimeout(timeoutMs);
+    }
+
+    /**
+     * Closes only the teacher's socket, leaving the learner's socket open.
+     * The learner's next read will throw an {@link java.io.EOFException} or
+     * {@link java.net.SocketException} ("Connection reset"), simulating an
+     * asymmetric teardown where the teacher side drops the connection.
+     */
+    public void disconnectTeacher() {
         try {
-            teacherOutput.close();
-            teacherInput.close();
-            learnerOutput.close();
-            learnerInput.close();
-
-            teacherOutputBuffer.close();
-            teacherInputBuffer.close();
-            learnerOutputBuffer.close();
-            learnerInputBuffer.close();
-
-            server.close();
             teacherSocket.close();
+        } catch (IOException e) {
+            e.printStackTrace(System.err);
+        }
+    }
+
+    /**
+     * Closes only the learner's socket, leaving the teacher's socket open.
+     * The teacher's next read will throw an {@link java.io.EOFException} or
+     * {@link java.net.SocketException} ("Connection reset"), simulating an
+     * asymmetric teardown where the learner side drops the connection.
+     */
+    public void disconnectLearner() {
+        try {
             learnerSocket.close();
         } catch (IOException e) {
-            // this is the test code, and we don't want the test to fail because of a close error
             e.printStackTrace(System.err);
         }
     }
@@ -119,12 +186,11 @@ public class PairedStreams implements AutoCloseable {
      * underneath all streams reading/writing the sockets.
      */
     public void disconnect() {
+        disconnectTeacher();
+        disconnectLearner();
         try {
             server.close();
-            teacherSocket.close();
-            learnerSocket.close();
         } catch (IOException e) {
-            // this is the test code, and we don't want the test to fail because of a close error
             e.printStackTrace(System.err);
         }
     }


### PR DESCRIPTION
Feat: #25597

  ## AsyncInputStream

  - **New unified read entry point: `readOrWait(YieldStrategy)`.** Replaces `readAnticipatedMessage()` (non-blocking) and `readAnticipatedMessageSync()` (blocking-with-timeout). Callers pick the wait strategy (`SPIN` / `PARK` / `SLEEP`) instead of relying on a config-driven timeout.
  - **Explicit lifecycle.** New `Status` enum (`NOT_STARTED → RUNNING → DONE`) replaces the `AtomicBoolean alive` + `CountDownLatch finishedLatch` pair. `start()` is idempotency-checked and throws `IllegalStateException` on re-start; failed `workGroup.execute` is reported via `handleError` and surfaced as
  `MerkleSynchronizationException`.
  - **Drain-on-shutdown race fix.** `readOrWait` re-polls the queue after seeing `isAlive() == false` to pick up the last message the producer enqueued before flipping state.
  - **Removed `abort()`.** Shutdown is driven purely by EOF marker / `IOException` / work-group interrupt; callers (`LearningSynchronizer`, `TeachingSynchronizer`) no longer call abort.
  - **Max-message-size guard.** New `MAX_MESSAGE_SIZE = 8 MiB`; oversized frames throw `MerkleSynchronizationException` instead of allocating an unbounded `byte[]`.
  - **Constructor takes `int queueSizeThreshold`** instead of the full `ReconnectConfig` — validated `> 0`.
  - **Backpressure tweak.** Threshold comparison is now `>=` (was `>`); aligns spin-wait release with the same boundary.
  - New `YieldStrategy` enum (`SPIN`, `PARK`, `SLEEP`) encapsulating the three wait modes.

  ## AsyncOutputStream

  - **Explicit lifecycle.** New `Status` enum (`NOT_STARTED → RUNNING → FINISHING → DONE`) replaces the `AtomicBoolean isDone`. `start()` is idempotency-checked; `sendAsync` rejects work unless `RUNNING`; `done()` is a guarded signal (no-op outside `RUNNING`).
  - **Background-loop rewrite.** Drop the spin-wait + `StopWatch` flush bookkeeping. Loop now `poll(flushInterval)`s the queue, writes when a message arrives, and flushes when `flushInterval` has elapsed since the last flush with buffered data pending. Shutdown drains the queue, writes the `-1` marker, and
   flushes.
  - **Removed the stream-close-on-timeout side effect** inside `sendAsync` — the timeout path now just throws.
  - **Error reporting via work group.** `IOException`/`InterruptedException` in the writer thread are caught, logged, routed through `workGroup.handleError(...)`; `Status.DONE` does not distinguish clean shutdown from failure (callers consult `workGroup.hasExceptions()`).
  - **Constructor takes `int bufferSize`, `Duration flushInterval`, `Duration timeout`** explicitly (all validated) instead of the full `ReconnectConfig`. Callers (`LearningSynchronizer`, `TeachingSynchronizer`, `BenchmarkSlowAsyncOutputStream`) updated.
  - **New `getStatus()`** accessor (status is package-private, for tests).

  ## Tests / fixtures

  - New `AsyncOutputStreamTest` and `PairedAsyncStreamsTest`; major expansion of `AsyncInputStreamTest`.
  - `BlockingInputStream` / `BlockingOutputStream` / `PairedStreams` fixtures updated for the new constructors and lifecycle.

