### PR TITLE
test(fees): remove legacy dual-mode fee assertion helpers

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -2628,26 +2628,6 @@ public class UtilVerbs {
         });
     }
 
-    public static CustomSpecAssert safeValidateInnerTxnChargedUsd(
-            String txn,
-            String parent,
-            double oldPrice,
-            double oldAllowedPercentDiff,
-            double newPrice,
-            double newAllowedPercentDiff) {
-        return assertionsHold((spec, assertLog) -> {
-            final var effectivePercentDiff = Math.max(newAllowedPercentDiff, 1.0);
-            final var actualUsdCharged = getChargedUsedForInnerTxn(spec, parent, txn);
-            assertEquals(
-                    newPrice,
-                    actualUsdCharged,
-                    (effectivePercentDiff / 100.0) * newPrice,
-                    String.format(
-                            "%s fee (%s) more than %.2f percent different than expected!",
-                            sdec(actualUsdCharged, 4), txn, effectivePercentDiff));
-        });
-    }
-
     /**
      * Validates that fee charged for a transaction is within the allowedPercentDiff of expected fee (taken
      * from pricing calculator) without the charge for gas.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
@@ -48,6 +48,7 @@ import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.emptyChildRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
@@ -66,7 +67,6 @@ import static com.hedera.services.bdd.suites.contract.leaky.LeakyContractTestsSu
 import static com.hedera.services.bdd.suites.contract.leaky.LeakyContractTestsSuite.TRANSFER_SIGNATURE;
 import static com.hedera.services.bdd.suites.contract.leaky.LeakyContractTestsSuite.TRANSFER_SIG_NAME;
 import static com.hedera.services.bdd.suites.crypto.CryptoCreateSuite.ACCOUNT;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CRYPTO_APPROVE_ALLOWANCE_FEE;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.MULTI_KEY;
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.TRANSFER_TXN;
@@ -765,7 +765,7 @@ public class CryptoApproveAllowanceSuite {
                         .blankMemo()
                         .logged(),
                 getTxnRecord(APPROVE_TXN),
-                validateFees(APPROVE_TXN, 0.05238, 3 * CRYPTO_APPROVE_ALLOWANCE_FEE),
+                validateChargedUsdWithin(APPROVE_TXN, 3 * CRYPTO_APPROVE_ALLOWANCE_FEE, 0.1),
                 getAccountDetails(PAYER)
                         .payingWith(GENESIS)
                         .has(accountDetailsWith()
@@ -1222,14 +1222,14 @@ public class CryptoApproveAllowanceSuite {
                         .addCryptoAllowance(SPENDER, ANOTHER_SPENDER, 100L)
                         .via(BASE_APPROVE_TXN)
                         .blankMemo(),
-                validateFees(BASE_APPROVE_TXN, 0.05, CRYPTO_APPROVE_ALLOWANCE_FEE),
+                validateChargedUsdWithin(BASE_APPROVE_TXN, CRYPTO_APPROVE_ALLOWANCE_FEE, 0.1),
                 cryptoApproveAllowance()
                         .payingWith(SPENDER)
                         .addCryptoAllowance(SPENDER, ANOTHER_SPENDER, 100L)
                         .addCryptoAllowance(SPENDER, SECOND_SPENDER, 100L)
                         .via(BASE_APPROVE_TXN)
                         .blankMemo(),
-                validateFees(BASE_APPROVE_TXN, 0.050455, 2 * CRYPTO_APPROVE_ALLOWANCE_FEE),
+                validateChargedUsdWithin(BASE_APPROVE_TXN, 2 * CRYPTO_APPROVE_ALLOWANCE_FEE, 0.1),
                 cryptoApproveAllowance()
                         .payingWith(SPENDER)
                         .addCryptoAllowance(SPENDER, ANOTHER_SPENDER, 100L)
@@ -1237,7 +1237,7 @@ public class CryptoApproveAllowanceSuite {
                         .addCryptoAllowance(SPENDER, THIRD_SPENDER, 100L)
                         .via(BASE_APPROVE_TXN)
                         .blankMemo(),
-                validateFees(BASE_APPROVE_TXN, 0.0509105, 3 * CRYPTO_APPROVE_ALLOWANCE_FEE));
+                validateChargedUsdWithin(BASE_APPROVE_TXN, 3 * CRYPTO_APPROVE_ALLOWANCE_FEE, 0.1));
     }
 
     @HapiTest
@@ -1278,8 +1278,8 @@ public class CryptoApproveAllowanceSuite {
                         .addCryptoAllowance(OWNER, SPENDER, 100L)
                         .via(BASE_APPROVE_TXN)
                         .blankMemo(),
-                validateFees(BASE_APPROVE_TXN, 0.05, CRYPTO_APPROVE_ALLOWANCE_FEE),
-                validateFees(BASE_APPROVE_TXN, 0.050392, CRYPTO_APPROVE_ALLOWANCE_FEE),
+                validateChargedUsdWithin(BASE_APPROVE_TXN, CRYPTO_APPROVE_ALLOWANCE_FEE, 0.1),
+                validateChargedUsdWithin(BASE_APPROVE_TXN, CRYPTO_APPROVE_ALLOWANCE_FEE, 0.1),
                 cryptoApproveAllowance()
                         .payingWith(OWNER)
                         .addCryptoAllowance(OWNER, ANOTHER_SPENDER, 100L)
@@ -1287,7 +1287,7 @@ public class CryptoApproveAllowanceSuite {
                         .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, SPENDER, false, List.of(1L))
                         .via(APPROVE_TXN)
                         .blankMemo(),
-                validateFees(APPROVE_TXN, 0.05238, 3 * CRYPTO_APPROVE_ALLOWANCE_FEE),
+                validateChargedUsdWithin(APPROVE_TXN, 3 * CRYPTO_APPROVE_ALLOWANCE_FEE, 0.1),
                 getAccountDetails(OWNER)
                         .payingWith(GENESIS)
                         .has(accountDetailsWith()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoDeleteAllowanceSuite.java
@@ -28,6 +28,7 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedBodyIds;
 import static com.hedera.services.bdd.suites.HapiSuite.APP_PROPERTIES;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
@@ -38,7 +39,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.TOKEN_TREASURY;
 import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.OWNER;
 import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.SPENDER;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CRYPTO_DELETE_ALLOWANCE_FEE;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SIGNATURE_FEE_AFTER_MULTIPLIER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_ALLOWANCES;
@@ -327,7 +327,7 @@ public class CryptoDeleteAllowanceSuite {
                         .blankMemo()
                         .addNftDeleteAllowance(MISSING_OWNER, nft, List.of(1L))
                         .via("baseDeleteNft"),
-                validateFees("baseDeleteNft", 0.05, CRYPTO_DELETE_ALLOWANCE_FEE),
+                validateChargedUsdWithin("baseDeleteNft", CRYPTO_DELETE_ALLOWANCE_FEE, 0.1),
                 cryptoApproveAllowance().payingWith(owner).addNftAllowance(owner, nft, "spender2", false, List.of(1L)),
                 /* with specifying owner */
                 cryptoDeleteAllowance()
