### PR TITLE
chore: Add CLAUDE.md files to all consensus layer modules

### DIFF
--- a/platform-sdk/consensus-concurrent/CLAUDE.md
+++ b/platform-sdk/consensus-concurrent/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`consensus-concurrent` is part of the **consensus layer** — a supporting module providing the
+concurrency primitives the consensus modules build on. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) — it
+documents the current implementation as canonical, anchored to specific files, classes, and
+methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/wiring-framework.md`](../docs/consensus-layer/architecture/topics/wiring-framework.md) — how components, wires, and soldering compose the runtime and where backpressure is applied.
+- [`architecture/topics/health-monitor-and-backpressure.md`](../docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md) — keeping the consensus layer bounded under load.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-event-creator-impl/CLAUDE.md
+++ b/platform-sdk/consensus-event-creator-impl/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`consensus-event-creator-impl` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/event-creator.md`](../docs/consensus-layer/architecture/topics/event-creator.md) — Tipset-style other-parent selection, event-creation cadence, filling events with transactions pulled from the execution layer.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — how the creator pulls transactions via `getTransactionsForEvent` and reports health.
+- [`concepts/birth-round.md`](../docs/consensus-layer/concepts/birth-round.md), [`concepts/event-lifecycle.md`](../docs/consensus-layer/concepts/event-lifecycle.md).
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-event-creator/CLAUDE.md
+++ b/platform-sdk/consensus-event-creator/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`consensus-event-creator` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/event-creator.md`](../docs/consensus-layer/architecture/topics/event-creator.md) — other-parent selection, event-creation cadence, filling events with transactions pulled from the execution layer.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — how the creator pulls transactions via `getTransactionsForEvent` and reports health.
+- [`concepts/birth-round.md`](../docs/consensus-layer/concepts/birth-round.md), [`concepts/event-lifecycle.md`](../docs/consensus-layer/concepts/event-lifecycle.md).
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-event-intake-concurrent/CLAUDE.md
+++ b/platform-sdk/consensus-event-intake-concurrent/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`consensus-event-intake-concurrent` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/event-intake.md`](../docs/consensus-layer/architecture/topics/event-intake.md) — validation, deduplication, topological ordering, branch detection, birth-round filtering, and emission downstream.
+- [`architecture/topics/wiring-framework.md`](../docs/consensus-layer/architecture/topics/wiring-framework.md) — how the concurrent intake stages are wired and backpressured.
+- [`concepts/event-lifecycle.md`](../docs/consensus-layer/concepts/event-lifecycle.md), [`concepts/branching.md`](../docs/consensus-layer/concepts/branching.md), [`concepts/birth-round.md`](../docs/consensus-layer/concepts/birth-round.md) — the mental models intake depends on.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-event-intake-impl/CLAUDE.md
+++ b/platform-sdk/consensus-event-intake-impl/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-event-intake-impl` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/event-intake.md`](../docs/consensus-layer/architecture/topics/event-intake.md) — validation, deduplication, topological ordering, branch detection, birth-round filtering, and emission downstream.
+- [`concepts/event-lifecycle.md`](../docs/consensus-layer/concepts/event-lifecycle.md), [`concepts/branching.md`](../docs/consensus-layer/concepts/branching.md), [`concepts/stale-events.md`](../docs/consensus-layer/concepts/stale-events.md), [`concepts/birth-round.md`](../docs/consensus-layer/concepts/birth-round.md) — the mental models intake depends on.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-event-intake/CLAUDE.md
+++ b/platform-sdk/consensus-event-intake/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-event-intake` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/event-intake.md`](../docs/consensus-layer/architecture/topics/event-intake.md) — validation, deduplication, topological ordering, branch detection, birth-round filtering, and emission downstream.
+- [`concepts/event-lifecycle.md`](../docs/consensus-layer/concepts/event-lifecycle.md), [`concepts/branching.md`](../docs/consensus-layer/concepts/branching.md), [`concepts/stale-events.md`](../docs/consensus-layer/concepts/stale-events.md), [`concepts/birth-round.md`](../docs/consensus-layer/concepts/birth-round.md) — the mental models intake depends on.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-event-stream/CLAUDE.md
+++ b/platform-sdk/consensus-event-stream/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-event-stream` is part of the **consensus layer** — a supporting module that writes
+the consensus event-stream files. When working here, consult the consensus-layer knowledge
+base at [`../docs/consensus-layer/`](../docs/consensus-layer/) — it documents the current
+implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/hashgraph.md`](../docs/consensus-layer/architecture/topics/hashgraph.md) — the consensus rounds and ordered events this module serializes.
+- [`concepts/event-lifecycle.md`](../docs/consensus-layer/concepts/event-lifecycle.md) — what an event carries once it reaches consensus.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-gossip-impl/CLAUDE.md
+++ b/platform-sdk/consensus-gossip-impl/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`consensus-gossip-impl` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/gossip.md`](../docs/consensus-layer/architecture/topics/gossip.md) — peer-to-peer communication, neighbor discipline, falling-behind detection, buffering for catch-up.
+- [`architecture/topics/reasons-not-to-gossip.md`](../docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md) — the conditions under which a node refuses to gossip events.
+- [`architecture/topics/health-monitor-and-backpressure.md`](../docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md) — keeping the consensus layer bounded under load.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-gossip/CLAUDE.md
+++ b/platform-sdk/consensus-gossip/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`consensus-gossip` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/gossip.md`](../docs/consensus-layer/architecture/topics/gossip.md) — peer-to-peer communication, neighbor discipline, falling-behind detection, buffering for catch-up.
+- [`architecture/topics/reasons-not-to-gossip.md`](../docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md) — the conditions under which a node refuses to gossip events.
+- [`architecture/topics/health-monitor-and-backpressure.md`](../docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md) — keeping the consensus layer bounded under load.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-gui/CLAUDE.md
+++ b/platform-sdk/consensus-gui/CLAUDE.md
@@ -1,0 +1,20 @@
+# Consensus Layer Knowledge Base
+
+`consensus-gui` is consensus-layer **tooling** — a GUI that visualizes the hashgraph (the DAG,
+rounds, witnesses, and judges). It is not part of the runtime layer the knowledge base
+documents, but rendering the hashgraph faithfully requires the consensus-layer mental models,
+so consult the knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/). It
+documents the current implementation as canonical, anchored to specific files, classes, and
+methods.
+
+**Most relevant to this module:**
+
+- The concepts this GUI renders: [`hashgraph-dag.md`](../docs/consensus-layer/concepts/hashgraph-dag.md), [`rounds-and-witnesses.md`](../docs/consensus-layer/concepts/rounds-and-witnesses.md), [`judges.md`](../docs/consensus-layer/concepts/judges.md), [`strongly-seeing.md`](../docs/consensus-layer/concepts/strongly-seeing.md).
+- [`architecture/topics/hashgraph.md`](../docs/consensus-layer/architecture/topics/hashgraph.md) — the algorithm whose structure the GUI displays.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/).

