### PR TITLE
chore: Update references to jrs-legacy

### DIFF
--- a/.github/workflows/817-call-jrs-regression.yaml
+++ b/.github/workflows/817-call-jrs-regression.yaml
@@ -23,7 +23,7 @@ on:
         description: ""
         required: false
         type: string
-        default: "swirlds/swirlds-platform-regression"
+        default: "hashgraph/jrs-legacy"
       regression-path:
         description: ""
         required: false
@@ -188,13 +188,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.access-token }}
         run: |
-          FEAT_BRANCH_EXISTS="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/swirlds/swirlds-platform-regression/branches/${{ inputs.branch-name }})"
+          FEAT_BRANCH_EXISTS="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/hashgraph/jrs-legacy/branches/${{ inputs.branch-name }})"
 
           BRANCH_NAME=""
           [[ "${FEAT_BRANCH_EXISTS}" -eq 200 ]] && BRANCH_NAME="${{ inputs.branch-name }}"
 
           if [[ -z "${BRANCH_NAME}" ]]; then
-            BASE_BRANCH_EXISTS="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/swirlds/swirlds-platform-regression/branches/${{ inputs.base-branch-name }})"
+            BASE_BRANCH_EXISTS="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/hashgraph/jrs-legacy/branches/${{ inputs.base-branch-name }})"
             [[ "${BASE_BRANCH_EXISTS}" -eq 200 ]] && BRANCH_NAME="${{ inputs.base-branch-name }}"
           fi
 
@@ -204,7 +204,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           path: platform-sdk/regression
-          repository: swirlds/swirlds-platform-regression
+          repository: hashgraph/jrs-legacy
           ref: ${{ steps.jrs-parameters.outputs.branch-name }}
           token: ${{ secrets.access-token }}
 


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/817-call-jrs-regression.yaml` workflow to use the `hashgraph/jrs-legacy` repository instead of `swirlds/swirlds-platform-regression`. The changes ensure that all references, API calls, and checkouts now point to the new repository.

Repository migration:

* Changed the default value for the `repository` input from `swirlds/swirlds-platform-regression` to `hashgraph/jrs-legacy`.
* Updated all API calls in the workflow that check for branch existence to use `hashgraph/jrs-legacy` instead of `swirlds/swirlds-platform-regression`.
* Modified the `actions/checkout` step to clone from `hashgraph/jrs-legacy` rather than `swirlds/swirlds-platform-regression`.

## Related Issue(s)

- Closes #26057 