### PR TITLE
ci(workflow): Update names in workflow files

### DIFF
--- a/.github/workflows/100-user-collect-workflow-logs.yaml
+++ b/.github/workflows/100-user-collect-workflow-logs.yaml
@@ -33,7 +33,7 @@ jobs:
         id: run_id
         run: |
           RUN_ID=$(gh api -H "Accept: application/vnd.github+json" \
-            /repos/hiero-ledger/hiero-consensus-node/actions/workflows/zxcron-extended-test-suite.yaml/runs \
+            /repos/hiero-ledger/hiero-consensus-node/actions/workflows/900-cron-extended-test-suite.yaml/runs \
             --jq '.workflow_runs[] | select(.run_number == ${{ inputs.workflow_id }}) | .id')
           echo "::set-output name=value::$RUN_ID"
 

--- a/.github/workflows/223-disp-sdct-controller.yaml
+++ b/.github/workflows/223-disp-sdct-controller.yaml
@@ -256,7 +256,7 @@ jobs:
 
           # Summary
           {
-            echo "# ZXF Canonical Test Workflow Summary"
+            echo "# 223: [DISP] SDCT Controller Workflow Summary"
             echo
             echo "## Overall Status: ${OVERALL_STATUS}"
             echo

--- a/.github/workflows/300-flow-build-application.yaml
+++ b/.github/workflows/300-flow-build-application.yaml
@@ -89,10 +89,10 @@ jobs:
           echo "Using workflow reference: ${RESOLVED_REF}"
           echo "workflow-ref=${RESOLVED_REF}" >> "${GITHUB_OUTPUT}"
 
-      - name: Trigger ZXF Deploy Production Release
+      - name: "Trigger 301: [FLOW] Deploy Prod Release"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
-          workflow: .github/workflows/node-flow-deploy-release-artifact.yaml
+          workflow: .github/workflows/301-flow-deploy-release-artifact.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
           ref: ${{ steps.resolve-ref.outputs.workflow-ref }} # ensure we are always using the correct workflow definition. Default to main.
           token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -151,7 +151,7 @@ jobs:
 
       # Classify the failure so each category gets a distinct Slack payload and
       # routing (e.g. test failures ping the commit author, environment issues
-      # go to citr-failures). The "workflow" failure-mode is set by zxc-mats-tests
+      # go to citr-failures). The "workflow" failure-mode is set by 800-call-mats-tests.yaml
       # when a non-test step (spotless, module-info check, etc.) fails.
       - name: Determine Report Category
         id: report-category

--- a/.github/workflows/301-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/301-flow-deploy-release-artifact.yaml
@@ -220,15 +220,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           JOB_ENABLED="true"
-          JOB_STATE=$(gh workflow list --all --json name,state | jq -r '.[]|select(.name=="ZXF: Prepare Extended Test Suite")|.state')
+          JOB_STATE=$(gh workflow list --all --json name,state | jq -r '.[]|select(.name=="302: [DISP] CITR Prepare XTS")|.state')
           [[ "${JOB_STATE}" == "disabled_manually" ]] && JOB_ENABLED="false"
           echo "enabled=${JOB_ENABLED}" >> "${GITHUB_OUTPUT}"
 
-      - name: Trigger ZXF Prepare Extended Test Suite
+      - name: "Trigger 302: [DISP] CITR Prepare XTS"
         if: ${{ needs.release-branch.result == 'success' && steps.check-xts-job.outputs.enabled == 'true' }}
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
-          workflow: .github/workflows/zxf-prepare-extended-test-suite.yaml
+          workflow: .github/workflows/302-disp-prepare-extended-test-suite.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
           ref: main # ensure we are always using the workflow definition from the main branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -259,11 +259,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           JOB_ENABLED="true"
-          JOB_STATE=$(gh workflow list --all --json name,state --limit 200 | jq -r '.[]|select(.name=="ZXF: [Node] Deploy Integration Network Release")|.state')
+          JOB_STATE=$(gh workflow list --all --json name,state --limit 200 | jq -r '.[]|select(.name=="303: [DISP] Deploy Integration")|.state')
           [[ "${JOB_STATE}" == "disabled_manually" ]] && JOB_ENABLED="false"
           echo "enabled=${JOB_ENABLED}" >> "${GITHUB_OUTPUT}"
 
-      - name: Trigger ZXF Deploy Integration
+      - name: "Trigger 303: [DISP] Deploy Integration"
         if: >-
           ${{
             inputs.dry-run-enabled == false &&
@@ -273,7 +273,7 @@ jobs:
           }}
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
-          workflow: .github/workflows/node-zxf-deploy-integration.yaml
+          workflow: .github/workflows/303-disp-deploy-integration.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
           ref: main # ensure we are always using the workflow definition from the main branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -246,7 +246,7 @@ jobs:
   # re-added separately via enable-hapi-tests-crypto-and-misc-serial. Excluded from set-failure-mode
   # so failures stay silent while the BLOCKS transition stabilizes.
   #
-  # MATS (zxc-mats-tests.yaml) is intentionally not touched: enable-hapi-tests-crypto-and-misc-serial
+  # MATS (800-call-mats-tests.yaml) is intentionally not touched: enable-hapi-tests-crypto-and-misc-serial
   # defaults to false there, so MATS behavior is unchanged.
   xts-hapi-tests-blocks:
     name: XTS HAPI Tests (BLOCKS)

--- a/.github/workflows/850-call-build-release-artifact.yaml
+++ b/.github/workflows/850-call-build-release-artifact.yaml
@@ -816,13 +816,13 @@ jobs:
             if [[ -d "data/lib" ]] && [[ "$(ls -A data/lib)" ]]; then
                 zip -r "${LIB_ARCHIVE_FILE}" data/lib
             else
-                echo "::warning file=node-zxc-build-release-artifact.yaml,line=823,title=No Libraries Found::No Library files were found to include in the libraries archive."
+                echo "::warning file=850-call-build-release-artifact.yaml,line=823,title=No Libraries Found::No Library files were found to include in the libraries archive."
             fi
 
             if [[ -d "data/apps" ]] && [[ "$(ls -A data/apps)" ]]; then
                 zip -r "${APPS_ARCHIVE_FILE}" data/apps
             else
-                echo "::warning file=node-zxc-build-release-artifact.yaml,line=829,title=No Apps Found::No apps files were found to include in the application archive."
+                echo "::warning file=850-call-build-release-artifact.yaml,line=829,title=No Apps Found::No apps files were found to include in the application archive."
             fi
 
             # remove testing tools (if present) before building the public release artifact
@@ -831,7 +831,7 @@ jobs:
             if [[ -d "data" ]] && [[ "$(ls -A data)" ]]; then
                 zip -r "${PUBLIC_ARCHIVE_FILE}" *
             else
-                echo "::warning file=node-zxc-build-release-artifact.yaml,line=838,title=Nothing Found for Public Archive::No files were found to include in the public archive."
+                echo "::warning file=850-call-build-release-artifact.yaml,line=838,title=Nothing Found for Public Archive::No files were found to include in the public archive."
             fi
 
           echo "::endgroup::"
@@ -844,7 +844,7 @@ jobs:
               gpg --output "${LIB_ARCHIVE_FILE}.asc" --detach-sig "${LIB_ARCHIVE_FILE}"
               gpg --output "${LIB_ARCHIVE_FILE}.sha256.asc" --detach-sig "${LIB_ARCHIVE_FILE}.sha256"
             else
-              echo "::warning file=node-zxc-build-release-artifact.yaml,line=849,title=Library Archive Missing::The library archive file is missing; skipping signing."
+              echo "::warning file=850-call-build-release-artifact.yaml,line=849,title=Library Archive Missing::The library archive file is missing; skipping signing."
             fi
 
             if [[ -f "${APPS_ARCHIVE_FILE}" ]]; then
@@ -853,7 +853,7 @@ jobs:
               gpg --output "${APPS_ARCHIVE_FILE}.asc" --detach-sig "${APPS_ARCHIVE_FILE}"
               gpg --output "${APPS_ARCHIVE_FILE}.sha256.asc" --detach-sig "${APPS_ARCHIVE_FILE}.sha256"
             else
-              echo "::warning file=node-zxc-build-release-artifact.yaml,line=858,title=Application Archive Missing::The application archive file is missing; skipping signing."
+              echo "::warning file=850-call-build-release-artifact.yaml,line=858,title=Application Archive Missing::The application archive file is missing; skipping signing."
             fi
 
             if [[ -f "${PUBLIC_ARCHIVE_FILE}" ]]; then
@@ -862,7 +862,7 @@ jobs:
               gpg --output "${PUBLIC_ARCHIVE_FILE}.asc" --detach-sig "${PUBLIC_ARCHIVE_FILE}"
               gpg --output "${PUBLIC_ARCHIVE_FILE}.sha256.asc" --detach-sig "${PUBLIC_ARCHIVE_FILE}.sha256"
             else
-              echo "::warning file=node-zxc-build-release-artifact.yaml,line=867,title=Public Archive Missing::The public archive file is missing; skipping signing."
+              echo "::warning file=850-call-build-release-artifact.yaml,line=867,title=Public Archive Missing::The public archive file is missing; skipping signing."
             fi
           echo "::endgroup::"
 
@@ -887,7 +887,7 @@ jobs:
             echo "::group::Uploading SDK Release Artifacts to GCP Bucket"
             gsutil -m cp -r "${SDK_ARCHIVE_DIR}"/* gs://platform-sdk-ci-release-artifacts/${RELEASE_TAG}/
           else
-            echo "::error file=node-zxc-build-release-artifact.yaml,line=911,title=SDK Archive Directory Missing::The SDK archive directory is missing; cannot upload release artifacts."
+            echo "::error file=850-call-build-release-artifact.yaml,line=911,title=SDK Archive Directory Missing::The SDK archive directory is missing; cannot upload release artifacts."
             exit 1
           fi
 

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -242,7 +242,7 @@ jobs:
             COMMIT_LIST_STR=""
             if [[ -z "${COMMIT_LIST//[[:space:]]/}" ]]; then
               # should never get here.
-              echo "::error file=zxcron-extended-test-suite.yaml,line=213::No commits associated with this release; exiting."
+              echo "::error file=900-cron-extended-test-suite.yaml,line=213::No commits associated with this release; exiting."
               exit 1
             elif [[ ${COMMIT_COUNT} -gt 15 ]]; then
               COMMIT_LIST_STR="Please refer to the workflow summary for the full list of associated commits."

--- a/.github/workflows/901-cron-promote-build-candidate.yaml
+++ b/.github/workflows/901-cron-promote-build-candidate.yaml
@@ -174,26 +174,26 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: "Trigger ZXF: [CITR] Single Day Performance Test (SDPT)"
+      - name: "Trigger 221: [DISP] CITR SDPT Controller"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
-          workflow: .github/workflows/zxf-single-day-performance-test-controller.yaml
+          workflow: .github/workflows/221-disp-sdpt-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
           ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
-      - name: "Trigger ZXF: [CITR] Single Day Longevity Test (SDLT)"
+      - name: "Trigger 222: [DISP] CITR SDLT Controller"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
-          workflow: .github/workflows/zxf-single-day-longevity-test-controller.yaml
+          workflow: .github/workflows/222-disp-sdlt-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
           ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
-      - name: "Trigger ZXF: [CITR] Single Day Canonical Test (SDCT)"
+      - name: "Trigger 223: [DISP] CITR SDCT Controller"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
-          workflow: .github/workflows/zxf-single-day-canonical-test.yaml
+          workflow: .github/workflows/223-disp-sdct-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
           ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

This pull request updates workflow and job names, file references, and error/warning messages across several GitHub Actions workflow YAML files to follow a new, more descriptive and numbered naming convention. It also updates references to workflow files and ensures error and warning messages point to the correct files and line numbers for improved traceability.

**Workflow and Job Naming Standardization:**

* Updated job and workflow names throughout the workflows to use a new numbered and descriptive format (e.g., `"Trigger ZXF: [CITR] Single Day Performance Test (SDPT)"` → `"Trigger 221: [DISP] CITR SDPT Controller"` and similar for other jobs). [[1]](diffhunk://#diff-5cadc65374e5157dfc08ee485145730e1a66e136cf8398a34857f63dc853bf2cL177-R196) [[2]](diffhunk://#diff-350bbb7f6739b0cdce06bf90c7155023fd3c0dea446918f5ecf93aeee8a37640L223-R231) [[3]](diffhunk://#diff-350bbb7f6739b0cdce06bf90c7155023fd3c0dea446918f5ecf93aeee8a37640L262-R266)

* Updated summary and step names to match the new naming convention (e.g., `"ZXF Canonical Test Workflow Summary"` → `"223: [DISP] SDCT Controller Workflow Summary"`).

**Workflow File Reference Updates:**

* Changed references to workflow YAML files to use new file names that match the new naming scheme (e.g., `zxf-single-day-canonical-test.yaml` → `223-disp-sdct-controller.yaml`; `zxf-prepare-extended-test-suite.yaml` → `302-disp-prepare-extended-test-suite.yaml`). [[1]](diffhunk://#diff-5cadc65374e5157dfc08ee485145730e1a66e136cf8398a34857f63dc853bf2cL177-R196) [[2]](diffhunk://#diff-350bbb7f6739b0cdce06bf90c7155023fd3c0dea446918f5ecf93aeee8a37640L223-R231) [[3]](diffhunk://#diff-350bbb7f6739b0cdce06bf90c7155023fd3c0dea446918f5ecf93aeee8a37640L276-R276) [[4]](diffhunk://#diff-1ba1a4b2ac47c2df3432f8353bcea5c5654b0c3dab341be1d47156326924e1fbL92-R95)

* Updated workflow references in API calls and triggers to use the new file names (e.g., `/repos/hiero-ledger/hiero-consensus-node/actions/workflows/zxcron-extended-test-suite.yaml/runs` → `/repos/hiero-ledger/hiero-consensus-node/actions/workflows/900-cron-extended-test-suite.yaml/runs`).

**Error and Warning Message Improvements:**

* Updated error and warning messages to reference the correct (renamed) workflow files and line numbers for better traceability (e.g., `::warning file=node-zxc-build-release-artifact.yaml,line=823::` → `::warning file=850-call-build-release-artifact.yaml,line=823::`). [[1]](diffhunk://#diff-8726d3cea9ffe794368b5bb55215028868cf19603a767daa498b54878319dec1L819-R825) [[2]](diffhunk://#diff-8726d3cea9ffe794368b5bb55215028868cf19603a767daa498b54878319dec1L834-R834) [[3]](diffhunk://#diff-8726d3cea9ffe794368b5bb55215028868cf19603a767daa498b54878319dec1L847-R847) [[4]](diffhunk://#diff-8726d3cea9ffe794368b5bb55215028868cf19603a767daa498b54878319dec1L856-R856) [[5]](diffhunk://#diff-8726d3cea9ffe794368b5bb55215028868cf19603a767daa498b54878319dec1L865-R865) [[6]](diffhunk://#diff-8726d3cea9ffe794368b5bb55215028868cf19603a767daa498b54878319dec1L890-R890) [[7]](diffhunk://#diff-866e104331e826b6cd78ccd5a768be8eb64e8a8c1b8590d987ad572cb4adba29L245-R245)

**Documentation and Inline Comment Updates:**

* Updated inline comments to reference the new workflow file names, ensuring documentation matches the current configuration (e.g., `MATS (zxc-mats-tests.yaml)` → `MATS (800-call-mats-tests.yaml)`). [[1]](diffhunk://#diff-43e85103968702a6937e05421c69612bd4ff1d5989734c02a6f0cdf5504bd98aL249-R249) [[2]](diffhunk://#diff-1ba1a4b2ac47c2df3432f8353bcea5c5654b0c3dab341be1d47156326924e1fbL154-R154)

These changes help maintain consistency, clarity, and traceability in the workflow configuration as the project transitions to the new naming scheme.

## Related Issue(s)

Refers to #23571 