### PR TITLE
chore: Apply changes from #26072 to release/0.75

### DIFF
--- a/.github/workflows/210-flow-merge-queue-controller.yaml
+++ b/.github/workflows/210-flow-merge-queue-controller.yaml
@@ -52,7 +52,7 @@ jobs:
       enable-sdk-tck-regression-panel: "true"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}

--- a/.github/workflows/flow-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/flow-dry-run-extended-test-suite.yaml
@@ -145,7 +145,7 @@ jobs:
       custom-job-label: "XTS (Dry Run):"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -273,7 +273,7 @@ jobs:
       enable-sdk-tck-regression-panel: "true"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      platform-access-token: ${{ secrets.PLATFORM_GH_ACCESS_TOKEN }}
+      platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}
       regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       gcp-project-number: ${{ secrets.PLATFORM_GCP_PROJECT_NUMBER }}
       gcp-sa-key-contents: ${{ secrets.PLATFORM_GCP_KEY_FILE }}


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow configuration to use a different secret for the `platform-access-token` in several workflow files. The change ensures that the workflows now reference `JRS_GH_ACCESS_TOKEN` instead of the previously used `PLATFORM_GH_ACCESS_TOKEN`.

Secret management updates:

* Updated the `platform-access-token` secret from `PLATFORM_GH_ACCESS_TOKEN` to `JRS_GH_ACCESS_TOKEN` in the following workflow files:
  * `.github/workflows/210-flow-merge-queue-controller.yaml`
  * `.github/workflows/flow-dry-run-extended-test-suite.yaml`
  * `.github/workflows/zxcron-extended-test-suite.yaml`

(Applied changes from #26072) 

## Related Issue(s)

- Closes #26075 