### PR TITLE
docs: Add init judge explanation

### DIFF
--- a/platform-sdk/docs/consensus-layer/CLAUDE.md
+++ b/platform-sdk/docs/consensus-layer/CLAUDE.md
@@ -13,6 +13,10 @@ conventions, frontmatter, and the canonicalization rule — lives in
   siblings drift; `FORMAT.md` is the schema.
 - Match the prevailing voice: terse, declarative statements. Detail goes in the
   sections the format designates for it, not in the headline claim.
+- Prefer short sentences and lists over flowing prose. A multi-step mechanism is
+  a numbered list, not a run-on paragraph; split any sentence that needs three
+  clauses to land. A long explanatory paragraph is a smell — it buries the fact
+  and hides unanchored claims in the gaps between sentences.
 
 ## Non-duplication is the prime directive
 
@@ -71,6 +75,12 @@ Behavioral claims tie to the specific code that makes them true. Match that bar
   reader cannot trace to code is either raised to a cited authority (a paper or
   protocol, the way invariants use `source`) or cut. "Don't fabricate an anchor"
   is the floor; **"every load-bearing claim carries one" is the bar.**
+- **No narrative exemption; anchor the surprising claim hardest.** A behavioral
+  sentence keeps its anchor mid-paragraph and in "explanatory" prose — anchor
+  each claim, not just the one that first names the component. And the
+  counter-intuitive assertion is the one a reader cannot take on faith, so it
+  gets the line-level cite, not a hand-wave: under-anchoring there is the worst
+  place to skimp.
 - **By document type — apply the right kind of anchor, don't over- or
   under-anchor:**
   - *Rules* — `components:` frontmatter is required and lists full paths; the

--- a/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Hashgraph
-last_reviewed: 2026-06-12
+last_reviewed: 2026-06-26
 ---
 
 # Hashgraph
@@ -247,12 +247,25 @@ just-added event is not yet classified as pre-consensus, because it
 might already have been part of a previously decided round. The
 flag is checked both before and after `consensus.addEvent`; the
 post-add check is the transition point out of waiting. When the last
-init judge arrives, the engine flushes any consensus events the
-just-decided rounds produced and the queued pre-consensus events
-into the output. Usually no rounds are decided in that same call,
-but a major roster change can produce some — in which case those
-consensus events are also reported as pre-consensus events so the
-downstream view of pre-consensus output stays complete.
+init judge arrives, `ConsensusImpl.checkInitJudges`
+(`ConsensusImpl.java:442`) takes the judges' common ancestors that are
+neither already consensus nor ancient (`AncestorSearch.commonAncestorsOf`
+under the `nonConsensusNonAncient` predicate) and marks each
+`setConsensus(true)` while deliberately leaving `roundReceived` unset:
+those events already reached consensus in the run that produced the
+loaded snapshot, so they are flagged decided solely to stop the
+algorithm from re-deciding them, and are never emitted as a consensus
+round. The engine then flushes the queued pre-consensus events into the
+output. Usually the call that finds the last judge decides no *new*
+rounds — consensus simply resumes, and later events decide the next
+round. Occasionally one decides immediately (the code attributes this to
+a major roster change); when it does, that round's events are *also*
+placed on the pre-consensus output, because the gate suppressed them
+earlier and every accepted event must still appear on the pre-consensus
+stream exactly once. Why this gate exists at the
+restart/replay boundary — not re-handling transactions already baked
+into the loaded state — is covered in
+[`../topics/restart-and-pces.md`](../topics/restart-and-pces.md#consensus-initialization-and-the-init-judge-gate).
 
 > **Note on the paper.** Round, witness, strongly-seeing, fame, and
 > judge mean the same thing in the paper and in the code. The notable

--- a/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Hashgraph
-last_reviewed: 2026-06-26
+last_reviewed: 2026-06-29
 ---
 
 # Hashgraph
@@ -242,12 +242,16 @@ judge IDs).
 restart or reconnect, `Consensus.waitingForInitJudges()` returns
 `true` until the linker has supplied enough events to reconstruct the
 snapshot's judges (handled by `InitJudges`). While that flag is set,
-`DefaultConsensusEngine.addEvent` returns an empty output — the
+`ConsensusImpl.addEvent` short-circuits to an empty result
+(`ConsensusImpl.java:290-293`) and `DefaultConsensusEngine.addEvent`
+returns an empty output (`DefaultConsensusEngine.java:148-153`) — the
 just-added event is not yet classified as pre-consensus, because it
