### PR TITLE
fix: ignore the gas price for noop context so that gas can be zero

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCharging.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/CustomGasCharging.java
@@ -71,7 +71,7 @@ public class CustomGasCharging {
         if (!context.shouldChargeGasFees()) {
             return;
         }
-        if (context.isNoopGasContext() || unusedGas == 0) {
+        if (context.isStaticCall() || unusedGas == 0) {
             return;
         }
         final var refund = unusedGas * context.gasPrice();
@@ -118,7 +118,7 @@ public class CustomGasCharging {
         // TODO: Revisit baselineGas with Pectra support epic
         final var intrinsicGas =
                 gasCalculator.transactionIntrinsicGasCost(transaction.evmPayload(), transaction.isCreate(), 0L);
-        if (context.isNoopGasContext()) {
+        if (context.isStaticCall()) {
             return new GasCharges(intrinsicGas, 0L);
         }
         validateTrue(transaction.gasLimit() >= intrinsicGas, INSUFFICIENT_GAS);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmContext.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmContext.java
@@ -38,7 +38,7 @@ public record HederaEvmContext(
     }
 
     public boolean isNoopGasContext() {
-        return staticCall || gasPrice == 0;
+        return staticCall;
     }
 
     public boolean isTransaction() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmContext.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmContext.java
@@ -37,7 +37,7 @@ public record HederaEvmContext(
         return blocks.blockValuesOf(gasLimit);
     }
 
-    public boolean isNoopGasContext() {
+    public boolean isStaticCall() {
         return staticCall;
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
@@ -29,7 +29,6 @@ import com.hedera.node.app.service.contract.impl.exec.gas.CustomGasCharging;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmBlocks;
-import com.hedera.node.app.service.contract.impl.hevm.HederaEvmContext;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.HederaEvmAccount;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
@@ -29,6 +29,7 @@ import com.hedera.node.app.service.contract.impl.exec.gas.CustomGasCharging;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.hevm.HederaEvmBlocks;
+import com.hedera.node.app.service.contract.impl.hevm.HederaEvmContext;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.service.contract.impl.records.ContractOperationStreamBuilder;
 import com.hedera.node.app.service.contract.impl.state.HederaEvmAccount;
@@ -85,6 +86,18 @@ class CustomGasChargingTest {
                 wellKnownHapiCall());
         assertEquals(0, chargingResult.relayerAllowanceUsed());
         verifyNoInteractions(worldUpdater);
+    }
+
+    @Test
+    void zeroPriceGasDoesChargeAndReturnIntrinsicGas() {
+        final var context =
+                new HederaEvmContext(0L, false, true, blocks, tinybarValues, systemContractGasCalculator, null, null);
+        givenWellKnownIntrinsicGasCost();
+        final var transaction = wellKnownHapiCall();
+        given(sender.getBalance()).willReturn(Wei.of(transaction.upfrontCostGiven(0)));
+        final var chargingResult = subject.chargeForGas(sender, relayer, context, worldUpdater, wellKnownHapiCall());
+        assertEquals(0, chargingResult.relayerAllowanceUsed());
+        assertEquals(TestHelpers.INTRINSIC_GAS, chargingResult.intrinsicGas());
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/CustomGasChargingTest.java
@@ -89,16 +89,6 @@ class CustomGasChargingTest {
     }
 
     @Test
-    void zeroPriceGasDoesNoChargingWorkButDoesReturnIntrinsicGas() {
-        final var context =
-                new HederaEvmContext(0L, false, true, blocks, tinybarValues, systemContractGasCalculator, null, null);
-        givenWellKnownIntrinsicGasCost();
-        final var chargingResult = subject.chargeForGas(sender, relayer, context, worldUpdater, wellKnownHapiCall());
-        assertEquals(0, chargingResult.relayerAllowanceUsed());
-        assertEquals(TestHelpers.INTRINSIC_GAS, chargingResult.intrinsicGas());
-    }
-
-    @Test
     void staticCallsDoNotRefundGas() {
         subject.maybeRefundGiven(
                 GAS_LIMIT / 2,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/SimpleFeesFreeScheduleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/SimpleFeesFreeScheduleTest.java
@@ -31,7 +31,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.SIMPLE_FEE_SCHEDULE;
-import static com.hedera.services.bdd.suites.contract.Utils.mirrorAddrWith;
 import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedContractCreateSimpleFeesUsd;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.getChargedGasForContractCreate;
@@ -59,7 +58,6 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.math.BigInteger;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -283,13 +281,9 @@ public class SimpleFeesFreeScheduleTest {
                                                                 .toStringUtf8())))
                                         .ethereumHash(ByteString.copyFrom(
                                                 spec.registry().getBytes(ETH_HASH_KEY)))))),
-                getAliasedAccountInfo(SECP_256K1_SOURCE_KEY).has(accountWith().nonce(3L))
-                ,
-                withOpContext((spec, opLog) -> swapSimpleFeeSchedule(spec, originalSimpleFeeSchedule.get()))
-
-        );
+                getAliasedAccountInfo(SECP_256K1_SOURCE_KEY).has(accountWith().nonce(3L)),
+                withOpContext((spec, opLog) -> swapSimpleFeeSchedule(spec, originalSimpleFeeSchedule.get())));
     }
