### PR TITLE
fix: cherry-pick: tss.wrapsProvingKeyPath default conflicts with WRAPS artifacts

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
@@ -41,7 +41,8 @@ import org.apache.logging.log4j.Logger;
  * is logged and a recurring retry is scheduled. The node continues startup regardless.
  *
  * <p>After successful hash verification, the proving key archive (.tar.gz) is extracted
- * to the parent directory of the proving key path.
+ * to the directory specified by the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} environment variable.
+ * The {@code tss.wrapsProvingKeyPath} config controls only where the archive file is stored on disk.
  */
 public class WrapsProvingKeyVerification {
     private static final Logger log = LogManager.getLogger(WrapsProvingKeyVerification.class);

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TssConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TssConfig.java
@@ -73,7 +73,7 @@ public record TssConfig(
         @ConfigProperty(defaultValue = "true") @NetworkProperty
         boolean wrapsProvingKeyDownloadEnabled,
 
-        @ConfigProperty(defaultValue = "data/keys/wraps") @NodeProperty
+        @ConfigProperty(defaultValue = "data/keys/wraps.tar.gz") @NodeProperty
         String wrapsProvingKeyPath,
 
         @ConfigProperty(


### PR DESCRIPTION
**Description**:
This PR cherry-picks commit 7774981ab6d6e0300df5815ef7f0108fff68efe7 for release/0.76

**Related issue(s)**:

Fixes #26018 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
