### PR TITLE
fix(consensus): charge each duplicate topic custom fee

### DIFF
--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
@@ -323,7 +323,7 @@ public class ConsensusSubmitMessageHandler implements TransactionHandler {
         final var assessedCustomFees = new ArrayList<AssessedCustomFee>();
 
         // 2. Dispatch each synthetic body
-        for (final var entry : syntheticBodies.entrySet()) {
+        for (final var entry : syntheticBodies) {
             final var syntheticBody = entry.getValue();
             final var cryptoTransferBody =
                     TransactionBody.newBuilder().cryptoTransfer(syntheticBody).build();

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/customfee/ConsensusCustomFeeAssessor.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/customfee/ConsensusCustomFeeAssessor.java
@@ -17,7 +17,6 @@ import com.hedera.hapi.node.transaction.FixedFee;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
@@ -35,16 +34,17 @@ public class ConsensusCustomFeeAssessor {
     }
 
     /**
-     * Constructs a map of synthetic crypto transfer transaction bodies.
-     * Each entry in the map represents a custom fee payment, with one transaction body per custom fee.
+     * Builds a synthetic crypto transfer body for each custom fee, one entry per fee.
+     * Returns a list (not a map) so identical duplicate fees are not collapsed: two equal
+     * {@link FixedCustomFee} entries would map to the same key, dropping one charge.
      *
      * @param customFees List of custom fees to be charged
      * @param payer The payer Account ID
-     * @return A map where each key is a FixedCustomFee and each value is a corresponding CryptoTransferTransactionBody.
+     * @return One (fee, CryptoTransferTransactionBody) pair per custom fee, preserving duplicates.
      */
-    public Map<FixedCustomFee, CryptoTransferTransactionBody> assessCustomFee(
+    public List<Map.Entry<FixedCustomFee, CryptoTransferTransactionBody>> assessCustomFee(
             @NonNull final List<FixedCustomFee> customFees, @NonNull final AccountID payer) {
-        final Map<FixedCustomFee, CryptoTransferTransactionBody> transactionBodies = new HashMap<>();
+        final List<Map.Entry<FixedCustomFee, CryptoTransferTransactionBody>> transactionBodies = new ArrayList<>();
 
         // build crypto transfer bodies for the first layer of custom fees,
         // if there is a second or third layer it will be assessed in crypto transfer handler
@@ -65,7 +65,7 @@ public class ConsensusCustomFeeAssessor {
                     .transfers(hbarTransfers.build())
                     .tokenTransfers(tokenTransfers);
 
-            transactionBodies.put(fee, syntheticBodyBuilder.build());
+            transactionBodies.add(Map.entry(fee, syntheticBodyBuilder.build()));
         }
 
         return transactionBodies;

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageHandlerTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusSubmitMessageHandlerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.google.protobuf.ByteString;
@@ -36,6 +37,7 @@ import com.hedera.hapi.node.consensus.ConsensusMessageChunkInfo;
 import com.hedera.hapi.node.consensus.ConsensusSubmitMessageTransactionBody;
 import com.hedera.hapi.node.state.consensus.Topic;
 import com.hedera.hapi.node.transaction.CustomFeeLimit;
+import com.hedera.hapi.node.transaction.FixedCustomFee;
 import com.hedera.hapi.node.transaction.FixedFee;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.consensus.ReadableTopicStore;
@@ -412,6 +414,43 @@ class ConsensusSubmitMessageHandlerTest extends ConsensusTestBase {
     }
 
     @Test
+    @DisplayName("assessCustomFee keeps two identical fees as separate entries")
+    void assessCustomFeeKeepsDuplicateFees() {
+        final var fee = FixedCustomFee.newBuilder()
+                .fixedFee(FixedFee.newBuilder().amount(1).build())
+                .feeCollectorAccountId(anotherPayer)
+                .build();
+
+        final var bodies = customFeeAssessor.assessCustomFee(List.of(fee, fee), payerId);
+
+        assertEquals(2, bodies.size());
+    }
+
+    @Test
+    @DisplayName("Two identical topic custom fees are charged twice, not collapsed")
+    void identicalTopicCustomFeesAreChargedTwice() {
+        final var dupFee = FixedCustomFee.newBuilder()
+                .fixedFee(FixedFee.newBuilder().amount(1).build())
+                .feeCollectorAccountId(anotherPayer)
+                .build();
+        givenTopicWithCustomFees(List.of(dupFee, dupFee));
+
+        given(handleContext.body()).willReturn(newSubmitMessageTxnWithHbarMaxFee(2));
+        given(handleContext.consensusNow()).willReturn(consensusTimestamp);
+        // hbar-only fees: payer + dispatch + not-fee-exempt (no token treasury lookup needed)
+        given(handleContext.payer()).willReturn(payerId);
+        given(handleContext.dispatch(any(DispatchOptions.class))).willReturn(streamBuilder);
+        given(streamBuilder.status()).willReturn(SUCCESS);
+        given(handleContext.keyVerifier()).willReturn(keyVerifier);
+        given(keyVerifier.verificationFor(any(Key.class), any())).willReturn(signatureVerification);
+        given(signatureVerification.passed()).willReturn(false);
+
+        subject.handle(handleContext);
+
+        verify(handleContext, times(2)).dispatch(any(DispatchOptions.class));
+    }
+
+    @Test
     void testSimpleKeyVerifierFromWithEd25519Key() {
         List<Key> signatories = List.of(ED25519KEY);
 
@@ -500,6 +539,34 @@ class ConsensusSubmitMessageHandlerTest extends ConsensusTestBase {
                 .consensusSubmitMessage(submitMessageBuilder.build())
                 .maxCustomFees(maxCustomFees)
                 .build();
+    }
+
+    private TransactionBody newSubmitMessageTxnWithHbarMaxFee(final long hbarLimit) {
+        final var txnId = TransactionID.newBuilder().accountID(payerId).build();
+        final var maxCustomFees = List.of(CustomFeeLimit.newBuilder()
+                .accountId(payerId)
+                .fees(List.of(FixedFee.newBuilder().amount(hbarLimit).build()))
+                .build());
+        final var submitMessageBuilder = ConsensusSubmitMessageTransactionBody.newBuilder()
+                .topicID(TopicID.newBuilder().topicNum(topicEntityNum).build())
+                .message(Bytes.wrap("duplicate-fee-message"));
+        return TransactionBody.newBuilder()
+                .transactionID(txnId)
+                .consensusSubmitMessage(submitMessageBuilder.build())
+                .maxCustomFees(maxCustomFees)
+                .build();
+    }
+
+    private void givenTopicWithCustomFees(final List<FixedCustomFee> fees) {
+        topic = topic.copyBuilder().customFees(fees).build();
+        writableTopicState = writableTopicStateWithOneKey();
+        readableTopicState = readableTopicState();
+        given(readableStates.<TopicID, Topic>get(TOPICS_STATE_ID)).willReturn(readableTopicState);
+        given(writableStates.<TopicID, Topic>get(TOPICS_STATE_ID)).willReturn(writableTopicState);
+        readableStore = new ReadableTopicStoreImpl(readableStates, readableEntityCounters);
+        writableStore = new WritableTopicStore(writableStates, entityCounters);
+        given(storeFactory.readableStore(ReadableTopicStore.class)).willReturn(readableStore);
+        given(storeFactory.writableStore(WritableTopicStore.class)).willReturn(writableStore);
     }
 
     private TransactionBody newDefaultSubmitMessageTxn() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/ConsensusServiceSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/ConsensusServiceSimpleFeesSuite.java
@@ -3,7 +3,9 @@ package com.hedera.services.bdd.suites.fees;
 
 import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTopicInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.deleteTopic;
@@ -288,6 +290,24 @@ public class ConsensusServiceSimpleFeesSuite {
                         .fee(ONE_HBAR)
                         .via("submitTxn"),
                 validateChargedUsd("submitTxn", SUBMIT_MESSAGE_WITH_CUSTOM_FEE_BASE_USD));
+    }
+
+    @HapiTest
+    @DisplayName("two identical topic custom fees are both charged, not collapsed")
+    final Stream<DynamicTest> identicalTopicCustomFeesAreBothCharged() {
+        return hapiTest(
+                cryptoCreate("dupCollector").balance(0L),
+                cryptoCreate("dupPayer").balance(ONE_HUNDRED_HBARS),
+                createTopic("dupFeeTopic")
+                        .withConsensusCustomFee(fixedConsensusHbarFee(ONE_HBAR, "dupCollector"))
+                        .withConsensusCustomFee(fixedConsensusHbarFee(ONE_HBAR, "dupCollector")),
+                submitMessageTo("dupFeeTopic")
+                        .message("dup")
+                        .payingWith("dupPayer")
+                        .fee(ONE_HBAR)
+                        .via("dupSubmitTxn"),
+                getTxnRecord("dupSubmitTxn").hasAssessedCustomFeesSize(2),
+                getAccountBalance("dupCollector").hasTinyBars(2 * ONE_HBAR));
     }
 
     @HapiTest


### PR DESCRIPTION
Two identical custom fees on a topic only charged once. The assessor stored synthetic transfers in a `HashMap<FixedCustomFee, ...>`; value-based `equals`/`hashCode` made the duplicate overwrite, dropping one charge, while the fee-limit check (`totalAmountToBeCharged`) still summed both.

Assessor now returns a list (one entry per fee) instead of a map, so each fee is charged and the charge path matches the limit sum. No proto or status-code change.
