### PR TITLE
chore: Sig map override in dispatchComputeFees

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeContext.java
@@ -6,7 +6,6 @@ import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
-import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.authorization.Authorizer;
@@ -103,23 +102,6 @@ public interface FeeContext {
      * @return the computed fees
      */
     Fees dispatchComputeFees(@NonNull TransactionBody txBody, @NonNull AccountID syntheticPayerId);
-
-    /**
-     * Dispatches the computation of fees for the given transaction body and synthetic payer ID,
-     * using the serialized size of {@code overrideSignatureMap} (when non-null) instead of the
-     * context-derived signature map size.
-     *
-     * @param txBody the transaction body
-     * @param syntheticPayerId the synthetic payer ID
-     * @param overrideSignatureMap when non-null, its serialized size replaces the default value
-     * @return the computed fees
-     */
-    default Fees dispatchComputeFees(
-            @NonNull TransactionBody txBody,
-            @NonNull AccountID syntheticPayerId,
-            @Nullable SignatureMap overrideSignatureMap) {
-        return dispatchComputeFees(txBody, syntheticPayerId);
-    }
 
     /**
      * Returns the active Exchange Rate.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeContext.java
@@ -6,6 +6,7 @@ import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.transaction.ExchangeRate;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.authorization.Authorizer;
@@ -102,6 +103,23 @@ public interface FeeContext {
      * @return the computed fees
      */
     Fees dispatchComputeFees(@NonNull TransactionBody txBody, @NonNull AccountID syntheticPayerId);
+
+    /**
+     * Dispatches the computation of fees for the given transaction body and synthetic payer ID,
+     * using the serialized size of {@code overrideSignatureMap} (when non-null) instead of the
+     * context-derived signature map size.
+     *
+     * @param txBody the transaction body
+     * @param syntheticPayerId the synthetic payer ID
+     * @param overrideSignatureMap when non-null, its serialized size replaces the default value
+     * @return the computed fees
+     */
+    default Fees dispatchComputeFees(
+            @NonNull TransactionBody txBody,
+            @NonNull AccountID syntheticPayerId,
+            @Nullable SignatureMap overrideSignatureMap) {
+        return dispatchComputeFees(txBody, syntheticPayerId);
+    }
 
     /**
      * Returns the active Exchange Rate.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleContext.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.entityid.EntityNumGenerator;
 import com.hedera.node.app.spi.authorization.SystemPrivilege;
@@ -369,7 +370,10 @@ public interface HandleContext {
     NetworkInfo networkInfo();
 
     /**
-     * Dispatches the fee calculation for a child transaction (that might then be dispatched).
+     * Dispatches the fee calculation for a child transaction (that might then be dispatched), with
+     * an optional override {@link SignatureMap} whose serialized size replaces the context-derived
+     * value when computing fees. Pass {@code null} for {@code overrideSignatureMap} to preserve
+     * existing behavior.
      *
      * <p>The override payer id still matters for this purpose, because a transaction can add
      * state whose lifetime is scoped to a payer account (the main current example is a
@@ -378,12 +382,15 @@ public interface HandleContext {
      * @param txBody the {@link TransactionBody} of the child transaction to compute fees for
      * @param syntheticPayerId the child payer
      * @param computeDispatchFeesAsTopLevel for mono fidelity, whether to compute fees as a top-level transaction
+     * @param overrideSignatureMap when non-null, the serialized size of this map is used instead of the
+     *                             context-derived signature map size
      * @return the calculated fees
      */
     Fees dispatchComputeFees(
             @NonNull TransactionBody txBody,
             @NonNull AccountID syntheticPayerId,
-            @NonNull ComputeDispatchFeesAsTopLevel computeDispatchFeesAsTopLevel);
+            @NonNull ComputeDispatchFeesAsTopLevel computeDispatchFeesAsTopLevel,
+            @Nullable SignatureMap overrideSignatureMap);
 
     /**
      * Dispatches a child transaction with the given options.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchHandleContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchHandleContext.java
@@ -288,7 +288,7 @@ public class DispatchHandleContext implements HandleContext, FeeContext, FeeChar
             @NonNull final TransactionBody childTxBody, @NonNull final AccountID syntheticPayerId) {
         requireNonNull(childTxBody);
         requireNonNull(syntheticPayerId);
-        return dispatchComputeFees(childTxBody, syntheticPayerId, ComputeDispatchFeesAsTopLevel.NO);
+        return dispatchComputeFees(childTxBody, syntheticPayerId, ComputeDispatchFeesAsTopLevel.NO, null);
     }
 
     @Override
@@ -430,7 +430,8 @@ public class DispatchHandleContext implements HandleContext, FeeContext, FeeChar
     public Fees dispatchComputeFees(
             @NonNull final TransactionBody txBody,
             @NonNull final AccountID syntheticPayerId,
-            @NonNull final ComputeDispatchFeesAsTopLevel computeDispatchFeesAsTopLevel) {
+            @NonNull final ComputeDispatchFeesAsTopLevel computeDispatchFeesAsTopLevel,
+            @Nullable final SignatureMap overrideSignatureMap) {
         final var bodyToDispatch = ensureTxnId(txBody);
         var function = HederaFunctionality.NONE;
         try {
@@ -442,7 +443,8 @@ public class DispatchHandleContext implements HandleContext, FeeContext, FeeChar
         } catch (UnknownHederaFunctionality ex) {
             throw new HandleException(ResponseCodeEnum.INVALID_TRANSACTION_BODY);
         }
-        final var signatureMapSize = SignatureMap.PROTOBUF.measureRecord(txnInfo.signatureMap());
+        final var effectiveSignatureMap = overrideSignatureMap != null ? overrideSignatureMap : txnInfo.signatureMap();
+        final var signatureMapSize = SignatureMap.PROTOBUF.measureRecord(effectiveSignatureMap);
         return dispatcher.dispatchComputeFees(new ChildFeeContext(
                 feeManager,
                 this,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchHandleContext.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchHandleContext.java
@@ -443,8 +443,13 @@ public class DispatchHandleContext implements HandleContext, FeeContext, FeeChar
         } catch (UnknownHederaFunctionality ex) {
             throw new HandleException(ResponseCodeEnum.INVALID_TRANSACTION_BODY);
         }
+        final var chargeForSigVerification = shouldChargeForSigVerification(txBody);
+        // When an override is provided, use its size unconditionally so that externally-supplied
+        // signatures (e.g. from a system-contract parameter) are reflected in the fee.
         final var effectiveSignatureMap = overrideSignatureMap != null ? overrideSignatureMap : txnInfo.signatureMap();
-        final var signatureMapSize = SignatureMap.PROTOBUF.measureRecord(effectiveSignatureMap);
+        final var signatureMapSize = (overrideSignatureMap != null || chargeForSigVerification)
+                ? SignatureMap.PROTOBUF.measureRecord(effectiveSignatureMap)
+                : 0;
         return dispatcher.dispatchComputeFees(new ChildFeeContext(
                 feeManager,
                 this,
@@ -454,8 +459,8 @@ public class DispatchHandleContext implements HandleContext, FeeContext, FeeChar
                 authorizer,
                 storeFactory.asReadOnly(),
                 consensusNow,
-                shouldChargeForSigVerification(txBody) ? verifier : null,
-                shouldChargeForSigVerification(txBody) ? signatureMapSize : 0,
+                chargeForSigVerification ? verifier : null,
+                signatureMapSize,
                 function));
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/ChildDispatchFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/ChildDispatchFactory.java
@@ -53,6 +53,7 @@ import com.hedera.node.app.spi.signatures.SignatureVerification;
 import com.hedera.node.app.spi.signatures.VerificationAssistant;
 import com.hedera.node.app.spi.store.ReadableStoreFactory;
 import com.hedera.node.app.spi.throttle.ThrottleAdviser;
+import com.hedera.node.app.spi.workflows.ComputeDispatchFeesAsTopLevel;
 import com.hedera.node.app.spi.workflows.DispatchOptions;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleContext.ConsensusThrottling;
@@ -308,8 +309,9 @@ public class ChildDispatchFactory {
                 category);
         // Charge as top-level transactions if the category is BATCH_INNER.
         final var childFees = category == BATCH_INNER
-                ? dispatchHandleContext.dispatchComputeFees(txnInfo.txBody(), payerId, YES)
-                : dispatchHandleContext.dispatchComputeFees(txnInfo.txBody(), payerId);
+                ? dispatchHandleContext.dispatchComputeFees(txnInfo.txBody(), payerId, YES, null)
+                : dispatchHandleContext.dispatchComputeFees(
+                        txnInfo.txBody(), payerId, ComputeDispatchFeesAsTopLevel.NO, null);
 
         // Child transactions can inherit highVolume from a parent synthetic dispatch.
         final var isHighVolume = txnInfo.txBody().highVolume();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
@@ -565,7 +565,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
             final var fees = new Fees(1L, 2L, 3L);
             given(dispatcher.dispatchComputeFees(any())).willReturn(fees);
             final var captor = ArgumentCaptor.forClass(FeeContext.class);
-            final var result = subject.dispatchComputeFees(txBody, account1002, ComputeDispatchFeesAsTopLevel.NO);
+            final var result = subject.dispatchComputeFees(txBody, account1002, ComputeDispatchFeesAsTopLevel.NO, null);
             verify(dispatcher).dispatchComputeFees(captor.capture());
             final var feeContext = captor.getValue();
             assertInstanceOf(ChildFeeContext.class, feeContext);
@@ -579,7 +579,7 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
             given(dispatcher.dispatchComputeFees(any())).willReturn(fees);
             final var captor = ArgumentCaptor.forClass(FeeContext.class);
             final var result =
-                    subject.dispatchComputeFees(txnBodyWithoutId, account1002, ComputeDispatchFeesAsTopLevel.NO);
+                    subject.dispatchComputeFees(txnBodyWithoutId, account1002, ComputeDispatchFeesAsTopLevel.NO, null);
             verify(dispatcher).dispatchComputeFees(captor.capture());
             final var feeContext = captor.getValue();
             assertInstanceOf(ChildFeeContext.class, feeContext);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/DispatchHandleContextTest.java
@@ -55,6 +55,7 @@ import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.NftTransfer;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.SignaturePair;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenTransferList;
 import com.hedera.hapi.node.base.TransactionID;
@@ -570,6 +571,29 @@ public class DispatchHandleContextTest extends StateTestBase implements Scenario
             final var feeContext = captor.getValue();
             assertInstanceOf(ChildFeeContext.class, feeContext);
             assertSame(fees, result);
+        }
+
+        @Test
+        void overrideSignatureMapIsUsedInsteadOfContextMap() {
+            // txnInfo uses SignatureMap.DEFAULT (0 bytes). An override with sig pairs produces
+            // a non-zero signatureMapSize, which is reflected in ChildFeeContext.numTxnBytes().
+            final var sigPair = SignaturePair.newBuilder()
+                    .pubKeyPrefix(Bytes.wrap(new byte[6]))
+                    .ed25519(Bytes.wrap(new byte[64]))
+                    .build();
+            final var overrideSigMap =
+                    SignatureMap.newBuilder().sigPair(sigPair).build();
+            final var fees = new Fees(1L, 2L, 3L);
+            given(dispatcher.dispatchComputeFees(any())).willReturn(fees);
+            final var captor = ArgumentCaptor.forClass(FeeContext.class);
+
+            subject.dispatchComputeFees(txBody, account1002, ComputeDispatchFeesAsTopLevel.NO, overrideSigMap);
+
+            verify(dispatcher).dispatchComputeFees(captor.capture());
+            final var feeContext = (ChildFeeContext) captor.getValue();
+            final var expectedSigMapSize = SignatureMap.PROTOBUF.measureRecord(overrideSigMap);
+            final var expectedTxnBytes = TransactionBody.PROTOBUF.measureRecord(txBody) + expectedSigMapSize;
+            assertThat(feeContext.numTxnBytes()).isEqualTo(expectedTxnBytes);
         }
 
         @SuppressWarnings("ConstantConditions")

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/QueryModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/QueryModule.java
@@ -51,9 +51,10 @@ public interface QueryModule {
     static SystemContractGasCalculator provideSystemContractGasCalculator(
             @NonNull final CanonicalDispatchPrices canonicalDispatchPrices,
             @NonNull final TinybarValues tinybarValues) {
-        return new SystemContractGasCalculator(tinybarValues, canonicalDispatchPrices, (body, payerId) -> {
-            throw new IllegalStateException("Queries should fail before dispatching a child transaction");
-        });
+        return new SystemContractGasCalculator(
+                tinybarValues, canonicalDispatchPrices, (body, payerId, signatureMap) -> {
+                    throw new IllegalStateException("Queries should fail before dispatching a child transaction");
+                });
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/TransactionModule.java
@@ -86,8 +86,8 @@ public interface TransactionModule {
             @NonNull final CanonicalDispatchPrices canonicalDispatchPrices,
             @NonNull final TinybarValues tinybarValues) {
         return new SystemContractGasCalculator(
-                tinybarValues, canonicalDispatchPrices, (body, payerId) -> context.dispatchComputeFees(
-                                body, payerId, ComputeDispatchFeesAsTopLevel.NO)
+                tinybarValues, canonicalDispatchPrices, (body, payerId, signatureMap) -> context.dispatchComputeFees(
+                                body, payerId, ComputeDispatchFeesAsTopLevel.NO, signatureMap)
                         .totalFee());
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/SystemContractGasCalculator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/gas/SystemContractGasCalculator.java
@@ -5,9 +5,10 @@ import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.FE
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.function.ToLongBiFunction;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * Computes the gas requirements for dispatching transactions or queries.
@@ -21,22 +22,38 @@ public class SystemContractGasCalculator {
     // per tiny cents). For more info -> https://hedera.com/blog/rolling-smart-contract-hedera-api-fees-into-gas-fees
     private static final long FIXED_TINY_CENT_GAS_PRICE_COST = 852_000L;
 
+    /**
+     * Computes the fee in tinybars for a dispatched child transaction, optionally using an
+     * externally-supplied {@link SignatureMap} to determine signature costs.
+     */
+    @FunctionalInterface
+    public interface FeeCalculatorFunction {
+        /**
+         * @param body the transaction body to compute fees for
+         * @param payer the synthetic payer account
+         * @param signatureMap when non-null, its serialized size is used instead of the
+         *                     context-derived signature map size
+         * @return the computed fee in tinybars
+         */
+        long computeFee(@NonNull TransactionBody body, @NonNull AccountID payer, @Nullable SignatureMap signatureMap);
+    }
+
     private final TinybarValues tinybarValues;
     private final CanonicalDispatchPrices dispatchPrices;
