### PR TITLE
refactor: remove legacy fee methods from token and crypto handlers

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoAddLiveHashHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoAddLiveHashHandler.java
@@ -5,8 +5,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -50,11 +48,5 @@ public class CryptoAddLiveHashHandler implements TransactionHandler {
         // because preHandle will throw a PreCheckException
         // before we get here
         throw new HandleException(ResponseCodeEnum.NOT_SUPPORTED);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(final FeeContext feeContext) {
-        return Fees.FREE;
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoApproveAllowanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoApproveAllowanceHandler.java
@@ -9,7 +9,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_PAYER_ACCOUNT_I
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NEGATIVE_ALLOWANCE_AMOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
-import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.CRYPTO_ALLOWANCE_SIZE;
 import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.LONG_SIZE;
 import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.NFT_ALLOWANCE_SIZE;
@@ -27,7 +26,6 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.NftID;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.AccountApprovalForAllAllowance;
@@ -43,8 +41,6 @@ import com.hedera.node.app.service.token.impl.WritableNftStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.ApproveAllowanceValidator;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -536,30 +532,6 @@ public class CryptoApproveAllowanceHandler implements TransactionHandler {
             // If owner is in modifications get the modified account from state
             return TokenHandlerHelper.getIfUsable(owner, accountStore, expiryValidator, INVALID_ALLOWANCE_OWNER_ID);
         }
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var body = feeContext.body();
-        final var op = body.cryptoApproveAllowanceOrThrow();
-        final var accountStore = feeContext.readableStore(ReadableAccountStore.class);
-
-        final var currentSecond =
-                body.transactionIDOrThrow().transactionValidStartOrThrow().seconds();
-        final var account = accountStore.getAccountById(feeContext.payer());
-
-        final var currentExpiry = account == null ? currentSecond : account.expirationSecond();
-        final long lifeTime = ESTIMATOR_UTILS.relativeLifetime(currentSecond, currentExpiry);
-        // If the value is being adjusted instead of inserting a new entry , the fee charged will be
-        // slightly less than the base price
-        final var adjustedBytes = getNewBytes(body.cryptoApproveAllowanceOrThrow(), account);
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .addBytesPerTransaction(bytesUsedInTxn(op))
-                .addRamByteSeconds(adjustedBytes > 0 ? (adjustedBytes * lifeTime) : 0)
-                .calculate();
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
@@ -19,16 +19,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_REQUIRED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
-import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.CREATE_SLOT_MULTIPLIER;
-import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.HOUR_TO_SECOND_MULTIPLIER;
-import static com.hedera.node.app.hapi.fees.usage.crypto.entities.CryptoEntitySizes.CRYPTO_ENTITY_SIZES;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BASIC_ENTITY_ID_SIZE;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BOOL_SIZE;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.INT_SIZE;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.LONG_SIZE;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.getAccountKeyStorageSize;
-import static com.hedera.node.app.hapi.utils.keys.KeyUtils.IMMUTABILITY_SENTINEL_KEY;
 import static com.hedera.node.app.hapi.utils.keys.KeyUtils.isEmpty;
 import static com.hedera.node.app.hapi.utils.keys.KeyUtils.isValid;
 import static com.hedera.node.app.service.token.AliasUtils.asKeyFromAlias;
@@ -50,25 +40,20 @@ import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePr
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
-import com.hedera.hapi.node.base.Duration;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.HookEntityId;
 import com.hedera.hapi.node.base.Key;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoCreateTransactionBody;
 import com.hedera.hapi.node.token.CryptoUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.entityid.EntityIdFactory;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.validators.CryptoCreateValidator;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
 import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -488,40 +473,6 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
                 .build());
 
         return builder.build();
-    }
-
-    @Override
-    @NonNull
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        // Variable bytes plus two additional longs for balance and auto-renew period; plus a boolean for receiver sig
-        // required.
-        final var op = feeContext.body().cryptoCreateAccountOrThrow();
-        final var keySize =
-                op.hasKey() ? getAccountKeyStorageSize(CommonPbjConverters.fromPbj(op.keyOrElse(Key.DEFAULT))) : 0L;
-        final var unlimitedAutoAssociations =
-                feeContext.configuration().getConfigData(EntitiesConfig.class).unlimitedAutoAssociationsEnabled();
-        final var maxAutoAssociationsSize =
-                !unlimitedAutoAssociations && op.maxAutomaticTokenAssociations() > 0 ? INT_SIZE : 0L;
-        final var baseSize = op.memo().length() + keySize + maxAutoAssociationsSize;
-        final var lifeTime = op.autoRenewPeriodOrElse(Duration.DEFAULT).seconds();
-        final var feeCalculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        final var fee = feeCalculator
-                .addBytesPerTransaction(baseSize + (2 * LONG_SIZE) + BOOL_SIZE)
-                .addRamByteSeconds((CRYPTO_ENTITY_SIZES.fixedBytesInAccountRepr() + baseSize) * lifeTime)
-                .addNetworkRamByteSeconds(BASIC_ENTITY_ID_SIZE * USAGE_PROPERTIES.legacyReceiptStorageSecs());
-        if (!unlimitedAutoAssociations && op.maxAutomaticTokenAssociations() > 0) {
-            fee.addRamByteSeconds(op.maxAutomaticTokenAssociations() * lifeTime * CREATE_SLOT_MULTIPLIER);
-        }
-        // Using SBS here because this part us not used in other calculations. It is a per hour cost
-        // so we convert to per second by multiplying by 1/3600. This will be changed with simple fees.
-        if (!op.hookCreationDetails().isEmpty()) {
-            fee.addStorageBytesSeconds(op.hookCreationDetails().size() * HOUR_TO_SECOND_MULTIPLIER);
-        }
-        if (IMMUTABILITY_SENTINEL_KEY.equals(op.key())) {
-            final var lazyCreationFee = feeContext.dispatchComputeFees(UPDATE_TXN_BODY_BUILDER, feeContext.payer());
-            return fee.calculate().plus(lazyCreationFee);
-        }
-        return fee.calculate();
     }
 
     private boolean isSystemFile(final long entityNum) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteAllowanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteAllowanceHandler.java
@@ -6,8 +6,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ALLOWANCE_OWNER
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.LONG_SIZE;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.NFT_DELETE_ALLOWANCE_SIZE;
 import static com.hedera.node.app.service.token.impl.validators.AllowanceValidator.isValidOwner;
 import static com.hedera.node.app.service.token.impl.validators.ApproveAllowanceValidator.getEffectiveOwner;
 import static com.hedera.node.app.spi.validation.Validations.mustExist;
@@ -18,7 +16,6 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.NftID;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.NftRemoveAllowance;
@@ -28,8 +25,6 @@ import com.hedera.node.app.service.token.impl.WritableNftStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.DeleteAllowanceValidator;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -199,19 +194,6 @@ public class CryptoDeleteAllowanceHandler implements TransactionHandler {
         final var nftAllowances = op.nftAllowances();
 
         deleteAllowanceValidator.validate(context, nftAllowances, payerAccount, accountStore);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var body = feeContext.body();
-        final var op = body.cryptoDeleteAllowanceOrThrow();
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .addBytesPerTransaction((long) op.nftAllowances().size() * NFT_DELETE_ALLOWANCE_SIZE
-                        + (long) countNftDeleteSerials(op.nftAllowances()) * LONG_SIZE)
-                .calculate();
     }
 
     private int countNftDeleteSerials(final List<NftRemoveAllowance> nftAllowancesList) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoDeleteHandler.java
@@ -9,14 +9,10 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.CryptoFeeBuilder;
 import com.hedera.node.app.service.addressbook.ReadableAccountNodeRelStore;
 import com.hedera.node.app.service.token.api.TokenServiceApi;
 import com.hedera.node.app.service.token.records.CryptoDeleteStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -80,17 +76,5 @@ public class CryptoDeleteHandler implements TransactionHandler {
                         context.expiryValidator(),
                         context.savepointStack().getBaseBuilder(CryptoDeleteStreamBuilder.class),
                         accountNodeRelStore);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        final var body = feeContext.body();
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj ->
-                        usageEstimator.getCryptoDeleteTxFeeMatrices(CommonPbjConverters.fromPbj(body), sigValueObj));
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountInfoHandler.java
@@ -33,7 +33,6 @@ import com.hedera.node.app.service.token.ReadableStakingInfoStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.api.AccountSummariesApi;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -177,18 +176,6 @@ public class CryptoGetAccountInfoHandler extends PaidQueryHandler {
                     instantSource.instant()));
             return Optional.of(info.build());
         }
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext queryContext) {
-        final var query = queryContext.query();
-        final var accountStore = queryContext.createStore(ReadableAccountStore.class);
-        final var op = query.cryptoGetInfoOrThrow();
-        final var accountId = op.accountIDOrElse(AccountID.DEFAULT);
-        final var account = accountStore.getAliasedAccountById(accountId);
-
-        return queryContext.feeCalculator().legacyCalculate(sigValueObj -> usageGiven(query, account));
     }
 
     private FeeData usageGiven(final com.hedera.hapi.node.transaction.Query query, final Account account) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountRecordsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoGetAccountRecordsHandler.java
@@ -6,7 +6,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseType.COST_ANSWER;
-import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
@@ -15,22 +14,16 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.QueryHeader;
 import com.hedera.hapi.node.base.ResponseHeader;
