### PR TITLE
fix: require explicit opt-in to allow uncheckedSubmit

### DIFF
--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -22,6 +22,8 @@ blockStream.buffer.bufferDirectory=data/block-buffer
 hedera.recordStream.logDir=data/recordStreams
 hedera.recordStream.wrappedRecordHashesDir=data/wrappedRecordHashes
 hedera.profiles.active=DEV
+# Test-only: enables uncheckedSubmit (bypasses ingest pre-checks). Never set on a real network.
+hedera.uncheckedSubmit.enabled=true
 grpc.nodeOperatorPortEnabled=true
 # For CI tests we want to override roster weights from override-network.json
 networkAdmin.preserveStateWeightsDuringOverride=false

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
@@ -123,15 +123,17 @@ public class SubmissionManager {
         // pre-checks. This is used in tests to check the reaction to illegal input.
         // FUTURE This should be deprecated and removed. We do not want this in our production system.
         if (txBody.hasUncheckedSubmit()) {
-            // We do NOT allow this call in production!
-            // check profile dynamically, this way we allow profile overriding in Hapi tests
+            // We do NOT allow this call in production! Default-deny: it must be explicitly enabled, and is
+            // refused on a PROD profile or a public-network ledger id. Read dynamically so Hapi tests can override.
             final var configuration = configProvider.getConfiguration();
             final var hederaConfig = configuration.getConfigData(HederaConfig.class);
             final var ledgerConfig = configuration.getConfigData(LedgerConfig.class);
-            if (hederaConfig.activeProfile() == Profile.PROD
-                    || MAIN_NET_LEDGER_ID.equals(ledgerConfig.id())
-                    || TEST_NET_LEDGER_ID.equals(ledgerConfig.id())
-                    || PREVIEW_NET_LEDGER_ID.equals(ledgerConfig.id())) {
+            final boolean allowed = hederaConfig.uncheckedSubmitEnabled()
+                    && hederaConfig.activeProfile() != Profile.PROD
+                    && !MAIN_NET_LEDGER_ID.equals(ledgerConfig.id())
+                    && !TEST_NET_LEDGER_ID.equals(ledgerConfig.id())
+                    && !PREVIEW_NET_LEDGER_ID.equals(ledgerConfig.id());
+            if (!allowed) {
                 throw new PreCheckException(PLATFORM_TRANSACTION_NOT_CREATED);
             }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
@@ -200,6 +200,7 @@ final class SubmissionManagerTest extends AppTestBase {
             config = () -> new VersionedConfigImpl(
                     HederaTestConfigBuilder.create()
                             .withValue("hedera.profiles.active", "TEST")
+                            .withValue("hedera.uncheckedSubmit.enabled", "true")
                             .withValue("ledger.id", "0x03")
                             .getOrCreateConfig(),
                     1);
@@ -235,6 +236,30 @@ final class SubmissionManagerTest extends AppTestBase {
             verify(platformTxnRejections, never()).cycle();
             // And the deduplication cache is updated
             verify(deduplicationCache).add(any());
+        }
+
+        @Test
+        @DisplayName("An unchecked transaction is refused by default when the flag is not enabled")
+        void testUncheckedSubmitDisabledByDefaultFails() {
+            // Given a non-PROD profile and a custom (non public-network) ledger id, but the
+            // uncheckedSubmit flag left at its secure default of false
+            config = () -> new VersionedConfigImpl(
+                    HederaTestConfigBuilder.create()
+                            .withValue("hedera.profiles.active", "TEST")
+                            .withValue("ledger.id", "0x03")
+                            .getOrCreateConfig(),
+                    1);
+            submissionManager = new SubmissionManager(transactionPool, deduplicationCache, config, mockedMetrics);
+
+            // When we submit an unchecked transaction, then it FAILS because the feature is not enabled
+            assertThatThrownBy(() -> submissionManager.submit(txBody, bytes, false))
+                    .isInstanceOf(PreCheckException.class)
+                    .hasFieldOrPropertyWithValue("responseCode", PLATFORM_TRANSACTION_NOT_CREATED);
+
+            // Then the platform NEVER sees the unchecked bytes
+            verify(transactionPool, never()).submitApplicationTransaction(uncheckedBytes);
+            verify(platformTxnRejections, never()).cycle();
+            verify(deduplicationCache, never()).add(any());
         }
 
         @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
@@ -269,6 +269,7 @@ final class SubmissionManagerTest extends AppTestBase {
             config = () -> new VersionedConfigImpl(
                     HederaTestConfigBuilder.create()
                             .withValue("hedera.profiles.active", "PROD")
+                            .withValue("hedera.uncheckedSubmit.enabled", "true")
                             .withValue("ledger.id", "0x03")
                             .getOrCreateConfig(),
                     1);
@@ -295,6 +296,7 @@ final class SubmissionManagerTest extends AppTestBase {
             config = () -> new VersionedConfigImpl(
                     HederaTestConfigBuilder.create()
                             .withValue("hedera.profiles.active", "TEST")
+                            .withValue("hedera.uncheckedSubmit.enabled", "true")
                             .withValue("ledger.id", "0x00")
                             .getOrCreateConfig(),
                     1);
@@ -321,6 +323,7 @@ final class SubmissionManagerTest extends AppTestBase {
             config = () -> new VersionedConfigImpl(
                     HederaTestConfigBuilder.create()
                             .withValue("hedera.profiles.active", "TEST")
+                            .withValue("hedera.uncheckedSubmit.enabled", "true")
                             .withValue("ledger.id", "0x01")
                             .getOrCreateConfig(),
                     1);
@@ -347,6 +350,7 @@ final class SubmissionManagerTest extends AppTestBase {
             config = () -> new VersionedConfigImpl(
                     HederaTestConfigBuilder.create()
                             .withValue("hedera.profiles.active", "TEST")
+                            .withValue("hedera.uncheckedSubmit.enabled", "true")
                             .withValue("ledger.id", "0x02")
                             .getOrCreateConfig(),
                     1);

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HederaConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HederaConfig.java
@@ -68,6 +68,9 @@ public record HederaConfig(
         @ConfigProperty(value = "profiles.active", defaultValue = "PROD") @NodeProperty
         Profile activeProfile,
 
+        @ConfigProperty(value = "uncheckedSubmit.enabled", defaultValue = "false") @NodeProperty
+        boolean uncheckedSubmitEnabled,
+
         @ConfigProperty(value = "workflow.verificationTimeoutMS", defaultValue = "20000") @NetworkProperty
         long workflowVerificationTimeoutMS,
         // FUTURE: Set<HederaFunctionality>.


### PR DESCRIPTION
**Description**:
The uncheckedSubmit ingest gate was allow-by-default: it only refused on a PROD profile or a mainnet/testnet/previewnet ledger id, so a privately-operated network left at a non-PROD profile with a custom ledger id fell open. Add a node-local hedera.uncheckedSubmit.enabled flag (default false) as the primary gate, keeping the profile/ledger checks as defense-in depth, and enable it only in the dev/test config.