### PR TITLE
refactor(fees): remove transitional createSimpleFeeSchedule flag

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -99,7 +99,6 @@ import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.BootstrapConfig;
 import com.hedera.node.config.data.ConsensusConfig;
-import com.hedera.node.config.data.FeesConfig;
 import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
@@ -477,25 +476,22 @@ public class SystemTransactions {
                                 ctx, createFileID(filesConfig.hapiPermissions(), config), bytes),
                         adminConfig.upgradePermissionOverridesFile(),
                         in -> parseConfig("override HAPI permissions", in))));
-        final var feesConfig = config.getConfigData(FeesConfig.class);
-        if (feesConfig.createSimpleFeeSchedule()) {
-            final var simpleFeesFileId = createFileID(filesConfig.simpleFeesSchedules(), config);
-            final var filesState =
-                    state.getReadableStates(FileService.NAME).<FileID, File>get(V0490FileSchema.FILES_STATE_ID);
-            if (filesState.get(simpleFeesFileId) == null) {
-                log.info(
-                        "Creating simple fee schedule file {}.{}.{} (upgrading from pre-simple-fees version)",
-                        simpleFeesFileId.shardNum(),
-                        simpleFeesFileId.realmNum(),
-                        simpleFeesFileId.fileNum());
-                fileService.fileSchema().createGenesisSimpleFeesSchedule(systemContext);
-            }
-            autoSysFileUpdates.add(new AutoEntityUpdate<>(
-                    (ctx, bytes) -> dispatchSynthFileUpdate(
-                            ctx, createFileID(filesConfig.simpleFeesSchedules(), config), bytes),
-                    adminConfig.upgradeSimpleFeeSchedulesFile(),
-                    SystemTransactions::parseSimpleFeesSchedules));
+        final var simpleFeesFileId = createFileID(filesConfig.simpleFeesSchedules(), config);
+        final var filesState =
+                state.getReadableStates(FileService.NAME).<FileID, File>get(V0490FileSchema.FILES_STATE_ID);
+        if (filesState.get(simpleFeesFileId) == null) {
+            log.info(
+                    "Creating simple fee schedule file {}.{}.{} (upgrading from pre-simple-fees version)",
+                    simpleFeesFileId.shardNum(),
+                    simpleFeesFileId.realmNum(),
+                    simpleFeesFileId.fileNum());
+            fileService.fileSchema().createGenesisSimpleFeesSchedule(systemContext);
         }
+        autoSysFileUpdates.add(new AutoEntityUpdate<>(
+                (ctx, bytes) ->
+                        dispatchSynthFileUpdate(ctx, createFileID(filesConfig.simpleFeesSchedules(), config), bytes),
+                adminConfig.upgradeSimpleFeeSchedulesFile(),
+                SystemTransactions::parseSimpleFeesSchedules));
 
         autoSysFileUpdates.forEach(update -> update.tryIfPresent(adminConfig.upgradeSysFilesLoc(), systemContext));
         final var autoNodeAdminKeyUpdates = new AutoEntityUpdate<Map<Long, Key>>(

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/config/BootstrapConfigProviderImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/config/BootstrapConfigProviderImplTest.java
@@ -11,13 +11,12 @@ import org.junit.jupiter.api.Test;
 class BootstrapConfigProviderImplTest {
     @Test
     void canOverrideBootstrapPropertiesViaConstructor() {
-        final boolean defaultCreateSimpleFeeSchedule =
-                DEFAULT_CONFIG.getConfigData(FeesConfig.class).createSimpleFeeSchedule();
+        final int defaultMultiplier =
+                DEFAULT_CONFIG.getConfigData(FeesConfig.class).tokenTransferUsageMultiplier();
         final var bootstrapConfigProvider = new BootstrapConfigProviderImpl(
-                Map.of("fees.createSimpleFeeSchedule", "" + !defaultCreateSimpleFeeSchedule));
+                Map.of("fees.tokenTransferUsageMultiplier", "" + (defaultMultiplier + 1)));
         final var bootstrapConfig = bootstrapConfigProvider.getConfiguration();
-        final boolean createSimpleFeeSchedule =
-                bootstrapConfig.getConfigData(FeesConfig.class).createSimpleFeeSchedule();
-        assertNotEquals(defaultCreateSimpleFeeSchedule, createSimpleFeeSchedule);
+        final int multiplier = bootstrapConfig.getConfigData(FeesConfig.class).tokenTransferUsageMultiplier();
+        assertNotEquals(defaultMultiplier, multiplier);
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/SystemTransactionsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/SystemTransactionsTest.java
@@ -443,7 +443,7 @@ class SystemTransactionsTest {
     @Test
     @SuppressWarnings("unchecked")
     void testPostUpgradeCreatesSimpleFeesFileWhenMissing() {
-        // Reconfigure with fees.createSimpleFeeSchedule=true and nodes.enableDAB=false
+        // Reconfigure with nodes.enableDAB=false
         final var config = HederaTestConfigBuilder.create()
                 .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("consensus.handleMaxPrecedingRecords", 3)
@@ -451,7 +451,6 @@ class SystemTransactionsTest {
                 .withValue("hedera.firstUserEntity", 1001)
                 .withValue("hedera.transactionMaxValidDuration", 180)
                 .withValue("accounts.systemAdmin", 50)
-                .withValue("fees.createSimpleFeeSchedule", "true")
                 .withValue("nodes.enableDAB", "false")
                 .getOrCreateConfig();
         given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(config, 1));
@@ -502,7 +501,7 @@ class SystemTransactionsTest {
     @Test
     @SuppressWarnings("unchecked")
     void testPostUpgradeSkipsSimpleFeesFileCreationWhenPresent() {
-        // Reconfigure with fees.createSimpleFeeSchedule=true and nodes.enableDAB=false
+        // Reconfigure with nodes.enableDAB=false
         final var config = HederaTestConfigBuilder.create()
                 .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("consensus.handleMaxPrecedingRecords", 3)
@@ -510,7 +509,6 @@ class SystemTransactionsTest {
                 .withValue("hedera.firstUserEntity", 1001)
                 .withValue("hedera.transactionMaxValidDuration", 180)
                 .withValue("accounts.systemAdmin", 50)
-                .withValue("fees.createSimpleFeeSchedule", "true")
                 .withValue("nodes.enableDAB", "false")
                 .getOrCreateConfig();
         given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(config, 1));

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/FeesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/FeesConfig.java
@@ -17,8 +17,5 @@ public record FeesConfig(
 
         @ConfigProperty(defaultValue = "DEFAULT(0,1:1)") EntityScaleFactors percentUtilizationScaleFactors,
 
-        @ConfigProperty(defaultValue = "true") @NetworkProperty
-        boolean createSimpleFeeSchedule,
-
         @ConfigProperty(defaultValue = "380") @NetworkProperty
         int tokenTransferUsageMultiplier) {}

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileServiceImpl.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/FileServiceImpl.java
@@ -16,7 +16,6 @@ import com.hedera.node.app.spi.RpcService;
 import com.hedera.node.app.spi.fees.QueryFeeCalculator;
 import com.hedera.node.app.spi.fees.ServiceFeeCalculator;
 import com.hedera.node.app.spi.workflows.SystemContext;
-import com.hedera.node.config.data.FeesConfig;
 import com.swirlds.state.lifecycle.SchemaRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
@@ -55,9 +54,7 @@ public final class FileServiceImpl implements FileService {
         fileSchema.createGenesisAddressBookAndNodeDetails(context, nodeStore);
         fileSchema.createGenesisFeeSchedule(context);
         fileSchema.createGenesisExchangeRate(context);
-        if (context.configuration().getConfigData(FeesConfig.class).createSimpleFeeSchedule()) {
-            fileSchema.createGenesisSimpleFeesSchedule(context);
-        }
+        fileSchema.createGenesisSimpleFeesSchedule(context);
         fileSchema.createGenesisNetworkProperties(context);
         fileSchema.createGenesisHapiPermissions(context);
         fileSchema.createGenesisThrottleDefinitions(context);


### PR DESCRIPTION
**Description**:

Remove the `fees.createSimpleFeeSchedule` config flag. It was a transitional gate from the simple-fees rollout (#21899, a couple releases back) and is never set false. Make the simple-fee schedule (file 113) creation unconditional.

* Genesis (`FileServiceImpl`): always `createGenesisSimpleFeesSchedule`
* Post-upgrade (`SystemTransactions`): ungate the backfill + auto-update (the backfill is still self-guarded by `file == null`, so it stays a no-op on networks that already have 113)
* Delete the `createSimpleFeeSchedule` field from `FeesConfig`; repoint `BootstrapConfigProviderImplTest` to `tokenTransferUsageMultiplier`

**Related issue(s)**:

Part of #21642

**Notes for reviewer**:

Behavior-preserving — the flag defaulted true and is never false, so unconditional == current behavior. Stacked on #26065 (the entangled BootstrapConfigProviderImplTest + FeesConfig); rebase to main once that merges. Validated: SystemTransactionsTest (incl the post-upgrade backfill test) + BootstrapConfigProviderImplTest pass.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)