### PR TITLE
ci(workflow-fix): add permissions to PR formatting check workflow

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -24,6 +24,8 @@ defaults:
 
 permissions:
   statuses: write
+  contents: read
+  pull-requests: read
 
 jobs:
   title-check:


### PR DESCRIPTION
**Description**:

Add read permissions to the PR Formatting check workflow

**Related Issue(s)**:

Fixes #25897