-import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoGetAccountRecordsResponse;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
-import com.hedera.hapi.node.transaction.TransactionRecord;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.CryptoFeeBuilder;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.records.RecordCache;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
-import com.hederahashgraph.api.proto.java.FeeData;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -104,26 +97,5 @@ public class CryptoGetAccountRecordsHandler extends PaidQueryHandler {
         }
 
         return Response.newBuilder().cryptoGetAccountRecords(response).build();
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext queryContext) {
-        final var query = queryContext.query();
-        final var accountStore = queryContext.createStore(ReadableAccountStore.class);
-        final var op = query.cryptoGetAccountRecordsOrThrow();
-        final var accountId = op.accountIDOrElse(AccountID.DEFAULT);
-        final var account = accountStore.getAccountById(accountId);
-        final var records = recordCache.getRecords(accountId);
-        return queryContext.feeCalculator().legacyCalculate(sigValueObj -> usageGivenFor(account, records));
-    }
-
-    private FeeData usageGivenFor(final Account account, List<TransactionRecord> pbjRecords) {
-        if (account == null) {
-            return CONSTANT_FEE_DATA;
-        }
-        final var records =
-                pbjRecords.stream().map(CommonPbjConverters::fromPbj).toList();
-        return usageEstimator.getCryptoAccountRecordsQueryFeeMatrices(records, null);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoTransferHandler.java
@@ -1,21 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.token.impl.handlers;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.SubType.DEFAULT;
 import static com.hedera.hapi.node.base.SubType.TOKEN_FUNGIBLE_COMMON;
 import static com.hedera.hapi.node.base.SubType.TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES;
 import static com.hedera.hapi.node.base.SubType.TOKEN_NON_FUNGIBLE_UNIQUE;
 import static com.hedera.hapi.node.base.SubType.TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
-import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.LONG_ACCOUNT_AMOUNT_BYTES;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage.LONG_BASIC_ENTITY_ID_SIZE;
-import static com.hedera.node.app.hapi.fees.usage.token.entities.TokenEntitySizes.TOKEN_ENTITY_SIZES;
 import static com.hedera.node.app.hapi.utils.CommonUtils.clampedAdd;
-import static com.hedera.node.app.hapi.utils.CommonUtils.clampedMultiply;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
 
@@ -33,20 +25,16 @@ import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
-import com.hedera.hapi.node.transaction.AssessedCustomFee;
 import com.hedera.node.app.service.entityid.EntityIdFactory;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableNftStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
-import com.hedera.node.app.service.token.impl.handlers.transfer.CustomFeeAssessmentStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferExecutor;
 import com.hedera.node.app.service.token.impl.handlers.transfer.hooks.HookCallsFactory;
 import com.hedera.node.app.service.token.impl.validators.CryptoTransferValidator;
 import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -56,13 +44,9 @@ import com.hedera.node.app.spi.workflows.TransactionHandler;
 import com.hedera.node.app.spi.workflows.WarmupContext;
 import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.config.data.AccountsConfig;
-import com.hedera.node.config.data.ContractsConfig;
-import com.hedera.node.config.data.FeesConfig;
 import com.hedera.node.config.data.HooksConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import javax.inject.Inject;
@@ -224,94 +208,6 @@ public class CryptoTransferHandler extends TransferExecutor implements Transacti
         final var recordBuilder = context.savepointStack().getBaseBuilder(CryptoTransferStreamBuilder.class);
 
         executeCryptoTransfer(txn, transferContext, context, recordBuilder);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var body = feeContext.body();
-        final var op = body.cryptoTransferOrThrow();
-        final var config = feeContext.configuration();
-        final var tokenMultiplier = config.getConfigData(FeesConfig.class).tokenTransferUsageMultiplier();
-
-        /* BPT calculations shouldn't include any custom fee payment usage */
-        int totalXfers =
-                op.transfersOrElse(TransferList.DEFAULT).accountAmounts().size();
-
-        var totalTokensInvolved = 0;
-        var totalTokenTransfers = 0;
-        var numNftOwnershipChanges = 0;
-        for (final var tokenTransfers : op.tokenTransfers()) {
-            totalTokensInvolved++;
-            totalTokenTransfers += tokenTransfers.transfers().size();
-            numNftOwnershipChanges += tokenTransfers.nftTransfers().size();
-        }
-
-        int weightedTokensInvolved = tokenMultiplier * totalTokensInvolved;
-        int weightedTokenXfers = tokenMultiplier * totalTokenTransfers;
-        final var bpt = weightedTokensInvolved * LONG_BASIC_ENTITY_ID_SIZE
-                + (weightedTokenXfers + totalXfers) * LONG_ACCOUNT_AMOUNT_BYTES
-                + TOKEN_ENTITY_SIZES.bytesUsedForUniqueTokenTransfers(numNftOwnershipChanges);
-
-        /* Include custom fee payment usage in RBS calculations */
-        var customFeeHbarTransfers = 0;
-        var customFeeTokenTransfers = 0;
-        final var involvedTokens = new HashSet<TokenID>();
-        final var customFeeAssessor = new CustomFeeAssessmentStep(op);
-        List<AssessedCustomFee> assessedCustomFees;
-        boolean triedAndFailedToUseCustomFees = false;
-        try {
-            assessedCustomFees = customFeeAssessor.assessNumberOfCustomFees(feeContext);
-        } catch (HandleException ex) {
-            final var status = ex.getStatus();
-            // If the transaction tried and failed to use custom fees, enable this flag.
-            // This is used to charge a different canonical fees.
-            triedAndFailedToUseCustomFees = status == INSUFFICIENT_PAYER_BALANCE_FOR_CUSTOM_FEE
-                    || status == INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE
-                    || status == CUSTOM_FEE_CHARGING_EXCEEDED_MAX_ACCOUNT_AMOUNTS;
-            assessedCustomFees = new ArrayList<>();
-        }
-        for (final var fee : assessedCustomFees) {
-            if (!fee.hasTokenId()) {
-                customFeeHbarTransfers++;
-            } else {
-                customFeeTokenTransfers++;
-                involvedTokens.add(fee.tokenId());
-            }
-        }
-        totalXfers += customFeeHbarTransfers;
-        weightedTokenXfers += tokenMultiplier * customFeeTokenTransfers;
-        weightedTokensInvolved += tokenMultiplier * involvedTokens.size();
-        long rbs = (totalXfers * LONG_ACCOUNT_AMOUNT_BYTES)
-                + TOKEN_ENTITY_SIZES.bytesUsedToRecordTokenTransfers(
-                        weightedTokensInvolved, weightedTokenXfers, numNftOwnershipChanges);
-
-        final var hookInfo =
-                getHookInfo(op, config.getConfigData(ContractsConfig.class).maxGasPerTransaction());
-        /* Get subType based on the above information */
-        final var subType = getSubType(
-                numNftOwnershipChanges,
-                totalTokenTransfers,
-                customFeeHbarTransfers,
-                customFeeTokenTransfers,
-                triedAndFailedToUseCustomFees);
-        final var fees = feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(subType)
-                .addBytesPerTransaction(bpt)
-                .addRamByteSeconds(rbs * USAGE_PROPERTIES.legacyReceiptStorageSecs())
-                .calculate();
-        if (hookInfo.numHookInvocations() > 0) {
-            final var hooksConfig = config.getConfigData(HooksConfig.class);
-            // We clamp each gas limit summed by the hook info in the [0, maxTxGasLimit] range; so with any
-            // reasonable gas price, this cannot overflow---clamped multiplication is just being paranoid
-            final long gasFees = clampedMultiply(hookInfo.totalGasLimitOfHooks(), feeContext.getGasPriceInTinycents());
-            final long hookFees =
-                    clampedMultiply(hookInfo.numHookInvocations(), hooksConfig.hookInvocationCostTinyCents());
-            final long tinyBarFees = feeContext.tinybarsFromTinycents(clampedAdd(gasFees, hookFees));
-            return fees.copyBuilder().addServiceFee(tinyBarFees).build();
-        }
-        return fees;
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -38,7 +38,6 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.HookEntityId;
 import com.hedera.hapi.node.base.Key;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoUpdateTransactionBody;
@@ -52,7 +51,6 @@ import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
 import com.hedera.node.app.service.token.records.CryptoUpdateStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -367,27 +365,6 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
                 op.stakedNodeId(),
                 accountStore,
                 context.networkInfo());
-    }
-
-    /**
-     * This method calculates the fees for the CryptoUpdate transaction.
-     * Currently, it just duplicates all the logic from mono-service
-     *
-     * @param feeContext the {@link FeeContext} with all information needed for the calculation
-     * @return the calculated fees
-     */
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        // Variable bytes plus two additional longs for balance and auto-renew period; plus a boolean for receiver sig
-        // required.
-        final var body = feeContext.body();
-        final var accountStore = feeContext.readableStore(ReadableAccountStore.class);
-        return cryptoUpdateFees(
-                body,
-                feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT),
-                accountStore,
-                feeContext.configuration());
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAccountWipeHandler.java
@@ -6,8 +6,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_WIPING_AMOUNT;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.node.app.service.token.impl.handlers.transfer.NFTOwnersChangeStep.removeFromList;
 import static com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator.verifyTokenInstanceAmounts;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