--- a/platform-sdk/consensus-hashgraph-impl/CLAUDE.md
+++ b/platform-sdk/consensus-hashgraph-impl/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-hashgraph-impl` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/hashgraph.md`](../docs/consensus-layer/architecture/topics/hashgraph.md) — the consensus algorithm, round production with judges and timestamps, roster-and-config changes carried as round metadata.
+- The concepts the algorithm rests on: [`hashgraph-dag.md`](../docs/consensus-layer/concepts/hashgraph-dag.md), [`rounds-and-witnesses.md`](../docs/consensus-layer/concepts/rounds-and-witnesses.md), [`strongly-seeing.md`](../docs/consensus-layer/concepts/strongly-seeing.md), [`judges.md`](../docs/consensus-layer/concepts/judges.md), [`voting.md`](../docs/consensus-layer/concepts/voting.md), [`coin-rounds.md`](../docs/consensus-layer/concepts/coin-rounds.md), [`birth-round.md`](../docs/consensus-layer/concepts/birth-round.md).
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-hashgraph/CLAUDE.md
+++ b/platform-sdk/consensus-hashgraph/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-hashgraph` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/hashgraph.md`](../docs/consensus-layer/architecture/topics/hashgraph.md) — the consensus algorithm, round production with judges and timestamps, roster-and-config changes carried as round metadata.
+- The concepts the algorithm rests on: [`hashgraph-dag.md`](../docs/consensus-layer/concepts/hashgraph-dag.md), [`rounds-and-witnesses.md`](../docs/consensus-layer/concepts/rounds-and-witnesses.md), [`strongly-seeing.md`](../docs/consensus-layer/concepts/strongly-seeing.md), [`judges.md`](../docs/consensus-layer/concepts/judges.md), [`voting.md`](../docs/consensus-layer/concepts/voting.md), [`coin-rounds.md`](../docs/consensus-layer/concepts/coin-rounds.md), [`birth-round.md`](../docs/consensus-layer/concepts/birth-round.md).
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-metrics/CLAUDE.md
+++ b/platform-sdk/consensus-metrics/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-metrics` is part of the **consensus layer** — a supporting module providing the
+metrics the consensus modules emit. When working here, consult the consensus-layer knowledge
+base at [`../docs/consensus-layer/`](../docs/consensus-layer/) — it documents the current
+implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/health-monitor-and-backpressure.md`](../docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md) — the health and flow-control signals many of these metrics observe.
+- [`tunables.md`](../docs/consensus-layer/tunables.md) — thresholds and parameters the metrics relate to.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-model/CLAUDE.md
+++ b/platform-sdk/consensus-model/CLAUDE.md
@@ -1,0 +1,23 @@
+# Consensus Layer Knowledge Base
+
+`consensus-model` is part of the **consensus layer** — the shared data model (events, rounds,
+judges, roster metadata, `PlatformStatus`, notifications) consumed by every consensus module.
+When working here, consult the consensus-layer knowledge base at
+[`../docs/consensus-layer/`](../docs/consensus-layer/) — it documents the current
+implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`concepts/`](../docs/consensus-layer/concepts/) and [`glossary.md`](../docs/consensus-layer/glossary.md) — the canonical definitions for the types modelled here (event, round, birth-round, judge, witness, roster).
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — many of these types are the payloads that travel across the consensus / execution boundary.
+- [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md) — how the model underpins all eleven topics.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-network-simulation/CLAUDE.md
+++ b/platform-sdk/consensus-network-simulation/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-network-simulation` is a **simulation harness for testing the consensus layer** — it
+exercises consensus modules under deterministic, simulated network conditions. To write or read
+simulations here you need the consensus-layer mental models, so consult the knowledge base at
+[`../docs/consensus-layer/`](../docs/consensus-layer/). It documents the current implementation
+as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md) — the module map and event flow the simulation reproduces.
+- [`concepts/`](../docs/consensus-layer/concepts/) — the mental models (hashgraph DAG, rounds and witnesses, judges, birth-round, event lifecycle) a simulation must respect.
+- [`scenarios/`](../docs/consensus-layer/scenarios/) and [`symptoms.md`](../docs/consensus-layer/symptoms.md) — edge cases and observable signatures worth reproducing or asserting against.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); diagnostics in
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-otter-docker-app/CLAUDE.md
+++ b/platform-sdk/consensus-otter-docker-app/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-otter-docker-app` is consensus-layer **tooling** — the containerized app that runs a
+consensus node for Otter tests (`ConsensusNodeManager`, `ConsensusRoundListener`,
+`EventMessageFactory`). It is not part of the runtime layer the knowledge base documents, but it
+wires up and drives the consensus layer, so consult the knowledge base at
+[`../docs/consensus-layer/`](../docs/consensus-layer/). It documents the current implementation
+as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md) — the module map and how a running consensus node is composed.
+- [`architecture/topics/wiring-framework.md`](../docs/consensus-layer/architecture/topics/wiring-framework.md) — how the modules are soldered into a running platform.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — the boundary this app stands up around the consensus layer.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/).

