### PR TITLE
ci(workflow): move solo version check to separate workflow

### DIFF
--- a/.github/workflows/857-call-solo-ge044.yaml
+++ b/.github/workflows/857-call-solo-ge044.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "857: [CALL] Compute solo-ge-0440 Gate"
+
+on:
+  workflow_call:
+    inputs:
+      solo-version:
+        description: "Solo version (with or without leading 'v') to compare against 0.44.0"
+        type: string
+        required: true
+    outputs:
+      solo-ge-0440:
+        description: "'true' if solo-version >= 0.44.0, else 'false'"
+        value: ${{ jobs.compute.outputs.solo-ge-0440 }}
+      solo-version-bare:
+        description: "Input solo-version with any leading 'v' stripped"
+        value: ${{ jobs.compute.outputs.solo-version-bare }}
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  compute:
+    name: Compute solo-ge-0440
+    runs-on: hl-cn-default-lin-sm
+    outputs:
+      solo-ge-0440: ${{ steps.compute.outputs.solo-ge-0440 }}
+      solo-version-bare: ${{ steps.compute.outputs.solo-version-bare }}
+    steps:
+      - name: Initialize Job
+        uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
+
+      - name: Compute Gate
+        id: compute
+        run: |
+          SOLO_VERSION="${{ inputs.solo-version }}"
+          SOLO_VERSION_BARE="${SOLO_VERSION#v}"
+          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION_BARE}" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]] && echo "true" || echo "false")
+          echo "::notice::SOLO_VERSION=${SOLO_VERSION} (bare=${SOLO_VERSION_BARE}) SOLO_GE_0440=${SOLO_GE_0440}"
+          echo "solo-version-bare=${SOLO_VERSION_BARE}" >> "${GITHUB_OUTPUT}"
+          echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/docs/workflow-manifest.md
+++ b/.github/workflows/docs/workflow-manifest.md
@@ -76,6 +76,7 @@
 | zxc-create-github-release.yaml                         | ZXC: Create Github Release                                        | 853-call-create-github-release.yaml          | 853: [CALL] Create Github Release  |
 | 802-extract-jdk-version.yaml                           | 802: [CALL] Extract JDK Version                                   | 854-extract-jdk-version.yaml                 | 854: [CALL] Extract JDK Version    |
 | 855-extract-citr-vars.yaml                             | 855: [CALL] Extract CITR Vars                                     | 855-extract-citr-vars.yaml                   | 855: [CALL] Extract CITR Vars      |
+| 857-call-solo-ge044.yaml                               | 857: [CALL] Compute solo-ge-0440 Gate                             | 857-call-solo-ge044.yaml                     | 857: [CALL] Compute solo-ge-0440   |
 |                                                        |                                                                   |                                              |                                    |
 | # CRON (900-999)                                       |                                                                   |                                              |                                    |
 | zxcron-extended-test-suite.yaml                        | ZXCron: [CITR] Extended Test Suite                                | 900-cron-extended-test-suite.yaml            | 900: [CRON] CITR Ext Test Suite    |

--- a/.github/workflows/flow-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/flow-dry-run-extended-test-suite.yaml
@@ -95,15 +95,24 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  compute-solo-ge-0440:
+    name: Compute solo-ge-0440
+    needs:
+      - extract-citr-vars
+    uses: ./.github/workflows/857-call-solo-ge044.yaml
+    with:
+      solo-version: ${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-xts-solo-version }}
+
   parameters:
     name: Workflow Parameters
     runs-on: hl-cn-default-lin-sm
     needs:
       - extract-citr-vars
+      - compute-solo-ge-0440
     outputs:
       solo-version: ${{ steps.params.outputs.solo-version }}
       helm-release-name: ${{ steps.params.outputs.helm-release-name }}
-      solo-ge-0440: ${{ steps.params.outputs.solo-ge-0440 }}
+      solo-ge-0440: ${{ needs.compute-solo-ge-0440.outputs.solo-ge-0440 }}
     steps:
       - name: Initialize GitHub Job
         uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
@@ -112,8 +121,7 @@ jobs:
         id: params
         run: |
           SOLO_VERSION="${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-xts-solo-version }}"