-    private final ToLongBiFunction<TransactionBody, AccountID> feeCalculator;
+    private final FeeCalculatorFunction feeCalculator;
 
     public SystemContractGasCalculator(
             @NonNull final TinybarValues tinybarValues,
             @NonNull final CanonicalDispatchPrices dispatchPrices,
-            @NonNull final ToLongBiFunction<TransactionBody, AccountID> feeCalculator) {
+            @NonNull final FeeCalculatorFunction feeCalculator) {
         this.tinybarValues = requireNonNull(tinybarValues);
         this.dispatchPrices = requireNonNull(dispatchPrices);
         this.feeCalculator = requireNonNull(feeCalculator);
     }
 
     /**
-     * Convenience method that, given a transaction body whose cost can be directly compared to the minimum
-     * cost of a dispatch type, returns the gas requirement for the transaction to be dispatched.
+     * Given a transaction body whose cost can be directly compared to the minimum cost of a dispatch
+     * type, returns the gas requirement for the transaction to be dispatched.
      *
      * @param body the transaction body to be dispatched
      * @param dispatchType the type of dispatch whose minimum cost should be respected
@@ -47,15 +64,37 @@ public class SystemContractGasCalculator {
             @NonNull final TransactionBody body,
             @NonNull final DispatchType dispatchType,
             @NonNull final AccountID payer) {
-        requireNonNull(body);
-        requireNonNull(dispatchType);
-        requireNonNull(payer);
-        return gasRequirementWithTinycents(body, payer, dispatchPrices.canonicalPriceInTinycents(dispatchType));
+        return gasRequirement(body, dispatchType, payer, null);
     }
 
     /**
-     * Compares the canonical price and the feeCalculator's calculated price and uses the maximum of the two to
-     * calculate the gas requirement and returns it.
+     * Given a transaction body whose cost can be directly compared to the minimum cost of a dispatch
+     * type, returns the gas requirement for the transaction to be dispatched. When
+     * {@code signatureMap} is non-null its serialized size is used instead of the context-derived
+     * signature map size.
+     *
+     * @param body the transaction body to be dispatched
+     * @param dispatchType the type of dispatch whose minimum cost should be respected
+     * @param payer the payer of the transaction
+     * @param signatureMap when non-null, its serialized size is used for fee computation
+     * @return the gas requirement for the transaction to be dispatched
+     */
+    public long gasRequirement(
+            @NonNull final TransactionBody body,
+            @NonNull final DispatchType dispatchType,
+            @NonNull final AccountID payer,
+            @Nullable final SignatureMap signatureMap) {
+        requireNonNull(body);
+        requireNonNull(dispatchType);
+        requireNonNull(payer);
+        return gasRequirementWithTinycents(
+                body, payer, dispatchPrices.canonicalPriceInTinycents(dispatchType), signatureMap);
+    }
+
+    /**
+     * Compares the canonical price and the feeCalculator's calculated price, uses the maximum of the
+     * two to calculate the gas requirement, and returns it.
+     *
      * @param body the transaction body
      * @param payer the payer of the transaction
      * @param minimumPriceInTinycents the minimum price in tiny cents
@@ -63,7 +102,26 @@ public class SystemContractGasCalculator {
      */
     public long gasRequirementWithTinycents(
             @NonNull final TransactionBody body, @NonNull final AccountID payer, final long minimumPriceInTinycents) {
-        final var computedPriceInTinybars = feeCalculator.applyAsLong(body, payer);
+        return gasRequirementWithTinycents(body, payer, minimumPriceInTinycents, null);
+    }
+
+    /**
+     * Compares the canonical price and the feeCalculator's calculated price, uses the maximum of the
+     * two to calculate the gas requirement, and returns it. When {@code signatureMap} is non-null its
+     * serialized size is used instead of the context-derived signature map size.
+     *
+     * @param body the transaction body
+     * @param payer the payer of the transaction
+     * @param minimumPriceInTinycents the minimum price in tiny cents
+     * @param signatureMap when non-null, its serialized size is used for fee computation
+     * @return the gas requirement for the transaction
+     */
+    public long gasRequirementWithTinycents(
+            @NonNull final TransactionBody body,
+            @NonNull final AccountID payer,
+            final long minimumPriceInTinycents,
+            @Nullable final SignatureMap signatureMap) {
+        final var computedPriceInTinybars = feeCalculator.computeFee(body, payer, signatureMap);
         final var priceInTinycents =
                 Math.max(minimumPriceInTinycents, tinybarValues.asTinycents(computedPriceInTinybars));
         // For the rare cases where computedPrice > minimumPriceInTinycents:
@@ -133,7 +191,7 @@ public class SystemContractGasCalculator {
      * @return the canonical price for that dispatch
      */
     public long feeCalculatorPriceInTinyBars(@NonNull final TransactionBody body, @NonNull final AccountID payer) {
-        return feeCalculator.applyAsLong(body, payer);
+        return feeCalculator.computeFee(body, payer, null);
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/QueryModuleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/QueryModuleTest.java
@@ -91,6 +91,7 @@ class QueryModuleTest {
         final var calculator = QueryModule.provideSystemContractGasCalculator(canonicalDispatchPrices, tinybarValues);
         assertThrows(
                 IllegalStateException.class,
-                () -> calculator.gasRequirement(TransactionBody.DEFAULT, DispatchType.APPROVE, AccountID.DEFAULT));
+                () -> calculator.gasRequirement(
+                        TransactionBody.DEFAULT, DispatchType.APPROVE, AccountID.DEFAULT, null));
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionModuleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/TransactionModuleTest.java
@@ -195,7 +195,8 @@ class TransactionModuleTest {
     @Test
     void providesSystemGasContractCalculator() {
         // Given a transaction-specific dispatch cost of 6 tinyBars which will be 12000 tinyCents...
-        given(context.dispatchComputeFees(TransactionBody.DEFAULT, AccountID.DEFAULT, ComputeDispatchFeesAsTopLevel.NO))
+        given(context.dispatchComputeFees(
+                        TransactionBody.DEFAULT, AccountID.DEFAULT, ComputeDispatchFeesAsTopLevel.NO, null))
                 .willReturn(new Fees(1, 2, 3));
         // The 6 tinyBars = 12000 tinyCents
         given(tinybarValues.asTinycents(6L)).willReturn(12000L);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/SystemContractGasCalculatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/SystemContractGasCalculatorTest.java
@@ -70,6 +70,32 @@ class SystemContractGasCalculatorTest {
         assertEquals(123L, subject.topLevelGasPriceInTinyBars());
     }
 
+    @Test
+    void gasRequirementDelegatesToFourArgWithNullSignatureMap() {
+        given(dispatchPrices.canonicalPriceInTinycents(DispatchType.ASSOCIATE)).willReturn(0L);
+        given(feeCalculator.computeFee(TransactionBody.DEFAULT, AccountID.DEFAULT, null))
+                .willReturn(0L);
+        given(tinybarValues.asTinycents(0L)).willReturn(0L);
+        given(tinybarValues.childTransactionTinycentGasPrice()).willReturn(1L);
+
+        final var via3Arg = subject.gasRequirement(TransactionBody.DEFAULT, DispatchType.ASSOCIATE, AccountID.DEFAULT);
+        final var via4Arg =
+                subject.gasRequirement(TransactionBody.DEFAULT, DispatchType.ASSOCIATE, AccountID.DEFAULT, null);
+        assertEquals(via3Arg, via4Arg);
+    }
+
+    @Test
+    void gasRequirementWithTinycentsDelegatesToFourArgWithNullSignatureMap() {
+        given(feeCalculator.computeFee(TransactionBody.DEFAULT, AccountID.DEFAULT, null))
+                .willReturn(0L);
+        given(tinybarValues.asTinycents(0L)).willReturn(0L);
+        given(tinybarValues.childTransactionTinycentGasPrice()).willReturn(1L);
+
+        final var via3Arg = subject.gasRequirementWithTinycents(TransactionBody.DEFAULT, AccountID.DEFAULT, 500L);
+        final var via4Arg = subject.gasRequirementWithTinycents(TransactionBody.DEFAULT, AccountID.DEFAULT, 500L, null);
+        assertEquals(via3Arg, via4Arg);
+    }
+
     /**
      * Verifies that providing a non-null {@code signatureMap} override to
      * {@link SystemContractGasCalculator#gasRequirement} results in higher gas than passing

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/SystemContractGasCalculatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/gas/SystemContractGasCalculatorTest.java
@@ -1,16 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl.test.exec.gas;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.SignaturePair;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.CanonicalDispatchPrices;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator.FeeCalculatorFunction;
 import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
-import java.util.function.ToLongBiFunction;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +28,7 @@ class SystemContractGasCalculatorTest {
     private TinybarValues tinybarValues;
 
     @Mock
-    private ToLongBiFunction<TransactionBody, AccountID> feeCalculator;
+    private FeeCalculatorFunction feeCalculator;
 
     @Mock
     private CanonicalDispatchPrices dispatchPrices;
@@ -48,7 +53,7 @@ class SystemContractGasCalculatorTest {
 
     @Test
     void computesCanonicalDispatch() {
-        given(feeCalculator.applyAsLong(TransactionBody.DEFAULT, AccountID.DEFAULT))
+        given(feeCalculator.computeFee(TransactionBody.DEFAULT, AccountID.DEFAULT, null))
                 .willReturn(123L);
         assertEquals(123L, subject.feeCalculatorPriceInTinyBars(TransactionBody.DEFAULT, AccountID.DEFAULT));
     }
@@ -63,5 +68,52 @@ class SystemContractGasCalculatorTest {
     void delegatesTopLevelGasPrice() {
         given(tinybarValues.topLevelTinybarGasPriceFullPrecision()).willReturn(123L);
         assertEquals(123L, subject.topLevelGasPriceInTinyBars());
+    }
+
+    /**
+     * Verifies that providing a non-null {@code signatureMap} override to
+     * {@link SystemContractGasCalculator#gasRequirement} results in higher gas than passing
+     * {@code null}, and that the extra gas is proportional to the number of signatures.
+     *
+     * <p>The {@link FeeCalculatorFunction} used here mirrors what
+     * {@code DispatchHandleContext.dispatchComputeFees} does: it measures the serialized size
+     * of the provided {@code SignatureMap} and incorporates that into the returned fee.
+     * With a gas price of 1 tinycent-per-unit and a 1:1 tinybar→tinycent conversion the
+     * fee formula is linear, so gas(3 sigs) == 3 × gas(1 sig) exactly.
+     */
+    @Test
+    void signatureMapOverrideIncreasesGasProportionallyToSignatureCount() {
+        // Build identical sig pairs — each contributes the same number of serialized bytes.
+        final var sigPair = SignaturePair.newBuilder()
+                .pubKeyPrefix(Bytes.wrap(new byte[6]))
+                .ed25519(Bytes.wrap(new byte[64]))
+                .build();
+        final var sigMap1 = SignatureMap.newBuilder().sigPair(sigPair).build();
+        final var sigMap3 =
+                SignatureMap.newBuilder().sigPair(sigPair, sigPair, sigPair).build();
+
+        // FeeCalculatorFunction that mirrors DispatchHandleContext: fee = serialized sigmap bytes.
+        final var calcSubject = new SystemContractGasCalculator(
+                tinybarValues,
+                dispatchPrices,
+                (body, payer, sigMap) -> sigMap == null ? 0L : SignatureMap.PROTOBUF.measureRecord(sigMap));
+
+        // Canonical price 0 so the feeCalculator result always wins; 1:1 tinybar→tinycent.
+        given(dispatchPrices.canonicalPriceInTinycents(DispatchType.ASSOCIATE)).willReturn(0L);
+        given(tinybarValues.asTinycents(anyLong())).willAnswer(inv -> (long) inv.getArguments()[0]);
+        // Gas price 1 tinycent/unit keeps arithmetic exact (FEE_SCHEDULE_UNITS_PER_TINYCENT divides evenly).
+        given(tinybarValues.childTransactionTinycentGasPrice()).willReturn(1L);
+
+        final var gasNoMap =
+                calcSubject.gasRequirement(TransactionBody.DEFAULT, DispatchType.ASSOCIATE, AccountID.DEFAULT);
+        final var gas1Sig =
+                calcSubject.gasRequirement(TransactionBody.DEFAULT, DispatchType.ASSOCIATE, AccountID.DEFAULT, sigMap1);
+        final var gas3Sigs =
+                calcSubject.gasRequirement(TransactionBody.DEFAULT, DispatchType.ASSOCIATE, AccountID.DEFAULT, sigMap3);
+
+        assertThat(gas1Sig).isGreaterThan(gasNoMap);
+        assertThat(gas3Sigs).isGreaterThan(gas1Sig);
+        // Three identical sig pairs → exactly 3× the serialized bytes → exactly 3× the gas overhead.
+        assertThat(gas3Sigs).isEqualTo(3L * gas1Sig);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hbarAllowance/HbarAllowanceCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hbarAllowance/HbarAllowanceCallTest.java
@@ -11,19 +11,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
-import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.CanonicalDispatchPrices;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator.FeeCalculatorFunction;
 import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarallowance.HbarAllowanceCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarallowance.HbarAllowanceTranslator;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import java.math.BigInteger;
-import java.util.function.ToLongBiFunction;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
@@ -43,7 +41,7 @@ class HbarAllowanceCallTest extends CallTestBase {
     private CanonicalDispatchPrices dispatchPrices;
 
     @Mock
-    private ToLongBiFunction<TransactionBody, AccountID> feeCalculator;
+    private FeeCalculatorFunction feeCalculator;
 
     @Test
     void revertsWithNoOwner() {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AssociateTokenRecipientsStep.java
@@ -218,7 +218,7 @@ public class AssociateTokenRecipientsStep extends BaseTokenHandler implements Tr
     }
 
     public static long associationFeeFor(@NonNull final HandleContext context, @NonNull final TransactionBody txnBody) {
-        return context.dispatchComputeFees(txnBody, context.payer(), ComputeDispatchFeesAsTopLevel.NO)
+        return context.dispatchComputeFees(txnBody, context.payer(), ComputeDispatchFeesAsTopLevel.NO, null)
                 .totalFee();
     }
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AssociateTokenRecipientsStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/AssociateTokenRecipientsStepTest.java
@@ -196,7 +196,7 @@ public class AssociateTokenRecipientsStepTest extends StepsBase {
                 .willReturn(TransactionBody.newBuilder()
                         .cryptoTransfer(txnNFTWithApproval)
                         .build());
-        given(handleContext.dispatchComputeFees(any(), any(), any())).willReturn(new Fees(1L, 2L, 3L));
+        given(handleContext.dispatchComputeFees(any(), any(), any(), any())).willReturn(new Fees(1L, 2L, 3L));
         lenient()
                 .when(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong()))
                 .thenReturn(ResponseCodeEnum.OK);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/StepsBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/StepsBase.java
@@ -199,7 +199,7 @@ public class StepsBase extends CryptoTokenHandlerTestBase {
         given(handleContext.body()).willReturn(txn);
         given(handleContext.configuration()).willReturn(configuration);
         given(handleContext.expiryValidator()).willReturn(expiryValidator);
-        given(handleContext.dispatchComputeFees(any(), any(), any())).willReturn(new Fees(1l, 2l, 3l));
+        given(handleContext.dispatchComputeFees(any(), any(), any(), any())).willReturn(new Fees(1l, 2l, 3l));
         transferContext = new TransferContextImpl(handleContext);
         given(configProvider.getConfiguration()).willReturn(versionedConfig);
     }
@@ -283,7 +283,7 @@ public class StepsBase extends CryptoTokenHandlerTestBase {
         given(handleContext.configuration()).willReturn(configuration);
         given(handleContext.expiryValidator()).willReturn(expiryValidator);
         given(handleContext.dispatch(any())).willReturn(tokenAirdropRecordBuilder);
-        given(handleContext.dispatchComputeFees(any(), any(), any())).willReturn(new Fees(1L, 2L, 3L));
+        given(handleContext.dispatchComputeFees(any(), any(), any(), any())).willReturn(new Fees(1L, 2L, 3L));
         given(configProvider.getConfiguration()).willReturn(versionedConfig);
     }
 
@@ -296,7 +296,7 @@ public class StepsBase extends CryptoTokenHandlerTestBase {
         given(handleContext.body()).willReturn(txn);
         given(handleContext.configuration()).willReturn(configuration);
         given(handleContext.expiryValidator()).willReturn(expiryValidator);
-        given(handleContext.dispatchComputeFees(any(), any(), any())).willReturn(new Fees(1L, 2L, 3L));
+        given(handleContext.dispatchComputeFees(any(), any(), any(), any())).willReturn(new Fees(1L, 2L, 3L));
         given(configProvider.getConfiguration()).willReturn(versionedConfig);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/util/CryptoTokenHandlerTestBase.java
@@ -1252,7 +1252,7 @@ public class CryptoTokenHandlerTestBase extends StateBuilderUtil {
         given(storeFactory.readableStore(ReadableEntityIdStore.class)).willReturn(readableEntityCounters);
         given(storeFactory.writableStore(WritableEntityIdStore.class)).willReturn(writableEntityCounters);
 
-        given(context.dispatchComputeFees(any(), any(), any())).willReturn(new Fees(1L, 2L, 3L));
+        given(context.dispatchComputeFees(any(), any(), any(), any())).willReturn(new Fees(1L, 2L, 3L));
 
         final var expiryValidator = mock(ExpiryValidator.class);
         lenient().when(context.expiryValidator()).thenReturn(expiryValidator);


### PR DESCRIPTION
**Description**:
This pull request enhances the fee calculation logic for dispatched child transactions by allowing an optional override of the signature map used in fee computations. This enables more accurate fee assessments, especially when signatures are supplied externally (such as by system contracts). The changes propagate this new capability through the relevant interfaces, implementations, and tests, and update the `SystemContractGasCalculator` to support the override.

Key changes include:

**Fee Calculation Enhancements:**

* The `HandleContext` and its implementations now support an optional `SignatureMap overrideSignatureMap` parameter in the `dispatchComputeFees` method, allowing callers to specify an external signature map for fee computation. [[1]](diffhunk://#diff-d0465805455ba2700e43f9a5d8c9784f272953ff40095129028698da7528e3dcL372-R376) [[2]](diffhunk://#diff-d0465805455ba2700e43f9a5d8c9784f272953ff40095129028698da7528e3dcR385-R393) [[3]](diffhunk://#diff-9d498c5518dff33f340b58c7f7d3338a2fae36c5078f95ade3431a165acb3630L433-R434) [[4]](diffhunk://#diff-9d498c5518dff33f340b58c7f7d3338a2fae36c5078f95ade3431a165acb3630L445-R452) [[5]](diffhunk://#diff-9d498c5518dff33f340b58c7f7d3338a2fae36c5078f95ade3431a165acb3630L455-R463) [[6]](diffhunk://#diff-031422266e2b86ca83572732e8e3997e8ddc2383a56b1fe8ed570261240fbe46L311-R314)

* The `SystemContractGasCalculator` is updated to accept a functional interface that takes an optional `SignatureMap` and exposes new overloads for `gasRequirement` and `gasRequirementWithTinycents` that accept the override. [[1]](diffhunk://#diff-93e2714e45f947ec6a87a8269431c3b1cae3a80454b908d094e7d1deb1b7cc34R25-R56) [[2]](diffhunk://#diff-93e2714e45f947ec6a87a8269431c3b1cae3a80454b908d094e7d1deb1b7cc34R67-R124) [[3]](diffhunk://#diff-93e2714e45f947ec6a87a8269431c3b1cae3a80454b908d094e7d1deb1b7cc34L136-R194)

**Interface and Dependency Updates:**

* The `SystemContractGasCalculator` provider methods and their callers are updated to use the new signature for fee calculation, ensuring that the override capability is available throughout the smart contract dispatch pipeline. [[1]](diffhunk://#diff-9eb1e92c91e1bbf78d0622960da41ab0fe4d73dcb23e32216185864aae98f945L54-R55) [[2]](diffhunk://#diff-0c0961d11032ea3ee49e3b17df4214d6268b93955e54bc527d1c7484bef01f73L89-R90)

**Testing Improvements:**

* New and updated tests verify that when an override signature map is provided, it is used for fee calculation instead of the context-derived map, ensuring correctness of the new logic. [[1]](diffhunk://#diff-658f71e7d18f1af40ce8e2600833a5bc00db9b8f0f3c944855f08f22e9c83800L568-R606) [[2]](diffhunk://#diff-658f71e7d18f1af40ce8e2600833a5bc00db9b8f0f3c944855f08f22e9c83800R58) [[3]](diffhunk://#diff-7d9f1e67be33bda2a38ebdd9ed0dd7b8421e457b95064ea3356026fd5be2bd65L94-R95)

**Miscellaneous:**

* Necessary imports and documentation are updated to reflect the new functionality and parameter. [[1]](diffhunk://#diff-d0465805455ba2700e43f9a5d8c9784f272953ff40095129028698da7528e3dcR8) [[2]](diffhunk://#diff-031422266e2b86ca83572732e8e3997e8ddc2383a56b1fe8ed570261240fbe46R56) [[3]](diffhunk://#diff-93e2714e45f947ec6a87a8269431c3b1cae3a80454b908d094e7d1deb1b7cc34R8-R11)

These changes collectively improve the flexibility and accuracy of fee computation for child transactions, especially in advanced scenarios involving external signatures.

**Related issue(s)**:

Fixes #25944 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
