### PR TITLE
ci(workflow-env): Update 855 to provide empty strings and verify outputs

### DIFF
--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -111,8 +111,7 @@ jobs:
             "${{ needs.extract-citr-vars.outputs.js-sdk-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.bn-release-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}" == "" || \
-            "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" == ""
-          ]]; then
+            "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" == "" ]]; then
             echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else

--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -90,10 +90,40 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.adhoc-xts-solo-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.citr-mirror-node-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.tck-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.js-sdk-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.block-node-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" == ""
+          ]]; then
+            echo "::error::One or more required CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   compute-solo-ge-0440:
     name: Compute solo-ge-0440
     needs:
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/856-call-solo-ge044.yaml
     with:
       solo-version: ${{ inputs.solo-version || needs.extract-citr-vars.outputs.adhoc-xts-solo-version }}
@@ -103,6 +133,7 @@ jobs:
     runs-on: hl-cn-default-lin-sm
     needs:
       - extract-citr-vars
+      - verify-citr-vars
       - compute-solo-ge-0440
     outputs:
       solo-version: ${{ steps.params.outputs.solo-version }}
@@ -168,6 +199,7 @@ jobs:
       - parameters
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/815-call-xts-tests.yaml
     with:
       ref: ${{ inputs.ref }}

--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -109,7 +109,7 @@ jobs:
             "${{ needs.extract-citr-vars.outputs.citr-mirror-node-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.tck-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.js-sdk-version }}" == "" || \
-            "${{ needs.extract-citr-vars.outputs.block-node-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.bn-release-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" == ""
           ]]; then

--- a/.github/workflows/200-user-mqpt-controller-adhoc.yaml
+++ b/.github/workflows/200-user-mqpt-controller-adhoc.yaml
@@ -119,7 +119,7 @@ jobs:
         id: check-outputs
         run: |
           if [[ "${{ needs.extract-citr-vars.outputs.adhoc-solo-version }}" == "" ]]; then
-            echo "::error::One or more CITR variables are missing. Failing the job."
+            echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else
             echo "All required CITR variables are present."

--- a/.github/workflows/200-user-mqpt-controller-adhoc.yaml
+++ b/.github/workflows/200-user-mqpt-controller-adhoc.yaml
@@ -103,11 +103,34 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.adhoc-solo-version }}" == "" ]]; then
+            echo "::error::One or more CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   run-merge-queue-test:
     name: MQ Performance Test
     needs:
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/830-call-merge-queue-performance-test.yaml
     with:
       test-asset: "${{ inputs.test-asset }}" # TODO: Once Chewie application is installed we can remove this input.

--- a/.github/workflows/201-user-sdpt-controller-adhoc.yaml
+++ b/.github/workflows/201-user-sdpt-controller-adhoc.yaml
@@ -139,12 +139,35 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.adhoc-solo-version }}" == "" ]]; then
+            echo "::error::One or more CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   run-single-day-performance-test:
     name: Performance Test
     needs:
       - verify-tag
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/831-call-single-day-performance-test.yaml
     if: ${{ needs.verify-tag.result == 'success' || inputs.disable-notifications == true }}
     with:

--- a/.github/workflows/201-user-sdpt-controller-adhoc.yaml
+++ b/.github/workflows/201-user-sdpt-controller-adhoc.yaml
@@ -155,7 +155,7 @@ jobs:
         id: check-outputs
         run: |
           if [[ "${{ needs.extract-citr-vars.outputs.adhoc-solo-version }}" == "" ]]; then
-            echo "::error::One or more CITR variables are missing. Failing the job."
+            echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else
             echo "All required CITR variables are present."

--- a/.github/workflows/202-user-sdlt-controller-adhoc.yaml
+++ b/.github/workflows/202-user-sdlt-controller-adhoc.yaml
@@ -158,7 +158,7 @@ jobs:
         id: check-outputs
         run: |
           if [[ "${{ needs.extract-citr-vars.outputs.adhoc-solo-version }}" == "" ]]; then
