### PR TITLE
chore: Update consensus to use event seq num instead of ngen

### DIFF
--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/HashgraphPictureOptions.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/HashgraphPictureOptions.java
@@ -46,6 +46,11 @@ public interface HashgraphPictureOptions {
     boolean writeNGen();
 
     /**
+     * @return should the sequence number be written for every event
+     */
+    boolean writeSeqNum();
+
+    /**
      * @return should the birth round be written for every event
      */
     boolean writeBirthRound();

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphGuiControls.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphGuiControls.java
@@ -45,6 +45,8 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
     private final Checkbox labelConsTimestampCheckbox;
     /** the Ngen number for the event */
     private final Checkbox labelNGenCheckbox;
+    /** the Sequence number for the event */
+    private final Checkbox labelSeqNumCheckbox;
     /** the birth round number for the event */
     private final Checkbox labelBirthroundCheckbox;
     /** the branch number for the event */
@@ -71,6 +73,7 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
         labelConsOrderCheckbox = new Checkbox("Labels: Order (consensus)");
         labelConsTimestampCheckbox = new Checkbox("Labels: Timestamp (consensus)");
         labelNGenCheckbox = new Checkbox("Labels: NGen (non-deterministic generation)");
+        labelSeqNumCheckbox = new Checkbox("Labels: Sequence Number");
         labelBirthroundCheckbox = new Checkbox("Labels: Birth round");
         labelBranchNumberCheckbox = new Checkbox("Labels: Branch number");
         labelDeGenCheckbox = new Checkbox("Labels: DeGen");
@@ -110,6 +113,7 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
             labelConsOrderCheckbox,
             labelConsTimestampCheckbox,
             labelNGenCheckbox,
+            labelSeqNumCheckbox,
             labelBirthroundCheckbox,
             labelBranchNumberCheckbox,
             labelDeGenCheckbox,
@@ -234,6 +238,11 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
     @Override
     public boolean writeNGen() {
         return labelNGenCheckbox.getState();
+    }
+
+    @Override
+    public boolean writeSeqNum() {
+        return labelSeqNumCheckbox.getState();
     }
 
     @Override

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphPicture.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphPicture.java
@@ -289,6 +289,10 @@ public class HashgraphPicture extends JPanel {
             s += " " + event.getNGen();
         }
 
+        if (options.writeSeqNum()) {
+            s += " " + event.getSequenceNumber();
+        }
+
         if (options.writeBirthRound()) {
             s += " " + event.getBirthRound();
         }

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphPicture.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphPicture.java
@@ -256,7 +256,7 @@ public class HashgraphPicture extends JPanel {
         g.fillOval(xPos, yPos, d, d);
         g.setFont(g.getFont().deriveFont(Font.BOLD));
 
-        StringBuilder s = new StringBuilder();
+        final StringBuilder s = new StringBuilder();
 
         if (options.writeRoundCreated()) {
             s.append(" ").append(event.getRoundCreated());
@@ -300,7 +300,8 @@ public class HashgraphPicture extends JPanel {
         final GossipEvent gossipEvent = event.getBaseEvent().getGossipEvent();
         if (options.writeBranches()
                 && hashgraphSource.getEventStorage().getBranchedEventsMetadata().containsKey(gossipEvent)) {
-            s.append(" " + "\\/ ")
+            s.append(" ")
+                    .append("\\/ ")
                     .append(hashgraphSource
                             .getEventStorage()
                             .getBranchedEventsMetadata()
@@ -312,17 +313,18 @@ public class HashgraphPicture extends JPanel {
             s.append(" ").append(event.getDeGen());
         }
         if (!s.isEmpty()) {
-            final Rectangle2D rect = fm.getStringBounds(s.toString(), g);
+            final String eventText = s.toString();
+            final Rectangle2D rect = fm.getStringBounds(eventText, g);
 
             final int x = (int) (pictureMetadata.xpos(event) - rect.getWidth() / 2. - fa / 4.);
             final int y = (int) (pictureMetadata.ypos(event) + rect.getHeight() / 2. - fd / 2);
             g.setColor(HashgraphGuiConstants.LABEL_OUTLINE);
-            g.drawString(s.toString(), x - 1, y - 1);
-            g.drawString(s.toString(), x + 1, y - 1);
-            g.drawString(s.toString(), x - 1, y + 1);
-            g.drawString(s.toString(), x + 1, y + 1);
+            g.drawString(eventText, x - 1, y - 1);
+            g.drawString(eventText, x + 1, y - 1);
+            g.drawString(eventText, x - 1, y + 1);
+            g.drawString(eventText, x + 1, y + 1);
             g.setColor(color);
-            g.drawString(s.toString(), x, y);
+            g.drawString(eventText, x, y);
         }
     }
 

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphPicture.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphPicture.java
@@ -256,73 +256,73 @@ public class HashgraphPicture extends JPanel {
         g.fillOval(xPos, yPos, d, d);
         g.setFont(g.getFont().deriveFont(Font.BOLD));
 
-        String s = "";
+        StringBuilder s = new StringBuilder();
 
         if (options.writeRoundCreated()) {
-            s += " " + event.getRoundCreated();
+            s.append(" ").append(event.getRoundCreated());
         }
         if (options.writeVote() && event.isWitness()) {
             for (int i = 0; i < event.getVotesSize(); i++) {
                 // showing T or F from true/false for readability on the picture
                 final String vote = event.getVote(i) ? "T" : "F";
-                s += vote;
+                s.append(vote);
             }
         }
         if (options.writeEventHash()) {
             // showing first two characters from the hash of the event
-            s += " h:" + event.getBaseHash().toString().substring(0, 2);
+            s.append(" h:").append(event.getBaseHash().toString(), 0, 2);
         }
         if (options.writeRoundReceived() && event.getRoundReceived() > 0) {
-            s += " " + event.getRoundReceived();
+            s.append(" ").append(event.getRoundReceived());
         }
         // if not consensus, then there's no order yet
         if (options.writeConsensusOrder() && event.isConsensus()) {
-            s += " " + event.getBaseEvent().getConsensusOrder();
+            s.append(" ").append(event.getBaseEvent().getConsensusOrder());
         }
         if (options.writeConsensusTimeStamp()) {
             final Instant t = event.getConsensusTimestamp();
             if (t != null) {
-                s += " " + HashgraphGuiConstants.FORMATTER.format(t);
+                s.append(" ").append(HashgraphGuiConstants.FORMATTER.format(t));
             }
         }
         if (options.writeNGen()) {
-            s += " " + event.getNGen();
+            s.append(" ").append(event.getNGen());
         }
 
         if (options.writeSeqNum()) {
-            s += " " + event.getSequenceNumber();
+            s.append(" ").append(event.getSequenceNumber());
         }
 
         if (options.writeBirthRound()) {
-            s += " " + event.getBirthRound();
+            s.append(" ").append(event.getBirthRound());
         }
 
         final GossipEvent gossipEvent = event.getBaseEvent().getGossipEvent();
         if (options.writeBranches()
                 && hashgraphSource.getEventStorage().getBranchedEventsMetadata().containsKey(gossipEvent)) {
-            s += " " + "\\/ "
-                    + hashgraphSource
+            s.append(" " + "\\/ ")
+                    .append(hashgraphSource
                             .getEventStorage()
                             .getBranchedEventsMetadata()
                             .get(gossipEvent)
-                            .branchIndex();
+                            .branchIndex());
         }
 
         if (options.writeDeGen()) {
-            s += " " + event.getDeGen();
+            s.append(" ").append(event.getDeGen());
         }
         if (!s.isEmpty()) {
-            final Rectangle2D rect = fm.getStringBounds(s, g);
+            final Rectangle2D rect = fm.getStringBounds(s.toString(), g);
 
             final int x = (int) (pictureMetadata.xpos(event) - rect.getWidth() / 2. - fa / 4.);
             final int y = (int) (pictureMetadata.ypos(event) + rect.getHeight() / 2. - fd / 2);
             g.setColor(HashgraphGuiConstants.LABEL_OUTLINE);
-            g.drawString(s, x - 1, y - 1);
-            g.drawString(s, x + 1, y - 1);
-            g.drawString(s, x - 1, y + 1);
-            g.drawString(s, x + 1, y + 1);
+            g.drawString(s.toString(), x - 1, y - 1);
+            g.drawString(s.toString(), x + 1, y - 1);
+            g.drawString(s.toString(), x - 1, y + 1);
+            g.drawString(s.toString(), x + 1, y + 1);
             g.setColor(color);
-            g.drawString(s, x, y);
+            g.drawString(s.toString(), x, y);
         }
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java
@@ -8,6 +8,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
 import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
+import static org.hiero.consensus.model.event.PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
 import static org.hiero.consensus.model.hashgraph.ConsensusConstants.FIRST_CONSENSUS_NUMBER;
 
 import com.hedera.hapi.node.state.roster.Roster;
@@ -36,7 +37,6 @@ import org.hiero.consensus.concurrent.throttle.RateLimitedLogger;
 import org.hiero.consensus.hashgraph.config.ConsensusConfig;
 import org.hiero.consensus.hashgraph.impl.EventImpl;
 import org.hiero.consensus.hashgraph.impl.metrics.ConsensusMetrics;
-import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
@@ -471,10 +471,10 @@ public class ConsensusImpl implements Consensus {
         });
         // This value is normally updated when a round gets decided, but since we are starting from
         // a snapshot, we need to set it here.
-        rounds.setConsensusRelevantNGen(initJudges.getJudges().stream()
-                .map(EventImpl::getNGen)
+        rounds.setConsensusRelevantSeqNum(initJudges.getJudges().stream()
+                .map(EventImpl::getSequenceNumber)
                 .min(Long::compareTo)
-                .orElse(NonDeterministicGeneration.FIRST_GENERATION));
+                .orElse(UNASSIGNED_SEQUENCE_NUMBER));
         initJudges = null;
 
         return true;
@@ -1136,9 +1136,9 @@ public class ConsensusImpl implements Consensus {
         //
         // events older than all the judges in the latest decided round as well as consensus events
         // have a round of -infinity. this covers ancient events as well because the ancient
-        // generation will always be older than the latest decided round generation
+        // boundary will always be older than the latest decided round's oldest judge.
         //
-        if (rounds.isOlderThanDecidedRoundGeneration(x) || x.isConsensus()) {
+        if (rounds.isOlderThanDecidedRoundSeqNum(x) || x.isConsensus()) {
             x.setRoundCreated(ConsensusConstants.ROUND_NEGATIVE_INFINITY);
             return ConsensusConstants.ROUND_NEGATIVE_INFINITY;
         }

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusRounds.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusRounds.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
+import static org.hiero.consensus.model.event.PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
+
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.hapi.platform.state.MinimumJudgeInfo;
@@ -16,7 +18,6 @@ import org.hiero.base.structures.SequentialRingBuffer;
 import org.hiero.consensus.hashgraph.config.ConsensusConfig;
 import org.hiero.consensus.hashgraph.impl.EventImpl;
 import org.hiero.consensus.model.event.EventConstants;
-import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
 import org.hiero.consensus.roster.RosterUtils;
 import org.hiero.consensus.round.RoundCalculationUtils;
@@ -41,11 +42,11 @@ public class ConsensusRounds {
     /** the current threshold below which all events are ancient */
     private long ancientThreshold = EventConstants.ANCIENT_THRESHOLD_UNDEFINED;
     /**
-     * The minimum non-deterministic generation of all the judges in the latest decided round. events with a lower
-     * non-deterministic generation than this do not affect any consensus calculations and do not have their metadata
-     * recalculated.
+     * The minimum sequence number (assigned by the orphan buffer) of all the judges in the latest decided round.
+     * Events with a lower sequence number than this (before this event topologically) do not affect any consensus
+     * calculations and do not have their metadata recalculated.
      */
-    private long consensusRelevantNGen = NonDeterministicGeneration.GENERATION_UNDEFINED;
+    private long consensusRelevantSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
 
     /** Constructs an empty object */
     public ConsensusRounds(@NonNull final ConsensusConfig config, @NonNull final Roster roster) {
@@ -62,7 +63,7 @@ public class ConsensusRounds {
         maxRoundCreated = ConsensusConstants.ROUND_UNDEFINED;
         roundElections.reset();
         updateAncientThreshold();
-        consensusRelevantNGen = NonDeterministicGeneration.GENERATION_UNDEFINED;
+        consensusRelevantSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
     }
 
     /**
@@ -110,23 +111,23 @@ public class ConsensusRounds {
     }
 
     /**
-     * Checks if the event is older than the round generation of the latest decided round. If no round has been decided
-     * yet, returns false.
+     * Checks if the event is older than the round sequence number of the latest decided round. If no round has been
+     * decided yet, returns false.
      *
      * @param event the event to check
      * @return true if its older
      */
-    public boolean isOlderThanDecidedRoundGeneration(@NonNull final EventImpl event) {
-        return consensusRelevantNGen > event.getNGen();
+    public boolean isOlderThanDecidedRoundSeqNum(@NonNull final EventImpl event) {
+        return consensusRelevantSeqNum > event.getSequenceNumber();
     }
 
     /**
-     * Setter for the {@link #consensusRelevantNGen} field. This is used when loading consensus from a snapshot.
+     * Setter for the {@link #consensusRelevantSeqNum} field. This is used when loading consensus from a snapshot.
      *
-     * @param consensusRelevantNGen the value to set
+     * @param consensusRelevantSeqNum the value to set
      */
-    public void setConsensusRelevantNGen(final long consensusRelevantNGen) {
-        this.consensusRelevantNGen = consensusRelevantNGen;
+    public void setConsensusRelevantSeqNum(final long consensusRelevantSeqNum) {
+        this.consensusRelevantSeqNum = consensusRelevantSeqNum;
     }
 
     /**
@@ -141,7 +142,7 @@ public class ConsensusRounds {
      */
     public void currentElectionDecided() {
         minimumJudgeStorage.add(roundElections.getRound(), roundElections.createMinimumJudgeInfo());
-        consensusRelevantNGen = roundElections.getMinNGen();
+        consensusRelevantSeqNum = roundElections.getMinSeqNum();
         roundElections.startNextElection();
         // Delete the oldest rounds with round number which is expired
         minimumJudgeStorage.removeOlderThan(getFameDecidedBelow() - config.roundsExpired());

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/RoundElections.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/RoundElections.java
@@ -37,7 +37,7 @@ public class RoundElections {
      * witnesses in a single round)
      */
     private final List<CandidateWitness> elections = new ArrayList<>();
-    /** The minimum non-deterministic generation of all the judges. Only set once the judges are found. */
+    /** The minimum sequence number of all the judges. Only set once the judges are found. */
     private long minSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
     /** the minimum birth round of all the judges, this is only set once the judges are found */
     private long minBirthRound = EventConstants.BIRTH_ROUND_UNDEFINED;

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/RoundElections.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/RoundElections.java
@@ -2,6 +2,7 @@
 package org.hiero.consensus.hashgraph.impl.consensus;
 
 import static com.swirlds.logging.legacy.LogMarker.CONSENSUS_VOTING;
+import static org.hiero.consensus.model.event.PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
 
 import com.hedera.hapi.platform.state.MinimumJudgeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -18,7 +19,6 @@ import org.hiero.base.IntReference;
 import org.hiero.base.utility.ArrayUtils;
 import org.hiero.consensus.hashgraph.impl.EventImpl;
 import org.hiero.consensus.model.event.EventConstants;
-import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
 import org.hiero.consensus.model.node.NodeId;
 
@@ -38,7 +38,7 @@ public class RoundElections {
      */
     private final List<CandidateWitness> elections = new ArrayList<>();
     /** The minimum non-deterministic generation of all the judges. Only set once the judges are found. */
-    private long minNGen = NonDeterministicGeneration.GENERATION_UNDEFINED;
+    private long minSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
     /** the minimum birth round of all the judges, this is only set once the judges are found */
     private long minBirthRound = EventConstants.BIRTH_ROUND_UNDEFINED;
 
@@ -101,14 +101,13 @@ public class RoundElections {
     }
 
     /**
-     * @return the minimum non-deterministic generation of all the judges(unique famous witnesses) in this round
+     * @return the minimum sequence number of all the judges(unique famous witnesses) in this round
      */
-    public long getMinNGen() {
-        if (minNGen == NonDeterministicGeneration.GENERATION_UNDEFINED) {
-            throw new IllegalStateException(
-                    "Cannot provide the minimum non-deterministic generation until all judges are found");
+    public long getMinSeqNum() {
+        if (minSeqNum == UNASSIGNED_SEQUENCE_NUMBER) {
+            throw new IllegalStateException("Cannot provide the minimum sequence number until all judges are found");
         }
-        return minNGen;
+        return minSeqNum;
     }
 
     /**
@@ -152,10 +151,10 @@ public class RoundElections {
             throw new IllegalStateException("No judges found in round " + round);
         }
         allJudges.sort(Comparator.comparingLong(e -> e.getCreatorId().id()));
-        minNGen = Long.MAX_VALUE;
+        minSeqNum = Long.MAX_VALUE;
         minBirthRound = Long.MAX_VALUE;
         for (final EventImpl judge : allJudges) {
-            minNGen = Math.min(minNGen, judge.getNGen());
+            minSeqNum = Math.min(minSeqNum, judge.getSequenceNumber());
             minBirthRound = Math.min(minBirthRound, judge.getBirthRound());
             judge.setJudgeTrue();
         }
@@ -191,7 +190,7 @@ public class RoundElections {
         round++;
         numUnknownFame.set(0);
         elections.clear();
-        minNGen = NonDeterministicGeneration.GENERATION_UNDEFINED;
+        minSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
         minBirthRound = EventConstants.BIRTH_ROUND_UNDEFINED;
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/GeneratorEventGraphSourceTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/GeneratorEventGraphSourceTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
+import static org.hiero.consensus.model.event.PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -356,6 +357,9 @@ class GeneratorEventGraphSourceTest {
             assertTrue(
                     event.getNGen() >= NonDeterministicGeneration.FIRST_GENERATION,
                     "ngen should be at least FIRST_GENERATION");
+            assertTrue(
+                    event.getSequenceNumber() >= UNASSIGNED_SEQUENCE_NUMBER,
+                    "sequence number should be at least UNASSIGNED_SEQUENCE_NUMBER");
         }
 
         // Verify that ngen actually advances beyond FIRST_GENERATION
@@ -363,6 +367,15 @@ class GeneratorEventGraphSourceTest {
                 events.stream().mapToLong(PlatformEvent::getNGen).max().orElse(0);
         assertTrue(
                 maxNGen > NonDeterministicGeneration.FIRST_GENERATION, "ngen should advance beyond FIRST_GENERATION");
+
+        // Verify that sequence number actually advances beyond UNASSIGNED_SEQUENCE_NUMBER
+        final long maxSeqNum = events.stream()
+                .mapToLong(PlatformEvent::getSequenceNumber)
+                .max()
+                .orElse(0);
+        assertTrue(
+                maxSeqNum > UNASSIGNED_SEQUENCE_NUMBER,
+                "sequence number should advance beyond UNASSIGNED_SEQUENCE_NUMBER");
     }
 
     @Test
@@ -376,6 +389,12 @@ class GeneratorEventGraphSourceTest {
 
         for (final PlatformEvent event : events) {
             assertFalse(event.hasNGen(), "events should not have ngen set when populateNgen is disabled");
+            assertTrue(
+                    event.hasSequenceNumber(),
+                    "every event should have sequence number assigned even if nGen is disabled");
+            assertTrue(
+                    event.getSequenceNumber() >= UNASSIGNED_SEQUENCE_NUMBER,
+                    "sequence number should be at least UNASSIGNED_SEQUENCE_NUMBER");
         }
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/GeneratorEventGraphSourceTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/GeneratorEventGraphSourceTest.java
@@ -380,7 +380,7 @@ class GeneratorEventGraphSourceTest {
 
     @Test
     @Tag(TestComponentTags.PLATFORM)
-    @DisplayName("Events do not have ngen set when populateNgen is disabled")
+    @DisplayName("Events do not have ngen or sequence number set when populateNgen is disabled")
     void populateNgenDisabled() {
         final GeneratorEventGraphSource generator =
                 GeneratorEventGraphSourceBuilder.builder().numNodes(4).seed(0L).build();
@@ -389,12 +389,9 @@ class GeneratorEventGraphSourceTest {
 
         for (final PlatformEvent event : events) {
             assertFalse(event.hasNGen(), "events should not have ngen set when populateNgen is disabled");
-            assertTrue(
+            assertFalse(
                     event.hasSequenceNumber(),
-                    "every event should have sequence number assigned even if nGen is disabled");
-            assertTrue(
-                    event.getSequenceNumber() >= UNASSIGNED_SEQUENCE_NUMBER,
-                    "sequence number should be at least UNASSIGNED_SEQUENCE_NUMBER");
+                    "events should not have sequence number assigned even if populateNgen is disabled");
         }
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/GeneratorEventGraphSource.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/GeneratorEventGraphSource.java
@@ -162,8 +162,8 @@ public class GeneratorEventGraphSource implements EventGraphSource {
             // the event sent to consensus will have its nGen value populated, we should copy this value if the caller
             // wants ngen values to be populated on the returned events
             copy.setNGen(platformEvent.getNGen());
+            copy.setSequenceNumber(platformEvent.getSequenceNumber());
         }
-        copy.setSequenceNumber(platformEvent.getSequenceNumber());
         return copy;
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/GeneratorEventGraphSource.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/GeneratorEventGraphSource.java
@@ -162,8 +162,8 @@ public class GeneratorEventGraphSource implements EventGraphSource {
             // the event sent to consensus will have its nGen value populated, we should copy this value if the caller
             // wants ngen values to be populated on the returned events
             copy.setNGen(platformEvent.getNGen());
-            copy.setSequenceNumber(platformEvent.getSequenceNumber());
         }
+        copy.setSequenceNumber(platformEvent.getSequenceNumber());
         return copy;
     }
 

--- a/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Hashgraph
-last_reviewed: 2026-06-29
+last_reviewed: 2026-06-30
 ---
 
 # Hashgraph
@@ -78,7 +78,7 @@ state at runtime:
   counter, and the `pcesMode` flag set when the platform is replaying
   the pre-consensus event stream.
 - `RoundElections` tracks witnesses voted on for a round and their
-  decided-fame status, plus `minNGen` and `minBirthRound` for the
+  decided-fame status, plus `minSeqNum` and `minBirthRound` for the
   judges.
 - The future-event buffer
   [`consensus-utility/.../FutureEventBuffer.java`](../../../../consensus-utility/src/main/java/org/hiero/consensus/event/FutureEventBuffer.java)
@@ -281,10 +281,16 @@ into the loaded state — is covered in
 > [`../../concepts/birth-round.md`](../../concepts/birth-round.md) for that
 > substitution. The
 > implementation also carries a few quantities that do not appear in
-> the paper — `NGen` (a locally-computed, non-deterministic generation
-> used only for picking a topological order and for
-> "higher in the hashgraph" comparisons; see `NonDeterministicGeneration`)
-> and the `DeGen`/`cGen` family used inside the algorithm. Conceptual
+> the paper — the orphan-buffer **event sequence number** (a
+> locally-computed, monotonic counter used for picking a topological
+> order and for "higher in the hashgraph" comparisons, e.g.
+> `consensusRelevantSeqNum` / `RoundElections.minSeqNum` and
+> `ConsensusRounds.isOlderThanDecidedRoundSeqNum`) and the `DeGen`/`cGen`
+> family used inside the algorithm. The sequence number replaced `NGen`
+> as the algorithm's ordering key (see
+> [`../../decisions/ADR-008-replace-ngen-with-sequence-number.md`](../../decisions/ADR-008-replace-ngen-with-sequence-number.md));
+> `NonDeterministicGeneration` lingers in this module only for the
+> not-yet-migrated `cGen` path. Conceptual
 > background lives in
 > [`../../concepts/rounds-and-witnesses.md`](../../concepts/rounds-and-witnesses.md)
 > and [`../../concepts/birth-round.md`](../../concepts/birth-round.md).

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
@@ -118,7 +118,7 @@ a dependency on it.
   |----------------------------------------------------------|----------------------------------------|--------------------|---------|
   | Compute the sequence number in the orphan buffer         | `consensus-utility`, `consensus-model` | #24841 (PR #24937) | done    |
   | Event creation / tipset                                  | `consensus-event-creator-impl`         | #24991             | done    |
-  | Consensus algorithm                                      | `consensus-hashgraph-impl`             | #24844             | pending |
+  | Consensus algorithm                                      | `consensus-hashgraph-impl`             | #24844             | done    |
   | Sync                                                     | `consensus-gossip-impl`                | #24843             | done    |
   | `cGen` handling                                          | `consensus-hashgraph-impl`             | #24883             | pending |
   | Tools (GUI, CLI)                                         | `consensus-gui`, `swirlds-cli`         | #24885             | pending |
@@ -256,8 +256,10 @@ See **Decision** above.
   implementation followed: PR #24937 (2026-04-16) added the counter and renamed
   the consensus-side `sequence` to `consensusSequence`; PR #24991 (2026-04-30)
   migrated the tipset. Sync (#24843) migrated the send-list sort to the sequence
-  number. Consensus (#24844), `cGen` (#24883), tools (#24885), and the final
-  `nGen` removal (#24846) remain open at the time of writing.
+  number. Consensus (#24844) migrated the algorithm's ordering key
+  (`consensusRelevantSeqNum`, `RoundElections.minSeqNum`,
+  `isOlderThanDecidedRoundSeqNum`). `cGen` (#24883), tools (#24885), and the
+  final `nGen` removal (#24846) remain open at the time of writing.
 - This entry fulfills #25482 ("Create ADR for replacing nGen with sequence
   number"). It supersedes an earlier draft scoped to event creation only; the
   scope was broadened to the full `nGen` removal.

--- a/platform-sdk/docs/consensus-layer/glossary.md
+++ b/platform-sdk/docs/consensus-layer/glossary.md
@@ -2,7 +2,7 @@
 type: glossary
 title: Glossary
 description: Canonical one-line definitions for vocabulary used across the consensus-layer KB, with disambiguation for overloaded terms (round, ancient, stale, falling behind).
-last_reviewed: 2026-06-08
+last_reviewed: 2026-06-30
 ---
 
 # Glossary
@@ -250,7 +250,8 @@ See [concepts/event-lifecycle.md](concepts/event-lifecycle.md).
 A per-event count: one plus the maximum parent generation. The paper used a single
 *deterministic* generation as the ancient horizon; current code uses *Birth round* for that
 and keeps three separate generation counters instead, each calculated differently and used
-for a different purpose — *nGen* (local, for topological ordering), *deGen* (deterministic,
+for a different purpose — *nGen* (local; topological ordering, now migrating to the event
+*Sequence number*, ADR-008), *deGen* (deterministic,
 for *Strongly seeing*), and *cGen* (deterministic, for consensus ordering within a
 *Consensus round*).
 See [concepts/birth-round.md](concepts/birth-round.md).
@@ -316,12 +317,14 @@ See [concepts/event-lifecycle.md](concepts/event-lifecycle.md).
 
 ### NGen
 
-*Non-deterministic generation* (`NonDeterministicGeneration`): orders events into one valid
-topological order and answers "higher in the hashgraph" comparisons. Assigned to every
-non-orphan event, locally by each node, so it may differ between nodes; set once at intake and
-then stable. Used throughout the consensus layer. Contrast the deterministic *DeGen* and
-*CGen*; see *Generation*.
-See [architecture/topics/event-intake.md](architecture/topics/event-intake.md).
+*Non-deterministic generation* (`NonDeterministicGeneration`): historically the consensus
+layer's local topological-ordering key, answering "higher in the hashgraph" comparisons.
+Assigned to every non-orphan event, locally by each node, so it may differ between nodes; set
+once at intake and then stable. That ordering role has moved to the event *Sequence number*
+(ADR-008); `nGen` now survives only for the not-yet-migrated `cGen` path, pending removal.
+Contrast the deterministic *DeGen* and *CGen*; see *Generation*.
+See [decisions/ADR-008-replace-ngen-with-sequence-number.md](decisions/ADR-008-replace-ngen-with-sequence-number.md)
+and [architecture/topics/event-intake.md](architecture/topics/event-intake.md).
 
 ### Orphan buffer
 
@@ -468,6 +471,16 @@ See [architecture/topics/event-creator.md](architecture/topics/event-creator.md)
 The parent edge to the creator's own previous event; an honest creator's events form a
 single chain under self-parent edges. Contrast *Other-parent*.
 See [concepts/hashgraph-dag.md](concepts/hashgraph-dag.md).
+
+### Sequence number
+
+A monotonic counter the *Orphan buffer* stamps on each event as it is released
+(`PlatformEvent.sequenceNumber`), assigned locally by each node so it may differ between
+nodes. The canonical local ordering key — used for "higher in the hashgraph" comparisons by
+event creation, *Sync*, and the consensus algorithm (e.g. `consensusRelevantSeqNum`). Unlike
+*NGen* it never resets, even when an event's parents have gone ancient, and it is never used
+for cross-node agreement.
+See [decisions/ADR-008-replace-ngen-with-sequence-number.md](decisions/ADR-008-replace-ngen-with-sequence-number.md).
 
 ### Shadowgraph
 


### PR DESCRIPTION
Fixes #24844