### PR TITLE
ci(workflow): update how release note commits are processed

### DIFF
--- a/.github/workflows/support/scripts/process_json_release_notes.py
+++ b/.github/workflows/support/scripts/process_json_release_notes.py
@@ -123,25 +123,31 @@ class MarkdownRenderer:
     # commit types.
     has_other = self._notes.has_lines(self._other_keys)
 
+    # Build the document as a list of lines. Each populated section is followed
+    # by an empty string, which renders as a blank-line separator once joined.
+    # Joining (rather than trailing each section with "\n") leaves exactly one
+    # newline at end of file.
+    lines = []
     if self._notes.has_lines(self._top_level_keys) or has_other:
-      out.write("# Release Notes\n")
+      lines.append("# Release Notes")
 
     for key in self._top_level_keys:
-      self._write_section(out, key, level=2)
+      self._append_section(lines, key, level=2)
 
     if has_other:
-      out.write("## Other Changes\n")
+      lines.append("## Other Changes")
       for key in self._other_keys:
-        self._write_section(out, key, level=3)
+        self._append_section(lines, key, level=3)
 
-  def _write_section(self, out, key, level):
-    lines = self._notes.lines_for(key)
-    if not lines:
+    out.write("\n".join(lines))
+
+  def _append_section(self, lines, key, level):
+    entries = self._notes.lines_for(key)
+    if not entries:
       return
-    out.write(f"{'#' * level} {self._notes.heading_for(key)}\n")
-    for line in lines:
-      out.write(f"- {line}\n")
-    out.write("\n")
+    lines.append(f"{'#' * level} {self._notes.heading_for(key)}")
+    lines.extend(f"- {entry}" for entry in entries)
+    lines.append("")  # blank-line separator after the section
 
 
 def main():

--- a/.github/workflows/support/scripts/process_json_release_notes.py
+++ b/.github/workflows/support/scripts/process_json_release_notes.py
@@ -1,191 +1,182 @@
 import json
 import os
 import re
-import requests
 import sys
 
-if len(sys.argv) < 3:
-  print("Usage: process_json_release_notes.py <input_json> <output_md>")
-  sys.exit(1)
+import requests
 
-json_file = sys.argv[1]
-output_file = sys.argv[2]
 
-repo = os.environ.get("GITHUB_REPOSITORY")
-if not repo:
-  print("GITHUB_REPOSITORY must be set")
-  sys.exit(1)
+# Ordered category definitions. Each conventional-commit type maps to the
+# heading used in the release notes. "feat" and "fix" get their own top-level
+# sections; everything else is grouped under the "Other Changes" section.
+# Unknown commit types fall through to the FALLBACK_TYPE bucket.
+TOP_LEVEL_SECTIONS = [
+  ("feat", "Features"),
+  ("fix", "Bug Fixes"),
+]
 
-token = os.environ.get("GITHUB_TOKEN")
-if not token:
-  print("GITHUB_TOKEN must be set")
-  sys.exit(1)
+OTHER_SECTIONS = [
+  ("build", "Build System"),
+  ("chore", "Chores"),
+  ("ci", "Continuous Integration"),
+  ("docs", "Documentation Updates"),
+  ("perf", "Performance Improvements"),
+  ("refactor", "Refactoring"),
+  ("style", "Style Changes"),
+  ("test", "Tests"),
+  ("other", "Everything Else"),
+]
 
-pr_url_prefix = f"https://github.com/{repo}/pull/"
+# Bucket key for any commit type we don't explicitly recognize.
+FALLBACK_TYPE = "other"
 
-session = requests.Session()
-session.headers["Authorization"] = f"Bearer {token}"
-session.headers["Accept"] = "application/vnd.github+json"
 
-# cache PR number list if we have multiple PR lookups
-pr_user_cache = {}
+class PrAuthorResolver:
+  """Looks up and caches the GitHub author for a pull request number."""
 
-with open(json_file) as f:
-  data = json.load(f)
+  def __init__(self, repo, token):
+    self._repo = repo
+    self._cache = {}
+    self._session = requests.Session()
+    self._session.headers["Authorization"] = f"Bearer {token}"
+    self._session.headers["Accept"] = "application/vnd.github+json"
 
-features = []
-fixes = []
-build = []
-chore = []
-ci = []
-docs = []
-performance = []
-refactoring = []
-style = []
-tests = []
-others = []
+  def author_for(self, pr_number):
+    if pr_number in self._cache:
+      return self._cache[pr_number]
 
