### PR TITLE
refactor: remove legacy fee methods from address book handlers

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
@@ -9,7 +9,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SERVICE_ENDPOINT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_NODES_CREATED;
-import static com.hedera.node.app.service.addressbook.AddressBookHelper.checkDABEnabled;
 import static com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator.validateX509Certificate;
 import static com.hedera.node.app.spi.workflows.HandleContext.DispatchMetadata.Type.SYSTEM_TXN_CREATION_ENTITY_NUM;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
@@ -18,7 +17,6 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.state.addressbook.Node;
 import com.hedera.node.app.service.addressbook.ReadableNodeStore;
 import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
@@ -27,8 +25,6 @@ import com.hedera.node.app.service.addressbook.impl.WritableNodeStore;
 import com.hedera.node.app.service.addressbook.impl.records.NodeCreateStreamBuilder;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -170,20 +166,6 @@ public class NodeCreateHandler implements TransactionHandler {
         final var recordBuilder = handleContext.savepointStack().getBaseBuilder(NodeCreateStreamBuilder.class);
 
         recordBuilder.nodeID(node.nodeId());
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext, "feeContext must not be null");
-        checkDABEnabled(feeContext);
-        final var calculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        calculator.resetUsage();
-        // The price of node create should be increased based on number of signatures.
-        // The first signature is free and is accounted in the base price, so we only need to add
-        // the price of the rest of the signatures.
-        calculator.addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1));
-        return calculator.calculate();
     }
 
     /**

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeDeleteHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeDeleteHandler.java
@@ -4,20 +4,16 @@ package com.hedera.node.app.service.addressbook.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NODE_DELETED;
-import static com.hedera.node.app.service.addressbook.AddressBookHelper.checkDABEnabled;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.addressbook.NodeDeleteTransactionBody;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.state.addressbook.Node;
 import com.hedera.node.app.service.addressbook.ReadableNodeStore;
 import com.hedera.node.app.service.addressbook.impl.WritableAccountNodeRelStore;
 import com.hedera.node.app.service.addressbook.impl.WritableNodeStore;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -99,18 +95,5 @@ public class NodeDeleteHandler implements TransactionHandler {
         It will not be committed to state until commit is called on the state.--- */
         nodeStore.put(nodeBuilder.build());
         accountNodeRelStore.remove(node.accountId());
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        checkDABEnabled(feeContext);
-        final var calculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        calculator.resetUsage();
-        // The price of node delete should be increased based on number of signatures.
-        // The first signature is free and is accounted in the base price, so we only need to add
-        // the price of the rest of the signatures.
-        calculator.addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1));
-        return calculator.calculate();
     }
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
@@ -10,7 +10,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NODE_ACCOUNT_HAS_ZERO_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UPDATE_NODE_ACCOUNT_NOT_ALLOWED;
-import static com.hedera.node.app.service.addressbook.AddressBookHelper.checkDABEnabled;
 import static com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator.validateX509Certificate;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
@@ -23,7 +22,6 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.KeyList;
 import com.hedera.hapi.node.base.ServiceEndpoint;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.ThresholdKey;
 import com.hedera.hapi.node.state.addressbook.Node;
 import com.hedera.node.app.service.addressbook.ReadableNodeStore;
