### PR TITLE
fix: cherry-pick (0.75): signSchedule(address,bytes) signatureMap size limit

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/signschedule/SignScheduleTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hss/signschedule/SignScheduleTranslator.java
@@ -37,6 +37,7 @@ import com.hedera.node.app.spi.signatures.SignatureVerifier.MessageType;
 import com.hedera.node.app.spi.signatures.SignatureVerifier.SimpleKeyStatus;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.data.ContractsConfig;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -108,10 +109,10 @@ public class SignScheduleTranslator extends AbstractCallTranslator<HssCallAttemp
     /**
      * Calculates the gas requirement for a {@code signSchedule()} call.
      *
-     * @param body the transaction body
+     * @param body                        the transaction body
      * @param systemContractGasCalculator the gas calculator
-     * @param enhancement the enhancement
-     * @param payerId the payer ID
+     * @param enhancement                 the enhancement
+     * @param payerId                     the payer ID
      * @return the gas requirement
      */
     public static long gasRequirement(
@@ -184,7 +185,7 @@ public class SignScheduleTranslator extends AbstractCallTranslator<HssCallAttemp
     }
 
     /**
-     * Extracts the key set for a {@code signSchedule(address, bytes)} call.  Otherwise, delegates to the call attempt.
+     * Extracts the key set for a {@code signSchedule(address, bytes)} call. Otherwise, delegates to the call attempt.
      *
      * @param attempt the call attempt
      * @return the key set
@@ -200,6 +201,20 @@ public class SignScheduleTranslator extends AbstractCallTranslator<HssCallAttemp
         return attempt.keySetFor();
     }
 
+    /**
+     * Validates the max size in bytes of the signatures map in {@code signSchedule(address, bytes)}
+     * based on the max regular transaction size.
+     *
+     * @param attempt                the HSS call attempt
+     * @param signaturesMapBytesSize {@code signSchedule(address, bytes)} signatures map size in bytes of the
+     */
+    private static void validateSignatureMapMaxLength(
+            @NonNull final HssCallAttempt attempt, final int signaturesMapBytesSize) {
+        final var maxRegularTxnSize =
+                attempt.configuration().getConfigData(HederaConfig.class).transactionMaxBytes();
+        validateTrue(signaturesMapBytesSize <= maxRegularTxnSize, INVALID_TRANSACTION_BODY);
+    }
+
     @VisibleForTesting
     @NonNull
     public static Set<Key> getKeyForSignSchedule(@NonNull HssCallAttempt attempt) {
@@ -211,6 +226,7 @@ public class SignScheduleTranslator extends AbstractCallTranslator<HssCallAttemp
         final var message = messageFromScheduleId(scheduleId);
 
         final var signatureBlob = (byte[]) call.get(SIGNATURE_MAP_INDEX);
+        validateSignatureMapMaxLength(attempt, signatureBlob.length);
         try {
             final var chainId =
                     attempt.configuration().getConfigData(ContractsConfig.class).chainId();
@@ -241,15 +257,16 @@ public class SignScheduleTranslator extends AbstractCallTranslator<HssCallAttemp
 
     /**
      * Verifies the signature for a given key.
+     *
      * @param attempt the call attempt
-     * @param key the key to verify
+     * @param key     the key to verify
      * @param message the message to verify - concatenation of realm, shard, and schedule numbers
-     * @param sigMap the signature map used for verification
+     * @param sigMap  the signature map used for verification
      * @return true if the signature is verified, false otherwise
      */
     private static boolean isVerifiedSignature(
             @NonNull HssCallAttempt attempt, Key key, Bytes message, SignatureMap sigMap) {
         return attempt.signatureVerifier()
-                .verifySignature(key, message, MessageType.RAW, sigMap, ky -> SimpleKeyStatus.ONLY_IF_CRYPTO_SIG_VALID);
+                .verifySignature(key, message, MessageType.RAW, sigMap, _ -> SimpleKeyStatus.ONLY_IF_CRYPTO_SIG_VALID);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/signschedule/SignScheduleTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/signschedule/SignScheduleTranslatorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.hapi.node.base.SignatureMap;
 import com.hedera.hapi.node.base.SignaturePair;
@@ -30,13 +31,18 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.Dispat
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.HssCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hss.signschedule.SignScheduleTranslator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.mint.MintTranslator;
+import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallAttemptTestBase;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.data.ContractsConfig;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,11 +50,18 @@ import org.mockito.Mock;
 
 class SignScheduleTranslatorTest extends CallAttemptTestBase {
 
+    private static final int TRANSACTION_MAX_BYTES = 6144;
+
     @Mock
     private HssCallAttempt attempt;
 
     @Mock
     private Configuration configuration;
+
+    private static final HederaConfig CONFIG_WITH_TRANSACTION_MAX_BYTES = HederaTestConfigBuilder.create()
+            .withValue("transaction.maxBytes", TRANSACTION_MAX_BYTES)
+            .getOrCreateConfig()
+            .getConfigData(HederaConfig.class);
 
     @Mock
     private ContractsConfig contractsConfig;
@@ -90,68 +103,58 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
         subject = new SignScheduleTranslator(systemContractMethodRegistry, contractMetrics);
     }
 
+    void testSignScheduleWithConfigChange(boolean configValue, @NonNull final SystemContractMethod selector) {
+        // when:
+        attempt = createHssCallAttempt(Bytes.wrap(selector.selector()), false, configuration, List.of(subject));
+
+        // then:
+        if (configValue) {
+            assertThat(subject.identifyMethod(attempt)).isPresent();
+        } else {
+            assertThat(subject.identifyMethod(attempt)).isEmpty();
+        }
+    }
+
     @Test
     void testMatchesWhenSignScheduleEnabled() {
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractSignScheduleEnabled()).willReturn(true);
-
-        // when:
-        attempt = createHssCallAttempt(
-                Bytes.wrap(SignScheduleTranslator.SIGN_SCHEDULE_PROXY.selector()),
-                false,
-                configuration,
-                List.of(subject));
-
-        // then:
-        assertThat(subject.identifyMethod(attempt)).isPresent();
+        testSignScheduleWithConfigChange(true, SignScheduleTranslator.SIGN_SCHEDULE_PROXY);
     }
 
     @Test
-    void testFailsMatchesWhenSignScheduleEnabled() {
+    void testFailsMatchesWhenSignScheduleDisabled() {
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractSignScheduleEnabled()).willReturn(false);
-
-        // when:
-        attempt = createHssCallAttempt(
-                Bytes.wrap(SignScheduleTranslator.SIGN_SCHEDULE_PROXY.selector()),
-                false,
-                configuration,
-                List.of(subject));
-
-        // then:
-        assertThat(subject.identifyMethod(attempt)).isEmpty();
+        testSignScheduleWithConfigChange(false, SignScheduleTranslator.SIGN_SCHEDULE_PROXY);
     }
 
     @Test
     void testMatchesWhenAuthorizeScheduleEnabled() {
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractAuthorizeScheduleEnabled()).willReturn(true);
-
-        // when:
-        attempt = createHssCallAttempt(
-                Bytes.wrap(SignScheduleTranslator.AUTHORIZE_SCHEDULE.selector()),
-                false,
-                configuration,
-                List.of(subject));
-
-        // then:
-        assertThat(subject.identifyMethod(attempt)).isPresent();
+        testSignScheduleWithConfigChange(true, SignScheduleTranslator.AUTHORIZE_SCHEDULE);
     }
 
     @Test
-    void testFailsMatchesWhenAuthorizeScheduleEnabled() {
+    void testFailsMatchesWhenAuthorizeScheduleDisabled() {
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.systemContractAuthorizeScheduleEnabled()).willReturn(false);
+        testSignScheduleWithConfigChange(false, SignScheduleTranslator.AUTHORIZE_SCHEDULE);
+    }
 
-        // when:
-        attempt = createHssCallAttempt(
-                Bytes.wrap(SignScheduleTranslator.AUTHORIZE_SCHEDULE.selector()),
-                false,
-                configuration,
-                List.of(subject));
+    @Test
+    void testMatchesWhenSignScheduleFromContractEnabled() {
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
+        given(contractsConfig.systemContractSignScheduleFromContractEnabled()).willReturn(true);
+        testSignScheduleWithConfigChange(true, SignScheduleTranslator.SIGN_SCHEDULE);
+    }
 
-        // then:
-        assertThat(subject.identifyMethod(attempt)).isEmpty();
+    @Test
+    void testFailsMatchesWhenSignScheduleFromContractDisabled() {
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
+        given(contractsConfig.systemContractSignScheduleFromContractEnabled()).willReturn(false);
+        testSignScheduleWithConfigChange(false, SignScheduleTranslator.SIGN_SCHEDULE);
     }
 
     @Test
@@ -230,7 +233,8 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
                 List.of(subject));
 
         // then:
