### PR TITLE
refactor: Move PCLI only classes to `swirlds-cli`

### DIFF
--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/DiagramCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/DiagramCommand.java
@@ -17,7 +17,6 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.platform.builder.ApplicationCallbacks;
 import com.swirlds.platform.config.DefaultConfiguration;
-import com.swirlds.platform.util.VirtualTerminal;
 import com.swirlds.platform.wiring.PlatformComponents;
 import com.swirlds.platform.wiring.PlatformWiring;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -33,6 +32,7 @@ import org.hiero.consensus.gossip.GossipModule;
 import org.hiero.consensus.hashgraph.HashgraphModule;
 import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.pcli.utility.NoOpExecutionLayer;
+import org.hiero.consensus.pcli.utility.VirtualTerminal;
 import picocli.CommandLine;
 
 @CommandLine.Command(

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/SignCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/SignCommand.java
@@ -2,7 +2,6 @@
 package org.hiero.consensus.pcli;
 
 import com.swirlds.logging.legacy.LogMarker;
-import com.swirlds.platform.util.FileSigningUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
@@ -14,6 +13,7 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.file.FileUtils;
+import org.hiero.consensus.pcli.utility.FileSigningUtils;
 import picocli.CommandLine;
 
 /**

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/utility/CommandResult.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/utility/CommandResult.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.util;
+package org.hiero.consensus.pcli.utility;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -10,7 +10,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param out      text written to stdout
  * @param error    text written to stderr
  */
-public record CommandResult(int exitCode, @NonNull String out, @NonNull String error) {
+public record CommandResult(
+        int exitCode, @NonNull String out, @NonNull String error) {
 
     /**
      * Returns true if the command exited with a zero exit code.

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/utility/FileSigningUtils.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/utility/FileSigningUtils.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.util;
+package org.hiero.consensus.pcli.utility;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/utility/ProgressIndicator.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/utility/ProgressIndicator.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.util;
+package org.hiero.consensus.pcli.utility;
 
 import static com.swirlds.base.formatting.TextEffect.BLUE;
 import static com.swirlds.base.formatting.TextEffect.CYAN;

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/utility/VirtualTerminal.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/utility/VirtualTerminal.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.util;
+package org.hiero.consensus.pcli.utility;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 

--- a/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/VirtualTerminalTests.java
+++ b/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/VirtualTerminalTests.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.util;
+package org.hiero.consensus.pcli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.hiero.consensus.pcli.utility.CommandResult;
+import org.hiero.consensus.pcli.utility.VirtualTerminal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Fixes #25797 