--- a/platform-sdk/consensus-otter-tests/CLAUDE.md
+++ b/platform-sdk/consensus-otter-tests/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`consensus-otter-tests` is consensus-layer **tooling** — the Otter test framework that exercises
+the consensus modules under simulated (Turtle) and containerized environments. It is not part
+of the runtime layer the knowledge base documents, but writing and reading these tests requires
+the consensus-layer mental models, so consult the knowledge base at
+[`../docs/consensus-layer/`](../docs/consensus-layer/). It documents the current implementation
+as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md) — the module map and event flow a test reproduces.
+- [`concepts/`](../docs/consensus-layer/concepts/) — the mental models (hashgraph DAG, rounds and witnesses, judges, birth-round, event lifecycle) a test must respect.
+- [`scenarios/`](../docs/consensus-layer/scenarios/) and [`symptoms.md`](../docs/consensus-layer/symptoms.md) — edge cases and observable signatures worth reproducing or asserting against.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-pces-impl/CLAUDE.md
+++ b/platform-sdk/consensus-pces-impl/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-pces-impl` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/restart-and-pces.md`](../docs/consensus-layer/architecture/topics/restart-and-pces.md) — Pre-Consensus Event Stream durability and replay across restarts.
+- [`concepts/event-lifecycle.md`](../docs/consensus-layer/concepts/event-lifecycle.md) — where PCES sits in an event's life.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-pces-noop-impl/CLAUDE.md
+++ b/platform-sdk/consensus-pces-noop-impl/CLAUDE.md
@@ -1,0 +1,20 @@
+# Consensus Layer Knowledge Base
+
+`consensus-pces-noop-impl` is part of the **consensus layer** — the no-op implementation of
+PCES-file handling. When working here, consult the consensus-layer knowledge base at
+[`../docs/consensus-layer/`](../docs/consensus-layer/) — it documents the current
+implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/restart-and-pces.md`](../docs/consensus-layer/architecture/topics/restart-and-pces.md) — Pre-Consensus Event Stream durability and replay; understand what behavior this no-op variant omits.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-pces/CLAUDE.md
+++ b/platform-sdk/consensus-pces/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-pces` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/restart-and-pces.md`](../docs/consensus-layer/architecture/topics/restart-and-pces.md) — Pre-Consensus Event Stream durability and replay across restarts.
+- [`concepts/event-lifecycle.md`](../docs/consensus-layer/concepts/event-lifecycle.md) — where PCES sits in an event's life.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-platformstate/CLAUDE.md
+++ b/platform-sdk/consensus-platformstate/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`consensus-platformstate` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/freeze-and-upgrade.md`](../docs/consensus-layer/architecture/topics/freeze-and-upgrade.md) — the freeze timestamps in `PlatformState` (written by the execution layer, read by the consensus layer).
+- [`architecture/topics/signed-state-management.md`](../docs/consensus-layer/architecture/topics/signed-state-management.md) — platform-state structures carried in signed state.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — shared state fields crossing the boundary.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-reconnect-impl/CLAUDE.md
+++ b/platform-sdk/consensus-reconnect-impl/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-reconnect-impl` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/reconnect.md`](../docs/consensus-layer/architecture/topics/reconnect.md) — recovering a node that has fallen too far behind for gossip to catch it up. The orchestration entry point lives in `swirlds-platform-core`.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — `StateLifecycleManager` calls (`createStateFrom`, `initWithState`) exercised during reconnect.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-reconnect/CLAUDE.md
+++ b/platform-sdk/consensus-reconnect/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-reconnect` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/reconnect.md`](../docs/consensus-layer/architecture/topics/reconnect.md) — recovering a node that has fallen too far behind for gossip to catch it up. The orchestration entry point lives in `swirlds-platform-core`.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — `StateLifecycleManager` calls (`createStateFrom`, `initWithState`) exercised during reconnect.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-roster/CLAUDE.md
+++ b/platform-sdk/consensus-roster/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-roster` is part of the **consensus layer**. When working here, consult the
+consensus-layer knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) —
+it documents the current implementation as canonical, anchored to specific files,
+classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/hashgraph.md`](../docs/consensus-layer/architecture/topics/hashgraph.md) — rosters are carried as round metadata so every module agrees which roster applies to which round.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — where rosters cross the boundary (carried in state and as round metadata).
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-sloth/CLAUDE.md
+++ b/platform-sdk/consensus-sloth/CLAUDE.md
@@ -1,0 +1,23 @@
+# Consensus Layer Knowledge Base
+
+`consensus-sloth` is consensus-layer **tooling** — a performance framework whose experiments
+(anti-selfishness, max creation rate, max other-parents, broadcast, signature) probe consensus
+behavior directly. It is not part of the runtime layer the knowledge base documents, but
+designing and reading these experiments requires the consensus-layer mental models, so consult
+the knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/). It documents the
+current implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`tunables.md`](../docs/consensus-layer/tunables.md) — the parameters these experiments sweep (creation rate, other-parent count, etc.).
+- [`architecture/topics/event-creator.md`](../docs/consensus-layer/architecture/topics/event-creator.md) and [`architecture/topics/gossip.md`](../docs/consensus-layer/architecture/topics/gossip.md) — the subsystems most of the experiments stress.
+- [`architecture/topics/health-monitor-and-backpressure.md`](../docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md) — the flow-control behavior under load that performance work observes.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-state/CLAUDE.md
+++ b/platform-sdk/consensus-state/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-state` is part of the **consensus layer** — consensus-side state structures shared
+at the boundary with the execution layer. When working here, consult the consensus-layer
+knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/) — it documents the
+current implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/signed-state-management.md`](../docs/consensus-layer/architecture/topics/signed-state-management.md) — round signing, state hashing, signature collection.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — how state structures are shared across the boundary. Note: the proposed design moves state under the execution layer; this module sits on the consensus side today.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/consensus-utility/CLAUDE.md
+++ b/platform-sdk/consensus-utility/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`consensus-utility` is part of the **consensus layer** — a supporting module of helpers
+consumed across the layer. When working here, consult the consensus-layer knowledge base at
+[`../docs/consensus-layer/`](../docs/consensus-layer/) — it documents the current
+implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md) — where this module's helpers sit in the module map and which topics consume them.
+- [`glossary.md`](../docs/consensus-layer/glossary.md) and [`concepts/`](../docs/consensus-layer/concepts/) — vocabulary the helpers operate on.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/swirlds-cli/CLAUDE.md
+++ b/platform-sdk/swirlds-cli/CLAUDE.md
@@ -1,0 +1,21 @@
+# Consensus Layer Knowledge Base
+
+`swirlds-cli` is consensus-layer **tooling** — the `pcli` command-line tool that operates on
+consensus artifacts, including event-stream recovery (`pcli/recovery`) and hashgraph graph
+generation (`pcli/graph`). It is not part of the runtime layer the knowledge base documents, but
+its consensus-facing commands require the consensus-layer mental models, so consult the
+knowledge base at [`../docs/consensus-layer/`](../docs/consensus-layer/). It documents the
+current implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/restart-and-pces.md`](../docs/consensus-layer/architecture/topics/restart-and-pces.md) — the Pre-Consensus Event Stream and event-stream files the recovery commands read.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — the offline `EventRecoveryWorkflow` path (`SwirldMain`, `onNewRecoveredState`) these commands drive.
+- [`architecture/topics/hashgraph.md`](../docs/consensus-layer/architecture/topics/hashgraph.md) and [`concepts/hashgraph-dag.md`](../docs/consensus-layer/concepts/hashgraph-dag.md) — the structure the graph commands render.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/).

--- a/platform-sdk/swirlds-common/CLAUDE.md
+++ b/platform-sdk/swirlds-common/CLAUDE.md
@@ -1,0 +1,24 @@
+# Consensus Layer Knowledge Base
+
+`swirlds-common` is shared infrastructure used by **both the consensus and execution layers**,
+not a consensus module per se. But it hosts platform-runtime primitives the consensus layer
+leans on — `NotificationEngine`, `PlatformContext`, and the `com.swirlds.common.platform`
+package — so when your work here touches those, the consensus-layer knowledge base at
+[`../docs/consensus-layer/`](../docs/consensus-layer/) is the reference for how they are used.
+It documents the current implementation as canonical, anchored to specific files, classes, and
+methods.
+
+**Most relevant when working on the consensus-facing parts:**
+
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — the `NotificationEngine` (reached via `Platform.getNotificationEngine()`) and the notification listeners that carry boundary traffic.
+- [`architecture/topics/wiring-framework.md`](../docs/consensus-layer/architecture/topics/wiring-framework.md) — how the platform runtime is composed.
+
+The bulk of this module (threading, IO, crypto helpers, generic utilities) is general
+infrastructure and outside the knowledge base's scope.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/).

--- a/platform-sdk/swirlds-component-framework/CLAUDE.md
+++ b/platform-sdk/swirlds-component-framework/CLAUDE.md
@@ -1,0 +1,22 @@
+# Consensus Layer Knowledge Base
+
+`swirlds-component-framework` is the **wiring framework** that composes the consensus-layer
+runtime: components, wires, and soldering, with backpressure applied at the wire level. When
+working here, consult the consensus-layer knowledge base at
+[`../docs/consensus-layer/`](../docs/consensus-layer/) — it documents the current
+implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/topics/wiring-framework.md`](../docs/consensus-layer/architecture/topics/wiring-framework.md) — how components, wires, and soldering compose the consensus runtime, and how wire-level backpressure throttles upstream producers.
+- [`architecture/topics/health-monitor-and-backpressure.md`](../docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md) — the flow-control behavior the framework enables.
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).

