### PR TITLE
fix: reset `blockStream_conn_activeConnIp` metric when block-nodes.json is removed

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -638,6 +638,11 @@ public class BlockNodeConnectionManager {
         final Instant now = Instant.now();
         final BlockNodeStreamingConnection activeConnection = activeConnectionRef.get();
 
+        // Re-emit the active connection IP (0 when there is no active connection) so the gauge does not
+        // remain stale after the active connection closes (e.g. when all block node configuration is removed).
+        blockStreamMetrics.recordActiveConnectionIp(
+                activeConnection == null ? 0L : activeConnection.ipV4AddressAsInt());
+
         checkActiveConnectionStalled(now, activeConnection);
 
         CloseReason closeReason = CloseReason.UNKNOWN;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnection.java
@@ -1161,8 +1161,6 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
          */
         private boolean doWork() {
             connStats.recordHeartbeat(System.currentTimeMillis());
-            // Re-emit the active connection IP metric so it is available on every metrics scrape
-            blockStreamMetrics.recordActiveConnectionIp(ipV4AddressAsInt());
 
             switchBlockIfNeeded();
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -1464,6 +1465,15 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         final BlockNode node = mock(BlockNode.class);
         when(node.configuration()).thenReturn(nodeConfig);
         when(node.isStreamingCandidate()).thenReturn(false);
+        // terminating the node ultimately closes its connection, which in production calls back into the
+        // manager via notifyConnectionClosed; drive that real callback so the active connection reference is
+        // cleared by production code rather than by the test poking the field directly
+        doAnswer(inv -> {
+                    connectionManager.notifyConnectionClosed(activeConnection);
+                    return null;
+                })
+                .when(node)
+                .onTerminate(CloseReason.CONFIG_UPDATE);
         blockNodes().put(nodeConfig.streamingEndpoint(), node);
         // the active configuration currently has a single block node
         activeConfigRef().set(new VersionedBlockNodeConfigurationSet(1, List.of(nodeConfig)));
@@ -1472,14 +1482,14 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         when(blockNodeConfigService.latestConfiguration())
                 .thenReturn(new VersionedBlockNodeConfigurationSet(2, List.of()));
 
-        // tick 1: the removal is detected and the node is told to terminate its connection; while the
-        // connection is still active the gauge reports its IP address
+        // tick 1: the removal is detected and the node terminates its connection; the resulting (real)
+        // notifyConnectionClosed callback clears the active connection reference. The connection was still
+        // active at the start of the tick, so the gauge reports its IP address.
         invoke_updateConnectionIfNeeded();
         verify(node).onTerminate(CloseReason.CONFIG_UPDATE);
         verify(metrics).recordActiveConnectionIp(3232235777L);
-
-        // simulate the connection actually closing (in production notifyConnectionClosed clears the active ref)
-        activeConnectionRef().set(null);
+        // the active connection reference was cleared by production code, not by the test
+        assertThat(activeConnectionRef()).hasNullValue();
 
         // tick 2: with no active connection remaining, the gauge transitions to 0 instead of keeping the old IP
         invoke_updateConnectionIfNeeded();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -1411,6 +1411,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         verify(newActiveConnection).initialize();
         verify(newActiveConnection).updateConnectionState(ConnectionState.ACTIVE);
         verify(metrics).recordActiveConnectionCount(anyLong());
+        verify(metrics).recordActiveConnectionIp(anyLong());
     }
 
     @Test
@@ -1444,6 +1445,44 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         invoke_updateConnectionIfNeeded();
 
         // with no active connection the gauge must transition to 0 rather than retaining a stale IP
+        verify(metrics).recordActiveConnectionIp(0L);
+    }
+
+    @Test
+    void testUpdateConnectionIfNeeded_recordsZeroIpAfterAllConfigRemoved() throws Throwable {
+        // an active connection is streaming to a configured block node (192.168.1.1 -> 3232235777)
+        final BlockNodeConfiguration nodeConfig = newBlockNodeConfig("localhost", 1234, 1);
+        final BlockNodeStreamingConnection activeConnection = mock(BlockNodeStreamingConnection.class);
+        final StreamingConnectionStatistics activeConnStats = mock(StreamingConnectionStatistics.class);
+        when(activeConnStats.lastHeartbeatMillis())
+                .thenReturn(Instant.now().plusSeconds(2).toEpochMilli());
+        when(activeConnection.connectionStatistics()).thenReturn(activeConnStats);
+        when(activeConnection.configuration()).thenReturn(nodeConfig);
+        when(activeConnection.autoResetTimestamp()).thenReturn(Instant.now().plusSeconds(90));
+        when(activeConnection.ipV4AddressAsInt()).thenReturn(3232235777L);
+        activeConnectionRef().set(activeConnection);
+        final BlockNode node = mock(BlockNode.class);
+        when(node.configuration()).thenReturn(nodeConfig);
+        when(node.isStreamingCandidate()).thenReturn(false);
+        blockNodes().put(nodeConfig.streamingEndpoint(), node);
+        // the active configuration currently has a single block node
+        activeConfigRef().set(new VersionedBlockNodeConfigurationSet(1, List.of(nodeConfig)));
+        when(bufferService.latestBufferStatus()).thenReturn(new BlockBufferStatus(Instant.now(), 0.0D, false));
+        // the whole block-nodes.json is removed -> the config service publishes an empty, version-bumped set
+        when(blockNodeConfigService.latestConfiguration())
+                .thenReturn(new VersionedBlockNodeConfigurationSet(2, List.of()));
+
+        // tick 1: the removal is detected and the node is told to terminate its connection; while the
+        // connection is still active the gauge reports its IP address
+        invoke_updateConnectionIfNeeded();
+        verify(node).onTerminate(CloseReason.CONFIG_UPDATE);
+        verify(metrics).recordActiveConnectionIp(3232235777L);
+
+        // simulate the connection actually closing (in production notifyConnectionClosed clears the active ref)
+        activeConnectionRef().set(null);
+
+        // tick 2: with no active connection remaining, the gauge transitions to 0 instead of keeping the old IP
+        invoke_updateConnectionIfNeeded();
         verify(metrics).recordActiveConnectionIp(0L);
     }
 
