### PR TITLE
chore: Increase tss.bootstrapProofKeyGracePeriod default to 300s

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TssConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TssConfig.java
@@ -22,7 +22,7 @@ public record TssConfig(
         @ConfigProperty(defaultValue = "10s") @NetworkProperty
         Duration wrapsMessageGracePeriod,
 
-        @ConfigProperty(defaultValue = "60s") @NetworkProperty
+        @ConfigProperty(defaultValue = "300s") @NetworkProperty
         Duration bootstrapProofKeyGracePeriod,
 
         @ConfigProperty(defaultValue = "300s") @NetworkProperty


### PR DESCRIPTION
Raises the genesis-phase proof-key grace period from 60s to 300s, matching `transitionProofKeyGracePeriod`.

This gives slow nodes more time to publish their Schnorr proof key at bootstrap before the history-proof construction is sealed (`ProofControllerImpl.shouldAssemble`).

Notes:
- `tss.bootstrapProofKeyGracePeriod` is a `@NetworkProperty` — coordinated network-wide default, no per-node divergence.
- No state or proof-format change.
- Happy path (all target nodes publish promptly) is unaffected, since `shouldAssemble()` short-circuits before the grace-period timer is consulted.
- Only effect: at genesis, if one or more nodes are slow, the network waits up to 5 minutes (instead of 1) before assembling with whatever weight has met threshold.