@@ -19,13 +17,11 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.NftID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -36,8 +32,6 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
 import com.hedera.node.app.service.token.records.TokenAccountWipeStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -51,7 +45,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -208,27 +201,6 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
         baseBuilderRecord.tokenType(token.tokenType());
     }
 
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var op = feeContext.body();
-        final var readableTokenStore = feeContext.readableStore(ReadableTokenStore.class);
-        final var tokenType = Optional.ofNullable(
-                        readableTokenStore.get(op.tokenWipeOrThrow().tokenOrElse(TokenID.DEFAULT)))
-                .map(Token::tokenType)
-                .orElse(TokenType.FUNGIBLE_COMMON);
-        final var meta = TOKEN_OPS_USAGE_UTILS.tokenWipeUsageFrom(CommonPbjConverters.fromPbj(op));
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(
-                        tokenType.equals(TokenType.FUNGIBLE_COMMON)
-                                ? SubType.TOKEN_FUNGIBLE_COMMON
-                                : SubType.TOKEN_NON_FUNGIBLE_UNIQUE)
-                .addBytesPerTransaction(meta.getBpt())
-                .addNetworkRamByteSeconds(meta.getTransferRecordDb() * USAGE_PROPERTIES.legacyReceiptStorageSecs())
-                .calculate();
-    }
-
     private ValidationResult validateSemantics(
             @NonNull final AccountID accountId,
             @NonNull final TokenID tokenId,
@@ -261,5 +233,7 @@ public final class TokenAccountWipeHandler implements TransactionHandler {
     }
 
     private record ValidationResult(
-            @NonNull Account account, @NonNull Token token, @NonNull TokenRelation accountTokenRel) {}
+            @NonNull Account account,
+            @NonNull Token token,
+            @NonNull TokenRelation accountTokenRel) {}
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
@@ -581,23 +581,6 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
     }
 
     /**
-     * Calculate the fees for the token airdrop transaction. Initially only the CryptoTransferFees is charged
-     * for the token airdrop transaction. The fees are charged based on number of pending airdrops that
-     * are created in the transaction. If there are no pending airdrops created, no extra fees is charged and
-     * only the CryptoTransferFees is charged.
-     */
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var op = feeContext.body().tokenAirdropOrThrow();
-        final var tokensConfig = feeContext.configuration().getConfigData(TokensConfig.class);
-        validateTrue(tokensConfig.airdropsEnabled(), NOT_SUPPORTED);
-        // Always charge CryptoTransferFee as base price and then each time a pending airdrop is created
-        // we charge airdrop fee in handle
-        return calculateCryptoTransferFees(feeContext, op.tokenTransfers());
-    }
-
-    /**
      * Calculates the CryptoTransfer fees by dispatching a synthetic CryptoTransfer transaction.
      *
      * @param feeContext the fee context

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAssociateToAccountHandler.java
@@ -7,7 +7,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_R
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKENS_PER_ACCOUNT_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_ID_REPEATED_IN_TOKEN_LIST;
-import static com.hedera.hapi.node.base.SubType.DEFAULT;
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
 import static com.hedera.node.app.service.token.impl.comparator.TokenComparators.TOKEN_ID_COMPARATOR;
 import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.hasAccountNumOrAlias;
@@ -26,16 +25,12 @@ import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.TxnUsageEstimator;
 import com.hedera.node.app.hapi.fees.usage.token.TokenAssociateUsage;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
-import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.TokenListChecks;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -186,40 +181,8 @@ public class TokenAssociateToAccountHandler extends BaseTokenHandler implements 
         return !tokenAssociationsLimited || (numAssociations + tokenIds.size() <= maxTokensPerAccount);
     }
 
-    private record Validated(@NonNull Account account, @NonNull List<Token> tokens) {}
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        final var body = feeContext.body();
-        final var op = body.tokenAssociateOrThrow();
-
-        final var calculator = feeContext.feeCalculatorFactory().feeCalculator(DEFAULT);
-        final var unlimitedAssociationsEnabled =
-                feeContext.configuration().getConfigData(EntitiesConfig.class).unlimitedAutoAssociationsEnabled();
-
-        // If the unlimited auto-associations feature is enabled, we calculate the fees in a new way, because the
-        // association price is changed to $0.05. When the feature is enabled the feeSchedules.json will be updated
-        // to reflect the price change and the else case will be removed.
-        // Until then, we calculate the fees using the legacy method.
-        // NOTE: If this flag is disabled, the feeSchedules.json should be modified as well
-        if (unlimitedAssociationsEnabled) {
-            calculator.resetUsage();
-            calculator.addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1));
-            calculator.addBytesPerTransaction(op.tokens().size());
-            return calculator.calculate();
-        } else {
-            final var accountId = op.accountOrThrow();
-            final var readableAccountStore = feeContext.readableStore(ReadableAccountStore.class);
-            final var account = readableAccountStore.getAccountById(accountId);
-            return feeContext
-                    .feeCalculatorFactory()
-                    .feeCalculator(DEFAULT)
-                    .legacyCalculate(
-                            sigValueObj -> usageGiven(CommonPbjConverters.fromPbj(body), sigValueObj, account));
-        }
-    }
+    private record Validated(
+            @NonNull Account account, @NonNull List<Token> tokens) {}
 
     private FeeData usageGiven(
             final com.hederahashgraph.api.proto.java.TransactionBody txn,

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenBurnHandler.java
@@ -9,20 +9,16 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_BURN_META
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TREASURY_MUST_OWN_BURNED_NFT;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator.verifyTokenInstanceAmounts;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
@@ -32,8 +28,6 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
 import com.hedera.node.app.service.token.records.TokenBurnStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -165,22 +159,6 @@ public final class TokenBurnHandler extends BaseTokenHandler implements Transact
         tokenBurnStreamBuilderRecord.tokenType(token.tokenType());
     }
 
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var op = feeContext.body();
-        final var meta = TOKEN_OPS_USAGE_UTILS.tokenBurnUsageFrom(CommonPbjConverters.fromPbj(op));
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(
-                        meta.getSerialNumsCount() > 0
-                                ? SubType.TOKEN_NON_FUNGIBLE_UNIQUE
-                                : SubType.TOKEN_FUNGIBLE_COMMON)
-                .addBytesPerTransaction(meta.getBpt())
-                .addNetworkRamByteSeconds(meta.getTransferRecordDb() * USAGE_PROPERTIES.legacyReceiptStorageSecs())
-                .calculate();
-    }
-
     private ValidationResult validateSemantics(
             @NonNull final TokenID tokenId,
             final long fungibleBurnCount,
@@ -204,5 +182,6 @@ public final class TokenBurnHandler extends BaseTokenHandler implements Transact
         return ownerID == null;
     }
 
-    private record ValidationResult(@NonNull Token token, @NonNull TokenRelation tokenTreasuryRel) {}
+    private record ValidationResult(
+            @NonNull Token token, @NonNull TokenRelation tokenTreasuryRel) {}
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCancelAirdropHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCancelAirdropHandler.java
@@ -20,14 +20,11 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.PendingAirdropId;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.token.TokenCancelAirdropTransactionBody;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableAirdropStore;
 import com.hedera.node.app.service.token.impl.util.PendingAirdropUpdater;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -124,18 +121,5 @@ public class TokenCancelAirdropHandler extends BaseTokenHandler implements Trans
         validateFalse(
                 op.pendingAirdrops().size() > tokensConfig.maxAllowedPendingAirdropsToCancel(),
                 PENDING_AIRDROP_ID_LIST_TOO_LONG);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        var tokensConfig = feeContext.configuration().getConfigData(TokensConfig.class);
-        validateTrue(tokensConfig.cancelTokenAirdropEnabled(), NOT_SUPPORTED);
-        final var feeCalculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        feeCalculator.resetUsage();
-
-        return feeCalculator
-                .addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1))
-                .calculate();
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenClaimAirdropHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenClaimAirdropHandler.java
@@ -17,8 +17,6 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.NftTransfer;
 import com.hedera.hapi.node.base.PendingAirdropId;
-import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenTransferList;
 import com.hedera.hapi.node.state.token.Token;
@@ -40,8 +38,6 @@ import com.hedera.node.app.service.token.impl.util.PendingAirdropUpdater;
 import com.hedera.node.app.service.token.impl.validators.CryptoTransferValidator;
 import com.hedera.node.app.service.token.impl.validators.TokenAirdropValidator;
 import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -192,19 +188,6 @@ public class TokenClaimAirdropHandler extends TransferExecutor implements Transa
                     TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY);
         }
         return standardAirdropIds;
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull FeeContext feeContext) {
-        var tokensConfig = feeContext.configuration().getConfigData(TokensConfig.class);
-        validateTrue(tokensConfig.airdropsClaimEnabled(), ResponseCodeEnum.NOT_SUPPORTED);
-        final var feeCalculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        feeCalculator.resetUsage();
-
-        return feeCalculator
-                .addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1))
-                .calculate();
     }
 
     private void createOrUpdateTransfers(

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenCreateHandler.java
@@ -5,9 +5,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
-import static com.hedera.node.app.hapi.fees.usage.token.entities.TokenEntitySizes.TOKEN_ENTITY_SIZES;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.verifyNotEmptyKey;
 import static com.hedera.node.app.service.token.impl.validators.CustomFeesValidator.SENTINEL_TOKEN_ID;
 import static com.hedera.node.app.spi.validation.ExpiryMeta.NA;
@@ -22,7 +19,6 @@ import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.TokenCreateTransactionBody;
 import com.hedera.hapi.node.transaction.CustomFee;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.entityid.EntityIdFactory;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
@@ -32,8 +28,6 @@ import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.CustomFeesValidator;
 import com.hedera.node.app.service.token.impl.validators.TokenCreateValidator;
 import com.hedera.node.app.service.token.records.TokenCreateStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -410,30 +404,6 @@ public class TokenCreateHandler extends BaseTokenHandler implements TransactionH
         } else {
             context.requireKeyIfReceiverSigRequired(collector, INVALID_CUSTOM_FEE_COLLECTOR);
         }
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        final var body = feeContext.body();
-        final var meta = TOKEN_OPS_USAGE_UTILS.tokenCreateUsageFrom(CommonPbjConverters.fromPbj(body));
-        final var op = body.tokenCreationOrThrow();
-        final var type = op.tokenType();
-
-        final long tokenSizes = TOKEN_ENTITY_SIZES.bytesUsedToRecordTokenTransfers(
-                        meta.getNumTokens(), meta.getFungibleNumTransfers(), meta.getNftsTransfers())
-                * USAGE_PROPERTIES.legacyReceiptStorageSecs();
-
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(tokenSubTypeFrom(
-                        type, op.hasFeeScheduleKey() || !op.customFees().isEmpty()))
-                .addBytesPerTransaction(meta.getBaseSize())
-                .addRamByteSeconds(tokenSizes)
-                .addNetworkRamByteSeconds(meta.getNetworkRecordRb() * USAGE_PROPERTIES.legacyReceiptStorageSecs())
-                .addRamByteSeconds((meta.getBaseSize() + meta.getCustomFeeScheduleSize()) * meta.getLifeTime())
-                .calculate();
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDeleteHandler.java
@@ -10,20 +10,16 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.token.TokenDeleteUsage;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -110,17 +106,6 @@ public class TokenDeleteHandler implements TransactionHandler {
         validateTrue(token.adminKey() != null, ResponseCodeEnum.TOKEN_IS_IMMUTABLE);
 
         return token;
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        final var op = feeContext.body();
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj -> usageGiven(CommonPbjConverters.fromPbj(op), sigValueObj));
     }
 
     private FeeData usageGiven(final com.hederahashgraph.api.proto.java.TransactionBody txn, final SigValueObj svo) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenDissociateFromAccountHandler.java
@@ -23,7 +23,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
@@ -31,17 +30,13 @@ import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.token.TokenDissociateTransactionBody;
 import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.token.TokenDissociateUsage;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
-import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.util.TokenRelListCalculator;
 import com.hedera.node.app.service.token.impl.validators.TokenListChecks;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -254,7 +249,8 @@ public class TokenDissociateFromAccountHandler implements TransactionHandler {
         return new ValidatedResult(acct, dissociations);
     }
 
-    private record ValidatedResult(@NonNull Account account, @NonNull List<Dissociation> dissociations) {}
+    private record ValidatedResult(
+            @NonNull Account account, @NonNull List<Dissociation> dissociations) {}
 
     private record Dissociation(
             @Nullable Token token,
@@ -263,22 +259,6 @@ public class TokenDissociateFromAccountHandler implements TransactionHandler {
             @NonNull Account acct,
             // This is the relation of the token's treasury account ID and the token ID
             @Nullable TokenRelation treasuryTokenRel) {}
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        final var body = feeContext.body();
-        final var op = body.tokenDissociateOrThrow();
-        final var accountId = op.accountOrThrow();
-        final var readableAccountStore = feeContext.readableStore(ReadableAccountStore.class);
-        final var account = readableAccountStore.getAccountById(accountId);
-
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj -> usageGiven(CommonPbjConverters.fromPbj(body), sigValueObj, account));
-    }
 
     public FeeData usageGiven(
             final com.hederahashgraph.api.proto.java.TransactionBody txn,

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFeeScheduleUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFeeScheduleUpdateHandler.java
@@ -6,21 +6,16 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.CUSTOM_SCHEDULE_ALREADY
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_FEE_SCHEDULE_KEY;
-import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage.LONG_BASIC_ENTITY_ID_SIZE;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
-import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.TokenFeeScheduleUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.CustomFee;
 import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
@@ -28,8 +23,6 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.CustomFeesValidator;
 import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -154,47 +147,6 @@ public class TokenFeeScheduleUpdateHandler implements TransactionHandler {
         validateTrue(token.hasFeeScheduleKey(), TOKEN_HAS_NO_FEE_SCHEDULE_KEY);
         validateTrue(op.customFees().size() <= config.maxCustomFeesAllowed(), CUSTOM_FEES_LIST_TOO_LONG);
         return token;
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var body = feeContext.body();
-        final var op = body.tokenFeeScheduleUpdateOrThrow();
-        final var token = feeContext.readableStore(ReadableTokenStore.class).get(op.tokenIdOrThrow());
-        final var tokenOpsUsage = new TokenOpsUsage();
-        var newFees = op.customFees();
-
-        // Ensure no null values for denominatingTokenId
-        newFees = newFees.stream()
-                .map(fee -> {
-                    if (fee.hasFixedFee() && fee.fixedFee().denominatingTokenId() == null) {
-                        return fee.copyBuilder()
-                                .fixedFee(fee.fixedFee()
-                                        .copyBuilder()
-                                        .denominatingTokenId(TokenID.DEFAULT)
-                                        .build())
-                                .build();
-                    }
-                    return fee;
-                })
-                .toList();
-
-        final var newReprBytes = tokenOpsUsage.bytesNeededToRepr(
-                newFees.stream().map(CommonPbjConverters::fromPbj).toList());
-        final var effConsTime =
-                body.transactionIDOrThrow().transactionValidStartOrThrow().seconds();
-        final var lifetime = Math.max(0, token == null ? 0 : token.expirationSecond() - effConsTime);
-        final List<CustomFee> customFees = token == null ? emptyList() : token.customFees();
-
-        final var existingFeeReprBytes = currentFeeScheduleSize(customFees, tokenOpsUsage);
-        final var rbsDelta = ESTIMATOR_UTILS.changeInBsUsage(existingFeeReprBytes, lifetime, newReprBytes, lifetime);
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .addBytesPerTransaction(LONG_BASIC_ENTITY_ID_SIZE + newReprBytes)
-                .addRamByteSeconds(rbsDelta)
-                .calculate();
     }
 
     private int currentFeeScheduleSize(List<CustomFee> feeSchedule, final TokenOpsUsage tokenOpsUsage) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFreezeAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenFreezeAccountHandler.java
@@ -4,13 +4,11 @@ package com.hedera.node.app.service.token.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.token.TokenFreezeAccountTransactionBody;
@@ -18,8 +16,6 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -130,16 +126,5 @@ public class TokenFreezeAccountHandler implements TransactionHandler {
 
         // Check that the token is associated to the account, and return it
         return TokenHandlerHelper.getIfUsable(accountId, tokenId, tokenRelStore);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var meta = TOKEN_OPS_USAGE_UTILS.tokenFreezeUsageFrom();
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .addBytesPerTransaction(meta.getBpt())
-                .calculate();
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetInfoHandler.java
@@ -14,7 +14,6 @@ import static com.hedera.hapi.node.base.TokenPauseStatus.PAUSED;
 import static com.hedera.hapi.node.base.TokenPauseStatus.PAUSE_NOT_APPLICABLE;
 import static com.hedera.hapi.node.base.TokenPauseStatus.UNPAUSED;
 import static com.hedera.node.app.hapi.utils.keys.KeyUtils.isEmpty;
-import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
@@ -25,20 +24,15 @@ import com.hedera.hapi.node.base.QueryHeader;
 import com.hedera.hapi.node.base.ResponseHeader;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.TokenID;
-import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.TokenGetInfoResponse;
 import com.hedera.hapi.node.token.TokenInfo;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
-import com.hedera.node.app.hapi.fees.usage.token.TokenGetInfoUsage;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.token.ReadableTokenStore;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hederahashgraph.api.proto.java.FeeData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -188,63 +182,6 @@ public class TokenGetInfoHandler extends PaidQueryHandler {
             info.customFees(token.customFees());
 
             return Optional.of(info.build());
-        }
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext queryContext) {
-        final var query = queryContext.query();
-        final var tokenStore = queryContext.createStore(ReadableTokenStore.class);
-        final var op = query.tokenGetInfoOrThrow();
-        final var tokenId = op.tokenOrElse(TokenID.DEFAULT);
-        final var token = tokenStore.get(tokenId);
-
-        return queryContext
-                .feeCalculator()
-                .legacyCalculate(sigValueObj -> usageGiven(CommonPbjConverters.fromPbj(query), token));
-    }
-
-    private FeeData usageGiven(final com.hederahashgraph.api.proto.java.Query query, final Token token) {
-        if (token != null) {
-            final var estimate = TokenGetInfoUsage.newEstimate(query)
-                    .givenCurrentAdminKey(
-                            token.hasAdminKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.adminKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentFreezeKey(
-                            token.hasFreezeKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.freezeKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentWipeKey(
-                            token.hasWipeKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.wipeKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentSupplyKey(
-                            token.hasSupplyKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.supplyKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentKycKey(
-                            token.hasKycKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.kycKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentPauseKey(
-                            token.hasPauseKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.pauseKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentMetadataKey(
-                            token.hasMetadataKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.metadataKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentName(token.name())
-                    .givenCurrentMemo(token.memo())
-                    .givenCurrentSymbol(token.symbol());
-            if (token.hasAutoRenewAccountId()) {
-                estimate.givenCurrentlyUsingAutoRenewAccount();
-            }
-            return estimate.get();
-        } else {
-            return CONSTANT_FEE_DATA;
         }
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetNftInfoHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGetNftInfoHandler.java
@@ -24,7 +24,6 @@ import com.hedera.node.app.hapi.fees.usage.token.TokenGetNftInfoUsage;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.token.ReadableNftStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -140,18 +139,6 @@ public class TokenGetNftInfoHandler extends PaidQueryHandler {
                     .build();
             return Optional.of(info);
         }
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext queryContext) {
-        final var query = queryContext.query();
-        final var nftStore = queryContext.createStore(ReadableNftStore.class);
-        final var op = query.tokenGetNftInfoOrThrow();
-        final var nftId = op.nftIDOrThrow();
-        final var nft = nftStore.get(nftId);
-
-        return queryContext.feeCalculator().legacyCalculate(sigValueObj -> usageGiven(query, nft));
     }
 
     private FeeData usageGiven(final com.hedera.hapi.node.transaction.Query query, final Nft nft) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGrantKycToAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenGrantKycToAccountHandler.java
@@ -11,19 +11,15 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.token.TokenGrantKycUsage;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -128,17 +124,6 @@ public class TokenGrantKycToAccountHandler implements TransactionHandler {
         // Throws if the token is unusable
         TokenHandlerHelper.getIfUsable(tokenId, tokenStore);
         return TokenHandlerHelper.getIfUsable(accountId, tokenId, tokenRelStore);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        final var op = feeContext.body();
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj -> usageGiven(CommonPbjConverters.fromPbj(op), sigValueObj));
     }
 
     private FeeData usageGiven(final com.hederahashgraph.api.proto.java.TransactionBody txn, final SigValueObj svo) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenMintHandler.java
@@ -11,10 +11,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TREASURY_ACCOUN
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_NFTS_IN_PRICE_REGIME_HAVE_BEEN_MINTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SERIAL_NUMBER_LIMIT_REACHED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_SUPPLY_KEY;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.node.app.service.token.impl.TokenServiceImpl.MAX_SERIAL_NO_ALLOWED;
-import static com.hedera.node.app.service.token.impl.TokenServiceImpl.THREE_MONTHS_IN_SECONDS;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
@@ -23,14 +20,12 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.NftID;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNftStore;
@@ -39,8 +34,6 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
 import com.hedera.node.app.service.token.records.TokenMintStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -276,32 +269,5 @@ public class TokenMintHandler extends BaseTokenHandler implements TransactionHan
                         .build())
                 .metadata(meta)
                 .build();
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var op = feeContext.body().tokenMintOrThrow();
-        final var subType = op.amount() > 0 ? SubType.TOKEN_FUNGIBLE_COMMON : SubType.TOKEN_NON_FUNGIBLE_UNIQUE;
-
-        final var calculator = feeContext.feeCalculatorFactory().feeCalculator(subType);
-        if (SubType.TOKEN_NON_FUNGIBLE_UNIQUE.equals(subType)) {
-            calculator.resetUsage();
-            // The price of nft mint should be increased based on number of signatures.
-            // The first signature is free and is accounted in the base price, so we only need to add
-            // the price of the rest of the signatures.
-            calculator.addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1));
-        }
-        // FUTURE: lifetime parameter is not being used by the function below, in order to avoid making changes
-        // to mono-service passed a default lifetime of 3 months here
-        final var meta = TOKEN_OPS_USAGE_UTILS.tokenMintUsageFrom(
-                CommonPbjConverters.fromPbj(feeContext.body()),
-                CommonPbjConverters.fromPbj(subType),
-                THREE_MONTHS_IN_SECONDS);
-
-        calculator.addBytesPerTransaction(meta.getBpt());
-        calculator.addRamByteSeconds(meta.getRbs());
-        calculator.addNetworkRamByteSeconds(meta.getTransferRecordDb() * USAGE_PROPERTIES.legacyReceiptStorageSecs());
-        return calculator.calculate();
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenPauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenPauseHandler.java
@@ -4,19 +4,15 @@ package com.hedera.node.app.service.token.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_WAS_DELETED;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -86,16 +82,5 @@ public class TokenPauseHandler implements TransactionHandler {
         if (!op.hasToken()) {
             throw new PreCheckException(INVALID_TOKEN_ID);
         }
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var meta = TOKEN_OPS_USAGE_UTILS.tokenPauseUsageFrom();
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .addBytesPerTransaction(meta.getBpt())
-                .calculate();
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenRejectHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenRejectHandler.java
@@ -261,14 +261,4 @@ public class TokenRejectHandler extends BaseTokenHandler implements TransactionH
 
         return createFungibleTransfer(tokenId, accountID, tokenRelation.balance(), token.treasuryAccountId());
     }
-
-    //    private SubType getSubType(final int numOfNFTRejections) {
-    //        return numOfNFTRejections != 0 ? TOKEN_NON_FUNGIBLE_UNIQUE : TOKEN_FUNGIBLE_COMMON;
-    //    }
-    //
-    //    private long calculateBytesPerTransaction(
-    //            final int weightedTokensInvolved, final int weightedFungibleTokens, final int numNFTRejections) {
-    //        return TOKEN_ENTITY_SIZES.bytesUsedToRecordTokenTransfers(
-    //                weightedTokensInvolved, weightedFungibleTokens, numNFTRejections);
-    //    }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenRejectHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenRejectHandler.java
@@ -15,10 +15,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TREASURY_ACCOUN
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_REFERENCE_REPEATED;
-import static com.hedera.hapi.node.base.SubType.TOKEN_FUNGIBLE_COMMON;
-import static com.hedera.hapi.node.base.SubType.TOKEN_NON_FUNGIBLE_UNIQUE;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
-import static com.hedera.node.app.hapi.fees.usage.token.entities.TokenEntitySizes.TOKEN_ENTITY_SIZES;
 import static com.hedera.node.app.hapi.utils.keys.KeyUtils.isValid;
 import static com.hedera.node.app.service.token.impl.util.CryptoTransferHelper.createFungibleTransfer;
 import static com.hedera.node.app.service.token.impl.util.CryptoTransferHelper.createNftTransfer;
@@ -35,7 +31,6 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.NftID;
 import com.hedera.hapi.node.base.NftTransfer;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenTransferList;
 import com.hedera.hapi.node.state.token.Account;
@@ -48,15 +43,12 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.transfer.AdjustFungibleTokenChangesStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.NFTOwnersChangeStep;
 import com.hedera.node.app.service.token.impl.handlers.transfer.TransferContextImpl;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hedera.node.config.data.FeesConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.TokensConfig;
 import com.swirlds.base.utility.Pair;
@@ -270,49 +262,13 @@ public class TokenRejectHandler extends BaseTokenHandler implements TransactionH
         return createFungibleTransfer(tokenId, accountID, tokenRelation.balance(), token.treasuryAccountId());
     }
 
-    @NonNull
-    @Override
-    public Fees calculateFees(final FeeContext feeContext) {
-        final var body = feeContext.body();
-        final var op = body.tokenRejectOrThrow();
-        final var config = feeContext.configuration();
-        final var tokenMultiplier =
-                requireNonNull(config).getConfigData(FeesConfig.class).tokenTransferUsageMultiplier();
-
-        final int totalRejections = op.rejections().size();
-        int numOfFungibleTokenRejections = 0;
-        int numOfNFTRejections = 0;
-        for (final var rejection : op.rejections()) {
-            if (rejection.hasFungibleToken()) {
-                // Each fungible token rejection involves 2 AccountAmount transfers
-                // We add 2 in order to match CryptoTransfer's bpt & rbs fee calculation
-                numOfFungibleTokenRejections += 2;
-            } else {
-                numOfNFTRejections++;
-            }
-        }
-
-        final int weightedTokensInvolved = tokenMultiplier * totalRejections;
-        final int weightedFungibleTokens = tokenMultiplier * numOfFungibleTokenRejections;
-        final long bpt =
-                calculateBytesPerTransaction(weightedTokensInvolved, weightedFungibleTokens, numOfNFTRejections);
-        final long rbs = USAGE_PROPERTIES.legacyReceiptStorageSecs() * bpt;
-
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(getSubType(numOfNFTRejections))
-                .addBytesPerTransaction(bpt)
-                .addRamByteSeconds(rbs)
-                .calculate();
-    }
-
-    private SubType getSubType(final int numOfNFTRejections) {
-        return numOfNFTRejections != 0 ? TOKEN_NON_FUNGIBLE_UNIQUE : TOKEN_FUNGIBLE_COMMON;
-    }
-
-    private long calculateBytesPerTransaction(
-            final int weightedTokensInvolved, final int weightedFungibleTokens, final int numNFTRejections) {
-        return TOKEN_ENTITY_SIZES.bytesUsedToRecordTokenTransfers(
-                weightedTokensInvolved, weightedFungibleTokens, numNFTRejections);
-    }
+    //    private SubType getSubType(final int numOfNFTRejections) {
+    //        return numOfNFTRejections != 0 ? TOKEN_NON_FUNGIBLE_UNIQUE : TOKEN_FUNGIBLE_COMMON;
+    //    }
+    //
+    //    private long calculateBytesPerTransaction(
+    //            final int weightedTokensInvolved, final int weightedFungibleTokens, final int numNFTRejections) {
+    //        return TOKEN_ENTITY_SIZES.bytesUsedToRecordTokenTransfers(
+    //                weightedTokensInvolved, weightedFungibleTokens, numNFTRejections);
+    //    }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenRevokeKycFromAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenRevokeKycFromAccountHandler.java
@@ -11,19 +11,15 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.node.app.hapi.fees.usage.SigUsage;
 import com.hedera.node.app.hapi.fees.usage.token.TokenRevokeKycUsage;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -133,18 +129,6 @@ public class TokenRevokeKycFromAccountHandler implements TransactionHandler {
         // Throws if token is unusable
         TokenHandlerHelper.getIfUsable(tokenId, tokenStore);
         return TokenHandlerHelper.getIfUsable(accountId, tokenId, tokenRelStore);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        final var op = feeContext.body();
-
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj -> usageGiven(CommonPbjConverters.fromPbj(op), sigValueObj));
     }
 
     public FeeData usageGiven(final com.hederahashgraph.api.proto.java.TransactionBody txn, final SigValueObj svo) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnfreezeAccountHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnfreezeAccountHandler.java
@@ -5,13 +5,11 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_FREEZE_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.token.TokenUnfreezeAccountTransactionBody;
@@ -19,8 +17,6 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
 import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -134,16 +130,5 @@ public class TokenUnfreezeAccountHandler implements TransactionHandler {
 
         // Return the token relation
         return tokenRel;
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var meta = TOKEN_OPS_USAGE_UTILS.tokenUnfreezeUsageFrom();
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .addBytesPerTransaction(meta.getBpt())
-                .calculate();
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
@@ -4,19 +4,15 @@ package com.hedera.node.app.service.token.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_WAS_DELETED;
-import static com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsageUtils.TOKEN_OPS_USAGE_UTILS;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -88,16 +84,5 @@ public class TokenUnpauseHandler implements TransactionHandler {
         tokenStore.put(copyBuilder.build());
         final var recordBuilder = context.savepointStack().getBaseBuilder(TokenBaseStreamBuilder.class);
         recordBuilder.tokenType(token.tokenType());
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var meta = TOKEN_OPS_USAGE_UTILS.tokenUnpauseUsageFrom();
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .addBytesPerTransaction(meta.getBpt())
-                .calculate();
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -11,12 +11,9 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 import static com.hedera.hapi.node.base.TokenKeyValidation.NO_VALIDATION;
 import static com.hedera.hapi.node.base.TokenType.FUNGIBLE_COMMON;
-import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
-import static com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage.txnEstimateFactory;
 import static com.hedera.node.app.hapi.utils.keys.KeyUtils.isValid;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
 import static com.hedera.node.app.service.token.impl.util.TokenKey.METADATA_KEY;
-import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 import static com.hedera.node.app.spi.validation.AttributeValidator.isKeyRemoval;
 import static com.hedera.node.app.spi.validation.Validations.mustExist;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
@@ -26,16 +23,11 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.KeyList;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.ThresholdKey;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.state.token.TokenRelation;
 import com.hedera.hapi.node.token.TokenUpdateTransactionBody;
-import com.hedera.node.app.hapi.fees.usage.SigUsage;
-import com.hedera.node.app.hapi.fees.usage.token.TokenUpdateUsage;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
-import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableTokenRelationStore;
@@ -43,8 +35,6 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.util.TokenKey;
 import com.hedera.node.app.service.token.impl.validators.TokenUpdateValidator;
 import com.hedera.node.app.service.token.records.TokenUpdateStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.validation.ExpiryMeta;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -52,11 +42,9 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
-import com.hederahashgraph.api.proto.java.FeeData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Arrays;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -592,69 +580,11 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
         tokenRelStore.put(newRelCopy.build());
     }
 
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        final var body = feeContext.body();
-        final var op = body.tokenUpdateOrThrow();
-        final var readableStore = feeContext.readableStore(ReadableTokenStore.class);
-        final var token = readableStore.get(op.tokenOrThrow());
-
-        return feeContext
-                .feeCalculatorFactory()
-                .feeCalculator(SubType.DEFAULT)
-                .legacyCalculate(sigValueObj -> usageGiven(CommonPbjConverters.fromPbj(body), sigValueObj, token));
-    }
-
     private boolean isHapiCallOrNonZeroTreasuryAccount(final boolean isHapiCall, final TokenUpdateTransactionBody op) {
         return isHapiCall || !isZeroAccount(op.treasuryOrElse(AccountID.DEFAULT));
     }
 
     private boolean isZeroAccount(@NonNull final AccountID accountID) {
         return accountID.equals(ZERO_ACCOUNT_ID);
-    }
-
-    private FeeData usageGiven(
-            final com.hederahashgraph.api.proto.java.TransactionBody txn, final SigValueObj svo, final Token token) {
-        final var sigUsage = new SigUsage(svo.getTotalSigCount(), svo.getSignatureSize(), svo.getPayerAcctSigCount());
-        if (token != null) {
-            final var estimate = TokenUpdateUsage.newEstimate(
-                            txn, txnEstimateFactory.get(sigUsage, txn, ESTIMATOR_UTILS))
-                    .givenCurrentAdminKey(
-                            token.hasAdminKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.adminKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentFreezeKey(
-                            token.hasFreezeKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.freezeKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentWipeKey(
-                            token.hasWipeKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.wipeKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentSupplyKey(
-                            token.hasSupplyKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.supplyKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentKycKey(
-                            token.hasKycKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.kycKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentPauseKey(
-                            token.hasPauseKey()
-                                    ? Optional.of(CommonPbjConverters.fromPbj(token.pauseKeyOrThrow()))
-                                    : Optional.empty())
-                    .givenCurrentName(token.name())
-                    .givenCurrentMemo(token.memo())
-                    .givenCurrentSymbol(token.symbol())
-                    .givenCurrentExpiry(token.expirationSecond());
-            if (token.hasAutoRenewAccountId()) {
-                estimate.givenCurrentlyUsingAutoRenewAccount();
-            }
-            return estimate.get();
-        } else {
-            return CONSTANT_FEE_DATA;
-        }
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateNftsHandler.java
@@ -14,7 +14,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.NftID;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.hapi.node.token.TokenUpdateNftsTransactionBody;
@@ -22,8 +21,6 @@ import com.hedera.node.app.service.token.ReadableNftStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableNftStore;
 import com.hedera.node.app.service.token.impl.validators.TokenAttributesValidator;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -127,21 +124,6 @@ public class TokenUpdateNftsHandler implements TransactionHandler {
                 nftStore.put(updatedNft);
             }
         }
-    }
-
-    /**
-     * The total price should be N * $0.001, where N is the number of NFTs in the transaction body.
-     * @param feeContext the {@link FeeContext} with all information needed for the calculation
-     * @return the total Fee
-     */
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        final var op = feeContext.body();
-        final var serials = op.tokenUpdateNftsOrThrow().serialNumbers();
-        final var feeCalculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.TOKEN_NON_FUNGIBLE_UNIQUE);
-        feeCalculator.resetUsage();
-        return feeCalculator.addBytesPerTransaction(serials.size()).calculate();
     }
 
     private void validateSemantics(

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoAddLiveHashHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoAddLiveHashHandlerTest.java
@@ -3,14 +3,10 @@ package com.hedera.node.app.service.token.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.mock;
 
 import com.hedera.node.app.service.token.impl.handlers.CryptoAddLiveHashHandler;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -53,12 +49,5 @@ class CryptoAddLiveHashHandlerTest {
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(NOT_SUPPORTED));
-    }
-
-    @Test
-    void calculateFeesFree() {
-        final var feeCtx = mock(FeeContext.class);
-        final var result = subject.calculateFees(feeCtx);
-        assertThat(result).isEqualTo(Fees.FREE);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
@@ -21,10 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.NftID;
@@ -37,17 +34,12 @@ import com.hedera.hapi.node.token.CryptoApproveAllowanceTransactionBody;
 import com.hedera.hapi.node.token.NftAllowance;
 import com.hedera.hapi.node.token.TokenAllowance;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.ReadableAccountStoreImpl;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.WritableNftStore;
 import com.hedera.node.app.service.token.impl.handlers.CryptoApproveAllowanceHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.ApproveAllowanceValidator;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -596,67 +588,6 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
         Assertions.assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(INVALID_PAYER_ACCOUNT_ID));