@@ -1487,6 +1526,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         // in the real world, when BlockNode#onTerminate(CloseReason) is called, it will close the connection
         // associated with the node, but since this is using mocks, those side effects aren't verifiable here
         verify(metrics).recordActiveConnectionCount(anyLong());
+        verify(metrics).recordActiveConnectionIp(anyLong());
     }
 
     @Test
@@ -1520,6 +1560,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         // the active connection - having some sort of connection is better than nothing in this scenario
         verify(activeConnection, never()).closeAtBlockBoundary(any(CloseReason.class));
         verify(metrics).recordActiveConnectionCount(anyLong());
+        verify(metrics).recordActiveConnectionIp(anyLong());
     }
 
     @Test
@@ -1581,6 +1622,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         verify(newActiveConnection).updateConnectionState(ConnectionState.ACTIVE);
         verify(lowerPriorityConnection).closeAtBlockBoundary(CloseReason.HIGHER_PRIORITY_FOUND);
         verify(metrics).recordActiveConnectionCount(anyLong());
+        verify(metrics).recordActiveConnectionIp(anyLong());
     }
 
     @Test
@@ -1636,6 +1678,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         verify(newActiveConnection).updateConnectionState(ConnectionState.ACTIVE);
         verify(existingActiveConnection, times(2)).closeAtBlockBoundary(CloseReason.PERIODIC_RESET);
         verify(metrics).recordActiveConnectionCount(anyLong());
+        verify(metrics).recordActiveConnectionIp(anyLong());
     }
 
     @Test
@@ -1666,6 +1709,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         // the active connection should not be changed
         assertThat(activeConnectionRef()).doesNotHaveNullValue().hasValue(activeConnection);
         verify(metrics).recordActiveConnectionCount(anyLong());