@@ -32,8 +30,6 @@ import com.hedera.node.app.service.addressbook.impl.WritableAccountNodeRelStore;
 import com.hedera.node.app.service.addressbook.impl.WritableNodeStore;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -180,19 +176,6 @@ public class NodeUpdateHandler implements TransactionHandler {
                 op.nodeId(),
                 Node.JSON.toJSON(existingNode),
                 Node.JSON.toJSON(updatedNode));
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        checkDABEnabled(feeContext);
-        final var calculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        calculator.resetUsage();
-        // The price of node update should be increased based on number of signatures.
-        // The first signature is free and is accounted in the base price, so we only need to add
-        // the price of the rest of the signatures.
-        calculator.addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1));
-        return calculator.calculate();
     }
 
     private Node.Builder updateNode(

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeCreateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeCreateHandler.java
@@ -3,18 +3,14 @@ package com.hedera.node.app.service.addressbook.impl.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_ENDPOINT;
-import static com.hedera.node.app.service.addressbook.AddressBookHelper.checkRegisteredNodesEnabled;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.records.RegisteredNodeCreateStreamBuilder;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -80,16 +76,5 @@ public class RegisteredNodeCreateHandler implements TransactionHandler {
         final var recordBuilder =
                 handleContext.savepointStack().getBaseBuilder(RegisteredNodeCreateStreamBuilder.class);
         recordBuilder.registeredNodeID(registeredNodeId);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext, "feeContext must not be null");
-        checkRegisteredNodesEnabled(feeContext);
-        final var calculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        calculator.resetUsage();
-        calculator.addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1));
-        return calculator.calculate();
     }
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeDeleteHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeDeleteHandler.java
@@ -4,18 +4,14 @@ package com.hedera.node.app.service.addressbook.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_NODE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REGISTERED_NODE_STILL_ASSOCIATED;
-import static com.hedera.node.app.service.addressbook.AddressBookHelper.checkRegisteredNodesEnabled;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.node.app.service.addressbook.ReadableNodeStore;
 import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -88,16 +84,5 @@ public class RegisteredNodeDeleteHandler implements TransactionHandler {
         validateFalse(isAssociated, REGISTERED_NODE_STILL_ASSOCIATED);
 
         registeredNodeStore.remove(registeredNodeId);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext, "feeContext must not be null");
-        checkRegisteredNodesEnabled(feeContext);
-        final var calculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        calculator.resetUsage();
-        calculator.addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1));
-        return calculator.calculate();
     }
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeUpdateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/RegisteredNodeUpdateHandler.java
@@ -3,20 +3,16 @@ package com.hedera.node.app.service.addressbook.impl.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_NODE_ID;
-import static com.hedera.node.app.service.addressbook.AddressBookHelper.checkRegisteredNodesEnabled;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.addressbook.RegisteredNodeUpdateTransactionBody;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
@@ -104,16 +100,5 @@ public class RegisteredNodeUpdateHandler implements TransactionHandler {
             builder.serviceEndpoint(op.serviceEndpoint());
         }
         return builder;
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext, "feeContext must not be null");
-        checkRegisteredNodesEnabled(feeContext);
-        final var calculator = feeContext.feeCalculatorFactory().feeCalculator(SubType.DEFAULT);
-        calculator.resetUsage();
-        calculator.addVerificationsPerTransaction(Math.max(0, feeContext.numTxnSignatures() - 1));
-        return calculator.calculate();
     }
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.doThrow;
@@ -44,10 +43,6 @@ import com.hedera.node.app.service.addressbook.impl.handlers.NodeCreateHandler;
 import com.hedera.node.app.service.addressbook.impl.records.NodeCreateStreamBuilder;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.validation.AttributeValidator;
@@ -802,26 +797,6 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
         subject.preHandle(context);
         assertThat(context.requiredNonPayerKeys()).contains(key);
         assertThat(context.requiredNonPayerKeys()).doesNotContain(aPrimitiveKey);
-    }
-
-    @Test
-    @DisplayName("check that fees are 1 for delete node trx")
-    void testCalculateFeesInvocations() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(any())).willReturn(feeCalc);
-
-        final var config = HederaTestConfigBuilder.create()
-                .withValue("nodes.enableDAB", true)
-                .getOrCreateConfig();
-        given(feeCtx.configuration()).willReturn(config);
-
-        given(feeCalc.addVerificationsPerTransaction(anyLong())).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(new Fees(1, 0, 0));
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(new Fees(1, 0, 0));
     }
 
     @Test

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeDeleteHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeDeleteHandlerTest.java
@@ -10,8 +10,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -30,10 +28,6 @@ import com.hedera.node.app.service.addressbook.impl.WritableAccountNodeRelStore;
 import com.hedera.node.app.service.addressbook.impl.WritableNodeStore;
 import com.hedera.node.app.service.addressbook.impl.handlers.NodeDeleteHandler;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -43,7 +37,6 @@ import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