-    }
-
-    @Test
-    void calculateFeesHappyPath() {
-        final var txn = cryptoApproveAllowanceTransaction(
-                payerId,
-                Timestamp.newBuilder().seconds(account.expirationSecond() - 1).build(),
-                false,
-                List.of(cryptoAllowance),
-                List.of(tokenAllowance),
-                List.of(nftAllowance));
-        final var feeCtx = mock(FeeContext.class);
-        given(feeCtx.body()).willReturn(txn);
-        given(feeCtx.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
-        given(feeCtx.payer()).willReturn(payerId);
-
-        final var feeCalcFactory = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFactory);
-        given(feeCalcFactory.feeCalculator(notNull())).willReturn(feeCalc);
-        given(feeCalc.addBytesPerTransaction(anyLong())).willReturn(feeCalc);
-        given(feeCalc.addRamByteSeconds(anyLong())).willReturn(feeCalc);
-        // The fees wouldn't be free in this scenario, but we don't care about the actual return
-        // value here since we're using a mock calculator
-        given(feeCalc.calculate()).willReturn(Fees.FREE);
-
-        subject.calculateFees(feeCtx);
-
-        verify(feeCalc).addBytesPerTransaction(128);
-        verify(feeCalc).addRamByteSeconds(112);
-    }
-
-    @Test
-    void calculateFeesAccountNotFound() {
-        final var txn = cryptoApproveAllowanceTransaction(
-                payerId,
-                Timestamp.newBuilder().seconds(account.expirationSecond() - 1).build(),
-                false,
-                List.of(cryptoAllowance),
-                List.of(tokenAllowance),
-                List.of(nftAllowance));
-        final var feeCtx = mock(FeeContext.class);
-        given(feeCtx.body()).willReturn(txn);
-        given(feeCtx.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
-        given(feeCtx.payer())
-                .willReturn(AccountID.newBuilder().accountNum(Long.MAX_VALUE).build());
-
-        final var feeCalcFactory = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFactory);
-        given(feeCalcFactory.feeCalculator(notNull())).willReturn(feeCalc);
-        given(feeCalc.addBytesPerTransaction(anyLong())).willReturn(feeCalc);
-        given(feeCalc.addRamByteSeconds(anyLong())).willReturn(feeCalc);
-        // The fees wouldn't be free in this scenario, but we don't care about the actual return
-        // value here since we're using a mock calculator
-        given(feeCalc.calculate()).willReturn(Fees.FREE);
-
-        subject.calculateFees(feeCtx);
-
-        verify(feeCalc).addBytesPerTransaction(128);
-        verify(feeCalc).addRamByteSeconds(0);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
@@ -16,7 +16,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_REQUIRED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MEMO_TOO_LONG;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PROXY_ACCOUNT_ID_FIELD_IS_DEPRECATED;
-import static com.hedera.hapi.node.base.SubType.DEFAULT;
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.ACCOUNTS_STATE_ID;
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.ALIASES_STATE_ID;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
@@ -60,10 +59,7 @@ import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTe
 import com.hedera.node.app.service.token.impl.validators.CryptoCreateValidator;
 import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.service.token.records.HookDispatchStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
 import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
-import com.hedera.node.app.spi.fixtures.fees.FakeFeeCalculator;
 import com.hedera.node.app.spi.fixtures.ids.FakeEntityIdFactoryImpl;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.info.NetworkInfo;
@@ -155,23 +151,6 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
 
         given(handleContext.networkInfo()).willReturn(networkInfo);
         subject = new CryptoCreateHandler(new CryptoCreateValidator(), null, idFactory);
-    }
-
-    @Test
-    @DisplayName("test CalculateFees When Free")
-    void testCalculateFeesWhenFree(@Mock FeeCalculatorFactory feeCalculatorFactory) {
-        var transactionBody = new CryptoCreateBuilder()
-                .withStakedAccountId(3)
-                .withMemo("blank")
-                .withKey(A_COMPLEX_KEY)
-                .build();
-        final var feeCalculator = new FakeFeeCalculator();
-        given(feeContext.body()).willReturn(transactionBody);
-        given(feeContext.feeCalculatorFactory()).willReturn(feeCalculatorFactory);
-        given(feeCalculatorFactory.feeCalculator(DEFAULT)).willReturn(feeCalculator);
-        given(feeContext.configuration()).willReturn(configuration);
-        final var result = subject.calculateFees(feeContext);
-        assertThat(result).isEqualTo(Fees.FREE);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteAllowanceHandlerTest.java
@@ -27,10 +27,6 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.handlers.CryptoDeleteAllowanceHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.DeleteAllowanceValidator;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -40,7 +36,6 @@ import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -317,43 +312,6 @@ class CryptoDeleteAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
         assertThat(writableNftStore.get(nftIdSl2).ownerId()).isEqualTo(payerId);
         assertThat(writableNftStore.get(nftIdSl1).spenderId()).isNull();
         assertThat(writableNftStore.get(nftIdSl2).spenderId()).isNull();
-    }
-
-    @Test
-    @DisplayName("check that fees are 1 for delete account allowance trx")
-    void testCalculateFeesReturnsCorrectFeeForDeleteAccountAllowance() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        final var txnBody = cryptoDeleteAllowanceTransaction(payerId);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCtx.body()).willReturn(txnBody);
-        given(feeCalcFact.feeCalculator(any())).willReturn(feeCalc);
-        given(feeCalc.addBytesPerTransaction(anyLong())).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(new Fees(1, 0, 0));
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(new Fees(1, 0, 0));
-    }
-
-    @Test
-    @DisplayName("calculate fees correctly considering bytes per transaction")
-    void testCalculateFeesConsideringBytesPerTransaction() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        final var txnBody = cryptoDeleteAllowanceTransaction(payerId);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCtx.body()).willReturn(txnBody);
-        given(feeCalcFact.feeCalculator(any())).willReturn(feeCalc);
-        final var cryptoDeleteAllowanceTransactionBody = txnBody.cryptoDeleteAllowanceOrThrow();
-        final var longSize = 8L;
-        final var nftDeleteAllowanceSize = 6 * longSize;
-        final var bytesPerTransaction =
-                cryptoDeleteAllowanceTransactionBody.nftAllowances().size() * nftDeleteAllowanceSize + (2 * longSize);
-        given(feeCalc.addBytesPerTransaction(bytesPerTransaction)).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(new Fees(1, 0, 0));
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(new Fees(1, 0, 0));
     }
 
     private TransactionBody cryptoDeleteAllowanceTransaction(final AccountID txnPayer) {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoDeleteHandlerTest.java
@@ -21,13 +21,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -48,10 +46,6 @@ import com.hedera.node.app.service.token.impl.handlers.CryptoDeleteHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.StakingValidator;
 import com.hedera.node.app.service.token.records.CryptoDeleteStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
@@ -63,9 +57,7 @@ import com.swirlds.state.spi.WritableStates;
 import com.swirlds.state.test.fixtures.MapReadableKVState;
 import java.util.List;
 import java.util.Map;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -381,19 +373,6 @@ class CryptoDeleteHandlerTest extends CryptoHandlerTestBase {
         assertThatThrownBy(() -> subject.pureChecks(pureChecksContext))
                 .isInstanceOf(PreCheckException.class)
                 .has(responseCode(ACCOUNT_ID_DOES_NOT_EXIST));
-    }
-
-    @Test
-    @DisplayName("check that fees are 1 for delete account trx")
-    void testCalculateFeesReturnsCorrectFeeForDeleteAccount() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(any())).willReturn(feeCalc);
-        given(feeCalc.legacyCalculate(any())).willReturn(new Fees(1, 0, 0));
-
-        Assertions.assertThat(subject.calculateFees(feeCtx)).isEqualTo(new Fees(1, 0, 0));
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountRecordsHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoGetAccountRecordsHandlerTest.java
@@ -8,12 +8,9 @@ import static com.hedera.hapi.node.base.ResponseType.ANSWER_ONLY;
 import static com.hedera.hapi.node.base.ResponseType.ANSWER_STATE_PROOF;
 import static com.hedera.hapi.node.base.ResponseType.COST_ANSWER;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.QueryHeader;
