### PR TITLE
ci(fix-access): Update access token for JRS panel (#26072)

### DIFF
--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -203,7 +203,7 @@ jobs:
       custom-job-label: "XTS (Dry Run):"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}

--- a/.github/workflows/602-flow-merge-queue-controller.yaml
+++ b/.github/workflows/602-flow-merge-queue-controller.yaml
@@ -77,7 +77,7 @@ jobs:
 
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -309,7 +309,7 @@ jobs:
       js-sdk-version: "${{ needs.extract-citr-vars.outputs.js-sdk-version }}"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}


### PR DESCRIPTION
##Description

This pull request updates the GitHub Actions workflow configuration to use a different secret for the `platform-access-token` in several workflow files. The main change is replacing the use of `PLATFORM_GH_ACCESS_TOKEN` with `JRS_GH_ACCESS_TOKEN` for improved consistency or permissions management.

Secret updates in workflow files:

* Updated the `platform-access-token` secret in `.github/workflows/001-user-dry-run-extended-test-suite.yaml` to use `JRS_GH_ACCESS_TOKEN` instead of `PLATFORM_GH_ACCESS_TOKEN`.
* Updated the `platform-access-token` secret in `.github/workflows/602-flow-merge-queue-controller.yaml` to use `JRS_GH_ACCESS_TOKEN` instead of `PLATFORM_GH_ACCESS_TOKEN`.
* Updated the `platform-access-token` secret in `.github/workflows/900-cron-extended-test-suite.yaml` to use `JRS_GH_ACCESS_TOKEN` instead of `PLATFORM_GH_ACCESS_TOKEN`.

(cherry picked from commit 0cc709860be30d5892ba5fa70ed9300ce4107628)

## Related Issue(s)

- Relates to #26075 