-        assertThrows(IllegalStateException.class, () -> subject.callFrom(attempt));
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> subject.callFrom(attempt));
+        assertThat(exception.getMessage()).isEqualTo("Unexpected function selector");
     }
 
     @Test
@@ -356,10 +360,11 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
         given(schedule.scheduleId()).willReturn(scheduleID);
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.chainId()).willReturn(296);
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(CONFIG_WITH_TRANSACTION_MAX_BYTES);
         given(signatureVerifier.verifySignature(any(), any(), any(), any(), any()))
                 .willReturn(true);
 
-        final var sigMapBytes = getSigMapKnownKeyTypeBytes(296);
+        final var sigMapBytes = getSigMapKnownKeyTypeBytes(296, 1, 1);
         attempt = createHssCallAttempt(
                 Bytes.wrapByteBuffer(SignScheduleTranslator.SIGN_SCHEDULE.encodeCall(
                         Tuple.of(APPROVED_HEADLONG_ADDRESS, sigMapBytes.toByteArray()))),
@@ -379,10 +384,11 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
         given(schedule.scheduleId()).willReturn(scheduleID);
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.chainId()).willReturn(296);
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(CONFIG_WITH_TRANSACTION_MAX_BYTES);
         given(signatureVerifier.verifySignature(any(), any(), any(), any(), any()))
                 .willReturn(false);
 
