### PR TITLE
feat: #26115 - skip WRAPS proving key download when artifacts already present

### DIFF
--- a/.github/workflows/105-user-publish-wraps-key.yaml
+++ b/.github/workflows/105-user-publish-wraps-key.yaml
@@ -79,6 +79,10 @@ jobs:
           done
           (cd "${STAGING_DIR}" && sha384sum decider_pp.bin decider_vp.bin nova_pp.bin nova_vp.bin | tee "${RUNNER_TEMP}/expected-artifact-hashes.txt")
 
+          # Sidecar consumed by the consensus node to detect the artifacts are already in place and
+          # skip re-downloading the archive (see WrapsProvingKeyVerification#WRAPS_HASH_FILE_NAME).
+          printf '%s\n' "${actual_sha384}" > "${STAGING_DIR}/wraps.sha384"
+
       - name: Setup QEmu Support
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
@@ -112,6 +116,7 @@ jobs:
       - name: Verify Published Image
         env:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          TARBALL_SHA384: ${{ steps.download.outputs.tarball-sha384 }}
         run: |
           docker pull "${IMAGE_NAME}@${IMAGE_DIGEST}"
           cid="$(docker create "${IMAGE_NAME}@${IMAGE_DIGEST}" true)"
@@ -119,6 +124,11 @@ jobs:
           docker cp "${cid}:/." "${RUNNER_TEMP}/verify/"
           docker rm "${cid}" >/dev/null
           (cd "${RUNNER_TEMP}/verify" && sha384sum -c "${RUNNER_TEMP}/expected-artifact-hashes.txt")
+          got="$(tr -d '[:space:]' < "${RUNNER_TEMP}/verify/wraps.sha384")"
+          if [[ "${got}" != "${TARBALL_SHA384}" ]]; then
+            echo "::error::wraps.sha384 in image (${got}) does not match tarball SHA-384 (${TARBALL_SHA384})"
+            exit 1
+          fi
 
       - name: Job Summary
         env:

--- a/.github/workflows/105-user-publish-wraps-key.yaml
+++ b/.github/workflows/105-user-publish-wraps-key.yaml
@@ -79,7 +79,7 @@ jobs:
           done
           (cd "${STAGING_DIR}" && sha384sum decider_pp.bin decider_vp.bin nova_pp.bin nova_vp.bin | tee "${RUNNER_TEMP}/expected-artifact-hashes.txt")
 
-          # Sidecar consumed by the consensus node to detect the artifacts are already in place and
+          # Hash file consumed by the consensus node to detect the artifacts are already in place and
           # skip re-downloading the archive (see WrapsProvingKeyVerification#WRAPS_HASH_FILE_NAME).
           printf '%s\n' "${actual_sha384}" > "${STAGING_DIR}/wraps.sha384"
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
@@ -46,10 +46,11 @@ import org.apache.logging.log4j.Logger;
  *
  * <p>To avoid re-downloading and re-extracting the multi-gigabyte archive on every startup when the
  * extracted artifacts are already present (e.g. mounted from the published data-only image), a
