### PR TITLE
ci(workflow-fix): update gradle cache cleanup to default behavior

### DIFF
--- a/.github/workflows/816-call-build-publish-state-validator.yaml
+++ b/.github/workflows/816-call-build-publish-state-validator.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
         with:
-          cache-cleanup: true
+          cache-cleanup: always
 
       - name: Build State Validator Uber shadowJar
         run: |

--- a/.github/workflows/816-call-build-publish-state-validator.yaml
+++ b/.github/workflows/816-call-build-publish-state-validator.yaml
@@ -68,8 +68,6 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
-        with:
-          cache-cleanup: always
 
       - name: Build State Validator Uber shadowJar
         run: |


### PR DESCRIPTION
**Description**:

The setup gradle action has been changed from a boolean (true/false) to a list of options: always, on-success, never.

This update changes from `true` and removes the flag entirely, which defaults to `on-success`.

**Related Issue(s)**:

Implements #26139
