### PR TITLE
refactor(fees): drop simpleFeesEnabled from high-volume checks

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/SimpleFeeCalculatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/SimpleFeeCalculatorImpl.java
@@ -18,7 +18,6 @@ import com.hedera.node.app.spi.fees.QueryFeeCalculator;
 import com.hedera.node.app.spi.fees.ServiceFeeCalculator;
 import com.hedera.node.app.spi.fees.SimpleFeeCalculator;
 import com.hedera.node.app.spi.fees.SimpleFeeContext;
-import com.hedera.node.config.data.FeesConfig;
 import com.hedera.node.config.data.NetworkAdminConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
@@ -209,10 +208,10 @@ public class SimpleFeeCalculatorImpl implements SimpleFeeCalculator {
     }
 
     /**
-     * Returns {@code true} when the high-volume feature is fully enabled, by checking both the
-     * {@code fees.simpleFeesEnabled} and {@code networkAdmin.highVolumeThrottlesEnabled} flags
-     * against the current configuration.  This mirrors the ingest-time guard in {@code IngestChecker}
-     * so that a config change between ingest and consensus cannot silently bypass the feature gate.
+     * Returns {@code true} when the high-volume feature is enabled, by checking the
+     * {@code networkAdmin.highVolumeThrottlesEnabled} flag against the current configuration.  This
+     * mirrors the ingest-time guard in {@code IngestChecker} so that a config change between ingest
+     * and consensus cannot silently bypass the feature gate.
      * Returns {@code false} when no {@link FeeContext} is available (standalone calculator).
      */
     private boolean isHighVolumeFeatureEnabled(@NonNull final SimpleFeeContext simpleFeeContext) {
@@ -221,8 +220,7 @@ public class SimpleFeeCalculatorImpl implements SimpleFeeCalculator {
             return false;
         }
         final var config = feeContext.configuration();
-        return config.getConfigData(FeesConfig.class).simpleFeesEnabled()
-                && config.getConfigData(NetworkAdminConfig.class).highVolumeThrottlesEnabled();
+        return config.getConfigData(NetworkAdminConfig.class).highVolumeThrottlesEnabled();
     }
 
     @Override
@@ -232,8 +230,7 @@ public class SimpleFeeCalculatorImpl implements SimpleFeeCalculator {
             return DEFAULT_HIGH_VOLUME_MULTIPLIER;
         }
         final var config = feeContext.configuration();
-        if (!(config.getConfigData(FeesConfig.class).simpleFeesEnabled()
-                && config.getConfigData(NetworkAdminConfig.class).highVolumeThrottlesEnabled())) {
+        if (!config.getConfigData(NetworkAdminConfig.class).highVolumeThrottlesEnabled()) {
             return DEFAULT_HIGH_VOLUME_MULTIPLIER;
         }
         final ServiceFeeDefinition serviceFeeDefinition = lookupServiceFee(feeSchedule, functionality);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -64,7 +64,6 @@ import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
-import com.hedera.node.config.data.FeesConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.JumboTransactionsConfig;
 import com.hedera.node.config.data.LedgerConfig;
@@ -522,11 +521,10 @@ public class ThrottleAccumulator {
         }
 
         // Check if this is a high-volume transaction and use appropriate throttle bucket.
-        // Verify feature flags here (mirrors the ingest-time guard in IngestChecker) so a config
+        // Verify the feature flag here (mirrors the ingest-time guard in IngestChecker) so a config
         // toggle between ingest and consensus does not silently route to the wrong throttle bucket.
         final boolean highVolumeEnabled =
-                configuration.getConfigData(FeesConfig.class).simpleFeesEnabled()
-                        && configuration.getConfigData(NetworkAdminConfig.class).highVolumeThrottlesEnabled();
+                configuration.getConfigData(NetworkAdminConfig.class).highVolumeThrottlesEnabled();
         final boolean isHighVolumeTxn = txBody.highVolume() && highVolumeEnabled;
         final boolean isHighVolumeFunction = HIGH_VOLUME_THROTTLE_FUNCTIONS.contains(function);
         final boolean useHighVolumeBucket = shouldUseHighVolumeBucket(

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -70,7 +70,6 @@ import com.hedera.node.app.workflows.TransactionChecker.RequireMinValidLifetimeB
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.purechecks.PureChecksContextImpl;
-import com.hedera.node.config.data.FeesConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.HooksConfig;
 import com.hedera.node.config.data.NetworkAdminConfig;
@@ -375,8 +374,7 @@ public final class IngestChecker {
         final var hederaConfig = configuration.getConfigData(HederaConfig.class);
         final var hooksConfig = configuration.getConfigData(HooksConfig.class);
         final var networkAdminConfig = configuration.getConfigData(NetworkAdminConfig.class);
-        final var feesConfig = configuration.getConfigData(FeesConfig.class);
-        assertThrottlingPreconditions(txInfo, hederaConfig, hooksConfig, networkAdminConfig, feesConfig);
+        assertThrottlingPreconditions(txInfo, hederaConfig, hooksConfig, networkAdminConfig);
         if (hederaConfig.ingestThrottleEnabled()
                 && synchronizedThrottleAccumulator.shouldThrottle(txInfo, state, throttleUsages)) {
             workflowMetrics.incrementThrottled(txInfo.functionality());
@@ -388,14 +386,11 @@ public final class IngestChecker {
             @NonNull final TransactionInfo txInfo,
             @NonNull final HederaConfig hederaConfig,
             @NonNull final HooksConfig hooksConfig,
-            @NonNull final NetworkAdminConfig networkAdminConfig,
-            @NonNull final FeesConfig feesConfig)
+            @NonNull final NetworkAdminConfig networkAdminConfig)
             throws PreCheckException {
         final var function = txInfo.functionality();
-        // Reject transactions with highVolume=true if the feature is not enabled.
-        // High volume entity creation HIP depends on simple fees to be enabled.
-        if (txInfo.txBody().highVolume()
-                && (!feesConfig.simpleFeesEnabled() || !networkAdminConfig.highVolumeThrottlesEnabled())) {
+        // Reject transactions with highVolume=true if the high-volume feature is not enabled.
+        if (txInfo.txBody().highVolume() && !networkAdminConfig.highVolumeThrottlesEnabled()) {
             throw new PreCheckException(NOT_SUPPORTED);
         }
         if (UNSUPPORTED_TRANSACTIONS.contains(function)) {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
@@ -337,8 +337,7 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
      */
     private long associationHighVolumeScalingDelta(@NonNull final HandleContext feeContext) {
         final var context = (FeeContext) feeContext;
-        if (!feeContext.configuration().getConfigData(FeesConfig.class).simpleFeesEnabled()
-                || !feeContext.body().highVolume()) {
+        if (!feeContext.body().highVolume()) {
             return 0L;
         }
 


### PR DESCRIPTION
Simplify the high-volume feature gating to check only `highVolumeThrottlesEnabled()` in `IngestChecker`, `ThrottleAccumulator`, `SimpleFeeCalculatorImpl` and `TokenAirdropHandler` (drops the redundant `simpleFeesEnabled() &&` term). IngestChecker still rejects high-volume txns when the feature is off. Behavior unchanged — both flags default `true`.

Flag deletion deferred: deleting `simpleFeesEnabled` from `FeesConfig` (plus old fee-schedule config options) breaks tests still owned by open siblings #25854/#25855/#25857/#25858/#25859. Remaining fee-mode branches that read the flag (`TokenAirdropHandler` airdropFee, `QueryWorkflowImpl`) stay for that follow-up.

Refs #25852