### PR TITLE
fix: log cancelled WRB signing at INFO not WARN

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -881,8 +881,15 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
                         allPrevBlocksRootHash,
                         serializedRosterSignatures))
                 .exceptionally(t -> {
-                    logger.warn(
-                            "Unhandled exception while signing WRB block #{} after record file close", blockNumber, t);
+                    if (t instanceof CancellationException || t.getCause() instanceof CancellationException) {
+                        // Expected when the node falls BEHIND and cancels in-flight RSA signings
+                        logger.info("Signing cancelled for WRB block #{} after record file close", blockNumber);
+                    } else {
+                        logger.warn(
+                                "Unhandled exception while signing WRB block #{} after record file close",
+                                blockNumber,
+                                t);
+                    }
                     return null;
                 });
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/BlockRecordManagerImplWrappedRecordFileBlockHashesTest.java
@@ -2007,6 +2007,75 @@ class BlockRecordManagerImplWrappedRecordFileBlockHashesTest extends AppTestBase
     }
 
     @Test
+    void logsAtInfoNotWarnWhenWrbSigningCancelled() throws Exception {
+        final var logCaptor = new LogCaptor(LogManager.getLogger(BlockRecordManagerImpl.class));
+        try {
+            final var app = appBuilder()
+                    .withService(new BlockRecordService())
+                    .withService(new PlatformStateService())
+                    .withConfigValue("hedera.recordStream.liveWritePrevWrappedRecordHashes", true)
+                    .withConfigValue("blockStream.streamWrappedRecordBlocks", true)
+                    .build();
+
+            seedRequiredState(app);
+
+            final var state = requireNonNullState(app.workingStateAccessor().getState());
+            final var recordFileHashFuture = new CompletableFuture<Bytes>();
+            final var producer = new FakeStreamProducer(recordFileHashFuture);
+            final var controller = new QuiescenceController(
+                    new QuiescenceConfig(false, Duration.ofSeconds(5)), InstantSource.system(), () -> 0);
+            final var heartbeat = new QuiescedHeartbeat(controller, app.platform());
+            final var diskWriter = mock(WrappedRecordFileBlockHashesDiskWriter.class);
+            final var blockHashSigner = mock(BlockHashSigner.class);
+            final var signatureListFuture = new CompletableFuture<Bytes>();
+            final var submissionFuture = new CompletableFuture<Void>();
+            when(blockHashSigner.sign(any(), eq(LIST_OF_PARTIAL_SIGNATURES)))
+                    .thenReturn(new BlockHashSigner.Attempt(null, null, signatureListFuture, submissionFuture));
+
+            try (final var mgr = new BlockRecordManagerImpl(
+                    app.configProvider(),
+                    state,
+                    producer,
+                    controller,
+                    heartbeat,
+                    app.platform(),
+                    diskWriter,
+                    () -> mock(BlockItemWriter.class),
+                    blockHashSigner,
+                    InitTrigger.RECONNECT)) {
+                final var t0 = InstantUtils.instant(10, 1);
+                mgr.startUserTransaction(t0, state);
+                mgr.endUserTransaction(Stream.of(sampleTxnRecord(t0, List.of())), state);
+                mgr.closeCurrentRecordFileIfOpen(state);
+
+                recordFileHashFuture.complete(LEGACY_RECORD_FILE_HASH);
+                verify(blockHashSigner, timeout(1_000))
+                        .sign(eq(LEGACY_RECORD_FILE_HASH), eq(LIST_OF_PARTIAL_SIGNATURES));
+
+                // Simulate the BEHIND status handler cancelling all in-flight RSA signings
+                signatureListFuture.cancel(false);
+
+                final long deadline = System.currentTimeMillis() + 2_000;
+                while (System.currentTimeMillis() < deadline
+                        && logCaptor.infoLogs().stream().noneMatch(s -> s.contains("Signing cancelled for WRB block"))
+                        && logCaptor.warnLogs().stream()
+                                .noneMatch(s -> s.contains("Unhandled exception while signing WRB block"))) {
+                    Thread.sleep(10);
+                }
+                assertTrue(
+                        logCaptor.infoLogs().stream().anyMatch(s -> s.contains("Signing cancelled for WRB block")),
+                        "expected INFO log for cancelled WRB signing");
+                assertTrue(
+                        logCaptor.warnLogs().stream()
+                                .noneMatch(s -> s.contains("Unhandled exception while signing WRB block")),
+                        "cancellation must not be logged at WARN");
+            }
+        } finally {
+            logCaptor.stopCapture();
+        }
+    }
+
+    @Test
     void closeFlushesPendingWrbWritersWhenFlagEnabled() {
         final var app = appBuilder()
                 .withService(new BlockRecordService())


### PR DESCRIPTION
Reconnect tests drive a node `BEHIND`, which since #25606 cancels in-flight RSA signings. The resulting `CancellationException` was logged at WARN in `BlockRecordManagerImpl.signAndCloseWrbAsync`, intermittently failing `LogValidationTest` in CI (e.g. [this run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/27017186919/job/79736161983)).

Cancellation is expected there (only triggered from the `BEHIND` handler), so log it at INFO; all other exceptions still WARN. Chose this over an `HgcaaLogValidator` allowlist entry so genuine signing failures stay visible. Unit test covers the cancelled path.