### PR TITLE
ci: use 'showVersion' instead of 'properties' Gradle task

### DIFF
--- a/.github/workflows/816-call-build-publish-state-validator.yaml
+++ b/.github/workflows/816-call-build-publish-state-validator.yaml
@@ -71,13 +71,13 @@ jobs:
 
       - name: Build State Validator Uber shadowJar
         run: |
-          ./gradlew --no-daemon --stacktrace :hedera-state-validator:shadowJar
+          ./gradlew --stacktrace :hedera-state-validator:shadowJar
 
       - name: Determine version and artifact
         id: version-and-artifact
         run: |
           set -euo pipefail
-          FULL_VER=$(./gradlew --no-daemon :hedera-state-validator:properties | grep '^version:' | cut -d ' ' -f2)
+          FULL_VER=$(./gradlew showVersion -q)
           # Remove -SNAPSHOT suffix if present
           VER_WITHOUT_SNAPSHOT=${FULL_VER%-SNAPSHOT}
           # Extract major.minor (first two segments)


### PR DESCRIPTION
**Description**:

The 'properties' task is not compatible with Isolated Projects.
[`showVersion`](https://github.com/hiero-ledger/hiero-gradle-conventions/blob/8e5825b09084485ee6455eef0788aa389dbd34aa/src/main/kotlin/org.hiero.gradle.feature.versioning.gradle.kts#L40) is a task we add explicitly to extract the version.

This also removes `--no-daemon` parameters to avoid overhead of shutting down the Gradle process before the second `gradlew` call.

**Related issue(s)**:

Follow-up to #25397 

**Notes for reviewer:**

I tested the adjusted bash script locally.

