### PR TITLE
ci: Add json-rpc-relay-version to hiero-consensus-node .citr-env

### DIFF
--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -144,7 +144,7 @@ jobs:
           echo "JS SDK Version: ${{ needs.extract-citr-vars.outputs.js-sdk-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Block Node Release Version: ${{ needs.extract-citr-vars.outputs.bn-release-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Block Node Regression Mirror Node Version: ${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
-          echo "JSON RPC Relay Regression Version: ${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" | tes -a "${GITHUB_STEP_SUMMARY}"
+          echo "JSON RPC Relay Regression Version: ${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Solo Version: ${SOLO_VERSION}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Solo Version >= 0.44.0 (gates Migration Testing + Block Node Regression): ${SOLO_GE_0440}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Helm Release Name: ${HELM_NAME}" | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -144,6 +144,7 @@ jobs:
           echo "JS SDK Version: ${{ needs.extract-citr-vars.outputs.js-sdk-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Block Node Release Version: ${{ needs.extract-citr-vars.outputs.bn-release-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Block Node Regression Mirror Node Version: ${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
+          echo "JSON RPC Relay Regression Version: ${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" | tes -a "${GITHUB_STEP_SUMMARY}"
           echo "Solo Version: ${SOLO_VERSION}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Solo Version >= 0.44.0 (gates Migration Testing + Block Node Regression): ${SOLO_GE_0440}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Helm Release Name: ${HELM_NAME}" | tee -a "${GITHUB_STEP_SUMMARY}"
@@ -198,6 +199,7 @@ jobs:
       js-sdk-version: "${{ needs.extract-citr-vars.outputs.js-sdk-version }}"
       bn-release-version: "${{ needs.extract-citr-vars.outputs.bn-release-version }}"
       bn-mirror-node-version: "${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}"
+      json-rpc-relay-version: "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}"
       custom-job-label: "XTS (Dry Run):"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/602-flow-merge-queue-controller.yaml
+++ b/.github/workflows/602-flow-merge-queue-controller.yaml
@@ -72,6 +72,7 @@ jobs:
       enable-otter-test-suite: "true"
       enable-hedera-node-jrs-panel: "true"
       enable-sdk-tck-regression-panel: "true"
+      tck-version: ${{ needs.extract-citr-vars.outputs.tck-version }}
       java-version: ${{ needs.extract-jdk-version.outputs.jdk-version }}
 
     secrets:

--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -90,22 +90,22 @@ on:
         description: "The TCK version to use for XTS Panels"
         type: string
         required: false
-        default: "latest"
       js-sdk-version:
         description: "The JavaScript SDK version to use for XTS Panels"
         type: string
         required: false
-        default: "latest"
       bn-release-version:
         description: "The Block Node release version to use for XTS Panels"
         type: string
         required: false
-        default: "latest"
       bn-mirror-node-version:
         description: "The Mirror Node release version to use for Block Node XTS Panels"
         type: string
         required: false
-        default: "latest"
+      json-rpc-relay-version:
+        description: "The JSON-RPC Relay release version to use for XTS Panels"
+        type: string
+        required: false
     secrets:
       access-token:
         description: "Github Access Token"
@@ -407,6 +407,7 @@ jobs:
       custom-job-name: "${{ inputs.custom-job-label }} JSON-RPC Relay Regression"
       solo-version: ${{ inputs.solo-version }}
       java-version: "${{ inputs.java-version }}"
+      json-rpc-relay-version: "${{ inputs.json-rpc-relay-version }}"
     secrets:
       access-token: ${{ secrets.regression-access-token }}
       slack-detailed-report-webhook: ${{ secrets.slack-citr-details-token }}

--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -24,6 +24,10 @@ on:
         description: "Java JDK Version:"
         type: string
         required: false
+      json-rpc-relay-version:
+        description: "The version of json-rpc-relay to use for the regression tests (if not specified, latest will be used):"
+        required: false
+        type: string
     secrets:
       access-token:
         description: "GitHub Access Token with write permissions to the repository."
@@ -87,6 +91,21 @@ jobs:
           repository: hiero-ledger/hiero-json-rpc-relay
           fetch-depth: 0
           fetch-tags: true
+
+      # Checkout the specified version tag
+      - name: Checkout JS-SDK Tag
+        run: |
+          cd regression-tests/json-rpc-relay
+          git fetch --tags
+
+          # If ${{ inputs.json-rpc-relay-version }} is in the tags, check it out.
+          if git rev-parse "refs/tags/${{ inputs.regression-tests/json-rpc-relay }}" >/dev/null 2>&1; then
+            echo "Checking out specified JS-SDK version: ${{ inputs.json-rpc-relay-version }}"
+            git checkout "tags/${{ inputs.json-rpc-relay-version }}"
+          else
+            echo "Specified JS-SDK version ${{ inputs.json-rpc-relay-version }} not found in tags."
+            exit 1 # fail the workflow if not present.
+          fi
 
       # Build the hiero-consensus-node artifacts
       - name: Build hiero-consensus-node

