### PR TITLE
fix: cherry-pick: Add `BlockRecordManager.Lifecycle` for `streamMode=RECORDS`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordInjectionModule.java
@@ -15,11 +15,13 @@ import com.hedera.node.app.records.impl.producers.StreamFileProducerSingleThread
 import com.hedera.node.app.records.impl.producers.formats.BlockRecordWriterFactoryImpl;
 import com.hedera.node.app.records.impl.producers.formats.v6.BlockRecordFormatV6;
 import com.hedera.node.app.records.impl.producers.formats.v7.BlockRecordFormatV7;
+import com.hedera.node.app.services.NodeFeeManager;
 import com.hedera.node.app.state.WorkingStateAccessor;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
+import com.swirlds.state.State;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -77,7 +79,8 @@ public abstract class BlockRecordInjectionModule {
             @NonNull final Platform platform,
             @NonNull final WrappedRecordFileBlockHashesDiskWriter wrappedRecordHashesDiskWriter,
             @NonNull final BlockHashSigner blockHashSigner,
-            @NonNull @Named("wrb") final Supplier<BlockItemWriter> wrbWriterSupplier) {
+            @NonNull @Named("wrb") final Supplier<BlockItemWriter> wrbWriterSupplier,
+            @NonNull final BlockRecordManager.Lifecycle blockLifecycle) {
         final var merkleState = state.getState();
         if (merkleState == null) {
             throw new IllegalStateException("Merkle state is null");
@@ -92,7 +95,25 @@ public abstract class BlockRecordInjectionModule {
                 wrappedRecordHashesDiskWriter,
                 wrbWriterSupplier,
                 blockHashSigner,
-                initTrigger);
+                initTrigger,
+                blockLifecycle);
+    }
+
+    @Provides
+    @Singleton
+    public static BlockRecordManager.Lifecycle provideBlockRecordManagerLifecycle(
+            @NonNull final NodeFeeManager nodeFeeManager) {
+        return new BlockRecordManager.Lifecycle() {
+            @Override
+            public void onOpenBlock(@NonNull final State state) {
+                nodeFeeManager.onOpenBlock(state);
+            }
+
+            @Override
+            public void onCloseBlock(@NonNull final State state) {
+                nodeFeeManager.onCloseBlock(state);
+            }
+        };
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/BlockRecordManager.java
@@ -45,6 +45,24 @@ import java.util.stream.Stream;
  * may have a consensus time that lies outside the "typical" block boundary.
  */
 public interface BlockRecordManager extends BlockRecordInfo, AutoCloseable {
+    /**
+     * Lifecycle hooks for record stream block boundaries.
+     */
+    interface Lifecycle {
+        /**
+         * Called when a record stream block is opened.
+         *
+         * @param state the state at the start of the block
+         */
+        void onOpenBlock(@NonNull State state);
+
+        /**
+         * Called when a record stream block is closed.
+         *
+         * @param state the state at the end of the block
+         */
+        void onCloseBlock(@NonNull State state);
+    }
 
     /**
      * Inform {@link BlockRecordManager} of the new consensus time at the beginning of a new transaction. This should

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -92,6 +92,17 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
     private static final Logger logger = LogManager.getLogger(BlockRecordManagerImpl.class);
 
     private static final long NO_BLOCK_SIGNING_REQUESTED = -1L;
+    private static final BlockRecordManager.Lifecycle NO_OP_BLOCK_LIFECYCLE = new BlockRecordManager.Lifecycle() {
+        @Override
+        public void onOpenBlock(@NonNull final State state) {
+            // No-op
+        }
+
+        @Override
+        public void onCloseBlock(@NonNull final State state) {
+            // No-op
+        }
+    };
 
     private static final Bytes EMPTY_INT_NODE = BlockImplUtils.hashInternalNode(HASH_OF_ZERO, HASH_OF_ZERO);
 
@@ -125,6 +136,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
     private final int recordFileVersion;
     private final WrappedRecordFileBlockHashesDiskWriter wrappedRecordHashesDiskWriter;
     private final BlockHashSigner blockHashSigner;
+    private final BlockRecordManager.Lifecycle blockLifecycle;
 
     /**
      * Supplier of a fresh {@link BlockItemWriter} (in practice a {@code GrpcBlockItemWriter}) used to forward
@@ -215,6 +227,32 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
             @NonNull final Supplier<BlockItemWriter> wrbWriterSupplier,
             @NonNull final BlockHashSigner blockHashSigner,
             @NonNull final InitTrigger initTrigger) {
+        this(
+                configProvider,
+                state,
+                streamFileProducer,
+                quiescenceController,
+                quiescedHeartbeat,
+                platform,
+                wrappedRecordHashesDiskWriter,
+                wrbWriterSupplier,
+                blockHashSigner,
+                initTrigger,
+                NO_OP_BLOCK_LIFECYCLE);
+    }
+
+    public BlockRecordManagerImpl(
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final State state,
+            @NonNull final BlockRecordStreamProducer streamFileProducer,
+            @NonNull final QuiescenceController quiescenceController,
+            @NonNull final QuiescedHeartbeat quiescedHeartbeat,
+            @NonNull final Platform platform,
+            @NonNull final WrappedRecordFileBlockHashesDiskWriter wrappedRecordHashesDiskWriter,
+            @NonNull final Supplier<BlockItemWriter> wrbWriterSupplier,
+            @NonNull final BlockHashSigner blockHashSigner,
+            @NonNull final InitTrigger initTrigger,
+            @NonNull final BlockRecordManager.Lifecycle blockLifecycle) {
         this.platform = platform;
         requireNonNull(state);
         this.quiescenceController = requireNonNull(quiescenceController);
@@ -224,6 +262,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
         this.wrappedRecordHashesDiskWriter = requireNonNull(wrappedRecordHashesDiskWriter);
         this.wrbWriterSupplier = requireNonNull(wrbWriterSupplier);
         this.blockHashSigner = requireNonNull(blockHashSigner);
+        this.blockLifecycle = requireNonNull(blockLifecycle);
         final var config = configProvider.getConfiguration();
         final var blockStreamConfig = config.getConfigData(BlockStreamConfig.class);
         this.streamMode = blockStreamConfig.streamMode();
@@ -444,6 +483,7 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
                 beginTrackingNewBlock(streamFileProducer.getRunningHash());
             }
             if (streamMode == RECORDS) {
+                blockLifecycle.onOpenBlock(state);
                 quiescenceController.startingBlock(lastBlockInfo.lastBlockNumber() + 1);
             }
 
@@ -894,6 +934,9 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
             wrappedIntermediateLeafCount = prevWrappedRecordBlockHashes.leafCount();
         }
 
+        if (streamMode == RECORDS) {
+            blockLifecycle.onCloseBlock(state);
+        }
         final var recordFileHashFuture = streamFileProducer.finishCurrentBlock();
         observeRecordFileHash(closedBlockNo, recordFileHashFuture);
         if (streamMode == RECORDS) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/SealRoundRecordClosureTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/SealRoundRecordClosureTest.java
@@ -18,6 +18,7 @@ import com.hedera.node.app.blocks.BlockItemWriter;
 import com.hedera.node.app.fixtures.AppTestBase;
 import com.hedera.node.app.quiescence.QuiescedHeartbeat;
 import com.hedera.node.app.quiescence.QuiescenceController;
+import com.hedera.node.app.records.BlockRecordManager;
 import com.hedera.node.app.records.BlockRecordService;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.system.InitTrigger;
@@ -79,6 +80,30 @@ class SealRoundRecordClosureTest extends AppTestBase {
         verify(ctx.producer, times(1)).finishCurrentBlock();
     }
 
+    @Test
+    void recordsModeInvokesBlockLifecycleOnOpenAndClose() {
+        final var ctx = newContext("RECORDS");
+        final var firstCons = Instant.ofEpochSecond(2_000L, 10);
+
+        ctx.manager.startUserTransaction(firstCons, ctx.state);
+        verify(ctx.lifecycle).onOpenBlock(ctx.state);
+
+        ctx.manager.closeCurrentRecordFileIfConsTimeElapsed(ctx.state, firstCons.plusSeconds(2));
+        verify(ctx.lifecycle).onCloseBlock(ctx.state);
+    }
+
+    @Test
+    void bothModeDoesNotInvokeRecordBlockLifecycle() {
+        final var ctx = newContext("BOTH");
+        final var firstCons = Instant.ofEpochSecond(2_000L, 10);
+
+        ctx.manager.startUserTransaction(firstCons, ctx.state);
+        ctx.manager.closeCurrentRecordFileIfOpen(ctx.state);
+
+        verify(ctx.lifecycle, times(0)).onOpenBlock(ctx.state);
+        verify(ctx.lifecycle, times(0)).onCloseBlock(ctx.state);
+    }
+
     private Context newContext(final String streamMode) {
         final var app = appBuilder()
                 .withService(new BlockRecordService())
@@ -126,6 +151,7 @@ class SealRoundRecordClosureTest extends AppTestBase {
         final var platform = app.platform();
         final var heartbeat = new QuiescedHeartbeat(controller, platform);
         final Supplier<BlockItemWriter> wrbSupplier = () -> Mockito.mock(BlockItemWriter.class);
+        final var lifecycle = Mockito.mock(BlockRecordManager.Lifecycle.class);
 
         final var manager = new BlockRecordManagerImpl(
                 app.configProvider(),
@@ -137,10 +163,14 @@ class SealRoundRecordClosureTest extends AppTestBase {
                 Mockito.mock(WrappedRecordFileBlockHashesDiskWriter.class),
                 wrbSupplier,
                 blockHashSigner,
-                InitTrigger.RESTART);
-        return new Context(manager, producer, app.workingStateAccessor().getState());
+                InitTrigger.RESTART,
+                lifecycle);
+        return new Context(manager, producer, app.workingStateAccessor().getState(), lifecycle);
     }
 
     private record Context(
-            BlockRecordManagerImpl manager, BlockRecordStreamProducer producer, com.swirlds.state.State state) {}
+            BlockRecordManagerImpl manager,
+            BlockRecordStreamProducer producer,
+            com.swirlds.state.State state,
+            BlockRecordManager.Lifecycle lifecycle) {}
 }


### PR DESCRIPTION
**Description**:
This PR cherry picks commit 5e644fa08ef14c4871ab57a06b060f9837b970c4 for release 0.75

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
