### PR TITLE
chore: cleanup node integration fee tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1299/UpdateNodeAccountTestEmbedded.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1299/UpdateNodeAccountTestEmbedded.java
@@ -24,11 +24,11 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.viewNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.NODE_UPDATE_BASE_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SIGNATURE_FEE_AFTER_MULTIPLIER;
 import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.generateX509Certificates;
@@ -199,7 +199,8 @@ public class UpdateNodeAccountTestEmbedded {
                             .payingWith(PAYER)
                             .signedBy(PAYER, initialNodeAccount, newNodeAccount, "adminKey")
                             .via("updateTxn"),
-                    validateFees("updateTxn", 0.0012, NODE_UPDATE_BASE_FEE_USD + 3 * SIGNATURE_FEE_AFTER_MULTIPLIER),
+                    validateChargedUsdWithin(
+                            "updateTxn", NODE_UPDATE_BASE_FEE_USD + 3 * SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
                     viewNode(
                             "testNode",
                             node -> assertEquals(
@@ -456,7 +457,8 @@ public class UpdateNodeAccountTestEmbedded {
                             .payingWith(PAYER)
                             .signedBy(PAYER, initialNodeAccount, contractWithAdminKey, "adminKey")
                             .via("updateTxn"),
-                    validateFees("updateTxn", 0.0012, NODE_UPDATE_BASE_FEE_USD + 3 * SIGNATURE_FEE_AFTER_MULTIPLIER),
+                    validateChargedUsdWithin(
+                            "updateTxn", NODE_UPDATE_BASE_FEE_USD + 3 * SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
                     viewNode(
                             "testNode",
                             node -> assertEquals(
@@ -488,7 +490,8 @@ public class UpdateNodeAccountTestEmbedded {
                             .payingWith(PAYER)
                             .signedBy(PAYER, initialNodeAccount, contractWithoutAdminKey, "adminKey")
                             .via("updateTxn"),
-                    validateFees("updateTxn", 0.0012, NODE_UPDATE_BASE_FEE_USD + 3 * SIGNATURE_FEE_AFTER_MULTIPLIER),
+                    validateChargedUsdWithin(
+                            "updateTxn", NODE_UPDATE_BASE_FEE_USD + 3 * SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
                     viewNode(
                             "testNode",
                             node -> assertEquals(
@@ -894,7 +897,8 @@ public class UpdateNodeAccountTestEmbedded {
                             .signedBy(PAYER, initialNodeAccount, contractWithAdminKey, "adminKey")
                             .via("updateTxn")
                             .hasKnownStatus(NODE_ACCOUNT_HAS_ZERO_BALANCE),
-                    validateFees("updateTxn", 0.0012, NODE_UPDATE_BASE_FEE_USD + 3 * SIGNATURE_FEE_AFTER_MULTIPLIER),
+                    validateChargedUsdWithin(
+                            "updateTxn", NODE_UPDATE_BASE_FEE_USD + 3 * SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
                     viewNode(
                             "testNode",
                             node -> assertNotEquals(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
@@ -60,7 +60,6 @@ import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.node.HapiNodeCreate;
 import com.hedera.services.bdd.spec.utilops.embedded.ViewNodeOp;
-import com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils;
 import com.hederahashgraph.api.proto.java.ServiceEndpoint;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateEncodingException;
@@ -458,10 +457,10 @@ public class NodeCreateTest {
                 // Validate that the failed transaction charges the correct fees.
                 withOpContext((spec, log) -> allRunFor(
                         spec,
-                        FeesChargingUtils.validateFees(
+                        validateChargedUsdWithin(
                                 "nodeCreationFailed",
-                                0.001,
-                                NODE_CREATE_BASE_FEE_USD + expectedFeeFromBytesFor(spec, log, "nodeCreationFailed")))),
+                                NODE_CREATE_BASE_FEE_USD + expectedFeeFromBytesFor(spec, log, "nodeCreationFailed"),
+                                0.1))),
                 nodeCreate("ntb", nodeAccount)
                         .adminKey(ED_25519_KEY)
                         .fee(ONE_HBAR)
@@ -483,12 +482,12 @@ public class NodeCreateTest {
                         .via("multipleSigsCreation"),
                 withOpContext((spec, log) -> allRunFor(
                         spec,
-                        FeesChargingUtils.validateFees(
+                        validateChargedUsdWithin(
                                 "multipleSigsCreation",
-                                0.0011276316,
                                 NODE_CREATE_BASE_FEE_USD
                                         + 2 * SIGNATURE_FEE_AFTER_MULTIPLIER
-                                        + expectedFeeFromBytesFor(spec, log, "multipleSigsCreation")))));
+                                        + expectedFeeFromBytesFor(spec, log, "multipleSigsCreation"),
+                                0.1))));
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeDeleteTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeDeleteTest.java
@@ -39,7 +39,6 @@ import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
-import com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -92,10 +91,10 @@ public class NodeDeleteTest {
                 // The fee is charged here because the payer is not privileged
                 withOpContext((spec, log) -> allRunFor(
                         spec,
-                        FeesChargingUtils.validateFees(
+                        validateChargedUsdWithin(
                                 "failedDeletion",
-                                0.001,
-                                NODE_DELETE_BASE_FEE_USD + expectedFeeFromBytesFor(spec, log, "failedDeletion")))),
+                                NODE_DELETE_BASE_FEE_USD + expectedFeeFromBytesFor(spec, log, "failedDeletion"),
+                                0.1))),
 
                 // Submit with several signatures and the price should increase
                 nodeDelete("node100")
@@ -107,12 +106,12 @@ public class NodeDeleteTest {
                         .via("multipleSigsDeletion"),
                 withOpContext((spec, log) -> allRunFor(
                         spec,
-                        FeesChargingUtils.validateFees(
+                        validateChargedUsdWithin(
                                 "multipleSigsDeletion",
-                                0.0011276316,
                                 NODE_DELETE_BASE_FEE_USD
                                         + 2 * SIGNATURE_FEE_AFTER_MULTIPLIER
-                                        + expectedFeeFromBytesFor(spec, log, "multipleSigsDeletion")))),
+                                        + expectedFeeFromBytesFor(spec, log, "multipleSigsDeletion"),
+                                0.1))),
                 nodeDelete("node100").via("deleteNode"),
                 // The fee is not charged here because the payer is privileged
                 validateChargedUsdWithin("deleteNode", 0.0, 1.0));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/UpdateAccountEnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/UpdateAccountEnabledTest.java
@@ -12,7 +12,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeUpdate;
 import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.viewNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.safeValidateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
@@ -108,7 +107,7 @@ public class UpdateAccountEnabledTest {
                         .via("failedUpdate"),
                 getTxnRecord("failedUpdate").logged(),
                 // The fee is charged here because the payer is not privileged
-                safeValidateChargedUsdWithin("failedUpdate", 0.001, 1.0, NODE_UPDATE_BASE_FEE_USD, 1.0),
+                validateChargedUsdWithin("failedUpdate", NODE_UPDATE_BASE_FEE_USD, 1.0),
                 nodeUpdate("node100")
                         .adminKey("testKey")
                         .accountId(nodeAccount2)
@@ -127,10 +126,8 @@ public class UpdateAccountEnabledTest {
                         .sigMapPrefixes(uniqueWithFullPrefixesFor("payer", "randomAccount", "testKey"))
                         .fee(ONE_HBAR)
                         .via("failedUpdateMultipleSigs"),
-                safeValidateChargedUsdWithin(
+                validateChargedUsdWithin(
                         "failedUpdateMultipleSigs",
-                        0.0011276316,
-                        3.0,
                         NODE_UPDATE_BASE_FEE_USD + 2 * SIGNATURE_FEE_AFTER_MULTIPLIER,
                         1.0));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeCreateTestEmbedded.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeCreateTestEmbedded.java
@@ -28,7 +28,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.SYSTEM_ADMIN;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedFeeFromBytesFor;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateInnerTxnFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.NODE_CREATE_BASE_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SIGNATURE_FEE_AFTER_MULTIPLIER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
@@ -221,10 +220,9 @@ class AtomicNodeCreateTestEmbedded {
                 // Validate that the failed transaction charges the correct fees.
                 withOpContext((spec, log) -> allRunFor(
                         spec,
-                        validateInnerTxnFees(
+                        validateInnerTxnChargedUsd(
                                 "nodeCreationFailed",
                                 "atomic",
-                                0.001,
                                 NODE_CREATE_BASE_FEE_USD + expectedFeeFromBytesFor(spec, log, "nodeCreationFailed"),
                                 3))),
                 atomicBatch(nodeCreate("ntb", nodeAccount)
@@ -256,10 +254,9 @@ class AtomicNodeCreateTestEmbedded {
                         .hasKnownStatus(INNER_TRANSACTION_FAILED),
                 withOpContext((spec, log) -> allRunFor(
                         spec,
-                        validateInnerTxnFees(
+                        validateInnerTxnChargedUsd(
                                 "multipleSigsCreation",
                                 "atomic",
-                                0.0011276316,
                                 NODE_CREATE_BASE_FEE_USD
                                         + 2 * SIGNATURE_FEE_AFTER_MULTIPLIER
                                         + expectedFeeFromBytesFor(spec, log, "multipleSigsCreation"),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeDeleteTestEmbedded.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeDeleteTestEmbedded.java
@@ -17,7 +17,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeDelete;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.viewNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.safeValidateInnerTxnChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateInnerTxnChargedUsd;
 import static com.hedera.services.bdd.suites.HapiSuite.ADDRESS_BOOK_CONTROL;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
@@ -104,7 +103,7 @@ class AtomicNodeDeleteTestEmbedded {
                         .hasKnownStatus(INNER_TRANSACTION_FAILED),
                 getTxnRecord("failedDeletion").logged(),
                 // The fee is charged here because the payer is not privileged
-                safeValidateInnerTxnChargedUsd("failedDeletion", "atomic", 0.001, 1.0, NODE_DELETE_BASE_FEE_USD, 1.0),
+                validateInnerTxnChargedUsd("failedDeletion", "atomic", NODE_DELETE_BASE_FEE_USD, 1.0),
 
                 // Submit with several signatures and the price should increase
                 atomicBatch(nodeDelete("node100")
@@ -117,11 +116,9 @@ class AtomicNodeDeleteTestEmbedded {
                         .via("atomic")
                         .payingWith(BATCH_OPERATOR)
                         .hasKnownStatus(INNER_TRANSACTION_FAILED),
-                safeValidateInnerTxnChargedUsd(
+                validateInnerTxnChargedUsd(
                         "multipleSigsDeletion",
                         "atomic",
-                        0.0011276316,
-                        1.0,
                         NODE_DELETE_BASE_FEE_USD + 2 * SIGNATURE_FEE_AFTER_MULTIPLIER,
                         1.0),
                 atomicBatch(nodeDelete("node100").via("deleteNode").batchKey(BATCH_OPERATOR))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/hip1195/Hip1195BasicTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/hip1195/Hip1195BasicTests.java
@@ -37,6 +37,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withAddressOfKey;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
@@ -46,7 +47,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.THOUSAND_HBAR;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONTRACT_CREATE_BASE_FEE;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CONTRACT_UPDATE_BASE_FEE;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.HOOK_UPDATES_FEE_USD;
@@ -1100,13 +1100,13 @@ public class Hip1195BasicTests {
                         .gas(5_000_000L)
                         .via("contractWithHookCreation")
                         .payingWith("payer"),
-                validateFees(
+                validateChargedUsdWithin(
                         "contractWithHookCreation",
-                        1.74,
                         CONTRACT_CREATE_BASE_FEE
                                 + HOOK_UPDATES_FEE_USD
                                 + 2 * KEYS_FEE_USD
-                                + SIGNATURE_FEE_AFTER_MULTIPLIER),
+                                + SIGNATURE_FEE_AFTER_MULTIPLIER,
+                        0.1),
                 contractCreate("CreateTrivial")
                         .withHooks(
                                 accountAllowanceHook(400L, TRUE_ALLOWANCE_HOOK.name()),
@@ -1117,13 +1117,13 @@ public class Hip1195BasicTests {
                         .via("contractsWithHookCreation")
                         .payingWith("payer"),
                 // One hook price 1 USD and contractCreate price 1 USD and 0.02 for keys and 0.001 for signature
-                validateFees(
+                validateChargedUsdWithin(
                         "contractsWithHookCreation",
-                        4.74,
                         CONTRACT_CREATE_BASE_FEE
                                 + 4 * HOOK_UPDATES_FEE_USD
                                 + 2 * KEYS_FEE_USD
-                                + SIGNATURE_FEE_AFTER_MULTIPLIER),
+                                + SIGNATURE_FEE_AFTER_MULTIPLIER,
+                        0.1),
                 contractUpdate("CreateTrivial")
                         .removingHook(400L)
                         .withHooks(
@@ -1133,10 +1133,10 @@ public class Hip1195BasicTests {
                         .blankMemo()
                         .via("hookUpdates")
                         .payingWith("payer"),
-                validateFees(
+                validateChargedUsdWithin(
                         "hookUpdates",
-                        4.026,
-                        CONTRACT_UPDATE_BASE_FEE + 4 * HOOK_UPDATES_FEE_USD + SIGNATURE_FEE_AFTER_MULTIPLIER));
+                        CONTRACT_UPDATE_BASE_FEE + 4 * HOOK_UPDATES_FEE_USD + SIGNATURE_FEE_AFTER_MULTIPLIER,
+                        0.1));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/hip1259/Hip1259EnabledTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/hip1259/Hip1259EnabledTests.java
@@ -40,6 +40,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.selectedItems;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepForBlockPeriod;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.streamMustIncludePassWithoutBackgroundTrafficFrom;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilStartOfNextStakingPeriod;
 import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.FEE_COLLECTOR;
@@ -50,7 +51,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.contract.Utils.asSolidityAddress;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.TRANSFERRING_CONTRACT;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CRYPTO_CREATE_TOTAL_FEE;
 import static com.hedera.services.bdd.suites.hip423.ScheduleLongTermSignTest.THIRTY_MINUTES;
 import static com.hedera.services.bdd.suites.integration.hip1259.ValidationUtils.feeDistributionValidator;
@@ -215,9 +215,7 @@ public class Hip1259EnabledTests {
                 }),
                 validateRecordContains("feeTxn", FEE_COLLECTOR_ACCOUNT),
                 validateRecordNotContains("feeTxn", UNEXPECTED_FEE_ACCOUNTS),
-
-                // Validate fee across both legacy and simple-fee modes.
-                validateFees("feeTxn", 0.053, CRYPTO_CREATE_TOTAL_FEE),
+                validateChargedUsdWithin("feeTxn", CRYPTO_CREATE_TOTAL_FEE, 0.1),
 
                 /*-------------------------------TRIGGER NEXT STAKING PERIOD ---------------------------------*/
                 waitUntilStartOfNextStakingPeriod(1),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/IssueRegressionTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/issues/IssueRegressionTests.java
@@ -31,18 +31,15 @@ import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfe
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sendModified;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedQueryIds;
 import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
-import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CRYPTO_DELETE_BASE_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.NODE_AND_NETWORK_BASE_FEE;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SIGNATURE_FEE_AFTER_MULTIPLIER;
@@ -285,7 +282,6 @@ public class IssueRegressionTests {
 
     @LeakyHapiTest
     final Stream<DynamicTest> transferAccountCannotBeDeleted() {
-        final var legacyDeletePriceUsd = 0.0113804;
         final var simpleDeletePriceUsd =
                 CRYPTO_DELETE_BASE_FEE_USD + NODE_AND_NETWORK_BASE_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER;
         return customizedHapiTest(
@@ -301,7 +297,7 @@ public class IssueRegressionTests {
                         .transfer(TRANSFER)
                         .hasKnownStatus(ACCOUNT_DELETED),
                 getTxnRecord(DELETE_TXN).logged(),
-                validateFees(DELETE_TXN, legacyDeletePriceUsd, simpleDeletePriceUsd));
+                validateChargedUsdWithin(DELETE_TXN, simpleDeletePriceUsd, 0.1));
     }
 
     @HapiTest
@@ -323,24 +319,6 @@ public class IssueRegressionTests {
                         .via(DELETE_TXN)
                         .transferContract("PayReceivable")
                         .hasKnownStatus(INVALID_CONTRACT_ID));
-    }
-
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
-    final Stream<DynamicTest> canSwitchSimpleFeesFromFalseToTrueWithoutException() {
-        final var payer = "payerForSimpleFeeToggle";
-        return hapiTest(
-                cryptoCreate(payer).balance(ONE_MILLION_HBARS),
-                uploadInitCode("CreateTrivial"),
-                overriding("fees.simpleFeesEnabled", "false"),
-                contractCreate("CreateTrivial").payingWith(payer).via("legacyContractCreate"),
-                overriding("fees.simpleFeesEnabled", "true"),
-                contractCreate("CreateTrivial")
-                        .payingWith(payer)
-                        .fee(ONE_HUNDRED_HBARS)
-                        .via("simpleContractCreate"),
-                // simple fees are always used now, so the toggle no longer changes the charged fee
-                validateChargedUsd("legacyContractCreate", 1.02),
-                validateChargedUsd("simpleContractCreate", 1.02));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

Drops dual-mode (`legacy` / `simple`) fee assertions across the remaining test suites not covered by the per-service cleanup tickets. Each call is collapsed to its Simple-Fees-only counterpart, with the legacy expectation removed:

- `validateFees(via, legacy, simple)` → `validateChargedUsdWithin(via, simple, 0.1)`
- `validateInnerTxnFees(via, parent, legacy, simple[, tol])` → `validateInnerTxnChargedUsd(via, parent, simple, tol)`
- `safeValidateChargedUsdWithin(via, legacyP, legacyTol, simpleP, simpleTol)` → `validateChargedUsdWithin(via, simpleP, simpleTol)`
- `safeValidateInnerTxnChargedUsd(via, parent, legacyP, legacyTol, simpleP, simpleTol)` → `validateInnerTxnChargedUsd(via, parent, simpleP, simpleTol)`

Net diff: **9 files modified, +41 / −72 lines.** Two commits to keep the diff legible:

1. **Node / address book** (6 files in `hip869/*` + `hip1299/UpdateNodeAccountTestEmbedded`).
2. **Integration / regression** (3 files in `integration/hip1195`, `integration/hip1259`, `issues/IssueRegressionTests`).

The `@LeakyHapiTest canSwitchSimpleFeesFromFalseToTrueWithoutException` in `IssueRegressionTests` is **deleted**: it explicitly toggled `fees.simpleFeesEnabled` between `"false"` and `"true"` within a single run to verify the contract-create fee was identical across modes. With Simple Fees now the only mode, the toggle is a no-op and the test has no remaining purpose. The unused `legacyDeletePriceUsd` local in `transferAccountCannotBeDeleted` and now-orphaned imports (`FeesChargingUtils.validateFees`, `safeValidateChargedUsdWithin`, `safeValidateInnerTxnChargedUsd`, `validateInnerTxnFees`, `overriding`, `validateChargedUsd`, `ONE_MILLION_HBARS`) are cleaned up in the same commits.

Closes #26005. Part of #21642.

## Test plan

- [x] `:test-clients:spotlessJavaCheck` — passes
- [x] `:test-clients:compileJava` — passes
- [x] `:test-clients:testEmbedded` against the 5 `validateFees()` test methods in `hip869/*` and the full `UpdateNodeAccountTestEmbedded` — **37 passing, 0 failing**
- [x] `:test-clients:testEmbedded --tests "*.IssueRegressionTests.transferAccountCannotBeDeleted"` and `*.Hip1195BasicTests.contractUpdateWithHookFeesScalesAsExpected` — passing
- [ ] CI MATS green (`Hip1259EnabledTests.feesAccumulateInNodePayments…` ran INTEGRATION-tagged via `:test-clients:test`; local run hit a known `SelectedItemsAssertion` 1-second timeout in async block-stream validation — unrelated to the fee-assertion change and expected to pass under CI's quieter runner)