### PR TITLE
ci(workflow-action-fix): update setup-gradle action input parameter

### DIFF
--- a/.github/workflows/816-call-build-publish-state-validator.yaml
+++ b/.github/workflows/816-call-build-publish-state-validator.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: true
 
       - name: Build State Validator Uber shadowJar
         run: |


### PR DESCRIPTION
**Description**:

The `gradle-home-cache-cleanup` input was deprecated in the `setup-gradle` action. We will instead use the `cache-cleanup` input.

**Related Issue(s)**:

Implements #26135

**Testing**:

XTS Dry Run [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/28391551799) ✅ 
