### PR TITLE
feat: Add registeredNodeId to block-nodes.json

### DIFF
--- a/hapi/hapi/src/main/proto/network/block_node_connections.proto
+++ b/hapi/hapi/src/main/proto/network/block_node_connections.proto
@@ -99,6 +99,25 @@ message BlockNodeConfig {
      * Valid port range is 1 to 65535.
      */
     google.protobuf.Int32Value service_port = 8;
+
+    /**
+     * Optional registered node identifier.<br/>
+     * If present, the consensus node SHALL attempt to look up the corresponding
+     * {@code RegisteredNode} in network state. When a matching registered node
+     * is found, its published block-node endpoints SHALL be used to populate
+     * the streaming endpoint (from a service endpoint advertising the
+     * {@code PUBLISH} API) and the service endpoint (from a service endpoint
+     * advertising the {@code STATUS} API).
+     * <p>
+     * Any explicit {@code address}, {@code streaming_port}, or
+     * {@code service_port} value present in this configuration SHALL take
+     * precedence over the values resolved from the registered node.
+     * <p>
+     * If the registered node cannot be found in state, an informational log
+     * entry SHALL be written and the entry SHALL be skipped unless explicit
+     * {@code address} and {@code streaming_port} values were also provided.
+     */
+    google.protobuf.UInt64Value registered_node_id = 9;
 }
 
 /**

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/RegisteredNodeChangeListener.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/RegisteredNodeChangeListener.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.addressbook.impl;
+
+/**
+ * Notified by the registered-node transaction handlers whenever a row in the registered-node state map is added,
+ * updated, or removed.
+ *
+ * <p><b>Threading contract.</b> {@link #onRegisteredNodeChanged()} is invoked synchronously on the consensus
+ * handle thread, immediately after the mutating handler persists its change to the savepoint stack. Implementations
+ * <b>MUST</b> be O(1) and side-effect free with respect to state: do not read state, do not block, do not perform
+ * I/O. The expected usage is to flip a flag and have the actual work happen on a later, safer thread (for example,
+ * when the block closes and the savepoint changes have been committed).
+ *
+ * <p>The handlers do not pass the modified registered-node id. Listeners that need to know which nodes changed
+ * should re-scan the relevant state once they observe a committed view.
+ */
+@FunctionalInterface
+public interface RegisteredNodeChangeListener {
+    /**
+     * Invoked once per successful registered-node mutation (create / update / delete).
+     */
+    void onRegisteredNodeChanged();
+}

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/RegisteredNodeChangeNotifier.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/RegisteredNodeChangeNotifier.java
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.addressbook.impl;
+
+import static java.util.Objects.requireNonNull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.concurrent.CopyOnWriteArrayList;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Publisher for {@link RegisteredNodeChangeListener} events. Used by the registered-node transaction handlers to
+ * broadcast that the registered-node state map has been mutated.
+ *
+ * <p>The publisher itself does not maintain any "dirty" state — it just dispatches synchronously to every listener
+ * that has registered, in registration order. Listeners are expected to be cheap (see
+ * {@link RegisteredNodeChangeListener} for the threading contract).
+ *
+ * <p>The dispatcher swallows exceptions thrown by listeners so a single misbehaving subscriber cannot abort the
+ * consensus handle for everyone else. Errors are logged at WARN.
+ */
+@Singleton
+public class RegisteredNodeChangeNotifier {
+
+    private static final Logger logger = LogManager.getLogger(RegisteredNodeChangeNotifier.class);
+
+    private final CopyOnWriteArrayList<RegisteredNodeChangeListener> listeners = new CopyOnWriteArrayList<>();
+
+    @Inject
+    public RegisteredNodeChangeNotifier() {
+        // no-op
+    }
+
+    /**
+     * Subscribes the given listener to subsequent {@link #notifyChanged()} calls. Registration is idempotent: the
+     * same listener instance will not be added twice.
+     */
+    public void register(@NonNull final RegisteredNodeChangeListener listener) {
+        requireNonNull(listener, "listener must not be null");
+        listeners.addIfAbsent(listener);
+    }
+
+    /**
+     * Unsubscribes a previously registered listener. No-op if the listener was not registered.
+     */
+    public void unregister(@NonNull final RegisteredNodeChangeListener listener) {
+        requireNonNull(listener, "listener must not be null");
+        listeners.remove(listener);
+    }
+
+    /**
+     * Dispatches a change event to every registered listener. Called by the registered-node handlers on the
+     * consensus handle thread after a successful state mutation.
+     */
+    public void notifyChanged() {
+        for (final RegisteredNodeChangeListener listener : listeners) {
+            try {
+                listener.onRegisteredNodeChanged();
+            } catch (final RuntimeException e) {
+                logger.warn("RegisteredNodeChangeListener threw onRegisteredNodeChanged; ignoring", e);
+            }
+        }
+    }
+}

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeCreateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeCreateHandler.java
@@ -10,6 +10,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeNotifier;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.records.RegisteredNodeCreateStreamBuilder;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
@@ -31,10 +32,14 @@ import javax.inject.Singleton;
 @Singleton
 public class RegisteredNodeCreateHandler implements TransactionHandler {
     private final AddressBookValidator addressBookValidator;
+    private final RegisteredNodeChangeNotifier changeNotifier;
 
     @Inject
-    public RegisteredNodeCreateHandler(@NonNull final AddressBookValidator addressBookValidator) {
+    public RegisteredNodeCreateHandler(
+            @NonNull final AddressBookValidator addressBookValidator,
+            @NonNull final RegisteredNodeChangeNotifier changeNotifier) {
         this.addressBookValidator = requireNonNull(addressBookValidator, "addressBookValidator must not be null");
+        this.changeNotifier = requireNonNull(changeNotifier, "changeNotifier must not be null");
     }
 
     @Override
@@ -76,6 +81,7 @@ public class RegisteredNodeCreateHandler implements TransactionHandler {
                 .serviceEndpoint(op.serviceEndpoint())
                 .build();
         registeredNodeStore.putAndIncrement(node);
+        changeNotifier.notifyChanged();
 
         final var recordBuilder =
                 handleContext.savepointStack().getBaseBuilder(RegisteredNodeCreateStreamBuilder.class);

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeDeleteHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeDeleteHandler.java
@@ -13,6 +13,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.node.app.service.addressbook.ReadableNodeStore;
 import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeNotifier;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
@@ -31,9 +32,11 @@ import javax.inject.Singleton;
  */
 @Singleton
 public class RegisteredNodeDeleteHandler implements TransactionHandler {
+    private final RegisteredNodeChangeNotifier changeNotifier;
+
     @Inject
-    public RegisteredNodeDeleteHandler() {
-        // exists for injection
+    public RegisteredNodeDeleteHandler(@NonNull final RegisteredNodeChangeNotifier changeNotifier) {
+        this.changeNotifier = requireNonNull(changeNotifier, "changeNotifier must not be null");
     }
 
     @Override
@@ -88,6 +91,7 @@ public class RegisteredNodeDeleteHandler implements TransactionHandler {
         validateFalse(isAssociated, REGISTERED_NODE_STILL_ASSOCIATED);
 
         registeredNodeStore.remove(registeredNodeId);
+        changeNotifier.notifyChanged();
     }
 
     @NonNull

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeUpdateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeUpdateHandler.java
@@ -13,6 +13,7 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeNotifier;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
 import com.hedera.node.app.spi.fees.FeeContext;
@@ -33,10 +34,14 @@ import javax.inject.Singleton;
 @Singleton
 public class RegisteredNodeUpdateHandler implements TransactionHandler {
     private final AddressBookValidator addressBookValidator;
+    private final RegisteredNodeChangeNotifier changeNotifier;
 
     @Inject
-    public RegisteredNodeUpdateHandler(@NonNull final AddressBookValidator addressBookValidator) {
+    public RegisteredNodeUpdateHandler(
+            @NonNull final AddressBookValidator addressBookValidator,
+            @NonNull final RegisteredNodeChangeNotifier changeNotifier) {
         this.addressBookValidator = requireNonNull(addressBookValidator, "addressBookValidator must not be null");
+        this.changeNotifier = requireNonNull(changeNotifier, "changeNotifier must not be null");
     }
 
     @Override
@@ -86,6 +91,7 @@ public class RegisteredNodeUpdateHandler implements TransactionHandler {
 
         final var builder = updateRegisteredNode(op, existing);
         registeredNodeStore.put(builder.build());
+        changeNotifier.notifyChanged();
     }
 
     private RegisteredNode.Builder updateRegisteredNode(

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/RegisteredNodeChangeNotifierTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/RegisteredNodeChangeNotifierTest.java
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.addressbook.impl.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeListener;
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeNotifier;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class RegisteredNodeChangeNotifierTest {
+
+    @Test
+    void noListenersIsNoOp() {
+        final RegisteredNodeChangeNotifier notifier = new RegisteredNodeChangeNotifier();
+        notifier.notifyChanged(); // should not throw
+    }
+
+    @Test
+    void registeredListenerIsCalledOncePerNotify() {
+        final RegisteredNodeChangeNotifier notifier = new RegisteredNodeChangeNotifier();
+        final AtomicInteger invocations = new AtomicInteger();
+        notifier.register(invocations::incrementAndGet);
+
+        notifier.notifyChanged();
+        notifier.notifyChanged();
+
+        assertThat(invocations.get()).isEqualTo(2);
+    }
+
+    @Test
+    void multipleListenersAreAllCalled() {
+        final RegisteredNodeChangeNotifier notifier = new RegisteredNodeChangeNotifier();
+        final AtomicInteger a = new AtomicInteger();
+        final AtomicInteger b = new AtomicInteger();
+        notifier.register(a::incrementAndGet);
+        notifier.register(b::incrementAndGet);
+
+        notifier.notifyChanged();
+
+        assertThat(a.get()).isEqualTo(1);
+        assertThat(b.get()).isEqualTo(1);
+    }
+
+    @Test
+    void duplicateRegistrationIsIgnored() {
+        final RegisteredNodeChangeNotifier notifier = new RegisteredNodeChangeNotifier();
+        final AtomicInteger invocations = new AtomicInteger();
+        final RegisteredNodeChangeListener listener = invocations::incrementAndGet;
+
+        notifier.register(listener);
+        notifier.register(listener);
+        notifier.notifyChanged();
+
+        assertThat(invocations.get()).isEqualTo(1);
+    }
+
+    @Test
+    void unregisterStopsListenerFromBeingCalled() {
+        final RegisteredNodeChangeNotifier notifier = new RegisteredNodeChangeNotifier();
+        final AtomicInteger invocations = new AtomicInteger();
+        final RegisteredNodeChangeListener listener = invocations::incrementAndGet;
+        notifier.register(listener);
+
+        notifier.notifyChanged();
+        notifier.unregister(listener);
+        notifier.notifyChanged();
+
+        assertThat(invocations.get()).isEqualTo(1);
+    }
+
+    @Test
+    void misbehavingListenerDoesNotBreakDispatchForOthers() {
+        final RegisteredNodeChangeNotifier notifier = new RegisteredNodeChangeNotifier();
+        final AtomicInteger goodInvocations = new AtomicInteger();
+        notifier.register(() -> {
+            throw new RuntimeException("boom");
+        });
+        notifier.register(goodInvocations::incrementAndGet);
+
+        notifier.notifyChanged(); // should not throw
+
+        assertThat(goodInvocations.get()).isEqualTo(1);
+    }
+}

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeCreateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeCreateHandlerTest.java
@@ -28,6 +28,7 @@ import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeNotifier;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.handlers.RegisteredNodeCreateHandler;
 import com.hedera.node.app.service.addressbook.impl.records.RegisteredNodeCreateStreamBuilder;
@@ -77,10 +78,15 @@ class RegisteredNodeCreateHandlerTest extends AddressBookTestBase {
     private RegisteredNodeCreateStreamBuilder recordBuilder;
 
     private RegisteredNodeCreateHandler subject;
+    private RegisteredNodeChangeNotifier changeNotifier;
+    private java.util.concurrent.atomic.AtomicInteger listenerInvocations;
 
     @BeforeEach
     void setUp() {
-        subject = new RegisteredNodeCreateHandler(new AddressBookValidator());
+        changeNotifier = new RegisteredNodeChangeNotifier();
+        listenerInvocations = new java.util.concurrent.atomic.AtomicInteger(0);
+        changeNotifier.register(listenerInvocations::incrementAndGet);
+        subject = new RegisteredNodeCreateHandler(new AddressBookValidator(), changeNotifier);
     }
 
     @Test
@@ -280,6 +286,7 @@ class RegisteredNodeCreateHandlerTest extends AddressBookTestBase {
                 .build());
 
         givenHandleContext(txn, newId, stack, attributeValidator);
+        assertThat(listenerInvocations.get()).isZero();
 
         assertDoesNotThrow(() -> subject.handle(handleContext));
 
@@ -293,6 +300,7 @@ class RegisteredNodeCreateHandlerTest extends AddressBookTestBase {
         assertEquals(List.of(endpoint), persisted.serviceEndpoint());
 
         verify(recordBuilder).registeredNodeID(newId);
+        assertThat(listenerInvocations.get()).isEqualTo(1);
     }
 
     @Test

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeDeleteHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeDeleteHandlerTest.java
@@ -19,6 +19,7 @@ import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.addressbook.ReadableNodeStore;
 import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeNotifier;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.handlers.RegisteredNodeDeleteHandler;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -74,13 +75,18 @@ class RegisteredNodeDeleteHandlerTest extends AddressBookTestBase {
     private FeeCalculator feeCalculator;
 
     private RegisteredNodeDeleteHandler subject;
+    private RegisteredNodeChangeNotifier changeNotifier;
+    private java.util.concurrent.atomic.AtomicInteger listenerInvocations;
 
     private final long registeredNodeId = 1234L;
     private RegisteredNode existing;
 
     @BeforeEach
     void setUp() {
-        subject = new RegisteredNodeDeleteHandler();
+        changeNotifier = new RegisteredNodeChangeNotifier();
+        listenerInvocations = new java.util.concurrent.atomic.AtomicInteger(0);
+        changeNotifier.register(listenerInvocations::incrementAndGet);
+        subject = new RegisteredNodeDeleteHandler(changeNotifier);
         existing = new RegisteredNode.Builder()
                 .registeredNodeId(registeredNodeId)
                 .adminKey(key)
@@ -238,9 +244,11 @@ class RegisteredNodeDeleteHandlerTest extends AddressBookTestBase {
     void handleDeletesWhenUnreferenced() {
         givenHandleContext();
         given(readableNodeStore.keys()).willReturn(List.of());
+        assertThat(listenerInvocations.get()).isZero();
 
         assertDoesNotThrow(() -> subject.handle(handleContext));
         verify(writableRegisteredNodeStore).remove(registeredNodeId);
+        assertThat(listenerInvocations.get()).isEqualTo(1);
     }
 
     @Test

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeUpdateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeUpdateHandlerTest.java
@@ -27,6 +27,7 @@ import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeNotifier;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.handlers.RegisteredNodeUpdateHandler;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
@@ -74,6 +75,8 @@ class RegisteredNodeUpdateHandlerTest extends AddressBookTestBase {
     private ReadableRegisteredNodeStore readableRegisteredNodeStore;
 
     private RegisteredNodeUpdateHandler subject;
+    private RegisteredNodeChangeNotifier changeNotifier;
+    private java.util.concurrent.atomic.AtomicInteger listenerInvocations;
 
     private final long registeredNodeId = 1234L;
     private RegisteredNode existing;
@@ -81,7 +84,10 @@ class RegisteredNodeUpdateHandlerTest extends AddressBookTestBase {
 
     @BeforeEach
     void setUp() {
-        subject = new RegisteredNodeUpdateHandler(new AddressBookValidator());
+        changeNotifier = new RegisteredNodeChangeNotifier();
+        listenerInvocations = new java.util.concurrent.atomic.AtomicInteger(0);
+        changeNotifier.register(listenerInvocations::incrementAndGet);
+        subject = new RegisteredNodeUpdateHandler(new AddressBookValidator(), changeNotifier);
         existing = new RegisteredNode.Builder()
                 .registeredNodeId(registeredNodeId)
                 .adminKey(key)
@@ -359,6 +365,7 @@ class RegisteredNodeUpdateHandlerTest extends AddressBookTestBase {
                 .description(newDesc)
                 .build());
         givenHandleContextWithExisting(txn);
+        assertThat(listenerInvocations.get()).isZero();
 
         assertDoesNotThrow(() -> subject.handle(handleContext));
 
@@ -370,6 +377,7 @@ class RegisteredNodeUpdateHandlerTest extends AddressBookTestBase {
         assertEquals(existing.adminKey(), persisted.adminKey());
         assertEquals(existing.serviceEndpoint(), persisted.serviceEndpoint());
         assertEquals(registeredNodeId, persisted.registeredNodeId());
+        assertThat(listenerInvocations.get()).isEqualTo(1);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamModule.java
@@ -137,10 +137,11 @@ public interface BlockStreamModule {
             @NonNull final NodeFeeManager nodeFeeManager,
             @NonNull final StateBackedRegisteredNodeResolver registeredNodeResolver,
             @NonNull final RegisteredNodeChangeNotifier registeredNodeChangeNotifier,
-            @NonNull final BlockNodeConfigService blockNodeConfigService) {
+            @NonNull final BlockNodeConfigService blockNodeConfigService,
+            @NonNull @Named("bn-blockingio-exec") final Supplier<ExecutorService> blockingIoExecutorSupplier) {
         // Set by the inline RegisteredNodeChangeListener below; the listener runs on the consensus handle thread
-        // and is required to be cheap, so it just flips this boolean. The lifecycle drains it from onCloseBlock
-        // (off the handle thread, after the savepoint commit), where revalidating against committed state is safe.
+        // and is required to be cheap, so it just flips this boolean. The lifecycle reads it from onCloseBlock and,
+        // when set, submits the actual revalidation work to the blocking-I/O pool so the handle thread is not delayed.
         final AtomicBoolean pendingRevalidation = new AtomicBoolean(false);
         final AtomicBoolean firstCloseBlockSeen = new AtomicBoolean(false);
         registeredNodeChangeNotifier.register(() -> pendingRevalidation.set(true));
@@ -157,6 +158,8 @@ public interface BlockStreamModule {
             public void onCloseBlock(@NonNull final State state) {
                 nodeFeeManager.onCloseBlock(state);
                 nodeRewardManager.onCloseBlock(state, listener.nodeFeesCollected());
+                // Publish the latest committed state to the resolver before submitting the async revalidation task so
+                // that the task always reads the state that corresponds to this block close, not a later one.
                 registeredNodeResolver.updateState(state);
                 // revalidate registered-node-backed block-node entries when:
                 //  - this is the first block close (covers cold-start where the config was loaded before state was
@@ -165,12 +168,14 @@ public interface BlockStreamModule {
                 final boolean firstClose = firstCloseBlockSeen.compareAndSet(false, true);
                 final boolean pending = pendingRevalidation.compareAndSet(true, false);
                 if (firstClose || pending) {
-                    try {
-                        blockNodeConfigService.revalidateRegisteredNodes();
-                    } catch (final RuntimeException e) {
-                        LIFECYCLE_LOGGER.warn(
-                                "Error while re-resolving registered-node block-node configurations (ignoring)", e);
-                    }
+                    blockingIoExecutorSupplier.get().execute(() -> {
+                        try {
+                            blockNodeConfigService.revalidateRegisteredNodes();
+                        } catch (final RuntimeException e) {
+                            LIFECYCLE_LOGGER.warn(
+                                    "Error while re-resolving registered-node block-node configurations (ignoring)", e);
+                        }
+                    });
                 }
             }
         };

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamModule.java
@@ -11,6 +11,7 @@ import com.hedera.node.app.blocks.impl.streaming.FileBlockItemWriter;
 import com.hedera.node.app.blocks.impl.streaming.GrpcBlockItemWriter;
 import com.hedera.node.app.blocks.impl.streaming.config.StateBackedRegisteredNodeResolver;
 import com.hedera.node.app.metrics.BlockStreamMetrics;
+import com.hedera.node.app.service.addressbook.impl.RegisteredNodeChangeNotifier;
 import com.hedera.node.app.services.NodeFeeManager;
 import com.hedera.node.app.services.NodeRewardManager;
 import com.hedera.node.app.spi.info.NetworkInfo;
@@ -25,12 +26,17 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.FileSystem;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 @Module
 public interface BlockStreamModule {
+    Logger LIFECYCLE_LOGGER = LogManager.getLogger(BlockStreamModule.class);
+
     @Provides
     @Singleton
     static BlockBufferService provideBlockBufferService(
@@ -129,7 +135,15 @@ public interface BlockStreamModule {
             @NonNull final NodeRewardManager nodeRewardManager,
             @NonNull final BoundaryStateChangeListener listener,
             @NonNull final NodeFeeManager nodeFeeManager,
-            @NonNull final StateBackedRegisteredNodeResolver registeredNodeResolver) {
+            @NonNull final StateBackedRegisteredNodeResolver registeredNodeResolver,
+            @NonNull final RegisteredNodeChangeNotifier registeredNodeChangeNotifier,
+            @NonNull final BlockNodeConfigService blockNodeConfigService) {
+        // Set by the inline RegisteredNodeChangeListener below; the listener runs on the consensus handle thread
+        // and is required to be cheap, so it just flips this boolean. The lifecycle drains it from onCloseBlock
+        // (off the handle thread, after the savepoint commit), where revalidating against committed state is safe.
+        final AtomicBoolean pendingRevalidation = new AtomicBoolean(false);
+        final AtomicBoolean firstCloseBlockSeen = new AtomicBoolean(false);
+        registeredNodeChangeNotifier.register(() -> pendingRevalidation.set(true));
         return new BlockStreamManager.Lifecycle() {
             @Override
             public void onOpenBlock(@NonNull final State state) {
@@ -144,6 +158,20 @@ public interface BlockStreamModule {
                 nodeFeeManager.onCloseBlock(state);
                 nodeRewardManager.onCloseBlock(state, listener.nodeFeesCollected());
                 registeredNodeResolver.updateState(state);
+                // revalidate registered-node-backed block-node entries when:
+                //  - this is the first block close (covers cold-start where the config was loaded before state was
+                //    available), OR
+                //  - a RegisteredNode create/update/delete txn signaled a change in this block via the listener
+                final boolean firstClose = firstCloseBlockSeen.compareAndSet(false, true);
+                final boolean pending = pendingRevalidation.compareAndSet(true, false);
+                if (firstClose || pending) {
+                    try {
+                        blockNodeConfigService.revalidateRegisteredNodes();
+                    } catch (final RuntimeException e) {
+                        LIFECYCLE_LOGGER.warn(
+                                "Error while re-resolving registered-node block-node configurations (ignoring)", e);
+                    }
+                }
             }
         };
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamModule.java
@@ -9,6 +9,7 @@ import com.hedera.node.app.blocks.impl.streaming.BlockNodeConnectionManager;
 import com.hedera.node.app.blocks.impl.streaming.FileAndGrpcBlockItemWriter;
 import com.hedera.node.app.blocks.impl.streaming.FileBlockItemWriter;
 import com.hedera.node.app.blocks.impl.streaming.GrpcBlockItemWriter;
+import com.hedera.node.app.blocks.impl.streaming.config.StateBackedRegisteredNodeResolver;
 import com.hedera.node.app.metrics.BlockStreamMetrics;
 import com.hedera.node.app.services.NodeFeeManager;
 import com.hedera.node.app.services.NodeRewardManager;
@@ -39,8 +40,12 @@ public interface BlockStreamModule {
 
     @Provides
     @Singleton
-    static BlockNodeConfigService provideBlockNodeConfigService(@NonNull final ConfigProvider configProvider) {
-        return new BlockNodeConfigService(configProvider);
+    static BlockNodeConfigService provideBlockNodeConfigService(
+            @NonNull final ConfigProvider configProvider,
+            @NonNull final StateBackedRegisteredNodeResolver registeredNodeResolver) {
+        final BlockNodeConfigService service = new BlockNodeConfigService(configProvider);
+        service.setRegisteredNodeResolver(registeredNodeResolver);
+        return service;
     }
 
     @Provides
@@ -123,19 +128,22 @@ public interface BlockStreamModule {
     static BlockStreamManager.Lifecycle provideBlockStreamManagerLifecycle(
             @NonNull final NodeRewardManager nodeRewardManager,
             @NonNull final BoundaryStateChangeListener listener,
-            @NonNull final NodeFeeManager nodeFeeManager) {
+            @NonNull final NodeFeeManager nodeFeeManager,
+            @NonNull final StateBackedRegisteredNodeResolver registeredNodeResolver) {
         return new BlockStreamManager.Lifecycle() {
             @Override
             public void onOpenBlock(@NonNull final State state) {
                 nodeFeeManager.onOpenBlock(state);
                 listener.resetCollectedNodeFees();
                 nodeRewardManager.onOpenBlock(state);
+                registeredNodeResolver.updateState(state);
             }
 
             @Override
             public void onCloseBlock(@NonNull final State state) {
                 nodeFeeManager.onCloseBlock(state);
                 nodeRewardManager.onCloseBlock(state, listener.nodeFeesCollected());
+                registeredNodeResolver.updateState(state);
             }
         };
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigService.java
@@ -7,8 +7,6 @@ import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint;
 import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint.BlockNodeEndpoint.BlockNodeApi;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.node.app.blocks.impl.streaming.config.BlockNodeConfiguration;
-import com.hedera.node.app.blocks.impl.streaming.config.BlockNodeHelidonGrpcConfiguration;
-import com.hedera.node.app.blocks.impl.streaming.config.BlockNodeHelidonHttpConfiguration;
 import com.hedera.node.app.blocks.impl.streaming.config.RegisteredNodeEndpointResolver;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockNodeConnectionConfig;
@@ -82,6 +80,12 @@ public class BlockNodeConfigService {
      */
     private final AtomicReference<VersionedBlockNodeConfigurationSet> latestConfigRef = new AtomicReference<>();
     /**
+     * The most recent {@link BlockNodeConnectionInfo} that was successfully parsed from disk. Retained so that the
+     * service can re-resolve {@code registeredNodeId} entries against the latest state without re-reading the file.
+     * Null until the first successful disk load.
+     */
+    private final AtomicReference<BlockNodeConnectionInfo> latestSourceRef = new AtomicReference<>();
+    /**
      * Holder for the file watcher service to detect configuration file changes.
      */
     private final AtomicReference<WatchService> watchServiceRef = new AtomicReference<>();
@@ -125,6 +129,31 @@ public class BlockNodeConfigService {
      */
     public @Nullable VersionedBlockNodeConfigurationSet latestConfiguration() {
         return latestConfigRef.get();
+    }
+
+    /**
+     * Re-resolves any entries in the most recently loaded {@code block-nodes.json} that reference a
+     * {@code registeredNodeId}, using the current state via the configured resolver. If the resolution produces a
+     * different set of configurations from the one currently held, the version counter is bumped and the latest
+     * configuration reference is updated so that downstream consumers (e.g. the connection manager) can pick up the
+     * change.
+     *
+     * <p>This is intended to be called on a schedule by the block-stream connection monitor so that registered-node
+     * endpoint changes propagate without requiring an edit to {@code block-nodes.json}.
+     *
+     * @return {@code true} if the configuration was updated as a result of re-resolution, {@code false} otherwise
+     */
+    public boolean revalidateRegisteredNodes() {
+        final BlockNodeConnectionInfo source = latestSourceRef.get();
+        if (source == null || source.nodes().isEmpty()) {
+            return false;
+        }
+        // only do work if at least one entry actually uses a registered node id
+        final boolean anyHasRegisteredId = source.nodes().stream().anyMatch(n -> n.registeredNodeId() != null);
+        if (!anyHasRegisteredId) {
+            return false;
+        }
+        return rebuildAndMaybePublish(source, /* announceNoChange= */ false);
     }
 
     /**
@@ -179,6 +208,7 @@ public class BlockNodeConfigService {
         logger.info("Stopping block node configuration watcher...");
 
         latestConfigRef.set(null);
+        latestSourceRef.set(null);
         configVersionCounter.incrementAndGet();
 
         final WatchService watchService = watchServiceRef.getAndSet(null);
@@ -200,7 +230,6 @@ public class BlockNodeConfigService {
     private void loadConfiguration() {
         final Path path = configDirectory.resolve(BLOCK_NODES_FILE_NAME);
         final BlockNodeConnectionInfo connectionInfo;
-        final List<BlockNodeConfiguration> nodeConfigs = new ArrayList<>();
 
         try {
             if (!Files.exists(path)) {
@@ -215,6 +244,8 @@ public class BlockNodeConfigService {
             return;
         }
 
+        latestSourceRef.set(connectionInfo);
+
         if (connectionInfo.nodes().isEmpty()) {
             // there is nothing in the configuration file - treat this as a valid configuration that effectively
             // disables any and all active block nodes we already know about
@@ -226,14 +257,30 @@ public class BlockNodeConfigService {
             return;
         }
 
+        rebuildAndMaybePublish(connectionInfo, /* announceNoChange= */ true);
+    }
+
+    /**
+     * Walks the supplied source config, applying resolution, and either publishes a new
+     * {@link VersionedBlockNodeConfigurationSet} (when the result differs from the current one) or leaves the existing
+     * configuration in place.
+     *
+     * @param source the parsed source from disk to rebuild from
+     * @param announceNoChange if {@code true}, log a warning when no configurations could be successfully processed; if
+     *                         {@code false}, stay quiet (used by the re-resolve path where no change is normal)
+     * @return {@code true} if a new versioned configuration was published, {@code false} otherwise
+     */
+    private boolean rebuildAndMaybePublish(
+            @NonNull final BlockNodeConnectionInfo source, final boolean announceNoChange) {
         final long defaultHardLimitBytes = configProvider
                 .getConfiguration()
                 .getConfigData(BlockNodeConnectionConfig.class)
                 .defaultMessageHardLimitBytes();
         final RegisteredNodeEndpointResolver resolver = registeredNodeResolverRef.get();
 
+        final List<BlockNodeConfiguration> nodeConfigs = new ArrayList<>();
         final Map<String, AtomicInteger> hostCounters = new HashMap<>();
-        for (final BlockNodeConfig nodeConfig : connectionInfo.nodes()) {
+        for (final BlockNodeConfig nodeConfig : source.nodes()) {
             try {
                 final BlockNodeConfiguration cfg = buildConfiguration(nodeConfig, defaultHardLimitBytes, resolver);
                 if (cfg == null) {
@@ -251,8 +298,10 @@ public class BlockNodeConfigService {
         }
 
         if (nodeConfigs.isEmpty()) {
-            logger.warn("No block node configurations successfully processed; skipping configuration update");
-            return;
+            if (announceNoChange) {
+                logger.warn("No block node configurations successfully processed; skipping configuration update");
+            }
+            return false;
         }
 
         // check for duplicates
@@ -266,7 +315,13 @@ public class BlockNodeConfigService {
 
         if (duplicatesFound) {
             logger.warn("One or more block node hosts have duplicate configurations; skipping configuration update");
-            return;
+            return false;
+        }
+
+        // skip if the rebuild produced the same list of configurations as what we already have
+        final VersionedBlockNodeConfigurationSet existing = latestConfigRef.get();
+        if (existing != null && existing.configs().equals(nodeConfigs)) {
+            return false;
         }
 
         final long version = configVersionCounter.incrementAndGet();
@@ -290,6 +345,7 @@ public class BlockNodeConfigService {
 
             logger.info("{}", sb);
         }
+        return true;
     }
 
     /**
@@ -313,23 +369,34 @@ public class BlockNodeConfigService {
         final int explicitStreamingPort = nodeConfig.streamingPort();
         final Integer explicitServicePort = nodeConfig.servicePort();
 
-        final RegisteredNode registeredNode = resolver.isStateAvailable() ? resolver.resolve(registeredNodeId) : null;
-        final boolean stateConsulted = resolver.isStateAvailable();
+        final boolean stateAvailable = resolver.isStateAvailable();
+        final RegisteredNode registeredNode = stateAvailable ? resolver.resolve(registeredNodeId) : null;
 
-        String resolvedAddress = null;
+        String resolvedStreamingHost = null;
+        String resolvedServiceHost = null;
         Integer resolvedStreamingPort = null;
         Integer resolvedServicePort = null;
         if (registeredNode != null) {
             final Optional<RegisteredServiceEndpoint> publishEp = pickEndpoint(registeredNode, BlockNodeApi.PUBLISH);
             final Optional<RegisteredServiceEndpoint> statusEp = pickEndpoint(registeredNode, BlockNodeApi.STATUS);
+            resolvedStreamingHost =
+                    publishEp.map(BlockNodeConfigService::endpointHost).orElse(null);
+            resolvedServiceHost =
+                    statusEp.map(BlockNodeConfigService::endpointHost).orElse(null);
             resolvedStreamingPort =
                     publishEp.map(RegisteredServiceEndpoint::port).orElse(null);
             resolvedServicePort = statusEp.map(RegisteredServiceEndpoint::port).orElse(null);
-            resolvedAddress = publishEp
-                    .map(BlockNodeConfigService::endpointHost)
-                    .orElseGet(() ->
-                            statusEp.map(BlockNodeConfigService::endpointHost).orElse(null));
-        } else if (stateConsulted) {
+            if (resolvedStreamingHost != null
+                    && resolvedServiceHost != null
+                    && !resolvedStreamingHost.equals(resolvedServiceHost)) {
+                logger.info(
+                        "Registered node id {} advertises PUBLISH host '{}' and STATUS host '{}' separately; "
+                                + "using each for its respective endpoint",
+                        registeredNodeId,
+                        resolvedStreamingHost,
+                        resolvedServiceHost);
+            }
+        } else if (stateAvailable) {
             logger.info(
                     "Block node configuration references registered node id {} which is not in state; "
                             + "falling back to any explicit address/port values",
@@ -341,7 +408,14 @@ public class BlockNodeConfigService {
                     registeredNodeId);
         }
 
-        final String finalAddress = !explicitAddress.isBlank() ? explicitAddress : resolvedAddress;
+        // streaming host falls back to resolved PUBLISH host, then to resolved STATUS host
+        final String resolvedStreamingHostOrAny =
+                resolvedStreamingHost != null ? resolvedStreamingHost : resolvedServiceHost;
+        final String finalStreamingHost = !explicitAddress.isBlank() ? explicitAddress : resolvedStreamingHostOrAny;
+        // service host: explicit > resolved STATUS > resolved PUBLISH (fallback to whatever streaming uses)
+        final String resolvedServiceHostOrAny =
+                resolvedServiceHost != null ? resolvedServiceHost : resolvedStreamingHost;
+        final String finalServiceHost = !explicitAddress.isBlank() ? explicitAddress : resolvedServiceHostOrAny;
         final int finalStreamingPort = explicitStreamingPort > 0
                 ? explicitStreamingPort
                 : (resolvedStreamingPort != null ? resolvedStreamingPort : -1);
@@ -349,25 +423,28 @@ public class BlockNodeConfigService {
                 ? explicitServicePort
                 : (resolvedServicePort != null ? resolvedServicePort : -1);
 
-        if (finalAddress == null || finalAddress.isBlank() || finalStreamingPort <= 0) {
+        if (finalStreamingHost == null || finalStreamingHost.isBlank() || finalStreamingPort <= 0) {
             logger.info(
                     "Skipping block node configuration for registered node id {}: no usable address or streaming port "
-                            + "(explicit address='{}', explicit streamingPort={}, resolved address='{}', resolved streamingPort={})",
+                            + "(explicit address='{}', explicit streamingPort={}, resolved streamingHost='{}', "
+                            + "resolved streamingPort={})",
                     registeredNodeId,
                     explicitAddress,
                     explicitStreamingPort,
-                    resolvedAddress,
+                    resolvedStreamingHost,
                     resolvedStreamingPort);
             return null;
         }
 
         // log differences between explicit values and what the registered node advertised
-        if (resolvedAddress != null && !explicitAddress.isBlank() && !explicitAddress.equals(resolvedAddress)) {
+        if (!explicitAddress.isBlank()
+                && resolvedStreamingHostOrAny != null
+                && !explicitAddress.equals(resolvedStreamingHostOrAny)) {
             logger.info(
                     "Registered node id {} advertises address '{}' but block-nodes.json explicitly sets '{}'; "
                             + "using the explicit value",
                     registeredNodeId,
-                    resolvedAddress,
+                    resolvedStreamingHostOrAny,
                     explicitAddress);
         }
         if (resolvedStreamingPort != null
@@ -391,21 +468,14 @@ public class BlockNodeConfigService {
                     explicitServicePort);
         }
 
-        final long softLimit =
-                nodeConfig.messageSizeSoftLimitBytesOrElse(BlockNodeConfiguration.DEFAULT_MESSAGE_SOFT_LIMIT_BYTES);
-        final long hardLimit = nodeConfig.messageSizeHardLimitBytesOrElse(defaultHardLimitBytes);
-
-        return BlockNodeConfiguration.newBuilder()
-                .address(finalAddress)
+        final BlockNodeConfiguration.Builder builder = BlockNodeConfiguration.newBuilder()
+                .address(finalStreamingHost)
+                .serviceAddress(finalServiceHost)
                 .streamingPort(finalStreamingPort)
                 .servicePort(finalServicePort)
-                .priority(nodeConfig.priority())
-                .messageSizeSoftLimitBytes(softLimit)
-                .messageSizeHardLimitBytes(hardLimit)
-                .clientGrpcConfig(BlockNodeHelidonGrpcConfiguration.from(nodeConfig.clientGrpcConfig()))
-                .clientHttpConfig(BlockNodeHelidonHttpConfiguration.from(nodeConfig.clientHttpConfig()))
-                .registeredNodeId(registeredNodeId)
-                .build();
+                .registeredNodeId(registeredNodeId);
+        BlockNodeConfiguration.populateSharedFields(builder, nodeConfig, defaultHardLimitBytes);
+        return builder.build();
     }
 
     private static @NonNull Optional<RegisteredServiceEndpoint> pickEndpoint(
@@ -466,6 +536,7 @@ public class BlockNodeConfigService {
                                 final VersionedBlockNodeConfigurationSet newConfig =
                                         new VersionedBlockNodeConfigurationSet(newVersionNumber, List.of());
                                 latestConfigRef.set(newConfig);
+                                latestSourceRef.set(null);
                             } else {
                                 loadConfiguration();
                             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigService.java
@@ -3,7 +3,13 @@ package com.hedera.node.app.blocks.impl.streaming;
 
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint;
+import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint.BlockNodeEndpoint.BlockNodeApi;
+import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.node.app.blocks.impl.streaming.config.BlockNodeConfiguration;
+import com.hedera.node.app.blocks.impl.streaming.config.BlockNodeHelidonGrpcConfiguration;
+import com.hedera.node.app.blocks.impl.streaming.config.BlockNodeHelidonHttpConfiguration;
+import com.hedera.node.app.blocks.impl.streaming.config.RegisteredNodeEndpointResolver;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockNodeConnectionConfig;
 import com.hedera.node.internal.network.BlockNodeConfig;
@@ -13,6 +19,8 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -26,6 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -76,6 +85,13 @@ public class BlockNodeConfigService {
      * Holder for the file watcher service to detect configuration file changes.
      */
     private final AtomicReference<WatchService> watchServiceRef = new AtomicReference<>();
+    /**
+     * Resolver used to look up {@link RegisteredNode} instances when a configuration entry references a
+     * {@code registeredNodeId}. Defaults to {@link RegisteredNodeEndpointResolver#NO_OP} so the service can be
+     * exercised without a running state (e.g. in unit tests of the loader itself).
+     */
+    private final AtomicReference<RegisteredNodeEndpointResolver> registeredNodeResolverRef =
+            new AtomicReference<>(RegisteredNodeEndpointResolver.NO_OP);
 
     /**
      * Creates a new configuration monitor service.
@@ -92,6 +108,16 @@ public class BlockNodeConfigService {
                 .blockNodeConnectionFileDir();
 
         this.configDirectory = FileUtils.getAbsolutePath(configDir);
+    }
+
+    /**
+     * Sets the {@link RegisteredNodeEndpointResolver} used to resolve {@code registeredNodeId} references in
+     * {@code block-nodes.json}. May be called multiple times; the latest resolver applies to subsequent reloads.
+     *
+     * @param resolver the resolver to use; pass {@link RegisteredNodeEndpointResolver#NO_OP} to disable resolution
+     */
+    public void setRegisteredNodeResolver(@NonNull final RegisteredNodeEndpointResolver resolver) {
+        registeredNodeResolverRef.set(requireNonNull(resolver, "resolver must not be null"));
     }
 
     /**
@@ -204,14 +230,19 @@ public class BlockNodeConfigService {
                 .getConfiguration()
                 .getConfigData(BlockNodeConnectionConfig.class)
                 .defaultMessageHardLimitBytes();
+        final RegisteredNodeEndpointResolver resolver = registeredNodeResolverRef.get();
 
         final Map<String, AtomicInteger> hostCounters = new HashMap<>();
         for (final BlockNodeConfig nodeConfig : connectionInfo.nodes()) {
             try {
-                nodeConfigs.add(BlockNodeConfiguration.from(nodeConfig, defaultHardLimitBytes));
+                final BlockNodeConfiguration cfg = buildConfiguration(nodeConfig, defaultHardLimitBytes, resolver);
+                if (cfg == null) {
+                    // resolution failed in a way that already logged; skip silently
+                    continue;
+                }
+                nodeConfigs.add(cfg);
                 hostCounters
-                        .computeIfAbsent(
-                                nodeConfig.address() + ":" + nodeConfig.streamingPort(), _ -> new AtomicInteger())
+                        .computeIfAbsent(cfg.address() + ":" + cfg.streamingPort(), _ -> new AtomicInteger())
                         .incrementAndGet();
             } catch (final RuntimeException e) {
                 logger.warn(
@@ -259,6 +290,146 @@ public class BlockNodeConfigService {
 
             logger.info("{}", sb);
         }
+    }
+
+    /**
+     * Builds a {@link BlockNodeConfiguration} from a parsed entry, applying registered-node-id resolution when
+     * applicable.
+     *
+     * <p>Returns {@code null} if the entry references a {@code registeredNodeId} that cannot be resolved and the
+     * entry does not carry enough explicit values to stand on its own; the caller treats this as a skip.
+     */
+    private @Nullable BlockNodeConfiguration buildConfiguration(
+            @NonNull final BlockNodeConfig nodeConfig,
+            final long defaultHardLimitBytes,
+            @NonNull final RegisteredNodeEndpointResolver resolver) {
+        final Long registeredId = nodeConfig.registeredNodeId();
+        if (registeredId == null) {
+            return BlockNodeConfiguration.from(nodeConfig, defaultHardLimitBytes);
+        }
+
+        final long registeredNodeId = registeredId;
+        final String explicitAddress = nodeConfig.address() == null ? "" : nodeConfig.address();
+        final int explicitStreamingPort = nodeConfig.streamingPort();
+        final Integer explicitServicePort = nodeConfig.servicePort();
+
+        final RegisteredNode registeredNode = resolver.isStateAvailable() ? resolver.resolve(registeredNodeId) : null;
+        final boolean stateConsulted = resolver.isStateAvailable();
+
+        String resolvedAddress = null;
+        Integer resolvedStreamingPort = null;
+        Integer resolvedServicePort = null;
+        if (registeredNode != null) {
+            final Optional<RegisteredServiceEndpoint> publishEp = pickEndpoint(registeredNode, BlockNodeApi.PUBLISH);
+            final Optional<RegisteredServiceEndpoint> statusEp = pickEndpoint(registeredNode, BlockNodeApi.STATUS);
+            resolvedStreamingPort =
+                    publishEp.map(RegisteredServiceEndpoint::port).orElse(null);
+            resolvedServicePort = statusEp.map(RegisteredServiceEndpoint::port).orElse(null);
+            resolvedAddress = publishEp
+                    .map(BlockNodeConfigService::endpointHost)
+                    .orElseGet(() ->
+                            statusEp.map(BlockNodeConfigService::endpointHost).orElse(null));
+        } else if (stateConsulted) {
+            logger.info(
+                    "Block node configuration references registered node id {} which is not in state; "
+                            + "falling back to any explicit address/port values",
+                    registeredNodeId);
+        } else {
+            logger.info(
+                    "Block node configuration references registered node id {} but state is not yet available; "
+                            + "using explicit address/port values for this load",
+                    registeredNodeId);
+        }
+
+        final String finalAddress = !explicitAddress.isBlank() ? explicitAddress : resolvedAddress;
+        final int finalStreamingPort = explicitStreamingPort > 0
+                ? explicitStreamingPort
+                : (resolvedStreamingPort != null ? resolvedStreamingPort : -1);
+        final int finalServicePort = explicitServicePort != null
+                ? explicitServicePort
+                : (resolvedServicePort != null ? resolvedServicePort : -1);
+
+        if (finalAddress == null || finalAddress.isBlank() || finalStreamingPort <= 0) {
+            logger.info(
+                    "Skipping block node configuration for registered node id {}: no usable address or streaming port "
+                            + "(explicit address='{}', explicit streamingPort={}, resolved address='{}', resolved streamingPort={})",
+                    registeredNodeId,
+                    explicitAddress,
+                    explicitStreamingPort,
+                    resolvedAddress,
+                    resolvedStreamingPort);
+            return null;
+        }
+
+        // log differences between explicit values and what the registered node advertised
+        if (resolvedAddress != null && !explicitAddress.isBlank() && !explicitAddress.equals(resolvedAddress)) {
+            logger.info(
+                    "Registered node id {} advertises address '{}' but block-nodes.json explicitly sets '{}'; "
+                            + "using the explicit value",
+                    registeredNodeId,
+                    resolvedAddress,
+                    explicitAddress);
+        }
+        if (resolvedStreamingPort != null
+                && explicitStreamingPort > 0
+                && resolvedStreamingPort != explicitStreamingPort) {
+            logger.info(
+                    "Registered node id {} advertises streaming port {} but block-nodes.json explicitly sets {}; "
+                            + "using the explicit value",
+                    registeredNodeId,
+                    resolvedStreamingPort,
+                    explicitStreamingPort);
+        }
+        if (resolvedServicePort != null
+                && explicitServicePort != null
+                && !resolvedServicePort.equals(explicitServicePort)) {
+            logger.info(
+                    "Registered node id {} advertises service port {} but block-nodes.json explicitly sets {}; "
+                            + "using the explicit value",
+                    registeredNodeId,
+                    resolvedServicePort,
+                    explicitServicePort);
+        }
+
+        final long softLimit =
+                nodeConfig.messageSizeSoftLimitBytesOrElse(BlockNodeConfiguration.DEFAULT_MESSAGE_SOFT_LIMIT_BYTES);
+        final long hardLimit = nodeConfig.messageSizeHardLimitBytesOrElse(defaultHardLimitBytes);
+
+        return BlockNodeConfiguration.newBuilder()
+                .address(finalAddress)
+                .streamingPort(finalStreamingPort)
+                .servicePort(finalServicePort)
+                .priority(nodeConfig.priority())
+                .messageSizeSoftLimitBytes(softLimit)
+                .messageSizeHardLimitBytes(hardLimit)
+                .clientGrpcConfig(BlockNodeHelidonGrpcConfiguration.from(nodeConfig.clientGrpcConfig()))
+                .clientHttpConfig(BlockNodeHelidonHttpConfiguration.from(nodeConfig.clientHttpConfig()))
+                .registeredNodeId(registeredNodeId)
+                .build();
+    }
+
+    private static @NonNull Optional<RegisteredServiceEndpoint> pickEndpoint(
+            @NonNull final RegisteredNode node, @NonNull final BlockNodeApi api) {
+        return node.serviceEndpoint().stream()
+                .filter(ep ->
+                        ep.hasBlockNode() && ep.blockNodeOrThrow().endpointApi().contains(api))
+                .findFirst();
+    }
+
+    private static @Nullable String endpointHost(@NonNull final RegisteredServiceEndpoint endpoint) {
+        if (endpoint.hasDomainName()) {
+            final String domain = endpoint.domainName();
+            return (domain == null || domain.isBlank()) ? null : domain;
+        }
+        if (endpoint.hasIpAddress()) {
+            final byte[] ip = endpoint.ipAddress().toByteArray();
+            try {
+                return InetAddress.getByAddress(ip).getHostAddress();
+            } catch (final UnknownHostException e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/config/BlockNodeConfiguration.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/config/BlockNodeConfiguration.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.internal.network.BlockNodeConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Objects;
 
 /**
@@ -60,6 +61,10 @@ public class BlockNodeConfiguration {
         clientGrpcConfig = requireNonNull(builder.clientGrpcConfig, "Client gRPC config must be specified");
         // default the service port to the streaming port
         final int servicePort = builder.servicePort == -1 ? builder.streamingPort : builder.servicePort;
+        // default the service address to the streaming address if unset/blank
+        final String serviceAddress = (builder.serviceAddress == null || builder.serviceAddress.isBlank())
+                ? builder.address
+                : builder.serviceAddress;
         priority = builder.priority;
         messageSizeSoftLimitBytes = builder.messageSizeSoftLimitBytes;
         messageSizeHardLimitBytes = builder.messageSizeHardLimitBytes;
@@ -86,7 +91,7 @@ public class BlockNodeConfiguration {
         }
 
         streamingEndpoint = new BlockNodeEndpoint(builder.address, builder.streamingPort);
-        serviceEndpoint = new BlockNodeEndpoint(builder.address, servicePort);
+        serviceEndpoint = new BlockNodeEndpoint(serviceAddress, servicePort);
     }
 
     public @NonNull BlockNodeEndpoint streamingEndpoint() {
@@ -189,19 +194,32 @@ public class BlockNodeConfiguration {
     public static @NonNull BlockNodeConfiguration from(
             @NonNull final BlockNodeConfig config, final long defaultHardLimitBytes) {
         requireNonNull(config, "config must be specified");
-
-        final Builder b = newBuilder();
-
-        b.address(config.address());
-        b.streamingPort(config.streamingPort());
-        b.servicePort(config.servicePortOrElse(-1));
-        b.priority(config.priority());
-        b.messageSizeSoftLimitBytes(config.messageSizeSoftLimitBytesOrElse(DEFAULT_MESSAGE_SOFT_LIMIT_BYTES));
-        b.messageSizeHardLimitBytes(config.messageSizeHardLimitBytesOrElse(defaultHardLimitBytes));
-        b.clientGrpcConfig(BlockNodeHelidonGrpcConfiguration.from(config.clientGrpcConfig()));
-        b.clientHttpConfig(BlockNodeHelidonHttpConfiguration.from(config.clientHttpConfig()));
-
+        final Builder b = newBuilder()
+                .address(config.address())
+                .streamingPort(config.streamingPort())
+                .servicePort(config.servicePortOrElse(-1));
+        populateSharedFields(b, config, defaultHardLimitBytes);
         return b.build();
+    }
+
+    /**
+     * Populates the builder fields that are independent of address/port resolution: priority, soft/hard message size
+     * limits, and Helidon client configs. Used by both {@link #from(BlockNodeConfig, long)} and by callers that resolve
+     * address/port separately (e.g. {@code BlockNodeConfigService} when resolving a {@code registeredNodeId}).
+     *
+     * @param builder the builder to populate
+     * @param config the source config to read from
+     * @param defaultHardLimitBytes the default hard limit to apply if the config does not specify one
+     */
+    public static void populateSharedFields(
+            @NonNull final Builder builder, @NonNull final BlockNodeConfig config, final long defaultHardLimitBytes) {
+        requireNonNull(builder, "builder must not be null");
+        requireNonNull(config, "config must not be null");
+        builder.priority(config.priority())
+                .messageSizeSoftLimitBytes(config.messageSizeSoftLimitBytesOrElse(DEFAULT_MESSAGE_SOFT_LIMIT_BYTES))
+                .messageSizeHardLimitBytes(config.messageSizeHardLimitBytesOrElse(defaultHardLimitBytes))
+                .clientGrpcConfig(BlockNodeHelidonGrpcConfiguration.from(config.clientGrpcConfig()))
+                .clientHttpConfig(BlockNodeHelidonHttpConfiguration.from(config.clientHttpConfig()));
     }
 
     public static Builder newBuilder() {
@@ -210,6 +228,7 @@ public class BlockNodeConfiguration {
 
     public static class Builder {
         private String address;
+        private @Nullable String serviceAddress;
         private int streamingPort;
         private int servicePort = -1;
         private int priority;
@@ -223,8 +242,22 @@ public class BlockNodeConfiguration {
             // no-op
         }
 
+        /**
+         * Sets the address used for the streaming endpoint, and, unless {@link #serviceAddress(String)} is also
+         * called, for the service endpoint.
+         */
         public @NonNull Builder address(final String address) {
             this.address = address;
+            return this;
+        }
+
+        /**
+         * Optional override for the service endpoint's host. When unset (or blank), the service endpoint reuses the
+         * value passed to {@link #address(String)}. This makes it possible to model a registered node that advertises
+         * its PUBLISH and STATUS APIs on different hosts.
+         */
+        public @NonNull Builder serviceAddress(@Nullable final String serviceAddress) {
+            this.serviceAddress = serviceAddress;
             return this;
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/config/BlockNodeConfiguration.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/config/BlockNodeConfiguration.java
@@ -16,6 +16,10 @@ public class BlockNodeConfiguration {
      */
     public static final long DEFAULT_MESSAGE_SOFT_LIMIT_BYTES = 2L * 1024 * 1024; // 2 MB
     /**
+     * Sentinel value indicating no registered node id is associated with this configuration.
+     */
+    public static final long NO_REGISTERED_NODE_ID = -1L;
+    /**
      * The streaming endpoint associated with this block node.
      */
     private final BlockNodeEndpoint streamingEndpoint;
@@ -23,6 +27,11 @@ public class BlockNodeConfiguration {
      * The service endpoint associated with this block node.
      */
     private final BlockNodeEndpoint serviceEndpoint;
+    /**
+     * The optional registered node id used to resolve this configuration, or
+     * {@link #NO_REGISTERED_NODE_ID} if the entry did not specify one.
+     */
+    private final long registeredNodeId;
     /**
      * Priority of the block node.
      */
@@ -54,6 +63,7 @@ public class BlockNodeConfiguration {
         priority = builder.priority;
         messageSizeSoftLimitBytes = builder.messageSizeSoftLimitBytes;
         messageSizeHardLimitBytes = builder.messageSizeHardLimitBytes;
+        registeredNodeId = builder.registeredNodeId;
 
         if (builder.address.isBlank()) {
             throw new IllegalArgumentException("Address must not be empty");
@@ -103,6 +113,21 @@ public class BlockNodeConfiguration {
         return priority;
     }
 
+    /**
+     * @return the registered node id this configuration was resolved from, or
+     *         {@link #NO_REGISTERED_NODE_ID} if no registered node id was specified
+     */
+    public long registeredNodeId() {
+        return registeredNodeId;
+    }
+
+    /**
+     * @return true if this configuration was resolved from a registered node id
+     */
+    public boolean hasRegisteredNodeId() {
+        return registeredNodeId != NO_REGISTERED_NODE_ID;
+    }
+
     public long messageSizeSoftLimitBytes() {
         return messageSizeSoftLimitBytes;
     }
@@ -128,6 +153,7 @@ public class BlockNodeConfiguration {
         return priority == that.priority
                 && messageSizeSoftLimitBytes == that.messageSizeSoftLimitBytes
                 && messageSizeHardLimitBytes == that.messageSizeHardLimitBytes
+                && registeredNodeId == that.registeredNodeId
                 && Objects.equals(streamingEndpoint, that.streamingEndpoint)
                 && Objects.equals(serviceEndpoint, that.serviceEndpoint)
                 && Objects.equals(clientHttpConfig, that.clientHttpConfig)
@@ -143,7 +169,8 @@ public class BlockNodeConfiguration {
                 messageSizeSoftLimitBytes,
                 messageSizeHardLimitBytes,
                 clientHttpConfig,
-                clientGrpcConfig);
+                clientGrpcConfig,
+                registeredNodeId);
     }
 
     @Override
@@ -155,7 +182,8 @@ public class BlockNodeConfiguration {
                 + messageSizeSoftLimitBytes + ", messageSizeHardLimitBytes="
                 + messageSizeHardLimitBytes + ", clientHttpConfig="
                 + clientHttpConfig + ", clientGrpcConfig="
-                + clientGrpcConfig + '}';
+                + clientGrpcConfig + ", registeredNodeId="
+                + registeredNodeId + '}';
     }
 
     public static @NonNull BlockNodeConfiguration from(
@@ -187,6 +215,7 @@ public class BlockNodeConfiguration {
         private int priority;
         private long messageSizeSoftLimitBytes;
         private long messageSizeHardLimitBytes;
+        private long registeredNodeId = NO_REGISTERED_NODE_ID;
         private BlockNodeHelidonGrpcConfiguration clientGrpcConfig;
         private BlockNodeHelidonHttpConfiguration clientHttpConfig;
 
@@ -231,6 +260,11 @@ public class BlockNodeConfiguration {
 
         public @NonNull Builder clientGrpcConfig(@NonNull final BlockNodeHelidonGrpcConfiguration clientGrpcConfig) {
             this.clientGrpcConfig = clientGrpcConfig;
+            return this;
+        }
+
+        public @NonNull Builder registeredNodeId(final long registeredNodeId) {
+            this.registeredNodeId = registeredNodeId;
             return this;
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/config/RegisteredNodeEndpointResolver.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/config/RegisteredNodeEndpointResolver.java
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl.streaming.config;
+
+import com.hedera.hapi.node.state.addressbook.RegisteredNode;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+/**
+ * Looks up a {@link RegisteredNode} from the latest visible state on behalf of
+ * {@link com.hedera.node.app.blocks.impl.streaming.BlockNodeConfigService}, which uses it to resolve block-node
+ * endpoints referenced by {@code registeredNodeId} in {@code block-nodes.json}.
+ */
+@FunctionalInterface
+public interface RegisteredNodeEndpointResolver {
+
+    /**
+     * Resolver that always returns {@code null}; used when no state-backed resolver is available
+     * (e.g. during early startup or in unit tests that do not exercise registered-node resolution).
+     */
+    RegisteredNodeEndpointResolver NO_OP = registeredNodeId -> null;
+
+    /**
+     * @param registeredNodeId the id to look up
+     * @return the registered node currently in state, or {@code null} if it does not exist or state
+     *         is not yet available
+     */
+    @Nullable
+    RegisteredNode resolve(long registeredNodeId);
+
+    /**
+     * @return {@code true} if this resolver is the {@link #NO_OP} placeholder
+     */
+    default boolean isNoOp() {
+        return this == NO_OP;
+    }
+
+    /**
+     * Marker used to indicate the resolver could not consult state at all (vs. consulted state and found nothing).
+     * The default implementation distinguishes this via {@link #isNoOp()}; custom resolvers should override
+     * {@link #isStateAvailable()} when they may transiently lack state.
+     */
+    default boolean isStateAvailable() {
+        return !isNoOp();
+    }
+
+    @NonNull
+    static RegisteredNodeEndpointResolver noOp() {
+        return NO_OP;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/config/StateBackedRegisteredNodeResolver.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/config/StateBackedRegisteredNodeResolver.java
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl.streaming.config;
+
+import com.hedera.hapi.node.state.addressbook.RegisteredNode;
+import com.hedera.node.app.service.addressbook.AddressBookService;
+import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
+import com.hedera.node.app.service.addressbook.impl.ReadableRegisteredNodeStoreImpl;
+import com.hedera.node.app.service.entityid.EntityIdService;
+import com.hedera.node.app.service.entityid.impl.ReadableEntityIdStoreImpl;
+import com.swirlds.state.State;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * State-backed implementation of {@link RegisteredNodeEndpointResolver}.
+ *
+ * <p>The latest visible {@link State} is published into this resolver from the block-stream
+ * lifecycle (see {@code BlockStreamModule#provideBlockStreamManagerLifecycle}), so subsequent
+ * resolution calls always observe the most recent State that the block stream manager has seen.
+ */
+@Singleton
+public class StateBackedRegisteredNodeResolver implements RegisteredNodeEndpointResolver {
+
+    private static final Logger logger = LogManager.getLogger(StateBackedRegisteredNodeResolver.class);
+
+    private final AtomicReference<State> stateRef = new AtomicReference<>();
+
+    @Inject
+    public StateBackedRegisteredNodeResolver() {
+        // no-op
+    }
+
+    /**
+     * Publishes the latest visible State. Subsequent {@link #resolve(long)} calls will use this State.
+     */
+    public void updateState(@NonNull final State state) {
+        stateRef.set(state);
+    }
+
+    @Override
+    public boolean isStateAvailable() {
+        return stateRef.get() != null;
+    }
+
+    @Override
+    public @Nullable RegisteredNode resolve(final long registeredNodeId) {
+        final State state = stateRef.get();
+        if (state == null) {
+            return null;
+        }
+        try {
+            final var addressBookStates = state.getReadableStates(AddressBookService.NAME);
+            final var entityIdStore = new ReadableEntityIdStoreImpl(state.getReadableStates(EntityIdService.NAME));
+            final ReadableRegisteredNodeStore store =
+                    new ReadableRegisteredNodeStoreImpl(addressBookStates, entityIdStore);
+            return store.get(registeredNodeId);
+        } catch (final RuntimeException e) {
+            logger.warn("Failed to resolve registered node id {} from state", registeredNodeId, e);
+            return null;
+        }
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigServiceTest.java
@@ -1007,6 +1007,106 @@ class BlockNodeConfigServiceTest extends BlockNodeCommunicationTestBase {
         assertThat(config).isNull();
     }
 
+    @Test
+    void testLoadConfiguration_registeredNodeId_distinctPublishStatusHosts() throws Throwable {
+        // PUBLISH on host A, STATUS on host B -> streamingEndpoint and serviceEndpoint should have different hosts
+        final RegisteredNode registered = RegisteredNode.newBuilder()
+                .registeredNodeId(7L)
+                .serviceEndpoint(
+                        blockNodeEndpoint("publish.example.com", 9100, BlockNodeApi.PUBLISH),
+                        blockNodeEndpoint("status.example.com", 9200, BlockNodeApi.STATUS))
+                .build();
+        configService.setRegisteredNodeResolver(staticResolver(7L, registered));
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        { "registeredNodeId": 7, "priority": 1 }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet config = configService.latestConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.configs()).hasSize(1);
+        final BlockNodeConfiguration nodeConfig = config.configs().getFirst();
+        assertThat(nodeConfig.streamingEndpoint().host()).isEqualTo("publish.example.com");
+        assertThat(nodeConfig.streamingEndpoint().port()).isEqualTo(9100);
+        assertThat(nodeConfig.serviceEndpoint().host()).isEqualTo("status.example.com");
+        assertThat(nodeConfig.serviceEndpoint().port()).isEqualTo(9200);
+        assertThat(nodeConfig.registeredNodeId()).isEqualTo(7L);
+    }
+
+    @Test
+    void testRevalidateRegisteredNodes_picksUpEndpointChange() throws Throwable {
+        // initial registered node advertises port 9100
+        final RegisteredNode initial = registeredNodeWithEndpoints("blocknode.example.com", 9100, 9200);
+        final AtomicReference<RegisteredNode> currentRegistered = new AtomicReference<>(initial);
+        configService.setRegisteredNodeResolver(new RegisteredNodeEndpointResolver() {
+            @Override
+            public boolean isStateAvailable() {
+                return true;
+            }
+
+            @Override
+            public RegisteredNode resolve(final long registeredNodeId) {
+                return registeredNodeId == 7L ? currentRegistered.get() : null;
+            }
+        });
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        { "registeredNodeId": 7, "priority": 1 }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet initialConfig = configService.latestConfiguration();
+        assertThat(initialConfig).isNotNull();
+        assertThat(initialConfig.configs().getFirst().streamingPort()).isEqualTo(9100);
+        final long initialVersion = initialConfig.versionNumber();
+
+        // re-resolving with the same registered node should be a no-op
+        assertThat(configService.revalidateRegisteredNodes()).isFalse();
+        assertThat(configService.latestConfiguration().versionNumber()).isEqualTo(initialVersion);
+
+        // simulate the registered node advertising new endpoints
+        currentRegistered.set(registeredNodeWithEndpoints("blocknode.example.com", 9999, 9200));
+
+        assertThat(configService.revalidateRegisteredNodes()).isTrue();
+        final VersionedBlockNodeConfigurationSet updatedConfig = configService.latestConfiguration();
+        assertThat(updatedConfig).isNotNull();
+        assertThat(updatedConfig.versionNumber()).isGreaterThan(initialVersion);
+        assertThat(updatedConfig.configs().getFirst().streamingPort()).isEqualTo(9999);
+    }
+
+    @Test
+    void testRevalidateRegisteredNodes_noopWhenNoRegisteredIdEntries() throws Throwable {
+        configService.setRegisteredNodeResolver(staticResolver(7L, registeredNodeWithEndpoints("h", 1234, 1234)));
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        { "address": "localhost", "streamingPort": 9999, "priority": 1 }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+        assertThat(configService.revalidateRegisteredNodes()).isFalse();
+    }
+
+    @Test
+    void testRevalidateRegisteredNodes_noopWhenNoSourceLoaded() {
+        // never loaded a config -> revalidate should report no change
+        assertThat(configService.revalidateRegisteredNodes()).isFalse();
+    }
+
     // Utilities =========
 
     void invoke_loadConfiguration() throws Throwable {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConfigServiceTest.java
@@ -14,7 +14,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint;
+import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint.BlockNodeEndpoint;
+import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint.BlockNodeEndpoint.BlockNodeApi;
+import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.node.app.blocks.impl.streaming.config.BlockNodeConfiguration;
+import com.hedera.node.app.blocks.impl.streaming.config.RegisteredNodeEndpointResolver;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfiguration;
 import com.hedera.node.config.data.BlockNodeConnectionConfig;
@@ -833,10 +838,212 @@ class BlockNodeConfigServiceTest extends BlockNodeCommunicationTestBase {
         }
     }
 
+    // Registered node id resolution =========
+
+    @Test
+    void testLoadConfiguration_registeredNodeId_resolvesEndpoints() throws Throwable {
+        final RegisteredNode registered = registeredNodeWithEndpoints("blocknode.example.com", 9100, 9200);
+        configService.setRegisteredNodeResolver(staticResolver(7L, registered));
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        { "registeredNodeId": 7, "priority": 1 }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet config = configService.latestConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.configs()).hasSize(1);
+        final BlockNodeConfiguration nodeConfig = config.configs().getFirst();
+        assertThat(nodeConfig.address()).isEqualTo("blocknode.example.com");
+        assertThat(nodeConfig.streamingPort()).isEqualTo(9100);
+        assertThat(nodeConfig.servicePort()).isEqualTo(9200);
+        assertThat(nodeConfig.hasRegisteredNodeId()).isTrue();
+        assertThat(nodeConfig.registeredNodeId()).isEqualTo(7L);
+    }
+
+    @Test
+    void testLoadConfiguration_registeredNodeId_explicitOverridesResolved() throws Throwable {
+        final RegisteredNode registered = registeredNodeWithEndpoints("resolved.example.com", 9100, 9200);
+        configService.setRegisteredNodeResolver(staticResolver(7L, registered));
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        {
+                            "registeredNodeId": 7,
+                            "address": "explicit.example.com",
+                            "streamingPort": 1111,
+                            "servicePort": 2222,
+                            "priority": 1
+                        }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet config = configService.latestConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.configs()).hasSize(1);
+        final BlockNodeConfiguration nodeConfig = config.configs().getFirst();
+        assertThat(nodeConfig.address()).isEqualTo("explicit.example.com");
+        assertThat(nodeConfig.streamingPort()).isEqualTo(1111);
+        assertThat(nodeConfig.servicePort()).isEqualTo(2222);
+        assertThat(nodeConfig.registeredNodeId()).isEqualTo(7L);
+    }
+
+    @Test
+    void testLoadConfiguration_registeredNodeId_notInState_skipsWhenNoExplicitEndpoints() throws Throwable {
+        configService.setRegisteredNodeResolver(staticResolver(7L, null));
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        { "registeredNodeId": 7, "priority": 1 },
+                        { "address": "localhost", "streamingPort": 9999, "priority": 2 }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet config = configService.latestConfiguration();
+        assertThat(config).isNotNull();
+        // The unresolved entry is skipped; the explicit entry survives.
+        assertThat(config.configs()).hasSize(1);
+        assertThat(config.configs().getFirst().streamingPort()).isEqualTo(9999);
+    }
+
+    @Test
+    void testLoadConfiguration_registeredNodeId_notInState_keepsExplicitEndpoints() throws Throwable {
+        configService.setRegisteredNodeResolver(staticResolver(7L, null));
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        {
+                            "registeredNodeId": 7,
+                            "address": "explicit.example.com",
+                            "streamingPort": 5555,
+                            "priority": 1
+                        }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet config = configService.latestConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.configs()).hasSize(1);
+        final BlockNodeConfiguration nodeConfig = config.configs().getFirst();
+        assertThat(nodeConfig.address()).isEqualTo("explicit.example.com");
+        assertThat(nodeConfig.streamingPort()).isEqualTo(5555);
+        assertThat(nodeConfig.servicePort()).isEqualTo(5555);
+        assertThat(nodeConfig.registeredNodeId()).isEqualTo(7L);
+    }
+
+    @Test
+    void testLoadConfiguration_registeredNodeId_stateNotAvailable_keepsExplicitEndpoints() throws Throwable {
+        // resolver explicitly reports state-not-available
+        configService.setRegisteredNodeResolver(new RegisteredNodeEndpointResolver() {
+            @Override
+            public boolean isStateAvailable() {
+                return false;
+            }
+
+            @Override
+            public RegisteredNode resolve(final long id) {
+                throw new AssertionError("should not be called when state is not available");
+            }
+        });
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        {
+                            "registeredNodeId": 7,
+                            "address": "explicit.example.com",
+                            "streamingPort": 5555,
+                            "priority": 1
+                        }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet config = configService.latestConfiguration();
+        assertThat(config).isNotNull();
+        assertThat(config.configs()).hasSize(1);
+        assertThat(config.configs().getFirst().address()).isEqualTo("explicit.example.com");
+    }
+
+    @Test
+    void testLoadConfiguration_registeredNodeId_resolvedHasNoMatchingApi() throws Throwable {
+        // registered node only advertises STATUS, not PUBLISH; no explicit streaming port -> skip
+        final RegisteredNode statusOnly = RegisteredNode.newBuilder()
+                .registeredNodeId(7L)
+                .serviceEndpoint(blockNodeEndpoint("status.example.com", 9200, BlockNodeApi.STATUS))
+                .build();
+        configService.setRegisteredNodeResolver(staticResolver(7L, statusOnly));
+
+        writeConfig("""
+                {
+                    "nodes": [
+                        { "registeredNodeId": 7, "priority": 1 }
+                    ]
+                }
+                """);
+
+        invoke_loadConfiguration();
+
+        final VersionedBlockNodeConfigurationSet config = configService.latestConfiguration();
+        assertThat(config).isNull();
+    }
+
     // Utilities =========
 
     void invoke_loadConfiguration() throws Throwable {
         loadConfigurationHandle.invoke(configService);
+    }
+
+    private static RegisteredNodeEndpointResolver staticResolver(final long expectedId, final RegisteredNode result) {
+        return new RegisteredNodeEndpointResolver() {
+            @Override
+            public boolean isStateAvailable() {
+                return true;
+            }
+
+            @Override
+            public RegisteredNode resolve(final long registeredNodeId) {
+                return registeredNodeId == expectedId ? result : null;
+            }
+        };
+    }
+
+    private static RegisteredNode registeredNodeWithEndpoints(
+            final String host, final int publishPort, final int statusPort) {
+        return RegisteredNode.newBuilder()
+                .registeredNodeId(7L)
+                .serviceEndpoint(
+                        blockNodeEndpoint(host, publishPort, BlockNodeApi.PUBLISH),
+                        blockNodeEndpoint(host, statusPort, BlockNodeApi.STATUS))
+                .build();
+    }
+
+    private static RegisteredServiceEndpoint blockNodeEndpoint(
+            final String host, final int port, final BlockNodeApi api) {
+        return RegisteredServiceEndpoint.newBuilder()
+                .domainName(host)
+                .port(port)
+                .blockNode(BlockNodeEndpoint.newBuilder().endpointApi(api).build())
+                .build();
     }
 
     void writeConfig(final String config) throws IOException {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/config/BlockNodeConfigurationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/config/BlockNodeConfigurationTest.java
@@ -179,6 +179,43 @@ class BlockNodeConfigurationTest {
     }
 
     @Test
+    void testServiceAddressOverride() {
+        final BlockNodeConfiguration config = BlockNodeConfiguration.newBuilder()
+                .address("publish.example.com")
+                .serviceAddress("status.example.com")
+                .streamingPort(9100)
+                .servicePort(9200)
+                .priority(1)
+                .messageSizeSoftLimitBytes(2_000)
+                .messageSizeHardLimitBytes(3_000)
+                .clientHttpConfig(BlockNodeHelidonHttpConfiguration.DEFAULT)
+                .clientGrpcConfig(BlockNodeHelidonGrpcConfiguration.DEFAULT)
+                .build();
+
+        assertThat(config.streamingEndpoint().host()).isEqualTo("publish.example.com");
+        assertThat(config.streamingEndpoint().port()).isEqualTo(9100);
+        assertThat(config.serviceEndpoint().host()).isEqualTo("status.example.com");
+        assertThat(config.serviceEndpoint().port()).isEqualTo(9200);
+    }
+
+    @Test
+    void testServiceAddressDefaultsToStreamingAddress() {
+        final BlockNodeConfiguration config = BlockNodeConfiguration.newBuilder()
+                .address("shared.example.com")
+                .streamingPort(9100)
+                .servicePort(9200)
+                .priority(1)
+                .messageSizeSoftLimitBytes(2_000)
+                .messageSizeHardLimitBytes(3_000)
+                .clientHttpConfig(BlockNodeHelidonHttpConfiguration.DEFAULT)
+                .clientGrpcConfig(BlockNodeHelidonGrpcConfiguration.DEFAULT)
+                .build();
+
+        assertThat(config.streamingEndpoint().host()).isEqualTo("shared.example.com");
+        assertThat(config.serviceEndpoint().host()).isEqualTo("shared.example.com");
+    }
+
+    @Test
     void testRegisteredNodeIdRoundTrip() {
         final BlockNodeConfiguration config = BlockNodeConfiguration.newBuilder()
                 .address("localhost")

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/config/BlockNodeConfigurationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/config/BlockNodeConfigurationTest.java
@@ -179,6 +179,41 @@ class BlockNodeConfigurationTest {
     }
 
     @Test
+    void testRegisteredNodeIdRoundTrip() {
+        final BlockNodeConfiguration config = BlockNodeConfiguration.newBuilder()
+                .address("localhost")
+                .streamingPort(8080)
+                .servicePort(8081)
+                .priority(1)
+                .messageSizeSoftLimitBytes(2_000)
+                .messageSizeHardLimitBytes(3_000)
+                .clientHttpConfig(BlockNodeHelidonHttpConfiguration.DEFAULT)
+                .clientGrpcConfig(BlockNodeHelidonGrpcConfiguration.DEFAULT)
+                .registeredNodeId(42L)
+                .build();
+
+        assertThat(config.hasRegisteredNodeId()).isTrue();
+        assertThat(config.registeredNodeId()).isEqualTo(42L);
+    }
+
+    @Test
+    void testRegisteredNodeIdDefaultsToSentinel() {
+        final BlockNodeConfiguration config = BlockNodeConfiguration.newBuilder()
+                .address("localhost")
+                .streamingPort(8080)
+                .servicePort(8081)
+                .priority(1)
+                .messageSizeSoftLimitBytes(2_000)
+                .messageSizeHardLimitBytes(3_000)
+                .clientHttpConfig(BlockNodeHelidonHttpConfiguration.DEFAULT)
+                .clientGrpcConfig(BlockNodeHelidonGrpcConfiguration.DEFAULT)
+                .build();
+
+        assertThat(config.hasRegisteredNodeId()).isFalse();
+        assertThat(config.registeredNodeId()).isEqualTo(BlockNodeConfiguration.NO_REGISTERED_NODE_ID);
+    }
+
+    @Test
     void testBuilder() {
         final BlockNodeHelidonHttpConfiguration clientHttpConfig =
                 BlockNodeHelidonHttpConfiguration.newBuilder().build();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -2,15 +2,19 @@
 package com.hedera.services.bdd.suites.blocknode;
 
 import static com.hedera.services.bdd.junit.TestTags.BLOCK_NODE;
+import static com.hedera.services.bdd.junit.hedera.ExternalPath.DATA_CONFIG_DIR;
 import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.registeredNodeCreate;
 import static com.hedera.services.bdd.spec.utilops.BlockNodeVerbs.blockNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertBlockNodeCommsLogContainsTimeframe;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertBlockNodeCommsLogDoesNotContainText;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.awaitBlockNodeCommsLogContainsText;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilNextBlocks;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.hedera.services.bdd.HapiBlockNode;
 import com.hedera.services.bdd.HapiBlockNode.BlockNodeConfig;
@@ -18,10 +22,15 @@ import com.hedera.services.bdd.HapiBlockNode.SubProcessNodeConfig;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.junit.hedera.BlockNodeMode;
+import com.hederahashgraph.api.proto.java.RegisteredServiceEndpoint;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Stream;
@@ -331,6 +340,79 @@ public class BlockNodeSuite {
         // Use fewer blocks than the single-node test since 4 real block node containers
         // and 4 consensus nodes need more startup time, reducing the window for block production
         return validateHappyPath(5);
+    }
+
+    @HapiTest
+    @HapiBlockNode(
+            networkSize = 1,
+            blockNodeConfigs = {@BlockNodeConfig(nodeId = 0, mode = BlockNodeMode.SIMULATOR)},
+            subProcessNodeConfigs = {
+                @SubProcessNodeConfig(
+                        nodeId = 0,
+                        blockNodeIds = {0},
+                        blockNodePriorities = {0},
+                        applicationPropertiesOverrides = {
+                            "blockStream.streamMode", "BLOCKS",
+                            "blockStream.writerMode", "FILE_AND_GRPC"
+                        })
+            })
+    @Order(6)
+    final Stream<DynamicTest> registeredNodeIdResolvesBlockNodeEndpoint() {
+        final String registeredNodeName = "blockNodeRegistered";
+        final String adminKey = "registeredAdminKey";
+        final AtomicLong registeredNodeIdRef = new AtomicLong();
+        return hapiTest(
+                // wait for at least one block so the consensus node has published State to the resolver
+                waitUntilNextBlocks(1).withBackgroundTraffic(true),
+                newKeyNamed(adminKey),
+                // create a registered node that advertises the simulator's port for both PUBLISH and STATUS
+                sourcingContextual(spec -> registeredNodeCreate(registeredNodeName)
+                        .adminKey(adminKey)
+                        .serviceEndpoints(
+                                List.of(blockNodePublishStatusEndpoint("localhost", spec.getBlockNodePortById(0))))
+                        .hasKnownStatus(SUCCESS)),
+                // capture the registered node id and rewrite block-nodes.json to reference it by id only
+                doingContextual(spec -> {
+                    registeredNodeIdRef.set(spec.registry().getRegisteredNodeId(registeredNodeName));
+                    rewriteBlockNodesJson(
+                            spec.targetNetworkOrThrow()
+                                    .getRequiredNode(byNodeId(0))
+                                    .getExternalPath(DATA_CONFIG_DIR)
+                                    .resolve("block-nodes.json"),
+                            registeredNodeIdRef.get());
+                }),
+                // assert the consensus node selected the resolved endpoint for streaming
+                sourcingContextual(spec -> awaitBlockNodeCommsLogContainsText(
+                        byNodeId(0),
+                        String.format(
+                                "Selected new block node for streaming: localhost:%s", spec.getBlockNodePortById(0)),
+                        Duration.ofSeconds(60))),
+                // verify the resolution log includes the registered node id we just looked up
+                sourcingContextual(spec -> awaitBlockNodeCommsLogContainsText(
+                        byNodeId(0),
+                        String.format("registeredNodeId=%d", registeredNodeIdRef.get()),
+                        Duration.ofSeconds(60))),
+                waitUntilNextBlocks(3).withBackgroundTraffic(true));
+    }
+
+    private static RegisteredServiceEndpoint blockNodePublishStatusEndpoint(final String host, final int port) {
+        return RegisteredServiceEndpoint.newBuilder()
+                .setDomainName(host)
+                .setPort(port)
+                .setBlockNode(RegisteredServiceEndpoint.BlockNodeEndpoint.newBuilder()
+                        .addEndpointApi(RegisteredServiceEndpoint.BlockNodeEndpoint.BlockNodeApi.PUBLISH)
+                        .addEndpointApi(RegisteredServiceEndpoint.BlockNodeEndpoint.BlockNodeApi.STATUS)
+                        .build())
+                .build();
+    }
+
+    private static void rewriteBlockNodesJson(final Path configPath, final long registeredNodeId) {
+        final String json = String.format("{\"nodes\":[{\"registeredNodeId\":%d,\"priority\":0}]}", registeredNodeId);
+        try {
+            Files.writeString(configPath, json);
+        } catch (final IOException e) {
+            throw new RuntimeException("Failed to rewrite block-nodes.json at " + configPath, e);
+        }
     }
 
     private Stream<DynamicTest> validateHappyPath(final int blocksToWait) {


### PR DESCRIPTION
**Description**:
This pull request introduces support for referencing registered node IDs in block node configurations, allowing configuration entries to resolve network addresses and ports dynamically from the current network state. It also adds the necessary plumbing to update this resolution as state changes, and extends the configuration model to track and expose the registered node ID used for each entry.

**Support for registered node IDs in block node configuration:**

* Added an optional `registered_node_id` field to the `BlockNodeConfig` proto, allowing configuration entries to reference a registered node in network state. If present, the system attempts to resolve addresses and ports from the registered node, with explicit values in the config taking precedence.
* Updated `BlockNodeConfigService` to use a pluggable `RegisteredNodeEndpointResolver` for resolving registered node IDs, with logic to merge explicit and resolved values and handle missing or incomplete state. [[1]](diffhunk://#diff-f2d37e95e357b01ae69d807607ba76c70888d2d9cd9a8e30d5bf667a8fe1cac4R88-R94) [[2]](diffhunk://#diff-f2d37e95e357b01ae69d807607ba76c70888d2d9cd9a8e30d5bf667a8fe1cac4R233-R245)
* Extended the configuration loading process to skip entries that cannot be resolved and lack sufficient explicit values, logging informative messages in these cases.

**Dependency injection and state update integration:**

* Modified the DI wiring in `BlockStreamModule` to inject and update the registered node resolver on state changes, ensuring that configuration resolution stays in sync with the network state. [[1]](diffhunk://#diff-857261b9da1b70aeed5d5331f663786e7e9ffc0572d71f819ac4fb9248438718R12) [[2]](diffhunk://#diff-857261b9da1b70aeed5d5331f663786e7e9ffc0572d71f819ac4fb9248438718L42-R48) [[3]](diffhunk://#diff-857261b9da1b70aeed5d5331f663786e7e9ffc0572d71f819ac4fb9248438718L126-R146)

**Configuration model enhancements:**

* Added a `registeredNodeId` field to `BlockNodeConfiguration` (with associated getter, equality, and string representation logic) to track the registered node ID used for each entry, and a sentinel value for entries without one. [[1]](diffhunk://#diff-a1d97451f45c460625c727b6b1ce1da4807f448db6dd2a9111c7075b6a8074d4R18-R21) [[2]](diffhunk://#diff-a1d97451f45c460625c727b6b1ce1da4807f448db6dd2a9111c7075b6a8074d4R30-R34) [[3]](diffhunk://#diff-a1d97451f45c460625c727b6b1ce1da4807f448db6dd2a9111c7075b6a8074d4R66) [[4]](diffhunk://#diff-a1d97451f45c460625c727b6b1ce1da4807f448db6dd2a9111c7075b6a8074d4R116-R130) [[5]](diffhunk://#diff-a1d97451f45c460625c727b6b1ce1da4807f448db6dd2a9111c7075b6a8074d4R156) [[6]](diffhunk://#diff-a1d97451f45c460625c727b6b1ce1da4807f448db6dd2a9111c7075b6a8074d4L146-R173) [[7]](diffhunk://#diff-a1d97451f45c460625c727b6b1ce1da4807f448db6dd2a9111c7075b6a8074d4L158-R186)

**Related issue(s)**:

Fixes #25802 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
