### PR TITLE
fix: 25937: MerkleDb state folder name should be fixed

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/DependencyMigrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/DependencyMigrationTest.java
@@ -22,6 +22,8 @@ import com.hedera.node.app.services.ServicesRegistryImpl;
 import com.hedera.node.app.spi.migrate.StartupNetworks;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
+import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.state.lifecycle.MigrationContext;
 import com.swirlds.state.lifecycle.Schema;
@@ -32,6 +34,7 @@ import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.state.merkle.VirtualMapStateImpl;
 import com.swirlds.state.spi.WritableStates;
 import com.swirlds.state.test.fixtures.merkle.MerkleTestBase;
+import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.LinkedList;
 import java.util.List;
@@ -69,7 +72,11 @@ class DependencyMigrationTest extends MerkleTestBase {
     @BeforeEach
     void setUp() {
         registry = mock(ConstructableRegistry.class);
-        vmState = new VirtualMapStateImpl(CONFIGURATION, FILE_SYSTEM_MANAGER, new NoOpMetrics());
+        final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
+        final MerkleDbDataSourceBuilder dsBuilder =
+                new MerkleDbDataSourceBuilder(CONFIGURATION, FILE_SYSTEM_MANAGER, merkleDbConfig.initialCapacity());
+        final VirtualMap virtualMap = new VirtualMap(dsBuilder, CONFIGURATION);
+        vmState = new VirtualMapStateImpl(virtualMap, new NoOpMetrics());
         configProvider = new ConfigProviderImpl();
         storeMetricsService = new StoreMetricsServiceImpl(new NoOpMetrics());
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BinaryStateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BinaryStateChangesValidator.java
@@ -19,6 +19,8 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.hedera.subprocess.SubProcessNetwork;
 import com.hedera.services.bdd.junit.support.BlockStreamValidator;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
+import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.state.BinaryState;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.state.merkle.VirtualMapStateImpl;
@@ -138,8 +140,12 @@ public class BinaryStateChangesValidator implements BlockStreamValidator {
         final var platformConfig = ServicesMain.buildPlatformConfig();
         final var pathsConfig = platformConfig.getConfigData(PathsConfig.class);
         final var metrics = new NoOpMetrics();
-        this.state = new VirtualMapStateImpl(
-                platformConfig, new FileSystemManager(pathsConfig.savedStateDir(), pathsConfig.tmpDir()), metrics);
+        final var merkleDbConfig = platformConfig.getConfigData(MerkleDbConfig.class);
+        final var fileSystemManager = new FileSystemManager(pathsConfig.savedStateDir(), pathsConfig.tmpDir());
+        final var dsBuilder =
+                new MerkleDbDataSourceBuilder(platformConfig, fileSystemManager, merkleDbConfig.initialCapacity());
+        final var virtualMap = new VirtualMap(dsBuilder, platformConfig);
+        this.state = new VirtualMapStateImpl(virtualMap, metrics);
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/WrapsFreeBlockSignaturesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/WrapsFreeBlockSignaturesValidator.java
@@ -43,6 +43,8 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.support.BlockStreamValidator;
 import com.hedera.services.bdd.junit.support.translators.inputs.TransactionParts;
+import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
+import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.merkle.VirtualMapStateImpl;
 import com.swirlds.virtualmap.VirtualMap;
@@ -210,7 +212,11 @@ public class WrapsFreeBlockSignaturesValidator implements BlockStreamValidator {
         final var platformConfig = ServicesMain.buildPlatformConfig();
         final var pathsConfig = platformConfig.getConfigData(PathsConfig.class);
         final var fileSystemManager = new FileSystemManager(pathsConfig.savedStateDir(), pathsConfig.tmpDir());
-        state = new VirtualMapStateImpl(platformConfig, fileSystemManager, metrics);
+        final var merkleDbConfig = platformConfig.getConfigData(MerkleDbConfig.class);
+        final var dsBuilder =
+                new MerkleDbDataSourceBuilder(platformConfig, fileSystemManager, merkleDbConfig.initialCapacity());
+        final var virtualMap = new VirtualMap(dsBuilder, platformConfig);
+        state = new VirtualMapStateImpl(virtualMap, metrics);
         this.hintsLibrary = new HintsLibraryImpl();
         logger.info("Initialized wrap-free signature validator with an empty binary state");
     }

--- a/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/ReconnectTest.java
+++ b/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/ReconnectTest.java
@@ -40,7 +40,6 @@ import org.hiero.consensus.state.signed.ReservedSignedState;
 import org.hiero.consensus.state.signed.SignedState;
 import org.hiero.consensus.test.fixtures.WeightGenerators;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -65,13 +64,6 @@ final class ReconnectTest {
     @TempDir
     Path tempDir;
 
-    private FileSystemManager fileSystemManager;
-
-    @BeforeEach
-    void setupFileSystemManager() {
-        fileSystemManager = new TestFileSystemManager(tempDir);
-    }
-
     @BeforeAll
     static void setUp() throws ConstructableRegistryException {
         ConstructableRegistration.registerSyncConstructables();
@@ -85,7 +77,9 @@ final class ReconnectTest {
         final ReconnectMetrics reconnectMetrics = mock(ReconnectMetrics.class);
 
         for (int index = 1; index <= numberOfReconnects; index++) {
-            executeReconnect(reconnectMetrics);
+            // Use a different data dir for every reconnect attempt
+            final FileSystemManager fileSystemManager = new TestFileSystemManager(tempDir.resolve("" + index));
+            executeReconnect(fileSystemManager, reconnectMetrics);
             verify(reconnectMetrics, times(index)).incrementReceiverStartTimes();
             verify(reconnectMetrics, times(index)).incrementSenderStartTimes();
             verify(reconnectMetrics, times(index)).incrementReceiverEndTimes();
@@ -93,7 +87,8 @@ final class ReconnectTest {
         }
     }
 
-    private void executeReconnect(final ReconnectMetrics reconnectMetrics) throws InterruptedException, IOException {
+    private void executeReconnect(final FileSystemManager fileSystemManager, final ReconnectMetrics reconnectMetrics)
+            throws InterruptedException, IOException {
         final long weightPerNode = 100L;
         final int numNodes = 4;
         final List<NodeId> nodeIds =

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -42,7 +42,6 @@ import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
@@ -753,6 +752,9 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                 }
             });
 
+            // Update valid key range in the metadata file
+            saveMetadata(dbPaths);
+
             // wait for the other threads in the rare case they are not finished yet. We need to
             // have all writing
             // done before we return as when we return the state version we are writing is deleted
@@ -1110,8 +1112,8 @@ public final class MerkleDbDataSource implements VirtualDataSource {
     private void saveMetadata(final MerkleDbPaths targetDir) throws IOException {
         final KeyRange leafRange = validLeafPathRange;
         final Path targetFile = targetDir.metadataFile;
-        try (final OutputStream fileOut =
-                Files.newOutputStream(targetFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+        // newOutputStream() overrides the file, if it exists, no need to delete explicitly
+        try (final OutputStream fileOut = Files.newOutputStream(targetFile)) {
             final WritableSequentialData out = new WritableStreamingData(fileOut);
             if (leafRange.getMinValidKey() != 0) {
                 ProtoWriterTools.writeTag(out, FIELD_DSMETADATA_MINVALIDKEY);
@@ -1162,7 +1164,6 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                 }
                 validLeafPathRange = new KeyRange(minValidKey, maxValidKey);
             }
-            Files.delete(sourceFile);
             return true;
         }
         return false;

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -1077,6 +1077,7 @@ public final class MerkleDbDataSource implements VirtualDataSource {
     @Override
     public String toString() {
         return new ToStringBuilder(this)
+                .append("storageDir", dbPaths.storageDir)
                 .append("initialCapacity", initialCapacity)
                 .append("preferDiskBasedIndexes", preferDiskBasedIndices)
                 .append("idToDiskLocationHashChunks.size", idToDiskLocationHashChunks.size())

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSourceBuilder.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSourceBuilder.java
@@ -33,37 +33,50 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
     /** Platform configuration */
     private final Configuration configuration;
 
+    /**
+     * A folder name for the first MerkleDb instance managed by this builder. It's used
+     * when a new data source is created from scratch or a data source is restored from a
+     * snapshot.
+     *
+     * <p>Also, this folder name (if not null or blank) is checked first, when a new data
+     * source is requested. If a folder with this nams exists in the file system manager's
+     * temp directory, this is considered a version upgrade, so the data source is created
+     * directly from that folder rather than from scratch.
+     */
+    private final String defaultDbFolderName;
+
     private final FileSystemManager fileSystemManager;
 
-    private long initialCapacity = 0;
+    private final long initialCapacity;
 
     /**
-     * Constructor for deserialization purposes.
-     * @param configuration configuration to use
-     * @param fileSystemManager file system manager to use
-     */
-    public MerkleDbDataSourceBuilder(
-            @NonNull final Configuration configuration, @NonNull final FileSystemManager fileSystemManager) {
-        this.configuration = requireNonNull(configuration);
-        this.fileSystemManager = requireNonNull(fileSystemManager);
-    }
-
-    /**
-     * Creates a new data source builder with the specified table configuration.
-     *
-     * @param initialCapacity initial capacity of the map
-     * @param configuration platform configuration
+     * Creates a new data source builder with the specified configuration, file system manager,
+     * and initial MerkleDb database capacity.
      */
     public MerkleDbDataSourceBuilder(
             @NonNull final Configuration configuration,
             @NonNull final FileSystemManager fileSystemManager,
             final long initialCapacity) {
+        this(null, configuration, fileSystemManager, initialCapacity);
+    }
+
+    /**
+     * Creates a new data source builder with the specified default folder name (may be null or
+     * blank), configuration, file system manager, and initial MerkleDb database capacity.
+     */
+    public MerkleDbDataSourceBuilder(
+            @Nullable String defaultDbFolderName,
+            @NonNull final Configuration configuration,
+            @NonNull final FileSystemManager fileSystemManager,
+            final long initialCapacity) {
+        this.defaultDbFolderName =
+                (defaultDbFolderName == null) || defaultDbFolderName.isBlank() ? null : defaultDbFolderName;
         this.configuration = requireNonNull(configuration);
         this.fileSystemManager = requireNonNull(fileSystemManager);
         this.initialCapacity = initialCapacity;
     }
 
-    private Path newDataSourceDir(final String label) {
+    private Path newTempDataSourceDir(final String label) {
         return fileSystemManager.resolveNewTemp(FOLDER_SUFFIX + label);
     }
 
@@ -102,7 +115,16 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
             throw new IllegalArgumentException("Initial map capacity not set");
         }
         try {
-            final Path dataSourceDir = newDataSourceDir(label);
+            Path dataSourceDir = null;
+            if (defaultDbFolderName != null) {
+                // The folder may or may not exist
+                dataSourceDir = fileSystemManager.getTempPath().resolve(defaultDbFolderName);
+            }
+            // If the default DB dir is not set, or the folder doesn't exist, create a new
+            // temp folder and use it as the storage dir
+            if (dataSourceDir == null) {
+                dataSourceDir = newTempDataSourceDir(label);
+            }
             return new MerkleDbDataSource(
                     dataSourceDir,
                     configuration,
@@ -138,7 +160,7 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
         }
         final String label = merkleDbDataSource.getTableName();
         if (snapshotDir == null) {
-            snapshotDir = newDataSourceDir(label);
+            snapshotDir = newTempDataSourceDir(label);
         }
         final Path snapshotDataSourceDir = snapshotDataDir(snapshotDir, label);
         snapshotDataSource(merkleDbDataSource, snapshotDataSourceDir);
@@ -159,7 +181,16 @@ public class MerkleDbDataSourceBuilder implements VirtualDataSourceBuilder {
             final boolean compactionEnabled,
             final boolean offlineUse) {
         try {
-            final Path dataSourceDir = newDataSourceDir(label);
+            Path dataSourceDir = null;
+            if (defaultDbFolderName != null) {
+                final Path defaultDir = fileSystemManager.getTempPath().resolve(defaultDbFolderName);
+                if (!Files.exists(defaultDir)) {
+                    dataSourceDir = defaultDir;
+                }
+            }
+            if (dataSourceDir == null) {
+                dataSourceDir = newTempDataSourceDir(label);
+            }
             final Path snapshotDataSourceDir = snapshotDataDir(snapshotDir, label);
             if (Files.isDirectory(snapshotDataSourceDir)) {
                 hardLinkTree(snapshotDataSourceDir, dataSourceDir);

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -11,6 +11,10 @@ import com.swirlds.config.api.validation.annotation.Positive;
 /**
  * Instance-wide config for {@code MerkleDbDataSource}.
  *
+ * @param defaultDbFolderName
+ *      If not null/blank, indicates a folder name in the file system manager's temp folder,
+ *      where MerkleDb is created from scratch, restored to from a snapshot, or loaded from
+ *      during version upgrade
  * @param initialCapacity initial capacity of the database
  * @param maxNumOfKeys
  * 	    The maximum number of unique keys to be stored in a database. This is a hard limit.
@@ -85,6 +89,7 @@ import com.swirlds.config.api.validation.annotation.Positive;
 // spotless:off
 @ConfigData("merkleDb")
 public record MerkleDbConfig(
+        @ConfigProperty(defaultValue = "merkledb-state") String defaultDbFolderName,
         @Positive @ConfigProperty(defaultValue = "1000000000") long initialCapacity,
         @Positive @ConfigProperty(defaultValue = "8000000000") long maxNumOfKeys,
         @Deprecated @Min(0) @ConfigProperty(defaultValue = "8388608") long hashesRamToDiskThreshold,

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -103,6 +103,8 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
 
     private final AtomicInteger bucketMaskBits = new AtomicInteger(0);
 
+    /** Storage dir */
+    private final Path storeDir;
     /** The name to use for the files prefix on disk */
     private final String storeName;
 
@@ -172,7 +174,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             final @NonNull Configuration configuration,
             final @NonNull FileSystemManager fileSystemManager,
             final long initialCapacity,
-            final Path storeDir,
+            final @NonNull Path storeDir,
             final String storeName,
             final String legacyStoreName,
             final boolean preferDiskBasedIndex)
@@ -188,6 +190,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
         // power of two, since the number of buckets is always a power of two
         final long bucketIndexCapacity =
                 calculateBucketIndexCapacity(merkleDbConfig.maxNumOfKeys(), goodAverageBucketEntryCount);
+        this.storeDir = requireNonNull(storeDir);
         this.storeName = storeName;
         Path indexFile = storeDir.resolve(storeName + BUCKET_INDEX_FILENAME_SUFFIX);
         // create bucket pool
@@ -277,8 +280,9 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
     }
 
     private void writeMetadata(final Path dir) throws IOException {
-        try (DataOutputStream metaOut =
-                new DataOutputStream(Files.newOutputStream(dir.resolve(storeName + METADATA_FILENAME_SUFFIX)))) {
+        final Path metadataFile = dir.resolve(storeName + METADATA_FILENAME_SUFFIX);
+        // newOutputStream() overrides the file, if it exists, no need to delete explicitly
+        try (DataOutputStream metaOut = new DataOutputStream(Files.newOutputStream(metadataFile))) {
             metaOut.writeInt(METADATA_FILE_FORMAT_VERSION);
             metaOut.writeInt(0); // backwards compatibility, was: minimumBuckets
             metaOut.writeInt(numOfBuckets.get());
@@ -556,6 +560,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             } else {
                 dataFileReader = null;
             }
+            writeMetadata(storeDir);
         } catch (final Exception z) {
             throw new RuntimeException("Exception in HDHM.endWriting()", z);
         } finally {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -14,10 +14,12 @@ import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 import org.hiero.base.constructable.ConstructableRegistryException;
 import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
 import org.hiero.consensus.constructable.ConstructableRegistration;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -120,6 +122,51 @@ class MerkleDbBuilderTest extends AbstractFileManagerAwareTest {
         } finally {
             original.close();
             copy.close();
+        }
+    }
+
+    @Test
+    void canCreateDataSourceWithNoDefaultDir() throws Exception {
+        final String defaultFolderName = "merkledb-state";
+        final Path defaultPath = fileSystemManager.getTempPath().resolve(defaultFolderName);
+        if (Files.isDirectory(defaultPath)) {
+            Files.deleteIfExists(defaultPath);
+        }
+        final MerkleDbDataSourceBuilder builder =
+                new MerkleDbDataSourceBuilder("merkledb-state", CONFIGURATION, fileSystemManager, INITIAL_SIZE);
+        final VirtualDataSource dataSource = builder.build("test", null, false, false);
+        try {
+            // Check the folder gets created
+            Assertions.assertTrue(Files.isDirectory(defaultPath));
+            // Check the data source is empty
+            Assertions.assertEquals(-1, dataSource.getFirstLeafPath());
+            Assertions.assertEquals(-1, dataSource.getLastLeafPath());
+        } finally {
+            dataSource.close();
+        }
+    }
+
+    @Test
+    void canCreateDataSourceWithDefaultDir() throws Exception {
+        final String defaultFolderName = "merkledb-state";
+        final Path defaultPath = fileSystemManager.getTempPath().resolve(defaultFolderName);
+        if (Files.isDirectory(defaultPath)) {
+            Files.deleteIfExists(defaultPath);
+        }
+        final MerkleDbDataSourceBuilder builder =
+                new MerkleDbDataSourceBuilder("merkledb-state", CONFIGURATION, fileSystemManager, INITIAL_SIZE);
+        final VirtualDataSource dataSource1 = builder.build("test", null, false, false);
+        try {
+            dataSource1.saveRecords(100, 200, Stream.of(), Stream.of(), Stream.of(), false);
+        } finally {
+            dataSource1.close(true);
+        }
+        final VirtualDataSource dataSource2 = builder.build("test", null, false, false);
+        try {
+            Assertions.assertEquals(100, dataSource2.getFirstLeafPath());
+            Assertions.assertEquals(200, dataSource2.getLastLeafPath());
+        } finally {
+            dataSource2.close();
         }
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbCompactionCoordinatorTest.java
@@ -50,6 +50,7 @@ class MerkleDbCompactionCoordinatorTest {
     void setUp() {
         final MerkleDbConfig defaultConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
         config = new MerkleDbConfig(
+                defaultConfig.defaultDbFolderName(),
                 defaultConfig.initialCapacity(),
                 defaultConfig.maxNumOfKeys(),
                 defaultConfig.hashesRamToDiskThreshold(),
@@ -1045,6 +1046,7 @@ class MerkleDbCompactionCoordinatorTest {
     private MerkleDbConfig configWithConsolidation(int maxInputSizeMB, int minFileCount) {
         final MerkleDbConfig d = CONFIGURATION.getConfigData(MerkleDbConfig.class);
         return new MerkleDbConfig(
+                d.defaultDbFolderName(),
                 d.initialCapacity(),
                 d.maxNumOfKeys(),
                 d.hashesRamToDiskThreshold(),

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
@@ -5,6 +5,7 @@ import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
+import com.swirlds.merkledb.MerkleDbDataSource;
 import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.test.fixtures.ExampleFixedValue;
 import com.swirlds.merkledb.test.fixtures.ExampleLongKey;
@@ -70,7 +71,7 @@ public class CloseFlushTest extends AbstractFileManagerAwareTest {
         final Path tmpFileDir = fileSystemManager.resolveNewTemp();
         Files.createDirectories(tmpFileDir);
         for (int j = 0; j < 100; j++) {
-            final VirtualDataSource dataSource = MerkleDbTestUtils.createDataSource(
+            final MerkleDbDataSource dataSource = MerkleDbTestUtils.createDataSource(
                     CONFIGURATION, fileSystemManager, "closeFlushTest", count, false, true);
             // Create a custom data source builder, which creates a custom data source to capture
             // all exceptions happened in saveRecords()
@@ -115,15 +116,15 @@ public class CloseFlushTest extends AbstractFileManagerAwareTest {
 
     public static class CustomDataSourceBuilder extends MerkleDbDataSourceBuilder {
 
-        private final VirtualDataSource delegate;
+        private final MerkleDbDataSource delegate;
         private final AtomicReference<Exception> exceptionSink;
 
         public CustomDataSourceBuilder(
-                final VirtualDataSource delegate,
+                final MerkleDbDataSource delegate,
                 AtomicReference<Exception> sink,
                 final @NonNull Configuration configuration,
                 final @NonNull FileSystemManager fileSystemManager) {
-            super(configuration, fileSystemManager);
+            super(configuration, fileSystemManager, delegate.getInitialCapacity());
             this.delegate = delegate;
             this.exceptionSink = sink;
         }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -46,7 +46,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.hiero.base.CompareTo;
 import org.hiero.base.constructable.ConstructableRegistryException;
@@ -79,9 +78,6 @@ class StateFileManagerTests {
     @TempDir
     private Path tmpDir;
 
-    // A counter used to create unique test folders for every test case
-    private static final AtomicInteger counter = new AtomicInteger(0);
-
     private Path testDirectory;
     private FileSystemManager fileSystemManager;
     private StateLifecycleManager<VirtualMapState, VirtualMap> stateLifecycleManager;
@@ -93,10 +89,7 @@ class StateFileManagerTests {
 
     @BeforeEach
     void beforeEach() {
-        // Make sure each test uses a different directory, so they don't conflict with each
-        // other, e.g. one test destroying a state (which is an async process under the cover)
-        // and another test is initializing from the same state folder
-        testDirectory = tmpDir.resolve("StateFileManagerTests" + counter.getAndIncrement());
+        testDirectory = tmpDir.resolve("StateFileManagerTests");
         fileSystemManager = new FileSystemManager(testDirectory);
         context = TestPlatformContextBuilder.create()
                 .withFileSystemManager(fileSystemManager)

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -46,6 +46,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.hiero.base.CompareTo;
 import org.hiero.base.constructable.ConstructableRegistryException;
@@ -78,6 +79,9 @@ class StateFileManagerTests {
     @TempDir
     private Path tmpDir;
 
+    // A counter used to create unique test folders for every test case
+    private static final AtomicInteger counter = new AtomicInteger(0);
+
     private Path testDirectory;
     private FileSystemManager fileSystemManager;
     private StateLifecycleManager<VirtualMapState, VirtualMap> stateLifecycleManager;
@@ -89,7 +93,10 @@ class StateFileManagerTests {
 
     @BeforeEach
     void beforeEach() {
-        testDirectory = tmpDir.resolve("SignedStateFileReadWriteTest");
+        // Make sure each test uses a different directory, so they don't conflict with each
+        // other, e.g. one test destroying a state (which is an async process under the cover)
+        // and another test is initializing from the same state folder
+        testDirectory = tmpDir.resolve("StateFileManagerTests" + counter.getAndIncrement());
         fileSystemManager = new FileSystemManager(testDirectory);
         context = TestPlatformContextBuilder.create()
                 .withFileSystemManager(fileSystemManager)
@@ -198,7 +205,6 @@ class StateFileManagerTests {
     @ValueSource(booleans = {true, false})
     @DisplayName("Sequence Of States Test")
     void sequenceOfStatesTest(final boolean startAtGenesis) throws IOException, ParseException {
-
         final Random random = getRandomPrintSeed();
 
         // Save state every 100 (simulated) seconds
@@ -320,12 +326,11 @@ class StateFileManagerTests {
                         CompareTo.isGreaterThan(nextBoundary, timestamp),
                         "next boundary should be after current timestamp");
             }
-
-            stateLifecycleManager.getMutableState().release();
         }
+
+        stateLifecycleManager.getMutableState().release();
     }
 
-    @SuppressWarnings("resource")
     @Test
     @DisplayName("State Deletion Test")
     void stateDeletionTest() throws IOException, ParseException {
@@ -413,10 +418,6 @@ class StateFileManagerTests {
     }
 
     void initLifecycleManagerAndMakeStateImmutable(final SignedState state) {
-        destroyStateLifecycleManager(stateLifecycleManager);
-        stateLifecycleManager = new VirtualMapStateLifecycleManager(
-                context.getMetrics(), context.getTime(), context.getConfiguration(), context.getFileSystemManager());
-
         stateLifecycleManager.initWithState(state.getState());
         stateLifecycleManager.getLatestImmutableState().release();
     }

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapStateImpl.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapStateImpl.java
@@ -27,9 +27,6 @@ import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.UncheckedParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.config.api.Configuration;
-import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
-import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.State;
 import com.swirlds.state.StateChangeListener;
@@ -80,7 +77,6 @@ import org.apache.logging.log4j.Logger;
 import org.hiero.base.Reservable;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.crypto.Mnemonics;
-import org.hiero.base.file.FileSystemManager;
 import org.json.JSONObject;
 
 /**
@@ -117,26 +113,6 @@ public class VirtualMapStateImpl implements VirtualMapState {
      * The state storage
      */
     protected VirtualMap virtualMap;
-
-    /**
-     * Initializes a {@link VirtualMapStateImpl}.
-     *
-     * @param configuration the platform configuration instance to use when creating the new instance of state
-     * @param metrics       the platform metric instance to use when creating the new instance of state
-     */
-    public VirtualMapStateImpl(
-            @NonNull final Configuration configuration,
-            @NonNull final FileSystemManager fileSystemManager,
-            @NonNull final Metrics metrics) {
-        requireNonNull(configuration);
-        this.metrics = requireNonNull(metrics);
-        final MerkleDbDataSourceBuilder dsBuilder;
-        final MerkleDbConfig merkleDbConfig = configuration.getConfigData(MerkleDbConfig.class);
-        dsBuilder = new MerkleDbDataSourceBuilder(configuration, fileSystemManager, merkleDbConfig.initialCapacity());
-
-        this.virtualMap = new VirtualMap(dsBuilder, configuration);
-        this.virtualMap.registerMetrics(metrics);
-    }
 
     /**
      * Initializes a {@link VirtualMapStateImpl} with the specified {@link VirtualMap}.

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapStateLifecycleManager.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapStateLifecycleManager.java
@@ -10,6 +10,7 @@ import static java.util.Objects.requireNonNull;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
+import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.State;
 import com.swirlds.state.StateLifecycleManager;
@@ -107,7 +108,12 @@ public class VirtualMapStateLifecycleManager implements StateLifecycleManager<Vi
 
         // Eagerly create a genesis state so getMutableState() is always valid after construction.
         // If the node is restarting from a snapshot, loadSnapshot() will replace this genesis state.
-        final VirtualMapStateImpl genesisState = new VirtualMapStateImpl(configuration, fileSystemManager, metrics);
+        final MerkleDbConfig merkleDbConfig = configuration.getConfigData(MerkleDbConfig.class);
+        final String defaultMerkleDbFodlerName = merkleDbConfig.defaultDbFolderName();
+        final MerkleDbDataSourceBuilder dsBuilder = new MerkleDbDataSourceBuilder(
+                defaultMerkleDbFodlerName, configuration, fileSystemManager, merkleDbConfig.initialCapacity());
+        final VirtualMap genesisVirtualMap = new VirtualMap(dsBuilder, configuration);
+        final VirtualMapState genesisState = new VirtualMapStateImpl(genesisVirtualMap, metrics);
         genesisState.getRoot().reserve();
         stateRef.set(genesisState);
     }
@@ -250,14 +256,15 @@ public class VirtualMapStateLifecycleManager implements StateLifecycleManager<Vi
     @Override
     public Hash loadSnapshot(@NonNull final Path targetPath) throws IOException {
         log.info(STARTUP.getMarker(), "Loading snapshot from disk {}", targetPath);
-        final VirtualMap virtualMap = VirtualMap.loadFromDirectory(
-                targetPath, configuration, () -> new MerkleDbDataSourceBuilder(configuration, fileSystemManager));
+        // MerkleDb capacity will be loaded from the snapshot, so can be set to 0 here
+        final VirtualMap snapshotVirtualMap = VirtualMap.loadFromDirectory(
+                targetPath, configuration, () -> new MerkleDbDataSourceBuilder(configuration, fileSystemManager, 0));
 
         // Capture the hash of the original immutable snapshot before releasing it
-        final Hash originalHash = virtualMap.getHash();
+        final Hash originalHash = snapshotVirtualMap.getHash();
 
-        final VirtualMap mutableCopy = virtualMap.copy();
-        virtualMap.release();
+        final VirtualMap mutableCopy = snapshotVirtualMap.copy();
+        snapshotVirtualMap.release();
 
         // VirtualMapStateImpl constructor calls registerMetrics internally
         final VirtualMapStateImpl loadedState = new VirtualMapStateImpl(mutableCopy, metrics);

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/VirtualMapStateTestUtils.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/VirtualMapStateTestUtils.java
@@ -3,6 +3,8 @@ package com.swirlds.state.test.fixtures.merkle;
 
 import static com.swirlds.state.test.fixtures.merkle.VirtualMapUtils.CONFIGURATION;
 
+import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
+import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.state.merkle.VirtualMapStateImpl;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -81,7 +83,11 @@ public final class VirtualMapStateTestUtils {
      * @return the created virtual map state.
      */
     public static VirtualMapStateImpl createTestState(@NonNull final FileSystemManager fileSystemManager) {
-        return new VirtualMapStateImpl(CONFIGURATION, fileSystemManager, new NoOpMetrics());
+        final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
+        final MerkleDbDataSourceBuilder dsBuilder =
+                new MerkleDbDataSourceBuilder(CONFIGURATION, fileSystemManager, merkleDbConfig.initialCapacity());
+        final VirtualMap virtualMap = new VirtualMap(dsBuilder, CONFIGURATION);
+        return new VirtualMapStateImpl(virtualMap, new NoOpMetrics());
     }
 
     private VirtualMapStateTestUtils() {}


### PR DESCRIPTION
Fix summary:

* A new config property is added to `MerkleDbConfig`: `defaultDbFolderName`
* This property (if not null or blank) is a folder name relative to the temp dir (usually, `data/saved/swirlds-tmp`), where MerkleDb data source builder will create a data source by default
* This means, a new data source created from scratch, or a new data source restored from a snapshot
* NB! If a folder with the default name exists in `swirlds-tmp`, the new data sources will be created in it. This is by design, and this is what will be used during ZDT. However, in tests this default folder may be created by one test and then reused by another, this may lead to various issues hard to debug. Some test changes in this PR are related to this issue
* No impact on MerkleDb snapshots
* Temporary MerkleDb instances used during snapshots or reconnects are still created with old folder names (like `<timestamp>-merkledb-state`)
* Some code is refactored, e.g. one of old `MerkleDbDataSourceBuilder` constructors was removed
* No changes to MerkleDb lifecycle. In particular, the storage dir is still removed completely, when a data source is closed. This will have to change for ZDT, but it will be done separately

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/25937
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
