### PR TITLE
test(fees): drop simpleFeesEnabled branches from simple-fee suites

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/ContractServiceQueriesSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/ContractServiceQueriesSimpleFeesTest.java
@@ -33,7 +33,6 @@ import com.hedera.services.bdd.spec.dsl.annotations.Account;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.entities.SpecAccount;
 import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,7 +62,6 @@ public class ContractServiceQueriesSimpleFeesTest {
 
     @BeforeAll
     public static void setup(final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
         lifecycle.doAdhoc(contract.getInfo(), largeBytecodeContract.getInfo(), civilian.getInfo(), relayer.getInfo());
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/ConsensusServiceSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/ConsensusServiceSimpleFeesSuite.java
@@ -14,7 +14,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.updateTopic;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedConsensusHbarFee;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedSimpleFees;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdForQueries;
@@ -36,7 +35,6 @@ import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.LeakyHapiTest;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -54,14 +52,13 @@ public class ConsensusServiceSimpleFeesSuite {
         private static final String PAYER = "payer";
         private static final String ADMIN = "admin";
 
-        @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+        @HapiTest
         @DisplayName("compare create topic")
         final Stream<DynamicTest> createTopicPlainComparison() {
             // Signatures: payer only; Keys: none.
             final var sigs = 1L;
             final var keys = 0L;
             return hapiTest(
-                    overriding("fees.simpleFeesEnabled", "true"),
                     cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                     createTopic("testTopic")
                             .blankMemo()
@@ -75,18 +72,16 @@ public class ConsensusServiceSimpleFeesSuite {
                                 KEYS, keys,
                                 PROCESSING_BYTES, (long) signedTxnSize));
                         allRunFor(spec, validateChargedSimpleFees("Simple Fees", "create-topic-txn", expectedFee, 1));
-                    }),
-                    overriding("fees.simpleFeesEnabled", "false"));
+                    }));
         }
 
-        @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+        @HapiTest
         @DisplayName("compare create topic with admin key")
         final Stream<DynamicTest> createTopicWithAdminComparison() {
             // Signatures: payer + admin key; Keys: 1 admin key
             final var sigs = 2L;
             final var keys = 1L;
             return hapiTest(
-                    overriding("fees.simpleFeesEnabled", "true"),
                     newKeyNamed(ADMIN),
                     cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                     createTopic("testTopic")
@@ -104,18 +99,16 @@ public class ConsensusServiceSimpleFeesSuite {
                         allRunFor(
                                 spec,
                                 validateChargedSimpleFees("Simple Fees", "create-topic-admin-txn", expectedFee, 1));
-                    }),
-                    overriding("fees.simpleFeesEnabled", "false"));
+                    }));
         }
 
-        @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+        @HapiTest
         @DisplayName("compare create topic with payer as admin key")
         final Stream<DynamicTest> createTopicWithPayerAdminComparison() {
             // Signatures: payer only (admin key is payer); Keys: 1 admin key.
             final var sigs = 1L;
             final var keys = 1L;
             return hapiTest(
-                    overriding("fees.simpleFeesEnabled", "true"),
                     newKeyNamed(ADMIN),
                     cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                     createTopic("testTopic")
@@ -133,18 +126,16 @@ public class ConsensusServiceSimpleFeesSuite {
                         allRunFor(
                                 spec,
                                 validateChargedSimpleFees("Simple Fees", "create-topic-admin-txn", expectedFee, 1));
-                    }),
-                    overriding("fees.simpleFeesEnabled", "false"));
+                    }));
         }
 
-        @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+        @HapiTest
         @DisplayName("compare create topic with custom fee")
         final Stream<DynamicTest> createTopicCustomFeeComparison() {
             // Signatures: payer only; Keys: none.
             final var sigs = 1L;
             final var keys = 0L;
             return hapiTest(
-                    overriding("fees.simpleFeesEnabled", "true"),
                     cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                     cryptoCreate("collector"),
                     createTopic("testTopic")
@@ -160,18 +151,16 @@ public class ConsensusServiceSimpleFeesSuite {
                                 KEYS, keys,
                                 PROCESSING_BYTES, (long) signedTxnSize));
                         allRunFor(spec, validateChargedSimpleFees("Simple Fees", "create-topic-txn", expectedFee, 1));
-                    }),
-                    overriding("fees.simpleFeesEnabled", "false"));
+                    }));
         }
 
-        @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+        @HapiTest
         @DisplayName("compare update topic with admin key")
         final Stream<DynamicTest> updateTopicComparisonWithPayerAdmin() {
             // Signatures: payer only; Keys: none (no key change).
             final var sigs = 1L;
             final var keys = 0L;
             return hapiTest(
-                    overriding("fees.simpleFeesEnabled", "true"),
                     cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                     createTopic("testTopic")
                             .blankMemo()
@@ -187,11 +176,10 @@ public class ConsensusServiceSimpleFeesSuite {
                                 KEYS, keys,
                                 PROCESSING_BYTES, (long) signedTxnSize));
                         allRunFor(spec, validateChargedSimpleFees("Simple Fees", "update-topic-txn", expectedFee, 1));
-                    }),
-                    overriding("fees.simpleFeesEnabled", "false"));
+                    }));
         }
 