-        final var sigMapBytes = getSigMapKnownKeyTypeBytes(296);
+        final var sigMapBytes = getSigMapKnownKeyTypeBytes(296, 1, 1);
         attempt = createHssCallAttempt(
                 Bytes.wrapByteBuffer(SignScheduleTranslator.SIGN_SCHEDULE.encodeCall(
                         Tuple.of(APPROVED_HEADLONG_ADDRESS, sigMapBytes.toByteArray()))),
@@ -400,10 +406,9 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
         given(nativeOperations.getSchedule(any(ScheduleID.class))).willReturn(schedule);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         given(schedule.scheduleId()).willReturn(scheduleID);
-        given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
-        given(contractsConfig.chainId()).willReturn(296);
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(CONFIG_WITH_TRANSACTION_MAX_BYTES);
 
-        final var sigMapBytes = getSigMapKnownKeyTypeBytes(396);
+        final var sigMapBytes = getSigMapKnownKeyTypeBytes(396, 1, 1);
         attempt = createHssCallAttempt(
                 Bytes.wrapByteBuffer(SignScheduleTranslator.SIGN_SCHEDULE.encodeCall(
                         Tuple.of(APPROVED_HEADLONG_ADDRESS, sigMapBytes.toByteArray()))),
@@ -411,7 +416,9 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
                 configuration,
                 List.of(subject));
 
-        assertThrows(HandleException.class, () -> SignScheduleTranslator.getKeyForSignSchedule(attempt));
+        HandleException exception =
+                assertThrows(HandleException.class, () -> SignScheduleTranslator.getKeyForSignSchedule(attempt));
+        assertThat(exception.getStatus()).isEqualTo(ResponseCodeEnum.INVALID_TRANSACTION_BODY);
     }
 
     @Test
@@ -421,6 +428,7 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
         given(schedule.scheduleId()).willReturn(scheduleID);
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
         given(contractsConfig.chainId()).willReturn(296);
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(CONFIG_WITH_TRANSACTION_MAX_BYTES);
 
         final var sigMapBytes = getSigMapUnknownKeyTypeBytes();
         attempt = createHssCallAttempt(
@@ -435,7 +443,28 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
         assertThat(keySet).isEmpty();
     }
 