@@ -30,9 +27,6 @@ import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.handlers.CryptoGetAccountRecordsHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTestBase;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.Fees;
-import com.hedera.node.app.spi.fixtures.fees.FakeFeeCalculator;
 import com.hedera.node.app.spi.records.RecordCache;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -45,7 +39,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -252,32 +245,6 @@ class CryptoGetAccountRecordsHandlerTest extends CryptoHandlerTestBase {
         Assertions.assertThat(result.cryptoGetAccountRecords().accountID()).isEqualTo(id);
         // Make sure no records are returned
         Assertions.assertThat(result.cryptoGetAccountRecords().records()).isEmpty();
-    }
-
-    @Test
-    void verifyFeeComputation() {
-        mockQueryContext(id, QueryHeader.newBuilder().responseType(COST_ANSWER).build());
-        // setup the readable store
-        given(context.createStore(ReadableAccountStore.class)).willReturn(readableStore);
-        final ResponseHeader.Builder testHeaderBuilder = ResponseHeader.newBuilder();
-        testHeaderBuilder.nodeTransactionPrecheckCode(ResponseCodeEnum.OK);
-        testHeaderBuilder.responseType(ResponseType.COST_ANSWER);
-
-        final FeeCalculator feeSpy = Mockito.spy(new FakeFeeCalculator());
-        given(context.feeCalculator()).willReturn(feeSpy);
-
-        // validate a schedule that is present in state
-        given(context.query())
-                .willReturn(Query.newBuilder()
-                        .cryptoGetProxyStakers(CryptoGetStakersQuery.DEFAULT)
-                        .cryptoGetAccountRecords(newAcctRecordsQuery(id).build())
-                        .build());
-        Fees actual = subject.computeFees(context);
-        assertThat(actual.networkFee()).isEqualTo(0L);
-        assertThat(actual.nodeFee()).isEqualTo(0L);
-        assertThat(actual.serviceFee()).isEqualTo(0L);
-        assertThat(actual.totalFee()).isEqualTo(0L);
-        verify(feeSpy).legacyCalculate(any());
     }
 
     @CsvSource({"ANSWER_ONLY", "COST_ANSWER_STATE_PROOF", "ANSWER_STATE_PROOF"})

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
@@ -11,14 +11,12 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
 import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.asAccount;
 import static com.hedera.node.app.service.token.impl.handlers.BaseTokenHandler.asToken;
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.aaWith;
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.nftTransferWith;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -26,21 +24,17 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.hedera.hapi.node.base.AccountAmount;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HookCall;
 import com.hedera.hapi.node.base.Key;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenTransferList;