--- a/platform-sdk/swirlds-platform-core/CLAUDE.md
+++ b/platform-sdk/swirlds-platform-core/CLAUDE.md
@@ -1,0 +1,25 @@
+# Consensus Layer Knowledge Base
+
+`swirlds-platform-core` is the **wiring root of the consensus layer**: where the consensus
+modules are composed into a running platform and where the consensus / execution boundary is
+drawn today (`ExecutionLayer`, `ConsensusStateEventHandler`, `PlatformBuilder`, reconnect
+orchestration, notifications). Nearly all of the knowledge base is relevant here. Consult it at
+[`../docs/consensus-layer/`](../docs/consensus-layer/) — it documents the current
+implementation as canonical, anchored to specific files, classes, and methods.
+
+**Most relevant to this module:**
+
+- [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md) — the module map and where the consensus / execution boundary runs.
+- [`architecture/interfaces/consensus-execution-boundary.md`](../docs/consensus-layer/architecture/interfaces/consensus-execution-boundary.md) — the full boundary surface (`PlatformBuilder`, `ExecutionLayer`, `ConsensusStateEventHandler`, `StateLifecycleManager`, `ApplicationCallbacks`, notification listeners).
+- [`architecture/topics/wiring-framework.md`](../docs/consensus-layer/architecture/topics/wiring-framework.md) — how modules are soldered together here.
+- The lifecycle topics rooted in this module: [`reconnect.md`](../docs/consensus-layer/architecture/topics/reconnect.md), [`signed-state-management.md`](../docs/consensus-layer/architecture/topics/signed-state-management.md), [`freeze-and-upgrade.md`](../docs/consensus-layer/architecture/topics/freeze-and-upgrade.md), [`health-monitor-and-backpressure.md`](../docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md).
+
+**Navigation.** Start at [`architecture/overview.md`](../docs/consensus-layer/architecture/overview.md).
+Vocabulary lives in [`glossary.md`](../docs/consensus-layer/glossary.md) and
+[`concepts/`](../docs/consensus-layer/concepts/); rationale in
+[`decisions/`](../docs/consensus-layer/decisions/); properties to preserve in
+[`invariants/`](../docs/consensus-layer/invariants/) and
+[`rules/`](../docs/consensus-layer/rules/); tunable parameters in
+[`tunables.md`](../docs/consensus-layer/tunables.md); known incidents and diagnostics in
+[`scenarios/`](../docs/consensus-layer/scenarios/) and
+[`heuristics/`](../docs/consensus-layer/heuristics/).


### PR DESCRIPTION
**Description**:

This PR adds `CLAUDE.md` files to all consensus layer modules that point to the knowledge base. This will ensure that Claude Code is aware of the knowledge base when working in these modules.

**Related issue(s)**:

Fixes #25727