-    private static com.hedera.pbj.runtime.io.buffer.Bytes getSigMapKnownKeyTypeBytes(final int chainId) {
+    @Test
+    void testGetKeysForSignScheduleMaxSize() {
+        given(nativeOperations.getSchedule(any(ScheduleID.class))).willReturn(schedule);
+        given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(schedule.scheduleId()).willReturn(scheduleID);
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(CONFIG_WITH_TRANSACTION_MAX_BYTES);
+
+        final var sigMapBytes = getSigMapKnownKeyTypeBytes(296, 31, 31);
+        attempt = createHssCallAttempt(
+                Bytes.wrapByteBuffer(SignScheduleTranslator.SIGN_SCHEDULE.encodeCall(
+                        Tuple.of(APPROVED_HEADLONG_ADDRESS, sigMapBytes.toByteArray()))),
+                false,
+                configuration,
+                List.of(subject));
+
+        HandleException exception =
+                assertThrows(HandleException.class, () -> SignScheduleTranslator.getKeyForSignSchedule(attempt));
+        assertThat(exception.getStatus()).isEqualTo(ResponseCodeEnum.INVALID_TRANSACTION_BODY);
+    }
+
+    private static com.hedera.pbj.runtime.io.buffer.Bytes getSigMapKnownKeyTypeBytes(
+            final int chainId, final int ecdsaKeysCount, final int ed25519KeysCount) {
         final var signatureEcdsa = randomBytes(66);
 
         int v = 35 + (chainId * 2);
@@ -445,15 +474,16 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
 
         final var signatureEd = randomBytes(64);
         final var sigMap = SignatureMap.newBuilder()
-                .sigPair(List.of(
-                        SignaturePair.newBuilder()
-                                .pubKeyPrefix(ecdsaKey.ecdsaSecp256k1OrThrow())
-                                .ecdsaSecp256k1(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(signatureEcdsa))
-                                .build(),
-                        SignaturePair.newBuilder()
-                                .pubKeyPrefix(ed25519.ed25519OrThrow())
-                                .ed25519(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(signatureEd))
-                                .build()))
+                .sigPair(Stream.concat(
+                                IntStream.range(0, ecdsaKeysCount).mapToObj(_ -> SignaturePair.newBuilder()
+                                        .pubKeyPrefix(ecdsaKey.ecdsaSecp256k1OrThrow())
+                                        .ecdsaSecp256k1(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(signatureEcdsa))
+                                        .build()),
+                                IntStream.range(0, ed25519KeysCount).mapToObj(_ -> SignaturePair.newBuilder()
+                                        .pubKeyPrefix(ed25519.ed25519OrThrow())
+                                        .ed25519(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(signatureEd))
+                                        .build()))
+                        .toList())
                 .build();
 
         return SignatureMap.PROTOBUF.toBytes(sigMap);
@@ -471,7 +501,7 @@ class SignScheduleTranslatorTest extends CallAttemptTestBase {
         return SignatureMap.PROTOBUF.toBytes(sigMap);
     }
 
-    public static byte[] randomBytes(Random r, int length) {
+    public static byte[] randomBytes(@NonNull final Random r, int length) {
         byte[] ret = new byte[length];
         r.nextBytes(ret);
         return ret;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
@@ -27,7 +27,6 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.node.base.HookCall;
-import com.hedera.hapi.node.base.ScheduleID;
 import com.hedera.node.app.hapi.fees.pricing.AssetsLoader;
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -40,6 +39,7 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.NftTransfer;
+import com.hederahashgraph.api.proto.java.ScheduleID;
 import com.hederahashgraph.api.proto.java.SubType;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TokenID;
@@ -194,7 +194,7 @@ public class Utils {
      * This method extracts the function ABI by the name of the desired function and the name of the
      * respective contract. Depending on the desired function type, it can deliver either a
      * constructor ABI, or function ABI from the contract ABI
-     *
+     * <p>
      * This overloaded method allows for a variant contract root folder
      *
      * @param variant variant contract root folder
@@ -493,6 +493,13 @@ public class Utils {
                         (int) contractId.getShardNum(), contractId.getRealmNum(), contractId.getContractNum()))));
     }
 
+    public static Address mirrorAddrWith(ScheduleID scheduleId) {
+        return Address.wrap(toChecksumAddress(new BigInteger(
+                1,
+                asSolidityAddress(
+                        (int) scheduleId.getShardNum(), scheduleId.getRealmNum(), scheduleId.getScheduleNum()))));
+    }
+
     public static Address mirrorAddrWith(HapiSpec spec, final long num) {
         return Address.wrap(
                 toChecksumAddress(new BigInteger(1, asSolidityAddress((int) spec.shard(), spec.realm(), num))));
@@ -669,7 +676,7 @@ public class Utils {
      * @param address the EVM address
      * @return the {@link ScheduleID}
      */
-    public static com.hederahashgraph.api.proto.java.ScheduleID asScheduleId(
+    public static ScheduleID asScheduleId(
             @NonNull final HapiSpec spec, @NonNull final com.esaulpaugh.headlong.abi.Address address) {
         var addressHex = toChecksumAddress(address.value());
         if (addressHex.startsWith("0x")) {
@@ -677,7 +684,7 @@ public class Utils {
         }
         var scheduleNum = addressHex.substring(24, 40);
 
-        return com.hederahashgraph.api.proto.java.ScheduleID.newBuilder()
+        return ScheduleID.newBuilder()
                 .setShardNum(spec.shard())
                 .setRealmNum(spec.realm())
                 .setScheduleNum(new BigInteger(scheduleNum, 16).longValue())

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/schedule/SignScheduleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/schedule/SignScheduleTest.java
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.precompile.schedule;
+
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCallWithFunctionAbi;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreate;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.getEd25519PrivateKeyFromSpec;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.restoreDefault;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
+import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
+import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
+import static com.hedera.services.bdd.suites.contract.Utils.mirrorAddrWith;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_EXECUTION_EXCEPTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static org.hyperledger.besu.evm.frame.ExceptionalHaltReason.INVALID_OPERATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.SignaturePair;
+import com.hedera.node.app.hapi.utils.CommonPbjConverters;
+import com.hedera.node.app.hapi.utils.SignatureGenerator;
+import com.hedera.node.app.service.contract.impl.utils.SystemContractUtils;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.SpecOperation;
+import com.hederahashgraph.api.proto.java.ScheduleID;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SignatureException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@Tag(SMART_CONTRACT)
+@HapiTestLifecycle
+public class SignScheduleTest {
+
+    private static final String HSS_ADDRESS = "0x000000000000000000000000000000000000016b";
+    private static final int TRANSACTION_MAX_GAS = 15_000_000;
+    private static final int TRANSACTION_MAX_BYTES = 6144;
+    private static final String SENDER = "signScheduleSender";
+    private static final String RECEIVER = "signScheduleReceiver";
+    private static final String SCHEDULE = "signSchedule";
+    private static final String KEY = "signScheduleKey";
+    private static final String TX_NAME = "signScheduleTx";
+
+    static final AtomicReference<ScheduleID> scheduleId = new AtomicReference<>();
+
+    @BeforeAll
+    public static void setup(TestLifecycle lifecycle) {
+        lifecycle.doAdhoc(
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
+                cryptoCreate(SENDER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER).receiverSigRequired(true),
+                scheduleCreate(SCHEDULE, cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1)))
+                        .payingWith(SENDER)
+                        .waitForExpiry()
+                        .expiringIn(600)
+                        .exposingCreatedIdTo(scheduleId::set));
+    }
+
+    @LeakyHapiTest(overrides = {"hedera.transaction.maxBytes"})
+    public Stream<DynamicTest> hapiScheduleSignSignatureMapSizeLimitTest() {
+        final var keysCount = TRANSACTION_MAX_BYTES / 100 + 1; // assuming each SignaturePair = ~100 bytes
+        return hapiTest(withOpContext((spec, _) -> {
+            List<String> keyNames = new ArrayList<>();
+            // create keys, we do not care if keys are from needed account or not, we interested just in keys count
+            allRunFor(
+                    spec,
+                    IntStream.range(0, keysCount)
+                            .boxed()
+                            .<SpecOperation>map(e -> {
+                                final var keyName = KEY + e;
+                                keyNames.add(keyName);
+                                return newKeyNamed(keyName);
+                            })
+                            .toList());
+            // prepare SignatureMap
+            final var signatureMap = prepareSignatureMap(spec, keyNames);
+            final var signatureMapBytes =
+                    SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+            final var function = getABIFor(FUNCTION, "signSchedule", "IHederaScheduleService");
+            // execute schedule sign
+            allRunFor(
+                    spec,
+                    overriding("hedera.transaction.maxBytes", String.valueOf(TRANSACTION_MAX_BYTES)),
+                    // limited by INVALID_TRANSACTION_BODY -> halt(INVALID_OPERATION)
+                    ethereumCallWithFunctionAbi(
+                                    false, HSS_ADDRESS, function, mirrorAddrWith(scheduleId.get()), signatureMapBytes)
+                            .signingWith(SECP_256K1_SOURCE_KEY)
+                            .payingWith(SENDER)
+                            .gasLimit(TRANSACTION_MAX_GAS)
+                            .via(TX_NAME)
+                            .hasKnownStatus(CONTRACT_EXECUTION_EXCEPTION),
+                    getTxnRecord(TX_NAME)
+                            .exposingTo(e -> assertEquals(
+                                    INVALID_OPERATION.toString(),
+                                    e.getContractCallResult().getErrorMessage())),
+                    // increasing 'transaction.maxBytes' to check if max signatures in map depends on
+                    // 'transaction.maxBytes'
+                    overriding("hedera.transaction.maxBytes", String.valueOf(TRANSACTION_MAX_BYTES * 2)),
+                    ethereumCallWithFunctionAbi(
+                                    false, HSS_ADDRESS, function, mirrorAddrWith(scheduleId.get()), signatureMapBytes)
+                            .signingWith(SECP_256K1_SOURCE_KEY)
+                            .payingWith(SENDER)
+                            .gasLimit(TRANSACTION_MAX_GAS)
+                            .hasKnownStatus(SUCCESS),
+                    restoreDefault("contracts.maxGasPerTransaction"));
+        }));
+    }
+
+    private static SignatureMap prepareSignatureMap(@NonNull final HapiSpec spec, @NonNull final List<String> keyNames)
+            throws SignatureException, NoSuchAlgorithmException, InvalidKeyException {
+        List<SignaturePair> sigPair = new ArrayList<>();
+        for (String keyName : keyNames) {
+            final var message = SystemContractUtils.messageFromScheduleId(CommonPbjConverters.toPbj(scheduleId.get()));
+            final var privateKey = getEd25519PrivateKeyFromSpec(spec, keyName);
+            final var publicKey = spec.registry().getKey(keyName).getEd25519();
+            final var signedBytes = SignatureGenerator.signBytes(message.toByteArray(), privateKey);
+            sigPair.add(SignaturePair.newBuilder()
+                    .ed25519(Bytes.wrap(signedBytes))
+                    .pubKeyPrefix(Bytes.wrap(publicKey.toByteArray()))
+                    .build());
+        }
+        return SignatureMap.newBuilder().sigPair(sigPair).build();
+    }
+}

--- a/hedera-node/test-clients/src/main/resources/contract/contracts/IHederaScheduleService/IHederaScheduleService.json
+++ b/hedera-node/test-clients/src/main/resources/contract/contracts/IHederaScheduleService/IHederaScheduleService.json
@@ -1,0 +1,653 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "schedule",
+        "type": "address"
+      }
+    ],
+    "name": "authorizeSchedule",
+    "outputs": [
+      {
+        "internalType": "int64",
+        "name": "responseCode",
+        "type": "int64"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "scheduleAddress",
+        "type": "address"
+      }
+    ],
+    "name": "getScheduledCreateFungibleTokenInfo",
+    "outputs": [
+      {
+        "internalType": "int64",
+        "name": "responseCode",
+        "type": "int64"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "string",
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "internalType": "string",
+                    "name": "symbol",
+                    "type": "string"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "treasury",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "string",
+                    "name": "memo",
+                    "type": "string"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "tokenSupplyType",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "maxSupply",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "freezeDefault",
+                    "type": "bool"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "uint256",
+                        "name": "keyType",
+                        "type": "uint256"
+                      },
+                      {
+                        "components": [
+                          {
+                            "internalType": "bool",
+                            "name": "inheritAccountKey",
+                            "type": "bool"
+                          },
+                          {
+                            "internalType": "address",
+                            "name": "contractId",
+                            "type": "address"
+                          },
+                          {
+                            "internalType": "bytes",
+                            "name": "ed25519",
+                            "type": "bytes"
+                          },
+                          {
+                            "internalType": "bytes",
+                            "name": "ECDSA_secp256k1",
+                            "type": "bytes"
+                          },
+                          {
+                            "internalType": "address",
+                            "name": "delegatableContractId",
+                            "type": "address"
+                          }
+                        ],
+                        "internalType": "struct IHederaTokenService.KeyValue",
+                        "name": "key",
+                        "type": "tuple"
+                      }
+                    ],
+                    "internalType": "struct IHederaTokenService.TokenKey[]",
+                    "name": "tokenKeys",
+                    "type": "tuple[]"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "uint32",
+                        "name": "second",
+                        "type": "uint32"
+                      },
+                      {
+                        "internalType": "address",
+                        "name": "autoRenewAccount",
+                        "type": "address"
+                      },
+                      {
+                        "internalType": "uint32",
+                        "name": "autoRenewPeriod",
+                        "type": "uint32"
+                      }
+                    ],
+                    "internalType": "struct IHederaTokenService.Expiry",
+                    "name": "expiry",
+                    "type": "tuple"
+                  }
+                ],
+                "internalType": "struct IHederaTokenService.HederaToken",
+                "name": "token",
+                "type": "tuple"
+              },
+              {
+                "internalType": "int64",
+                "name": "totalSupply",
+                "type": "int64"
+              },
+              {
+                "internalType": "bool",
+                "name": "deleted",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "defaultKycStatus",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "pauseStatus",
+                "type": "bool"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "uint32",
+                    "name": "amount",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "tokenId",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "useHbarsForPayment",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "useCurrentTokenForPayment",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "feeCollector",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct IHederaTokenService.FixedFee[]",
+                "name": "fixedFees",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "uint32",
+                    "name": "numerator",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "denominator",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "minimumAmount",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "maximumAmount",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "netOfTransfers",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "feeCollector",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct IHederaTokenService.FractionalFee[]",
+                "name": "fractionalFees",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "uint32",
+                    "name": "numerator",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "denominator",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "amount",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "tokenId",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "useHbarsForPayment",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "feeCollector",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct IHederaTokenService.RoyaltyFee[]",
+                "name": "royaltyFees",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "string",
+                "name": "ledgerId",
+                "type": "string"
+              }
+            ],
+            "internalType": "struct IHederaTokenService.TokenInfo",
+            "name": "tokenInfo",
+            "type": "tuple"
+          },
+          {
+            "internalType": "uint32",
+            "name": "decimals",
+            "type": "uint32"
+          }
+        ],
+        "internalType": "struct IHederaTokenService.FungibleTokenInfo",
+        "name": "fungibleTokenInfo",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "scheduleAddress",
+        "type": "address"
+      }
+    ],
+    "name": "getScheduledCreateNonFungibleTokenInfo",
+    "outputs": [
+      {
+        "internalType": "int64",
+        "name": "responseCode",
+        "type": "int64"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "components": [
+                  {
+                    "internalType": "string",
+                    "name": "name",
+                    "type": "string"
+                  },
+                  {
+                    "internalType": "string",
+                    "name": "symbol",
+                    "type": "string"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "treasury",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "string",
+                    "name": "memo",
+                    "type": "string"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "tokenSupplyType",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "maxSupply",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "freezeDefault",
+                    "type": "bool"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "uint256",
+                        "name": "keyType",
+                        "type": "uint256"
+                      },
+                      {
+                        "components": [
+                          {
+                            "internalType": "bool",
+                            "name": "inheritAccountKey",
+                            "type": "bool"
+                          },
+                          {
+                            "internalType": "address",
+                            "name": "contractId",
+                            "type": "address"
+                          },
+                          {
+                            "internalType": "bytes",
+                            "name": "ed25519",
+                            "type": "bytes"
+                          },
+                          {
+                            "internalType": "bytes",
+                            "name": "ECDSA_secp256k1",
+                            "type": "bytes"
+                          },
+                          {
+                            "internalType": "address",
+                            "name": "delegatableContractId",
+                            "type": "address"
+                          }
+                        ],
+                        "internalType": "struct IHederaTokenService.KeyValue",
+                        "name": "key",
+                        "type": "tuple"
+                      }
+                    ],
+                    "internalType": "struct IHederaTokenService.TokenKey[]",
+                    "name": "tokenKeys",
+                    "type": "tuple[]"
+                  },
+                  {
+                    "components": [
+                      {
+                        "internalType": "uint32",
+                        "name": "second",
+                        "type": "uint32"
+                      },
+                      {
+                        "internalType": "address",
+                        "name": "autoRenewAccount",
+                        "type": "address"
+                      },
+                      {
+                        "internalType": "uint32",
+                        "name": "autoRenewPeriod",
+                        "type": "uint32"
+                      }
+                    ],
+                    "internalType": "struct IHederaTokenService.Expiry",
+                    "name": "expiry",
+                    "type": "tuple"
+                  }
+                ],
+                "internalType": "struct IHederaTokenService.HederaToken",
+                "name": "token",
+                "type": "tuple"
+              },
+              {
+                "internalType": "int64",
+                "name": "totalSupply",
+                "type": "int64"
+              },
+              {
+                "internalType": "bool",
+                "name": "deleted",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "defaultKycStatus",
+                "type": "bool"
+              },
+              {
+                "internalType": "bool",
+                "name": "pauseStatus",
+                "type": "bool"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "uint32",
+                    "name": "amount",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "tokenId",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "useHbarsForPayment",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "useCurrentTokenForPayment",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "feeCollector",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct IHederaTokenService.FixedFee[]",
+                "name": "fixedFees",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "uint32",
+                    "name": "numerator",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "denominator",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "minimumAmount",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "maximumAmount",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "netOfTransfers",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "feeCollector",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct IHederaTokenService.FractionalFee[]",
+                "name": "fractionalFees",
+                "type": "tuple[]"
+              },
+              {
+                "components": [
+                  {
+                    "internalType": "uint32",
+                    "name": "numerator",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "denominator",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "uint32",
+                    "name": "amount",
+                    "type": "uint32"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "tokenId",
+                    "type": "address"
+                  },
+                  {
+                    "internalType": "bool",
+                    "name": "useHbarsForPayment",
+                    "type": "bool"
+                  },
+                  {
+                    "internalType": "address",
+                    "name": "feeCollector",
+                    "type": "address"
+                  }
+                ],
+                "internalType": "struct IHederaTokenService.RoyaltyFee[]",
+                "name": "royaltyFees",
+                "type": "tuple[]"
+              },
+              {
+                "internalType": "string",
+                "name": "ledgerId",
+                "type": "string"
+              }
+            ],
+            "internalType": "struct IHederaTokenService.TokenInfo",
+            "name": "tokenInfo",
+            "type": "tuple"
+          },
+          {
+            "internalType": "int64",
+            "name": "serialNumber",
+            "type": "int64"
+          },
+          {
+            "internalType": "address",
+            "name": "ownerId",
+            "type": "address"
+          },
+          {
+            "internalType": "int64",
+            "name": "creationTime",
+            "type": "int64"
+          },
+          {
+            "internalType": "bytes",
+            "name": "metadata",
+            "type": "bytes"
+          },
+          {
+            "internalType": "address",
+            "name": "spenderId",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct IHederaTokenService.NonFungibleTokenInfo",
+        "name": "nonFungibleTokenInfo",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "systemContractAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "payer",
+        "type": "address"
+      }
+    ],
+    "name": "scheduleNative",
+    "outputs": [
+      {
+        "internalType": "int64",
+        "name": "responseCode",
+        "type": "int64"
+      },
+      {
+        "internalType": "address",
+        "name": "scheduleAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "schedule",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signatureMap",
+        "type": "bytes"
+      }
+    ],
+    "name": "signSchedule",
+    "outputs": [
+      {
+        "internalType": "int64",
+        "name": "responseCode",
+        "type": "int64"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/hedera-node/test-clients/src/main/resources/contract/contracts/IHederaScheduleService/IHederaScheduleService.sol
+++ b/hedera-node/test-clients/src/main/resources/contract/contracts/IHederaScheduleService/IHederaScheduleService.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.4.9 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+import "./IHederaTokenService.sol";
+interface IHederaScheduleService {
+
+    /// Authorizes the calling contract as a signer to the schedule transaction.
+    /// @param schedule the address of the schedule transaction.
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function authorizeSchedule(address schedule) external returns (int64 responseCode);
+
+    /// Allows for the signing of a schedule transaction given a protobuf encoded signature map
+    /// The message signed by the keys is defined to be the concatenation of the shard, realm, and schedule transaction ID.
+    /// @param schedule the address of the schedule transaction.
+    /// @param signatureMap the protobuf encoded signature map
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function signSchedule(address schedule, bytes memory signatureMap) external returns (int64 responseCode);
+
+    /// Allows for the creation of a schedule transaction for given a system contract address, abi encoded call data and payer address
+    /// Currently supports the Hedera Token Service System Contract (0x167) with encoded call data for
+    /// createFungibleToken, createNonFungibleToken, createFungibleTokenWithCustomFees, createNonFungibleTokenWithCustomFees
+    /// and updateToken functions
+    /// @param systemContractAddress the address of the system contract from which to create the schedule transaction
+    /// @param callData the abi encoded call data for the system contract function
+    /// @param payer the address of the account that will pay for the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return scheduleAddress The address of the newly created schedule transaction.
+    function scheduleNative(address systemContractAddress, bytes memory callData, address payer) external returns (int64 responseCode, address scheduleAddress);
+
+    /// Returns the token information for a scheduled fungible token create transaction
+    /// @param scheduleAddress the address of the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return fungibleTokenInfo The token information for the scheduled fungible token create transaction
+    function getScheduledCreateFungibleTokenInfo(address scheduleAddress) external returns (int64 responseCode, IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo);
+
+    /// Returns the token information for a scheduled non fungible token create transaction
+    /// @param scheduleAddress the address of the schedule transaction
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    /// @return nonFungibleTokenInfo The token information for the scheduled non fungible token create transaction
+    function getScheduledCreateNonFungibleTokenInfo(address scheduleAddress) external returns (int64 responseCode, IHederaTokenService.NonFungibleTokenInfo memory nonFungibleTokenInfo);
+}


### PR DESCRIPTION
**Description**:
Cherry pick for `signSchedule(address,bytes)` refactoring to `release/0.75`