-            echo "::error::One or more CITR variables are missing. Failing the job."
+            echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else
             echo "All required CITR variables are present."

--- a/.github/workflows/202-user-sdlt-controller-adhoc.yaml
+++ b/.github/workflows/202-user-sdlt-controller-adhoc.yaml
@@ -142,12 +142,35 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.adhoc-solo-version }}" == "" ]]; then
+            echo "::error::One or more CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   run-single-day-longevity-test:
     name: Longevity Test
     needs:
       - verify-tag
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/833-call-single-day-longevity-test.yaml
     if: ${{ needs.verify-tag.result == 'success' || inputs.disable-notifications == true }}
     with:

--- a/.github/workflows/220-disp-mqpt-controller.yaml
+++ b/.github/workflows/220-disp-mqpt-controller.yaml
@@ -39,11 +39,34 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" ]]; then
+            echo "::error::One or more CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   run-merge-queue-performance-test:
     name: MQ Performance Test
     needs:
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/830-call-merge-queue-performance-test.yaml
     with:
       test-asset: "${{ inputs.test-asset }}" # TODO: Once Chewie application is installed we can remove this input.

--- a/.github/workflows/220-disp-mqpt-controller.yaml
+++ b/.github/workflows/220-disp-mqpt-controller.yaml
@@ -55,7 +55,7 @@ jobs:
         id: check-outputs
         run: |
           if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" ]]; then
-            echo "::error::One or more CITR variables are missing. Failing the job."
+            echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else
             echo "All required CITR variables are present."

--- a/.github/workflows/221-disp-sdpt-controller.yaml
+++ b/.github/workflows/221-disp-sdpt-controller.yaml
@@ -85,7 +85,7 @@ jobs:
         id: check-outputs
         run: |
           if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" ]]; then
-            echo "::error::One or more CITR variables are missing. Failing the job."
+            echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else
             echo "All required CITR variables are present."

--- a/.github/workflows/221-disp-sdpt-controller.yaml
+++ b/.github/workflows/221-disp-sdpt-controller.yaml
@@ -69,12 +69,35 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" ]]; then
+            echo "::error::One or more CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   run-single-day-performance-test:
     name: Performance Test
     needs:
       - verify-tag
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/831-call-single-day-performance-test.yaml
     if: ${{ needs.verify-tag.result == 'success' }}
     with:

--- a/.github/workflows/222-disp-sdlt-controller.yaml
+++ b/.github/workflows/222-disp-sdlt-controller.yaml
@@ -69,12 +69,35 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" ]]; then
+            echo "::error::One or more CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   run-single-day-longevity-test:
     name: Longevity Test
     needs:
       - verify-tag
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/833-call-single-day-longevity-test.yaml
     if: ${{ needs.verify-tag.result == 'success' }}
     with:

--- a/.github/workflows/222-disp-sdlt-controller.yaml
+++ b/.github/workflows/222-disp-sdlt-controller.yaml
@@ -85,7 +85,7 @@ jobs:
         id: check-outputs
         run: |
           if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" ]]; then
-            echo "::error::One or more CITR variables are missing. Failing the job."
+            echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else
             echo "All required CITR variables are present."

--- a/.github/workflows/602-flow-merge-queue-controller.yaml
+++ b/.github/workflows/602-flow-merge-queue-controller.yaml
@@ -33,6 +33,31 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.tck-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.mqpt-cluster }}" == ""
+          ]]; then
+            echo "::error::One or more CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   trigger-mats-tests:
     name: MQ MATS
     needs:
@@ -58,6 +83,7 @@ jobs:
     needs:
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/815-call-xts-tests.yaml
     with:
       ref: ${{ github.ref }}
@@ -97,6 +123,7 @@ jobs:
     needs:
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/830-call-merge-queue-performance-test.yaml
     with:
       test-asset: "${{ needs.extract-citr-vars.outputs.mqpt-cluster }}"