-import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Nft;
@@ -58,10 +52,6 @@ import com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesSte
 import com.hedera.node.app.service.token.impl.handlers.transfer.ReplaceAliasesWithIDsInOp;
 import com.hedera.node.app.service.token.records.CryptoCreateStreamBuilder;
 import com.hedera.node.app.service.token.records.CryptoTransferStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.store.ReadableStoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext.DispatchMetadata;
@@ -71,18 +61,15 @@ import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.WarmupContext;
 import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.store.ReadableStoreFactoryImpl;
-import com.hedera.node.app.workflows.handle.DispatchHandleContext;
 import com.hedera.node.app.workflows.handle.cache.CacheWarmer;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import java.util.ArrayList;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -159,151 +146,6 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
 
         verify(readableTokenRelationStore, times(1)).warm(ACCOUNT_ID_3333, TOKEN_2468);
         verify(readableNftStore, times(1)).warm(any());
-    }
-
-    @Test
-    void calculateFeesHbarTransfer() {
-        config = defaultConfig()
-                .withValue("fees.tokenTransferUsageMultiplier", 1)
-                .getOrCreateConfig();
-        List<AccountAmount> acctAmounts = new ArrayList<>();
-        List<TokenTransferList> tokenTransferLists = new ArrayList<>();
-        acctAmounts.add(aaWith(ACCOUNT_ID_3333, -5));
-        acctAmounts.add(aaWith(ACCOUNT_ID_4444, 5));
-
-        CryptoTransferTransactionBody cryptoTransfer = CryptoTransferTransactionBody.newBuilder()
-                .transfers(TransferList.newBuilder().accountAmounts(acctAmounts))
-                .tokenTransfers(tokenTransferLists)
-                .build();
-
-        FeeContext feeContext = mock(DispatchHandleContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        Fees fees = mock(Fees.class);
-
-        when(feeContext.body())
-                .thenReturn(TransactionBody.newBuilder()
-                        .transactionID(TransactionID.newBuilder().accountID(ACCOUNT_ID_3333))
-                        .cryptoTransfer(cryptoTransfer)
-                        .build());
-        when(feeContext.configuration()).thenReturn(config);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(fees);
-
-        subject.calculateFees(feeContext);
-
-        // Not interested in return value from calculate, just that it was called and bpt and rbs were set appropriately
-        InOrder inOrder = inOrder(feeCalculatorFactory, feeCalculator);
-        inOrder.verify(feeCalculatorFactory, times(1)).feeCalculator(SubType.DEFAULT);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(64L);
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(64L * USAGE_PROPERTIES.legacyReceiptStorageSecs());
-        inOrder.verify(feeCalculator, times(1)).calculate();
-    }
-
-    @Test
-    void calculateFeesFtCustomFeesTransfer() {
-        config = defaultConfig()
-                .withValue("fees.tokenTransferUsageMultiplier", 2)
-                .getOrCreateConfig();
-        List<AccountAmount> acctAmounts = new ArrayList<>();
-        List<TokenTransferList> tokenTransferLists = new ArrayList<>();
-        tokenTransferLists.add(TokenTransferList.newBuilder()
-                .token(fungibleTokenId)
-                .transfers(
-                        AccountAmount.newBuilder()
-                                .accountID(ACCOUNT_ID_3333)
-                                .amount(-5)
-                                .build(),
-                        AccountAmount.newBuilder()
-                                .accountID(ACCOUNT_ID_4444)
-                                .amount(5)
-                                .build())
-                .build());
-
-        CryptoTransferTransactionBody cryptoTransfer = CryptoTransferTransactionBody.newBuilder()
-                .transfers(TransferList.newBuilder().accountAmounts(acctAmounts))
-                .tokenTransfers(tokenTransferLists)
-                .build();
-
-        FeeContext feeContext = mock(DispatchHandleContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        Fees fees = mock(Fees.class);
-
-        when(feeContext.body())
-                .thenReturn(TransactionBody.newBuilder()
-                        .transactionID(TransactionID.newBuilder().accountID(ACCOUNT_ID_3333))
-                        .cryptoTransfer(cryptoTransfer)
-                        .build());
-        when(feeContext.configuration()).thenReturn(config);
-        when(feeContext.readableStore(ReadableTokenStore.class)).thenReturn(readableTokenStore);
-        when(feeContext.readableStore(ReadableTokenRelationStore.class)).thenReturn(readableTokenRelStore);
-        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableAccountStore);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(fees);
-
-        subject.calculateFees(feeContext);
-
-        // Not interested in return value from calculate, just that it was called and bpt and rbs were set appropriately
-        InOrder inOrder = inOrder(feeCalculatorFactory, feeCalculator);
-        inOrder.verify(feeCalculatorFactory, times(1)).feeCalculator(SubType.TOKEN_FUNGIBLE_COMMON_WITH_CUSTOM_FEES);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(176L);
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(320L * USAGE_PROPERTIES.legacyReceiptStorageSecs());
-        inOrder.verify(feeCalculator, times(1)).calculate();
-    }
-
-    @Test
-    void calculateFeesNftCustomFeesTransfer() {
-        config = defaultConfig()
-                .withValue("fees.tokenTransferUsageMultiplier", 2)
-                .getOrCreateConfig();
-        List<AccountAmount> acctAmounts = new ArrayList<>();
-        List<TokenTransferList> tokenTransferLists = new ArrayList<>();
-        tokenTransferLists.add(TokenTransferList.newBuilder()
-                .token(nonFungibleTokenId)
-                .nftTransfers(SERIAL_1_FROM_3333_TO_4444)
-                .build());
-
-        CryptoTransferTransactionBody cryptoTransfer = CryptoTransferTransactionBody.newBuilder()
-                .transfers(TransferList.newBuilder().accountAmounts(acctAmounts))
-                .tokenTransfers(tokenTransferLists)
-                .build();
-
-        FeeContext feeContext = mock(DispatchHandleContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        Fees fees = mock(Fees.class);
-
-        when(feeContext.body())
-                .thenReturn(TransactionBody.newBuilder()
-                        .transactionID(TransactionID.newBuilder().accountID(ACCOUNT_ID_3333))
-                        .cryptoTransfer(cryptoTransfer)
-                        .build());
-        when(feeContext.configuration()).thenReturn(config);
-        when(feeContext.readableStore(ReadableTokenStore.class)).thenReturn(readableTokenStore);
-        when(feeContext.readableStore(ReadableTokenRelationStore.class)).thenReturn(readableTokenRelStore);
-        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableAccountStore);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(fees);
-
-        subject.calculateFees(feeContext);
-
-        // Not interested in return value from calculate, just that it was called and bpt and rbs were set appropriately
-        InOrder inOrder = inOrder(feeCalculatorFactory, feeCalculator);
-        inOrder.verify(feeCalculatorFactory, times(1))
-                .feeCalculator(SubType.TOKEN_NON_FUNGIBLE_UNIQUE_WITH_CUSTOM_FEES);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(104L);
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(136L * USAGE_PROPERTIES.legacyReceiptStorageSecs());
-        inOrder.verify(feeCalculator, times(1)).calculate();
     }
 
     @Test
@@ -694,71 +536,6 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS));
-    }
-
-    @Test
-    void checkCalculateFeesHandlesExceptionInternally() {
-        // need to set up a transaction that fails because of insufficient payer balance for custom fee
-        config = defaultConfig().getOrCreateConfig();
-        // setup all of the standard stores
-        givenStoresAndConfig(handleContext);
-        // make txn with owner sending 1000 w/ allowances to unknown aliased id
-        // and token transfer of FT from owner 1000 w/ allowances to unknown aliased id
-        // and one NFT from owner to unknown aliased ID
-        givenTxnWithAllowances();
-        ensureAliasesStep = new EnsureAliasesStep(body);
-        replaceAliasesWithIDsInOp = new ReplaceAliasesWithIDsInOp();
-        associateTokenRecepientsStep = new AssociateTokenRecipientsStep(body);
-
-        CryptoCreateStreamBuilder cryptoCreateRecordBuilder = mock(CryptoCreateStreamBuilder.class);
-
-        given(handleContext.dispatch(
-                        argThat(options -> CryptoCreateStreamBuilder.class.equals(options.streamBuilderType())
-                                && spenderId.equals(options.payerId()))))
-                .will((invocation) -> {
-                    final var copy =
-                            account.copyBuilder().accountId(hbarReceiverId).build();
-                    writableAccountStore.put(copy);
-                    writableAliases.put(ecKeyAlias, asAccount(0L, 0L, hbarReceiver));
-                    return cryptoCreateRecordBuilder;
-                })
-                .will((invocation) -> {
-                    final var copy =
-                            account.copyBuilder().accountId(tokenReceiverId).build();
-                    writableAccountStore.put(copy);
-                    writableAliases.put(edKeyAlias, asAccount(0L, 0L, tokenReceiver));
-                    writableTokenRelStore.put(fungibleTokenRelation
-                            .copyBuilder()
-                            .kycGranted(true)
-                            .accountId(tokenReceiverId)
-                            .build());
-                    return cryptoCreateRecordBuilder;
-                });
-
-        when(handleContext.dispatchMetadata()).thenReturn(mock(DispatchMetadata.class));
-
-        FeeContext feeContext = mock(DispatchHandleContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        Fees fees = mock(Fees.class);
-        when(feeContext.body())
-                .thenReturn(TransactionBody.newBuilder()
-                        .transactionID(TransactionID.newBuilder().accountID(ACCOUNT_ID_3333))
-                        .cryptoTransfer(body)
-                        .build());
-        when(feeContext.configuration()).thenReturn(config);
-        when(feeContext.readableStore(ReadableTokenStore.class)).thenReturn(readableTokenStore);
-        when(feeContext.readableStore(ReadableTokenRelationStore.class)).thenReturn(readableTokenRelStore);
-        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableAccountStore);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(fees);
-
-        // this confirms that the exception thrown by customFeeAssessor.assessNumberOfCustomFees() is
-        // handled properly by calculateFees()
-        assertThatNoException().isThrownBy(() -> subject.calculateFees(feeContext));
     }
 
     @Mock(strictness = LENIENT)

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -19,7 +19,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.REQUESTED_NUM_AUTOMATIC
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.ACCOUNTS_STATE_ID;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,11 +30,8 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Duration;
@@ -47,17 +43,12 @@ import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.token.CryptoUpdateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.impl.CryptoSignatureWaiversImpl;
 import com.hedera.node.app.service.token.impl.ReadableAccountStoreImpl;
 import com.hedera.node.app.service.token.impl.WritableAccountStore;
 import com.hedera.node.app.service.token.impl.handlers.CryptoUpdateHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoHandlerTestBase;
 import com.hedera.node.app.service.token.records.CryptoUpdateStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.info.NodeInfo;
