### PR TITLE
chore: Update sync sorting to use sequence number instead of nGen

### DIFF
--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/SyncUtils.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/SyncUtils.java
@@ -205,9 +205,9 @@ public final class SyncUtils {
      * @param sendList The list of events to sort.
      */
     static void sort(@NonNull final List<PlatformEvent> sendList) {
-        // Note: regardless of ancient mode, sorting uses generations and not birth rounds.
-        //       Sorting by generations yields a list in topological order, sorting by birth rounds does not.
-        sendList.sort(Comparator.comparingLong(PlatformEvent::getNGen));
+        // Note: regardless of ancient mode, sorting uses locally calculated sequence number and not birth rounds.
+        //       Sorting by sequence number yields a list in topological order, sorting by birth rounds does not.
+        sendList.sort(Comparator.comparingLong(PlatformEvent::getSequenceNumber));
     }
 
     /**

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/ShadowgraphSynchronizerTruncationTest.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/ShadowgraphSynchronizerTruncationTest.java
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.gossip.impl.gossip.shadowgraph;
+
+import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.swirlds.base.test.fixtures.time.FakeTime;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.hiero.base.crypto.Hash;
+import org.hiero.consensus.event.NoOpIntakeEventCounter;
+import org.hiero.consensus.gossip.impl.gossip.sync.SyncMetrics;
+import org.hiero.consensus.metrics.noop.NoOpMetrics;
+import org.hiero.consensus.model.event.EventDescriptorWrapper;
+import org.hiero.consensus.model.event.PlatformEvent;
+import org.hiero.consensus.model.hashgraph.EventWindow;
+import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.test.fixtures.event.TestingEventBuilder;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@link ShadowgraphSynchronizer#createSendList} truncates the send list to {@code sync.maxSyncEventCount}
+ * after the topological sort, so the events that are kept form a topological prefix (every parent of a kept event is
+ * also kept). Because the send list is sorted by the ever-increasing sequence number, a parent always sorts before its
+ * children, so truncation never drops a parent while keeping its child.
+ */
+class ShadowgraphSynchronizerTruncationTest {
+
+    private static final int NUM_NODES = 4;
+
+    /**
+     * A genesis event window: birth round 1 is non-ancient and non-expired, so every event the test builds is eligible
+     * to send (none are filtered out before truncation).
+     */
+    private static EventWindow nonAncientWindow() {
+        return EventWindow.getGenesisEventWindow();
+    }
+
+    @Test
+    void createSendListTruncatesToTopologicalPrefix() {
+        final Random random = getRandomPrintSeed();
+
+        final int maxSyncEventCount = 3;
+        final Configuration configuration = new TestConfigBuilder()
+                // isolate truncation: do not let the duplicate filter drop events based on age
+                .withValue("sync.filterLikelyDuplicates", false)
+                .withValue("sync.maxSyncEventCount", maxSyncEventCount)
+                .getOrCreateConfig();
+
+        final NodeId selfId = NodeId.of(0);
+        final ShadowgraphSynchronizer synchronizer = new ShadowgraphSynchronizer(
+                configuration,
+                new NoOpMetrics(),
+                new FakeTime(),
+                NUM_NODES,
+                mock(SyncMetrics.class),
+                new NoOpIntakeEventCounter(),
+                progress -> {});
+
+        synchronizer.updateEventWindow(nonAncientWindow());
+
+        // Build a single-creator chain of 6 events, parent-first. Each event's self-parent is the previous event. The
+        // sequence number is assigned explicitly and strictly increasing down the chain, mirroring the orphan buffer
+        // assigning an ever-increasing number at release time (a parent always exits before its child).
+        final int chainLength = 6;
+        final List<PlatformEvent> chain = new ArrayList<>();
+        PlatformEvent selfParent = null;
+        for (int i = 0; i < chainLength; i++) {
+            final PlatformEvent event = new TestingEventBuilder(random)
+                    .setCreatorId(selfId)
+                    .setSelfParent(selfParent)
+                    .setBirthRound(1)
+                    .setSequenceNumberOverride(i + 1)
+                    .build();
+            chain.add(event);
+            synchronizer.addEvent(event);
+            selfParent = event;
+        }
+
+        final Set<ShadowEvent> knownSet = new HashSet<>();
+        final List<PlatformEvent> sendList =
+                synchronizer.createSendList(selfId, knownSet, nonAncientWindow(), nonAncientWindow(), false);
+
+        // The list is truncated to the configured maximum.
+        assertEquals(maxSyncEventCount, sendList.size(), "send list must be truncated to maxSyncEventCount");
+
+        // The kept events are exactly the maxSyncEventCount events with the lowest sequence numbers.
+        final Set<Hash> expectedHashes = chain.stream()
+                .sorted(Comparator.comparingLong(PlatformEvent::getSequenceNumber))
+                .limit(maxSyncEventCount)
+                .map(PlatformEvent::getHash)
+                .collect(Collectors.toSet());
+        final Set<Hash> actualHashes =
+                sendList.stream().map(PlatformEvent::getHash).collect(Collectors.toSet());
+        assertEquals(expectedHashes, actualHashes, "truncation must keep the lowest-sequence-number events");
+
+        // The kept set is a topological prefix: every parent of a kept event is also kept. This is the property the
+        // sequence-number sort guarantees and that truncation must not break by shipping an orphan.
+        for (final PlatformEvent event : sendList) {
+            for (final EventDescriptorWrapper parent : event.getAllParents()) {
+                assertTrue(
+                        actualHashes.contains(parent.hash()),
+                        "a parent of a sent event must also be sent (no orphan in the truncated list)");
+            }
+        }
+    }
+}

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/SyncUtilsSortTest.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/SyncUtilsSortTest.java
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.gossip.impl.gossip.shadowgraph;
+
+import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.hiero.base.crypto.Hash;
+import org.hiero.consensus.model.event.EventDescriptorWrapper;
+import org.hiero.consensus.model.event.PlatformEvent;
+import org.hiero.consensus.model.test.fixtures.event.TestingEventBuilder;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SyncUtils#sort(List)}, which orders the phase-3 send list. Sorting uses the locally calculated
+ * sequence number (assigned at orphan-buffer exit), not the birth round, so that the list is topologically ordered
+ * before it is sent to a peer.
+ */
+class SyncUtilsSortTest {
+
+    /**
+     * The send list must come back ordered by ascending sequence number regardless of its initial order.
+     */
+    @Test
+    void sortOrdersBySequenceNumberAscending() {
+        final Random random = getRandomPrintSeed();
+
+        // Build events whose sequence numbers are deliberately out of order relative to the list order.
+        final long[] sequenceNumbers = {5, 1, 4, 2, 3};
+        final List<PlatformEvent> events = new ArrayList<>();
+        for (final long sequenceNumber : sequenceNumbers) {
+            events.add(new TestingEventBuilder(random)
+                    .setSequenceNumberOverride(sequenceNumber)
+                    .build());
+        }
+
+        SyncUtils.sort(events);
+
+        long previous = Long.MIN_VALUE;
+        for (final PlatformEvent event : events) {
+            assertTrue(
+                    event.getSequenceNumber() > previous, "events must be in strictly ascending sequence-number order");
+            previous = event.getSequenceNumber();
+        }
+        assertEquals(sequenceNumbers.length, events.size(), "sort must not add or drop events");
+    }
+
+    /**
+     * A creator's self-parent always leaves the orphan buffer before its child, and parents are released before their
+     * children, so sequence numbers increase down every parent edge. Sorting by sequence number must therefore place
+     * every parent before its children, even when the input is shuffled.
+     */
+    @Test
+    void sortYieldsTopologicalOrder() {
+        final Random random = getRandomPrintSeed();
+
+        // Build a small DAG parent-first. TestingEventBuilder assigns an ever-increasing sequence number at build
+        // time, mirroring the orphan buffer assigning it at release time, so a parent always has a lower sequence
+        // number than its children.
+        final PlatformEvent a = new TestingEventBuilder(random).build();
+        final PlatformEvent b = new TestingEventBuilder(random).build();
+        final PlatformEvent c = new TestingEventBuilder(random)
+                .setSelfParent(a)
+                .setOtherParent(b)
+                .build();
+        final PlatformEvent d = new TestingEventBuilder(random)
+                .setSelfParent(b)
+                .setOtherParent(c)
+                .build();
+        final PlatformEvent e = new TestingEventBuilder(random)
+                .setSelfParent(c)
+                .setOtherParent(d)
+                .build();
+
+        final List<PlatformEvent> events = new ArrayList<>(List.of(a, b, c, d, e));
+        Collections.shuffle(events, random);
+
+        SyncUtils.sort(events);
+
+        // Record the position of each event in the sorted list, keyed by hash.
+        final Map<Hash, Integer> positionByHash = new HashMap<>();
+        for (int i = 0; i < events.size(); i++) {
+            positionByHash.put(events.get(i).getHash(), i);
+        }
+
+        // Every parent that is present in the list must appear before its child.
+        for (int i = 0; i < events.size(); i++) {
+            final PlatformEvent event = events.get(i);
+            for (final EventDescriptorWrapper parent : event.getAllParents()) {
+                final Integer parentPosition = positionByHash.get(parent.hash());
+                if (parentPosition != null) {
+                    assertTrue(
+                            parentPosition < i, "parent must be sorted before its child to preserve topological order");
+                }
+            }
+        }
+    }
+}

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
@@ -119,7 +119,7 @@ a dependency on it.
   | Compute the sequence number in the orphan buffer         | `consensus-utility`, `consensus-model` | #24841 (PR #24937) | done    |
   | Event creation / tipset                                  | `consensus-event-creator-impl`         | #24991             | done    |
   | Consensus algorithm                                      | `consensus-hashgraph-impl`             | #24844             | pending |
-  | Sync                                                     | `consensus-gossip-impl`                | #24843             | pending |
+  | Sync                                                     | `consensus-gossip-impl`                | #24843             | done    |
   | `cGen` handling                                          | `consensus-hashgraph-impl`             | #24883             | pending |
   | Tools (GUI, CLI)                                         | `consensus-gui`, `swirlds-cli`         | #24885             | pending |
   | Remove `nGen` from the orphan buffer and `PlatformEvent` | `consensus-utility`, `consensus-model` | #24846             | pending |
@@ -230,7 +230,7 @@ See **Decision** above.
   `RoundElections`, `ConsensusSorter`, `LocalConsensusGeneration`: the consensus
   and `cGen` consumers still on `nGen` (#24844, #24883).
 - `consensus-gossip-impl/.../shadowgraph/SyncUtils.java` — sorts the send list by
-  `nGen` (#24843).
+  `sequenceNumber` (#24843).
 - `consensus-gui/.../hashgraph/util/PictureMetadata.java`,
   `HashgraphPicture.java` — use `nGen` as graph height for layout (#24885).
 - `consensus-hashgraph-impl/.../EventImpl.java`, `.../metrics/Sequencer.java` —
@@ -255,9 +255,9 @@ See **Decision** above.
   (closed 2026-04-08); the decision date above reflects that approval. Staged
   implementation followed: PR #24937 (2026-04-16) added the counter and renamed
   the consensus-side `sequence` to `consensusSequence`; PR #24991 (2026-04-30)
-  migrated the tipset. Consensus (#24844), sync (#24843), `cGen` (#24883), tools
-  (#24885), and the final `nGen` removal (#24846) remain open at the time of
-  writing.
+  migrated the tipset. Sync (#24843) migrated the send-list sort to the sequence
+  number. Consensus (#24844), `cGen` (#24883), tools (#24885), and the final
+  `nGen` removal (#24846) remain open at the time of writing.
 - This entry fulfills #25482 ("Create ADR for replacing nGen with sequence
   number"). It supersedes an earlier draft scoped to event creation only; the
   scope was broadened to the full `nGen` removal.


### PR DESCRIPTION
**Description**:
Changes sync event sorting to use sequence number instead of nGen, and adds some unit tests to related sync utility methods that were previously untested and related to the change.

**Related issue(s)**:

Fixes #24843

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
