### PR TITLE
fix(history): retry WRAPS publication after a library-not-ready noop

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
@@ -58,6 +58,7 @@ import org.apache.logging.log4j.Logger;
 public class WrapsHistoryProver implements HistoryProver {
     private static final Logger log = LogManager.getLogger(WrapsHistoryProver.class);
     public static final String MISSING_MESSAGES_FAILURE_PREFIX = "Still missing messages from R1 nodes ";
+    public static final String WRAPS_NOT_READY_FAILURE_PREFIX = "WRAPS library is not ready";
 
     private final long selfId;
     private final Duration wrapsMessageGracePeriod;
@@ -77,6 +78,13 @@ public class WrapsHistoryProver implements HistoryProver {
     private final Map<WrapsPhase, SortedMap<Long, WrapsMessagePublication>> phaseMessages =
             new EnumMap<>(WrapsPhase.class);
     private final Map<Long, Bytes> explicitHistoryProofHashes = new HashMap<>();
+
+    /**
+     * If non-null, the phase whose last publish returned a WRAPS-not-ready noop;
+     * cleared at the next publishIfNeeded so the publish is retried.
+     */
+    @Nullable
+    private volatile WrapsPhase phaseNeedingWrapsReadinessRetry;
 
     /**
      * If not null, the WRAPS message being signed for the current construction.
@@ -419,10 +427,38 @@ public class WrapsHistoryProver implements HistoryProver {
         if (shouldSkipAfterCancellation(constructionId, phase)) {
             return;
         }
+        final boolean isWrapsReadinessRetry = phase == phaseNeedingWrapsReadinessRetry;
+        if (isWrapsReadinessRetry) {
+            consumerOf(phase).accept(null);
+            phaseNeedingWrapsReadinessRetry = null;
+        }
+        // Skip building sourceBook/proofKeyList/chained futures while the WRAPS library is still loading.
+        final boolean needsWrapsForOutput = phase == POST_AGGREGATION
+                || (phase == AGGREGATE && sourceProof != null && tssConfig.wrapsEnabled());
+        if (needsWrapsForOutput && !historyLibrary.wrapsProverReady()) {
+            if (isWrapsReadinessRetry) {
+                log.debug(
+                        "Deferring {} output for construction #{}: WRAPS library is not ready",
+                        phase,
+                        constructionId);
+            } else {
+                log.info(
+                        "Deferring {} output for construction #{}: WRAPS library is not ready (will retry each consensus round until ready)",
+                        phase,
+                        constructionId);
+            }
+            phaseNeedingWrapsReadinessRetry = phase;
+            return;
+        }
         if (futureOf(phase) == null
                 && (POST_MPC_PHASES.contains(phase)
                         || !phaseMessages.getOrDefault(phase, emptySortedMap()).containsKey(selfId))) {
-            if (phase == POST_AGGREGATION) {
+            if (isWrapsReadinessRetry) {
+                log.debug(
+                        "Re-attempting publication of {} output on construction #{} after a WRAPS-not-ready noop",
+                        phase,
+                        constructionId);
+            } else if (phase == POST_AGGREGATION) {
                 log.info("Considering publication of vote for genesis WRAPS proof on construction #{}", constructionId);
             } else {
                 log.info("Considering publication of WRAPS {} output on construction #{}", phase, constructionId);
@@ -494,11 +530,21 @@ public class WrapsHistoryProver implements HistoryProver {
                                                         .build();
                                                 scheduleVoteWithJitter(constructionId, tssConfig, proof);
                                             }
-                                            case NoopOutput noopOutput ->
-                                                log.info(
-                                                        "Skipping publication of {} output: {}",
-                                                        phase,
-                                                        noopOutput.reason());
+                                            case NoopOutput noopOutput -> {
+                                                if (WRAPS_NOT_READY_FAILURE_PREFIX.equals(noopOutput.reason())) {
+                                                    // Flag instead of clearing voteFuture inline; the outer accept() hasn't returned yet.
+                                                    log.debug(
+                                                            "Deferring {} output: {} (will retry next round)",
+                                                            phase,
+                                                            noopOutput.reason());
+                                                    phaseNeedingWrapsReadinessRetry = phase;
+                                                } else {
+                                                    log.info(
+                                                            "Skipping publication of {} output: {}",
+                                                            phase,
+                                                            noopOutput.reason());
+                                                }
+                                            }
                                         }
                                     },
                                     executor)
@@ -656,7 +702,7 @@ public class WrapsHistoryProver implements HistoryProver {
                                     signature, signers.stream().toList());
                         } else {
                             if (!historyLibrary.wrapsProverReady()) {
-                                yield new NoopOutput("WRAPS library is not ready");
+                                yield new NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX);
                             }
                             final var isValid = historyLibrary.verifyAggregateSignature(
                                     message,
@@ -708,7 +754,7 @@ public class WrapsHistoryProver implements HistoryProver {
                     }
                     case POST_AGGREGATION -> {
                         if (!historyLibrary.wrapsProverReady()) {
-                            yield new NoopOutput("WRAPS library is not ready");
+                            yield new NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX);
                         }
                         final var signature = requireNonNull(aggregatedSignatureProof)
                                 .chainOfTrustProofOrThrow()

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
@@ -433,14 +433,12 @@ public class WrapsHistoryProver implements HistoryProver {
             phaseNeedingWrapsReadinessRetry = null;
         }
         // Skip building sourceBook/proofKeyList/chained futures while the WRAPS library is still loading.
-        final boolean needsWrapsForOutput = phase == POST_AGGREGATION
-                || (phase == AGGREGATE && sourceProof != null && tssConfig.wrapsEnabled());
+        final boolean needsWrapsForOutput =
+                phase == POST_AGGREGATION || (phase == AGGREGATE && sourceProof != null && tssConfig.wrapsEnabled());
         if (needsWrapsForOutput && !historyLibrary.wrapsProverReady()) {
             if (isWrapsReadinessRetry) {
                 log.debug(
-                        "Deferring {} output for construction #{}: WRAPS library is not ready",
-                        phase,
-                        constructionId);
+                        "Deferring {} output for construction #{}: WRAPS library is not ready", phase, constructionId);
             } else {
                 log.info(
                         "Deferring {} output for construction #{}: WRAPS library is not ready (will retry each consensus round until ready)",
@@ -532,7 +530,8 @@ public class WrapsHistoryProver implements HistoryProver {
                                             }
                                             case NoopOutput noopOutput -> {
                                                 if (WRAPS_NOT_READY_FAILURE_PREFIX.equals(noopOutput.reason())) {
-                                                    // Flag instead of clearing voteFuture inline; the outer accept() hasn't returned yet.
+                                                    // Flag instead of clearing voteFuture inline; the outer accept()
+                                                    // hasn't returned yet.
                                                     log.debug(
                                                             "Deferring {} output: {} (will retry next round)",
                                                             phase,

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
@@ -940,7 +940,8 @@ class WrapsHistoryProverTest {
         final var captor = ArgumentCaptor.forClass(HistoryProof.class);
         verify(submissions).submitExplicitProofVote(eq(CONSTRUCTION_ID), captor.capture());
         final var proof = captor.getValue();
-        assertTrue(proof.chainOfTrustProofOrThrow().hasWrapsProof(),
+        assertTrue(
+                proof.chainOfTrustProofOrThrow().hasWrapsProof(),
                 "Retry must publish a recursive wraps_proof, not another aggregated_node_signatures vote");
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -943,6 +944,120 @@ class WrapsHistoryProverTest {
         assertTrue(
                 proof.chainOfTrustProofOrThrow().hasWrapsProof(),
                 "Retry must publish a recursive wraps_proof, not another aggregated_node_signatures vote");
+    }
+
+    @Test
+    void postAggregationFlagsRetryWhenOutputFutureProducesWrapsNotReadyNoop() {
+        // Covers the race window where wrapsProverReady() flips to false between the
+        // publishIfNeeded early-exit guard (where it read true and we proceeded to
+        // build the chained future) and the outputFuture supplier (where it now reads
+        // false and yields NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX)). The chained
+        // NoopOutput case must set phaseNeedingWrapsReadinessRetry so the very next
+        // advance() re-enters publishIfNeeded and clears the stale voteFuture, rather
+        // than short-circuiting on it forever.
+        subject = new WrapsHistoryProver(
+                SELF_ID,
+                GRACE_PERIOD,
+                KEY_PAIR,
+                null,
+                weights,
+                proofKeys,
+                delayer,
+                Runnable::run,
+                historyLibrary,
+                submissions,
+                new WrapsMpcStateMachine());
+        given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
+        given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
+        // First call (publishIfNeeded early-exit guard): true -> skips early-exit.
+        // Second call (inside outputFuture supplier): false -> NoopOutput.
+        // Third call (next-round retry early-exit guard): true -> proceeds to publish.
+        given(historyLibrary.wrapsProverReady()).willReturn(true, false, true);
+        given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
+                .willReturn(
+                        new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
+        given(submissions.submitExplicitProofVote(eq(CONSTRUCTION_ID), any()))
+                .willReturn(CompletableFuture.completedFuture(null));
+
+        final var aggregatedSignatureProof = HistoryProof.newBuilder()
+                .chainOfTrustProof(ChainOfTrustProof.newBuilder()
+                        .aggregatedNodeSignatures(new AggregatedNodeSignatures(
+                                AGG_SIG, new ArrayList<>(List.of(SELF_ID, OTHER_NODE_ID)), TARGET_METADATA)))
+                .build();
+        final var construction = HistoryProofConstruction.newBuilder()
+                .constructionId(CONSTRUCTION_ID)
+                .wrapsSigningState(
+                        WrapsSigningState.newBuilder().phase(AGGREGATE).build())
+                .targetProof(aggregatedSignatureProof)
+                .build();
+
+        // First advance: early-exit guard reads true, supplier reads false -> NoopOutput case fires.
+        final var firstOutcome =
+                subject.advance(EPOCH, construction, TARGET_METADATA, targetProofKeys, tssConfig, LEDGER_ID);
+        assertSame(HistoryProver.Outcome.InProgress.INSTANCE, firstOutcome);
+        verifyNoInteractions(submissions);
+        assertSame(
+                WrapsPhase.POST_AGGREGATION,
+                getField("phaseNeedingWrapsReadinessRetry"),
+                "NoopOutput WRAPS_NOT_READY_FAILURE_PREFIX must flag the phase even when the early-exit guard let us through");
+
+        // Second advance: isWrapsReadinessRetry true -> voteFuture cleared; early-exit guard reads true -> publish.
+        final var secondOutcome =
+                subject.advance(EPOCH, construction, TARGET_METADATA, targetProofKeys, tssConfig, LEDGER_ID);
+        assertSame(HistoryProver.Outcome.InProgress.INSTANCE, secondOutcome);
+        final var captor = ArgumentCaptor.forClass(HistoryProof.class);
+        verify(submissions).submitExplicitProofVote(eq(CONSTRUCTION_ID), captor.capture());
+        assertTrue(
+                captor.getValue().chainOfTrustProofOrThrow().hasWrapsProof(),
+                "Once WRAPS is ready, the retry must publish the recursive wraps_proof");
+    }
+
+    @Test
+    void postAggregationKeepsRetryFlagAcrossMultipleStillNotReadyRounds() {
+        // Covers the case where the next consensus round arrives but WRAPS is still
+        // loading: isWrapsReadinessRetry=true at the top of publishIfNeeded clears the
+        // stale voteFuture, then the early-exit guard re-fires because the library is
+        // still not ready, and the phase stays flagged for yet-another retry.
+        subject = new WrapsHistoryProver(
+                SELF_ID,
+                GRACE_PERIOD,
+                KEY_PAIR,
+                null,
+                weights,
+                proofKeys,
+                delayer,
+                Runnable::run,
+                historyLibrary,
+                submissions,
+                new WrapsMpcStateMachine());
+        given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
+        given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
+        // Stays false across every advance() — exercises the retry loop while the library is still loading.
+        given(historyLibrary.wrapsProverReady()).willReturn(false);
+
+        final var aggregatedSignatureProof = HistoryProof.newBuilder()
+                .chainOfTrustProof(ChainOfTrustProof.newBuilder()
+                        .aggregatedNodeSignatures(new AggregatedNodeSignatures(
+                                AGG_SIG, new ArrayList<>(List.of(SELF_ID, OTHER_NODE_ID)), TARGET_METADATA)))
+                .build();
+        final var construction = HistoryProofConstruction.newBuilder()
+                .constructionId(CONSTRUCTION_ID)
+                .wrapsSigningState(
+                        WrapsSigningState.newBuilder().phase(AGGREGATE).build())
+                .targetProof(aggregatedSignatureProof)
+                .build();
+
+        for (int i = 0; i < 3; i++) {
+            final var outcome =
+                    subject.advance(EPOCH, construction, TARGET_METADATA, targetProofKeys, tssConfig, LEDGER_ID);
+            assertSame(HistoryProver.Outcome.InProgress.INSTANCE, outcome);
+            assertSame(
+                    WrapsPhase.POST_AGGREGATION,
+                    getField("phaseNeedingWrapsReadinessRetry"),
+                    "Iteration " + i + ": phase must remain flagged while WRAPS is still loading");
+        }
+        verifyNoInteractions(submissions);
+        verify(historyLibrary, never()).constructGenesisWrapsProof(any(), any(), any(), any(), any());
     }
 
     private void setField(String name, Object value) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
@@ -879,6 +879,71 @@ class WrapsHistoryProverTest {
         verifyNoInteractions(submissions);
     }
 
+    @Test
+    void postAggregationRetriesPublishOnceWrapsLibraryBecomesReady() {
+        // Models the WRAPS download race: a construction has already been finalized in
+        // bootstrap form (aggregated_node_signatures chain-of-trust proof), then the
+        // POST_AGGREGATION publish attempt finds the native WRAPS library still loading.
+        // The first advance() should noop without submitting a vote, and crucially must
+        // clear voteFuture so the next consensus round re-enters publishIfNeeded. Once
+        // wrapsProverReady() flips true (the proving key archive having finished
+        // extracting), the next advance() must publish the recursive wraps_proof form
+        // so the construction can upgrade per HIP-1200.
+        subject = new WrapsHistoryProver(
+                SELF_ID,
+                GRACE_PERIOD,
+                KEY_PAIR,
+                null,
+                weights,
+                proofKeys,
+                delayer,
+                Runnable::run,
+                historyLibrary,
+                submissions,
+                new WrapsMpcStateMachine());
+        given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
+        given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
+        // Not ready on the first advance() (download still in flight); ready on the second.
+        given(historyLibrary.wrapsProverReady()).willReturn(false, true);
+        given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
+                .willReturn(
+                        new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
+        given(submissions.submitExplicitProofVote(eq(CONSTRUCTION_ID), any()))
+                .willReturn(CompletableFuture.completedFuture(null));
+
+        final var aggregatedSignatureProof = HistoryProof.newBuilder()
+                .chainOfTrustProof(ChainOfTrustProof.newBuilder()
+                        .aggregatedNodeSignatures(new AggregatedNodeSignatures(
+                                AGG_SIG, new ArrayList<>(List.of(SELF_ID, OTHER_NODE_ID)), TARGET_METADATA)))
+                .build();
+        final var construction = HistoryProofConstruction.newBuilder()
+                .constructionId(CONSTRUCTION_ID)
+                .wrapsSigningState(
+                        WrapsSigningState.newBuilder().phase(AGGREGATE).build())
+                .targetProof(aggregatedSignatureProof)
+                .build();
+
+        // First advance: wrapsProverReady=false → noop, no vote submitted, phase flagged for retry
+        final var firstOutcome =
+                subject.advance(EPOCH, construction, TARGET_METADATA, targetProofKeys, tssConfig, LEDGER_ID);
+        assertSame(HistoryProver.Outcome.InProgress.INSTANCE, firstOutcome);
+        verifyNoInteractions(submissions);
+        assertSame(
+                WrapsPhase.POST_AGGREGATION,
+                getField("phaseNeedingWrapsReadinessRetry"),
+                "Noop due to WRAPS-not-ready must flag the phase so the next round retries");
+
+        // Second advance: wrapsProverReady=true → real ProofPhaseOutput → explicit vote on wraps_proof
+        final var secondOutcome =
+                subject.advance(EPOCH, construction, TARGET_METADATA, targetProofKeys, tssConfig, LEDGER_ID);
+        assertSame(HistoryProver.Outcome.InProgress.INSTANCE, secondOutcome);
+        final var captor = ArgumentCaptor.forClass(HistoryProof.class);
+        verify(submissions).submitExplicitProofVote(eq(CONSTRUCTION_ID), captor.capture());
+        final var proof = captor.getValue();
+        assertTrue(proof.chainOfTrustProofOrThrow().hasWrapsProof(),
+                "Retry must publish a recursive wraps_proof, not another aggregated_node_signatures vote");
+    }
+
     private void setField(String name, Object value) {
         try {
             final var field = WrapsHistoryProver.class.getDeclaredField(name);


### PR DESCRIPTION
## Summary
- `WrapsHistoryProver.publishIfNeeded` assigns the phase future before the chained `outputFuture` runs. When `outputFuture` returns `NoopOutput("WRAPS library is not ready")` — emitted while the proving-key archive is still downloading/extracting at startup — the prior code only logged the noop and left the future assigned, so the `futureOf(phase) == null` guard short-circuited every subsequent consensus round. The publish was never retried, the construction's vote was never submitted, and the network sat on the prior chain-of-trust until a restart.
- Detect the WRAPS-not-ready noop explicitly and flag the phase via a new `phaseNeedingWrapsReadinessRetry` field. The next `publishIfNeeded` call clears the stale future and re-enters the publish path.
- Short-circuit the WRAPS-needing phases (`POST_AGGREGATION`, and `AGGREGATE` when a `sourceProof` exists and `tssConfig.wrapsEnabled()` is true) at the top of `publishIfNeeded` on `!historyLibrary.wrapsProverReady()` so we no longer build `sourceBook`/`proofKeyList`/chained futures every round just to throw them away.
- First deferral logs at INFO; subsequent per-round retries log at DEBUG so the INFO log is not flooded.

Non-WRAPS-readiness noops (`WRAPS aggregation returned null for nodes …`, `Invalid aggregate signature using nodes …`, `Incremental WRAPS proof construction returned null`, `Genesis WRAPS proof construction returned null`) keep their original behaviour — INFO log under `Skipping publication of {} output: {}`, no retry — because those are construction-level failures, not transient init races.

Fixes #25650.

## Test plan
- [x] New unit test `postAggregationRetriesPublishOnceWrapsLibraryBecomesReady` simulates the race: first `advance()` runs with `historyLibrary.wrapsProverReady()` returning false → noop, no submission, phase flagged; second `advance()` runs with true → recursive `wraps_proof` explicit vote.
- [x] `:hedera-app:test --tests WrapsHistoryProverTest` passes.
- [x] CI: re-runs of the e2e cutover scenarios that previously stalled on the genesis WRAPS construction now reach the post-cutover publish.