-# func to get the author of a PR
-def get_pr_author(pr_number: str):
-  if pr_number in pr_user_cache:
-    return pr_user_cache[pr_number]
+    url = f"https://api.github.com/repos/{self._repo}/pulls/{pr_number}"
+    resp = self._session.get(url)
+    username = None
+    if resp.status_code == 200:
+      username = resp.json().get("user", {}).get("login")
+    self._cache[pr_number] = username
+    return username
 
-  url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}"
-  resp = session.get(url)
-  if resp.status_code != 200:
-    pr_user_cache[pr_number] = None
-    return None
-  data = resp.json()
-  username = data.get("user", {}).get("login")
-  pr_user_cache[pr_number] = username
-  return username
 
-for item in data:
-  commit_type = item.get("type")
-  desc = item.get("description", "").strip()
-  if not desc:
-    continue
+class DescriptionFormatter:
+  """Turns a raw commit description into a release-notes line: PR references
+  become Markdown links and the resolved PR authors are appended."""
 
-  # find all PR numbers in the release notes
-  pr_numbers = re.findall(r"#(\d+)", desc)
+  PR_REFERENCE = re.compile(r"#(\d+)")
+  PR_PARENTHETICAL = re.compile(r"\(#(\d+)\)")
 
-  # convert PR numbers into links
-  desc = re.sub(r"\(#(\d+)\)", r"[#\1](" + pr_url_prefix + r"\1)", desc)
+  def __init__(self, repo, author_resolver):
+    self._pr_url_prefix = f"https://github.com/{repo}/pull/"
+    self._authors = author_resolver
 
-  # get the authors on the PR
-  authors = []
-  for pr_number in pr_numbers:
-    username = get_pr_author(pr_number)
-    if username:
-      authors.append(f"@{username}")
+  def format(self, desc):
+    pr_numbers = self.PR_REFERENCE.findall(desc)
+    desc = self.PR_PARENTHETICAL.sub(
+      r"[#\1](" + self._pr_url_prefix + r"\1)", desc
+    )
 
-  # deduplicate authors while keeping order
-  seen = set()
-  deduped_authors = []
-  for a in authors:
-    if a not in seen:
-      deduped_authors.append(a)
-      seen.add(a)
+    authors = self._collect_authors(pr_numbers)
+    if authors:
+      desc = f"{desc} by {', '.join(authors)}"
+    return desc
 
-  # add the deduped authors to description
-  if deduped_authors:
-    desc = f"{desc} by {', '.join(deduped_authors)}"
+  def _collect_authors(self, pr_numbers):
+    # Resolve authors, dropping misses and de-duplicating while keeping order.
+    seen = set()
+    authors = []
+    for pr_number in pr_numbers:
+      username = self._authors.author_for(pr_number)
+      if username and username not in seen:
+        authors.append(f"@{username}")
+        seen.add(username)
+    return authors
 
-  # categorize commits by conventional commit type
-  if commit_type == "feat":
-    features.append(desc)
-  elif commit_type == "fix":
-    fixes.append(desc)
-  elif commit_type == "build":
-    build.append(desc)
-  elif commit_type == "chore":
-    chore.append(desc)
-  elif commit_type == "ci":
-    ci.append(desc)
-  elif commit_type == "docs":
-    docs.append(desc)
-  elif commit_type == "perf":
-    performance.append(desc)
-  elif commit_type == "refactor":
-    refactoring.append(desc)
-  elif commit_type == "style":
-    style.append(desc)
-  elif commit_type == "test":
-    tests.append(desc)
-  else:
-    others.append(desc)
 
-# if we have other commits, we'll need to create the Other Changes section
-other_commits_exist = any([
-  build,
-  chore,
-  ci,
-  docs,
-  performance,
-  refactoring,
-  style,
-  tests
-])
+class ReleaseNotes:
+  """Collects formatted release-note lines, bucketed by commit type."""
 
