### PR TITLE
test: cherry-picked 25128 to 0.75: reapply latency metrics in nlg (25128) (#25190)

### DIFF
--- a/.github/workflows/support/citr/application.properties.txt
+++ b/.github/workflows/support/citr/application.properties.txt
@@ -5,3 +5,9 @@ bootstrap.throttleJsonDef.resource=genesis/throttles-dev.json
 networkAdmin.exportCandidateRoster=true
 addressBook.useRosterLifecycle=true
 nodes.gossipFqdnRestricted=false
+
+#enable Latency Metrics
+blockNode.globalCoolDownSeconds=1
+blockNode.basicNodeCoolDownSeconds=1
+blockNode.extendedNodeCoolDownSeconds=1
+blockNode.connectionStallThresholdMillis=5000

--- a/.github/workflows/zxc-single-day-longevity-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-test.yaml
@@ -473,7 +473,7 @@ jobs:
 
           test=LongevityLoadTest
 
-          NLGargs="-K ECDSA -R -c ${NLG_c} -a ${{ inputs.nlg-accounts }}  -n ${n} -T 1000 -S hot -p 50"
+          NLGargs="-K ECDSA -L -R -c ${NLG_c} -a ${{ inputs.nlg-accounts }}  -n ${n} -T 1000 -S hot -p 50"
 
           echo kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
             ${run_NLGDebugparams} -cp /app/lib/*:\$(ls -1 /app/network-load-generator-*.jar) com.hedera.benchmark.${test} \
@@ -877,7 +877,7 @@ jobs:
 
           test=LongevityLoadTest
 
-          NLGargs="-K ECDSA -R -c ${NLG_c} -a ${{ inputs.nlg-accounts }}  -n ${n} -T 1000 -S hot -p 50"
+          NLGargs="-K ECDSA -L -R -c ${NLG_c} -a ${{ inputs.nlg-accounts }}  -n ${n} -T 1000 -S hot -p 50"
 
           echo kubectl -n "${{ needs.acquire-kubernetes-resources.outputs.namespace }}" exec ${nlgpod} -c nlg -- bash -c "nohup /usr/bin/env java -Xmx30g \
             ${run_NLGDebugparams} -cp /app/lib/*:\$(ls -1 /app/network-load-generator-*.jar) com.hedera.benchmark.${test} \


### PR DESCRIPTION
**Description**:
Cherry-picked 25128 to 0.75

Fixes #25128

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ X] Documented (Code comments, README, etc.)
- [ X] Tested (unit, integration, etc.)
