### PR TITLE
fix(contract): correct bonneville SDIV/SMOD signed arithmetic

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/BEVM.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/BEVM.java
@@ -94,6 +94,13 @@ class BEVM {
         _mem = new Memory();
     }
 
+    // Test-only: bare instance for exercising the stack/arithmetic in isolation.
+    BEVM() {
+        _top = null;
+        _gasCalc = null;
+        _mem = null;
+    }
+
     // Setup for a new contract execution
     BEVM init(CodeV2 code, MessageFrame frame, Address parentContract) {
         // the BESU/Hedera Frame; hope someday to remove this
@@ -229,10 +236,14 @@ class BEVM {
         return push(x0, x1, x2, x3);
     }
 
-    private ExceptionalHaltReason push(BigInteger bi) {
+    // Sign-extend negatives into the high bytes; push() zero-fills otherwise.
+    ExceptionalHaltReason push(BigInteger bi) {
         var bytes = bi.toByteArray();
+        var out = new byte[32];
+        if( bi.signum() < 0 ) Arrays.fill(out, (byte) 0xFF);
         var len = Math.min(32, bytes.length);
-        return push(bytes, bytes.length - len, len);
+        System.arraycopy(bytes, bytes.length - len, out, 32 - len, len);
+        return push32(out);
     }
 
     // TODO, common case, optimize
@@ -649,7 +660,7 @@ class BEVM {
         return push(dividend.divide(divisor));
     }
 
-    private ExceptionalHaltReason sdiv() {
+    ExceptionalHaltReason sdiv() {
         long lhs0 = STK0[--_sp], lhs1 = STK1[_sp], lhs2 = STK2[_sp], lhs3 = STK3[_sp];
         long rhs0 = STK0[--_sp], rhs1 = STK1[_sp], rhs2 = STK2[_sp], rhs3 = STK3[_sp];
         // Divide by 0,1,2^n shortcuts
@@ -661,17 +672,18 @@ class BEVM {
             if( rhs0 == 1) return push(lhs0, lhs1, lhs2, lhs3);
         }
         int rbc0 = Long.bitCount(rhs0), rbc1 = Long.bitCount(rhs1), rbc2 = Long.bitCount(rhs2), rbc3 = Long.bitCount(rhs3);
-        if( rbc0 + rbc1 + rbc2 + rbc3 == 1) {
+        // sar floors, SDIV truncates: only equal for non-negative dividend, positive power-of-two divisor.
+        if( rbc0 + rbc1 + rbc2 + rbc3 == 1 && lhs3 >= 0 && rhs3 >= 0) {
             int shf = shf(rbc0, rbc1, rbc2, rbc3, rhs0, rhs1, rhs2, rhs3);
             return sar(shf, lhs0, lhs1, lhs2, lhs3);
         }
         if( lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2 && lhs3 == rhs3)
             return push(1);
 
-        // BigInteger fallback
+        // Signed two's-complement decode of the 32-byte stack words.
         _sp += 2; // Re-push bytes
-        var dividend = new BigInteger((int) (lhs3 >> 63), popBytes().toArrayUnsafe());
-        var divisor  = new BigInteger((int) (rhs3 >> 63), popBytes().toArrayUnsafe());
+        var dividend = new BigInteger(popBytes().toArrayUnsafe());
+        var divisor  = new BigInteger(popBytes().toArrayUnsafe());
         return push(dividend.divide(divisor));
     }
 
@@ -701,16 +713,17 @@ class BEVM {
     }
 
     // Signed mod
-    private ExceptionalHaltReason smod() {
+    ExceptionalHaltReason smod() {
         long lhs0 = STK0[--_sp], lhs1 = STK1[_sp], lhs2 = STK2[_sp], lhs3 = STK3[_sp];
         long rhs0 = STK0[--_sp], rhs1 = STK1[_sp], rhs2 = STK2[_sp], rhs3 = STK3[_sp];
-        if( (lhs0 | lhs1 | lhs2 | lhs3) == 0) return push0();
-        if( lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2 && lhs3 == rhs3) return push(1);
-        // BigInteger fallback
+        if( (lhs0 | lhs1 | lhs2 | lhs3) == 0) return push0();      // a==0
+        if( (rhs0 | rhs1 | rhs2 | rhs3) == 0) return push0();      // b==0
+        if( lhs0 == rhs0 && lhs1 == rhs1 && lhs2 == rhs2 && lhs3 == rhs3) return push(0); // a%a
+        // Signed decode; remainder() keeps the dividend's sign (mod() does not).
         _sp += 2; // Re-push bytes
-        var dividend = new BigInteger((int) (lhs3 >> 63), popBytes().toArrayUnsafe());
-        var divisor  = new BigInteger((int) (rhs3 >> 63), popBytes().toArrayUnsafe());
-        return push(dividend.mod(divisor));
+        var dividend = new BigInteger(popBytes().toArrayUnsafe());
+        var divisor  = new BigInteger(popBytes().toArrayUnsafe());
+        return push(dividend.remainder(divisor));
     }
 
     private ExceptionalHaltReason addmod() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/bonneville/BEVMSignedArithmeticTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/bonneville/BEVMSignedArithmeticTest.java
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.contract.impl.bonneville;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigInteger;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Known-answer tests for signed EVM arithmetic (SDIV/SMOD) in {@link BEVM}, checked against the EVM
+ * specification (evm.codes) with stack words treated as 256-bit two's-complement.
+ */
+class BEVMSignedArithmeticTest {
+
+    // -2^255: the most-negative 256-bit word.
+    private static final BigInteger MIN = BigInteger.TWO.pow(255).negate();
+
+    @ParameterizedTest(name = "{0} SDIV {1} = {2}")
+    @MethodSource("sdivCases")
+    void sdivMatchesEvmSpec(BigInteger a, BigInteger b, BigInteger expected) {
+        assertEquals(expected, sdiv(a, b));
+    }
+
+    static Stream<Arguments> sdivCases() {
+        return Stream.of(
+                Arguments.of(bi(7), bi(3), bi(2)),
+                Arguments.of(bi(-3), bi(2), bi(-1)), // truncates toward zero
+                Arguments.of(bi(-9), bi(2), bi(-4)),
+                Arguments.of(bi(-6), bi(2), bi(-3)),
+                Arguments.of(bi(9), bi(2), bi(4)),
+                Arguments.of(bi(-7), bi(3), bi(-2)),
+                Arguments.of(bi(-7), bi(-3), bi(2)),
+                Arguments.of(bi(7), bi(-3), bi(-2)),
+                Arguments.of(MIN, bi(-1), MIN), // -2^255 / -1 overflows back to -2^255
+                Arguments.of(bi(5), bi(0), bi(0)), // divide by zero -> 0
+                Arguments.of(bi(0), bi(5), bi(0)));
+    }
+
+    @ParameterizedTest(name = "{0} SMOD {1} = {2}")
+    @MethodSource("smodCases")
+    void smodMatchesEvmSpec(BigInteger a, BigInteger b, BigInteger expected) {
+        assertEquals(expected, smod(a, b));
+    }
+
+    static Stream<Arguments> smodCases() {
+        return Stream.of(
+                Arguments.of(bi(-7), bi(3), bi(-1)), // sign follows the dividend
+                Arguments.of(bi(7), bi(-3), bi(1)),
+                Arguments.of(bi(-7), bi(-3), bi(-1)),
+                Arguments.of(bi(7), bi(3), bi(1)),
+                Arguments.of(bi(5), bi(5), bi(0)), // a % a
+                Arguments.of(bi(5), bi(0), bi(0)), // mod by zero -> 0
+                Arguments.of(bi(0), bi(5), bi(0)));
+    }
+
+    // push/pop must preserve the full 256-bit signed word.
+    @ParameterizedTest(name = "push/pop {0}")
+    @MethodSource("roundTripValues")
+    void pushRoundTripsSignedWord(BigInteger v) {
+        final var evm = new BEVM();
+        evm.push(v);
+        assertEquals(v, signed(evm.popBytes().toArrayUnsafe()));
+    }
+
+    static Stream<Arguments> roundTripValues() {
+        return Stream.of(
+                Arguments.of(bi(-1)),
+                Arguments.of(bi(-3)),
+                Arguments.of(bi(-255)),
+                Arguments.of(MIN),
+                Arguments.of(bi(0)),
+                Arguments.of(bi(42)),
+                Arguments.of(BigInteger.TWO.pow(255).subtract(BigInteger.ONE))); // max positive word
+    }
+
+    // Drive "a SDIV b" through the interpreter stack (dividend on top) and read back the signed result.
+    private static BigInteger sdiv(BigInteger a, BigInteger b) {
+        final var evm = new BEVM();
+        evm.push(b);
+        evm.push(a);
+        evm.sdiv();
+        return signed(evm.popBytes().toArrayUnsafe());
+    }
+
+    private static BigInteger smod(BigInteger a, BigInteger b) {
+        final var evm = new BEVM();
+        evm.push(b);
+        evm.push(a);
+        evm.smod();
+        return signed(evm.popBytes().toArrayUnsafe());
+    }
+
+    private static BigInteger signed(byte[] word32) {
+        return new BigInteger(word32); // 32-byte two's-complement -> signed value
+    }
+
+    private static BigInteger bi(long v) {
+        return BigInteger.valueOf(v);
+    }
+}


### PR DESCRIPTION
Fixes signed integer arithmetic in the Bonneville EVM interpreter (SDIV and SMOD). Operands and results are now decoded and stored as 256-bit two's-complement, the power-of-two SDIV shortcut only applies where it matches truncated division, and SMOD keeps the dividend's sign and handles a zero divisor.

Bonneville is gated behind `contracts.evm.UseBonnevilleEVM` (default false), so there is no behavior change on current networks.

Adds a known-answer test suite covering signed division and modulo against the EVM spec.