+        verify(metrics).recordActiveConnectionIp(anyLong());
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -1414,6 +1414,40 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
+    void testUpdateConnectionIfNeeded_recordsActiveConnectionIpWhenConnectionActive() throws Throwable {
+        // a healthy active connection exists with a known IP address (192.168.1.1 -> 3232235777)
+        final BlockNodeStreamingConnection activeConnection = mock(BlockNodeStreamingConnection.class);
+        final StreamingConnectionStatistics activeConnStats = mock(StreamingConnectionStatistics.class);
+        when(activeConnStats.lastHeartbeatMillis())
+                .thenReturn(Instant.now().plusSeconds(2).toEpochMilli());
+        when(activeConnection.connectionStatistics()).thenReturn(activeConnStats);
+        when(activeConnection.configuration()).thenReturn(newBlockNodeConfig("localhost", 1234, 1));
+        when(activeConnection.autoResetTimestamp()).thenReturn(Instant.now().plusSeconds(90));
+        when(activeConnection.ipV4AddressAsInt()).thenReturn(3232235777L);
+        activeConnectionRef().set(activeConnection);
+        // healthy buffer and no configuration changes so the active connection is left in place
+        when(bufferService.latestBufferStatus()).thenReturn(new BlockBufferStatus(Instant.now(), 0.0D, false));
+
+        invoke_updateConnectionIfNeeded();
+
+        // the gauge should report the active connection's IP address
+        verify(metrics).recordActiveConnectionIp(3232235777L);
+    }
+
+    @Test
+    void testUpdateConnectionIfNeeded_recordsZeroIpWhenNoActiveConnection() throws Throwable {
+        // no active connection exists
+        activeConnectionRef().set(null);
+        // healthy buffer and no configured block nodes so no new connection is selected
+        when(bufferService.latestBufferStatus()).thenReturn(new BlockBufferStatus(Instant.now(), 0.0D, false));
+
+        invoke_updateConnectionIfNeeded();
+
+        // with no active connection the gauge must transition to 0 rather than retaining a stale IP
+        verify(metrics).recordActiveConnectionIp(0L);
+    }
+
+    @Test
     void testUpdateConnectionIfNeeded_updatedConfigOnly() throws Throwable {
         // set active connection that is healthy
         final BlockNodeConfiguration nodeConfig = newBlockNodeConfig("localhost", 1234, 1);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -1497,6 +1497,52 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
+    void testUpdateConnectionIfNeeded_recordsZeroIpWhenNoBlockNodeConnectable() throws Throwable {
+        // an active connection is streaming to a configured block node (192.168.1.1 -> 3232235777)
+        final BlockNodeConfiguration nodeConfig = newBlockNodeConfig("localhost", 1234, 1);
+        final BlockNodeStreamingConnection activeConnection = mock(BlockNodeStreamingConnection.class);
+        final StreamingConnectionStatistics activeConnStats = mock(StreamingConnectionStatistics.class);
+        when(activeConnStats.lastHeartbeatMillis())
+                .thenReturn(Instant.now().plusSeconds(2).toEpochMilli());
+        when(activeConnection.connectionStatistics()).thenReturn(activeConnStats);
+        when(activeConnection.configuration()).thenReturn(nodeConfig);
+        when(activeConnection.autoResetTimestamp()).thenReturn(Instant.now().plusSeconds(90));
+        when(activeConnection.ipV4AddressAsInt()).thenReturn(3232235777L);
+        activeConnectionRef().set(activeConnection);
+        // the block node stays in configuration, but it cannot be connected to (e.g. unreachable / in cool-down)
+        final BlockNode node = mock(BlockNode.class);
+        lenient().when(node.configuration()).thenReturn(nodeConfig);
+        when(node.isStreamingCandidate()).thenReturn(false);
+        blockNodes().put(nodeConfig.streamingEndpoint(), node);
+        // the block node configuration is unchanged - the node is simply unreachable
+        final VersionedBlockNodeConfigurationSet configSet =
+                new VersionedBlockNodeConfigurationSet(1, List.of(nodeConfig));
+        activeConfigRef().set(configSet);
+        when(blockNodeConfigService.latestConfiguration()).thenReturn(configSet);
+        when(bufferService.latestBufferStatus()).thenReturn(new BlockBufferStatus(Instant.now(), 0.0D, false));
+
+        // tick 1: the connection is still active and healthy, so the gauge reports its IP address
+        invoke_updateConnectionIfNeeded();
+        verify(metrics).recordActiveConnectionIp(3232235777L);
+
+        // the active connection is lost (e.g. the block node became unreachable); production clears the active ref
+        connectionManager.notifyConnectionClosed(activeConnection);
+        assertThat(activeConnectionRef()).hasNullValue();
+
+        // tick 2: a reconnection is attempted, but no block node is connectable, so no replacement connection is
+        // established and the gauge transitions to 0 instead of retaining the old IP
+        try (final MockedConstruction<BlockNodeStreamingConnection> mockConnection =
+                mockConstruction(BlockNodeStreamingConnection.class)) {
+            invoke_updateConnectionIfNeeded();
+            assertThat(mockConnection.constructed()).isEmpty();
+        }
+
+        verify(node, atLeastOnce()).isStreamingCandidate();
+        assertThat(activeConnectionRef()).hasNullValue();
+        verify(metrics).recordActiveConnectionIp(0L);
+    }
+
+    @Test
     void testUpdateConnectionIfNeeded_updatedConfigOnly() throws Throwable {
         // set active connection that is healthy
         final BlockNodeConfiguration nodeConfig = newBlockNodeConfig("localhost", 1234, 1);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
@@ -382,7 +382,6 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         verify(metrics, atLeastOnce()).recordRequestBytes(anyLong());
         verify(metrics, atLeastOnce()).recordStreamingBlockNumber(anyLong());
         verify(metrics, atLeastOnce()).recordLatestBlockEndOfBlockSent(anyLong());
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
         verify(connectionManager).notifyConnectionActive(connection);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -468,7 +467,6 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         verify(bufferService).getHighestAckedBlockNumber();
         verify(connectionManager).notifyConnectionClosed(connection);
         verify(metrics, atLeastOnce()).recordStreamingBlockNumber(anyLong());
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
         verify(connectionManager).notifyConnectionActive(connection);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -627,7 +625,6 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         verify(metrics, atLeastOnce()).recordRequestBytes(anyLong());
         verify(metrics, atLeastOnce()).recordLatestBlockEndOfBlockSent(anyLong());
         verify(metrics, atLeastOnce()).recordHeaderSentToBlockEndSentLatency(anyLong());
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
         verify(connectionManager).notifyConnectionActive(connection);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -743,7 +740,6 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         verify(metrics).recordRequestLatency(anyLong());
         verify(metrics).recordRequestEndStreamSent(EndStream.Code.RESET);
         verify(metrics).recordConnectionClosed(CloseReason.SHUTDOWN);
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
 
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -870,7 +866,6 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         verify(metrics).recordRequestSent(RequestOneOfType.END_OF_BLOCK);
         verify(metrics).recordRequestEndStreamSent(EndStream.Code.RESET);
         verify(metrics).recordConnectionClosed(CloseReason.SHUTDOWN);
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
 
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -1097,7 +1092,6 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         verify(metrics, atLeastOnce()).recordRequestBytes(anyLong());
         verify(metrics, atLeastOnce()).recordLatestBlockEndOfBlockSent(anyLong());
         verify(metrics, atLeastOnce()).recordHeaderSentToBlockEndSentLatency(anyLong());
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
         verify(connectionManager).notifyConnectionActive(connection);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(bufferService);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionTest.java
@@ -1253,7 +1253,6 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         verify(bufferService).getBlockState(101);
         verifyNoMoreInteractions(bufferService);
         verifyNoInteractions(connectionManager);
-        verify(metrics).recordActiveConnectionIp(anyLong());
         verifyNoMoreInteractions(metrics);
         verifyNoInteractions(requestPipeline);
     }
@@ -1275,7 +1274,6 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         verify(bufferService).getLastBlockNumberProduced();
         verifyNoMoreInteractions(bufferService);
         verifyNoInteractions(connectionManager);
-        verify(metrics).recordActiveConnectionIp(anyLong());
         verifyNoMoreInteractions(metrics);
         verifyNoInteractions(requestPipeline);
     }