-          SOLO_VERSION_BARE="${SOLO_VERSION#v}"
-          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION_BARE}" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]] && echo "true" || echo "false")
+          SOLO_GE_0440="${{ needs.compute-solo-ge-0440.outputs.solo-ge-0440 }}"
           HELM_NAME="mirror"
           if [[ "${SOLO_GE_0440}" == "true" ]]; then
             HELM_NAME="mirror-1"
@@ -138,7 +146,6 @@ jobs:
 
           echo "solo-version=${SOLO_VERSION}" >> "${GITHUB_OUTPUT}"
           echo "helm-release-name=${HELM_NAME}" >> "${GITHUB_OUTPUT}"
-          echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
 
   extract-jdk-version:
     name: Extract Java Version

--- a/.github/workflows/flow-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/flow-dry-run-extended-test-suite.yaml
@@ -112,7 +112,8 @@ jobs:
         id: params
         run: |
           SOLO_VERSION="${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-xts-solo-version }}"
-          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION}" "v0.44.0" | sort -V | head -n1)" == "v0.44.0" ]] && echo "true" || echo "false")
+          SOLO_VERSION_BARE="${SOLO_VERSION#v}"
+          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION_BARE}" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]] && echo "true" || echo "false")
           HELM_NAME="mirror"
           if [[ "${SOLO_GE_0440}" == "true" ]]; then
             HELM_NAME="mirror-1"
@@ -132,6 +133,7 @@ jobs:
           echo "Enable Migration Testing Panel: ${{ inputs.enable-migration-testing-panel }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Enable HAPI Tests BLOCKS Suite: ${{ inputs.enable-hapi-tests-blocks-suite }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Solo Version: ${SOLO_VERSION}" | tee -a "${GITHUB_STEP_SUMMARY}"
+          echo "Solo Version >= 0.44.0 (gates Migration Testing + Block Node Regression): ${SOLO_GE_0440}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Helm Release Name: ${HELM_NAME}" | tee -a "${GITHUB_STEP_SUMMARY}"
 
           echo "solo-version=${SOLO_VERSION}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxc-xts-tests.yaml
+++ b/.github/workflows/zxc-xts-tests.yaml
@@ -405,6 +405,25 @@ jobs:
       access-token: ${{ secrets.regression-access-token }}
       slack-detailed-report-webhook: ${{ secrets.slack-citr-details-token }}
 