-import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -102,26 +95,6 @@ class NodeDeleteHandlerTest extends AddressBookTestBase {
         given(pureChecksContext.body()).willReturn(newDeleteTxn());
 
         assertThatCode(() -> subject.pureChecks(pureChecksContext)).doesNotThrowAnyException();
-    }
-
-    @Test
-    @DisplayName("check that fees are 1 for delete node trx")
-    void testCalculateFeesInvocations() throws IOException {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(any())).willReturn(feeCalc);
-
-        final var config = HederaTestConfigBuilder.create()
-                .withValue("nodes.enableDAB", true)
-                .getOrCreateConfig();
-        given(feeCtx.configuration()).willReturn(config);
-
-        given(feeCalc.addVerificationsPerTransaction(anyLong())).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(new Fees(1, 0, 0));
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(new Fees(1, 0, 0));
     }
 
     @Test

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeUpdateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeUpdateHandlerTest.java
@@ -22,12 +22,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.addressbook.AssociatedRegisteredNodeList;
 import com.hedera.hapi.node.addressbook.NodeUpdateTransactionBody;
@@ -49,10 +46,6 @@ import com.hedera.node.app.service.addressbook.impl.WritableNodeStore;
 import com.hedera.node.app.service.addressbook.impl.handlers.NodeUpdateHandler;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.validation.AttributeValidator;
@@ -548,25 +541,6 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
     }
 
     @Test
-    @DisplayName("check that fees are 1 for delete node trx")
-    void testCalculateFeesInvocations() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(any())).willReturn(feeCalc);
-        final var config = HederaTestConfigBuilder.create()
-                .withValue("nodes.enableDAB", true)
-                .getOrCreateConfig();
-        given(feeCtx.configuration()).willReturn(config);
-
-        given(feeCalc.addVerificationsPerTransaction(anyLong())).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(new Fees(1, 0, 0));
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(new Fees(1, 0, 0));
-    }
-
-    @Test
     void preHandleSpecialCaseWhenOnlyUpdatingAccountId() throws PreCheckException {
         // Setup existing node with an account ID
         givenValidNode();
@@ -724,29 +698,6 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
         assertDoesNotThrow(() -> subject.handle(handleContext));
         // Verify decline reward was updated to true
         assertTrue(writableStore.get(nodeId.number()).declineReward());
-    }
-
-    @Test
-    void testCalculateFeesWithDifferentNumSignatures() {
-        // Test with 3 signatures
-        FeeContext feeCtx = mock(FeeContext.class);
-        FeeCalculatorFactory feeCalcFact = mock(FeeCalculatorFactory.class);
-        FeeCalculator feeCalc = mock(FeeCalculator.class);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(any())).willReturn(feeCalc);
-        given(feeCtx.configuration())
-                .willReturn(HederaTestConfigBuilder.create()
-                        .withValue("nodes.enableDAB", true)
-                        .getOrCreateConfig());
-        given(feeCtx.numTxnSignatures()).willReturn(3);
-        given(feeCalc.addVerificationsPerTransaction(2L)).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(new Fees(3, 0, 0));
-
-        Fees result = subject.calculateFees(feeCtx);
-
-        // Verify that addVerificationsPerTransaction was called with 2 (3-1)
-        verify(feeCalc).addVerificationsPerTransaction(2L);
-        assertThat(result).isEqualTo(new Fees(3, 0, 0));
     }
 
     @Test

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeCreateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeCreateHandlerTest.java
@@ -7,7 +7,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_ENDP
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_ENDPOINT_ADDRESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_ENDPOINT_TYPE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_REQUIRED;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REGISTERED_ENDPOINTS_EXCEEDED_LIMIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -24,7 +23,6 @@ import com.hedera.hapi.node.addressbook.RegisteredNodeCreateTransactionBody;
 import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.KeyList;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.hapi.node.transaction.TransactionBody;