@@ -335,7 +335,7 @@ public class CryptoDeleteAllowanceSuite {
                         .blankMemo()
                         .addNftDeleteAllowance(owner, nft, List.of(1L))
                         .via("baseDeleteNft"),
-                validateFees("baseDeleteNft", 0.05, CRYPTO_DELETE_ALLOWANCE_FEE),
+                validateChargedUsdWithin("baseDeleteNft", CRYPTO_DELETE_ALLOWANCE_FEE, 0.1),
 
                 /* with 2 serials */
                 cryptoDeleteAllowance()
@@ -343,7 +343,7 @@ public class CryptoDeleteAllowanceSuite {
                         .blankMemo()
                         .addNftDeleteAllowance(owner, nft, List.of(2L, 3L))
                         .via("twoDeleteNft"),
-                validateFees("twoDeleteNft", 0.050101, CRYPTO_DELETE_ALLOWANCE_FEE),
+                validateChargedUsdWithin("twoDeleteNft", CRYPTO_DELETE_ALLOWANCE_FEE, 0.1),
                 /* with 2 sigs */
                 cryptoApproveAllowance().payingWith(owner).addNftAllowance(owner, nft, "spender2", false, List.of(1L)),
                 cryptoDeleteAllowance()
@@ -352,7 +352,8 @@ public class CryptoDeleteAllowanceSuite {
                         .addNftDeleteAllowance(owner, nft, List.of(1L))
                         .signedBy(payer, owner)
                         .via("twoDeleteNft"),
-                validateFees("twoDeleteNft", 0.08124, CRYPTO_DELETE_ALLOWANCE_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER));
+                validateChargedUsdWithin(
+                        "twoDeleteNft", CRYPTO_DELETE_ALLOWANCE_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1));
     }
 
     @HapiTest