-
 
     private static void swapSimpleFeeSchedule(HapiSpec spec, ByteString newFeeSchedule) {
         allRunFor(spec, updateLargeFile(GENESIS, SIMPLE_FEE_SCHEDULE, newFeeSchedule));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/SimpleFeesFreeScheduleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/SimpleFeesFreeScheduleTest.java
@@ -3,19 +3,36 @@ package com.hedera.services.bdd.suites.fees;
 
 import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.assertions.AssertUtils.inOrder;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateLargeFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.ETH_HASH_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.SIMPLE_FEE_SCHEDULE;
+import static com.hedera.services.bdd.suites.contract.Utils.mirrorAddrWith;
+import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedContractCreateSimpleFeesUsd;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.getChargedGasForContractCreate;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.getGasUsedForContractCreate;
@@ -30,6 +47,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.HapiTest;
@@ -39,7 +57,10 @@ import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.math.BigInteger;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -192,6 +213,84 @@ public class SimpleFeesFreeScheduleTest {
                 withOpContext((spec, opLog) -> swapSimpleFeeSchedule(spec, originalSimpleFeeSchedule.get())));
     }
 
+    private static final String PAY_RECEIVABLE_CONTRACT = "PayReceivable";
+
+    private static final String DEPOSIT = "deposit";
+    public static final long depositAmount = 20_000L;
+
+    @LeakyHapiTest(overrides = {"fees.simpleFeesAreFree"})
+    final Stream<DynamicTest> depositSuccess() {
+        final AtomicReference<ByteString> originalSimpleFeeSchedule = new AtomicReference<>();
+        return hapiTest(
+                withOpContext((spec, opLog) -> saveFeeSchedule(spec, originalSimpleFeeSchedule)),
+                withOpContext((spec, opLog) -> swapSimpleFeeSchedule(spec, simpleFeesWithCheapGas())),
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                        .via("autoAccount"),
+                getTxnRecord("autoAccount").andAllChildRecords(),
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD),
+                // EIP1559 Ethereum Calls Work
+                ethereumCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(depositAmount))
+                        .type(EthTxData.EthTransactionType.EIP1559)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .payingWith(RELAYER)
+                        .via("payTxn")
+                        .nonce(0)
+                        .maxFeePerGas(50L)
+                        .maxPriorityGas(2L)
+                        .gasLimit(1_000_000L)
+                        .sending(depositAmount)
+                        .hasKnownStatus(ResponseCodeEnum.SUCCESS),
+                // Legacy Ethereum Calls Work
+                ethereumCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(depositAmount))
+                        .type(EthTxData.EthTransactionType.LEGACY_ETHEREUM)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .payingWith(RELAYER)
+                        .via("payTxn")
+                        .nonce(1)
+                        .gasPrice(50L)
+                        .maxPriorityGas(2L)
+                        .gasLimit(1_000_000L)
+                        .sending(depositAmount)
+                        .hasKnownStatus(ResponseCodeEnum.SUCCESS),
+                // Ethereum Call with FileID callData works
+                ethereumCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(depositAmount))
+                        .type(EthTxData.EthTransactionType.EIP1559)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .payingWith(RELAYER)
+                        .via("payTxn")
+                        .nonce(2)
+                        .maxFeePerGas(50L)
+                        .maxPriorityGas(2L)
+                        .gasLimit(1_000_000L)
+                        .sending(depositAmount)
+                        .createCallDataFile()
+                        .hasKnownStatus(ResponseCodeEnum.SUCCESS),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, SECP_256K1_SOURCE_KEY)),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        getTxnRecord("payTxn")
+                                .logged()
+                                .hasPriority(recordWith()
+                                        .contractCallResult(resultWith()
+                                                .logs(inOrder())
+                                                .senderId(spec.registry()
+                                                        .getAccountID(spec.registry()
+                                                                .keyAliasIdFor(spec, SECP_256K1_SOURCE_KEY)
+                                                                .getAlias()
+                                                                .toStringUtf8())))
+                                        .ethereumHash(ByteString.copyFrom(
+                                                spec.registry().getBytes(ETH_HASH_KEY)))))),
+                getAliasedAccountInfo(SECP_256K1_SOURCE_KEY).has(accountWith().nonce(3L))
+                ,
+                withOpContext((spec, opLog) -> swapSimpleFeeSchedule(spec, originalSimpleFeeSchedule.get()))
+
+        );
+    }
+
+
     private static void swapSimpleFeeSchedule(HapiSpec spec, ByteString newFeeSchedule) {
         allRunFor(spec, updateLargeFile(GENESIS, SIMPLE_FEE_SCHEDULE, newFeeSchedule));
         assertTrue(spec.tryReinitializingFees(), "Failed to reinitialize fees after overriding simple fee schedule");
@@ -225,6 +324,25 @@ public class SimpleFeesFreeScheduleTest {
                 if (extra instanceof ObjectNode objectNode) {
                     if (objectNode.path("name").asText().equals("GAS")) {
                         objectNode.put("fee", 100);
+                    }
+                }
+            }
+            final var pbjSimpleFees = FeeSchedule.JSON.parse(Bytes.wrap(MAPPER.writeValueAsBytes(root)));
+            return ByteString.copyFrom(
+                    FeeSchedule.PROTOBUF.toBytes(pbjSimpleFees).toByteArray());
+        } catch (final Exception e) {
+            throw new IllegalStateException("Unable to build Simple Fees schedule with everything free", e);
+        }
+    }
+
+    private static ByteString simpleFeesWithCheapGas() {
+        try {
+            final JsonNode root =
+                    MAPPER.readTree(V0490FileSchema.loadResourceInPackage("genesis/simpleFeesSchedules.json"));
+            for (final var extra : root.path("extras")) {
+                if (extra instanceof ObjectNode objectNode) {
+                    if (extra.path("name").asText().equals("GAS")) {
+                        objectNode.put("fee", 1);
                     }
                 }
             }


### PR DESCRIPTION
**Description**:

The Single Day Performance Test (SDPT) is failing because it sets the price of the GAS extra to 1. Under Simple Fees all values are in tiny cents, so a fee of 1 will get rounded to 0 when it is converted to tiny bars at a rate of 12 to 1. This triggers isNoopGasContext() to return true even though the price of gas is really more than zero.

This PR fixes the SDPT failure on a gas price of 1 tinycent by changing `HederaEvmContext.isNoopGasContext()` to not care about the price of gas, only if it is a static call.



**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
