### PR TITLE
chore: reduce the default block buffer size to 30 blocks

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
@@ -32,7 +32,7 @@ import java.time.Duration;
  */
 @ConfigData("blockStream.buffer")
 public record BlockBufferConfig(
-        @ConfigProperty(defaultValue = "150") @Min(0) @NetworkProperty int maxBlocks,
+        @ConfigProperty(defaultValue = "30") @Min(0) @NetworkProperty int maxBlocks,
         @ConfigProperty(defaultValue = "1s") @Min(1) @NetworkProperty Duration workerInterval,
         @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty double actionStageThreshold,
         @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty Duration actionGracePeriod,


### PR DESCRIPTION
**Description**:
Reduce the default number of blocks held by the block buffer from 150 to 30. This will mean we hold approximately 60 seconds worth of blocks (based on consensus time).

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