@@ -902,7 +903,7 @@ public class CryptoDeleteAllowanceSuite {
                         .blankMemo()
                         .via("cryptoDeleteAllowanceTxn")
                         .logged(),
-                validateFees("cryptoDeleteAllowanceTxn", 0.05, CRYPTO_DELETE_ALLOWANCE_FEE),
+                validateChargedUsdWithin("cryptoDeleteAllowanceTxn", CRYPTO_DELETE_ALLOWANCE_FEE, 0.1),
                 getAccountDetails(owner)
                         .payingWith(GENESIS)
                         .has(accountDetailsWith().nftApprovedForAllAllowancesCount(1)),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -33,6 +33,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedBodyIds;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
@@ -41,7 +42,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.THREE_MONTHS_IN_SECONDS;
 import static com.hedera.services.bdd.suites.HapiSuite.ZERO_BYTE_MEMO;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractUpdateSuite.ADMIN_KEY;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CRYPTO_UPDATE_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EXISTING_AUTOMATIC_ASSOCIATIONS_EXCEED_GIVEN_LIMIT;
@@ -274,11 +274,11 @@ public class CryptoUpdateSuite {
                         .maxAutomaticAssociations(-1)
                         .via(validNegativeTxn),
                 getAccountInfo("autoAssocTarget").hasMaxAutomaticAssociations(-1),
-                validateFees(baseTxn, baseFeeWithExpiry, CRYPTO_UPDATE_FEE),
-                validateFees(plusOneTxn, baseFee, CRYPTO_UPDATE_FEE),
-                validateFees(plusTenTxn, baseFee, CRYPTO_UPDATE_FEE),
-                validateFees(plusFiveKTxn, baseFee, CRYPTO_UPDATE_FEE),
-                validateFees(validNegativeTxn, baseFee, CRYPTO_UPDATE_FEE));
+                validateChargedUsdWithin(baseTxn, CRYPTO_UPDATE_FEE, 0.1),
+                validateChargedUsdWithin(plusOneTxn, CRYPTO_UPDATE_FEE, 0.1),
+                validateChargedUsdWithin(plusTenTxn, CRYPTO_UPDATE_FEE, 0.1),
+                validateChargedUsdWithin(plusFiveKTxn, CRYPTO_UPDATE_FEE, 0.1),
+                validateChargedUsdWithin(validNegativeTxn, CRYPTO_UPDATE_FEE, 0.1));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/LeakyCryptoTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/LeakyCryptoTestsSuite.java
@@ -53,6 +53,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithChild;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
@@ -81,7 +82,6 @@ import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.
 import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.THIRD_SPENDER;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
 import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.expectedCryptoTransferHbarFullFeeUsd;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CRYPTO_CREATE_TOTAL_FEE;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.CRYPTO_UPDATE_FEE;
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.SUPPLY_KEY;
@@ -189,7 +189,7 @@ public class LeakyCryptoTestsSuite {
                         .payingWith(shortLivedAutoAssocUser)
                         .maxAutomaticAssociations(10)
                         .via(updateWithExpiredAccount),
-                validateFees(updateWithExpiredAccount, baseFee, CRYPTO_UPDATE_FEE));
+                validateChargedUsdWithin(updateWithExpiredAccount, CRYPTO_UPDATE_FEE, 0.1));
     }
 
     @RepeatableHapiTest(NEEDS_SYNCHRONOUS_HANDLE_WORKFLOW)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/FeesChargingUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/utils/FeesChargingUtils.java