-        @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+        @HapiTest
         @DisplayName("compare update topic with admin key")
         final Stream<DynamicTest> updateTopicComparisonWithAdmin() {
             final String ADMIN = "admin";
@@ -199,7 +187,6 @@ public class ConsensusServiceSimpleFeesSuite {
             final var sigs = 2L;
             final var keys = 1L;
             return hapiTest(
-                    overriding("fees.simpleFeesEnabled", "true"),
                     newKeyNamed(ADMIN),
                     cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                     createTopic("testTopic")
@@ -220,8 +207,7 @@ public class ConsensusServiceSimpleFeesSuite {
                                 KEYS, keys,
                                 PROCESSING_BYTES, (long) signedTxnSize));
                         allRunFor(spec, validateChargedSimpleFees("Simple Fees", "update-topic-txn", expectedFee, 1));
-                    }),
-                    overriding("fees.simpleFeesEnabled", "false"));
+                    }));
         }
 
         @HapiTest
@@ -235,13 +221,12 @@ public class ConsensusServiceSimpleFeesSuite {
                     validateChargedUsdForQueries("getInfo", EXPECTED_CRYPTO_TRANSFER_FEE, 1));
         }
 
-        @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+        @HapiTest
         @DisplayName("compare delete topic with admin key")
         final Stream<DynamicTest> deleteTopicPlainComparison() {
             // Signatures: payer only; Keys: none.
             final var sigs = 1L;
             return hapiTest(
-                    overriding("fees.simpleFeesEnabled", "true"),
                     cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                     createTopic("testTopic")
                             .blankMemo()
@@ -259,8 +244,7 @@ public class ConsensusServiceSimpleFeesSuite {
                         final var expectedFee = expectedTopicDeleteFullFeeUsd(
                                 Map.of(SIGNATURES, sigs, PROCESSING_BYTES, (long) signedTxnSize));
                         allRunFor(spec, validateChargedSimpleFees("Simple Fees", "delete-topic-txn", expectedFee, 1));
-                    }),
-                    overriding("fees.simpleFeesEnabled", "false"));
+                    }));
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoQuerySimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoQuerySimpleFeesSuite.java
@@ -21,12 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -42,11 +38,6 @@ public class CryptoQuerySimpleFeesSuite {
     private static final double CRYPTO_GET_INFO_USD = 0.0001;
     private static final double CRYPTO_GET_ACCOUNT_RECORDS_USD = 0.0001;
     private static final long EXPECTED_NODE_PAYMENT_TINYCENTS = 84L;
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @HapiTest
     @DisplayName("crypto get info simple fee")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoSimpleFeesSuite.java
@@ -30,6 +30,7 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static java.util.List.*;
 
 import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
@@ -67,12 +68,10 @@ public class CryptoSimpleFeesSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto create plain")
     final Stream<DynamicTest> cryptoCreatePlain() {
         return compareSimpleToOld(
@@ -86,7 +85,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto create with key")
     final Stream<DynamicTest> cryptoCreateWithKey() {
         return compareSimpleToOld(
@@ -104,7 +103,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto delete plain")
     final Stream<DynamicTest> cryptoDeletePlain() {
         return compareSimpleToOld(
@@ -124,13 +123,12 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto update basic (no key change)")
     final Stream<DynamicTest> cryptoUpdateBasic() {
         // Extra signatures: payer only (node includes 1 signature).
         final var extraSignatures = 0L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 cryptoCreate("accountToUpdate").balance(ONE_HBAR),
                 cryptoUpdate("accountToUpdate")
                         .memo("Updated memo")
@@ -143,17 +141,15 @@ public class CryptoSimpleFeesSuite {
                     final var expectedFee = cryptoUpdateSimpleFeeUsd(extraSignatures, signedTxnSize);
                     allRunFor(
                             spec, validateChargedSimpleFees("Simple Fees", "updateAccountBasicTxn", expectedFee, 1.0));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto update with key change")
     final Stream<DynamicTest> cryptoUpdateWithKey() {
         // Extra signatures: payer + new key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed("newAccountKey"),
                 cryptoCreate("accountToUpdate").balance(ONE_HBAR),
                 cryptoUpdate("accountToUpdate")
@@ -166,17 +162,15 @@ public class CryptoSimpleFeesSuite {
                     final var signedTxnSize = signedTxnSizeFor(spec, "updateAccountKeyTxn");
                     final var expectedFee = cryptoUpdateSimpleFeeUsd(extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "updateAccountKeyTxn", expectedFee, 1.0));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto update memo only")
     final Stream<DynamicTest> cryptoUpdateMemo() {
         // Extra signatures: payer only (node includes 1 signature).
         final var extraSignatures = 0L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 cryptoCreate("accountToUpdate").balance(ONE_HBAR).memo("Original memo"),
                 cryptoUpdate("accountToUpdate")
                         .memo("Updated memo text")
@@ -188,17 +182,15 @@ public class CryptoSimpleFeesSuite {
                     final var signedTxnSize = signedTxnSizeFor(spec, "updateAccountMemoTxn");
                     final var expectedFee = cryptoUpdateSimpleFeeUsd(extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "updateAccountMemoTxn", expectedFee, 1.0));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto update combined (key + memo)")
     final Stream<DynamicTest> cryptoUpdateCombined() {
         // Extra signatures: payer + new key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed("combinedKey"),
                 cryptoCreate("accountToUpdate").balance(ONE_HBAR).memo("Original"),
                 cryptoUpdate("accountToUpdate")
@@ -214,11 +206,10 @@ public class CryptoSimpleFeesSuite {
                     allRunFor(
                             spec,
                             validateChargedSimpleFees("Simple Fees", "updateAccountCombinedTxn", expectedFee, 1.0));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto create with single hook")
     final Stream<DynamicTest> cryptoCreateWithSingleHook() {
         return compareSimpleToOld(
@@ -239,7 +230,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto create with two hooks")
     final Stream<DynamicTest> cryptoCreateWithTwoHooks() {
         return compareSimpleToOld(
@@ -261,7 +252,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto create with five hooks")
     final Stream<DynamicTest> cryptoCreateWithFiveHooks() {
         return compareSimpleToOld(
@@ -287,7 +278,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto create with hooks and key")
     final Stream<DynamicTest> cryptoCreateWithHooksAndKeys() {
         return compareSimpleToOld(
@@ -311,7 +302,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto update with single hook creation")
     final Stream<DynamicTest> cryptoUpdateWithSingleHook() {
         return compareSimpleToOld(
@@ -334,7 +325,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto update with multiple hook")
     final Stream<DynamicTest> cryptoUpdateWithMultipleHooks() {
         return compareSimpleToOld(
@@ -358,7 +349,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto update with hook deletion")
     final Stream<DynamicTest> cryptoUpdateWithHookDeletion() {
         return compareSimpleToOld(
@@ -383,7 +374,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto update with hook creation and deletion")
     final Stream<DynamicTest> cryptoUpdateWithHookCreationAndDeletion() {
         return compareSimpleToOld(
@@ -408,7 +399,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled", "hooks.hooksEnabled"})
+    @LeakyHapiTest(overrides = {"hooks.hooksEnabled"})
     @DisplayName("crypto update with hook and key change")
     final Stream<DynamicTest> cryptoUpdateWithHookAndKey() {
         return compareSimpleToOld(
@@ -432,7 +423,7 @@ public class CryptoSimpleFeesSuite {
                 1.0);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto approve allowance plain")
     final Stream<DynamicTest> cryptoApproveAllowancePlain() {
         return hapiTest(
@@ -445,7 +436,7 @@ public class CryptoSimpleFeesSuite {
                 validateChargedUsd("approveTxn", CRYPTO_APPROVE_ALLOWANCE_FEE));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto approve allowance with multiple allowances")
     final Stream<DynamicTest> cryptoApproveAllowanceMultiple() {
         return hapiTest(
@@ -463,7 +454,7 @@ public class CryptoSimpleFeesSuite {
                 validateChargedUsd("approveMultipleTxn", 3 * CRYPTO_APPROVE_ALLOWANCE_FEE));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto delete allowance plain")
     final Stream<DynamicTest> cryptoDeleteAllowancePlain() {
         return hapiTest(
@@ -481,7 +472,7 @@ public class CryptoSimpleFeesSuite {
                 validateChargedUsd("deleteTxn", CRYPTO_DELETE_ALLOWANCE_FEE));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto delete allowance with multiple allowances")
     final Stream<DynamicTest> cryptoDeleteAllowanceMultiple() {
         return hapiTest(
@@ -514,7 +505,7 @@ public class CryptoSimpleFeesSuite {
                 validateChargedUsd("deleteMultipleTxn", 3 * CRYPTO_DELETE_ALLOWANCE_FEE));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto approve allowance with multiple signatures")
     final Stream<DynamicTest> cryptoApproveAllowanceMultipleSignatures() {
         return hapiTest(
@@ -532,7 +523,7 @@ public class CryptoSimpleFeesSuite {
                         "approveMultiSigTxn", CRYPTO_APPROVE_ALLOWANCE_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("crypto delete allowance with multiple signatures")
     final Stream<DynamicTest> cryptoDeleteAllowanceMultipleSignatures() {
         return hapiTest(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoTransferSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoTransferSimpleFeesSuite.java
@@ -23,12 +23,8 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -61,11 +57,6 @@ public class CryptoTransferSimpleFeesSuite {
     private static final String FUNGIBLE_TOKEN_WITH_FEES = "fungibleTokenWithFees";
     private static final String NFT_TOKEN = "nftToken";
     private static final String NFT_TOKEN_WITH_FEES = "nftTokenWithFees";
-
-    @BeforeAll
-    public static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     // ==================== FEE TIER TESTS ====================
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoTransferWithHooksSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/CryptoTransferWithHooksSimpleFeesSuite.java
@@ -53,7 +53,7 @@ public class CryptoTransferWithHooksSimpleFeesSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true", "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/TokenServiceSimpleFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/TokenServiceSimpleFeesSuite.java
@@ -39,7 +39,6 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedSimpleFees;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
@@ -77,7 +76,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenClaimAirdrop;
 import com.hederahashgraph.api.proto.java.AccountAmount;
@@ -127,11 +125,10 @@ public class TokenServiceSimpleFeesSuite {
         return serviceBaseUsd + nodeFeeUsd * (NETWORK_MULTIPLIER + 1);
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate create fungible token simple fees")
     final Stream<DynamicTest> validateCreateFungibleToken() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS),
                 tokenCreate(FUNGIBLE_TOKEN)
@@ -148,11 +145,10 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "create-token-txn", 1.0, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate create non-fungible token simple fees")
     final Stream<DynamicTest> validateCreateNonFungibleToken() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS),
@@ -172,11 +168,10 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "create-nft-txn", 1.0, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate create fungible token with custom fees simple fees")
     final Stream<DynamicTest> validateCreateFungibleTokenWithCustomFees() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS),
@@ -199,11 +194,10 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "create-token-custom-fees-txn", 2.0, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate create fungible common token with custom fees simple fees")
     final Stream<DynamicTest> validateCreateFungibleCommonTokenWithCustomFees() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS),
                 cryptoCreate(HBAR_COLLECTOR).balance(0L),
@@ -223,7 +217,7 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "create-ft-custom-fees-txn", 2.0, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate update fungible token simple fees")
     final Stream<DynamicTest> validateUpdateFungibleToken() {
         final var newSupplyKey = "newSupplyKey";
@@ -231,7 +225,6 @@ public class TokenServiceSimpleFeesSuite {
         final var extraSignatures = 2L;
 
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(newSupplyKey),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
@@ -257,12 +250,11 @@ public class TokenServiceSimpleFeesSuite {
                 }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate mint common token simple fees")
     final Stream<DynamicTest> validateMintCommonToken() {
         // TOKEN_MINT_BASE_FEE_USD (0.0009) ≈ 0.001
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -283,12 +275,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "fungible-mint-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate mint multiple common tokens simple fees")
     final Stream<DynamicTest> validateMintMultipleCommonToken() {
         // TOKEN_MINT_BASE_FEE_USD (0.0009) ≈ 0.001
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -309,12 +300,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "fungible-mint-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate mint a unique token simple fees")
     final Stream<DynamicTest> validateMintUniqueToken() {
         // TOKEN_MINT_BASE_FEE_USD (0.0009) = 0.0209
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(METADATA_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
@@ -336,12 +326,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "nft-mint-txn", 0.02, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate mint multiple unique tokens simple fees")
     final Stream<DynamicTest> validateMintMultipleUniqueToken() {
         // TOKEN_MINT_BASE_FEE_USD (0.019) + TOKEN_MINT_NFT_FEE_USD (0.02) * 2 = 0.06
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(METADATA_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
@@ -368,13 +357,12 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "nft-multiple-mint-txn", 0.06, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("compare pause a common token")
     final Stream<DynamicTest> comparePauseToken() {
         // Extra signatures: payer + pause key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(PAUSE_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -399,17 +387,15 @@ public class TokenServiceSimpleFeesSuite {
                     final var expectedFee =
                             simpleTokenOpFeeUsd(TOKEN_PAUSE_BASE_FEE_USD, extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "pause-token-txn", expectedFee, 1));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("compare unpause a common token")
     final Stream<DynamicTest> compareUnpauseToken() {
         // Extra signatures: payer + pause key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
                 newKeyNamed(PAUSE_KEY),
@@ -435,17 +421,15 @@ public class TokenServiceSimpleFeesSuite {
                     final var expectedFee =
                             simpleTokenOpFeeUsd(TOKEN_UNPAUSE_BASE_FEE_USD, extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "unpause-token-txn", expectedFee, 1));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("compare freeze a common token")
     final Stream<DynamicTest> compareFreezeToken() {
         // Extra signatures: payer + freeze key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(FREEZE_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -472,17 +456,15 @@ public class TokenServiceSimpleFeesSuite {
                     final var expectedFee =
                             simpleTokenOpFeeUsd(TOKEN_FREEZE_BASE_FEE_USD, extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "freeze-token-txn", expectedFee, 1));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("compare unfreeze a common token")
     final Stream<DynamicTest> compareUnfreezeToken() {
         // Extra signatures: payer + freeze key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
                 cryptoCreate(OTHER),
@@ -510,16 +492,14 @@ public class TokenServiceSimpleFeesSuite {
                     final var expectedFee =
                             simpleTokenOpFeeUsd(TOKEN_UNFREEZE_BASE_FEE_USD, extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "unfreeze-token-txn", expectedFee, 1));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate burn a common token simple fees")
     final Stream<DynamicTest> validateBurnToken() {
         // TOKEN_BURN_BASE_FEE_USD (0.0009) ≈ 0.001
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
                 tokenCreate(FUNGIBLE_TOKEN)
@@ -541,13 +521,12 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "burn-token-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("compare delete a common token")
     final Stream<DynamicTest> compareDeleteToken() {
         // Extra signatures: payer + admin key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -574,16 +553,14 @@ public class TokenServiceSimpleFeesSuite {
                     final var expectedFee =
                             simpleTokenOpFeeUsd(TOKEN_DELETE_BASE_FEE_USD, extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "delete-token-txn", expectedFee, 1));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate associate a token simple fees")
     final Stream<DynamicTest> validateAssociateToken() {
         // TOKEN_ASSOCIATE_BASE_FEE_USD (0.0499) ≈ 0.05
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -603,12 +580,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "token-associate-txn", 0.05, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate dissociate a token simple fees")
     final Stream<DynamicTest> validateDissociateToken() {
         // TOKEN_DISSOCIATE_BASE_FEE_USD = 0.0499 ≈ 0.05
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -626,12 +602,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "dissociate-txn", 0.05, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate grant kyc simple fees")
     final Stream<DynamicTest> validateGrantKyc() {
         // TOKEN_GRANT_KYC_BASE_FEE_USD = 0.0009 ≈ 0.001
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(KYC_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
@@ -655,12 +630,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "grant-kyc-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate revoke kyc simple fees")
     final Stream<DynamicTest> validateRevokeKyc() {
         // TOKEN_REVOKE_KYC_BASE_FEE_USD = 0.0009 ≈ 0.001
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(KYC_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
@@ -685,12 +659,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "revoke-kyc-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate reject simple fees")
     final Stream<DynamicTest> validateReject() {
         // TOKEN_REJECT_BASE_FEE_USD (0.0009) ≈ 0.001
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(KYC_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS).key(KYC_KEY),
@@ -719,12 +692,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "token-reject-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate reject nft simple fees")
     final Stream<DynamicTest> validateRejectNft() {
         // TOKEN_REJECT_BASE_FEE_USD (0.0009) ≈ 0.001, same base fee as the fungible reject
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -755,12 +727,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "token-reject-nft-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate token account wipe simple fees")
     final Stream<DynamicTest> validateTokenAccountWipe() {
         // TOKEN_WIPE_BASE_FEE_USD (0.0009) ≈ 0.001
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(WIPE_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
@@ -793,7 +764,7 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "token-wipe-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate token fee schedule update simple fees")
     final Stream<DynamicTest> validateTokenFeeScheduleUpdate() {
         final var htsAmount = 2_345L;
@@ -801,7 +772,6 @@ public class TokenServiceSimpleFeesSuite {
         final var htsCollector = "denomFee";
 
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(FEE_SCHEDULE_KEY),
                 cryptoCreate(htsCollector),
                 tokenCreate(feeDenom).treasury(htsCollector),
@@ -823,12 +793,11 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "fee-schedule-update-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate token update nfts simple fees")
     final Stream<DynamicTest> validateTokenUpdateNFTs() {
         final String NFT_TEST_METADATA = " test metadata";
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(WIPE_KEY),
                 newKeyNamed(FEE_SCHEDULE_KEY),
@@ -859,11 +828,10 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "token-update-nfts-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate TokenGetInfoQuery simple fees")
     final Stream<DynamicTest> validateTokenGetInfo() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(FREEZE_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -880,11 +848,10 @@ public class TokenServiceSimpleFeesSuite {
                 validateNodePaymentAmountForQuery("get-token-info-query", 84L));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate TokenGetNftInfoQuery simple fees")
     final Stream<DynamicTest> validateTokenGetNftInfo() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
                 tokenCreate(NFT_TOKEN)
@@ -908,14 +875,13 @@ public class TokenServiceSimpleFeesSuite {
                 validateNodePaymentAmountForQuery("get-token-nft-info-query", 84L));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("token get info - invalid token fails - no fee charged")
     final Stream<DynamicTest> tokenGetInfoInvalidTokenFails() {
         final AtomicLong initialBalance = new AtomicLong();
         final AtomicLong afterBalance = new AtomicLong();
 
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                 getAccountBalance(PAYER).exposingBalanceTo(initialBalance::set),
                 getTokenInfo("0.0.99999999").payingWith(PAYER).hasCostAnswerPrecheck(INVALID_TOKEN_ID),
@@ -925,14 +891,13 @@ public class TokenServiceSimpleFeesSuite {
                 }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("token get nft info - invalid token fails - no fee charged")
     final Stream<DynamicTest> tokenGetNftInfoInvalidTokenFails() {
         final AtomicLong initialBalance = new AtomicLong();
         final AtomicLong afterBalance = new AtomicLong();
 
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
                 getAccountBalance(PAYER).exposingBalanceTo(initialBalance::set),
                 getTokenNftInfo("0.0.99999999", 1L).payingWith(PAYER).hasCostAnswerPrecheck(INVALID_NFT_ID),
@@ -942,12 +907,11 @@ public class TokenServiceSimpleFeesSuite {
                 }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate burn nft simple fees")
     final Stream<DynamicTest> validateBurnNft() {
         // TOKEN_BURN_BASE_FEE_USD (0.0009) ≈ 0.001, same base fee as the fungible burn
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
                 tokenCreate(NFT_TOKEN)
@@ -971,13 +935,12 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedSimpleFees("Simple Fees", "burn-nft-txn", 0.001, 1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate freeze nft simple fees")
     final Stream<DynamicTest> validateFreezeNft() {
         // Extra signatures: payer + freeze key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(FREEZE_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -1000,17 +963,15 @@ public class TokenServiceSimpleFeesSuite {
                     final var expectedFee =
                             simpleTokenOpFeeUsd(TOKEN_FREEZE_BASE_FEE_USD, extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "freeze-nft-txn", expectedFee, 1));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate unfreeze nft simple fees")
     final Stream<DynamicTest> validateUnfreezeNft() {
         // Extra signatures: payer + freeze key (node includes 1 signature)
         final var extraSignatures = 1L;
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(FREEZE_KEY),
                 cryptoCreate(PAYER).balance(ONE_MILLION_HBARS).key(SUPPLY_KEY),
@@ -1034,16 +995,14 @@ public class TokenServiceSimpleFeesSuite {
                     final var expectedFee =
                             simpleTokenOpFeeUsd(TOKEN_UNFREEZE_BASE_FEE_USD, extraSignatures, signedTxnSize);
                     allRunFor(spec, validateChargedSimpleFees("Simple Fees", "unfreeze-nft-txn", expectedFee, 1));
-                }),
-                overriding("fees.simpleFeesEnabled", "false"));
+                }));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("validate wipe nft simple fees")
     final Stream<DynamicTest> validateWipeNft() {
         // TOKEN_WIPE_BASE_FEE_USD (0.0009) ≈ 0.001, same base fee as the fungible wipe
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(WIPE_KEY),
                 cryptoCreate(ADMIN).balance(ONE_MILLION_HBARS),
@@ -1334,11 +1293,10 @@ public class TokenServiceSimpleFeesSuite {
                 validateChargedUsdWithin("updateTxn", TOKEN_UPDATE_NFT_FEE * updateAmounts.size(), 0.1));
     }
 
-    @LeakyHapiTest(overrides = {"fees.simpleFeesEnabled"})
+    @HapiTest
     @DisplayName("BASELINE: Valid single fungible token transfer charged correct token fee")
     final Stream<DynamicTest> validFungibleTransferUndercharged() {
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 cryptoCreate("payer").balance(ONE_HUNDRED_HBARS),
                 cryptoCreate("receiver").balance(0L),
                 tokenCreate("fungibleToken")
@@ -1383,7 +1341,6 @@ public class TokenServiceSimpleFeesSuite {
                         .via("attackTxn")
                         .hasKnownStatus(INVALID_TOKEN_ID),
                 // verify that the regular fee is charged even though the transfer failed due to an invalid token id
-                validateChargedUsd("attackTxn", TOKEN_TRANSFER_FEE),
-                overriding("fees.simpleFeesEnabled", "false"));
+                validateChargedUsd("attackTxn", TOKEN_TRANSFER_FEE));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/AtomicBatchBoundarySimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/AtomicBatchBoundarySimpleFeesTest.java
@@ -82,9 +82,7 @@ public class AtomicBatchBoundarySimpleFeesTest {
     private static final String NON_FUNGIBLE_TOKEN = "nonFungibleToken";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("Outer Batch PROCESSING_BYTES Scaling Scenarios")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/AtomicBatchCrossServiceSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/AtomicBatchCrossServiceSimpleFeesTest.java
@@ -109,9 +109,7 @@ public class AtomicBatchCrossServiceSimpleFeesTest {
     private static final String EMPTY_CONSTRUCTOR_CONTRACT = "EmptyConstructor";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("Atomic Batch Cross Service Simple Fees Tests")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/AtomicBatchNegativeSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/AtomicBatchNegativeSimpleFeesTest.java
@@ -137,9 +137,7 @@ public class AtomicBatchNegativeSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/ContractServiceSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/ContractServiceSimpleFeesTest.java
@@ -81,9 +81,7 @@ public class ContractServiceSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoApproveAllowanceSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoApproveAllowanceSimpleFeesTest.java
@@ -83,9 +83,7 @@ public class CryptoApproveAllowanceSimpleFeesTest {
     private static final String DUPLICATE_TXN_ID = "duplicateTxnId";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("CryptoApproveAllowance Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateSimpleFeesEmbeddedTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateSimpleFeesEmbeddedTest.java
@@ -55,9 +55,7 @@ public class CryptoCreateSimpleFeesEmbeddedTest {
     private static final String CRYPTO_CREATE_TXN_INNER_ID = "crypto-create-txn-inner-id";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("CryptoCreate Simple Fees Failures on Pre-Handle")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateSimpleFeesTest.java
@@ -94,9 +94,7 @@ public class CryptoCreateSimpleFeesTest {
     private static final String cryptoCreatetxn = "cryptoCreatetxn";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("CryptoCreate Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateWithHooksSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateWithHooksSimpleFeesTest.java
@@ -46,7 +46,7 @@ public class CryptoCreateWithHooksSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true", "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoDeleteAllowanceSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoDeleteAllowanceSimpleFeesTest.java
@@ -88,9 +88,7 @@ public class CryptoDeleteAllowanceSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoDeleteSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoDeleteSimpleFeesTest.java
@@ -79,9 +79,7 @@ public class CryptoDeleteSimpleFeesTest {
     private static final String DUPLICATE_TXN_ID = "duplicateTxnId";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("CryptoDelete Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferSimpleFeesTest.java
@@ -139,9 +139,7 @@ public class CryptoTransferSimpleFeesTest {
     private static final String nftTransferTxn = "nftTransferTxn";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("Crypto Transfer Simple Fees Tests")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesAndHooksSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesAndHooksSimpleFeesTest.java
@@ -74,7 +74,7 @@ public class CryptoTransferWithCustomFeesAndHooksSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true", "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithCustomFeesSimpleFeesTest.java
@@ -97,9 +97,7 @@ public class CryptoTransferWithCustomFeesSimpleFeesTest {
     private static final String tokenTransferTxn = "tokenTransferTxn";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("Crypto Transfer with Custom Fees - Fixed Fees - Simple Fees Test")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithHooksSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoTransferWithHooksSimpleFeesTest.java
@@ -80,7 +80,7 @@ public class CryptoTransferWithHooksSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true", "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoUpdateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoUpdateSimpleFeesTest.java
@@ -96,9 +96,7 @@ public class CryptoUpdateSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/FileServiceSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/FileServiceSimpleFeesTest.java
@@ -103,9 +103,7 @@ public class FileServiceSimpleFeesTest {
     private static final int NODE_PROCESSING_BYTES_ABOVE_THRESHOLD = NODE_PROCESSING_BYTES_THRESHOLD + 1;
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("File Service Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/ScheduleServiceSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/ScheduleServiceSimpleFeesTest.java
@@ -95,9 +95,7 @@ public class ScheduleServiceSimpleFeesTest {
     private static final String scheduleDeleteTxn = "scheduleDeleteTxn";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @Nested
     @DisplayName("ScheduleCreate Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenAirdropSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenAirdropSimpleFeesTest.java
@@ -131,9 +131,7 @@ public class TokenAirdropSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "hooks.hooksEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("hooks.hooksEnabled", "true"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenAssociateAndDissociateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenAssociateAndDissociateSimpleFeesTest.java
@@ -62,14 +62,11 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -94,11 +91,6 @@ public class TokenAssociateAndDissociateSimpleFeesTest {
     private static final String TOKEN3 = "token3";
     private static final String tokenAssociateTxn = "tokenAssociateTxn";
     private static final String tokenDissociateTxn = "tokenDissociateTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenAssociate Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenBurnSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenBurnSimpleFeesTest.java
@@ -51,14 +51,11 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -81,11 +78,6 @@ public class TokenBurnSimpleFeesTest {
     private static final String FUNGIBLE_TOKEN = "fungibleToken";
     private static final String NFT_TOKEN = "nftToken";
     private static final String tokenBurnTxn = "tokenBurnTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenBurn Fungible Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenClaimAndCancelAirdropSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenClaimAndCancelAirdropSimpleFeesTest.java
@@ -105,9 +105,7 @@ public class TokenClaimAndCancelAirdropSimpleFeesTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "entities.unlimitedAutoAssociationsEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("entities.unlimitedAutoAssociationsEnabled", "true"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenCreateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenCreateSimpleFeesTest.java
@@ -62,14 +62,11 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -99,11 +96,6 @@ public class TokenCreateSimpleFeesTest {
     private static final String PAYER_KEY = "payerKey";
     private static final String HBAR_COLLECTOR = "hbarCollector";
     private static final String tokenCreateTxn = "tokenCreateTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenCreate Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenDeleteSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenDeleteSimpleFeesTest.java
@@ -57,14 +57,11 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -85,11 +82,6 @@ public class TokenDeleteSimpleFeesTest {
     private static final String PAYER_KEY = "payerKey";
     private static final String TOKEN = "fungibleToken";
     private static final String tokenDeleteTxn = "tokenDeleteTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenDelete Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenFeeScheduleUpdateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenFeeScheduleUpdateSimpleFeesTest.java
@@ -65,15 +65,12 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -96,11 +93,6 @@ public class TokenFeeScheduleUpdateSimpleFeesTest {
     private static final String TOKEN = "fungibleToken";
     private static final String FEE_COLLECTOR = "feeCollector";
     private static final String feeScheduleUpdateTxn = "feeScheduleUpdateTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenFeeScheduleUpdate Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenFreezeSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenFreezeSimpleFeesTest.java
@@ -53,13 +53,10 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -82,11 +79,6 @@ public class TokenFreezeSimpleFeesTest {
     private static final String freezeTxn = "freezeTxn";
     private static final String unfreezeTxn = "unfreezeTxn";
     private static final String DUPLICATE_TXN_ID = "duplicateFreezeTxnId";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenFreeze Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenKycSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenKycSimpleFeesTest.java
@@ -52,13 +52,10 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -82,11 +79,6 @@ public class TokenKycSimpleFeesTest {
     private static final String grantKycTxn = "grantKycTxn";
     private static final String revokeKycTxn = "revokeKycTxn";
     private static final String DUPLICATE_TXN_ID = "duplicateGrantKycTxnId";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenGrantKyc Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenMintSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenMintSimpleFeesTest.java
@@ -55,14 +55,11 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -86,11 +83,6 @@ public class TokenMintSimpleFeesTest {
     private static final String FUNGIBLE_TOKEN = "fungibleToken";
     private static final String NFT_TOKEN = "nftToken";
     private static final String tokenMintTxn = "tokenMintTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenMint Fungible Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenOpsShortPrefixTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenOpsShortPrefixTest.java
@@ -97,9 +97,7 @@ public class TokenOpsShortPrefixTest {
     private static final String COLLECTOR = "collector";
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @HapiTest
     @DisplayName("TokenFreeze succeeds with short (unique) prefixes")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenPauseSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenPauseSimpleFeesTest.java
@@ -50,13 +50,10 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -79,11 +76,6 @@ public class TokenPauseSimpleFeesTest {
     private static final String pauseTxn = "pauseTxn";
     private static final String unpauseTxn = "unpauseTxn";
     private static final String DUPLICATE_TXN_ID = "duplicatePauseTxnId";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenPause Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenUpdateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenUpdateSimpleFeesTest.java
@@ -49,13 +49,10 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -86,11 +83,6 @@ public class TokenUpdateSimpleFeesTest {
     private static final String NEW_FEE_SCHEDULE_KEY = "newFeeScheduleKey";
     private static final String HBAR_COLLECTOR = "hbarCollector";
     private static final String tokenUpdateTxn = "tokenUpdateTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenUpdate Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenWipeSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TokenWipeSimpleFeesTest.java
@@ -55,14 +55,11 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -86,11 +83,6 @@ public class TokenWipeSimpleFeesTest {
     private static final String NFT_TOKEN = "nftToken";
     private static final String wipeTxn = "wipeTxn";
     private static final String DUPLICATE_TXN_ID = "duplicateWipeTxnId";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TokenWipe Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicCreateCustomFeeSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicCreateCustomFeeSimpleFeesTest.java
@@ -48,13 +48,10 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -81,11 +78,6 @@ public class TopicCreateCustomFeeSimpleFeesTest {
     private static final String TOPIC = "testTopic";
     private static final String createTopicTxn = "createTopicTxn";
     private static final String DUPLICATE_TXN_ID = "duplicateTopicDeleteTxnId";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TopicCreate with Custom Fee Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicCreateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicCreateSimpleFeesTest.java
@@ -47,14 +47,11 @@ import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -71,11 +68,6 @@ public class TopicCreateSimpleFeesTest {
     private static final String ADMIN_KEY = "adminKey";
     private static final String PAYER_KEY = "payerKey";
     private static final String createTopicTxn = "create-topic-txn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     class CreateTopicSimpleFeesPositiveTests {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicDeleteSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicDeleteSimpleFeesTest.java
@@ -41,13 +41,10 @@ import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -69,11 +66,6 @@ public class TopicDeleteSimpleFeesTest {
     private static final String TOPIC = "testTopic";
     private static final String DUPLICATE_TXN_ID = "duplicateTopicDeleteTxnId";
     private static final String topicDeleteTxn = "topicDeleteTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TopicDelete Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicDeleteSimpleFeesTestEmbedded.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicDeleteSimpleFeesTestEmbedded.java
@@ -30,14 +30,11 @@ import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.TargetEmbeddedMode;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.ControlForKey;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -58,11 +55,6 @@ public class TopicDeleteSimpleFeesTestEmbedded {
     private static final String PAYER_KEY = "payerKey";
     private static final String TOPIC = "testTopic";
     private static final String NODE_ACCOUNT_ID = "0.0.4";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TopicDelete Failures on Pre-Handle")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicGetInfoSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicGetInfoSimpleFeesTest.java
@@ -21,11 +21,8 @@ import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -42,11 +39,6 @@ public class TopicGetInfoSimpleFeesTest {
     private static final String PAYER = "payer";
     private static final String ADMIN_KEY = "adminKey";
     private static final String TOPIC = "testTopic";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("GetTopicInfo Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicSubmitMessageSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicSubmitMessageSimpleFeesTest.java
@@ -53,13 +53,10 @@ import static org.hiero.hapi.support.fees.Extra.STATE_BYTES;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -81,11 +78,6 @@ public class TopicSubmitMessageSimpleFeesTest {
     private static final String PAYER_KEY = "payerKey";
     private static final String TOPIC = "testTopic";
     private static final String submitMessageTxn = "submitMessageTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("SubmitMessage Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicUpdateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/TopicUpdateSimpleFeesTest.java
@@ -48,13 +48,10 @@ import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -78,11 +75,6 @@ public class TopicUpdateSimpleFeesTest {
     private static final String PAYER_KEY = "payerKey";
     private static final String TOPIC = "testTopic";
     private static final String topicUpdateTxn = "topicUpdateTxn";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
 
     @Nested
     @DisplayName("TopicUpdate Simple Fees Positive Test Cases")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/UniquePrefixesSmokeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/UniquePrefixesSmokeTest.java
@@ -16,7 +16,6 @@ import com.hedera.services.bdd.spec.infrastructure.providers.ops.BiasedDelegatin
 import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.suites.regression.UmbrellaRedux;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -34,9 +33,7 @@ import org.junit.jupiter.api.Tag;
 public class UniquePrefixesSmokeTest {
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("fees.simpleFeesEnabled", "true"));
-    }
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {}
 
     @HapiTest
     @DisplayName("All major transaction types succeed with UNIQUE_PREFIXES")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/SimpleFeesCongestionPricingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/SimpleFeesCongestionPricingTest.java
@@ -10,7 +10,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uncheckedSubmit
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.SysFileOverrideOp.Target.THROTTLES;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.blockingOrder;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
@@ -77,15 +76,13 @@ public class SimpleFeesCongestionPricingTest {
               ]
             }""";
 
-    @LeakyHapiTest(
-            overrides = {"fees.percentCongestionMultipliers", "fees.minCongestionPeriod", "fees.simpleFeesEnabled"})
+    @LeakyHapiTest(overrides = {"fees.percentCongestionMultipliers", "fees.minCongestionPeriod"})
     Stream<DynamicTest> simpleFeesApplyCongestionMultiplierToTransfers() {
         AtomicLong normalPrice = new AtomicLong();
         AtomicLong congestedPrice = new AtomicLong();
         final int burstTxns = 24;
 
         return hapiTest(
-                overriding("fees.simpleFeesEnabled", "true"),
                 cryptoCreate(CIVILIAN_ACCOUNT).payingWith(GENESIS).balance(ONE_MILLION_HBARS),
                 cryptoTransfer(tinyBarsFromTo(CIVILIAN_ACCOUNT, FUNDING, 5L))
                         .payingWith(CIVILIAN_ACCOUNT)


### PR DESCRIPTION
**Description**:

Collapse the `fees.simpleFeesEnabled` flag branches in the simple-fee test suites to the simple-fees path. Behavior-preserving — the flag defaults true.

* Drop `overriding`/`overrideInClass`/`doWithStartupConfig` flag toggles in `hip1261/*SimpleFeesTest`
* Collapse simple-vs-legacy branches in `fees/*SimpleFeesSuite` to the simple-fee assertions

**Related issue(s)**:

Part of #25852

**Notes for reviewer**:

Scoped to the simple-fee suites only; no production or shared-helper changes. The simple-fee suites continue to pass under `:test-clients:testEmbedded`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)