### PR TITLE
chore: minor hardening fixes for block node communication

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -478,6 +478,18 @@ public class BlockNodeConnectionManager {
                 continue;
             }
 
+            final BlockNodeEndpoint streamingEndpoint = node.configuration().streamingEndpoint();
+
+            if (status.latestBlockAvailable() < -1 || willAdditionOverflow(status.latestBlockAvailable(), 1)) {
+                node.applyCoolDown(new BlockNodeOutOfRange(Long.MAX_VALUE));
+                logger.info(
+                        "[{}:{}] Block node is not a candidate for streaming (reason: block out of range (latestBlockAvailable: {}))",
+                        streamingEndpoint.host(),
+                        streamingEndpoint.port(),
+                        status.latestBlockAvailable());
+                continue;
+            }
+
             /*
             There is a scenario in which this consensus node may not have any blocks loaded. For example, this node may
             be initializing for the first time or the node may have restarted but there aren't any buffered blocks that
@@ -488,7 +500,6 @@ public class BlockNodeConnectionManager {
             node, then existing reconnect operations will engage to sort things out.
              */
 
-            final BlockNodeEndpoint streamingEndpoint = node.configuration().streamingEndpoint();
             final long wantedBlock = status.latestBlockAvailable() == -1 ? -1 : status.latestBlockAvailable() + 1;
             if (latestAvailableBlock != -1) {
                 if (wantedBlock != -1 && wantedBlock < earliestAvailableBlock) {
@@ -537,6 +548,16 @@ public class BlockNodeConnectionManager {
                 .filter(c -> c.wantedBlock() == lowestAheadWantedBlock)
                 .toList();
         return new GroupSelectionOutcome(List.of(), lowestAheadCandidates, lowestAheadWantedBlock);
+    }
+
+    /**
+     * @param x the first value
+     * @param y the second value
+     * @return true if the addition of the specified values will overflow a long, else false
+     */
+    private static boolean willAdditionOverflow(final long x, final long y) {
+        final long r = x + y;
+        return ((x ^ r) & (y ^ r)) < 0;
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStats.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStats.java
@@ -7,11 +7,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Queue;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Tracks information for a block node across multiple connection instances.
@@ -19,6 +22,11 @@ import java.util.concurrent.atomic.AtomicInteger;
  * implement rate limiting and health monitoring.
  */
 public class BlockNodeStats {
+    /**
+     * Maximum number of entries to track in the block proof timing dataset.
+     */
+    static final int MAX_BLOCK_PROOF_TRACKING_ENTRIES = 100;
+
     /**
      * Queue for tracking EndOfStream response timestamps for rate limiting.
      */
@@ -32,13 +40,13 @@ public class BlockNodeStats {
     /**
      * Timestamp when the current BehindPublisher ignore period ends. Null if not currently ignoring.
      */
-    private Instant behindPublisherIgnoreUntil;
+    private final AtomicReference<Instant> behindPublisherIgnoreUntil = new AtomicReference<>();
 
     /**
      * Map for tracking the timestamps when blocks are sent to the block node.
      * The key is the block number and the value is the timestamp when the block was sent.
      */
-    private final Map<Long, Instant> blockProofSendTimestamps = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Long, Instant> blockProofSendTimestamps = new ConcurrentHashMap<>();
 
     /**
      * Counter for tracking consecutive high-latency events.
@@ -160,16 +168,17 @@ public class BlockNodeStats {
 
         // If the queue is empty, we're in a new window - reset the ignore period
         if (behindPublisherTimestamps.isEmpty()) {
-            behindPublisherIgnoreUntil = null;
+            behindPublisherIgnoreUntil.set(null);
         }
 
         // Check if we're within the ignore period
-        if (behindPublisherIgnoreUntil != null && now.isBefore(behindPublisherIgnoreUntil)) {
+        final Instant ignoreUntilTimestamp = behindPublisherIgnoreUntil.get();
+        if (ignoreUntilTimestamp != null && now.isBefore(ignoreUntilTimestamp)) {
             return true;
         }
 
         // Start a new ignore period
-        behindPublisherIgnoreUntil = now.plus(ignorePeriod);
+        behindPublisherIgnoreUntil.set(now.plus(ignorePeriod));
         return false;
     }
 
@@ -182,6 +191,17 @@ public class BlockNodeStats {
     public void recordBlockProofSent(final long blockNumber, @NonNull final Instant timestamp) {
         requireNonNull(timestamp, "timestamp must not be null");
         blockProofSendTimestamps.put(blockNumber, timestamp);
+
+        if (blockProofSendTimestamps.size() > MAX_BLOCK_PROOF_TRACKING_ENTRIES) {
+            // There are a lot of block proof timestamps held that aren't being cleared, likely because we are not
+            // receiving acknowledgements fast enough. To guard against a slow memory leak, prune the oldest entries.
+            final int numToRemove = blockProofSendTimestamps.size() - MAX_BLOCK_PROOF_TRACKING_ENTRIES;
+            final SortedSet<Long> sortedKeys = new TreeSet<>(blockProofSendTimestamps.keySet());
+            for (int i = 0; i < numToRemove; ++i) {
+                final long blockNumberToRemove = sortedKeys.removeFirst();
+                blockProofSendTimestamps.remove(blockNumberToRemove);
+            }
+        }
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * A "block state" is the collection of items contained with a single block and can be streamed to a block node.
@@ -48,7 +49,7 @@ public class BlockState {
     /**
      * The size of the block in bytes.
      */
-    private long sizeBytes;
+    private final LongAdder sizeBytes = new LongAdder();
     /**
      * Monotonic nanoTime when this block was opened. Used for latency computation.
      */
@@ -100,7 +101,7 @@ public class BlockState {
             openedNanos = System.nanoTime();
             openedTimestamp = Instant.now();
         }
-        sizeBytes += serializedItem.length();
+        sizeBytes.add(serializedItem.length());
 
         return index;
     }
@@ -175,7 +176,7 @@ public class BlockState {
      * @return the size of the block in bytes
      */
     public long sizeBytes() {
-        return sizeBytes;
+        return sizeBytes.sum();
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -802,6 +802,10 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         when(node1.configuration()).thenReturn(newBlockNodeConfig("localhost", 1234, 1));
         final BlockNode node2 = mock(BlockNode.class);
         when(node2.configuration()).thenReturn(newBlockNodeConfig("localhost", 2345, 1));
+        final BlockNode node3 = mock(BlockNode.class);
+        when(node3.configuration()).thenReturn(newBlockNodeConfig("localhost", 3456, 1));
+        final BlockNode node4 = mock(BlockNode.class);
+        when(node4.configuration()).thenReturn(newBlockNodeConfig("localhost", 4567, 1));
         when(bufferService.getEarliestAvailableBlockNumber()).thenReturn(10L);
         when(bufferService.getLastBlockNumberProduced()).thenReturn(20L);
         final Future<Object> node1Future = mock(Future.class);
@@ -810,10 +814,16 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         final Future<Object> node2Future = mock(Future.class);
         when(node2Future.state()).thenReturn(State.SUCCESS);
         when(node2Future.resultNow()).thenReturn(new BlockNodeStatus(true, 10, 14));
+        final Future<Object> node3Future = mock(Future.class);
+        when(node3Future.state()).thenReturn(State.SUCCESS);
+        when(node3Future.resultNow()).thenReturn(new BlockNodeStatus(true, 10, Long.MAX_VALUE));
+        final Future<Object> node4Future = mock(Future.class);
+        when(node4Future.state()).thenReturn(State.SUCCESS);
+        when(node4Future.resultNow()).thenReturn(new BlockNodeStatus(true, 10, -100L));
         when(blockingIoExecutor.invokeAll(anyCollection(), anyLong(), any(TimeUnit.class)))
-                .thenReturn(List.of(node1Future, node2Future));
+                .thenReturn(List.of(node1Future, node2Future, node3Future, node4Future));
 
-        final GroupSelectionOutcome outcome = invoke_findAvailableNode(List.of(node1, node2));
+        final GroupSelectionOutcome outcome = invoke_findAvailableNode(List.of(node1, node2, node3, node4));
 
         assertThat(outcome).isNotNull();
         assertThat(outcome.inRangeCandidates())
@@ -827,13 +837,23 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         verify(node1Future).resultNow();
         verify(node2Future).state();
         verify(node2Future).resultNow();
+        verify(node3Future).state();
+        verify(node3Future).resultNow();
+        verify(node4Future).state();
+        verify(node4Future).resultNow();
         verify(node1, times(3)).configuration();
         verify(node2, times(3)).configuration();
+        verify(node3, times(3)).configuration();
+        verify(node4, times(3)).configuration();
         verify(node1).onServerStatusCheck(any(BlockNodeStatus.class));
         verify(node2).onServerStatusCheck(any(BlockNodeStatus.class));
+        verify(node3).onServerStatusCheck(any(BlockNodeStatus.class));
+        verify(node4).onServerStatusCheck(any(BlockNodeStatus.class));
+        verify(node3).applyCoolDown(any(BlockNodeOutOfRange.class));
+        verify(node4).applyCoolDown(any(BlockNodeOutOfRange.class));
         verifyNoMoreInteractions(blockingIoExecutor);
-        verifyNoMoreInteractions(node1Future, node2Future);
-        verifyNoMoreInteractions(node1, node2);
+        verifyNoMoreInteractions(node1Future, node2Future, node3Future, node4Future);
+        verifyNoMoreInteractions(node1, node2, node3, node4);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStatsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStatsTest.java
@@ -3,8 +3,12 @@ package com.hedera.node.app.blocks.impl.streaming;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.VarHandle;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ConcurrentMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,6 +16,19 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BlockNodeStatsTest {
+
+    private static final VarHandle blockProofSendTimestampsHandle;
+
+    static {
+        try {
+            final Class<BlockNodeStats> cls = BlockNodeStats.class;
+            final Lookup lookup = MethodHandles.privateLookupIn(cls, MethodHandles.lookup());
+
+            blockProofSendTimestampsHandle = lookup.findVarHandle(cls, "blockProofSendTimestamps", ConcurrentMap.class);
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     private BlockNodeStats blockNodeStats;
 
@@ -177,5 +194,36 @@ class BlockNodeStatsTest {
         // Third message in new window (after timeframe expires, queue empty due to pruning) - should NOT be ignored
         assertThat(blockNodeStats.shouldIgnoreBehindPublisher(now.plusSeconds(35), ignorePeriod, timeFrame))
                 .isFalse();
+    }
+
+    @Test
+    void testRecordBlockProofSent_pruneOldEntries() {
+        final int numBlocksToPrime = BlockNodeStats.MAX_BLOCK_PROOF_TRACKING_ENTRIES - 1;
+        final ConcurrentMap<Long, Instant> blockProofSendTimestamps = blockProofSendTimestamps();
+        long blockNumber = 0;
+
+        for (; blockNumber < numBlocksToPrime; ++blockNumber) {
+            blockProofSendTimestamps.put(blockNumber, Instant.now());
+        }
+
+        assertThat(blockProofSendTimestamps).hasSize(numBlocksToPrime);
+
+        // we should now be at MAX_SIZE - 1, so adding another entry should prune anything
+        blockNodeStats.recordBlockProofSent(++blockNumber, Instant.now());
+        assertThat(blockProofSendTimestamps)
+                .hasSize(BlockNodeStats.MAX_BLOCK_PROOF_TRACKING_ENTRIES)
+                .containsKey(0L); // make sure the oldest key exists
+
+        // now if we add another entry, the oldest should be removed and the new one should exist
+        blockNodeStats.recordBlockProofSent(++blockNumber, Instant.now());
+        assertThat(blockProofSendTimestamps)
+                .hasSize(BlockNodeStats.MAX_BLOCK_PROOF_TRACKING_ENTRIES)
+                .containsKey(blockNumber) // make sure the new entry exists
+                .doesNotContainKey(0L); // make sure the oldest entry is now removed
+    }
+
+    @SuppressWarnings("unchecked")
+    private ConcurrentMap<Long, Instant> blockProofSendTimestamps() {
+        return (ConcurrentMap<Long, Instant>) blockProofSendTimestampsHandle.get(blockNodeStats);
     }
 }


### PR DESCRIPTION
**Description**:
Various minor hardening improvements for block stream communications, including:
* Better handling of BN status API responses for out of bounds latest block available
* Concurrency fixes
* Make sure some of the datasets in the block node stats are size bound so they don't grow too big/forever

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