@@ -11,7 +11,6 @@ import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.getChargedUsedForInnerTxn;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.safeValidateChargedUsdWithin;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithChild;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateInnerTxnChargedUsd;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
@@ -2235,13 +2234,6 @@ public class FeesChargingUtils {
 
     // -------- Dual-mode validation utils ---------//
 
-    /*
-     * Validates the simple fee charged for a transaction.
-     */
-    public static SpecOperation validateFees(final String txn, final double legacyFee, final double simpleFee) {
-        return validateChargedUsdWithin(txn, simpleFee, 0.1);
-    }
-
     public static SpecOperation validateInnerTxnFees(String txn, String parent, double legacyFee, double simpleFee) {
         return validateInnerTxnFees(txn, parent, legacyFee, simpleFee, 0.1);
     }
@@ -2267,15 +2259,6 @@ public class FeesChargingUtils {
             final double simpleFeesAllowedPercentDiff) {
         return validateInnerChargedUsdWithinWithTxnSize(
                 innerTxnId, parentTxnId, expectedSimpleFeesUsd, simpleFeesAllowedPercentDiff);
-    }
-
-    /**
-     * Validates the simple fee charged for a transaction including child dispatch fees.
-     * Uses {@code validateChargedUsdWithChild} which includes child dispatch fees.
-     */
-    public static SpecOperation validateFeesWithChild(
-            final String txn, final double legacyFee, final double simpleFee, final double tolerance) {
-        return validateChargedUsdWithChild(txn, simpleFee, tolerance);
     }
 
     public static CustomSpecAssert validateBatchChargedCorrectly(String batchTxn) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -55,6 +55,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.FREEZE_ADMIN;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
@@ -69,7 +70,6 @@ import static com.hedera.services.bdd.suites.contract.opcodes.Create2OperationSu
 import static com.hedera.services.bdd.suites.contract.opcodes.Create2OperationSuite.setExpectedCreate2Address;
 import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
 import static com.hedera.services.bdd.suites.crypto.TransferWithCustomFixedFees.htsFee;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.AIRDROPS_FEE_USD;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SIGNATURE_FEE_AFTER_MULTIPLIER;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.TOKEN_ASSOCIATE_EXTRA_FEE_USD;
@@ -335,11 +335,9 @@ public class TokenAirdropTest extends TokenAirdropBase {
                         tokenAirdrop(moving(1, FUNGIBLE_TOKEN).between(OWNER, receiver))
                                 .payingWith(OWNER)
                                 .via("second airdrop"),
-                        validateFees(
-                                "airdrop",
-                                0.1004310852,
-                                TOKEN_TRANSFER_FEE + AIRDROPS_FEE_USD + TOKEN_ASSOCIATE_EXTRA_FEE_USD),
-                        validateFees("second airdrop", 0.050431086, TOKEN_TRANSFER_FEE + AIRDROPS_FEE_USD));
+                        validateChargedUsdWithin(
+                                "airdrop", TOKEN_TRANSFER_FEE + AIRDROPS_FEE_USD + TOKEN_ASSOCIATE_EXTRA_FEE_USD, 0.1),
+                        validateChargedUsdWithin("second airdrop", TOKEN_TRANSFER_FEE + AIRDROPS_FEE_USD, 0.1));
             }
 
             @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
@@ -1002,10 +1000,10 @@ public class TokenAirdropTest extends TokenAirdropBase {
                     // assert collector balance is not changed
                     doingContextual(
                             _ -> Assertions.assertEquals(currentCollectorBalance.get(), newCollectorBalance.get())),
-                    validateFees(
+                    validateChargedUsdWithin(
                             "NFT with royalty fee airdrop to collector",
-                            0.0008029,
-                            TOKEN_TRANSFER_WITH_CUSTOM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER));
+                            TOKEN_TRANSFER_WITH_CUSTOM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER,
+                            0.1));
         }
 
         @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
@@ -1082,10 +1080,10 @@ public class TokenAirdropTest extends TokenAirdropBase {
                         // assert treasury balance is not changed
                         Assertions.assertEquals(currentTreasuryBalance.get(), newTreasuryBalance.get());
                     }),
-                    validateFees(
+                    validateChargedUsdWithin(
                             "NFT with royalty fee airdrop to treasury",
-                            0.0008029,
-                            TOKEN_TRANSFER_WITH_CUSTOM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER));
+                            TOKEN_TRANSFER_WITH_CUSTOM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER,
+                            0.1));
         }
 
         @EmbeddedHapiTest(NEEDS_STATE_ACCESS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenClaimAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenClaimAirdropTest.java
@@ -46,6 +46,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedBodyIds;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
@@ -58,7 +59,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hedera.services.bdd.suites.contract.leaky.LeakyContractTestsSuite.RECEIVER;
 import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.LAZY_MEMO;
 import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFees;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.SIGNATURE_FEE_AFTER_MULTIPLIER;
 import static com.hedera.services.bdd.suites.hip1261.utils.SimpleFeesScheduleConstantsInUsd.TOKEN_CLAIM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
@@ -171,7 +171,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                                         moving(10, FUNGIBLE_TOKEN).between(OWNER, RECEIVER)))
                                 .tokenTransfers(includingNonfungibleMovement(
                                         movingUnique(NON_FUNGIBLE_TOKEN, 1).between(OWNER, RECEIVER)))),
