### PR TITLE
test: add CryptoUpdate simple-fee null-memo coverage

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/calculator/CryptoUpdateFeeCalculatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/calculator/CryptoUpdateFeeCalculatorTest.java
@@ -323,6 +323,27 @@ class CryptoUpdateFeeCalculatorTest {
         }
 
         @Test
+        @DisplayName("calculateTxFee with no memo set charges base fee without throwing")
+        void calculateTxFeeWithNoMemo() {
+            // Simple-fee replacement for the legacy null-account-memo crash test: the calculator
+            // prices purely from the transaction body op and never reads the account memo, so an
+            // absent memo just yields the base fee.
+            lenient().when(feeContext.numTxnSignatures()).thenReturn(1);
+            final var op = CryptoUpdateTransactionBody.newBuilder()
+                    .accountIDToUpdate(AccountID.newBuilder().accountNum(1001L).build())
+                    .build();
+            final var body =
+                    TransactionBody.newBuilder().cryptoUpdateAccount(op).build();
+
+            final var result = feeCalculator.calculateTxFee(body, new SimpleFeeContextImpl(feeContext, null));
+
+            assertThat(result).isNotNull();
+            assertThat(result.getServiceTotalTinycents()).isEqualTo(1200000L);
+            assertThat(result.getNodeTotalTinycents()).isEqualTo(100000L);
+            assertThat(result.getNetworkTotalTinycents()).isEqualTo(900000L);
+        }
+
+        @Test
         @DisplayName("verify getTransactionType returns CRYPTO_UPDATE_ACCOUNT")
         void verifyTransactionType() {
             // Given


### PR DESCRIPTION
Follow-up to #25913 review. Adds the simple-fees analog of the deleted legacy CryptoUpdateHandlerTest.testNullAccountMemo/testNullAccount crash tests.

The legacy calculateFees read the account memo from state and could NPE on null. The simple-fee CryptoUpdateFeeCalculator prices purely from the transaction body op and never dereferences the account, so this test asserts a CryptoUpdate with no memo set just charges the base fee without throwing.

Refs #25850