### PR TITLE
feat: Change default number of max other parents to 4

### DIFF
--- a/platform-sdk/consensus-event-creator/src/main/java/org/hiero/consensus/event/creator/config/EventCreationConfig.java
+++ b/platform-sdk/consensus-event-creator/src/main/java/org/hiero/consensus/event/creator/config/EventCreationConfig.java
@@ -43,4 +43,4 @@ public record EventCreationConfig(
         @ConfigProperty(defaultValue = "1024") int eventIntakeThrottle,
         @ConfigProperty(defaultValue = "1s") Duration maximumPermissibleUnhealthyDuration,
         @ConfigProperty(defaultValue = "15") int maxAllowedSyncLag,
-        @ConfigProperty(defaultValue = "1") int maxOtherParents) {}
+        @ConfigProperty(defaultValue = "4") int maxOtherParents) {}

--- a/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/DocExamplesTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/DocExamplesTest.java
@@ -69,7 +69,7 @@ class DocExamplesTest {
                 network.newConsensusResults().results().getFirst().lastRoundNum();
 
         // This assertion will always pass with seed=42
-        assertThat(lastRound).isEqualTo(47L);
+        assertThat(lastRound).isEqualTo(69L);
     }
 
     // This test is used in the writing-tests.md file.


### PR DESCRIPTION
**Description**:

Change the default number of other parents to 4, which seems to be currently the best tradeoff between increased IO utilization and improved latency.


**Related issue(s)**: 

Fixes #24319 

**Notes for reviewer**:
Please see https://github.com/hiero-ledger/hiero-consensus-node/issues/24658 and https://github.com/hiero-ledger/hiero-consensus-node/issues/24657 for testing results from Latitude and perf1

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