@@ -79,7 +70,6 @@ import java.util.function.LongSupplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -727,184 +717,6 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(ACCOUNT_DELETED));
-    }
-
-    @Test
-    void testCalculateFeesHappyPath() {
-        FeeContext feeContext = mock(FeeContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        final var config = HederaTestConfigBuilder.create()
-                .withValue("entities.unlimitedAutoAssociationsEnabled", true)
-                .getOrCreateConfig();
-
-        TransactionBody cryptoUpdateTransaction = new CryptoUpdateBuilder()
-                .withPayer(id)
-                .withAutoRenewPeriod(account.autoRenewSeconds())
-                .withReceiverSigReq(account.receiverSigRequired())
-                .withDeclineReward(account.declineReward())
-                .withStakedNodeId(account.stakedNodeId())
-                .withStakedAccountId(
-                        account.stakedAccountId() == null
-                                ? 0L
-                                : account.stakedAccountId().accountNum())
-                .withExpiration(account.expirationSecond())
-                .withMaxAutoAssociations(account.maxAutoAssociations())
-                .withMemo("")
-                .withKey(account.key())
-                .withTarget(id)
-                .build();
-
-        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableStore);
-        when(feeContext.body()).thenReturn(cryptoUpdateTransaction);
-        when(feeContext.configuration()).thenReturn(config);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(Fees.FREE);
-
-        subject.calculateFees(feeContext);
-
-        InOrder inOrder = inOrder(feeCalculator);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(212L);
-        inOrder.verify(feeCalculator, times(2)).addRamByteSeconds(0L);
-        inOrder.verify(feeCalculator, times(1)).calculate();
-    }
-
-    @Test
-    void testNullAccount() {
-        // mock the account memo to return null. calculateFees should not crash
-        FeeContext feeContext = mock(FeeContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        final var config = HederaTestConfigBuilder.create().getOrCreateConfig();
-
-        // put a null account into the readable store
-        final var emptyStateBuilder = emptyReadableAccountStateBuilder();
-        emptyStateBuilder.value(account.accountId(), null);
-        readableAccounts = emptyStateBuilder.build();
-        given(readableStates.<AccountID, Account>get(ACCOUNTS_STATE_ID)).willReturn(readableAccounts);
-        readableStore = new ReadableAccountStoreImpl(readableStates, readableEntityCounters);
-
-        TransactionBody cryptoUpdateTransaction = new CryptoUpdateBuilder()
-                .withPayer(id)
-                .withAutoRenewPeriod(account.autoRenewSeconds())
-                .withReceiverSigReq(account.receiverSigRequired())
-                .withDeclineReward(account.declineReward())
-                .withStakedNodeId(account.stakedNodeId())
-                .withStakedAccountId(
-                        account.stakedAccountId() == null
-                                ? 0L
-                                : account.stakedAccountId().accountNum())
-                .withExpiration(account.expirationSecond())
-                .withMaxAutoAssociations(account.maxAutoAssociations())
-                .withKey(account.key())
-                .withTarget(id)
-                .build();
-
-        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableStore);
-        when(feeContext.body()).thenReturn(cryptoUpdateTransaction);
-        when(feeContext.configuration()).thenReturn(config);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(Fees.FREE);
-
-        assertThatNoException().isThrownBy(() -> subject.calculateFees(feeContext));
-
-        InOrder inOrder = inOrder(feeCalculator);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(212L);
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(0L);
-        inOrder.verify(feeCalculator, times(1)).calculate();
-    }
-
-    @Test
-    void testNullAccountMemo() {
-        // mock the account memo to return null. calculateFees should not crash
-        FeeContext feeContext = mock(FeeContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        final var config = HederaTestConfigBuilder.create().getOrCreateConfig();
-
-        account = mock(Account.class);
-        given(account.keyOrElse(Key.DEFAULT)).willReturn(Key.DEFAULT);
-        given(account.memo()).willReturn(null);
-        updateReadableAccountStore(Map.of(accountNum, account));
-
-        TransactionBody cryptoUpdateTransaction = new CryptoUpdateBuilder()
-                .withPayer(id)
-                .withAutoRenewPeriod(account.autoRenewSeconds())
-                .withReceiverSigReq(account.receiverSigRequired())
-                .withDeclineReward(account.declineReward())
-                .withStakedNodeId(account.stakedNodeId())
-                .withStakedAccountId(
-                        account.stakedAccountId() == null
-                                ? 0L
-                                : account.stakedAccountId().accountNum())
-                .withExpiration(account.expirationSecond())
-                .withMaxAutoAssociations(account.maxAutoAssociations())
-                .withKey(account.key())
-                .withTarget(id)
-                .build();
-
-        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableStore);
-        when(feeContext.body()).thenReturn(cryptoUpdateTransaction);
-        when(feeContext.configuration()).thenReturn(config);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(Fees.FREE);
-
-        assertThatNoException().isThrownBy(() -> subject.calculateFees(feeContext));
-    }
-
-    @Test
-    void testUnlimitedAutoAssociationsDisabled() {
-        // disable unlimited auto associations
-        // and set a new max of 30
-        FeeContext feeContext = mock(FeeContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        final var config = HederaTestConfigBuilder.create()
-                .withValue("entities.unlimitedAutoAssociationsEnabled", false)
-                .getOrCreateConfig();
-
-        TransactionBody cryptoUpdateTransaction = new CryptoUpdateBuilder()
-                .withPayer(id)
-                .withAutoRenewPeriod(account.autoRenewSeconds())
-                .withReceiverSigReq(account.receiverSigRequired())
-                .withDeclineReward(account.declineReward())
-                .withStakedNodeId(account.stakedNodeId())
-                .withStakedAccountId(
-                        account.stakedAccountId() == null
-                                ? 0L
-                                : account.stakedAccountId().accountNum())
-                .withExpiration(account.expirationSecond())
-                .withMaxAutoAssociations(30) // set new max to 30
-                .withKey(account.key())
-                .withTarget(id)
-                .build();
-
-        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableStore);
-        when(feeContext.body()).thenReturn(cryptoUpdateTransaction);
-        when(feeContext.configuration()).thenReturn(config);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(Fees.FREE);
-
-        subject.calculateFees(feeContext);
-
-        InOrder inOrder = inOrder(feeCalculator);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(212L);
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(0L);
-        // slots increases, so we have a new fee
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(3732480000000L);
-        inOrder.verify(feeCalculator, times(1)).calculate();
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
@@ -14,8 +14,6 @@ import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AirD
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AirDropTransferType.TOKEN_AND_NFT_AIRDROP;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -574,43 +572,6 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
         Assertions.assertThatThrownBy(() -> tokenAirdropHandler.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT));
