### PR TITLE
docs: Dedup knowledge base

### DIFF
--- a/platform-sdk/docs/consensus-layer/LAYOUT.md
+++ b/platform-sdk/docs/consensus-layer/LAYOUT.md
@@ -6,7 +6,7 @@ Canonical structure for the consensus-layer knowledge base in the repo. Tools (T
 
 ## Scope
 
-The consensus layer of the platform-sdk — the 11 topics under `architecture/topics/` and the cross-cutting catalogs that support them. Out of scope: execution-layer internals, block production, TSS, transaction-handling internals, application semantics.
+The consensus layer of the platform-sdk — the 13 topics under `architecture/topics/` and the cross-cutting catalogs that support them. Out of scope: execution-layer internals, block production, TSS, transaction-handling internals, application semantics.
 
 ## Directory tree
 
@@ -29,7 +29,7 @@ platform-sdk/docs/consensus-layer/
 ├── architecture/
 │   ├── README.md
 │   ├── overview.md                        high-level shape; adapts from Consensus-Layer.md
-│   ├── topics/                            one file per topic (the 11)
+│   ├── topics/                            one file per topic (the 13)
 │   │   ├── wiring-framework.md
 │   │   ├── gossip.md
 │   │   ├── event-intake.md
@@ -37,7 +37,9 @@ platform-sdk/docs/consensus-layer/
 │   │   ├── hashgraph.md
 │   │   ├── health-monitor-and-backpressure.md
 │   │   ├── reasons-not-to-gossip.md
+│   │   ├── quiescence.md
 │   │   ├── signed-state-management.md
+│   │   ├── iss-detection.md
 │   │   ├── restart-and-pces.md
 │   │   ├── freeze-and-upgrade.md
 │   │   └── reconnect.md
@@ -134,7 +136,7 @@ Single file. Controlled vocabulary of observable symptoms (`SYM-NNN`) referenced
 
 The topic-organized lens on the consensus layer.
 - `architecture/overview.md` — adapts the high-level shape from `Consensus-Layer.md` for KB use.
-- `architecture/topics/` — one file per topic (the 11). Each describes the topic's responsibilities, state, contracts, and links to related concepts, invariants, decisions, and scenarios.
+- `architecture/topics/` — one file per topic (the 13). Each describes the topic's responsibilities, state, contracts, and links to related concepts, invariants, decisions, and scenarios.
 - `architecture/interfaces/consensus-execution-boundary.md` — the Consensus public API (`initialize`, `destroy`, `nextRound`, `onBehind`, `onPreHandleEvent`, `getTransactionsForEvent`, etc.).
 
 ### `decisions/`

--- a/platform-sdk/docs/consensus-layer/README.md
+++ b/platform-sdk/docs/consensus-layer/README.md
@@ -2,7 +2,7 @@
 
 Reference documentation for the consensus layer of the platform-sdk — the subsystem that reaches Byzantine-fault-tolerant agreement on event ordering using a hashgraph-based algorithm.
 
-The KB covers eleven topics — wiring, gossip, event intake, event creation, the hashgraph algorithm, health monitoring and backpressure, reasons not to gossip, signed state management, restart and PCES, freeze and upgrade, and reconnect — and the cross-cutting catalogs that support them.
+The KB covers thirteen topics — wiring, gossip, event intake, event creation, the hashgraph algorithm, health monitoring and backpressure, reasons not to gossip, quiescence, signed state management, ISS detection, restart and PCES, freeze and upgrade, and reconnect — and the cross-cutting catalogs that support them.
 
 **Current implementation is canonical.** Entries describe what runs today, anchored to specific files, classes, and methods. The proposed future shape from `../proposals/consensus-layer/Consensus-Layer.md` appears only as clearly-marked sidebars in topic files and is tracked per-topic under `delta-map/`.
 

--- a/platform-sdk/docs/consensus-layer/architecture/topics/event-creator.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/event-creator.md
@@ -147,7 +147,7 @@ computed by `Tipset#getTipAdvancementWeight(NodeId selfId, Tipset that)`
 
 The snapshot is the moving baseline against which improvement is
 measured. `TipsetWeightCalculator` holds the current `snapshot` and a
-bounded `snapshotHistory` (default `tipsetSnapshotHistorySize = 10`).
+bounded `snapshotHistory` (sized by `tipsetSnapshotHistorySize`, TUN-136).
 Whenever `TipsetWeightCalculator#addEventAndGetAdvancementWeight`
 (lines 165–198) is called for a new self-event, it computes the
 partial-weighted score of that event's tipset against the current
@@ -269,7 +269,7 @@ rule agrees. The rules cover distinct concerns.
 - **`PlatformHealthRule`**
   (`consensus-event-creator-impl/.../rules/PlatformHealthRule.java`)
   blocks event creation whenever the duration reported via `reportUnhealthyDuration`
-  exceeds `maximumPermissibleUnhealthyDuration` (default `1s`),
+  exceeds `maximumPermissibleUnhealthyDuration` (TUN-138),
   giving slow downstream components room to catch up. The signal
   framework that produces the unhealthy-duration measurement lives
   in [health-monitor-and-backpressure.md](health-monitor-and-backpressure.md).

--- a/platform-sdk/docs/consensus-layer/architecture/topics/gossip.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/gossip.md
@@ -85,10 +85,10 @@ Layered on the RPC pipeline, simple broadcast pushes each self-event to every co
 
 `RpcOverloadMonitor` (`platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcOverloadMonitor.java`) enforces the simple-backpressure rule per peer:
 
-- Output queue size exceeds `BroadcastConfig.throttleOutputQueueThreshold` (default `200` items), or
-- Round-trip ping time exceeds `BroadcastConfig.disablePingThreshold` (default `900ms`).
+- Output queue size exceeds `BroadcastConfig.throttleOutputQueueThreshold` (TUN-154), or
+- Round-trip ping time exceeds `BroadcastConfig.disablePingThreshold` (TUN-153).
 
-When either trips, broadcast is paused for `BroadcastConfig.pauseOnLag` (default `30s`) and sync handles the connection during the cooldown. See `BroadcastConfig` (`platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/BroadcastConfig.java`).
+When either trips, broadcast is paused for `BroadcastConfig.pauseOnLag` (TUN-155) and sync handles the connection during the cooldown. See `BroadcastConfig` (`platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/BroadcastConfig.java`).
 
 Broadcast remains disabled until the initial sync with a peer completes, so newly connected nodes catch up via sync first.
 

--- a/platform-sdk/docs/consensus-layer/architecture/topics/gossip.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/gossip.md
@@ -123,4 +123,4 @@ Gossip permits, queue-overflow signalling, and the global health-monitor feedbac
 
 ## Future state (sidebar)
 
-The [Consensus-Layer proposal](../../../proposals/consensus-layer/Consensus-Layer.md) introduces a Sheriff module for peer discipline, layered above gossip rather than replacing any current mechanism. Sheriff is not present in current code; this topic intentionally does not assert peer-discipline semantics tied to it.
+The proposal's Sheriff module for peer discipline would layer *above* gossip rather than replace any current mechanism; it is absent from current code, so this topic does not assert peer-discipline semantics tied to it. Sheriff is described for the whole layer in the [overview's Future state](../overview.md#future-state).

--- a/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
@@ -256,9 +256,10 @@ downstream view of pre-consensus output stays complete.
 
 > **Note on the paper.** Round, witness, strongly-seeing, fame, and
 > judge mean the same thing in the paper and in the code. The notable
-> divergence is the ancient/expired horizon: the paper uses the
-> deterministic generation (max parent generation + 1) to define
-> ancient-ness, and the current code uses `birthRound` instead. The
+> divergence is the ancient/expired horizon — the paper uses an event's
+> deterministic generation where the current code uses `birthRound`; see
+> [`../concepts/birth-round.md`](../concepts/birth-round.md) for that
+> substitution. The
 > implementation also carries a few quantities that do not appear in
 > the paper — `NGen` (a locally-computed, non-deterministic generation
 > used only for picking a topological order and for
@@ -335,13 +336,9 @@ Conceptual background:
 
 ## Future state
 
-> **Future state.** The proposal envisions a single Consensus public
-> API on which Execution calls `nextRound(roster)` to pull each round,
-> giving natural backpressure; today rounds flow over the wired
-> `consensusRoundOutputWire` and the boundary is split across
-> `ExecutionLayer` and `ConsensusStateEventHandler` in
-> `swirlds-platform-core`. The proposal also introduces a separate
-> Sheriff module that aggregates misbehavior reports; it is not present
-> in the current `consensus-hashgraph` module or anywhere else in the
-> code, and a reader looking for it inside the hashgraph topic will
-> not find it.
+> **Future state.** Two proposal items touch this topic: the
+> `nextRound(roster)` pull that would replace today's wired
+> `consensusRoundOutputWire`, and the Sheriff module (absent from
+> `consensus-hashgraph`, so a reader will not find it here). Both are
+> described once, for the whole layer, in the
+> [overview's Future state](../overview.md#future-state).

--- a/platform-sdk/docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md
@@ -92,39 +92,28 @@ See [restart-and-pces.md](restart-and-pces.md) for the replay lifecycle.
 
 ## Tunables
 
-All keys are sourced from the platform/Hedera `@ConfigData` records cited above. See [../../tunables.md](../../tunables.md) for the full catalog and any non-default deployment values.
+The detection cadence and per-reaction thresholds are all configured
+parameters; their defaults, types, and full effects live in the canonical
+catalog [../../tunables.md](../../tunables.md) and are not repeated here. The
+relevant entries, grouped by where they act:
 
-Detection (in `WiringConfig`, namespace `platform.wiring`):
-
-- `platform.wiring.healthMonitorEnabled` (default `true`) — master switch for the monitor.
-- `platform.wiring.healthMonitorHeartbeatPeriod` (default `1ms`) — polling cadence.
-- `platform.wiring.healthMonitorSchedulerCapacity` (default `500`) — capacity of the health monitor's own scheduler.
-- `platform.wiring.hardBackpressureEnabled` (default `false`) — when `true`, queue insertion would block at capacity; left off so the soft-signal model applies.
-- `platform.wiring.healthLogThreshold` (default `1s`) — minimum unhealthy duration before a log warning is emitted.
-- `platform.wiring.healthLogPeriod` (default `10m`) — minimum interval between warnings for the same scheduler.
-- `platform.wiring.healthyReportThreshold` (default `1s`) — interval at which a sustained healthy state is re-reported.
-
-Event-creation throttling (in `EventCreationConfig`):
-
-- `event.creation.maximumPermissibleUnhealthyDuration` (default `1s`) — gate for self-event creation.
-
-Gossip permits (in `SyncConfig`):
-
-- `sync.unhealthyGracePeriod` (default `1s`) — grace before permits start to be revoked.
-- `sync.permitsRevokedPerSecond` (default `5`) — revoke rate while unhealthy.
-- `sync.permitsReturnedPerSecond` (default `1`) — return rate while healthy.
-- `sync.minimumHealthyUnrevokedPermitCount` (default `1`) — floor of un-revoked permits when healthy.
-- `sync.keepSendingEventsWhenUnhealthy` (default `true`) — keep sending self events while unhealthy; only inbound processing is suppressed.
-
-Transaction acceptance (in Hedera-side `HederaConfig`):
-
-- `transaction.maximumPermissibleUnhealthySeconds` (default `1`) — gate for application transaction acceptance.
-
-PCES replay (in `PcesConfig`):
-
-- `event.preconsensus.replayHealthThreshold` (default `1ms`) — gate for PCES replay.
-- `event.preconsensus.limitReplayFrequency` (default `true`) — toggle for the replay rate limiter.
-- `event.preconsensus.maxEventReplayFrequency` (default `5000`) — maximum events per second replayed.
+- **Detection** (`WiringConfig`, `platform.wiring.*`): TUN-003
+  (`healthMonitorEnabled`), TUN-004 (`hardBackpressureEnabled`), TUN-007
+  (`healthMonitorSchedulerCapacity`), TUN-008 (`healthMonitorHeartbeatPeriod`),
+  TUN-009 (`healthLogThreshold`), TUN-010 (`healthLogPeriod`), TUN-011
+  (`healthyReportThreshold`).
+- **Event-creation throttling** (`EventCreationConfig`): TUN-138
+  (`maximumPermissibleUnhealthyDuration`).
+- **Gossip permits** (`SyncConfig`): TUN-181 (`unhealthyGracePeriod`), TUN-182
+  (`permitsRevokedPerSecond`), TUN-183 (`permitsReturnedPerSecond`), TUN-184
+  (`minimumHealthyUnrevokedPermitCount`), TUN-190
+  (`keepSendingEventsWhenUnhealthy`).
+- **PCES replay** (`PcesConfig`): TUN-126 (`replayHealthThreshold`), TUN-127
+  (`limitReplayFrequency`), TUN-128 (`maxEventReplayFrequency`).
+- **Transaction acceptance**: `transaction.maximumPermissibleUnhealthySeconds`
+  is a Hedera-side `HederaConfig` key, outside the consensus-layer tunables
+  catalog; see the [Transaction acceptance gate](#transaction-acceptance-gate)
+  reaction above for its behaviour.
 
 ## Cross-references
 

--- a/platform-sdk/docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md
@@ -125,4 +125,4 @@ relevant entries, grouped by where they act:
 
 ## Future state (sidebar)
 
-The Consensus-Layer proposal at [../../../proposals/consensus-layer/Consensus-Layer.md](../../../proposals/consensus-layer/Consensus-Layer.md) (see *Slow Execution*, around lines 227–270) introduces a coarser, module-API-level backpressure: Execution drives the rate at which `nextRound` is called, and the Hashgraph module never advances faster than Execution requests. This is an overlay on top of the wire-level / queue-saturation mechanism described above — a per-round sliding window in addition to the per-queue health signal, not a replacement for it.
+The proposal introduces a coarser, module-API-level backpressure (the `nextRound` pull; see the [overview's Future state](../overview.md#future-state)): Execution drives the rate at which `nextRound` is called, and the Hashgraph module never advances faster than Execution requests. This is an overlay on top of the wire-level / queue-saturation mechanism described above — a per-round sliding window in addition to the per-queue health signal, not a replacement for it.

--- a/platform-sdk/docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/health-monitor-and-backpressure.md
@@ -25,7 +25,7 @@ The detection mechanism sits on top of the wiring substrate; for the underlying 
 
 ## Detection
 
-Detection lives in `swirlds-component-framework`, in `com.swirlds.component.framework.model.internal.monitor.HealthMonitor`. The model wires a heartbeat to `HealthMonitor.checkSystemHealth(Instant)` at construction time (`StandardWiringModel#StandardWiringModel`, around line 124: `buildHeartbeatWire(builder.getHealthMonitorPeriod()).solderTo(healthMonitorInputWire)`). The heartbeat period is `platform.wiring.healthMonitorHeartbeatPeriod` (default `1ms`).
+Detection lives in `swirlds-component-framework`, in `com.swirlds.component.framework.model.internal.monitor.HealthMonitor`. The model wires a heartbeat to `HealthMonitor.checkSystemHealth(Instant)` at construction time (`StandardWiringModel#StandardWiringModel`, around line 124: `buildHeartbeatWire(builder.getHealthMonitorPeriod()).solderTo(healthMonitorInputWire)`). The heartbeat period is `platform.wiring.healthMonitorHeartbeatPeriod` (TUN-008).
 
 For each watched scheduler the monitor compares `TaskScheduler.getUnprocessedTaskCount()` with `TaskScheduler.getCapacity()` (`HealthMonitor.checkSystemHealth`, line 123). A scheduler is "unhealthy" when its unprocessed-task count exceeds its capacity. Capacity is set per component via `TaskSchedulerBuilder.withUnhandledTaskCapacity(long)`; schedulers built with `UNLIMITED_CAPACITY` are skipped at registration time (`HealthMonitor` constructor, line 93) and are never reported as unhealthy.
 
@@ -36,7 +36,7 @@ Output reaches consumers two ways:
 - A wire publication via `StandardWiringModel.getHealthMonitorWire()` returning `OutputWire<Duration>` (line 165). Soldered to consumers in `swirlds-platform-core/.../PlatformWiring` (around lines 98–110): event creator, gossip module, and the execution layer (which forwards to `TransactionPoolNexus`).
 - A polled accessor `WiringModel.getUnhealthyDuration()` (line 174), used by PCES replay.
 
-A reported `Duration.ZERO` means all watched schedulers are healthy. A non-zero value means at least one scheduler is over capacity, with the magnitude indicating how long. To avoid spamming consumers, the monitor suppresses repeat reports of the same duration unless the system has been continuously healthy for `platform.wiring.healthyReportThreshold` (default `1s`), at which point a healthy state is re-asserted (`HealthMonitor.checkSystemHealth`, lines 142–157).
+A reported `Duration.ZERO` means all watched schedulers are healthy. A non-zero value means at least one scheduler is over capacity, with the magnitude indicating how long. To avoid spamming consumers, the monitor suppresses repeat reports of the same duration unless the system has been continuously healthy for `platform.wiring.healthyReportThreshold` (TUN-011), at which point a healthy state is re-asserted (`HealthMonitor.checkSystemHealth`, lines 142–157).
 
 The wire-soldered consumers (event creator, gossip, transaction acceptance) are therefore **edge-driven**: only deltas arrive, and each consumer's `reportUnhealthyDuration` handler is responsible for tracking the last value it saw. PCES is the exception — it polls `getUnhealthyDuration()` directly and always sees the current level.
 
@@ -48,7 +48,7 @@ Each reaction site reads the unhealthy-duration signal independently and applies
 
 Site: `consensus-event-creator-impl/.../rules/PlatformHealthRule.isEventCreationPermitted()` (line 40). Installed as one of the rules consulted by `DefaultEventCreationManager` (line 111: `rules.add(new PlatformHealthRule(config.maximumPermissibleUnhealthyDuration(), this::getUnhealthyDuration))`). The signal flows in through `EventCreationManager.reportUnhealthyDuration(Duration)`, soldered in `DefaultEventCreatorModule` (line 136).
 
-Trigger: when the reported unhealthy duration exceeds `event.creation.maximumPermissibleUnhealthyDuration` (default `1s`), the rule returns `false` from `isEventCreationPermitted()` and the event creator stops minting new self events. When the duration drops back to or below the threshold, event creation resumes; the rule reports `EventCreationStatus.OVERLOADED` while engaged.
+Trigger: when the reported unhealthy duration exceeds `event.creation.maximumPermissibleUnhealthyDuration` (TUN-138), the rule returns `false` from `isEventCreationPermitted()` and the event creator stops minting new self events. When the duration drops back to or below the threshold, event creation resumes; the rule reports `EventCreationStatus.OVERLOADED` while engaged.
 
 See [event-creator.md](event-creator.md) for the rest of the rules and the event-creation lifecycle.
 
@@ -58,11 +58,11 @@ Site: `consensus-gossip-impl/.../gossip/permits/SyncPermitProvider.reportUnhealt
 
 Triggers and rates:
 
-- Reactions are gated by a grace period: `SyncPermitProvider` only enters the unhealthy branch once the reported duration reaches `sync.unhealthyGracePeriod` (default `1s`). Brief blips below the grace period leave permits untouched.
-- While unhealthy, permits are revoked at `sync.permitsRevokedPerSecond` (default `5`).
-- When the system returns to healthy, permits are returned at `sync.permitsReturnedPerSecond` (default `1`).
-- A floor of `sync.minimumHealthyUnrevokedPermitCount` (default `1`) un-revoked permits is enforced as soon as the system becomes healthy, so a recovered system is not stuck at zero permits while it waits for the gradual return rate.
-- `sync.keepSendingEventsWhenUnhealthy` (default `true`) softens the reaction further: when set, the node continues to send its own events during an unhealthy period and only stops receiving and processing remote events. Continuing to send self events lets the rest of the network build on them, which prevents the local node's recent events — and the user transactions they carry — from going stale and expiring before they reach consensus.
+- Reactions are gated by a grace period: `SyncPermitProvider` only enters the unhealthy branch once the reported duration reaches `sync.unhealthyGracePeriod` (TUN-181). Brief blips below the grace period leave permits untouched.
+- While unhealthy, permits are revoked at `sync.permitsRevokedPerSecond` (TUN-182).
+- When the system returns to healthy, permits are returned at `sync.permitsReturnedPerSecond` (TUN-183).
+- A floor of `sync.minimumHealthyUnrevokedPermitCount` (TUN-184) un-revoked permits is enforced as soon as the system becomes healthy, so a recovered system is not stuck at zero permits while it waits for the gradual return rate.
+- `sync.keepSendingEventsWhenUnhealthy` (TUN-190) softens the reaction further: when set, the node continues to send its own events during an unhealthy period and only stops receiving and processing remote events. Continuing to send self events lets the rest of the network build on them, which prevents the local node's recent events — and the user transactions they carry — from going stale and expiring before they reach consensus.
 
 When `sync.keepSendingEventsWhenUnhealthy` is `true`, the health-driven permit revoke path is bypassed entirely: `SyncPermitProvider.computeRevokedPermits()` (line 274) guards the unhealthy-branch delta computation with `if (!keepSendingEventsWhenUnhealthy)`, so permit accounting and the keep-sending mode are mutually exclusive — only one of them reacts to an unhealthy report. Permit accounting still applies on reconnect: `SyncPermitProvider.revokeAll()` (line 194) is invoked when a reconnect begins, and the configured `permitsReturnedPerSecond` then slowly restores permits once the reconnect finishes.
 
@@ -82,9 +82,9 @@ Note: this is a **separate** config key from the event-creator threshold, even t
 
 Site: `consensus-pces-impl/.../replayer/PcesReplayer.waitUntilHealthy()` (line 206). The replay loop calls `waitUntilHealthy()` before each event (`PcesReplayer.replayPces`, line 172) and blocks (sleeping 100 ms at a time) until the supplied health check returns true.
 
-The health check is constructed in `consensus-pces-impl/.../DefaultPcesModule` (lines 124–133) as `() -> isLessThan(model.getUnhealthyDuration(), replayHealthThreshold)`. Trigger: when the polled unhealthy duration meets or exceeds `event.preconsensus.replayHealthThreshold` (default `1ms`, much tighter than the gossip-side `1s`).
+The health check is constructed in `consensus-pces-impl/.../DefaultPcesModule` (lines 124–133) as `() -> isLessThan(model.getUnhealthyDuration(), replayHealthThreshold)`. Trigger: when the polled unhealthy duration meets or exceeds `event.preconsensus.replayHealthThreshold` (TUN-126) — a much tighter threshold than the gossip-side grace period (TUN-181).
 
-In addition to the health gate, replay is rate-limited by a `RateLimiter` constructed with `event.preconsensus.maxEventReplayFrequency` (default `5000` events/second), checked at `PcesReplayer.replayPces` line 174. The rate limiter can be disabled via `event.preconsensus.limitReplayFrequency` (default `true`). The rate limiter exists because replay can vastly outstrip the rate at which the system can ingest events — fast enough that the health monitor cannot detect the overload before the system is flooded, so a separate frequency cap is required.
+In addition to the health gate, replay is rate-limited by a `RateLimiter` constructed with `event.preconsensus.maxEventReplayFrequency` (TUN-128), checked at `PcesReplayer.replayPces` line 174. The rate limiter can be disabled via `event.preconsensus.limitReplayFrequency` (TUN-127). The rate limiter exists because replay can vastly outstrip the rate at which the system can ingest events — fast enough that the health monitor cannot detect the overload before the system is flooded, so a separate frequency cap is required.
 
 PCES is the only reaction site that polls the signal rather than receiving it on a wire; this is appropriate because the replay loop is naturally a polling site and benefits from the freshest possible value.
 

--- a/platform-sdk/docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md
@@ -58,7 +58,8 @@ ranges are accurate at last review and may shift with refactors.
 - Code anchor: [`consensus-pces`](../../../../consensus-pces) PCES writer;
   the wiring routes self-events through the writer before they reach the
   gossip path. Configuration: `event.preconsensus.inlinePcesSyncOption`
-  (default `EVERY_SELF_EVENT`).
+  (TUN-129; default `DONT_SYNC` — the durability guarantee holds without a
+  per-event fsync, see [`restart-and-pces.md`](restart-and-pces.md)).
 - Rationale: a self-event gossiped before persistence can cause a branch
   on restart, since the node may rebuild a different self-event on the
   same self-parent. Documented in

--- a/platform-sdk/docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md
@@ -305,6 +305,7 @@ ranges are accurate at last review and may shift with refactors.
 > **Future state.** The proposal's **Sheriff** module (described for the
 > whole layer in the [overview's Future state](../overview.md#future-state))
 > would absorb some peer-discipline rules. Of this catalog, "peer fallen
-> behind" and parts of the broadcast-not-running composite may move under
-> Sheriff once it lands; others are protocol invariants that will not. No
-> `Sheriff` exists in current code; this file describes current code only.
+>
+>> behind" and parts of the broadcast-not-running composite may move under
+>> Sheriff once it lands; others are protocol invariants that will not. No
+>> `Sheriff` exists in current code; this file describes current code only.

--- a/platform-sdk/docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md
@@ -302,13 +302,9 @@ ranges are accurate at last review and may shift with refactors.
 
 ## Future state
 
-> **Future state.** The proposal introduces a separate **Sheriff** module
-> that aggregates misbehavior reports from Gossip and Event Intake and
-> decides when to "shun" or "welcome" a neighbor. No `Sheriff` module or
-> class exists in current code; the rules in this catalog are
-> distributed across the gossip protocol classes. Some rules — for
-> example "peer fallen behind" and parts of the broadcast-not-running
-> composite — may move under Sheriff once it lands; others are protocol
-> invariants that will not. This file describes current code only; the
-> proposal is in
-> [`Consensus-Layer.md`](../../../proposals/consensus-layer/Consensus-Layer.md).
+> **Future state.** The proposal's **Sheriff** module (described for the
+> whole layer in the [overview's Future state](../overview.md#future-state))
+> would absorb some peer-discipline rules. Of this catalog, "peer fallen
+> behind" and parts of the broadcast-not-running composite may move under
+> Sheriff once it lands; others are protocol invariants that will not. No
+> `Sheriff` exists in current code; this file describes current code only.

--- a/platform-sdk/docs/consensus-layer/architecture/topics/restart-and-pces.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/restart-and-pces.md
@@ -66,8 +66,8 @@ writtenEventOutputWire.solderTo(components.eventCreatorModule().orderedEventInpu
 The general guarantee applies to every event: consensus never observes an event whose write has not returned. Applied
 specifically to self-events on the gossip path, the same guarantee also serves an anti-branching role. If a node
 gossiped a self-event and crashed before it was written, on restart the node would not know the event existed and could
-build a new self-event on the same self-parent — a hashgraph branch. Branches are an attack on consensus and are
-punishable; honest nodes must not branch. Persisting self-events before they reach gossip eliminates that gap.
+build a new self-event on the same self-parent — a hashgraph branch (a Byzantine fault; see
+[`../concepts/branching.md`](../concepts/branching.md)). Persisting self-events before they reach gossip eliminates that gap.
 
 The `OBSERVING` status provides a secondary defense against branching in case PCES data is lost from disk. A restarting
 node sits in `OBSERVING` — gossiping but not creating events — for a configurable window, giving it time to pick up any

--- a/platform-sdk/docs/consensus-layer/architecture/topics/wiring-framework.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/wiring-framework.md
@@ -159,4 +159,4 @@ A few specifics worth pinning down. The default `unhandledTaskCapacity` on the f
 
 ## Future state (sidebar)
 
-> A planned **module-API-level** backpressure will operate above wire-level backpressure, not in place of it. Execution will drive a `nextRound` pull that throttles Consensus end-to-end across the module boundary. The two layers compose: wire-level backpressure remains the per-component mechanism; the `nextRound` pull is an additional throttle at the Consensus / Execution boundary. See `../interfaces/consensus-execution-boundary.md` *(planned)* for where the module-API backpressure differs from the wire-level mechanism described above.
+> A planned **module-API-level** backpressure (the `nextRound` pull; see the [overview's Future state](../overview.md#future-state)) will operate *above* wire-level backpressure, not in place of it. The two compose: wire-level backpressure stays the per-component mechanism, and the `nextRound` pull adds a throttle at the Consensus / Execution boundary. See [`../interfaces/consensus-execution-boundary.md`](../interfaces/consensus-execution-boundary.md) for the boundary view.

--- a/platform-sdk/docs/consensus-layer/concepts/voting.md
+++ b/platform-sdk/docs/consensus-layer/concepts/voting.md
@@ -24,8 +24,10 @@ is a *first vote* — does the voter directly see the candidate? If
 the prior-round witnesses that the voter strongly sees, with fame
 decided when a super-majority of weight lands on either side. When *d*
 is a multiple of the configured coin frequency the round is a *coin
-round*: the vote cannot decide fame, and a stalled vote falls back to
-a pseudo-random bit derived from the witness signature.
+round*: the vote cannot decide fame, and a voter that does not strongly
+see a super-majority falls back to a pseudo-random bit. The source of
+that bit and the rest of the coin-round mechanics live in
+[`coin-rounds.md`](coin-rounds.md).
 
 ## Example
 


### PR DESCRIPTION
Fixes #25899

This PR intentionally leaves some overlap between related rules and ADRs, since one describes the decision and the other describes the property and why it holds.