### PR TITLE
fix: cherry-pick: WRB BlockHeader.blockTimestamp incorrectly set to blockCreationTime instead of first consensus timestamp

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesCalculator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesCalculator.java
@@ -73,7 +73,7 @@ public final class WrappedRecordFileBlockHashesCalculator {
         final var header = BlockHeader.newBuilder()
                 .hapiProtoVersion(in.hapiProtoVersion())
                 .number(in.blockNumber())
-                .blockTimestamp(in.blockCreationTime())
+                .blockTimestamp(firstConsensusTimestamp)
                 .hashAlgorithm(BlockHashAlgorithm.SHA2_384);
 
         final var headerItem = BlockItem.newBuilder().blockHeader(header).build();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesCalculatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesCalculatorTest.java
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.records.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.transaction.TransactionRecord;
+import com.hedera.hapi.streams.RecordStreamItem;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class WrappedRecordFileBlockHashesCalculatorTest {
+
+    @Test
+    void blockHeaderUsesFirstConsensusTimeAndRecordFileItemUsesBlockCreationTime() {
+        final var blockCreationTime = new Timestamp(1_000L, 0);
+        final var firstConsensusTime = new Timestamp(2_000L, 0);
+
+        final var firstItem = new RecordStreamItem(
+                Transaction.DEFAULT,
+                TransactionRecord.newBuilder()
+                        .consensusTimestamp(firstConsensusTime)
+                        .build());
+
+        final var input = new WrappedRecordFileBlockHashesComputationInput(
+                1L,
+                blockCreationTime,
+                SemanticVersion.DEFAULT,
+                Bytes.wrap(new byte[48]),
+                Bytes.wrap(new byte[48]),
+                List.of(firstItem),
+                List.of(),
+                1024 * 1024);
+
+        final var result = WrappedRecordFileBlockHashesCalculator.computeWithItems(input);
+
+        final var actualCreationTime =
+                result.recordFileItem().recordFileOrThrow().creationTime();
+        final var actualBlockTimestamp =
+                result.headerItem().blockHeaderOrThrow().blockTimestamp();
+
+        assertEquals(blockCreationTime, actualCreationTime, "RecordFileItem.creationTime must equal blockCreationTime");
+        assertEquals(
+                firstConsensusTime,
+                actualBlockTimestamp,
+                "BlockHeader.blockTimestamp must equal first consensus timestamp of the first item");
+    }
+}


### PR DESCRIPTION
**Description**:
This PR cherry-picks commit 361d47b2b35a7dec5d34aba77df49f7dc2280200 for release/0.75

**Related issue(s)**:

Fixes #25740 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
