### PR TITLE
ci(fix-access): Update access token for JRS panel

### DIFF
--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -203,7 +203,7 @@ jobs:
       custom-job-label: "XTS (Dry Run):"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}

--- a/.github/workflows/602-flow-merge-queue-controller.yaml
+++ b/.github/workflows/602-flow-merge-queue-controller.yaml
@@ -77,7 +77,7 @@ jobs:
 
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}

--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -350,7 +350,7 @@ jobs:
       panel-config: "configs/services/suites/daily/GCP-Daily-Services-Abbrev-DAB-Update-4N-2C.json"
       java-version: "${{ inputs.java-version }}"
     secrets:
-      access-token: ${{ secrets.regression-access-token }}
+      access-token: ${{ secrets.platform-access-token }}
       jrs-ssh-user-name: ${{ secrets.jrs-ssh-user-name }}
       jrs-ssh-key-file: ${{ secrets.jrs-ssh-key-file }}
       gcp-project-number: ${{ secrets.gcp-project-number }}

--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -350,7 +350,7 @@ jobs:
       panel-config: "configs/services/suites/daily/GCP-Daily-Services-Abbrev-DAB-Update-4N-2C.json"
       java-version: "${{ inputs.java-version }}"
     secrets:
-      access-token: ${{ secrets.platform-access-token }}
+      access-token: ${{ secrets.regression-access-token }}
       jrs-ssh-user-name: ${{ secrets.jrs-ssh-user-name }}
       jrs-ssh-key-file: ${{ secrets.jrs-ssh-key-file }}
       gcp-project-number: ${{ secrets.gcp-project-number }}

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -309,7 +309,7 @@ jobs:
       js-sdk-version: "${{ needs.extract-citr-vars.outputs.js-sdk-version }}"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow configuration to use a new secret for the `platform-access-token` across several workflow files. The change improves consistency and potentially security by standardizing the secret used.

Secrets management updates:

* Updated the `platform-access-token` secret from `PLATFORM_GH_ACCESS_TOKEN` to `JRS_GH_ACCESS_TOKEN` in the following workflow files:
  * `.github/workflows/001-user-dry-run-extended-test-suite.yaml`
  * `.github/workflows/602-flow-merge-queue-controller.yaml`
  * `.github/workflows/900-cron-extended-test-suite.yaml`

The update is required since we transferred `swirlds/swirlds-platform-regression` to `hashgraph/jrs-legacy`

## Related Issue(s)

- Relates to #26057

## Notes

Will need to cherry pick this to `release/0.76` and `release/0.75` branches.