-                validateFees("claimTxn", 0.001, TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER),
+                validateChargedUsdWithin("claimTxn", TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
 
                 // assert balances
                 getAccountBalance(RECEIVER).hasTokenBalance(FUNGIBLE_TOKEN, 10),
@@ -430,7 +430,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
         return blockingOrder(
                 claimFn.get().via("claimTxn" + claimNum),
                 claimFn.get().hasKnownStatus(INVALID_PENDING_AIRDROP_ID),
-                validateFees("claimTxn" + claimNum, 0.0010031904, TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER));
+                validateChargedUsdWithin("claimTxn" + claimNum, TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1));
     }
 
     @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
@@ -479,7 +479,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                         .payingWith(BOB)
                         .signedBy(BOB, CAROL, YULIA, TOM, STEVE)
                         .via("claimTxn"),
-                validateFees("claimTxn", 0.0010127628, TOKEN_CLAIM_FEE + 4 * SIGNATURE_FEE_AFTER_MULTIPLIER),
+                validateChargedUsdWithin("claimTxn", TOKEN_CLAIM_FEE + 4 * SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
                 tokenClaimAirdrop(
                                 pendingAirdrop(ALICE, BOB, FUNGIBLE_TOKEN_1),
                                 pendingAirdrop(ALICE, CAROL, FUNGIBLE_TOKEN_2),
@@ -678,7 +678,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                         .hasPriority(recordWith()
                                 .tokenTransfers(includingFungibleMovement(
                                         moving(1, FUNGIBLE_TOKEN).between(OWNER, RECEIVER)))),
-                validateFees("claimTxn", 0.00100319, TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER),
+                validateChargedUsdWithin("claimTxn", TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
 
                 // assert token associations
                 getAccountInfo(RECEIVER).hasToken(relationshipWith(FUNGIBLE_TOKEN)),
@@ -704,7 +704,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                         .hasPriority(recordWith()
                                 .tokenTransfers(includingFungibleMovement(
                                         moving(1, FUNGIBLE_TOKEN).between(OWNER, RECEIVER)))),
-                validateFees("claimTxn", 0.00100319, TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER),
+                validateChargedUsdWithin("claimTxn", TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
 
                 // assert token associations
                 getAccountInfo(RECEIVER).hasToken(relationshipWith(FUNGIBLE_TOKEN)),
@@ -930,7 +930,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                         .payingWith(validAlias)
                         .sigMapPrefixes(uniqueWithFullPrefixesFor(validAlias))
                         .via("claimTxn"),
-                validateFees("claimTxn", 0.001, TOKEN_CLAIM_FEE),
+                validateChargedUsdWithin("claimTxn", TOKEN_CLAIM_FEE, 0.1),
 
                 // check if account was finalized and auto associations were not modified
                 getAliasedAccountInfo(validAlias).isNotHollow().hasMaxAutomaticAssociations(0)));
@@ -952,7 +952,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                         .signedBy(carol, alias)
                         .sigMapPrefixes(uniqueWithFullPrefixesFor(alias))
                         .via("claimTxn"),
-                validateFees("claimTxn", 0.0010031904, TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER),
+                validateChargedUsdWithin("claimTxn", TOKEN_CLAIM_FEE + SIGNATURE_FEE_AFTER_MULTIPLIER, 0.1),
                 // check if account was finalized and auto associations were not modified
                 getAliasedAccountInfo(alias).isNotHollow().hasMaxAutomaticAssociations(0)));
     }
@@ -974,8 +974,8 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                         .payingWith(RECEIVER_WITH_0_AUTO_ASSOCIATIONS)
                         .signedBy(RECEIVER_WITH_0_AUTO_ASSOCIATIONS)
                         .hasKnownStatus(INVALID_PENDING_AIRDROP_ID),
-                validateFees("claimTxn1", 0.001, TOKEN_CLAIM_FEE),
-                validateFees("claimTxn2", 0.001, TOKEN_CLAIM_FEE)));
+                validateChargedUsdWithin("claimTxn1", TOKEN_CLAIM_FEE, 0.1),
+                validateChargedUsdWithin("claimTxn2", TOKEN_CLAIM_FEE, 0.1)));
     }
 
     @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
@@ -1040,7 +1040,7 @@ public class TokenClaimAirdropTest extends TokenAirdropBase {
                                 RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS),
                 getAccountBalance(RECEIVER_WITH_0_AUTO_ASSOCIATIONS).hasTokenBalance(FUNGIBLE_TOKEN, 1),
                 getAccountBalance(RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS).hasTokenBalance(FUNGIBLE_TOKEN, 1),