-    }
-
-    @Test
-    void calculateFeesWithNoAirdropBody() {
-        when(feeContext.body()).thenReturn(TransactionBody.DEFAULT);
-        assertThrows(NullPointerException.class, () -> tokenAirdropHandler.calculateFees(feeContext));
-    }
-
-    @Test
-    void calculateFeesNotSupportedOperation() {
-        setupAirdropMocks(TokenAirdropTransactionBody.DEFAULT, false);
-
-        final var exception = assertThrows(HandleException.class, () -> tokenAirdropHandler.calculateFees(feeContext));
-        assertEquals(ResponseCodeEnum.NOT_SUPPORTED, exception.getStatus());
-    }
-
-    @Test
-    void calculateFeesShouldChargeBaseFee() {
-        final var fungibleTransferList = TokenTransferList.newBuilder()
-                .token(TOKEN_2468)
-                .transfers(ACCT_4444_MINUS_5)
-                .build();
-        final var nonFungibleTransferList = TokenTransferList.newBuilder()
-                .token(asToken(2469))
-                .nftTransfers(SERIAL_1_FROM_3333_TO_4444)
-                .build();
-        final var airdropBody = TokenAirdropTransactionBody.newBuilder()
-                .tokenTransfers(fungibleTransferList, nonFungibleTransferList)
-                .build();
-        setupAirdropMocks(airdropBody, true);
-
-        when(feeContext.dispatchComputeFees(any(), any())).thenReturn(new Fees(30, 30, 30));
-
-        final var fees = tokenAirdropHandler.calculateFees(feeContext);
-        assertEquals(30, fees.networkFee());
-        assertEquals(30, fees.nodeFee());
-        assertEquals(30, fees.serviceFee());
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCancelAirdropHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenCancelAirdropHandlerTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -29,7 +28,6 @@ import com.hedera.node.app.service.token.impl.WritableAirdropStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenCancelAirdropHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.TokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.util.PendingAirdropUpdater;
-import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -265,17 +263,6 @@ class TokenCancelAirdropHandlerTest extends TokenHandlerTestBase {
         when(handleContext.body()).thenReturn(transactionBody);
 
         assertThrows(HandleException.class, () -> subject.handle(handleContext));
-    }
-
-    @Test
-    void calculateFeesThrowsWhenCancelDisabled() {
-        var testConfig = HederaTestConfigBuilder.create()
-                .withValue("tokens.airdrops.cancel.enabled", false)
-                .getOrCreateConfig();
-        var feeContext = mock(FeeContext.class);
-        when(feeContext.configuration()).thenReturn(testConfig);
-
-        assertThrows(HandleException.class, () -> subject.calculateFees(feeContext));
     }
 
     private void mockHandleContext() {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenFeeScheduleUpdateHandlerTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.token.impl.test.handlers;
 
-import static com.hedera.hapi.node.base.HederaFunctionality.TOKEN_FEE_SCHEDULE_UPDATE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CUSTOM_FEES_LIST_TOO_LONG;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_HAS_NO_FEE_SCHEDULE_KEY;
@@ -12,39 +11,26 @@ import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.TO
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.base.TokenID;
-import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.token.TokenFeeScheduleUpdateTransactionBody;
-import com.hedera.hapi.node.transaction.CustomFee;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.fees.FeeManager;
-import com.hedera.node.app.fees.context.IngestFeeContext;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
-import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenFeeScheduleUpdateHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.CustomFeesValidator;
 import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.ids.FakeEntityIdFactoryImpl;
-import com.hedera.node.app.spi.store.ReadableStoreFactory;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.validation.ExpiryValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -52,16 +38,12 @@ import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
-import com.hedera.node.app.store.ReadableStoreFactoryImpl;
 import com.hedera.node.app.throttle.SynchronizedThrottleAccumulator;
-import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.state.test.fixtures.MapWritableKVState;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -266,98 +248,6 @@ class TokenFeeScheduleUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         assertThatThrownBy(() -> subject.pureChecks(pureChecksContext))
                 .isInstanceOf(PreCheckException.class)
                 .has(responseCode(INVALID_TOKEN_ID));
-    }
-
-    @Test
-    public void testCalculateFeesHappyPath() {
-        TransactionInfo txnInfo = mock(TransactionInfo.class);
-        FeeManager feeManager = mock(FeeManager.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        ReadableStoreFactory storeFactory = mock(ReadableStoreFactoryImpl.class);
-        TransactionBody transactionBody = mock(TransactionBody.class);
-        TokenFeeScheduleUpdateTransactionBody tokenFeeScheduleUpdateTransactionBody =
-                mock(TokenFeeScheduleUpdateTransactionBody.class);
-        TransactionID transactionID = mock(TransactionID.class);
-
-        List<CustomFee> customFees = new ArrayList<>();
-        customFees.add(withFixedFee(hbarFixedFee));
-        customFees.add(withFractionalFee(fractionalFee));
-        customFees.add(withRoyaltyFee(royaltyFee));
-
-        when(feeManager.createFeeCalculator(any(), any(), any(), anyInt(), anyInt(), any(), any(), anyBoolean(), any()))
-                .thenReturn(feeCalculator);
-        when(txnInfo.txBody()).thenReturn(transactionBody);
-        when(transactionBody.tokenFeeScheduleUpdateOrThrow()).thenReturn(tokenFeeScheduleUpdateTransactionBody);
-        when(tokenFeeScheduleUpdateTransactionBody.customFees()).thenReturn(customFees);
-        when(tokenFeeScheduleUpdateTransactionBody.tokenIdOrThrow()).thenReturn(fungibleTokenId);
-        when(storeFactory.readableStore(ReadableTokenStore.class)).thenReturn(readableTokenStore);
-        when(transactionBody.transactionIDOrThrow()).thenReturn(transactionID);
-        when(transactionID.transactionValidStartOrThrow()).thenReturn(consensusTimestamp);
-        when(txnInfo.signatureMap()).thenReturn(SignatureMap.DEFAULT);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(Fees.FREE);
-        when(txnInfo.functionality()).thenReturn(TOKEN_FEE_SCHEDULE_UPDATE);
-
-        final var feeContext = new IngestFeeContext(
-                consensusInstant,
-                txnInfo,
-                payerKey,
-                payerId,
-                feeManager,
-                storeFactory,
-                configuration,
-                null,
-                -1,
-                transactionDispatcher,
-                synchronizedThrottleAccumulator);
-
-        final var calculateFees = subject.calculateFees(feeContext);
-        assertEquals(calculateFees, Fees.FREE);
-    }
-
-    @Test
-    @DisplayName("If the requested token ID does not exist, the fee calculation should not throw an exception")
-    void calculateFeesTokenDoesNotExist() {
-        TransactionInfo txnInfo = mock(TransactionInfo.class);
-        FeeManager feeManager = mock(FeeManager.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        ReadableStoreFactory storeFactory = mock(ReadableStoreFactoryImpl.class);
-        TransactionBody transactionBody = mock(TransactionBody.class);
-        TokenFeeScheduleUpdateTransactionBody tokenFeeScheduleUpdateTransactionBody =
-                mock(TokenFeeScheduleUpdateTransactionBody.class);
-        TransactionID transactionID = mock(TransactionID.class);
-
-        when(feeManager.createFeeCalculator(any(), any(), any(), anyInt(), anyInt(), any(), any(), anyBoolean(), any()))
-                .thenReturn(feeCalculator);
-        when(txnInfo.txBody()).thenReturn(transactionBody);
-        when(transactionBody.tokenFeeScheduleUpdateOrThrow()).thenReturn(tokenFeeScheduleUpdateTransactionBody);
-        // Any token ID that doesn't exist:
-        when(tokenFeeScheduleUpdateTransactionBody.tokenIdOrThrow())
-                .thenReturn(TokenID.newBuilder().tokenNum(1500).build());
-        when(storeFactory.readableStore(ReadableTokenStore.class)).thenReturn(readableTokenStore);
-        when(transactionBody.transactionIDOrThrow()).thenReturn(transactionID);
-        when(transactionID.transactionValidStartOrThrow()).thenReturn(consensusTimestamp);
-        when(txnInfo.signatureMap()).thenReturn(SignatureMap.DEFAULT);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
-        when(feeCalculator.calculate()).thenReturn(Fees.FREE);
-        when(txnInfo.functionality()).thenReturn(TOKEN_FEE_SCHEDULE_UPDATE);
-
-        final var feeContext = new IngestFeeContext(
-                consensusInstant,
-                txnInfo,
-                payerKey,
-                payerId,
-                feeManager,
-                storeFactory,
-                configuration,
-                null,
-                -1,
-                transactionDispatcher,
-                synchronizedThrottleAccumulator);
-
-        Assertions.assertThatNoException().isThrownBy(() -> subject.calculateFees(feeContext));
     }
 
     private void givenTxn() {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenMintHandlerTest.java
@@ -19,9 +19,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.token.TokenMintTransactionBody;
@@ -32,9 +30,6 @@ import com.hedera.node.app.service.token.impl.handlers.TokenMintHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.TokenSupplyChangeOpsValidator;
 import com.hedera.node.app.service.token.records.TokenMintStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -230,29 +225,6 @@ class TokenMintHandlerTest extends CryptoTokenHandlerTestBase {
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(MAX_NFTS_IN_PRICE_REGIME_HAVE_BEEN_MINTED));
-    }
-
-    @Test
-    void calculateFeesAddsCorrectFeeComponents() {
-        final var metadata = List.of(metadata1, metadata2);
-        final var txnBody = givenMintTxn(nonFungibleTokenId, metadata, null);
-
-        final var feeCalculator = mock(FeeCalculator.class);
-        final var feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        final var feeContext = mock(FeeContext.class);
-        given(feeContext.body()).willReturn(txnBody);
-        given(feeContext.feeCalculatorFactory()).willReturn(feeCalculatorFactory);
-        given(feeCalculatorFactory.feeCalculator(SubType.TOKEN_NON_FUNGIBLE_UNIQUE))
-                .willReturn(feeCalculator);
-        final var numSigs = 5;
-        given(feeContext.numTxnSignatures()).willReturn(numSigs);
-
-        // We don't need the result of this call since the fee calculator is a mock
-        subject.calculateFees(feeContext);
-        verify(feeCalculator).addVerificationsPerTransaction(numSigs - 1);
-        verify(feeCalculator).addBytesPerTransaction(metadata.size());
-        verify(feeCalculator).addRamByteSeconds(0);
-        verify(feeCalculator).addNetworkRamByteSeconds(0);
     }
 
     private TransactionBody givenMintTxn(final TokenID tokenId, final List<Bytes> metadata, final Long amount) {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenPauseHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenPauseHandlerTest.java
@@ -12,16 +12,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.token.Account;
@@ -35,9 +31,6 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenPauseHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.TokenHandlerTestBase;
 import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -48,7 +41,6 @@ import com.swirlds.state.test.fixtures.MapReadableKVState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -116,23 +108,6 @@ class TokenPauseHandlerTest extends TokenHandlerTestBase {
         given(pureChecksContext.body()).willReturn(transaction);
 
         assertThatCode(() -> subject.pureChecks(pureChecksContext)).doesNotThrowAnyException();
-    }
-
-    @Test
-    public void testCalculateFeesInvocations() {
-        FeeContext feeContext = mock(FeeContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(SubType.DEFAULT)).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-
-        subject.calculateFees(feeContext);
-
-        InOrder inOrder = inOrder(feeCalculatorFactory, feeCalculator);
-        inOrder.verify(feeCalculatorFactory).feeCalculator(SubType.DEFAULT);
-        inOrder.verify(feeCalculator).addBytesPerTransaction(anyLong());
-        inOrder.verify(feeCalculator).calculate();
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenRejectHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenRejectHandlerTest.java
@@ -6,26 +6,21 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIA
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_REFERENCE_REPEATED;
-import static com.hedera.node.app.hapi.fees.usage.SingletonUsageProperties.USAGE_PROPERTIES;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.NftID;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.token.TokenReference;
 import com.hedera.hapi.node.token.TokenRejectTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hedera.node.app.fees.context.IngestFeeContext;
 import com.hedera.node.app.service.token.impl.handlers.TokenRejectHandler;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
@@ -44,7 +39,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -119,61 +113,6 @@ class TokenRejectHandlerTest extends CryptoTransferHandlerTestBase {
         assertThat(endSenderBalance).isEqualTo(initialSenderBalance);
         final var feeCollectorBalance = writableAccountStore.get(feeCollectorId).tinybarBalance();
         assertThat(feeCollectorBalance).isEqualTo(initialFeeCollectorBalance);
-    }
-
-    @Test
-    void calculateFeesFungibleReject() {
-        final var txn = newTokenReject(ACCOUNT_ID_3333, tokenRefFungible);
-
-        FeeContext feeContext = mock(IngestFeeContext.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        setupFeeTest(txn, feeContext, feeCalculator, feeCalculatorFactory);
-
-        subject.calculateFees(feeContext);
-
-        // Not interested in return value from calculate, just that it was called and bpt and rbs were set appropriately
-        InOrder inOrder = inOrder(feeCalculatorFactory, feeCalculator);
-        inOrder.verify(feeCalculatorFactory, times(1)).feeCalculator(SubType.TOKEN_FUNGIBLE_COMMON);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(176L);
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(176L * USAGE_PROPERTIES.legacyReceiptStorageSecs());
-        inOrder.verify(feeCalculator, times(1)).calculate();
-    }
-
-    @Test
-    void calculateFeesNonFungibleReject() {
-        final var txn = newTokenReject(ACCOUNT_ID_3333, tokenRefNFT);
-        FeeContext feeContext = mock(IngestFeeContext.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        setupFeeTest(txn, feeContext, feeCalculator, feeCalculatorFactory);
-
-        subject.calculateFees(feeContext);
-
-        // Not interested in return value from calculate, just that it was called and bpt and rbs were set appropriately
-        InOrder inOrder = inOrder(feeCalculatorFactory, feeCalculator);
-        inOrder.verify(feeCalculatorFactory, times(1)).feeCalculator(SubType.TOKEN_NON_FUNGIBLE_UNIQUE);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(104L);
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(104L * USAGE_PROPERTIES.legacyReceiptStorageSecs());
-        inOrder.verify(feeCalculator, times(1)).calculate();
-    }
-
-    @Test
-    void calculateFeesFungibleAndNonFungibleRejects() {
-        final var txn = newTokenReject(ACCOUNT_ID_3333, tokenRefNFT, tokenRefFungible);
-        FeeContext feeContext = mock(IngestFeeContext.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        setupFeeTest(txn, feeContext, feeCalculator, feeCalculatorFactory);
-
-        subject.calculateFees(feeContext);
-
-        // Not interested in return value from calculate, just that it was called and bpt and rbs were set appropriately
-        InOrder inOrder = inOrder(feeCalculatorFactory, feeCalculator);
-        inOrder.verify(feeCalculatorFactory, times(1)).feeCalculator(SubType.TOKEN_NON_FUNGIBLE_UNIQUE);
-        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(280L);
-        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(280L * USAGE_PROPERTIES.legacyReceiptStorageSecs());
-        inOrder.verify(feeCalculator, times(1)).calculate();
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnpauseHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUnpauseHandlerTest.java
@@ -12,15 +12,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.Key;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.token.Account;
@@ -34,9 +30,6 @@ import com.hedera.node.app.service.token.impl.WritableTokenStore;
 import com.hedera.node.app.service.token.impl.handlers.TokenUnpauseHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.TokenHandlerTestBase;
 import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -47,7 +40,6 @@ import com.swirlds.state.test.fixtures.MapReadableKVState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -113,23 +105,6 @@ class TokenUnpauseHandlerTest extends TokenHandlerTestBase {
         given(pureChecksContext.body()).willReturn(transaction);
 
         assertThatCode(() -> subject.pureChecks(pureChecksContext)).doesNotThrowAnyException();
-    }
-
-    @Test
-    public void testCalculateFeesInvocations() {
-        FeeContext feeContext = mock(FeeContext.class);
-        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
-        when(feeCalculatorFactory.feeCalculator(SubType.DEFAULT)).thenReturn(feeCalculator);
-        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
-
-        subject.calculateFees(feeContext);
-
-        InOrder inOrder = inOrder(feeCalculatorFactory, feeCalculator);
-        inOrder.verify(feeCalculatorFactory).feeCalculator(SubType.DEFAULT);
-        inOrder.verify(feeCalculator).addBytesPerTransaction(anyLong());
-        inOrder.verify(feeCalculator).calculate();
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateNftsHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateNftsHandlerTest.java
@@ -19,13 +19,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.base.TransactionID;
@@ -44,9 +42,6 @@ import com.hedera.node.app.service.token.impl.handlers.TokenUpdateHandler;
 import com.hedera.node.app.service.token.impl.handlers.TokenUpdateNftsHandler;
 import com.hedera.node.app.service.token.impl.test.handlers.util.CryptoTokenHandlerTestBase;
 import com.hedera.node.app.service.token.impl.validators.TokenAttributesValidator;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -378,27 +373,6 @@ class TokenUpdateNftsHandlerTest extends CryptoTokenHandlerTestBase {
         Assertions.assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(INVALID_NFT_ID));
-    }
-
-    @Test
-    void calculateFeesAddsCorrectFeeComponents() {
-        final var metadata1 = Bytes.wrap("test metadata one");
-
-        final List<Long> serialNumbers = new ArrayList<>(Arrays.asList(1L, 2L));
-        final var txnBody =
-                new TokenUpdateNftBuilder().newNftUpdateTransactionBody(TOKEN_123, metadata1, serialNumbers.get(1));
-        final var feeCalculator = mock(FeeCalculator.class);
-        final var feeCalculatorFactory = mock(FeeCalculatorFactory.class);
-        final var feeContext = mock(FeeContext.class);
-
-        given(feeContext.body()).willReturn(txnBody);
-        given(feeContext.feeCalculatorFactory()).willReturn(feeCalculatorFactory);
-        given(feeCalculatorFactory.feeCalculator(SubType.TOKEN_NON_FUNGIBLE_UNIQUE))
-                .willReturn(feeCalculator);
-        given(feeCalculator.addBytesPerTransaction(1L)).willReturn(feeCalculator);
-        subject.calculateFees(feeContext);
-
-        verify(feeCalculator).addBytesPerTransaction(1L);
     }
 
     private class TokenUpdateNftBuilder {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetInfoRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetInfoRegression.java
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 import static org.hiero.base.utility.CommonUtils.unhex;
 
 import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
@@ -242,12 +243,9 @@ public class CryptoGetInfoRegression {
                         .hasAnswerOnlyPrecheck(INSUFFICIENT_PAYER_BALANCE));
     }
 
-    @LeakyEmbeddedHapiTest(
-            reason = NEEDS_STATE_ACCESS,
-            overrides = {"fees.simpleFeesEnabled"})
+    @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
     final Stream<DynamicTest> failsForInsufficientPayment() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "false"),
                 cryptoCreate(CIVILIAN_PAYER),
                 getAccountInfo(GENESIS)
                         .payingWith(CIVILIAN_PAYER)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetRecordsRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetRecordsRegression.java
@@ -13,7 +13,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
@@ -23,8 +22,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
+import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.spec.assertions.AssertUtils;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
@@ -82,12 +81,9 @@ public class CryptoGetRecordsRegression {
                         .hasAnswerOnlyPrecheck(INSUFFICIENT_PAYER_BALANCE));
     }
 
-    @LeakyEmbeddedHapiTest(
-            reason = NEEDS_STATE_ACCESS,
-            overrides = {"fees.simpleFeesEnabled"})
+    @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
     final Stream<DynamicTest> failsForInsufficientPayment() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "false"),
                 cryptoCreate(PAYER),
                 getAccountRecords(GENESIS)
                         .payingWith(PAYER)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
@@ -8,15 +8,14 @@ import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RECEIVING_NODE_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
+import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -35,12 +34,9 @@ public class QueryPaymentSuite {
      * 2. TransactionPayer will pay for query payment to node and payer has less balance
      * 3. Transaction payer is not involved in transfers for query payment to node and one or more have less balance
      */
-    @LeakyEmbeddedHapiTest(
-            reason = NEEDS_STATE_ACCESS,
-            overrides = {"fees.simpleFeesEnabled"})
+    @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
     final Stream<DynamicTest> queryPaymentsFailsWithInsufficientFunds() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "false"),
                 cryptoCreate("a").balance(500_000_000L),
                 cryptoCreate("b").balance(1_234L),
                 cryptoCreate("c").balance(1_234L),


### PR DESCRIPTION
Deletes calculateFees/usageGiven/computeFees from the token service handlers and updates their unit tests.

Splits #25473. Part of #25850.
Closes #25874