### PR TITLE
ci(fix): update solo version

### DIFF
--- a/.github/workflows/support/citr/.citr-env
+++ b/.github/workflows/support/citr/.citr-env
@@ -1,6 +1,6 @@
-citr-solo-version=0.76.0
-adhoc-solo-version=0.76.0
-adhoc-xts-solo-version=0.76.0
+citr-solo-version=0.79.0
+adhoc-solo-version=0.79.0
+adhoc-xts-solo-version=0.79.0
 citr-mirror-node-version=0.145.2
 mqpt-cluster=Dallas_n10
 tck-version=v0.11.0

--- a/.github/workflows/support/citr/.citr-env
+++ b/.github/workflows/support/citr/.citr-env
@@ -1,10 +1,10 @@
 citr-solo-version=0.79.0
 adhoc-solo-version=0.79.0
 adhoc-xts-solo-version=0.79.0
-citr-mirror-node-version=0.145.2
+citr-mirror-node-version=0.157.0
 mqpt-cluster=Dallas_n10
 tck-version=v0.11.0
 js-sdk-version=v2.85.0
 block-node-version=v0.35.1
-bn-mirror-node-version=v0.156.0
+bn-mirror-node-version=v0.157.0
 json-rpc-relay-version=v0.77.1


### PR DESCRIPTION
**Description**:

XTS Mirror Node Regression tests are failing due to a solo compatibility issue. Updating solo from v0.76.0 to v0.79.0 fixes it.

Update default solo version to 0.79.0

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
