### PR TITLE
refactor(fees): delete simpleFeesEnabled config field

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/config/BootstrapConfigProviderImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/config/BootstrapConfigProviderImplTest.java
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.Test;
 class BootstrapConfigProviderImplTest {
     @Test
     void canOverrideBootstrapPropertiesViaConstructor() {
-        final boolean defaultSimpleFeesEnabled =
-                DEFAULT_CONFIG.getConfigData(FeesConfig.class).simpleFeesEnabled();
-        final var bootstrapConfigProvider =
-                new BootstrapConfigProviderImpl(Map.of("fees.simpleFeesEnabled", "" + !defaultSimpleFeesEnabled));
+        final boolean defaultCreateSimpleFeeSchedule =
+                DEFAULT_CONFIG.getConfigData(FeesConfig.class).createSimpleFeeSchedule();
+        final var bootstrapConfigProvider = new BootstrapConfigProviderImpl(
+                Map.of("fees.createSimpleFeeSchedule", "" + !defaultCreateSimpleFeeSchedule));
         final var bootstrapConfig = bootstrapConfigProvider.getConfiguration();
-        final boolean simpleFeesEnabled =
-                bootstrapConfig.getConfigData(FeesConfig.class).simpleFeesEnabled();
-        assertNotEquals(defaultSimpleFeesEnabled, simpleFeesEnabled);
+        final boolean createSimpleFeeSchedule =
+                bootstrapConfig.getConfigData(FeesConfig.class).createSimpleFeeSchedule();
+        assertNotEquals(defaultCreateSimpleFeeSchedule, createSimpleFeeSchedule);
     }
 }

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/FeesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/FeesConfig.java
@@ -18,9 +18,6 @@ public record FeesConfig(
         @ConfigProperty(defaultValue = "DEFAULT(0,1:1)") EntityScaleFactors percentUtilizationScaleFactors,
 
         @ConfigProperty(defaultValue = "true") @NetworkProperty
-        boolean simpleFeesEnabled,
-
-        @ConfigProperty(defaultValue = "true") @NetworkProperty
         boolean createSimpleFeeSchedule,
 
         @ConfigProperty(defaultValue = "380") @NetworkProperty

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -1505,13 +1505,6 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
         }
     }
 