@@ -32,10 +30,6 @@ import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.handlers.RegisteredNodeCreateHandler;
 import com.hedera.node.app.service.addressbook.impl.records.RegisteredNodeCreateStreamBuilder;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -437,65 +431,6 @@ class RegisteredNodeCreateHandlerTest extends AddressBookTestBase {
 
         final var msg = assertThrows(HandleException.class, () -> subject.handle(handleContext));
         assertThat(msg.getStatus()).isEqualTo(INVALID_REGISTERED_ENDPOINT);
-    }
-
-    @Test
-    @DisplayName("calculateFees uses signature-based pricing with SubType.DEFAULT")
-    void calculateFeesUsesSignatureBasedPricing() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        final var expectedFees = new Fees(1, 0, 0);
-        final var config = new TestConfigBuilder()
-                .withConfigDataType(NodesConfig.class)
-                .withValue("nodes.registeredNodesEnabled", true)
-                .getOrCreateConfig();
-        given(feeCtx.configuration()).willReturn(config);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(SubType.DEFAULT)).willReturn(feeCalc);
-        given(feeCtx.numTxnSignatures()).willReturn(3);
-        given(feeCalc.addVerificationsPerTransaction(2L)).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(expectedFees);
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(expectedFees);
-        verify(feeCalc).resetUsage();
-        verify(feeCalc).addVerificationsPerTransaction(2L);
-    }
-
-    @Test
-    @DisplayName("calculateFees with zero signatures adds zero verifications")
-    void calculateFeesWithZeroSignatures() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        final var expectedFees = new Fees(1, 0, 0);
-        final var config = new TestConfigBuilder()
-                .withConfigDataType(NodesConfig.class)
-                .withValue("nodes.registeredNodesEnabled", true)
-                .getOrCreateConfig();
-        given(feeCtx.configuration()).willReturn(config);
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(SubType.DEFAULT)).willReturn(feeCalc);
-        given(feeCtx.numTxnSignatures()).willReturn(0);
-        given(feeCalc.addVerificationsPerTransaction(0L)).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(expectedFees);
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(expectedFees);
-        verify(feeCalc).addVerificationsPerTransaction(0L);
-    }
-
-    @Test
-    @DisplayName("calculateFees throws NOT_SUPPORTED when registeredNodesEnabled is false")
-    void calculateFeesThrowsWhenDisabled() {
-        final var feeCtx = mock(FeeContext.class);
-        final var config = new TestConfigBuilder()
-                .withConfigDataType(NodesConfig.class)
-                .withValue("nodes.registeredNodesEnabled", false)
-                .getOrCreateConfig();
-        given(feeCtx.configuration()).willReturn(config);
-
-        final var ex = assertThrows(HandleException.class, () -> subject.calculateFees(feeCtx));
-        assertEquals(NOT_SUPPORTED, ex.getStatus());
     }
 
     // ─── Port boundary tests ────────────────────────────────────────────

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeDeleteHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeDeleteHandlerTest.java
@@ -2,9 +2,7 @@
 package com.hedera.node.app.service.addressbook.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_NODE_ID;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REGISTERED_NODE_STILL_ASSOCIATED;
-import static com.hedera.hapi.node.base.SubType.DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,7 +23,6 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
 import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.fixtures.workflows.FakePreHandleContext;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