-                validateFees("claimTxn", 0.001, TOKEN_CLAIM_FEE)));
+                validateChargedUsdWithin("claimTxn", TOKEN_CLAIM_FEE, 0.1)));
     }
 
     @EmbeddedHapiTest(NEEDS_STATE_ACCESS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/UnlimitedAutoAssociationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/UnlimitedAutoAssociationSuite.java
@@ -26,6 +26,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertCloseEnough;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithChild;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
@@ -38,7 +39,6 @@ import static com.hedera.services.bdd.suites.contract.Utils.ocWith;
 import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.FUNGIBLE_TOKEN;
 import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.NON_FUNGIBLE_TOKEN;
 import static com.hedera.services.bdd.suites.crypto.CryptoDeleteSuite.TREASURY;
-import static com.hedera.services.bdd.suites.hip1261.utils.FeesChargingUtils.validateFeesWithChild;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.MULTI_KEY;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
@@ -186,8 +186,8 @@ public class UnlimitedAutoAssociationSuite {
                         .hasAlreadyUsedAutomaticAssociations(2)
                         .logged(),
                 // Total fee should include  a token association fee ($0.05) and CryptoTransfer fee ($0.001)
-                validateFeesWithChild(transferFungible, 0.051, 0.051, 0.1),
-                validateFeesWithChild(transferNonFungible, 0.051, 0.051, 0.1));
+                validateChargedUsdWithChild(transferFungible, 0.051, 0.1),
+                validateChargedUsdWithChild(transferNonFungible, 0.051, 0.1));
     }
 
     @HapiTest
@@ -305,8 +305,7 @@ public class UnlimitedAutoAssociationSuite {
                 getAliasedAccountInfo(hollowKey)
                         .has(accountWith().key(hollowKey).maxAutoAssociations(-1))
                         .hasAlreadyUsedAutomaticAssociations(2),
-                validateFeesWithChild(
-                        hollowAccountTxn, transferAndAssociationFee, simpleFeesTransferAndAssociationFee, 1.0));
+                validateChargedUsdWithChild(hollowAccountTxn, simpleFeesTransferAndAssociationFee, 1.0));
     }
 
     @DisplayName("Hollow account creation with NFT transfer has correct auto associations")
@@ -407,8 +406,7 @@ public class UnlimitedAutoAssociationSuite {
                         getAliasedAccountInfo(hollowAccountKey)
                                 .has(accountWith().key(hollowAccountKey).maxAutoAssociations(-1))
                                 .hasAlreadyUsedAutomaticAssociations(2))),
-                validateFeesWithChild(
-                        hollowTransferTxn, transferAndAssociationFee, simpleFeesTransferAndAssociationFee, 1.0));
+                validateChargedUsdWithChild(hollowTransferTxn, simpleFeesTransferAndAssociationFee, 1.0));
     }
 
     @DisplayName("Hollow account creation with multiple senders correct auto associations")
@@ -484,10 +482,7 @@ public class UnlimitedAutoAssociationSuite {
                                 .payingWith(CAROL)
                                 .signedBy(CAROL, DAVE)
                                 .sigMapPrefixes(uniqueWithFullPrefixesFor(CAROL)),
-                        validateFeesWithChild(
-                                transfersToHollowAccountTxn,
-                                expectedCryptoTransferAndAssociationUsd,
-                                expectedCryptoTransferAndAssociationUsd,
-                                1.0))));
+                        validateChargedUsdWithChild(
+                                transfersToHollowAccountTxn, expectedCryptoTransferAndAssociationUsd, 1.0))));
     }
 }


### PR DESCRIPTION
**Description**

Removes the transitional dual-mode fee assertion wrappers now that simple fees are always on. `validateFees(txn, legacyFee, simpleFee)` and `validateFeesWithChild(...)` only forwarded to the simple-fee helper and ignored the legacy arg, so the 37 call sites are repointed straight to `validateChargedUsdWithin` / `validateChargedUsdWithChild` and the wrappers are deleted. Also drops the dead `safeValidateInnerTxnChargedUsd` (zero callers) from `UtilVerbs`.

Behavior is unchanged (the wrappers did exactly this). `validateChargedUsdWithin` is kept (simple-fee tests use it).

**Related issue(s)**

Closes #25860

**Notes for reviewer**

- Scope is the two helpers the issue names; the other dual-mode utils (`validateBatchFee`, `validateInnerTxnFees`, `validateFeeModeAwareWithTxnSize`) are left as-is.
- Touches `FeesChargingUtils` (also edited by #25983) — different methods, so only same-file proximity, no logic overlap.
