### PR TITLE
fix: resolve relative paths before WRAPS artifacts path consistency check

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
@@ -217,7 +217,9 @@ public class WrapsProvingKeyVerification {
     /**
      * Validates that the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} environment variable (which the native
      * WRAPS library reads to locate unpacked artifacts) is consistent with the extraction directory
-     * derived from {@code tss.wrapsProvingKeyPath} (the packed tar file).
+     * derived from {@code tss.wrapsProvingKeyPath} (the packed tar file). Relative paths are resolved
+     * against the working directory before comparison, so the default relative
+     * {@code tss.wrapsProvingKeyPath} is compatible with an absolute env var value.
      *
      * @param provingKeyPath the configured path to the packed proving key archive
      * @param envArtifactsPath the value of the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} env var, or null
@@ -239,8 +241,8 @@ public class WrapsProvingKeyVerification {
                     WRAPS_ARTIFACTS_ENV_VAR);
             return;
         }
-        final var envPath = Paths.get(envArtifactsPath).normalize();
-        final var normalizedTarget = extractionTarget.normalize();
+        final var envPath = Paths.get(envArtifactsPath).toAbsolutePath().normalize();
+        final var normalizedTarget = extractionTarget.toAbsolutePath().normalize();
         if (!envPath.startsWith(normalizedTarget)) {
             throw new IllegalStateException(WRAPS_ARTIFACTS_ENV_VAR + " (" + envArtifactsPath
                     + ") is not under the extraction directory (" + normalizedTarget

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
@@ -186,6 +186,25 @@ class WrapsProvingKeyVerificationTest {
     }
 
     @Test
+    void succeedsWithRelativeProvingKeyPathAndAbsoluteEnvArtifactsPath() {
+        // The default tss.wrapsProvingKeyPath is relative (data/keys/wraps) while the env var is
+        // typically absolute; both must be resolved against the working directory before comparison
+        final var provingKeyPath = Paths.get("data/keys/wraps-archive");
+        final var absoluteEnvPath =
+                Paths.get("data/keys/wraps").toAbsolutePath().toString();
+
+        assertDoesNotThrow(() -> validateArtifactsPathConsistency(provingKeyPath, absoluteEnvPath));
+    }
+
+    @Test
+    void throwsWithRelativeProvingKeyPathAndAbsoluteEnvArtifactsPathOutsideExtractionDir() {
+        final var provingKeyPath = Paths.get("data/keys/wraps-archive");
+        final var wrongEnvPath = "/completely/different/path";
+
+        assertThrows(IllegalStateException.class, () -> validateArtifactsPathConsistency(provingKeyPath, wrongEnvPath));
+    }
+
+    @Test
     void doesNotThrowWhenEnvArtifactsPathIsNull() {
         final var provingKeyPath = Paths.get("/opt/hgcapp/wraps-v1.0.0.tar.gz");
 


### PR DESCRIPTION
## Description

`validateArtifactsPathConsistency` compared the env var path against the extraction directory with a syntactic `Path.startsWith`, so the default relative `tss.wrapsProvingKeyPath=data/keys/wraps` could never match an absolute `TSS_LIB_WRAPS_ARTIFACTS_PATH`, failing node startup even when the env var pointed at the correct directory.

Resolve both paths with `toAbsolutePath()` before comparing.

## Verification

Verified the fix end-to-end with `solo-075-to-076-tss.sh`:

- Removed `tss.wrapsProvingKeyPath` (and the other `tss.wrapsProvingKey*` overrides) from the 0.76 application.properties, so the node uses main's default relative path `data/keys/wraps` — the exact config that previously threw the `IllegalStateException` at startup.
- Set the env var to an absolute path: `TSS_LIB_WRAPS_ARTIFACTS_PATH=/opt/hgcapp/services-hedera/HapiApp2.0/data/keys/wraps-unpacked` (a sibling of the tar, since with the default config `data/keys/wraps` is the downloaded archive file itself).

All four nodes confirmed `tss.wrapsProvingKeyPath = data/keys/wraps` in their effective config, passed validation, self-downloaded and extracted the v1.0.0 artifacts, and reached WRAPS proof construction. All script gates pass: upgrade clean, Block Node verifying blocks across the upgrade, mirror node imported the LedgerIdPublication.