### PR TITLE
fix: 26067: Intermittent Blockstream Diff Testing for Previewnet Node failure

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
@@ -37,6 +37,9 @@ public class StateOperatorCommand implements Runnable {
     /** Marker file written after a successful GCS download to distinguish complete from partial caches. */
     private static final String DOWNLOAD_COMPLETE_MARKER = ".download-complete";
 
+    private static final String STATE_DIR_PROPERTY = "state.dir";
+    private static final String TMP_DIR_PROPERTY = "tmp.dir";
+
     @Parameters(index = "0", description = "State directory. Accepts a local path or a GCS URI (gs://...).")
     private String stateDir;
 
@@ -71,7 +74,8 @@ public class StateOperatorCommand implements Runnable {
     void resolveAndGetStateDir() {
         if (resolvedStateDir != null) {
             // Already resolved (idempotent)
-            System.setProperty("state.dir", resolvedStateDir.getAbsolutePath());
+            System.setProperty(STATE_DIR_PROPERTY, resolvedStateDir.getAbsolutePath());
+            initializeTmpDirIfUnset();
             return;
         }
 
@@ -127,7 +131,17 @@ public class StateOperatorCommand implements Runnable {
             }
         }
 
-        System.setProperty("state.dir", resolvedStateDir.getAbsolutePath());
+        System.setProperty(STATE_DIR_PROPERTY, resolvedStateDir.getAbsolutePath());
+        initializeTmpDirIfUnset();
+    }
+
+    private void initializeTmpDirIfUnset() {
+        final String existingTmpDir = System.getProperty(TMP_DIR_PROPERTY, "");
+        if (!existingTmpDir.isBlank()) {
+            return;
+        }
+        System.setProperty(
+                TMP_DIR_PROPERTY, "state-validator-" + ProcessHandle.current().pid());
     }
 
     /**

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ConfigUtils.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/util/ConfigUtils.java
@@ -140,8 +140,9 @@ public final class ConfigUtils {
                 .withConverter(HederaFunctionalitySet.class, new FunctionalitySetConverter())
                 .withConverter(Bytes.class, new BytesConverter());
         if (!TMP_DIR.isEmpty()) {
-            configurationBuilder.withSource(
-                    new SimpleConfigSource().withValue("temporaryFiles.temporaryFilePath", TMP_DIR));
+            configurationBuilder.withSource(new SimpleConfigSource()
+                    .withValue("paths.tmpDir", TMP_DIR)
+                    .withValue("temporaryFiles.temporaryFilePath", TMP_DIR));
         }
         configuration = configurationBuilder.build();
     }


### PR DESCRIPTION
**Description**:
Fixes an Intermittent Blockstream Diff Testing for Previewnet Node failure.
Root cause: both background export JVMs initialize `FileSystemManager` with the same default `paths.tmpDir` (swirlds-tmp). `MerkleDB` then uses the same temp area, so one JVM can delete or observe the other JVM’s partially initialized MerkleDB state.

Changes:
- Maps `-Dtmp.dir` to `paths.tmpDir`, which is the value used by `FileSystemManager`.
- Generates a unique relative temp directory per validator JVM when `tmp.dir` is not explicitly set.


**Related issue(s)**:
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/26067

