### PR TITLE
refactor: remove legacy fee methods from network admin handlers

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeHandler.java
@@ -22,8 +22,6 @@ import com.hedera.node.app.service.file.ReadableUpgradeFileStore;
 import com.hedera.node.app.service.networkadmin.ReadableFreezeStore;
 import com.hedera.node.app.service.networkadmin.impl.WritableFreezeStore;
 import com.hedera.node.app.service.token.ReadableStakingInfoStore;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
@@ -218,14 +216,6 @@ public class FreezeHandler implements TransactionHandler {
             // UNKNOWN_FREEZE_TYPE will fail at preHandle, this code should never get called
             case UNKNOWN_FREEZE_TYPE -> throw new HandleException(ResponseCodeEnum.INVALID_FREEZE_TRANSACTION_BODY);
         }
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(@NonNull final FeeContext feeContext) {
-        requireNonNull(feeContext);
-        // Can only reach consensus with a privileged account as payer
-        return Fees.FREE;
     }
 
     /**

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetAccountDetailsHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetAccountDetailsHandler.java
@@ -11,8 +11,6 @@ import static com.hedera.hapi.node.base.TokenFreezeStatus.UNFROZEN;
 import static com.hedera.hapi.node.base.TokenKycStatus.GRANTED;
 import static com.hedera.hapi.node.base.TokenKycStatus.KYC_NOT_APPLICABLE;
 import static com.hedera.hapi.node.base.TokenKycStatus.REVOKED;
-import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
-import static com.hedera.node.app.spi.fees.Fees.CONSTANT_FEE_DATA;
 import static com.hedera.node.app.spi.validation.Validations.mustExist;
 import static java.util.Objects.requireNonNull;
 
@@ -38,18 +36,15 @@ import com.hedera.hapi.node.token.GrantedTokenAllowance;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
 import com.hedera.node.app.hapi.fees.usage.crypto.CryptoOpsUsage;
-import com.hedera.node.app.hapi.fees.usage.crypto.ExtantCryptoContext;
 import com.hedera.node.app.service.networkadmin.impl.utils.NetworkAdminServiceUtil;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.config.data.TokensConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hederahashgraph.api.proto.java.FeeData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -299,34 +294,5 @@ public class NetworkGetAccountDetailsHandler extends PaidQueryHandler {
             return cryptoAllowances;
         }
         return Collections.emptyList();
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext queryContext) {
-        final var query = queryContext.query();
-        final var accountStore = queryContext.createStore(ReadableAccountStore.class);
-        final var op = query.accountDetailsOrThrow();
-        final var accountId = op.accountIdOrElse(AccountID.DEFAULT);
-        final var account = accountStore.getAliasedAccountById(accountId);
-
-        return queryContext.feeCalculator().legacyCalculate(sigValueObj -> usageGiven(query, account));
-    }
-
-    private FeeData usageGiven(final com.hedera.hapi.node.transaction.Query query, final Account account) {
-        if (account == null) {
-            return CONSTANT_FEE_DATA;
-        }
-        final var ctx = ExtantCryptoContext.newBuilder()
-                .setCurrentKey(fromPbj(account.key()))
-                .setCurrentMemo(account.memo())
-                .setCurrentExpiry(account.expirationSecond())
-                .setCurrentNumTokenRels(account.numberAssociations())
-                .setCurrentMaxAutomaticAssociations(account.maxAutoAssociations())
-                .setCurrentCryptoAllowances(Collections.emptyMap())
-                .setCurrentTokenAllowances(Collections.emptyMap())
-                .setCurrentApproveForAllNftAllowances(Collections.emptySet())
-                .build();
-        return cryptoOpsUsage.cryptoInfoUsage(fromPbj(query), ctx);
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetVersionInfoHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkGetVersionInfoHandler.java
@@ -15,8 +15,6 @@ import com.hedera.hapi.node.base.ResponseType;
 import com.hedera.hapi.node.network.NetworkGetVersionInfoResponse;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -98,13 +96,5 @@ public class NetworkGetVersionInfoHandler extends PaidQueryHandler {
         }
 
         return Response.newBuilder().networkGetVersionInfo(responseBuilder).build();
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext queryContext) {
-        requireNonNull(queryContext);
-
-        return queryContext.feeCalculator().legacyCalculate(sigValueObj -> CommonPbjConverters.fromPbj(FIXED_USAGE));
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkTransactionGetRecordHandler.java
@@ -5,12 +5,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.RECORD_NOT_FOUND;
 import static com.hedera.hapi.node.base.ResponseType.COST_ANSWER;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BASIC_QUERY_HEADER;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BASIC_QUERY_RES_HEADER;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BASIC_TX_ID_SIZE;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.BASIC_TX_RECORD_SIZE;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.FEE_MATRICES_CONST;
-import static com.hedera.node.app.hapi.utils.fee.FeeBuilder.STATE_PROOF_SIZE;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -18,13 +12,9 @@ import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.QueryHeader;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.ResponseHeader;
-import com.hedera.hapi.node.base.ResponseType;
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.hapi.node.transaction.Response;
-import com.hedera.hapi.node.transaction.TransactionGetRecordQuery;
 import com.hedera.hapi.node.transaction.TransactionGetRecordResponse;
-import com.hedera.node.app.spi.fees.Fees;
-import com.hedera.node.app.spi.records.RecordCache;
 import com.hedera.node.app.spi.workflows.PaidQueryHandler;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.QueryContext;
@@ -136,46 +126,6 @@ public class NetworkTransactionGetRecordHandler extends PaidQueryHandler {
         }
 
         return Response.newBuilder().transactionGetRecord(responseBuilder).build();
-    }
-
-    @NonNull
-    @Override
-    public Fees computeFees(@NonNull final QueryContext queryContext) {
-        final RecordCache recordCache = queryContext.recordCache();
-        final TransactionGetRecordQuery op = queryContext.query().transactionGetRecordOrThrow();
-
-        // fees are the same for all records for a given response type,
-        // so we calculate them once and multiply by the number of records found
-
-        // calculate per-record fees
-        final ResponseType responseType = op.headerOrThrow().responseType();
-        final int stateProofSize =
-                responseType == ResponseType.ANSWER_STATE_PROOF || responseType == ResponseType.COST_ANSWER_STATE_PROOF
-                        ? STATE_PROOF_SIZE
-                        : 0;
-        final FeeComponents feeMatricesForTxNode = FeeComponents.newBuilder()
-                .setConstant(FEE_MATRICES_CONST)
-                .setBpt(BASIC_QUERY_HEADER + BASIC_TX_ID_SIZE)
-                .setBpr(BASIC_QUERY_RES_HEADER + BASIC_TX_RECORD_SIZE + stateProofSize)
-                .build();
-        final FeeData perRecordFeeData = FeeData.newBuilder()
-                .setNetworkdata(FeeComponents.getDefaultInstance())
-                .setNodedata(feeMatricesForTxNode)
-                .setServicedata(FeeComponents.getDefaultInstance())
-                .build();
-
-        int recordCount = 1;
-        if (op.includeDuplicates() || op.includeChildRecords()) {
-            final var history = recordCache.getHistory(op.transactionIDOrThrow());
-            if (history != null) {
-                recordCount += op.includeDuplicates() ? history.duplicateCount() : 0;
-                recordCount += op.includeChildRecords() ? history.childRecords().size() : 0;
-            }
-        }
-
-        // multiply node fees to include duplicate and/or child records
-        final FeeData feeData = multiplierOfUsages(perRecordFeeData, recordCount);
-        return queryContext.feeCalculator().legacyCalculate(sigValueObj -> feeData);
     }
 
     private static FeeData multiplierOfUsages(final FeeData feeData, final int multiplier) {

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/NetworkUncheckedSubmitHandler.java
@@ -5,8 +5,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
@@ -50,11 +48,5 @@ public class NetworkUncheckedSubmitHandler implements TransactionHandler {
         // because preHandle will always throw
         requireNonNull(context);
         throw new HandleException(NOT_SUPPORTED);
-    }
-
-    @NonNull
-    @Override
-    public Fees calculateFees(final FeeContext feeContext) {
-        return Fees.FREE;
     }
 }

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkAdminHandlerTestBase.java
@@ -41,7 +41,6 @@ import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.ReadableAccountStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenRelationStoreImpl;
 import com.hedera.node.app.service.token.impl.ReadableTokenStoreImpl;
-import com.hedera.node.app.spi.fees.FeeCalculator;
 import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.migrate.StartupNetworks;
 import com.hedera.node.app.state.DeduplicationCache;
@@ -184,9 +183,6 @@ public class NetworkAdminHandlerTestBase {
 
     @Mock
     private StartupNetworks startupNetworks;
-
-    @Mock
-    protected FeeCalculator feeCalculator;
 
     @Mock
     protected ReadableEntityCounters readableEntityCounters;

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetRecordHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkTransactionGetRecordHandlerTest.java
@@ -8,7 +8,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.QueryHeader;
@@ -22,15 +21,12 @@ import com.hedera.hapi.node.transaction.TransactionGetRecordQuery;
 import com.hedera.hapi.node.transaction.TransactionGetRecordResponse;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkTransactionGetRecordHandler;
-import com.hedera.node.app.spi.fees.FeeCalculator;
-import com.hedera.node.app.spi.fixtures.fees.FakeFeeCalculator;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.node.app.state.HederaRecordCache;
 import com.hedera.node.app.state.recordcache.PartialRecordSource;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
@@ -239,35 +235,6 @@ class NetworkTransactionGetRecordHandlerTest extends NetworkAdminHandlerTestBase
         assertThat(op.transactionRecord()).isEqualTo(otherRecord);
         assertThat(op.childTransactionRecords()).isEqualTo(expectedChildRecordList);
         assertThat(op.childTransactionRecords().size()).isEqualTo(expectedChildRecordList.size());
-    }
-
-    @Test
-    @DisplayName("test computeFees When Free")
-    void testComputeFees() {
-        final var query = createGetTransactionRecordQuery(transactionID, false, false);
-        given(context.query()).willReturn(query);
-        given(context.recordCache()).willReturn(cache);
-        given(context.feeCalculator()).willReturn(feeCalculator);
-        feeCalculator.addNetworkRamByteSeconds(6);
-        assertThatCode(() -> networkTransactionGetRecordHandler.computeFees(context))
-                .doesNotThrowAnyException();
-        verify(feeCalculator).addNetworkRamByteSeconds(6);
-    }
-
-    @Test
-    @DisplayName("test computeFees with duplicates and children")
-    void testComputeFeesWithDuplicatesAndChildRecords() {
-        final var query = createGetTransactionRecordQuery(transactionID, true, true);
-        given(context.query()).willReturn(query);
-        given(context.recordCache()).willReturn(cache);
-        FeeCalculator feeCalc = new FakeFeeCalculator();
-        feeCalc.addBytesPerTransaction(1000L);
-        feeCalc.addNetworkRamByteSeconds(6);
-        given(context.feeCalculator()).willReturn(feeCalc);
-        assertThatCode(() -> networkTransactionGetRecordHandler.computeFees(context))
-                .doesNotThrowAnyException();
-        var networkFee = networkTransactionGetRecordHandler.computeFees(context).networkFee();
-        assertThat(networkFee).isZero();
     }
 
     private TransactionRecord getExpectedRecord() {

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkUncheckedSubmitHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/NetworkUncheckedSubmitHandlerTest.java
@@ -3,20 +3,14 @@ package com.hedera.node.app.service.networkadmin.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mock.Strictness.LENIENT;
-import static org.mockito.Mockito.mock;
 
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkUncheckedSubmitHandler;
-import com.hedera.node.app.spi.fees.FeeContext;
-import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -44,14 +38,5 @@ class NetworkUncheckedSubmitHandlerTest {
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(NOT_SUPPORTED));
-    }
-
-    @Test
-    @DisplayName("testCalculateFees")
-    void testCalculateFees() {
-        FeeContext mockFeeContext = mock(FeeContext.class);
-        assertThatNoException().isThrownBy(() -> subject.calculateFees(mockFeeContext));
-        final var result = subject.calculateFees(mockFeeContext);
-        assertThat(result).isEqualTo(Fees.FREE);
     }
 }


### PR DESCRIPTION
Deletes calculateFees/usageGiven/computeFees from the network admin service handlers and updates their unit tests. Also drops the now-dead legacy computeFees tests in NetworkTransactionGetRecordHandlerTest and the unused FeeCalculator mock in the test base.

Splits #25473. Part of #25850.
Closes #25877