@@ -1297,7 +1295,6 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         verify(bufferService).getBlockState(10);
         verifyNoMoreInteractions(bufferService);
         verifyNoInteractions(connectionManager);
-        verify(metrics).recordActiveConnectionIp(anyLong());
         verifyNoMoreInteractions(metrics);
         verifyNoInteractions(requestPipeline);
     }
@@ -1319,7 +1316,6 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         assertThat(streamingBlockNumber).hasValue(10);
         assertThat(connection.closeReason()).isEqualTo(CloseReason.BLOCK_NODE_BEHIND);
 
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
         verify(metrics).recordRequestLatency(anyLong());
         verify(metrics).recordRequestEndStreamSent(EndStream.Code.TOO_FAR_BEHIND);
         verify(metrics).recordConnectionClosed(CloseReason.BLOCK_NODE_BEHIND);
@@ -1395,7 +1391,6 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         verify(metrics, atLeastOnce()).recordStreamingBlockNumber(anyLong());
         verify(metrics, atLeastOnce()).recordLatestBlockEndOfBlockSent(anyLong());
         verify(metrics, atLeastOnce()).recordHeaderSentToBlockEndSentLatency(anyLong());
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
 
         verifyNoMoreInteractions(bufferService);
         verifyNoMoreInteractions(connectionManager);
@@ -1496,7 +1491,6 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
 
         verify(metrics).recordRequestExceedsHardLimit();
         verify(metrics).recordConnectionClosed(CloseReason.INTERNAL_ERROR);
-        verify(metrics, atLeastOnce()).recordActiveConnectionIp(anyLong());
         verify(metrics, times(5)).recordRequestLatency(anyLong());
         verify(requestPipeline).onComplete();
         verify(bufferService).getEarliestAvailableBlockNumber();


### PR DESCRIPTION
**Description**:

**Root cause:** the gauge was only written from the per-connection worker loop
(`BlockNodeStreamingConnection.doWork()`). When the config is removed the connection closes and the
worker exits, so nothing ever reset the gauge. Its sibling `activeConnectionCount` doesn't have this
bug because the connection-monitor loop re-emits it every tick.

**Fix:** make the monitor loop the single owner of the gauge, mirroring `recordActiveConnectionCount`.
`BlockNodeConnectionManager.updateConnectionIfNeeded()` now emits the active connection's IP, or `0`
when there is no active connection, on every tick; the redundant worker-loop emission is removed
(which also avoids a reset/re-emit race between the monitor and worker threads).

**Related issue(s)**:

Fixes #25732 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
