### PR TITLE
ci(workflow-fix): fix solo version processing check

### DIFF
--- a/.github/workflows/flow-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/flow-dry-run-extended-test-suite.yaml
@@ -112,7 +112,8 @@ jobs:
         id: params
         run: |
           SOLO_VERSION="${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-xts-solo-version }}"
-          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION}" "v0.44.0" | sort -V | head -n1)" == "v0.44.0" ]] && echo "true" || echo "false")
+          SOLO_VERSION_BARE="${SOLO_VERSION#v}"
+          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION_BARE}" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]] && echo "true" || echo "false")
           HELM_NAME="mirror"
           if [[ "${SOLO_GE_0440}" == "true" ]]; then
             HELM_NAME="mirror-1"
@@ -132,6 +133,7 @@ jobs:
           echo "Enable Migration Testing Panel: ${{ inputs.enable-migration-testing-panel }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Enable HAPI Tests BLOCKS Suite: ${{ inputs.enable-hapi-tests-blocks-suite }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Solo Version: ${SOLO_VERSION}" | tee -a "${GITHUB_STEP_SUMMARY}"
+          echo "Solo Version >= 0.44.0 (gates Migration Testing + Block Node Regression): ${SOLO_GE_0440}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Helm Release Name: ${HELM_NAME}" | tee -a "${GITHUB_STEP_SUMMARY}"
 
           echo "solo-version=${SOLO_VERSION}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -61,16 +61,19 @@ jobs:
       - name: Set Parameters
         id: set-parameters
         run: |
-          SOLO_GE_0440=$([[ "$(printf '%s\n' "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" "v0.44.0" | sort -V | head -n1)" == "v0.44.0" ]] && echo "true" || echo "false")
+          SOLO_VERSION="${{ needs.extract-citr-vars.outputs.citr-solo-version }}"
+          SOLO_VERSION_BARE="${SOLO_VERSION#v}"
+          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION_BARE}" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]] && echo "true" || echo "false")
           HELM_NAME="mirror"
           if [[ "${SOLO_GE_0440}" == "true" ]]; then
             HELM_NAME="mirror-1"
           fi
 
           echo "::debug::SOLO_GE_0440=${SOLO_GE_0440}"
+          echo "::notice::SOLO_VERSION=${SOLO_VERSION} SOLO_GE_0440=${SOLO_GE_0440} (gates Migration Testing + Block Node Regression panels)"
           echo "helm-release-name=${HELM_NAME}" >> "${GITHUB_OUTPUT}"
           echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
-          echo "solo-version=${{ needs.extract-citr-vars.outputs.citr-solo-version }}" >> "${GITHUB_OUTPUT}"
+          echo "solo-version=${SOLO_VERSION}" >> "${GITHUB_OUTPUT}"
 
   extract-jdk-version:
     name: Extract Java Version


### PR DESCRIPTION
**Description**:

Update the solo version check logic to strip leading `v` off the version number if it exists.

**Related Issue(s)**:

Fixes #25924

**Testing**:

- [XTS Dry Run Here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/27550550810) ✅ 
