### PR TITLE
ci(workflow): update services syntax for docker definition

### DIFF
--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -66,7 +66,7 @@ jobs:
 
     services:
       registry:
-        image: registry:latest
+        image: registry@sha256:85347ed2ecde64161c7a4788a4d7d3dcc9d6f86f7be95834022e3c6a423a945a # v3.1.1
         ports:
           - 5000:5000
 
@@ -238,7 +238,7 @@ jobs:
 
     services:
       registry:
-        image: registry:latest
+        image: registry@sha256:85347ed2ecde64161c7a4788a4d7d3dcc9d6f86f7be95834022e3c6a423a945a # v3.1.1
         ports:
           - 5000:5000
 

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -66,7 +66,7 @@ jobs:
 
     services:
       registry:
-        image: registry@sha256:85347ed2ecde64161c7a4788a4d7d3dcc9d6f86f7be95834022e3c6a423a945a # v3.1.1
+        image: registry@sha256:8a7c1aae9db5028cbc1cfe83e5969d270a50e8bc0b72eef3cc5657542ec383c9 # v3.1.0
         ports:
           - 5000:5000
 
@@ -238,7 +238,7 @@ jobs:
 
     services:
       registry:
-        image: registry@sha256:85347ed2ecde64161c7a4788a4d7d3dcc9d6f86f7be95834022e3c6a423a945a # v3.1.1
+        image: registry@sha256:8a7c1aae9db5028cbc1cfe83e5969d270a50e8bc0b72eef3cc5657542ec383c9 # v3.1.0
         ports:
           - 5000:5000
 

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -64,6 +64,12 @@ jobs:
       name: ${{ steps.baseline.outputs.name }}
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
 
+    services:
+      registry:
+        image: registry:latest
+        ports:
+          - 5000:5000
+
     steps:
       - name: Prepare Job
         uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
@@ -132,10 +138,6 @@ jobs:
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
-
-      - name: Setup Local Docker Registry
-        if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
-        run: docker run -d -p 5000:5000 --restart=always --name registry registry:latest
 
       - name: Show Docker Version
         if: ${{ steps.baseline.outputs.exists == 'false' && !failure() && !cancelled() }}
@@ -233,6 +235,13 @@ jobs:
           - hl-cn-docker-determinism-lin-d12-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+
+    services:
+      registry:
+        image: registry:latest
+        ports:
+          - 5000:5000
+
     steps:
       - name: Standardize Git Line Endings
         run: |
@@ -341,9 +350,6 @@ jobs:
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]
-
-      - name: Setup Local Docker Registry
-        run: docker run -d -p 5000:5000 --restart=always --name registry registry:latest
 
       - name: Show Docker Version
         run: docker version


### PR DESCRIPTION
**Description**:

This pull request updates the `.github/workflows/zxc-verify-docker-build-determinism.yaml` workflow to improve how a local Docker registry is provisioned during CI jobs. The main change is switching from manually running the registry container in a step to using GitHub Actions' built-in `services` feature, which simplifies and standardizes the setup.

**Improvements to Docker registry provisioning:**

* Added a `services` section to relevant jobs to provision a local Docker registry using the `registry@sha256:8a7c1aae9db5028cbc1cfe83e5969d270a50e8bc0b72eef3cc5657542ec383c9` image, exposing port 5000. This replaces the previous manual `docker run` step. [[1]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30R67-R72) [[2]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30R238-R244)
* Removed the explicit step that manually started the Docker registry container with `docker run`, as it is now handled by the `services` configuration. [[1]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30L136-L139) [[2]](diffhunk://#diff-5f6a4c896a6331e49b320770db33604fb001660a599444e2e7a50a607c237d30L345-L347)

**Related issue(s)**:

Implements #25759 

**Testing**:

- It works with `registry:latest` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/27032796846)
- It works with `registry@sha256:85347ed2ecde64161c7a4788a4d7d3dcc9d6f86f7be95834022e3c6a423a945a # v3.1.1` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/27033728316/job/79793056120)
- It works with `registry@sha256:8a7c1aae9db5028cbc1cfe83e5969d270a50e8bc0b72eef3cc5657542ec383c9 # v3.1.0` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/27034509749)