### PR TITLE
docs: Add CLAUDE.md for consensus layer KB

### DIFF
--- a/platform-sdk/docs/consensus-layer/CLAUDE.md
+++ b/platform-sdk/docs/consensus-layer/CLAUDE.md
@@ -50,11 +50,14 @@ at random can promote the stale copy. Surface it; let the curator adjudicate.
 - **Allocate the ID and write the index row in the same change.** The
   `README.md` index row is a sanctioned duplication with a sync obligation
   (`LAYOUT.md`). An entry without its row, or a row without its entry, is a bug.
-- **Single-file catalogs append, they do not get a new file.** A new symptom
-  is the next `SYM-NNN` row appended to `symptoms.md`, every column filled,
-  table kept in ID order. The file is its own index — there is no separate
-  `README.md` row. Never reuse or renumber an ID; retire by marking, not
-  deleting.
+- **Symptoms are a shared index, not a knowledge file.** `symptoms.md` is a
+  controlled vocabulary; the diagnostic knowledge lives in `heuristics/` and
+  `scenarios/`, which cite a `SYM-NNN` rather than describe the symptom inline.
+  So symptoms are *reused*, not created per entry: point a `symptoms:` field at
+  an existing `SYM-NNN` where one fits, and only when none does, append a new
+  one to `symptoms.md` first — never cite an uncatalogued symptom. The integrity
+  rule is enforced by `heuristics/FORMAT.md` and `scenarios/FORMAT.md`; the
+  append mechanics and ID discipline live in `symptoms.md`.
 
 ## Anchor every claim to code
 

--- a/platform-sdk/docs/consensus-layer/CLAUDE.md
+++ b/platform-sdk/docs/consensus-layer/CLAUDE.md
@@ -16,22 +16,28 @@ conventions, frontmatter, and the canonicalization rule — lives in
 
 ## Non-duplication is the prime directive
 
-`LAYOUT.md` defines the rule (one canonical home per fact; reference, don't
-restate; the narrative-restatement exception). This is the part that is easy to
-get wrong, so apply it deliberately:
+`LAYOUT.md` defines the rule: one canonical home per fact; reference, don't
+restate; the narrative-restatement exception. Easy to get wrong — apply it
+deliberately:
 
 - **Before changing any fact, find every place it already appears.** Search the
   whole KB for the ID, the term, the parameter value, and the file path before
   you edit. An agent that updates "4 of the 5" copies of a value silently
   corrupts the KB — the surviving stale copy is indistinguishable from the truth.
   Grepping first is not optional.
-- **The reason the rule exists is to make that search return one hit.** When you
-  add content, prefer a reference over a copy precisely so the next editor has
-  one place to change, not five. If you find yourself copying a load-bearing
-  value, stop and link instead.
+- **Prefer a reference over a copy.** The rule exists so the next editor's
+  search returns one hit, not five places to change in lockstep. If you find
+  yourself copying a load-bearing value, stop and link instead.
 - **When you do restate for the reader, restate the summary, not the value.**
   Link to the canonical home for the authoritative version. See `LAYOUT.md`,
   "Narrative restatement vs. duplicated source of truth."
+
+## Stop and ask on conflict
+
+If a grep surfaces two places that disagree — two values, two statuses, two
+accounts of one behavior — do not guess and do not silently reconcile. A
+conflict means a fact has two homes, or code moved under one of them; choosing
+at random can promote the stale copy. Surface it; let the curator adjudicate.
 
 ## Adding entries
 
@@ -44,13 +50,17 @@ get wrong, so apply it deliberately:
 - **Allocate the ID and write the index row in the same change.** The
   `README.md` index row is a sanctioned duplication with a sync obligation
   (`LAYOUT.md`). An entry without its row, or a row without its entry, is a bug.
+- **Single-file catalogs append, they do not get a new file.** A new symptom
+  is the next `SYM-NNN` row appended to `symptoms.md`, every column filled,
+  table kept in ID order. The file is its own index — there is no separate
+  `README.md` row. Never reuse or renumber an ID; retire by marking, not
+  deleting.
 
 ## Anchor every claim to code
 