-    public boolean simpleFeesEnabled() {
-        return this.targetNetworkOrThrow()
-                .startupProperties()
-                .get("fees.simpleFeesEnabled")
-                .equals("true");
-    }
-
     @Override
     public String toString() {
         final SpecStatus passingSpecStatus = ((status == PASSED) && notOk(this)) ? PASSED_UNEXPECTEDLY : status;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -327,16 +327,7 @@ public abstract class HapiSpecOperation implements SpecOperation {
         if (fee.isPresent()) {
             txn = provisional;
         } else {
-            final Key payerKey =
-                    spec.registry().getKey(payer.orElse(spec.setup().defaultPayerName()));
-            if (spec.simpleFeesEnabled()) {
-                netDef = netDef.andThen(b -> b.setTransactionFee(ONE_HUNDRED_HBARS));
-            } else {
-                final int numPayerKeys =
-                        hardcodedNumPayerKeys.orElse(spec.keys().controlledKeyCount(payerKey, overrides));
-                final long customFee = feeFor(spec, provisional, numPayerKeys);
-                netDef = netDef.andThen(b -> b.setTransactionFee(customFee));
-            }
+            netDef = netDef.andThen(b -> b.setTransactionFee(ONE_HUNDRED_HBARS));
             txn = getSigned(spec, spec.txns().getReadyToSign(netDef, bodyMutation, spec), keys);
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -2489,13 +2489,7 @@ public class UtilVerbs {
     }
 
     public static SpecOperation safeValidateChargedUsd(String txnName, double oldPrice, double newPrice) {
-        return doWithStartupConfig("fees.simpleFeesEnabled", flag -> {
-            if ("true".equalsIgnoreCase(flag)) {
-                return validateChargedUsd(txnName, newPrice);
-            } else {
-                return validateChargedUsd(txnName, oldPrice);
-            }
-        });
+        return validateChargedUsd(txnName, newPrice);
     }
 
     public static SpecOperation safeValidateChargedUsdWithin(
@@ -2504,13 +2498,7 @@ public class UtilVerbs {
             double oldAllowedPercentDiff,
             double newPrice,
             double newAllowedPercentDiff) {
-        return doWithStartupConfig("fees.simpleFeesEnabled", flag -> {
-            if ("true".equalsIgnoreCase(flag)) {
-                return validateChargedUsdWithin(txnName, newPrice, newAllowedPercentDiff);
-            } else {
-                return validateChargedUsdWithin(txnName, oldPrice, oldAllowedPercentDiff);
-            }
-        });
+        return validateChargedUsdWithin(txnName, newPrice, newAllowedPercentDiff);
     }
 
     public static SpecOperation recordCurrentOwnerEvmHookSlotUsage(
@@ -2541,13 +2529,8 @@ public class UtilVerbs {
             OpsProvider provider, String txName, double simpleFee, double simpleDiff, double oldFee, double oldDiff) {
         List<SpecOperation> opsList = new ArrayList<>();
 
-        opsList.add(overriding("fees.simpleFeesEnabled", "true"));
         opsList.addAll(provider.provide());
         opsList.add(validateChargedSimpleFees("Simple Fees", txName, simpleFee, simpleDiff));
-
-        opsList.add(overriding("fees.simpleFeesEnabled", "false"));
-        opsList.addAll(provider.provide());
-        opsList.add(validateChargedSimpleFees("Old Fees", txName, oldFee, oldDiff));
 
         return hapiTest(opsList.toArray(new SpecOperation[opsList.size()]));
     }
@@ -2653,28 +2636,15 @@ public class UtilVerbs {
             double newPrice,
             double newAllowedPercentDiff) {
         return assertionsHold((spec, assertLog) -> {
-            final var flag = spec.targetNetworkOrThrow().startupProperties().get("fees.simpleFeesEnabled");
-            if ("true".equalsIgnoreCase(flag)) {
-                final var effectivePercentDiff = Math.max(newAllowedPercentDiff, 1.0);
-                final var actualUsdCharged = getChargedUsedForInnerTxn(spec, parent, txn);
-                assertEquals(
-                        newPrice,
-                        actualUsdCharged,
-                        (effectivePercentDiff / 100.0) * newPrice,
-                        String.format(
-                                "%s fee (%s) more than %.2f percent different than expected!",
-                                sdec(actualUsdCharged, 4), txn, effectivePercentDiff));
-            } else {
-                final var effectivePercentDiff = Math.max(oldAllowedPercentDiff, 1.0);
-                final var actualUsdCharged = getChargedUsedForInnerTxn(spec, parent, txn);
-                assertEquals(
-                        oldPrice,
-                        actualUsdCharged,
-                        (effectivePercentDiff / 100.0) * oldPrice,
-                        String.format(
-                                "%s fee (%s) more than %.2f percent different than expected!",
-                                sdec(actualUsdCharged, 4), txn, effectivePercentDiff));
-            }
+            final var effectivePercentDiff = Math.max(newAllowedPercentDiff, 1.0);
+            final var actualUsdCharged = getChargedUsedForInnerTxn(spec, parent, txn);
+            assertEquals(
+                    newPrice,
+                    actualUsdCharged,
+                    (effectivePercentDiff / 100.0) * newPrice,
+                    String.format(
+                            "%s fee (%s) more than %.2f percent different than expected!",
+                            sdec(actualUsdCharged, 4), txn, effectivePercentDiff));
         });
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1137/RegisteredNodeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1137/RegisteredNodeTest.java
@@ -678,12 +678,11 @@ public class RegisteredNodeTest {
                         .hasPrecheck(NOT_SUPPORTED));
     }
 
-    @LeakyHapiTest(overrides = {"nodes.registeredNodesEnabled", "fees.simpleFeesEnabled"})
+    @LeakyHapiTest(overrides = {"nodes.registeredNodesEnabled"})
     @DisplayName("create fails with NOT_SUPPORTED when registeredNodesEnabled is false and simple fees enabled")
     final Stream<DynamicTest> createFailsWhenFeatureDisabledWithSimpleFees() {
         return hapiTest(
                 overriding("nodes.registeredNodesEnabled", "false"),
-                overriding("fees.simpleFeesEnabled", "true"),
                 newKeyNamed(ADMIN_KEY),
                 registeredNodeCreate(REGISTERED_NODE)
                         .adminKey(ADMIN_KEY)
@@ -691,7 +690,7 @@ public class RegisteredNodeTest {
                         .hasPrecheck(NOT_SUPPORTED));
     }
 
-    @LeakyHapiTest(overrides = {"nodes.registeredNodesEnabled", "fees.simpleFeesEnabled"})
+    @LeakyHapiTest(overrides = {"nodes.registeredNodesEnabled"})
     @DisplayName("update fails with NOT_SUPPORTED when registeredNodesEnabled is false and simple fees enabled")
     final Stream<DynamicTest> updateFailsWhenFeatureDisabledWithSimpleFees() {
         return hapiTest(
@@ -701,14 +700,13 @@ public class RegisteredNodeTest {
                         .serviceEndpoints(DEFAULT_ENDPOINTS)
                         .hasKnownStatus(SUCCESS),
                 overriding("nodes.registeredNodesEnabled", "false"),
-                overriding("fees.simpleFeesEnabled", "true"),
                 registeredNodeUpdate(REGISTERED_NODE)
                         .description("updated")
                         .signedBy(DEFAULT_PAYER, ADMIN_KEY)
                         .hasPrecheck(NOT_SUPPORTED));
     }
 
-    @LeakyHapiTest(overrides = {"nodes.registeredNodesEnabled", "fees.simpleFeesEnabled"})
+    @LeakyHapiTest(overrides = {"nodes.registeredNodesEnabled"})
     @DisplayName("delete fails with NOT_SUPPORTED when registeredNodesEnabled is false and simple fees enabled")
     final Stream<DynamicTest> deleteFailsWhenFeatureDisabledWithSimpleFees() {
         return hapiTest(
@@ -718,7 +716,6 @@ public class RegisteredNodeTest {
                         .serviceEndpoints(DEFAULT_ENDPOINTS)
                         .hasKnownStatus(SUCCESS),
                 overriding("nodes.registeredNodesEnabled", "false"),
-                overriding("fees.simpleFeesEnabled", "true"),
                 registeredNodeDelete(REGISTERED_NODE)
                         .signedBy(DEFAULT_PAYER, ADMIN_KEY)
                         .hasPrecheck(NOT_SUPPORTED));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/FeesChargingUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/FeesChargingUtils.java
@@ -9,10 +9,8 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.HapiTxnOp.serializedSignedTxFrom;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doWithStartupConfig;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.getChargedUsedForInnerTxn;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.safeValidateChargedUsdWithin;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithChild;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateInnerTxnChargedUsd;
@@ -2238,18 +2236,10 @@ public class FeesChargingUtils {
     // -------- Dual-mode validation utils ---------//
 
     /*
-     * Dual-mode fee validation that branches on {@code fees.simpleFeesEnabled} at runtime.
-     * When simple fees are enabled, validates against {@code simpleFee};
-     * otherwise validates against {@code legacyFee}.
+     * Validates the simple fee charged for a transaction.
      */
     public static SpecOperation validateFees(final String txn, final double legacyFee, final double simpleFee) {
-        return doWithStartupConfig("fees.simpleFeesEnabled", flag -> {
-            if ("true".equals(flag)) {
-                return validateChargedUsdWithin(txn, simpleFee, 0.1);
-            } else {
-                return validateChargedUsdWithin(txn, legacyFee, 1);
-            }
-        });
+        return validateChargedUsdWithin(txn, simpleFee, 0.1);
     }
 
     public static SpecOperation validateInnerTxnFees(String txn, String parent, double legacyFee, double simpleFee) {
@@ -2257,26 +2247,16 @@ public class FeesChargingUtils {
     }
 
     /**
-     * Dual-mode fee validation for inner atomic batch transactions that branches on {@code fees.simpleFeesEnabled} at runtime.
-     * When simple fees are enabled, validates against {@code simpleFee};
-     * otherwise validates against {@code legacyFee}.
+     * Validates the simple fee charged for an inner atomic batch transaction.
      * @param allowedDiff the allowed percent difference.
      */
     public static SpecOperation validateInnerTxnFees(
             String txn, String parent, double legacyFee, double simpleFee, double allowedDiff) {
-        return doWithStartupConfig("fees.simpleFeesEnabled", flag -> {
-            if ("true".equals(flag)) {
-                return validateInnerTxnChargedUsd(txn, parent, simpleFee, allowedDiff);
-            } else {
-                return validateInnerTxnChargedUsd(txn, parent, legacyFee, allowedDiff);
-            }
-        });
+        return validateInnerTxnChargedUsd(txn, parent, simpleFee, allowedDiff);
     }
 
     /**
-     * Dual-mode fee validation for inner atomic batch transactions that branches on {@code fees.simpleFeesEnabled} at runtime.
-     * When simple fees are enabled, validates against {@code expectedSimpleFeesUsd} using the provided function;
-     * otherwise validates against {@code legacyExpectedUsd}.
+     * Validates the simple fee charged for an inner atomic batch transaction using the provided txn-size function.
      */
     public static SpecOperation validateInnerTxnFeesWithTxnSize(
             final String innerTxnId,
@@ -2285,31 +2265,17 @@ public class FeesChargingUtils {
             final double legacyAllowedPercentDiff,
             final IntToDoubleFunction expectedSimpleFeesUsd,
             final double simpleFeesAllowedPercentDiff) {
-        return doWithStartupConfig("fees.simpleFeesEnabled", flag -> {
-            if ("true".equals(flag)) {
-                return validateInnerChargedUsdWithinWithTxnSize(
-                        innerTxnId, parentTxnId, expectedSimpleFeesUsd, simpleFeesAllowedPercentDiff);
-            } else {
-                return validateInnerTxnChargedUsd(innerTxnId, parentTxnId, legacyExpectedUsd, legacyAllowedPercentDiff);
-            }
-        });
+        return validateInnerChargedUsdWithinWithTxnSize(
+                innerTxnId, parentTxnId, expectedSimpleFeesUsd, simpleFeesAllowedPercentDiff);
     }
 
     /**
-     * Dual-mode fee validation with child records that branches on {@code fees.simpleFeesEnabled} at runtime.
-     * When simple fees are enabled, validates against {@code simpleFee};
-     * otherwise validates against {@code legacyFee}.
+     * Validates the simple fee charged for a transaction including child dispatch fees.
      * Uses {@code validateChargedUsdWithChild} which includes child dispatch fees.
      */
     public static SpecOperation validateFeesWithChild(
             final String txn, final double legacyFee, final double simpleFee, final double tolerance) {
-        return doWithStartupConfig("fees.simpleFeesEnabled", flag -> {
-            if ("true".equals(flag)) {
-                return validateChargedUsdWithChild(txn, simpleFee, tolerance);
-            } else {
-                return validateChargedUsdWithChild(txn, legacyFee, tolerance);
-            }
-        });
+        return validateChargedUsdWithChild(txn, simpleFee, tolerance);
     }
 
     public static CustomSpecAssert validateBatchChargedCorrectly(String batchTxn) {
@@ -2324,17 +2290,10 @@ public class FeesChargingUtils {
     }
 
     public static SpecOperation validateBatchFee(final String batchTxnName, final double legacyExpectedUsd) {
-        return doWithStartupConfig("fees.simpleFeesEnabled", flag -> {
-            if ("true".equals(flag)) {
-                return validateChargedUsdWithinWithTxnSize(
-                        batchTxnName,
-                        txnSize ->
-                                expectedAtomicBatchFullFeeUsd(Map.of(SIGNATURES, 1L, PROCESSING_BYTES, (long) txnSize)),
-                        0.1);
-            } else {
-                return validateChargedUsd(batchTxnName, legacyExpectedUsd);
-            }
-        });
+        return validateChargedUsdWithinWithTxnSize(
+                batchTxnName,
+                txnSize -> expectedAtomicBatchFullFeeUsd(Map.of(SIGNATURES, 1L, PROCESSING_BYTES, (long) txnSize)),
+                0.1);
     }
 
     // --------- Utils for dual-mode validation ---------//
@@ -2357,22 +2316,13 @@ public class FeesChargingUtils {
             final Map<LegacyFeeParam, Double> legacyParams,
             final double simpleFeesAllowedPercentDiff,
             final ExpectedUsdFromExtras expectedUsdSimpleFees) {
-        return doWithStartupConfig("fees.simpleFeesEnabled", flag -> {
-            if ("true".equals(flag)) {
-                return validateChargedUsdWithinWithTxnSize(
-                        txnId,
-                        txnSize -> {
-                            final var extrasWithProcessingBytes = new HashMap<>(simpleFeesExtras);
-                            extrasWithProcessingBytes.put(Extra.PROCESSING_BYTES, (long) txnSize);
-                            return expectedUsdSimpleFees.compute(extrasWithProcessingBytes);
-                        },
-                        simpleFeesAllowedPercentDiff);
-            } else {
-                final double expectedUsd = legacyParams.getOrDefault(LegacyFeeParam.LEGACY_EXPECTED_USD, 0.0);
-                final double allowedPercentDiff =
-                        legacyParams.getOrDefault(LegacyFeeParam.LEGACY_ALLOWED_PERCENT_DIFF, 1.0);
-                return validateChargedUsdWithin(txnId, expectedUsd, allowedPercentDiff);
-            }
-        });
+        return validateChargedUsdWithinWithTxnSize(
+                txnId,
+                txnSize -> {
+                    final var extrasWithProcessingBytes = new HashMap<>(simpleFeesExtras);
+                    extrasWithProcessingBytes.put(Extra.PROCESSING_BYTES, (long) txnSize);
+                    return expectedUsdSimpleFees.compute(extrasWithProcessingBytes);
+                },
+                simpleFeesAllowedPercentDiff);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
@@ -12,7 +12,6 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.getDeduction;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.getNonFeeDeduction;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeCreate;
@@ -87,9 +86,6 @@ public class DuplicateManagementTest {
                                 recordWith().status(DUPLICATE_TRANSACTION))),
                 sleepFor(MS_TO_WAIT_FOR_CONSENSUS),
                 withOpContext((spec, opLog) -> {
-                    final var flag =
-                            spec.targetNetworkOrThrow().startupProperties().get("fees.simpleFeesEnabled");
-
                     var cheapGet = getTxnRecord("cheapTxn").assertingNothingAboutHashes();
                     var costlyGet = getTxnRecord("costlyTxn").assertingNothingAboutHashes();
                     allRunFor(spec, cheapGet, costlyGet);
@@ -97,32 +93,20 @@ public class DuplicateManagementTest {
                     var costlyRecord = costlyGet.getResponseRecord();
                     opLog.info("cheapRecord: {}", cheapRecord);
                     opLog.info("costlyRecord: {}", costlyRecord);
-                    if ("true".equals(flag)) {
-                        var cheapPrice = getDeduction(
-                                        cheapRecord.getTransferList(),
-                                        cheapRecord.getTransactionID().getAccountID())
-                                .orElse(0);
-                        var costlyPrice = getDeduction(
-                                        costlyRecord.getTransferList(),
-                                        costlyRecord.getTransactionID().getAccountID())
-                                .orElse(0);
-                        final var expectedCostly = 3 * cheapPrice;
-                        assertTrue(
-                                Math.abs(expectedCostly - costlyPrice) <= DUPLICATE_FEE_TOLERANCE_TINYBARS,
-                                String.format(
-                                        "Costly (%d) should be about 3x more expensive than cheap (%d)!",
-                                        costlyPrice, cheapPrice));
-
-                    } else {
-                        var cheapPrice = getNonFeeDeduction(cheapRecord).orElse(0);
-                        var costlyPrice = getNonFeeDeduction(costlyRecord).orElse(0);
-                        final var expectedCostly = 3 * cheapPrice - 1;
-                        assertTrue(
-                                Math.abs(expectedCostly - costlyPrice) <= DUPLICATE_FEE_TOLERANCE_TINYBARS,
-                                String.format(
-                                        "Costly (%d) should be about 3x more expensive than cheap (%d)!",
-                                        costlyPrice, cheapPrice));
-                    }
+                    var cheapPrice = getDeduction(
+                                    cheapRecord.getTransferList(),
+                                    cheapRecord.getTransactionID().getAccountID())
+                            .orElse(0);
+                    var costlyPrice = getDeduction(
+                                    costlyRecord.getTransferList(),
+                                    costlyRecord.getTransactionID().getAccountID())
+                            .orElse(0);
+                    final var expectedCostly = 3 * cheapPrice;
+                    assertTrue(
+                            Math.abs(expectedCostly - costlyPrice) <= DUPLICATE_FEE_TOLERANCE_TINYBARS,
+                            String.format(
+                                    "Costly (%d) should be about 3x more expensive than cheap (%d)!",
+                                    costlyPrice, cheapPrice));
                 }));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/hip1313/Hip1313DisabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/hip1313/Hip1313DisabledTest.java
@@ -7,8 +7,8 @@ import static com.hedera.services.bdd.junit.TestTags.SIMPLE_FEES;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThrottles;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
@@ -38,10 +38,10 @@ public class Hip1313DisabledTest {
 
     @LeakyHapiTest(
             requirement = {PROPERTY_OVERRIDES},
-            overrides = {"fees.simpleFeesEnabled", "networkAdmin.highVolumeThrottlesEnabled"})
+            overrides = {"networkAdmin.highVolumeThrottlesEnabled"})
     final Stream<DynamicTest> highVolumeTxnRejectedWhenFeatureDisabled() {
         return hapiTest(
-                overridingTwo("fees.simpleFeesEnabled", "false", "networkAdmin.highVolumeThrottlesEnabled", "false"),
+                overriding("networkAdmin.highVolumeThrottlesEnabled", "false"),
                 createTopic("hvDisabledTopic")
                         .payingWith(CIVILIAN_PAYER)
                         .withHighVolume()
@@ -50,10 +50,10 @@ public class Hip1313DisabledTest {
 
     @LeakyHapiTest(
             requirement = {PROPERTY_OVERRIDES},
-            overrides = {"fees.simpleFeesEnabled", "networkAdmin.highVolumeThrottlesEnabled"})
+            overrides = {"networkAdmin.highVolumeThrottlesEnabled"})
     final Stream<DynamicTest> highVolumeTxnRejectedWhenSimpleFeesEnabledButHighVolumeThrottlesDisabled() {
         return hapiTest(
-                overridingTwo("fees.simpleFeesEnabled", "true", "networkAdmin.highVolumeThrottlesEnabled", "false"),
+                overriding("networkAdmin.highVolumeThrottlesEnabled", "false"),
                 createTopic("hvRequiresThrottleFlag")
                         .payingWith(CIVILIAN_PAYER)
                         .withHighVolume()
@@ -62,11 +62,11 @@ public class Hip1313DisabledTest {
 
     @LeakyHapiTest(
             requirement = {THROTTLE_OVERRIDES, PROPERTY_OVERRIDES},
-            overrides = {"fees.simpleFeesEnabled", "networkAdmin.highVolumeThrottlesEnabled"},
+            overrides = {"networkAdmin.highVolumeThrottlesEnabled"},
             throttles = "testSystemFiles/hip1313-disabled-one-tps-create.json")
     final Stream<DynamicTest> existingThrottlesStillApplyWhenHip1313Disabled() {
         return hapiTest(
-                overridingTwo("fees.simpleFeesEnabled", "true", "networkAdmin.highVolumeThrottlesEnabled", "false"),
+                overriding("networkAdmin.highVolumeThrottlesEnabled", "false"),
                 overridingThrottles("testSystemFiles/hip1313-disabled-one-tps-create.json"),
                 cryptoCreate("regularCreateA")
                         .payingWith(CIVILIAN_PAYER)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/hip1313/Hip1313EnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/hip1313/Hip1313EnabledTest.java
@@ -25,8 +25,8 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.allVisibleItems;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHollow;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThrottles;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.streamMustIncludeNoFailuresFrom;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateLargeFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithChild;
@@ -133,9 +133,7 @@ public class Hip1313EnabledTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "fees.simpleFeesEnabled", "true",
-                "networkAdmin.highVolumeThrottlesEnabled", "true"));
+        testLifecycle.overrideInClass(Map.of("networkAdmin.highVolumeThrottlesEnabled", "true"));
         testLifecycle.doAdhoc(cryptoCreate(CIVILIAN_PAYER).balance(ONE_MILLION_HBARS));
     }
 
@@ -359,7 +357,7 @@ public class Hip1313EnabledTest {
                 streamMustIncludeNoFailuresFrom(allVisibleItems(feeMultiplierValidator(highVolumeTxns))),
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted),
                 cryptoCreate(CIVILIAN_PAYER).balance(ONE_MILLION_HBARS),
-                overridingTwo("fees.simpleFeesEnabled", "true", "networkAdmin.highVolumeThrottlesEnabled", "true"),
+                overriding("networkAdmin.highVolumeThrottlesEnabled", "true"),
                 withOpContext((spec, opLog) -> submitHighVolumeCryptoCreates(spec, 200)),
                 // ensure one record is closed
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted),
@@ -401,7 +399,7 @@ public class Hip1313EnabledTest {
                 streamMustIncludeNoFailuresFrom(allVisibleItems(feeMultiplierValidator(highVolumeTxns))),
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted),
                 cryptoCreate(CIVILIAN_PAYER).balance(ONE_MILLION_HBARS),
-                overridingTwo("fees.simpleFeesEnabled", "true", "networkAdmin.highVolumeThrottlesEnabled", "true"),
+                overriding("networkAdmin.highVolumeThrottlesEnabled", "true"),
                 withOpContext((spec, opLog) -> submitMixedHighVolumeTopicAndScheduleCreates(spec, numBursts)),
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted),
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted),
@@ -467,7 +465,7 @@ public class Hip1313EnabledTest {
                 streamMustIncludeNoFailuresFrom(allVisibleItems(feeMultiplierValidator(highVolumeTxns))),
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted),
                 cryptoCreate(CIVILIAN_PAYER).balance(ONE_MILLION_HBARS),
-                overridingTwo("fees.simpleFeesEnabled", "true", "networkAdmin.highVolumeThrottlesEnabled", "true"),
+                overriding("networkAdmin.highVolumeThrottlesEnabled", "true"),
                 withOpContext((spec, opLog) -> {
                     allRunFor(
                             spec,
@@ -529,7 +527,7 @@ public class Hip1313EnabledTest {
                 overridingThrottles("testSystemFiles/hip1313-pricing-sim-throttles.json"),
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted),
                 cryptoCreate(CIVILIAN_PAYER).balance(ONE_MILLION_HBARS),
-                overridingTwo("fees.simpleFeesEnabled", "true", "networkAdmin.highVolumeThrottlesEnabled", "true"),
+                overriding("networkAdmin.highVolumeThrottlesEnabled", "true"),
                 withOpContext((spec, opLog) -> {
                     allRunFor(
                             spec,


### PR DESCRIPTION
**Description**:

Delete the `fees.simpleFeesEnabled` config field now that nothing reads it (production reads were removed in #26029; simple fees are always on).

* Remove the `simpleFeesEnabled` field from `FeesConfig`
* Collapse the remaining flag reads to the simple-fees path: `HapiSpec.simpleFeesEnabled()` accessor (deleted) + `HapiSpecOperation`, `UtilVerbs` (safe* / compareSimpleToOld), `FeesChargingUtils` validators
* Drop leftover flag overrides in `RegisteredNodeTest`, `Hip1313Disabled/EnabledTest`, `DuplicateManagementTest`; repoint `BootstrapConfigProviderImplTest` to `createSimpleFeeSchedule`

**Related issue(s)**:

Closes #25852

**Notes for reviewer**:

Behavior-preserving — the flag defaulted true, so the simple branch was already the live path. `FeesChargingUtils` overlaps josh's open #25983 (different region ~2168 vs ~2241+); minor rebase if both land. Validated: config/app/test-clients compile, BootstrapConfigProviderImplTest + AtomicBatchBoundarySimpleFeesTest + TopicCustomFeeSubmitMessageTest pass embedded.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)