--- a/.github/workflows/602-flow-merge-queue-controller.yaml
+++ b/.github/workflows/602-flow-merge-queue-controller.yaml
@@ -50,9 +50,8 @@ jobs:
         run: |
           if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.tck-version }}" == "" || \
-            "${{ needs.extract-citr-vars.outputs.mqpt-cluster }}" == ""
-          ]]; then
-            echo "::error::One or more CITR variables are missing. Failing the job."
+            "${{ needs.extract-citr-vars.outputs.mqpt-cluster }}" == "" ]]; then
+            echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else
             echo "All required CITR variables are present."

--- a/.github/workflows/855-call-extract-citr-vars.yaml
+++ b/.github/workflows/855-call-extract-citr-vars.yaml
@@ -69,37 +69,49 @@ jobs:
         id: get-citr-vars
         run: |
           echo "::group::Extract CITR variables from .citr-env"
+
+          # Ensure the environment file is present
           ENV_FILE=".github/workflows/support/citr/.citr-env"
           if [[ ! -f "${ENV_FILE}" ]]; then
             echo "::error::CITR environment file not found at ${ENV_FILE}"
             exit 1
           fi
 
+          # Read the environment file and set outputs for each variable
           while IFS='=' read -r key value; do
+            # Skip empty lines and comments (lines starting with #)
             [[ -z "${key}" || "${key}" == \#* ]] && continue
+
+            # Write the key-value pair to GITHUB_OUTPUT for GitHub Actions to recognize
             echo "${key}=${value}" | tee -a "${GITHUB_OUTPUT}"
           done < "${ENV_FILE}"
           echo "::endgroup::"
 
-      - name: Verify Extracted CITR vars
-        if:
-          ${{ steps.get-citr-vars.outputs.adhoc-solo-version == '' || steps.get-citr-vars.outputs.adhoc-xts-solo-version == '' ||
-          steps.get-citr-vars.outputs.citr-mirror-node-version == '' || steps.get-citr-vars.outputs.citr-solo-version == '' ||
-          steps.get-citr-vars.outputs.mqpt-cluster == '' || steps.get-citr-vars.outputs.tck-version == '' ||
-          steps.get-citr-vars.outputs.js-sdk-version == '' || steps.get-citr-vars.outputs.block-node-version == '' ||
-          steps.get-citr-vars.outputs.bn-mirror-node-version == '' || steps.get-citr-vars.outputs.json-rpc-relay-version == '' }}
-        run: |
-          echo "::error::One or more required CITR variables are missing or empty. Please ensure .citr-env contains all necessary variables."
-          echo "::group::Extracted Variables"
-            echo "adhoc-solo-version: '${{ steps.get-citr-vars.outputs.adhoc-solo-version }}'"
-            echo "adhoc-xts-solo-version: '${{ steps.get-citr-vars.outputs.adhoc-xts-solo-version }}'"
-            echo "citr-mirror-node-version: '${{ steps.get-citr-vars.outputs.citr-mirror-node-version }}'"
-            echo "citr-solo-version: '${{ steps.get-citr-vars.outputs.citr-solo-version }}'"
-            echo "mqpt-cluster: '${{ steps.get-citr-vars.outputs.mqpt-cluster }}'"
-            echo "tck-version: '${{ steps.get-citr-vars.outputs.tck-version }}'"
-            echo "js-sdk-version: '${{ steps.get-citr-vars.outputs.js-sdk-version }}'"
-            echo "block-node-version: '${{ steps.get-citr-vars.outputs.block-node-version }}'"
-            echo "mirror-node-version: '${{ steps.get-citr-vars.outputs.bn-mirror-node-version }}'"
-            echo "json-rpc-relay-version: '${{ steps.get-citr-vars.outputs.json-rpc-relay-version }}'"
+          # Define the expected keys to check (aligns with the outputs defined in the workflow_call)
+          echo "::group::Verify expected CITR variables"
+          EXPECTED_KEYS=(
+            "adhoc-solo-version"
+            "adhoc-xts-solo-version"
+            "citr-mirror-node-version"
+            "citr-solo-version"
+            "mqpt-cluster"
+            "tck-version"
+            "js-sdk-version"
+            "block-node-version"
+            "bn-mirror-node-version"
+            "json-rpc-relay-version"
+          )
+
+          # Loop through expected keys and check if they are set in GITHUB_OUTPUT
+          for key in "${EXPECTED_KEYS[@]}"; do
+            value=$(grep "^${key}=" "${GITHUB_OUTPUT}" | cut -d'=' -f2-)
+
+            # If the value is empty or not set, log a warning and assign an empty string
+            if [[ -z "${value}" ]]; then
+              echo "::warning::CITR variable '${key}' is missing or empty, defaulting to empty string"
+              echo "${key}=" | tee -a "${GITHUB_OUTPUT}"
+            else
+              echo "  OK: ${key}=${value}"
+            fi
+          done
           echo "::endgroup::"
-          exit 1

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -45,10 +45,40 @@ jobs:
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.tck-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.js-sdk-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.citr-mirror-node-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.bn-release-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" == ""
+          ]]; then
+            echo "::error::One or more CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
   compute-solo-ge-0440:
     name: Compute solo-ge-0440
     needs:
       - extract-citr-vars