-This is the single most important property of this KB and the easiest to let
-slip. The current entries hold a high bar: claims about how the system behaves
-are tied to the specific code that makes them true. Match that bar — it is what
-separates this KB from prose that rots.
+The single most important property of this KB, and the easiest to let slip.
+Behavioral claims tie to the specific code that makes them true. Match that bar
+— it is what separates this KB from prose that rots.
 
 - **Coverage, not just honesty.** A behavioral claim names the class, and where
   it matters the method, that realizes it — the way RUL-002 ties its ordering
@@ -62,16 +72,17 @@ separates this KB from prose that rots.
   under-anchor:**
   - *Rules* — `components:` frontmatter is required and lists full paths; the
     body names the guard, ordering, or structure the property rests on.
-    Enforced by `rules/FORMAT.md`; keep `last_verified_against` honest.
+    Enforced by `rules/FORMAT.md`. Rules carry no date marker; keep `status`
+    honest (mark `divergent` the moment the code no longer matches) and
+    `provenance` traceable.
   - *Invariants* — anchor the *basis* to the external `source` (paper/protocol)
     **and** the *enforcement* to the code site, in `verification` and the body,
     as INV-001 does (`ConsensusImpl.recalculateAndVote`). Do not conflate the
     two: the authority is permanent, the code site is contingent.
-  - *Architecture topics* — these carry the heaviest anchor load and have **no
-    `FORMAT.md` enforcing it**, so the discipline rests entirely here: name
-    every component with its class and file path. This is a de facto standard
-    held up by hand — a new or expanded topic that names components without
-    anchoring them is a regression, even though no schema will reject it.
+  - *Architecture topics* — the heaviest anchor load, with **no `FORMAT.md`
+    enforcing it**: name every component with its class and file path. The
+    standard is held up by hand — naming a component without anchoring it is a
+    regression no schema will catch.
   - *Concepts, ADRs, scenarios* — anchor proportionally. Concepts cite code only
     where a mental model touches it; ADRs anchor the mechanism, not every
     sentence of rationale; scenarios anchor the events and identifiers in the
@@ -85,19 +96,50 @@ separates this KB from prose that rots.
 - **Verify before you write; refresh on touch.** Confirm every class, method,
   path, and commit exists before citing it — never invent line numbers or
   commit hashes. When you change a claim, re-check that its anchors still
