### PR TITLE
ci(bug-fix): Fix json-rpc-relay checkout tag step

### DIFF
--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -144,7 +144,7 @@ jobs:
           echo "JS SDK Version: ${{ needs.extract-citr-vars.outputs.js-sdk-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Block Node Release Version: ${{ needs.extract-citr-vars.outputs.bn-release-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Block Node Regression Mirror Node Version: ${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
-          echo "JSON RPC Relay Regression Version: ${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" | tes -a "${GITHUB_STEP_SUMMARY}"
+          echo "JSON RPC Relay Regression Version: ${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Solo Version: ${SOLO_VERSION}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Solo Version >= 0.44.0 (gates Migration Testing + Block Node Regression): ${SOLO_GE_0440}" | tee -a "${GITHUB_STEP_SUMMARY}"
           echo "Helm Release Name: ${HELM_NAME}" | tee -a "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -93,17 +93,17 @@ jobs:
           fetch-tags: true
 
       # Checkout the specified version tag
-      - name: Checkout JS-SDK Tag
+      - name: Checkout JSON-RPC Relay Tag
         run: |
           cd regression-tests/json-rpc-relay
           git fetch --tags
 
           # If ${{ inputs.json-rpc-relay-version }} is in the tags, check it out.
-          if git rev-parse "refs/tags/${{ inputs.regression-tests/json-rpc-relay }}" >/dev/null 2>&1; then
-            echo "Checking out specified JS-SDK version: ${{ inputs.json-rpc-relay-version }}"
+          if git rev-parse "refs/tags/${{ inputs.json-rpc-relay-version  }}" >/dev/null 2>&1; then
+            echo "Checking out specified JSON-RPC Relay version: ${{ inputs.json-rpc-relay-version }}"
             git checkout "tags/${{ inputs.json-rpc-relay-version }}"
           else
-            echo "Specified JS-SDK version ${{ inputs.json-rpc-relay-version }} not found in tags."
+            echo "Specified JSON-RPC Relay version ${{ inputs.json-rpc-relay-version }} not found in tags."
             exit 1 # fail the workflow if not present.
           fi
 


### PR DESCRIPTION
## Description

This pull request updates the workflow for checking out the correct version tag in the `.github/workflows/818-call-json-rpc-relay-regression.yaml` file. The main change is to correct the naming and variable usage related to the JSON-RPC Relay component, ensuring the workflow references and checks out the intended version.

**Workflow improvements:**

* Renamed the checkout step from "Checkout JS-SDK Tag" to "Checkout JSON-RPC Relay Tag" to accurately reflect the component being checked out.
* Fixed the conditional logic to use the correct input variable `${{ inputs.json-rpc-relay-version }}` when checking for and checking out the tag, and updated all related log messages to reference "JSON-RPC Relay" instead of "JS-SDK".

## Related Issue(s)

- Fixes: #26050