+  block-node-regression-skipped-notice:
+    name: Block Node Regression Panel (Skipped — solo < 0.44.0)
+    needs:
+      - build
+    if: ${{ needs.build.result == 'success' && inputs.enable-block-node-regression-panel == 'true' && inputs.solo-ge-0440 != 'true' }}
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Announce Skip
+        run: |
+          echo "::warning::Block Node Regression Panel was requested (enable-block-node-regression-panel=true) but skipped because solo-ge-0440='${{ inputs.solo-ge-0440 }}' (solo-version='${{ inputs.solo-version }}'). The panel requires Solo >= 0.44.0."
+          {
+            echo "## Block Node Regression Panel — SKIPPED"
+            echo ""
+            echo "Requested via \`enable-block-node-regression-panel=true\` but the \`solo-ge-0440\` gate is \`${{ inputs.solo-ge-0440 }}\`."
+            echo ""
+            echo "- Requested Solo version: \`${{ inputs.solo-version }}\`"
+            echo "- Required: \`>= 0.44.0\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   migration-testing-panel:
     name: Migration Testing Panel
     needs:
@@ -420,6 +439,25 @@ jobs:
     secrets:
       access-token: ${{ secrets.regression-access-token }}
       slack-detailed-report-webhook: ${{ secrets.slack-citr-details-token }}
+
+  migration-testing-skipped-notice:
+    name: Migration Testing Panel (Skipped — solo < 0.44.0)
+    needs:
+      - build
+    if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 != 'true' }}
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Announce Skip
+        run: |
+          echo "::warning::Migration Testing Panel was requested (enable-migration-testing-panel=true) but skipped because solo-ge-0440='${{ inputs.solo-ge-0440 }}' (solo-version='${{ inputs.solo-version }}'). The panel requires Solo >= 0.44.0."
+          {
+            echo "## Migration Testing Panel — SKIPPED"
+            echo ""
+            echo "Requested via \`enable-migration-testing-panel=true\` but the \`solo-ge-0440\` gate is \`${{ inputs.solo-ge-0440 }}\`."
+            echo ""
+            echo "- Requested Solo version: \`${{ inputs.solo-version }}\`"
+            echo "- Required: \`>= 0.44.0\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   set-failure-mode:
     name: Set Failure Mode

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -45,13 +45,22 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  compute-solo-ge-0440:
+    name: Compute solo-ge-0440
+    needs:
+      - extract-citr-vars
+    uses: ./.github/workflows/857-call-solo-ge044.yaml
+    with:
+      solo-version: ${{ needs.extract-citr-vars.outputs.citr-solo-version }}
+
   parameters:
     name: Determine Configurable Parameters
     runs-on: hl-cn-default-lin-sm
     needs:
       - extract-citr-vars
+      - compute-solo-ge-0440
     outputs:
-      solo-ge-0440: ${{ steps.set-parameters.outputs.solo-ge-0440 }}
+      solo-ge-0440: ${{ needs.compute-solo-ge-0440.outputs.solo-ge-0440 }}
       solo-version: ${{ steps.set-parameters.outputs.solo-version }}
       helm-release-name: ${{ steps.set-parameters.outputs.helm-release-name }}
     steps:
@@ -62,17 +71,13 @@ jobs:
         id: set-parameters
         run: |
           SOLO_VERSION="${{ needs.extract-citr-vars.outputs.citr-solo-version }}"
-          SOLO_VERSION_BARE="${SOLO_VERSION#v}"
-          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION_BARE}" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]] && echo "true" || echo "false")
+          SOLO_GE_0440="${{ needs.compute-solo-ge-0440.outputs.solo-ge-0440 }}"
           HELM_NAME="mirror"
           if [[ "${SOLO_GE_0440}" == "true" ]]; then
             HELM_NAME="mirror-1"
           fi
 
-          echo "::debug::SOLO_GE_0440=${SOLO_GE_0440}"
-          echo "::notice::SOLO_VERSION=${SOLO_VERSION} SOLO_GE_0440=${SOLO_GE_0440} (gates Migration Testing + Block Node Regression panels)"
           echo "helm-release-name=${HELM_NAME}" >> "${GITHUB_OUTPUT}"
-          echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
           echo "solo-version=${SOLO_VERSION}" >> "${GITHUB_OUTPUT}"
 
   extract-jdk-version:

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -61,16 +61,19 @@ jobs:
       - name: Set Parameters
         id: set-parameters
         run: |
-          SOLO_GE_0440=$([[ "$(printf '%s\n' "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" "v0.44.0" | sort -V | head -n1)" == "v0.44.0" ]] && echo "true" || echo "false")
+          SOLO_VERSION="${{ needs.extract-citr-vars.outputs.citr-solo-version }}"
+          SOLO_VERSION_BARE="${SOLO_VERSION#v}"
+          SOLO_GE_0440=$([[ "$(printf '%s\n' "${SOLO_VERSION_BARE}" "0.44.0" | sort -V | head -n1)" == "0.44.0" ]] && echo "true" || echo "false")
           HELM_NAME="mirror"
           if [[ "${SOLO_GE_0440}" == "true" ]]; then
             HELM_NAME="mirror-1"
           fi
 
           echo "::debug::SOLO_GE_0440=${SOLO_GE_0440}"
+          echo "::notice::SOLO_VERSION=${SOLO_VERSION} SOLO_GE_0440=${SOLO_GE_0440} (gates Migration Testing + Block Node Regression panels)"
           echo "helm-release-name=${HELM_NAME}" >> "${GITHUB_OUTPUT}"
           echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
-          echo "solo-version=${{ needs.extract-citr-vars.outputs.citr-solo-version }}" >> "${GITHUB_OUTPUT}"
+          echo "solo-version=${SOLO_VERSION}" >> "${GITHUB_OUTPUT}"
 
   extract-jdk-version:
     name: Extract Java Version


### PR DESCRIPTION
**Description**:

Update the solo version check logic to strip leading `v` off the version number if it exists.

**Related Issue(s)**:

Fixes #25924