-might already have been part of a previously decided round. The
-flag is checked both before and after `consensus.addEvent`; the
-post-add check is the transition point out of waiting. When the last
-init judge arrives, `ConsensusImpl.checkInitJudges`
+might already have been part of a previously decided round. The engine
+samples the flag both before and after `consensus.addEvent`
+(`waitingForJudgesBeforeAdd` / `waitingForJudgesAfterAdd`,
+`DefaultConsensusEngine.java:140-144`); the post-add check is the
+transition point out of waiting. When the last init judge arrives,
+`ConsensusImpl.checkInitJudges`
 (`ConsensusImpl.java:442`) takes the judges' common ancestors that are
 neither already consensus nor ancient (`AncestorSearch.commonAncestorsOf`
 under the `nonConsensusNonAncient` predicate) and marks each
@@ -256,13 +260,16 @@ those events already reached consensus in the run that produced the
 loaded snapshot, so they are flagged decided solely to stop the
 algorithm from re-deciding them, and are never emitted as a consensus
 round. The engine then flushes the queued pre-consensus events into the
-output. Usually the call that finds the last judge decides no *new*
-rounds — consensus simply resumes, and later events decide the next
-round. Occasionally one decides immediately (the code attributes this to
-a major roster change); when it does, that round's events are *also*
-placed on the pre-consensus output, because the gate suppressed them
-earlier and every accepted event must still appear on the pre-consensus
-stream exactly once. Why this gate exists at the
+output (`consensus.getPreConsensusEvents()`,
+`DefaultConsensusEngine.java:168-172`). Usually the call that finds the
+last judge decides no *new* rounds — `ConsensusImpl.addEvent` routes
+through `recalculateAndVote` (`ConsensusImpl.java:295-297`), consensus
+simply resumes, and later events decide the next round. If that
+recalculation does decide a round immediately, the engine *also* places
+the round's events on the pre-consensus output
+(`DefaultConsensusEngine.java:163-166`), because the gate suppressed
+them earlier and every accepted event must still appear on the
+pre-consensus stream exactly once. Why this gate exists at the
 restart/replay boundary — not re-handling transactions already baked
 into the loaded state — is covered in
 [`../topics/restart-and-pces.md`](../topics/restart-and-pces.md#consensus-initialization-and-the-init-judge-gate).

--- a/platform-sdk/docs/consensus-layer/architecture/topics/reconnect.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/reconnect.md
@@ -191,6 +191,11 @@ The orchestration lives in
 see that method for the exact set of overrides and injections it
 performs.
 
+As at restart, the re-initialised hashgraph emits no rounds until it has
+re-identified the judges of the learned state's snapshot, so it never
+re-emits a round already baked into that state — see
+[`restart-and-pces.md`](restart-and-pces.md#consensus-initialization-and-the-init-judge-gate).
+
 Status transitions follow loading in two stages.
 `ReconnectController` submits a `ReconnectCompleteAction` once a
 valid state has been learned, and the platform status machine moves

--- a/platform-sdk/docs/consensus-layer/architecture/topics/restart-and-pces.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/restart-and-pces.md
@@ -144,24 +144,14 @@ on-disk PCES files rather than gossip.
 ## Consensus initialization and the init-judge gate
 
 Replay (above) feeds events back through the consensus algorithm, but many of them already reached consensus in the run
-that produced the signed state being loaded — their transactions are already reflected in that state. If the hashgraph
-re-emitted those rounds, the system would handle the same transactions twice: the resulting state would be wrong, and
-even if the application recognized the duplicates and ignored them, recomputing and re-dispatching them is wasted work.
-So during initialization the consensus algorithm produces *no* output at all until it can tell which replayed events are
-already decided — and then it never emits them.
+that produced the signed state being loaded — their transactions are already reflected in that state. Re-emitting those
+rounds would corrupt the resulting state, and even if the application detected and dropped the duplicates, recomputing
+them is wasted work.
 
-The judges of the snapshot round are what let it draw that line. The loaded state's `ConsensusSnapshot` carries their
-hashes; consensus is handed the snapshot at the restart (and reconnect) boundary and then stays silent — emitting
-neither consensus rounds nor pre-consensus events — until every one of those judges has been replayed. When the last of
-them arrives, consensus marks each event the judges already decided as having reached consensus *without* outputting it,
-and only then resumes normal operation, emitting rounds for events that had not yet reached consensus in the loaded
-state. This is the mechanism that upholds INV-008 (consensus, once reached, is permanent) across a restart: no round
-that fed the loaded state flows out of the hashgraph a second time.
-
-The gate lives in the consensus algorithm, not in PCES. Its engine-side mechanics — loading the snapshot via the
-hashgraph module's snapshot input wire, the `waitingForInitJudges` check that suppresses output, the marking of the
-judges' common ancestors as consensus, and the flush when the gate releases — are detailed in
-[`hashgraph.md`](hashgraph.md#algorithm-in-current-code) under *Init-judge gate*.
+To prevent that, consensus emits no rounds during initialization until the snapshot round's judges have been replayed,
+then marks the events they already decided as consensus *without* emitting them — so no round that fed the loaded state
+flows out of the hashgraph a second time (upholding INV-008). The gate lives in the consensus algorithm, not in PCES;
+its mechanics are detailed in [`hashgraph.md`](hashgraph.md#algorithm-in-current-code) under *Init-judge gate*.
 
 ## Offline ISS recovery
 

--- a/platform-sdk/docs/consensus-layer/architecture/topics/restart-and-pces.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/restart-and-pces.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Restart and PCES
-last_reviewed: 2026-06-12
+last_reviewed: 2026-06-26
 ---
 
 # Restart and PCES
@@ -141,6 +141,28 @@ on-disk PCES files rather than gossip.
   read-side throughput is throttled implicitly by the emit-side block. See `health-monitor-and-backpressure.md` for the
   health-monitor mechanism.
 
+## Consensus initialization and the init-judge gate
+
+Replay (above) feeds events back through the consensus algorithm, but many of them already reached consensus in the run
+that produced the signed state being loaded — their transactions are already reflected in that state. If the hashgraph
+re-emitted those rounds, the system would handle the same transactions twice: the resulting state would be wrong, and
+even if the application recognized the duplicates and ignored them, recomputing and re-dispatching them is wasted work.
+So during initialization the consensus algorithm produces *no* output at all until it can tell which replayed events are
+already decided — and then it never emits them.
+
+The judges of the snapshot round are what let it draw that line. The loaded state's `ConsensusSnapshot` carries their
+hashes; consensus is handed the snapshot at the restart (and reconnect) boundary and then stays silent — emitting
+neither consensus rounds nor pre-consensus events — until every one of those judges has been replayed. When the last of
+them arrives, consensus marks each event the judges already decided as having reached consensus *without* outputting it,
+and only then resumes normal operation, emitting rounds for events that had not yet reached consensus in the loaded
+state. This is the mechanism that upholds INV-008 (consensus, once reached, is permanent) across a restart: no round
+that fed the loaded state flows out of the hashgraph a second time.
+
+The gate lives in the consensus algorithm, not in PCES. Its engine-side mechanics — loading the snapshot via the
+hashgraph module's snapshot input wire, the `waitingForInitJudges` check that suppresses output, the marking of the
+judges' common ancestors as consensus, and the flush when the gate releases — are detailed in
+[`hashgraph.md`](hashgraph.md#algorithm-in-current-code) under *Init-judge gate*.
+
 ## Offline ISS recovery
 
 A network-wide ISS that prevents progress is resolved offline by replaying PCES on top of a known-good signed state
@@ -150,7 +172,7 @@ recipe any driver must follow, and the record/block-file coordination with the e
 
 ## Cross-references
 
-- **Topics:** `signed-state-management.md`, `reconnect.md`, `freeze-and-upgrade.md`, `event-creator.md`,
+- **Topics:** `hashgraph.md`, `signed-state-management.md`, `reconnect.md`, `freeze-and-upgrade.md`, `event-creator.md`,
   `event-intake.md`, `health-monitor-and-backpressure.md`.
 - **Source docs:** `../../../core/inlinePces/inlinePces.md`, `../../../core/pces-disaster-recovery.md`.
 - **Invariants:** INV-008 — consensus, once reached, is permanent; INV-005 — every honest event eventually reaches consensus or becomes stale.


### PR DESCRIPTION
**Description**:
Adds a description of the init judge gate in the hashgraph module that prevents previous consensus rounds from being outputted after restart/reconnect and PCES replay.

Fixes #26120 
