### PR TITLE
ci(fix): add xts-tag-exists to the slack-cancelled-summary template

### DIFF
--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -642,6 +642,7 @@ jobs:
         if: ${{ steps.report-category.outputs.category == 'cancelled' }}
         env:
           SLACK_SUMMARY_TEXT: ":no_entry_sign: XTS run cancelled${{ needs.fetch-xts-candidate.outputs.xts-info != '' && format(' ({0})', needs.fetch-xts-candidate.outputs.xts-info) || '' }} — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+          XTS_TAG_EXISTS: "${{needs.fetch-xts-candidate.outputs.xts-tag-exists}}"
         run: gomplate -f .github/workflows/templates/slack-cancelled-summary.json.tpl -o slack_payload_summary.json
 
       # Notification routing:

--- a/.github/workflows/templates/slack-cancelled-summary.json.tpl
+++ b/.github/workflows/templates/slack-cancelled-summary.json.tpl
@@ -1,3 +1,4 @@
+{{- $xts_tag_exists := getenv "XTS_TAG_EXISTS" | required "XTS_TAG_EXISTS must be set" -}}
 {
   "attachments": [
     {
@@ -8,6 +9,10 @@
           "text": {
             "type": "mrkdwn",
             "text": {{ getenv "SLACK_SUMMARY_TEXT" | required "SLACK_SUMMARY_TEXT must be set" | data.ToJSON }}
+          },
+          "text": {
+            "type": "mrkdwn",
+            "text": {{- if eq $xts_tag_exists "true" -}}{{ tag exists }}{{No new XTS Candidate available}}
           }
         }
       ]

--- a/.github/workflows/templates/slack-cancelled-summary.json.tpl
+++ b/.github/workflows/templates/slack-cancelled-summary.json.tpl
@@ -1,4 +1,4 @@
-{{- $xts_tag_exists := getenv "XTS_TAG_EXISTS" | required "XTS_TAG_EXISTS must be set" -}}
+{{- $xts_tag_exists := (getenv "XTS_TAG_EXISTS" | required "XTS_TAG_EXISTS must be set") -}}
 {
   "attachments": [
     {
@@ -12,7 +12,7 @@
           },
           "text": {
             "type": "mrkdwn",
-            "text": {{- if eq $xts_tag_exists "true" -}}{{ tag exists }}{{No new XTS Candidate available}}
+            "text": {{- if eq $xts_tag_exists "true" -}}{{ "tag exists" }}{{else}}{{"No new XTS Candidate available."}}{{end}}
           }
         }
       ]


### PR DESCRIPTION
**Description**:

Modify the XTS canceled slack message to include more information.

If the xts-tag-exists is false, then it's likely the cron job and nothing changed on main. Print out that there is no new xts candidate.


<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #https://github.com/hiero-ledger/hiero-consensus-node/issues/25513

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