-  resolve and bump the file's freshness marker (`last_verified_against` for
-  rules, `last_reviewed` for narrative docs). **A stale-but-present anchor is
-  more dangerous than none** — it reads as verified. If you cannot verify an
-  anchor, say so in the entry rather than guessing.
+  resolve, then refresh the file's currency marker (see
+  [When to bump the freshness marker](#when-to-bump-the-freshness-marker)).
+  **A stale-but-present anchor is more dangerous than none** — it reads as
+  verified. If you cannot verify an anchor, say so rather than guessing.
+
+## When to bump the freshness marker
+
+`last_reviewed` (a date) is the freshness marker on narrative and
+single-file-catalog docs (`concepts/`, `architecture/**`, `glossary.md`,
+`symptoms.md`, `tunables.md`). It asserts one thing: the file's code-anchored
+claims were checked against current code on that date. Bump it only when that
+is true. ID-catalog entries (`rules/`, `invariants/`, …) carry no date marker —
+their currency is `status`, kept honest under
+[Keep load-bearing frontmatter in sync](#keep-load-bearing-frontmatter-in-sync).
+
+- **Bump when** you add, change, or re-confirm a code-anchored claim: you
+  re-anchor to moved code, confirm existing anchors still resolve against
+  current code, or revise what a claim asserts.
+- **Do not bump** for edits that touch no claim and no anchor: typo fixes,
+  formatting, link repair, reordering, wording changes that leave every claim
+  intact.
+- **Never bump without verifying.** Advancing the date is itself a claim —
+  that you re-checked the anchors. If you edit a claim but cannot re-verify it,
+  leave the date and flag the gap in the entry. A falsely-fresh marker is the
+  stale-anchor failure one level up.
 
 ## Keep load-bearing frontmatter in sync
 
-`status` especially — tools read it. When a rule goes `divergent`, an ADR goes
-`superseded`, or a scenario reaches `verified`, update the entry, its
-`README.md` row, and any field the format marks load-bearing, together.
+`status` especially — tools read it. Tools do not just read frontmatter; they
+**query by `id` and by frontmatter field**. A malformed, missing, or
+off-format field drops the entry from query results as surely as deleting it.
+The format is a hard requirement, not a style preference. When a rule goes
+`divergent`, an ADR goes `superseded`, or a scenario reaches `verified`, update
+the entry, its `README.md` row, and any field the format marks load-bearing,
+together.
 
 ## Scope and altitude
 
+- **The KB describes the current code; current code is canonical.** Entries
+  state what runs today. Proposed or future-state design goes only into a
+  clearly-marked `## Future state (sidebar)` in the topic file and/or the
+  topic's `delta-map/` entry — never into the body of a claim about how the
+  system behaves. See [`README.md`](README.md) and
+  [`delta-map/FORMAT.md`](delta-map/FORMAT.md).
 - The KB covers the consensus-layer topics named in `LAYOUT.md`. Content
   drifting into execution-layer internals, block production, TSS, or application
   semantics is out of scope — flag it, do not absorb it.

--- a/platform-sdk/docs/consensus-layer/CLAUDE.md
+++ b/platform-sdk/docs/consensus-layer/CLAUDE.md
@@ -1,0 +1,107 @@
+# Authoring the Consensus Layer KB
+
+Instructions for any agent (or person) adding to or updating this knowledge
+base. Read this before editing. The structural contract — directory layout, ID
+conventions, frontmatter, and the canonicalization rule — lives in
+[`LAYOUT.md`](LAYOUT.md); the per-catalog entry schemas live in each catalog's
+`FORMAT.md`. Read the relevant one before you write.
+
+## Before you start
+
+- Read `LAYOUT.md` for where the content belongs, and the target catalog's
+  `FORMAT.md` for the entry shape. Do not infer the format from a sibling file —
+  siblings drift; `FORMAT.md` is the schema.
+- Match the prevailing voice: terse, declarative statements. Detail goes in the
+  sections the format designates for it, not in the headline claim.
+
+## Non-duplication is the prime directive
+
+`LAYOUT.md` defines the rule (one canonical home per fact; reference, don't
+restate; the narrative-restatement exception). This is the part that is easy to
+get wrong, so apply it deliberately:
+
+- **Before changing any fact, find every place it already appears.** Search the
+  whole KB for the ID, the term, the parameter value, and the file path before
+  you edit. An agent that updates "4 of the 5" copies of a value silently
+  corrupts the KB — the surviving stale copy is indistinguishable from the truth.
+  Grepping first is not optional.
+- **The reason the rule exists is to make that search return one hit.** When you
+  add content, prefer a reference over a copy precisely so the next editor has
+  one place to change, not five. If you find yourself copying a load-bearing
+  value, stop and link instead.
+- **When you do restate for the reader, restate the summary, not the value.**
+  Link to the canonical home for the authoritative version. See `LAYOUT.md`,
+  "Narrative restatement vs. duplicated source of truth."
+
+## Adding entries
+
+- **Search before you create.** Check the catalog's `README.md` index and grep
+  for the concept before opening a new `INV`/`RUL`/`SCN`/`HEU`/`ADR`. A
+  near-duplicate entry is the same disease as a duplicated fact, one level up.
+- **Apply the discriminator; don't guess.** Invariant vs. rule, scenario vs.
+  heuristic — each catalog's `README.md` states the test. A single fact is filed
+  in one catalog, never both.
+- **Allocate the ID and write the index row in the same change.** The
+  `README.md` index row is a sanctioned duplication with a sync obligation
+  (`LAYOUT.md`). An entry without its row, or a row without its entry, is a bug.
+
+## Anchor every claim to code
+
+This is the single most important property of this KB and the easiest to let
+slip. The current entries hold a high bar: claims about how the system behaves
+are tied to the specific code that makes them true. Match that bar — it is what
+separates this KB from prose that rots.
+
+- **Coverage, not just honesty.** A behavioral claim names the class, and where
+  it matters the method, that realizes it — the way RUL-002 ties its ordering
+  claim to `PlatformCoordinator.flushIntakePipeline()`. A load-bearing claim a
+  reader cannot trace to code is either raised to a cited authority (a paper or
+  protocol, the way invariants use `source`) or cut. "Don't fabricate an anchor"
+  is the floor; **"every load-bearing claim carries one" is the bar.**
+- **By document type — apply the right kind of anchor, don't over- or
+  under-anchor:**
+  - *Rules* — `components:` frontmatter is required and lists full paths; the
+    body names the guard, ordering, or structure the property rests on.
+    Enforced by `rules/FORMAT.md`; keep `last_verified_against` honest.
+  - *Invariants* — anchor the *basis* to the external `source` (paper/protocol)
+    **and** the *enforcement* to the code site, in `verification` and the body,
+    as INV-001 does (`ConsensusImpl.recalculateAndVote`). Do not conflate the
+    two: the authority is permanent, the code site is contingent.
+  - *Architecture topics* — these carry the heaviest anchor load and have **no
+    `FORMAT.md` enforcing it**, so the discipline rests entirely here: name
+    every component with its class and file path. This is a de facto standard
+    held up by hand — a new or expanded topic that names components without
+    anchoring them is a regression, even though no schema will reject it.
+  - *Concepts, ADRs, scenarios* — anchor proportionally. Concepts cite code only
+    where a mental model touches it; ADRs anchor the mechanism, not every
+    sentence of rationale; scenarios anchor the events and identifiers in the
+    timeline. Lighter is correct here — do not force file paths where they don't
+    belong.
+- **Path convention.** Inline anchors use the abbreviated form
+  `module/.../File.java` (e.g.
+  `consensus-event-creator-impl/.../tipset/TipsetEventCreator.java`); full,
+  unabbreviated paths belong in `components:` frontmatter. Follow the
+  surrounding file.
+- **Verify before you write; refresh on touch.** Confirm every class, method,
+  path, and commit exists before citing it — never invent line numbers or
+  commit hashes. When you change a claim, re-check that its anchors still
+  resolve and bump the file's freshness marker (`last_verified_against` for
+  rules, `last_reviewed` for narrative docs). **A stale-but-present anchor is
+  more dangerous than none** — it reads as verified. If you cannot verify an
+  anchor, say so in the entry rather than guessing.
+
+## Keep load-bearing frontmatter in sync
+
+`status` especially — tools read it. When a rule goes `divergent`, an ADR goes
+`superseded`, or a scenario reaches `verified`, update the entry, its
+`README.md` row, and any field the format marks load-bearing, together.
+
+## Scope and altitude
+
+- The KB covers the consensus-layer topics named in `LAYOUT.md`. Content
+  drifting into execution-layer internals, block production, TSS, or application
+  semantics is out of scope — flag it, do not absorb it.
+- Structural changes (new catalog, new ID prefix, convention change) land in the
+  same PR as the corresponding `LAYOUT.md` update. Content additions to existing
+  catalogs do not touch `LAYOUT.md` — that is what the catalog `README.md` files
+  are for.

--- a/platform-sdk/docs/consensus-layer/LAYOUT.md
+++ b/platform-sdk/docs/consensus-layer/LAYOUT.md
@@ -34,7 +34,7 @@ platform-sdk/docs/consensus-layer/
 ├── architecture/
 │   ├── README.md
 │   ├── overview.md                        high-level shape; adapts from Consensus-Layer.md
-│   ├── topics/                            one file per topic (the 13)
+│   ├── topics/                            one file per topic
 │   │   ├── wiring-framework.md
 │   │   ├── gossip.md
 │   │   ├── event-intake.md
@@ -145,7 +145,7 @@ Single file. Controlled vocabulary of observable symptoms (`SYM-NNN`) referenced
 
 The topic-organized lens on the consensus layer.
 - `architecture/overview.md` — adapts the high-level shape from `Consensus-Layer.md` for KB use.
-- `architecture/topics/` — one file per topic (the 13). Each describes the topic's responsibilities, state, contracts, and links to related concepts, invariants, decisions, and scenarios.
+- `architecture/topics/` — one file per topic. Each describes the topic's responsibilities, state, contracts, and links to related concepts, invariants, decisions, and scenarios.
 - `architecture/interfaces/consensus-execution-boundary.md` — the Consensus public API (`initialize`, `destroy`, `nextRound`, `onBehind`, `onPreHandleEvent`, `getTransactionsForEvent`, etc.).
 
 ### `decisions/`
@@ -227,6 +227,53 @@ Type vocabulary:
 | `delta-map/*.md`               | `delta-map`              |
 | `symptoms.md`                  | `symptom-catalog`        |
 | `tunables.md`                  | `tunable-catalog`        |
+
+## Canonicalization and non-duplication
+
+Each fact has exactly one canonical home in this KB. Every other mention
+references that home — by ID, by link, or by name — rather than restating the
+fact. This is the structural rule that keeps the KB maintainable: when a fact
+changes, there is one place to change it, not a scattered set that must all be
+found and edited in lockstep.
+
+Canonical homes, by kind of fact:
+
+|              Kind of fact              |                          Canonical home                          |
+|----------------------------------------|------------------------------------------------------------------|
+| Term definition / mental model         | `glossary.md` (term), `concepts/` (model)                        |
+| Observable symptom                     | `symptoms.md` (`SYM-NNN`)                                        |
+| Configurable parameter, threshold      | `tunables.md`                                                    |
+| Why a load-bearing choice was made     | `decisions/` (`ADR-NNN`)                                         |
+| Property true under any correct impl   | `invariants/` (`INV-NNN`)                                        |
+| Property true of the code as it is     | `rules/` (`RUL-NNN`)                                             |
+| Catalog entry title + one-line summary | the entry file (mirrored into its `README.md` index — see below) |
+
+### Narrative restatement vs. duplicated source of truth
+
+Repetition is not absolutely forbidden — an ADR or rule may restate orienting
+context so a human can read it without chasing links, and that is fine. The
+line is between two kinds of repetition:
+
+- **Narrative restatement** — a prose summary that orients the reader. Allowed.
+  Keep it a summary, and link to the canonical home for the authoritative version.
+- **Duplicated source of truth** — a load-bearing value copied verbatim: a
+  parameter value or threshold, an ID, a file path, a `status`, a commit hash.
+  **Not allowed.** State it once in its canonical home and reference it.
+
+The test: *if this fact changes, must I also edit it here?* If yes, it is a
+duplicated source of truth and must become a reference instead.
+
+### Sanctioned duplication
+
+One duplication is built into the structure: each catalog entry's title and
+one-line summary appear both in the entry file and in its `README.md` index
+row. This is deliberate — the index is the navigable catalog. Because it is a
+duplication, it carries a sync obligation: the index row is updated in the same
+change as the entry it describes, never separately.
+
+The procedure a contributor (human or agent) follows to honor these rules —
+including how to find every existing reference before changing a fact — lives in
+[`CLAUDE.md`](CLAUDE.md). This section states the rule; that file states how to apply it.
 
 ## When to update this file
 

--- a/platform-sdk/docs/consensus-layer/LAYOUT.md
+++ b/platform-sdk/docs/consensus-layer/LAYOUT.md
@@ -158,7 +158,7 @@ Per-file catalog of design-guaranteed properties of the form **this is true, and
 
 ### `rules/`
 
-Per-file catalog of implementation-true properties of the form **this is true of the code as it stands, and a correct change could make it false**. Each entry has an ID (`RUL-NNN`), statement, code anchor, `last_verified_against` commit, and account of what would break it. A rule observed false is a divergence signal — the code moved, or the rule was mis-stated — not, by itself, a bug. Pairs with `invariants/`: an entry that turns out to be design-guaranteed is promoted to `invariants/`.
+Per-file catalog of implementation-true properties of the form **this is true of the code as it stands, and a correct change could make it false**. Each entry has an ID (`RUL-NNN`), statement, code anchor (`components:`), `status`, and account of what would break it. A rule observed false is a divergence signal — the code moved, or the rule was mis-stated — not, by itself, a bug. Pairs with `invariants/`: an entry that turns out to be design-guaranteed is promoted to `invariants/`.
 
 ### `tunables.md`
 

--- a/platform-sdk/docs/consensus-layer/LAYOUT.md
+++ b/platform-sdk/docs/consensus-layer/LAYOUT.md
@@ -139,7 +139,7 @@ Single file. ~50 terms. The canonical definition for each term referenced anywhe
 
 ### `symptoms.md`
 
-Single file. Controlled vocabulary of observable symptoms (`SYM-NNN`) referenced by per-file catalogs that key off observation — currently `heuristics/` and `scenarios/`. Each entry has an ID, name, description, and source of observation. A symptom here is something observable and recorded, independent of cause; many heuristics or scenarios may share one symptom, and that is the point of the catalog.
+Single file. Controlled vocabulary of observable symptoms (`SYM-NNN`) referenced by per-file catalogs that key off observation — currently `heuristics/` and `scenarios/`. It is an index, not a knowledge file: it carries no diagnostic content of its own. The knowledge — suspected cause, validation, incident timeline — lives in the `heuristics/` and `scenarios/` entries that cite the `SYM-NNN`. Each entry has an ID, name, description, and source of observation. A symptom here is something observable and recorded, independent of cause; many heuristics or scenarios may share one symptom, and that is the point of the catalog.
 
 ### `architecture/`
 

--- a/platform-sdk/docs/consensus-layer/README.md
+++ b/platform-sdk/docs/consensus-layer/README.md
@@ -2,11 +2,13 @@
 
 Reference documentation for the consensus layer of the platform-sdk — the subsystem that reaches Byzantine-fault-tolerant agreement on event ordering using a hashgraph-based algorithm.
 
-The KB covers thirteen topics — wiring, gossip, event intake, event creation, the hashgraph algorithm, health monitoring and backpressure, reasons not to gossip, quiescence, signed state management, ISS detection, restart and PCES, freeze and upgrade, and reconnect — and the cross-cutting catalogs that support them.
+The KB covers the consensus layer's topics — gossip, event intake and creation, the hashgraph algorithm, signed-state management, ISS detection, freeze and upgrade, reconnect, and more — and the cross-cutting catalogs that support them. The full topic list lives in [`architecture/`](architecture/README.md).
 
 **Current implementation is canonical.** Entries describe what runs today, anchored to specific files, classes, and methods. The proposed future shape from `../proposals/consensus-layer/Consensus-Layer.md` appears only as clearly-marked sidebars in topic files and is tracked per-topic under `delta-map/`.
 
 For the structural contract — file naming, ID conventions, catalog formats, the discriminator rules between catalogs (invariant vs. rule, scenario vs. heuristic), and what changes require a structural update — see [LAYOUT.md](LAYOUT.md).
+
+Before adding or updating content, read [CLAUDE.md](CLAUDE.md) — the authoring guide for this KB: non-duplication, anchoring every claim to code, and the entry-discipline checklist. It applies to human and agent contributors alike.
 
 ## What's here
 

--- a/platform-sdk/docs/consensus-layer/architecture/README.md
+++ b/platform-sdk/docs/consensus-layer/architecture/README.md
@@ -1,6 +1,6 @@
 # Architecture
 
-The topic-organized lens on the consensus layer. Eleven topics, plus an overview and the module-boundary APIs.
+The topic-organized lens on the consensus layer: one file per topic, plus an overview and the module-boundary APIs.
 
 Where `../concepts/` defines foundational mental models and the catalog directories (`../invariants/`, `../rules/`, `../decisions/`, `../scenarios/`, `../heuristics/`) capture cross-cutting claims, this directory walks the consensus layer one topic at a time. Each topic file describes its responsibilities, state, contracts, and code anchors, and cross-references the catalog entries that touch it.
 
@@ -10,7 +10,7 @@ Where `../concepts/` defines foundational mental models and the catalog director
 
 ## Topics
 
-One file per topic, in `topics/`. Twelve topics total.
+One file per topic, in `topics/`; the full set is the table below.
 
 |                 Topic file                  |              Topic              |                                                                        Summary                                                                         |
 |---------------------------------------------|---------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|---|

--- a/platform-sdk/docs/consensus-layer/architecture/overview.md
+++ b/platform-sdk/docs/consensus-layer/architecture/overview.md
@@ -7,7 +7,7 @@ last_reviewed: 2026-06-12
 # Architecture overview
 
 This file is the navigation map for the consensus-layer KB. It names the
-modules, names the thirteen topics, places them in the module structure, and
+modules, names the topics, places them in the module structure, and
 shows where the Consensus / Execution boundary runs in current code. It is
 deliberately shallow: each topic gets a sentence or two and a forward link
 to the per-topic file where the depth lives. Motivation and design
@@ -100,7 +100,7 @@ path.
 
 ## Topic map
 
-The thirteen topics below are the KB's main navigation axis. The grouping
+The topics below are the KB's main navigation axis. The grouping
 is for orientation only — it is not a structural ontology, and the
 topics are not strictly disjoint.
 

--- a/platform-sdk/docs/consensus-layer/delta-map/README.md
+++ b/platform-sdk/docs/consensus-layer/delta-map/README.md
@@ -2,7 +2,7 @@
 
 Per-topic record of how the current code aligns with the proposed future-state design in `../../proposals/consensus-layer/Consensus-Layer.md`. The KB treats current code as canonical; the delta map is where the future shape and the work it implies are tracked.
 
-One file per topic, eleven topics total. Each file states the topic's status, then enumerates what aligns, what doesn't, and (where known) why.
+One file per topic. Each file states the topic's status, then enumerates what aligns, what doesn't, and (where known) why.
 
 ## Status values
 

--- a/platform-sdk/docs/consensus-layer/invariants/FORMAT.md
+++ b/platform-sdk/docs/consensus-layer/invariants/FORMAT.md
@@ -2,7 +2,7 @@
 
 Specification for `invariants/INV-NNN-short-slug.md` entries. This file
 defines the structure only; allowed values for the `topics` field are the
-eleven topic slugs under `architecture/topics/`. The test for whether
+topic slugs under `architecture/topics/`. The test for whether
 something is an invariant rather than a rule is defined in `README.md` —
 apply it before filing here.
 

--- a/platform-sdk/docs/consensus-layer/rules/FORMAT.md
+++ b/platform-sdk/docs/consensus-layer/rules/FORMAT.md
@@ -1,7 +1,7 @@
 # Rules — Entry Format
 
 Specification for `rules/RUL-NNN-short-slug.md` entries. This file defines the
-structure only; allowed values for the `topics` field are the eleven topic
+structure only; allowed values for the `topics` field are the topic
 slugs under `architecture/topics/`. The test for whether something is a rule
 rather than an invariant is defined in `README.md` — apply it before filing
 here.


### PR DESCRIPTION
**Description**:
This PR adds a CLAUDE.md file to the consensus-layer knowledge base which instructs future claude instances on the proper ways to update and add content to the KB. This approach was specifically suggested by claude to ensure long term integrity of the KB.

In addition, some duplication was cleaned up (non-duplication was one of the rules in the new CLAUDE.md file).

**Related issue(s)**:

Fixes #26047