-with open(output_file, "w") as out:
-  if features or fixes or other_commits_exist:
-    out.write("# Release Notes\n")
-  if features:
-    out.write("## Features\n")
-    for f in features:
-      out.write(f"- {f}\n")
+  def __init__(self):
+    self._headings = dict(TOP_LEVEL_SECTIONS + OTHER_SECTIONS)
+    self._lines = {key: [] for key in self._headings}
+
+  def add(self, commit_type, line):
+    key = commit_type if commit_type in self._lines else FALLBACK_TYPE
+    self._lines[key].append(line)
+
+  def lines_for(self, key):
+    return self._lines[key]
+
+  def heading_for(self, key):
+    return self._headings[key]
+
+  def has_lines(self, keys):
+    return any(self._lines[key] for key in keys)
+
+
+class MarkdownRenderer:
+  """Renders collected release notes to Markdown."""
+
+  def __init__(self, notes):
+    self._notes = notes
+    self._top_level_keys = [key for key, _ in TOP_LEVEL_SECTIONS]
+    self._other_keys = [key for key, _ in OTHER_SECTIONS]
+
+  def render(self, out):
+    # The "Other Changes" section is emitted when any non-feat/fix type has
+    # content, including the catch-all FALLBACK_TYPE bucket for unrecognized
+    # commit types.
+    has_other = self._notes.has_lines(self._other_keys)
+
+    if self._notes.has_lines(self._top_level_keys) or has_other:
+      out.write("# Release Notes\n")
+
+    for key in self._top_level_keys:
+      self._write_section(out, key, level=2)
+
+    if has_other:
+      out.write("## Other Changes\n")
+      for key in self._other_keys:
+        self._write_section(out, key, level=3)
+
+  def _write_section(self, out, key, level):
+    lines = self._notes.lines_for(key)
+    if not lines:
+      return
+    out.write(f"{'#' * level} {self._notes.heading_for(key)}\n")
+    for line in lines:
+      out.write(f"- {line}\n")
     out.write("\n")
 
-  if fixes:
-    out.write("## Bug Fixes\n")
-    for f in fixes:
-      out.write(f"- {f}\n")
-    out.write("\n")
 
-  if other_commits_exist:
-    out.write("## Other Changes\n")
-    if build:
-      out.write("### Build System\n")
-      for f in build:
-        out.write(f"- {f}\n")
-      out.write("\n")
-    if chore:
-      out.write("### Chores\n")
-      for f in chore:
-        out.write(f"- {f}\n")
-      out.write("\n")
-    if ci:
-      out.write("### Continuous Integration\n")
-      for f in ci:
-        out.write(f"- {f}\n")
-      out.write("\n")
-    if docs:
-      out.write("### Documentation Updates\n")
-      for f in docs:
-        out.write(f"- {f}\n")
-      out.write("\n")
-    if performance:
-      out.write("### Performance Improvements\n")
-      for f in performance:
-        out.write(f"- {f}\n")
-      out.write("\n")
-    if refactoring:
-      out.write("### Refactoring\n")
-      for f in refactoring:
-        out.write(f"- {f}\n")
-      out.write("\n")
-    if style:
-      out.write("### Style Changes\n")
-      for f in style:
-        out.write(f"- {f}\n")
-      out.write("\n")
-    if tests:
-      out.write("### Tests\n")
-      for f in tests:
-        out.write(f"- {f}\n")
-      out.write("\n")
-    if others:
-      out.write("### Everything Else\n")
-      for f in others:
-        out.write(f"- {f}\n")
-      out.write("\n")
+def main():
+  if len(sys.argv) < 3:
+    print("Usage: process_json_release_notes.py <input_json> <output_md>")
+    sys.exit(1)
+
+  json_file = sys.argv[1]
+  output_file = sys.argv[2]
+
+  repo = os.environ.get("GITHUB_REPOSITORY")
+  if not repo:
+    print("GITHUB_REPOSITORY must be set")
+    sys.exit(1)
+
+  token = os.environ.get("GITHUB_TOKEN")
+  if not token:
+    print("GITHUB_TOKEN must be set")
+    sys.exit(1)
+
+  with open(json_file) as f:
+    data = json.load(f)
+
+  formatter = DescriptionFormatter(repo, PrAuthorResolver(repo, token))
+  notes = ReleaseNotes()
+
+  for item in data:
+    desc = item.get("description", "").strip()
+    if not desc:
+      continue
+    notes.add(item.get("type"), formatter.format(desc))
+
+  with open(output_file, "w") as out:
+    MarkdownRenderer(notes).render(out)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
**Description**:

Update how the release notes for commits are built and processed.

**Related Issue(s)**:

Implements #22370

**Testing**:

Ran 2 workflow runs of the `Generate Release Notes` workflow against the `v0.74.0` tag.
- Workflow from `main` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/28379507438) ✅ 
- Workflow from `private branch` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/28391130430) ✅ 

Downloaded both artifacts output from above workflows and compared identical to one another.