- * sidecar hash file ({@value #WRAPS_HASH_FILE_NAME}) is consulted in the artifacts directory before
- * any download. If the sidecar's hash matches {@code tss.wrapsProvingKeyHash} and the required
- * artifacts are present, the download and extraction are skipped entirely. After a successful
- * extraction the sidecar is (re)written so subsequent startups can short-circuit.
+ * hash file ({@value #WRAPS_HASH_FILE_NAME}) is consulted in the artifacts directory before any
+ * download. If its hash matches {@code tss.wrapsProvingKeyHash} and the required artifacts are
+ * present, the download and extraction are skipped entirely. After a successful extraction the hash
+ * file is (re)written so subsequent startups can short-circuit. (This hash file is unrelated to
+ * record-stream sidecar files.)
  */
 public class WrapsProvingKeyVerification {
     private static final Logger log = LogManager.getLogger(WrapsProvingKeyVerification.class);
@@ -57,7 +58,7 @@ public class WrapsProvingKeyVerification {
     static final String WRAPS_ARTIFACTS_ENV_VAR = "TSS_LIB_WRAPS_ARTIFACTS_PATH";
 
     /**
-     * Name of the sidecar file written into the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} directory that
+     * Name of the hash file written into the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} directory that
      * holds the SHA-384 hash (bare lowercase hex) of the proving key archive the artifacts were
      * extracted from. Its presence and value let a node skip re-downloading when the artifacts are
      * already in place. Must match the file produced by the published proving-key image build.
@@ -120,7 +121,7 @@ public class WrapsProvingKeyVerification {
         final var envArtifactsPath = System.getenv(WRAPS_ARTIFACTS_ENV_VAR);
         validateArtifactsPathConsistency(provingKeyPath, envArtifactsPath);
 
-        // If the extracted artifacts are already in place with a sidecar hash matching config, there is
+        // If the extracted artifacts are already in place with a hash file matching config, there is
         // nothing to download or extract (e.g. the artifacts directory is mounted from the published image).
         if (artifactsAlreadyPresent(envArtifactsPath, bootstrapHash)) {
             log.info(
@@ -138,7 +139,7 @@ public class WrapsProvingKeyVerification {
     /**
      * Determines whether the extracted WRAPS artifacts are already present in the artifacts directory
      * and up to date, so that the archive download and extraction can be skipped. This is the case when
-     * the sidecar hash file ({@value #WRAPS_HASH_FILE_NAME}) exists, its contents match the expected
+     * the hash file ({@value #WRAPS_HASH_FILE_NAME}) exists, its contents match the expected
      * archive hash from config, and all {@link #REQUIRED_ARTIFACT_FILES} are present.
      *
      * @param envArtifactsPath the value of the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} env var, or null
@@ -350,7 +351,7 @@ public class WrapsProvingKeyVerification {
     }
 
     /**
-     * Writes the sidecar hash file ({@value #WRAPS_HASH_FILE_NAME}) into the artifacts directory so that
+     * Writes the hash file ({@value #WRAPS_HASH_FILE_NAME}) into the artifacts directory so that
      * subsequent startups can detect the artifacts are already present and skip the download/extraction.
      * A failure to write (e.g. a read-only mount) is logged but is non-fatal: the extracted artifacts
      * remain usable.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
@@ -43,11 +43,27 @@ import org.apache.logging.log4j.Logger;
  * <p>After successful hash verification, the proving key archive (.tar.gz) is extracted
  * to the directory specified by the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} environment variable.
  * The {@code tss.wrapsProvingKeyPath} config controls only where the archive file is stored on disk.
+ *
+ * <p>To avoid re-downloading and re-extracting the multi-gigabyte archive on every startup when the
+ * extracted artifacts are already present (e.g. mounted from the published data-only image), a
+ * sidecar hash file ({@value #WRAPS_HASH_FILE_NAME}) is consulted in the artifacts directory before
+ * any download. If the sidecar's hash matches {@code tss.wrapsProvingKeyHash} and the required
+ * artifacts are present, the download and extraction are skipped entirely. After a successful
+ * extraction the sidecar is (re)written so subsequent startups can short-circuit.
  */
 public class WrapsProvingKeyVerification {
     private static final Logger log = LogManager.getLogger(WrapsProvingKeyVerification.class);
 
     static final String WRAPS_ARTIFACTS_ENV_VAR = "TSS_LIB_WRAPS_ARTIFACTS_PATH";
+
+    /**
+     * Name of the sidecar file written into the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} directory that
+     * holds the SHA-384 hash (bare lowercase hex) of the proving key archive the artifacts were
+     * extracted from. Its presence and value let a node skip re-downloading when the artifacts are
+     * already in place. Must match the file produced by the published proving-key image build.
+     */
+    static final String WRAPS_HASH_FILE_NAME = "wraps.sha384";
+
     public static final int READ_BUFFER_SIZE = 50 * 1024 * 1024; // ~50 MB
     static final Set<String> REQUIRED_ARTIFACT_FILES =
             Set.of("decider_pp.bin", "decider_vp.bin", "nova_pp.bin", "nova_vp.bin");
@@ -101,11 +117,71 @@ public class WrapsProvingKeyVerification {
         log.info("WRAPS proving key hash from config: {}", expectedHash);
 
         final var provingKeyPath = Paths.get(tssConfig.wrapsProvingKeyPath());
-        validateArtifactsPathConsistency(provingKeyPath, System.getenv(WRAPS_ARTIFACTS_ENV_VAR));
+        final var envArtifactsPath = System.getenv(WRAPS_ARTIFACTS_ENV_VAR);
+        validateArtifactsPathConsistency(provingKeyPath, envArtifactsPath);
+
+        // If the extracted artifacts are already in place with a sidecar hash matching config, there is
+        // nothing to download or extract (e.g. the artifacts directory is mounted from the published image).
+        if (artifactsAlreadyPresent(envArtifactsPath, bootstrapHash)) {
+            log.info(
+                    "WRAPS artifacts already present in {} with matching {} hash; skipping download and extraction",
+                    envArtifactsPath,
+                    WRAPS_HASH_FILE_NAME);
+            return;
+        }
 
         final var downloadUrl = tssConfig.wrapsProvingKeyDownloadUrl();
         final var retryInterval = tssConfig.wrapsProvingKeyRetryInterval();
         verifyFileAndDownloadIfNeeded(provingKeyPath, bootstrapHash, downloadUrl, downloader, retryInterval);
+    }
+
+    /**
+     * Determines whether the extracted WRAPS artifacts are already present in the artifacts directory
+     * and up to date, so that the archive download and extraction can be skipped. This is the case when
+     * the sidecar hash file ({@value #WRAPS_HASH_FILE_NAME}) exists, its contents match the expected
+     * archive hash from config, and all {@link #REQUIRED_ARTIFACT_FILES} are present.
+     *
+     * @param envArtifactsPath the value of the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} env var, or null
+     * @param expectedHashHex the expected archive hash (bare hex) from {@code tss.wrapsProvingKeyHash}
+     * @return true if the artifacts are already present and match; false if a download is needed
+     */
+    static boolean artifactsAlreadyPresent(
+            @Nullable final String envArtifactsPath, @NonNull final String expectedHashHex) {
+        if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
+            return false;
+        }
+        final var artifactsDir = Paths.get(envArtifactsPath);
+        final var hashFile = artifactsDir.resolve(WRAPS_HASH_FILE_NAME);
+        if (!Files.isRegularFile(hashFile)) {
+            return false;
+        }
+        final String storedHash;
+        try {
+            storedHash = Files.readString(hashFile).trim();
+        } catch (final IOException e) {
+            log.warn("Failed to read WRAPS hash file {}; will verify the archive instead", hashFile, e);
+            return false;
+        }
+        if (!storedHash.equalsIgnoreCase(expectedHashHex.trim())) {
+            log.info(
+                    "WRAPS hash file {} ({}) does not match configured hash ({}); will download and extract",
+                    hashFile,
+                    storedHash,
+                    expectedHashHex);
+            return false;
+        }
+        final var missingArtifacts = REQUIRED_ARTIFACT_FILES.stream()
+                .filter(name -> !Files.isRegularFile(artifactsDir.resolve(name)))
+                .toList();
+        if (!missingArtifacts.isEmpty()) {
+            log.warn(
+                    "WRAPS hash file {} matches config but artifacts {} are missing in {}; will download and extract",
+                    hashFile,
+                    missingArtifacts,
+                    artifactsDir);
+            return false;
+        }
+        return true;
     }
 
     private void verifyFileAndDownloadIfNeeded(
@@ -131,7 +207,7 @@ public class WrapsProvingKeyVerification {
             return;
         }
         // Hash matches - extract the archive
-        tryExtractTarGz(provingKeyPath);
+        tryExtractTarGz(provingKeyPath, expectedHash.toHex());
     }
 
     private void asyncDownloadAndVerify(
@@ -153,7 +229,7 @@ public class WrapsProvingKeyVerification {
                             scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
                             return;
                         }
-                        tryExtractTarGz(provingKeyPath);
+                        tryExtractTarGz(provingKeyPath, expectedHash.toHex());
                         log.info("Successfully downloaded and verified WRAPS proving key (hash={})", expectedHash);
                     } catch (final Throwable t) {
                         log.error(
@@ -185,7 +261,7 @@ public class WrapsProvingKeyVerification {
                         downloader.download(downloadUrl, provingKeyPath);
                         final Bytes downloadedHash = hashFile(provingKeyPath);
                         if (downloadedHash.equals(expectedHash)) {
-                            tryExtractTarGz(provingKeyPath);
+                            tryExtractTarGz(provingKeyPath, expectedHash.toHex());
                             log.info(
                                     "Successfully downloaded and verified WRAPS proving key on retry (hash={})",
                                     expectedHash);
@@ -253,7 +329,7 @@ public class WrapsProvingKeyVerification {
 
     // --- Tar.gz extraction ---
 
-    private static void tryExtractTarGz(@NonNull final Path tarGzPath) {
+    private static void tryExtractTarGz(@NonNull final Path tarGzPath, @NonNull final String expectedHashHex) {
         final var envArtifactsPath = System.getenv(WRAPS_ARTIFACTS_ENV_VAR);
         if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
             log.warn(
@@ -267,8 +343,28 @@ public class WrapsProvingKeyVerification {
             TarGzExtractor.extract(tarGzPath, extractionDir);
             log.info("Extracted WRAPS proving key archive {} to {}", tarGzPath, extractionDir);
             verifyArtifactsDirectoryExists();
+            writeHashFile(extractionDir, expectedHashHex);
         } catch (final IOException e) {
             log.error("Failed to extract WRAPS proving key archive {}", tarGzPath, e);
+        }
+    }
+
+    /**
+     * Writes the sidecar hash file ({@value #WRAPS_HASH_FILE_NAME}) into the artifacts directory so that
+     * subsequent startups can detect the artifacts are already present and skip the download/extraction.
+     * A failure to write (e.g. a read-only mount) is logged but is non-fatal: the extracted artifacts
+     * remain usable.
+     *
+     * @param extractionDir the directory the artifacts were extracted into
+     * @param hashHex the archive hash (bare hex) to record
+     */
+    private static void writeHashFile(@NonNull final Path extractionDir, @NonNull final String hashHex) {
+        final var hashFile = extractionDir.resolve(WRAPS_HASH_FILE_NAME);
+        try {
+            Files.writeString(hashFile, hashHex);
+            log.info("Wrote WRAPS proving key hash file {} ({})", hashFile, hashHex);
+        } catch (final IOException e) {
+            log.error("Failed to write WRAPS proving key hash file {}", hashFile, e);
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
@@ -365,10 +365,10 @@ class WrapsProvingKeyVerificationTest {
         verify(scheduledFuture, Mockito.never()).cancel(Mockito.anyBoolean());
     }
 
-    // ===== sidecar hash file logic =====
+    // ===== hash file logic =====
 
     @Test
-    void artifactsAlreadyPresentTrueWhenSidecarMatchesAndArtifactsPresent() throws IOException {
+    void artifactsAlreadyPresentTrueWhenHashFileMatchesAndArtifactsPresent() throws IOException {
         writeRequiredArtifacts(tempDir);
         Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
 
@@ -386,7 +386,7 @@ class WrapsProvingKeyVerificationTest {
     }
 
     @Test
-    void artifactsAlreadyPresentFalseWhenSidecarMismatches() throws IOException {
+    void artifactsAlreadyPresentFalseWhenHashFileMismatches() throws IOException {
         writeRequiredArtifacts(tempDir);
         Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), "bb".repeat(48));
 
@@ -395,14 +395,14 @@ class WrapsProvingKeyVerificationTest {
 
     @Test
     void artifactsAlreadyPresentFalseWhenArtifactMissing() throws IOException {
-        // Sidecar matches config but a required artifact file is absent
+        // Hash file matches config but a required artifact file is absent
         Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
 
         assertFalse(artifactsAlreadyPresent(tempDir.toString(), HASH_A.toHex()));
     }
 
     @Test
-    void artifactsAlreadyPresentFalseWhenNoSidecar() throws IOException {
+    void artifactsAlreadyPresentFalseWhenNoHashFile() throws IOException {
         writeRequiredArtifacts(tempDir);
 
         assertFalse(artifactsAlreadyPresent(tempDir.toString(), HASH_A.toHex()));
@@ -416,12 +416,13 @@ class WrapsProvingKeyVerificationTest {
     }
 
     @Test
-    void skipsDownloadWhenSidecarMatchesAndArtifactsPresent(final EnvironmentVariables environment) throws IOException {
+    void skipsDownloadWhenHashFileMatchesAndArtifactsPresent(final EnvironmentVariables environment)
+            throws IOException {
         writeRequiredArtifacts(tempDir);
         Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
         environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
 
-        // No archive on disk; only the extracted artifacts + sidecar are present (mounted-image scenario)
+        // No archive on disk; only the extracted artifacts + hash file are present (mounted-image scenario)
         given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
         given(tssConfig.wrapsProvingKeyHash()).willReturn(HASH_A.toHex());
         given(tssConfig.wrapsProvingKeyPath())
@@ -433,7 +434,7 @@ class WrapsProvingKeyVerificationTest {
     }
 
     @Test
-    void downloadsWhenSidecarMismatches(final EnvironmentVariables environment) throws Exception {
+    void downloadsWhenHashFileMismatches(final EnvironmentVariables environment) throws Exception {
         writeRequiredArtifacts(tempDir);
         Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), "bb".repeat(48));
         environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
@@ -448,8 +449,8 @@ class WrapsProvingKeyVerificationTest {
     }
 
     @Test
-    void downloadsWhenSidecarMatchesButArtifactMissing(final EnvironmentVariables environment) throws Exception {
-        // Sidecar matches config but a required artifact is missing -> not "already present"
+    void downloadsWhenHashFileMatchesButArtifactMissing(final EnvironmentVariables environment) throws Exception {
+        // Hash file matches config but a required artifact is missing -> not "already present"
         Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
         environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
 
@@ -463,7 +464,7 @@ class WrapsProvingKeyVerificationTest {
     }
 
     @Test
-    void writesSidecarAfterSuccessfulExtraction(final EnvironmentVariables environment) throws Exception {
+    void writesHashFileAfterSuccessfulExtraction(final EnvironmentVariables environment) throws Exception {
         // A real archive containing the four required artifacts, present on disk and matching config
         final byte[] archiveBytes = createTarGz(
                 entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
@@ -483,14 +484,14 @@ class WrapsProvingKeyVerificationTest {
 
         subject.ensureProvingKey(configuration, downloader);
 
-        // No download (archive already present and verified); artifacts extracted; sidecar written
+        // No download (archive already present and verified); artifacts extracted; hash file written
         verifyNoInteractions(downloader);
         for (final var artifact : WrapsProvingKeyVerification.REQUIRED_ARTIFACT_FILES) {
             assertTrue(Files.isRegularFile(extractionDir.resolve(artifact)), "missing extracted artifact " + artifact);
         }
-        final var sidecar = extractionDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME);
-        assertTrue(Files.isRegularFile(sidecar), "sidecar hash file was not written");
-        assertEquals(archiveHash, Files.readString(sidecar).trim());
+        final var hashFile = extractionDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME);
+        assertTrue(Files.isRegularFile(hashFile), "hash file was not written");
+        assertEquals(archiveHash, Files.readString(hashFile).trim());
     }
 
     // ===== helpers =====

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
@@ -2,8 +2,11 @@
 package com.hedera.node.app.history;
 
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
+import static com.hedera.node.app.history.WrapsProvingKeyVerification.artifactsAlreadyPresent;
 import static com.hedera.node.app.history.WrapsProvingKeyVerification.validateArtifactsPathConsistency;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,8 +23,10 @@ import com.hedera.cryptography.wraps.WRAPSLibraryBridge;
 import com.hedera.node.config.data.TssConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -29,6 +34,7 @@ import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.GZIPOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -359,6 +365,134 @@ class WrapsProvingKeyVerificationTest {
         verify(scheduledFuture, Mockito.never()).cancel(Mockito.anyBoolean());
     }
 
+    // ===== sidecar hash file logic =====
+
+    @Test
+    void artifactsAlreadyPresentTrueWhenSidecarMatchesAndArtifactsPresent() throws IOException {
+        writeRequiredArtifacts(tempDir);
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
+
+        assertTrue(artifactsAlreadyPresent(tempDir.toString(), HASH_A.toHex()));
+    }
+
+    @Test
+    void artifactsAlreadyPresentTrimsAndIgnoresCase() throws IOException {
+        writeRequiredArtifacts(tempDir);
+        Files.writeString(
+                tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME),
+                "  " + HASH_A.toHex().toUpperCase() + "\n");
+
+        assertTrue(artifactsAlreadyPresent(tempDir.toString(), HASH_A.toHex()));
+    }
+
+    @Test
+    void artifactsAlreadyPresentFalseWhenSidecarMismatches() throws IOException {
+        writeRequiredArtifacts(tempDir);
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), "bb".repeat(48));
+
+        assertFalse(artifactsAlreadyPresent(tempDir.toString(), HASH_A.toHex()));
+    }
+
+    @Test
+    void artifactsAlreadyPresentFalseWhenArtifactMissing() throws IOException {
+        // Sidecar matches config but a required artifact file is absent
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
+
+        assertFalse(artifactsAlreadyPresent(tempDir.toString(), HASH_A.toHex()));
+    }
+
+    @Test
+    void artifactsAlreadyPresentFalseWhenNoSidecar() throws IOException {
+        writeRequiredArtifacts(tempDir);
+
+        assertFalse(artifactsAlreadyPresent(tempDir.toString(), HASH_A.toHex()));
+    }
+
+    @Test
+    void artifactsAlreadyPresentFalseWhenEnvPathNullOrBlank() {
+        assertFalse(artifactsAlreadyPresent(null, HASH_A.toHex()));
+        assertFalse(artifactsAlreadyPresent("", HASH_A.toHex()));
+        assertFalse(artifactsAlreadyPresent("   ", HASH_A.toHex()));
+    }
+
+    @Test
+    void skipsDownloadWhenSidecarMatchesAndArtifactsPresent(final EnvironmentVariables environment) throws IOException {
+        writeRequiredArtifacts(tempDir);
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
+
+        // No archive on disk; only the extracted artifacts + sidecar are present (mounted-image scenario)
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(HASH_A.toHex());
+        given(tssConfig.wrapsProvingKeyPath())
+                .willReturn(tempDir.resolve("wraps.tar.gz").toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        verifyNoInteractions(downloader);
+    }
+
+    @Test
+    void downloadsWhenSidecarMismatches(final EnvironmentVariables environment) throws Exception {
+        writeRequiredArtifacts(tempDir);
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), "bb".repeat(48));
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
+
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        givenConfigWithHashAndPath(HASH_A.toHex(), archivePath);
+        givenDownloaderWritesContent(archivePath, CONTENT_A);
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        verify(downloader).download(DOWNLOAD_URL, archivePath);
+    }
+
+    @Test
+    void downloadsWhenSidecarMatchesButArtifactMissing(final EnvironmentVariables environment) throws Exception {
+        // Sidecar matches config but a required artifact is missing -> not "already present"
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
+
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        givenConfigWithHashAndPath(HASH_A.toHex(), archivePath);
+        givenDownloaderWritesContent(archivePath, CONTENT_A);
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        verify(downloader).download(DOWNLOAD_URL, archivePath);
+    }
+
+    @Test
+    void writesSidecarAfterSuccessfulExtraction(final EnvironmentVariables environment) throws Exception {
+        // A real archive containing the four required artifacts, present on disk and matching config
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+
+        final var extractionDir = tempDir.resolve("extracted");
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        // No download (archive already present and verified); artifacts extracted; sidecar written
+        verifyNoInteractions(downloader);
+        for (final var artifact : WrapsProvingKeyVerification.REQUIRED_ARTIFACT_FILES) {
+            assertTrue(Files.isRegularFile(extractionDir.resolve(artifact)), "missing extracted artifact " + artifact);
+        }
+        final var sidecar = extractionDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME);
+        assertTrue(Files.isRegularFile(sidecar), "sidecar hash file was not written");
+        assertEquals(archiveHash, Files.readString(sidecar).trim());
+    }
+
     // ===== helpers =====
 
     private void givenConfigWithHashAndPath(final String bootstrapHash, final Path provingKeyPath) {
@@ -376,5 +510,73 @@ class WrapsProvingKeyVerificationTest {
                 })
                 .when(downloader)
                 .download(anyString(), eq(path));
+    }
+
+    private static void writeRequiredArtifacts(final Path dir) throws IOException {
+        for (final var artifact : WrapsProvingKeyVerification.REQUIRED_ARTIFACT_FILES) {
+            Files.write(dir.resolve(artifact), artifact.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    // ===== minimal tar.gz builder (mirrors TarGzExtractorTest) =====
+
+    private static final int BLOCK_SIZE = 512;
+
+    private static byte[] createTarGz(final byte[]... entries) throws IOException {
+        final var tarBaos = new ByteArrayOutputStream();
+        for (final byte[] entry : entries) {
+            tarBaos.write(entry);
+        }
+        // Two zero blocks mark end of archive
+        tarBaos.write(new byte[BLOCK_SIZE]);
+        tarBaos.write(new byte[BLOCK_SIZE]);
+
+        final var gzBaos = new ByteArrayOutputStream();
+        try (final var gzos = new GZIPOutputStream(gzBaos)) {
+            gzos.write(tarBaos.toByteArray());
+        }
+        return gzBaos.toByteArray();
+    }
+
+    /** Creates a tar entry (header + data blocks) for a regular file. */
+    private static byte[] entry(final String name, final byte[] content) {
+        final byte[] header = new byte[BLOCK_SIZE];
+        final byte[] nameBytes = name.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(nameBytes, 0, header, 0, Math.min(nameBytes.length, 100));
+        writeOctal(header, 100, 8, 0644); // mode
+        writeOctal(header, 108, 8, 0); // uid
+        writeOctal(header, 116, 8, 0); // gid
+        writeOctal(header, 124, 12, content.length); // size
+        writeOctal(header, 136, 12, 0); // mtime
+        header[156] = (byte) '0'; // regular file
+        System.arraycopy("ustar\0".getBytes(StandardCharsets.US_ASCII), 0, header, 257, 6);
+        header[263] = '0';
+        header[264] = '0';
+        recomputeChecksum(header);
+
+        final int dataBlocks = (content.length + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        final byte[] result = new byte[BLOCK_SIZE + dataBlocks * BLOCK_SIZE];
+        System.arraycopy(header, 0, result, 0, BLOCK_SIZE);
+        System.arraycopy(content, 0, result, BLOCK_SIZE, content.length);
+        return result;
+    }
+
+    private static void writeOctal(final byte[] header, final int offset, final int fieldLen, final long value) {
+        final String octal = String.format("%0" + (fieldLen - 1) + "o", value);
+        final byte[] octalBytes = octal.getBytes(StandardCharsets.US_ASCII);
+        System.arraycopy(octalBytes, 0, header, offset, octalBytes.length);
+        header[offset + octalBytes.length] = 0;
+    }
+
+    private static void recomputeChecksum(final byte[] header) {
+        for (int i = 148; i < 156; i++) {
+            header[i] = ' ';
+        }
+        long checksum = 0;
+        for (int i = 0; i < BLOCK_SIZE; i++) {
+            checksum += (header[i] & 0xFF);
+        }
+        final String chkStr = String.format("%06o\0 ", checksum);
+        System.arraycopy(chkStr.getBytes(StandardCharsets.US_ASCII), 0, header, 148, 8);
     }
 }

--- a/hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key/Containerfile
+++ b/hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key/Containerfile
@@ -4,4 +4,4 @@
 # be mounted read-only (Kubernetes `image:` volume source, or copied out of by an
 # init container). See README.md for provenance and build instructions.
 FROM scratch
-COPY decider_pp.bin decider_vp.bin nova_pp.bin nova_vp.bin /
+COPY decider_pp.bin decider_vp.bin nova_pp.bin nova_vp.bin wraps.sha384 /

--- a/hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key/README.md
+++ b/hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key/README.md
@@ -20,7 +20,7 @@ runner images or downloading it per job. It is consumed by the `hapiTestWraps` a
 | `nova_pp.bin`    | 8454224      | `18d89cfff6e5abebfa8d1740974ce0bd2b60449c67ef7d7de0d3ab377c4b265ab9a99c01fcd03d33da77c6dc47a8c467` |
 | `nova_vp.bin`    | 65768        | `c45e3146f4b3b093c3301ec42171d18f7015c01615d29ca1ab9354d790b5c7ca888f82f26a458366d3b1ff623c8d6c1f` |
 
-The image also carries a `wraps.sha384` sidecar containing the bare hex SHA-384 of the source
+The image also carries a `wraps.sha384` hash file containing the bare hex SHA-384 of the source
 tarball (the value under **Provenance** below). The consensus node reads it from the mounted
 artifacts directory to detect that the artifacts are already in place and skip re-downloading the
 archive on every startup (see `WrapsProvingKeyVerification#WRAPS_HASH_FILE_NAME`).
@@ -48,9 +48,10 @@ podman push <registry>/wraps-proving-key:v1.0.0
 ```
 
 Works identically with `docker build`/`docker push` or `buildah`. Tag per artifact version;
-consumers should pin by digest. At runtime the consensus node compares the `wraps.sha384` sidecar
-against `tss.wrapsProvingKeyHash`: a match means the mounted artifacts are trusted and the separate
-tar.gz download is skipped; otherwise it falls back to downloading and verifying the archive.
+consumers should pin by digest. Assuming all required artifacts are present in the path, the
+consensus node compares the `wraps.sha384` hash file against `tss.wrapsProvingKeyHash`: a match
+means the mounted artifacts are trusted and the separate tar.gz download is skipped; otherwise it
+falls back to downloading and verifying the archive.
 
 ## Consuming on Kubernetes runners
 

--- a/hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key/README.md
+++ b/hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key/README.md
@@ -20,6 +20,11 @@ runner images or downloading it per job. It is consumed by the `hapiTestWraps` a
 | `nova_pp.bin`    | 8454224      | `18d89cfff6e5abebfa8d1740974ce0bd2b60449c67ef7d7de0d3ab377c4b265ab9a99c01fcd03d33da77c6dc47a8c467` |
 | `nova_vp.bin`    | 65768        | `c45e3146f4b3b093c3301ec42171d18f7015c01615d29ca1ab9354d790b5c7ca888f82f26a458366d3b1ff623c8d6c1f` |
 
+The image also carries a `wraps.sha384` sidecar containing the bare hex SHA-384 of the source
+tarball (the value under **Provenance** below). The consensus node reads it from the mounted
+artifacts directory to detect that the artifacts are already in place and skip re-downloading the
+archive on every startup (see `WrapsProvingKeyVerification#WRAPS_HASH_FILE_NAME`).
+
 ## Provenance
 
 - Source: <https://builds.hedera.com/tss/hiero/wraps/v1.0/wraps-v1.0.0.tar.gz>
@@ -37,13 +42,15 @@ digest. To build manually instead:
 curl -fSLo wraps-v1.0.0.tar.gz https://builds.hedera.com/tss/hiero/wraps/v1.0/wraps-v1.0.0.tar.gz
 shasum -a 384 -c <<< "620cbcf69098d31a0893081cb76113ee0f72091b3417e601178cdc376c81e5c2407c1827d123df44bccb78ad4bb11fb3  wraps-v1.0.0.tar.gz"
 mkdir wraps-v1.0.0 && tar xzf wraps-v1.0.0.tar.gz -C wraps-v1.0.0
+printf '%s\n' 620cbcf69098d31a0893081cb76113ee0f72091b3417e601178cdc376c81e5c2407c1827d123df44bccb78ad4bb11fb3 > wraps-v1.0.0/wraps.sha384
 podman build -f path/to/this/Containerfile -t <registry>/wraps-proving-key:v1.0.0 wraps-v1.0.0
 podman push <registry>/wraps-proving-key:v1.0.0
 ```
 
 Works identically with `docker build`/`docker push` or `buildah`. Tag per artifact version;
-consumers should pin by digest (nothing at runtime verifies the directory contents — the
-`tss.wrapsProvingKeyHash` machinery covers only the separate tar.gz download path).
+consumers should pin by digest. At runtime the consensus node compares the `wraps.sha384` sidecar
+against `tss.wrapsProvingKeyHash`: a match means the mounted artifacts are trusted and the separate
+tar.gz download is skipped; otherwise it falls back to downloading and verifying the archive.
 
 ## Consuming on Kubernetes runners
 


### PR DESCRIPTION
## Problem

Consensus nodes re-download and re-extract the multi-GB WRAPS proving key archive on **every** startup — even when the extracted artifacts are already mounted from the published data-only image. The `wraps.tar.gz` itself isn't present in that setup, so the existing check always falls through to a download.

## Change

**Node** (`WrapsProvingKeyVerification`) — before downloading, read a sidecar `wraps.sha384` from `TSS_LIB_WRAPS_ARTIFACTS_PATH` and compare it to `tss.wrapsProvingKeyHash`:
- match **and** all four artifacts present → skip download & extraction
- mismatch / missing artifact / no sidecar → download + extract, then (re)write the sidecar

**Image** — the publish workflow + `Containerfile` now bake `wraps.sha384` (the tarball SHA-384 the workflow already computes) into the proving-key image; README updated.

## Tests

Unit tests cover the match / mismatch / missing-artifact / absent paths and the write-after-extraction path. `:app` history tests + `spotlessCheck` pass; a local image build confirmed the sidecar is baked in with the correct hash.

Backward-compatible: with no sidecar present, behavior is identical to today, so the node and image changes can land independently.

Fixes #26115