@@ -317,74 +314,6 @@ class RegisteredNodeDeleteHandlerTest extends AddressBookTestBase {
 
         final var msg = assertThrows(HandleException.class, () -> subject.handle(handleContext));
         assertEquals(REGISTERED_NODE_STILL_ASSOCIATED, msg.getStatus());
-    }
-
-    // ─── calculateFees ─────────────────────────────────────────────
-
-    @Test
-    @DisplayName("calculateFees uses signature-based pricing with SubType.DEFAULT")
-    void calculateFeesUsesSignatureBasedPricing() {
-        final var expectedFees = new Fees(1L, 2L, 3L);
-        given(feeContext.configuration())
-                .willReturn(HederaTestConfigBuilder.create()
-                        .withValue("nodes.registeredNodesEnabled", true)
-                        .getOrCreateConfig());
-        given(feeContext.feeCalculatorFactory()).willReturn(feeCalculatorFactory);
-        given(feeCalculatorFactory.feeCalculator(DEFAULT)).willReturn(feeCalculator);
-        given(feeContext.numTxnSignatures()).willReturn(2);
-        given(feeCalculator.calculate()).willReturn(expectedFees);
-
-        final var result = subject.calculateFees(feeContext);
-
-        assertEquals(expectedFees, result);
-        verify(feeCalculator).resetUsage();
-        verify(feeCalculator).addVerificationsPerTransaction(1);
-    }
-
-    @Test
-    @DisplayName("calculateFees floors verification count at zero for single signature")
-    void calculateFeesWithZeroSignatures() {
-        given(feeContext.configuration())
-                .willReturn(HederaTestConfigBuilder.create()
-                        .withValue("nodes.registeredNodesEnabled", true)
-                        .getOrCreateConfig());
-        given(feeContext.feeCalculatorFactory()).willReturn(feeCalculatorFactory);
-        given(feeCalculatorFactory.feeCalculator(DEFAULT)).willReturn(feeCalculator);
-        given(feeContext.numTxnSignatures()).willReturn(0);
-        given(feeCalculator.calculate()).willReturn(Fees.FREE);
-
-        subject.calculateFees(feeContext);
-
-        verify(feeCalculator).addVerificationsPerTransaction(0);
-    }
-
-    @Test
-    @DisplayName("calculateFees adds n-1 verifications for multiple signatures")
-    void calculateFeesWithMultipleSignatures() {
-        given(feeContext.configuration())
-                .willReturn(HederaTestConfigBuilder.create()
-                        .withValue("nodes.registeredNodesEnabled", true)
-                        .getOrCreateConfig());
-        given(feeContext.feeCalculatorFactory()).willReturn(feeCalculatorFactory);
-        given(feeCalculatorFactory.feeCalculator(DEFAULT)).willReturn(feeCalculator);
-        given(feeContext.numTxnSignatures()).willReturn(5);
-        given(feeCalculator.calculate()).willReturn(Fees.FREE);
-
-        subject.calculateFees(feeContext);
-
-        verify(feeCalculator).addVerificationsPerTransaction(4);
-    }
-
-    @Test
-    @DisplayName("calculateFees throws NOT_SUPPORTED when registeredNodesEnabled is false")
-    void calculateFeesThrowsWhenDisabled() {
-        final var config = HederaTestConfigBuilder.create()
-                .withValue("nodes.registeredNodesEnabled", false)
-                .getOrCreateConfig();
-        given(feeContext.configuration()).willReturn(config);
-
-        final var ex = assertThrows(HandleException.class, () -> subject.calculateFees(feeContext));
-        assertEquals(NOT_SUPPORTED, ex.getStatus());
     }
 
     // ─── helpers ───────────────────────────────────────────────────

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeUpdateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/RegisteredNodeUpdateHandlerTest.java
@@ -8,21 +8,18 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_ENDP
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_ENDPOINT_TYPE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_REGISTERED_NODE_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_REQUIRED;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REGISTERED_ENDPOINTS_EXCEEDED_LIMIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.addressbook.RegisteredNodeUpdateTransactionBody;
 import com.hedera.hapi.node.addressbook.RegisteredServiceEndpoint;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.KeyList;
-import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.addressbook.RegisteredNode;
 import com.hedera.hapi.node.transaction.TransactionBody;