+      - verify-citr-vars
     uses: ./.github/workflows/856-call-solo-ge044.yaml
     with:
       solo-version: ${{ needs.extract-citr-vars.outputs.citr-solo-version }}
@@ -58,6 +88,7 @@ jobs:
     runs-on: hl-cn-default-lin-sm
     needs:
       - extract-citr-vars
+      - verify-citr-vars
       - compute-solo-ge-0440
     outputs:
       solo-ge-0440: ${{ needs.compute-solo-ge-0440.outputs.solo-ge-0440 }}
@@ -289,6 +320,7 @@ jobs:
       - state-validator-uberjar
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
     uses: ./.github/workflows/815-call-xts-tests.yaml
     with:
@@ -331,6 +363,7 @@ jobs:
       - state-validator-uberjar
       - extract-jdk-version
       - extract-citr-vars
+      - verify-citr-vars
     if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
     uses: ./.github/workflows/815-call-xts-tests.yaml
     with:

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -66,9 +66,8 @@ jobs:
             "${{ needs.extract-citr-vars.outputs.citr-mirror-node-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.bn-release-version }}" == "" || \
             "${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}" == "" || \
-            "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" == ""
-          ]]; then
-            echo "::error::One or more CITR variables are missing. Failing the job."
+            "${{ needs.extract-citr-vars.outputs.json-rpc-relay-version }}" == "" ]]; then
+            echo "::error::One or more required CITR variables are missing. Failing the job."
             exit 1
           else
             echo "All required CITR variables are present."


### PR DESCRIPTION
## Description

This pull request introduces a standardized verification step for CITR environment variables across multiple GitHub Actions workflow files. The main goal is to ensure that all required CITR variables are present before proceeding with downstream jobs, improving reliability and early failure detection for missing configuration. The verification logic is now separated into dedicated `verify-citr-vars` jobs, and the extraction logic in `855-call-extract-citr-vars.yaml` is refactored for better robustness and clarity.

Key changes include:

**1. Addition of CITR variable verification jobs to workflows**
- Added a new `verify-citr-vars` job to all relevant workflow files (e.g., `001-user-dry-run-extended-test-suite.yaml`, `200-user-mqpt-controller-adhoc.yaml`, `201-user-sdpt-controller-adhoc.yaml`, `202-user-sdlt-controller-adhoc.yaml`, `220-disp-mqpt-controller.yaml`, `221-disp-sdpt-controller.yaml`, `222-disp-sdlt-controller.yaml`, `602-flow-merge-queue-controller.yaml`, `900-cron-extended-test-suite.yaml`). Each job checks for the presence of required CITR variables and fails early if any are missing. [[1]](diffhunk://#diff-fc48e60027e54d32716e09c017578a3f33aaf6c00fc9ebe195c5b278331f0788R98-R131) [[2]](diffhunk://#diff-5e1592c12b5abbcd4f111aa41828ece4b058abff4349d2822ff35c5ba8cd9ea6R106-R133) [[3]](diffhunk://#diff-c615d4b99cef3494839dde2d1d123025f1309f95ff9a5bc6f0d2933a1be3ae47R142-R170) [[4]](diffhunk://#diff-52b87d885fea813a000deceb4efb099ab1f6a10c314eca210855cd6063686b40R145-R173) [[5]](diffhunk://#diff-fd02cb315b740a73db7790560e3d3867141d9deb8f6208a39dbe57febbe47a25R42-R69) [[6]](diffhunk://#diff-736481ad36aa9611ef9f6e489676e724fc3e25f1c4a2ff7836981c6177ee4941R72-R100) [[7]](diffhunk://#diff-d9aa549b91895ec9139c5195d55897bf54e82050f9f0fd9cd3dd9a695dddbfecR72-R100) [[8]](diffhunk://#diff-3c05977a4a90bf7279e15c5966aa4e2047fbba8c9ae9a93f2136228c451d5066R36-R60) [[9]](diffhunk://#diff-866e104331e826b6cd78ccd5a768be8eb64e8a8c1b8590d987ad572cb4adba29R48-R81)

**2. Enforcement of verification as a dependency**
- Updated downstream jobs in all affected workflows to depend on `verify-citr-vars`, ensuring that no subsequent steps run unless CITR variables are verified. [[1]](diffhunk://#diff-fc48e60027e54d32716e09c017578a3f33aaf6c00fc9ebe195c5b278331f0788R141) [[2]](diffhunk://#diff-fc48e60027e54d32716e09c017578a3f33aaf6c00fc9ebe195c5b278331f0788R208) [[3]](diffhunk://#diff-5e1592c12b5abbcd4f111aa41828ece4b058abff4349d2822ff35c5ba8cd9ea6R106-R133) [[4]](diffhunk://#diff-c615d4b99cef3494839dde2d1d123025f1309f95ff9a5bc6f0d2933a1be3ae47R142-R170) [[5]](diffhunk://#diff-52b87d885fea813a000deceb4efb099ab1f6a10c314eca210855cd6063686b40R145-R173) [[6]](diffhunk://#diff-fd02cb315b740a73db7790560e3d3867141d9deb8f6208a39dbe57febbe47a25R42-R69) [[7]](diffhunk://#diff-736481ad36aa9611ef9f6e489676e724fc3e25f1c4a2ff7836981c6177ee4941R72-R100) [[8]](diffhunk://#diff-d9aa549b91895ec9139c5195d55897bf54e82050f9f0fd9cd3dd9a695dddbfecR72-R100) [[9]](diffhunk://#diff-3c05977a4a90bf7279e15c5966aa4e2047fbba8c9ae9a93f2136228c451d5066R86) [[10]](diffhunk://#diff-3c05977a4a90bf7279e15c5966aa4e2047fbba8c9ae9a93f2136228c451d5066R126) [[11]](diffhunk://#diff-866e104331e826b6cd78ccd5a768be8eb64e8a8c1b8590d987ad572cb4adba29R91) [[12]](diffhunk://#diff-866e104331e826b6cd78ccd5a768be8eb64e8a8c1b8590d987ad572cb4adba29R323) [[13]](diffhunk://#diff-866e104331e826b6cd78ccd5a768be8eb64e8a8c1b8590d987ad572cb4adba29R366)

**3. Refactoring and improvement of CITR variable extraction**
- Refactored the extraction step in `855-call-extract-citr-vars.yaml` to robustly read variables from the `.citr-env` file, skip comments and empty lines, and ensure all expected keys are set (assigning empty strings and warnings if missing). The previous inline verification step was removed in favor of the new dedicated verification job.

These changes collectively improve the maintainability, clarity, and robustness of the workflow automation around CITR variable management.

## Related Issue(s)

- Closes #26084 