--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -93,17 +93,17 @@ jobs:
           fetch-tags: true
 
       # Checkout the specified version tag
-      - name: Checkout JS-SDK Tag
+      - name: Checkout JSON-RPC Relay Tag
         run: |
           cd regression-tests/json-rpc-relay
           git fetch --tags
 
           # If ${{ inputs.json-rpc-relay-version }} is in the tags, check it out.
-          if git rev-parse "refs/tags/${{ inputs.regression-tests/json-rpc-relay }}" >/dev/null 2>&1; then
-            echo "Checking out specified JS-SDK version: ${{ inputs.json-rpc-relay-version }}"
+          if git rev-parse "refs/tags/${{ inputs.json-rpc-relay-version  }}" >/dev/null 2>&1; then
+            echo "Checking out specified JSON-RPC Relay version: ${{ inputs.json-rpc-relay-version }}"
             git checkout "tags/${{ inputs.json-rpc-relay-version }}"
           else
-            echo "Specified JS-SDK version ${{ inputs.json-rpc-relay-version }} not found in tags."
+            echo "Specified JSON-RPC Relay version ${{ inputs.json-rpc-relay-version }} not found in tags."
             exit 1 # fail the workflow if not present.
           fi
 

--- a/.github/workflows/855-call-extract-citr-vars.yaml
+++ b/.github/workflows/855-call-extract-citr-vars.yaml
@@ -31,6 +31,8 @@ on:
         value: ${{ jobs.extract-citr-vars.outputs.block-node-version }}
       bn-mirror-node-version:
         value: ${{ jobs.extract-citr-vars.outputs.bn-mirror-node-version }}
+      json-rpc-relay-version:
+        value: ${{ jobs.extract-citr-vars.outputs.json-rpc-relay-version }}
 
 permissions:
   contents: read
@@ -53,6 +55,7 @@ jobs:
       js-sdk-version: ${{ steps.get-citr-vars.outputs.js-sdk-version }}
       block-node-version: ${{ steps.get-citr-vars.outputs.block-node-version }}
       bn-mirror-node-version: ${{ steps.get-citr-vars.outputs.bn-mirror-node-version }}
+      json-rpc-relay-version: ${{ steps.get-citr-vars.outputs.json-rpc-relay-version }}
     steps:
       - name: Initialize Job
         uses: pandaswhocode/initialize-github-job@c392c3e699995ab6030915302d2fc9bffb1e861f # v1.1.0
@@ -84,7 +87,7 @@ jobs:
           steps.get-citr-vars.outputs.citr-mirror-node-version == '' || steps.get-citr-vars.outputs.citr-solo-version == '' ||
           steps.get-citr-vars.outputs.mqpt-cluster == '' || steps.get-citr-vars.outputs.tck-version == '' ||
           steps.get-citr-vars.outputs.js-sdk-version == '' || steps.get-citr-vars.outputs.block-node-version == '' ||
-          steps.get-citr-vars.outputs.bn-mirror-node-version == '' }}
+          steps.get-citr-vars.outputs.bn-mirror-node-version == '' || steps.get-citr-vars.outputs.json-rpc-relay-version == '' }}
         run: |
           echo "::error::One or more required CITR variables are missing or empty. Please ensure .citr-env contains all necessary variables."
           echo "::group::Extracted Variables"
@@ -97,5 +100,6 @@ jobs:
             echo "js-sdk-version: '${{ steps.get-citr-vars.outputs.js-sdk-version }}'"
             echo "block-node-version: '${{ steps.get-citr-vars.outputs.block-node-version }}'"
             echo "mirror-node-version: '${{ steps.get-citr-vars.outputs.bn-mirror-node-version }}'"
+            echo "json-rpc-relay-version: '${{ steps.get-citr-vars.outputs.json-rpc-relay-version }}'"
           echo "::endgroup::"
           exit 1

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -353,6 +353,7 @@ jobs:
       js-sdk-version: "${{ needs.extract-citr-vars.outputs.js-sdk-version }}"
       bn-release-version: "${{ needs.extract-citr-vars.outputs.bn-release-version }}"
       bn-mirror-node-version: "${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}"
+      json-rpc-relay-version: "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}"
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-citr-details-token: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}

--- a/.github/workflows/support/citr/.citr-env
+++ b/.github/workflows/support/citr/.citr-env
@@ -7,3 +7,4 @@ tck-version=v0.11.0
 js-sdk-version=v2.85.0
 block-node-version=v0.35.1
 bn-mirror-node-version=v0.156.0
+json-rpc-relay-version=v0.77.1


### PR DESCRIPTION
## Description

Perform cherry pick

> ci: Add json-rpc-relay-version to hiero-consensus-node .citr-env (#26050)
> (cherry picked from commit 507076b01f2dcd76ff7c5e111d0595b2f1cd1e1d)

## Related Issue(s)

- Closes #26053 