@@ -30,10 +27,6 @@ import com.hedera.node.app.service.addressbook.ReadableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.WritableRegisteredNodeStore;
 import com.hedera.node.app.service.addressbook.impl.handlers.RegisteredNodeUpdateHandler;
 import com.hedera.node.app.service.addressbook.impl.validators.AddressBookValidator;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fees.FeeCalculatorFactory;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -658,77 +651,6 @@ class RegisteredNodeUpdateHandlerTest extends AddressBookTestBase {
         assertEquals(existing.description(), persisted.description());
         assertEquals(existing.serviceEndpoint(), persisted.serviceEndpoint());
         assertEquals(existing.registeredNodeId(), persisted.registeredNodeId());
-    }
-
-    // ========== calculateFees tests ==========
-
-    @Test
-    @DisplayName("calculateFees uses signature-based pricing with SubType.DEFAULT")
-    void calculateFeesUsesSignatureBasedPricing() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        final var expectedFees = new Fees(1, 0, 0);
-        given(feeCtx.configuration()).willReturn(newConfig());
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(SubType.DEFAULT)).willReturn(feeCalc);
-        given(feeCtx.numTxnSignatures()).willReturn(3);
-        given(feeCalc.addVerificationsPerTransaction(2L)).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(expectedFees);
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(expectedFees);
-        verify(feeCalc).resetUsage();
-        verify(feeCalc).addVerificationsPerTransaction(2L);
-    }
-
-    @Test
-    @DisplayName("calculateFees with zero signatures adds zero verifications")
-    void calculateFeesWithZeroSignatures() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        final var expectedFees = new Fees(1, 0, 0);
-        given(feeCtx.configuration()).willReturn(newConfig());
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(SubType.DEFAULT)).willReturn(feeCalc);
-        given(feeCtx.numTxnSignatures()).willReturn(0);
-        given(feeCalc.addVerificationsPerTransaction(0L)).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(expectedFees);
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(expectedFees);
-        verify(feeCalc).addVerificationsPerTransaction(0L);
-    }
-
-    @Test
-    @DisplayName("calculateFees with multiple signatures adds n-1 verifications")
-    void calculateFeesWithMultipleSignatures() {
-        final var feeCtx = mock(FeeContext.class);
-        final var feeCalcFact = mock(FeeCalculatorFactory.class);
-        final var feeCalc = mock(FeeCalculator.class);
-        final var expectedFees = new Fees(1, 0, 0);
-        given(feeCtx.configuration()).willReturn(newConfig());
-        given(feeCtx.feeCalculatorFactory()).willReturn(feeCalcFact);
-        given(feeCalcFact.feeCalculator(SubType.DEFAULT)).willReturn(feeCalc);
-        given(feeCtx.numTxnSignatures()).willReturn(5);
-        given(feeCalc.addVerificationsPerTransaction(4L)).willReturn(feeCalc);
-        given(feeCalc.calculate()).willReturn(expectedFees);
-
-        assertThat(subject.calculateFees(feeCtx)).isEqualTo(expectedFees);
-        verify(feeCalc).addVerificationsPerTransaction(4L);
-    }
-
-    @Test
-    @DisplayName("calculateFees throws NOT_SUPPORTED when registeredNodesEnabled is false")
-    void calculateFeesThrowsWhenDisabled() {
-        final var feeCtx = mock(FeeContext.class);
-        final var config = new TestConfigBuilder()
-                .withConfigDataType(NodesConfig.class)
-                .withValue("nodes.registeredNodesEnabled", false)
-                .getOrCreateConfig();
-        given(feeCtx.configuration()).willReturn(config);
-
-        final var ex = assertThrows(HandleException.class, () -> subject.calculateFees(feeCtx));
-        assertEquals(NOT_SUPPORTED, ex.getStatus());
     }
 
     // ========== helper methods ==========


### PR DESCRIPTION
Deletes calculateFees/usageGiven from the address book service handlers and updates their unit tests.

Splits #25473. Part of #25850.
Closes #25876