### PR TITLE
fix: refine delegated NFT allowance handling and validation

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoApproveAllowanceHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoApproveAllowanceHandler.java
@@ -13,6 +13,7 @@ import static com.hedera.node.app.hapi.utils.fee.FeeConstants.CRYPTO_ALLOWANCE_S
 import static com.hedera.node.app.hapi.utils.fee.FeeConstants.LONG_SIZE;
 import static com.hedera.node.app.hapi.utils.fee.FeeConstants.NFT_ALLOWANCE_SIZE;
 import static com.hedera.node.app.hapi.utils.fee.FeeConstants.TOKEN_ALLOWANCE_SIZE;
+import static com.hedera.node.app.service.token.impl.validators.AllowanceValidator.isDelegatingSpenderPresent;
 import static com.hedera.node.app.service.token.impl.validators.AllowanceValidator.isValidOwner;
 import static com.hedera.node.app.service.token.impl.validators.AllowanceValidator.validateAllowanceLimit;
 import static com.hedera.node.app.spi.validation.Validations.mustExist;
@@ -409,7 +410,12 @@ public class CryptoApproveAllowanceHandler implements TransactionHandler {
             final var effectiveOwner = getEffectiveOwnerAccount(owner, payerId, accountStore, expiryValidator);
             final var mutableNftAllowances = new ArrayList<>(effectiveOwner.approveForAllNftAllowances());
 
-            if (allowance.hasApprovedForAll()) {
+            // A delegating spender may only sub-delegate individual serials on the owner's behalf; it must never
+            // add or remove the owner's approveForAll grants. Only the owner (who is the one required to sign when
+            // there is no delegating spender) can change the approveForAll list. See NftAllowance.delegating_spender
+            // in the protobuf.
+            final var isDelegated = isDelegatingSpenderPresent(allowance);
+            if (!isDelegated && allowance.hasApprovedForAll()) {
                 final var approveForAllAllowance = AccountApprovalForAllAllowance.newBuilder()
                         .tokenId(tokenId)
                         .spenderId(spender)

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/AllowanceValidator.java
@@ -155,4 +155,20 @@ public class AllowanceValidator {
                     NOT_ALIASED_ID);
         }
     }
+
+    /**
+     * Returns whether the given NFT allowance carries a (non-default) delegating spender. A delegated allowance may
+     * only sub-delegate individual serial numbers on the owner's behalf; it must never add or remove the owner's
+     * approveForAll grants. Both {@code ApproveAllowanceValidator} and the apply logic in
+     * {@code CryptoApproveAllowanceHandler} use this single definition of "is a delegated allowance" so the two
+     * cannot drift apart.
+     *
+     * @param allowance the nft allowance
+     * @return true if a non-default delegating spender is present
+     */
+    public static boolean isDelegatingSpenderPresent(@NonNull final NftAllowance allowance) {
+        requireNonNull(allowance, "allowance must not be null");
+        return allowance.hasDelegatingSpender()
+                && allowance.delegatingSpenderOrThrow().accountNumOrThrow() != 0;
+    }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/ApproveAllowanceValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/ApproveAllowanceValidator.java
@@ -4,6 +4,7 @@ package com.hedera.node.app.service.token.impl.validators;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AMOUNT_EXCEEDS_TOKEN_MAX_SUPPLY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DELEGATING_SPENDER_CANNOT_GRANT_APPROVE_FOR_ALL;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.EMPTY_ALLOWANCES;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.FUNGIBLE_TOKEN_IN_NFT_ALLOWANCES;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ALLOWANCE_SPENDER_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_DELEGATING_SPENDER;
@@ -193,8 +194,7 @@ public class ApproveAllowanceValidator extends AllowanceValidator {
 
             // If a spender has been given approveForAll privileges, then it has the same privileges as owner of NFT.
             // But, the spender is not allowed to grant approveForAll privileges to anyone else.
-            if (allowance.hasDelegatingSpender()
-                    && allowance.delegatingSpenderOrThrow().accountNumOrThrow() != 0) {
+            if (isDelegatingSpenderPresent(allowance)) {
 
                 // validate delegating spender
                 getIfUsable(
@@ -216,6 +216,10 @@ public class ApproveAllowanceValidator extends AllowanceValidator {
                 validateTrue(
                         effectiveOwner.approveForAllNftAllowances().contains(approveForAllKey),
                         DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL);
+                // A delegated allowance exists solely to sub-delegate specific serials on the owner's behalf; it must
+                // never modify the owner's approveForAll grants. With no serials it can accomplish nothing, so reject
+                // it rather than silently accepting a no-op (this was the shape of the approveForAll-revocation bug).
+                validateFalse(serialNums.isEmpty(), EMPTY_ALLOWANCES);
             }
 
             validateSerialNums(serialNums, tokenId, uniqueTokenStore);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoApproveAllowanceHandlerTest.java
@@ -28,6 +28,7 @@ import com.hedera.hapi.node.base.NftID;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.hapi.node.state.token.AccountApprovalForAllAllowance;
 import com.hedera.hapi.node.state.token.Nft;
 import com.hedera.hapi.node.token.CryptoAllowance;
 import com.hedera.hapi.node.token.CryptoApproveAllowanceTransactionBody;
@@ -342,6 +343,95 @@ class CryptoApproveAllowanceHandlerTest extends CryptoTokenHandlerTestBase {
         assertThat(writableNftStore.get(nftIdSl2).ownerId()).isEqualTo(ownerId);
         assertThat(writableNftStore.get(nftIdSl1).spenderId()).isEqualTo(spenderId);
         assertThat(writableNftStore.get(nftIdSl2).spenderId()).isEqualTo(spenderId);
+    }
+
+    @Test
+    void delegatingSpenderCannotRevokeAnotherSpendersApproveForAll() {
+        final var victimApproval = AccountApprovalForAllAllowance.newBuilder()
+                .tokenId(nonFungibleTokenId)
+                .spenderId(spenderId)
+                .build();
+        final var delegatingApproval = AccountApprovalForAllAllowance.newBuilder()
+                .tokenId(nonFungibleTokenId)
+                .spenderId(delegatingSpenderId)
+                .build();
+        // The owner has granted approve-for-all to both the (victim) spender and the delegating spender.
+        writableAccountStore.put(writableAccountStore
+                .getAccountById(ownerId)
+                .copyBuilder()
+                .approveForAllNftAllowances(victimApproval, delegatingApproval)
+                .build());
+
+        // The delegating spender sub-delegates individual serials to the (victim) spender with approvedForAll=false.
+        // This must NOT strip the victim's owner-granted approve-for-all (nftAllowanceWithDelegatingSpender uses
+        // spender=spenderId, delegatingSpender=delegatingSpenderId, approvedForAll=false, serials=[1, 2]).
+        final var txn = cryptoApproveAllowanceTransaction(payerId, true, List.of(), List.of(), List.of());
+        given(handleContext.body()).willReturn(txn);
+        assertThat(writableAccountStore.getAccountById(ownerId).approveForAllNftAllowances())
+                .containsExactlyInAnyOrder(victimApproval, delegatingApproval);
+
+        subject.handle(handleContext);
+
+        final var modifiedOwner = writableAccountStore.getAccountById(ownerId);
+        // Both approve-for-all grants remain intact - the delegating spender cannot revoke a peer's grant.
+        assertThat(modifiedOwner.approveForAllNftAllowances())
+                .containsExactlyInAnyOrder(victimApproval, delegatingApproval);
+        // The legitimate per-serial sub-delegation still takes effect.
+        assertThat(writableNftStore.get(nftIdSl1).spenderId()).isEqualTo(spenderId);
+        assertThat(writableNftStore.get(nftIdSl2).spenderId()).isEqualTo(spenderId);
+    }
+
+    @Test
+    void delegatingSpenderWithEmptySerialsIsRejected() {
+        // Owner has granted approve-for-all to the delegating spender, so it is otherwise a valid delegating spender.
+        writableAccountStore.put(writableAccountStore
+                .getAccountById(ownerId)
+                .copyBuilder()
+                .approveForAllNftAllowances(AccountApprovalForAllAllowance.newBuilder()
+                        .tokenId(nonFungibleTokenId)
+                        .spenderId(delegatingSpenderId)
+                        .build())
+                .build());
+
+        // A delegated allowance with no serials can accomplish nothing (it is the shape of the exploit) and must be
+        // rejected rather than silently no-op'd.
+        final var delegatedWithNoSerials = NftAllowance.newBuilder()
+                .owner(ownerId)
+                .spender(spenderId)
+                .tokenId(nonFungibleTokenId)
+                .approvedForAll(Boolean.FALSE)
+                .delegatingSpender(delegatingSpenderId)
+                .build();
+        final var txn = cryptoApproveAllowanceTransaction(
+                payerId, false, List.of(), List.of(), List.of(delegatedWithNoSerials));
+        given(handleContext.body()).willReturn(txn);
+
+        assertThatThrownBy(() -> subject.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(EMPTY_ALLOWANCES));
+    }
+
+    @Test
+    void ownerCanRevokeApproveForAllWithEmptySerials() {
+        // A non-delegated approvedForAll=false with empty serials is the legitimate way an owner revokes a blanket
+        // grant - the new delegated-empty-serials guard must NOT reject it. (Owner already holds a single
+        // approve-for-all grant to spenderId from the base setup.)
+        final var revoke = NftAllowance.newBuilder()
+                .owner(ownerId)
+                .spender(spenderId)
+                .tokenId(nonFungibleTokenId)
+                .approvedForAll(Boolean.FALSE)
+                .build();
+        final var txn = cryptoApproveAllowanceTransaction(payerId, false, List.of(), List.of(), List.of(revoke));
+        given(handleContext.body()).willReturn(txn);
+        assertThat(writableAccountStore.getAccountById(ownerId).approveForAllNftAllowances())
+                .hasSize(1);
+
+        // Must not throw EMPTY_ALLOWANCES; it should simply remove the owner's blanket grant.
+        subject.handle(handleContext);
+
+        assertThat(writableAccountStore.getAccountById(ownerId).approveForAllNftAllowances())
+                .isEmpty();
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/ApproveAllowanceValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/ApproveAllowanceValidatorTest.java
@@ -219,6 +219,30 @@ class ApproveAllowanceValidatorTest extends CryptoTokenHandlerTestBase {
     }
 
     @Test
+    void cannotGrantEmptySerialNftAllowanceWithDelegatingSpender() {
+        // The delegating spender (spenderId) holds approve-for-all, so it is a valid delegating spender; but a
+        // delegated allowance carrying no serials can only have been an attempt to tamper with the owner's
+        // approve-for-all grants, so it is rejected rather than accepted as a no-op.
+        givenApproveAllowanceTxn(
+                payerId,
+                false,
+                List.of(),
+                List.of(),
+                List.of(nftAllowance
+                        .copyBuilder()
+                        .owner(ownerId)
+                        .spender(delegatingSpenderId)
+                        .delegatingSpender(spenderId)
+                        .approvedForAll(Boolean.FALSE)
+                        .serialNumbers(List.of())
+                        .build()));
+
+        assertThatThrownBy(() -> subject.validate(handleContext, account, readableAccountStore))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(EMPTY_ALLOWANCES));
+    }
+
+    @Test
     void failsWhenTokenNotAssociatedToAccount() {
         givenApproveAllowanceTxn(
                 payerId,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountDetailsAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountDetailsAsserts.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.spec.assertions;
 
 import static com.hederahashgraph.api.proto.java.GetAccountDetailsResponse.AccountDetails;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hederahashgraph.api.proto.java.GrantedCryptoAllowance;
@@ -78,12 +79,26 @@ public class AccountDetailsAsserts extends BaseErroringAssertsProvider<AccountDe
     }
 
     public AccountDetailsAsserts nftApprovedAllowancesContaining(String token, String spender) {
+        return nftApprovedAllowances(token, spender, true);
+    }
+
+    public AccountDetailsAsserts nftApprovedAllowancesNotContaining(String token, String spender) {
+        return nftApprovedAllowances(token, spender, false);
+    }
+
+    private AccountDetailsAsserts nftApprovedAllowances(String token, String spender, boolean shouldContain) {
         registerProvider((spec, o) -> {
-            var nftAllowance = GrantedNftAllowance.newBuilder()
+            final var nftAllowance = GrantedNftAllowance.newBuilder()
                     .setTokenId(spec.registry().getTokenID(token))
                     .setSpender(spec.registry().getAccountID(spender))
                     .build();
-            assertTrue(((AccountDetails) o).getGrantedNftAllowancesList().contains(nftAllowance), "Bad NftAllowances!");
+            final var present =
+                    ((AccountDetails) o).getGrantedNftAllowancesList().contains(nftAllowance);
+            if (shouldContain) {
+                assertTrue(present, "Bad NftAllowances!");
+            } else {
+                assertFalse(present, "Unexpected NftAllowance!");
+            }
         });
         return this;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoApproveAllowanceSuite.java
@@ -543,6 +543,167 @@ public class CryptoApproveAllowanceSuite {
     }
 
     @HapiTest
+    final Stream<DynamicTest> approveForAllSpenderCannotRevokeAnotherApproveForAllSpender() {
+        final String delegatingSpender = "delegatingSpender";
+        final String victimSpender = "victimSpender";
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
+                cryptoCreate(delegatingSpender).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(victimSpender).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY).balance(100 * ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .maxSupply(10L)
+                        .initialSupply(0)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenAssociate(OWNER, NON_FUNGIBLE_TOKEN),
+                tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(ByteString.copyFromUtf8("a")))
+                        .via(NFT_TOKEN_MINT_TXN),
+                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L).between(TOKEN_TREASURY, OWNER)),
+                // The owner grants approve-for-all to two independent operators.
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, delegatingSpender, true, List.of())
+                        .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, victimSpender, true, List.of())
+                        .signedBy(DEFAULT_PAYER, OWNER),
+                getAccountDetails(OWNER)
+                        .payingWith(GENESIS)
+                        .has(accountDetailsWith()
+                                .nftApprovedForAllAllowancesCount(2)
+                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, delegatingSpender)
+                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, victimSpender)),
+                // One operator issues a delegated allowance naming the other operator as spender, signed only by the
+                // delegating spender (the owner does NOT sign). A delegating spender may only sub-delegate serials, so
+                // a delegated allowance carrying no serials can only have been an attempt to tamper with the owner's
+                // approve-for-all grants - it is rejected outright.
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addDelegatedNftAllowance(
+                                OWNER, NON_FUNGIBLE_TOKEN, victimSpender, delegatingSpender, false, List.of())
+                        .signedBy(DEFAULT_PAYER, delegatingSpender)
+                        .hasKnownStatus(EMPTY_ALLOWANCES),
+                // Both approve-for-all grants remain intact.
+                getAccountDetails(OWNER)
+                        .payingWith(GENESIS)
+                        .has(accountDetailsWith()
+                                .nftApprovedForAllAllowancesCount(2)
+                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, delegatingSpender)
+                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, victimSpender)),
+                // The victim still holds approve-for-all and can transfer the owner's NFT.
+                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1L).between(OWNER, RECEIVER))
+                        .payingWith(victimSpender)
+                        .signedBy(victimSpender));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> subDelegatedSerialDoesNotGrantApproveForAll() {
+        final String delegatingSpender = "delegatingSpender";
+        final String newSpender = "newSpender";
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
+                cryptoCreate(delegatingSpender).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(newSpender).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY).balance(100 * ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .maxSupply(10L)
+                        .initialSupply(0)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenAssociate(OWNER, NON_FUNGIBLE_TOKEN),
+                tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(ByteString.copyFromUtf8("a")))
+                        .via(NFT_TOKEN_MINT_TXN),
+                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L).between(TOKEN_TREASURY, OWNER)),
+                // Owner grants approve-for-all to the delegating spender only.
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, delegatingSpender, true, List.of())
+                        .signedBy(DEFAULT_PAYER, OWNER),
+                // The delegating spender sub-delegates serial 1 to a new spender, signed only by the delegating
+                // spender.
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addDelegatedNftAllowance(
+                                OWNER, NON_FUNGIBLE_TOKEN, newSpender, delegatingSpender, false, List.of(1L))
+                        .signedBy(DEFAULT_PAYER, delegatingSpender),
+                // Sub-delegation grants only a per-serial spender: newSpender must NOT gain approve-for-all, and the
+                // delegating spender's own grant must be untouched (still exactly one approve-for-all entry).
+                getTokenNftInfo(NON_FUNGIBLE_TOKEN, 1L).hasSpenderID(newSpender),
+                getAccountDetails(OWNER)
+                        .payingWith(GENESIS)
+                        .has(accountDetailsWith()
+                                .nftApprovedForAllAllowancesCount(1)
+                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, delegatingSpender)
+                                .nftApprovedAllowancesNotContaining(NON_FUNGIBLE_TOKEN, newSpender)),
+                // The sub-delegated spender can transfer exactly that serial.
+                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1L).between(OWNER, RECEIVER))
+                        .payingWith(newSpender)
+                        .signedBy(newSpender));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> approveForAllSpenderCannotRevokePeerViaNonEmptySerialAllowance() {
+        final String delegatingSpender = "delegatingSpender";
+        final String victimSpender = "victimSpender";
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
+                cryptoCreate(delegatingSpender).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(victimSpender).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY).balance(100 * ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .maxSupply(10L)
+                        .initialSupply(0)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenAssociate(OWNER, NON_FUNGIBLE_TOKEN),
+                tokenAssociate(RECEIVER, NON_FUNGIBLE_TOKEN),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(ByteString.copyFromUtf8("a"), ByteString.copyFromUtf8("b")))
+                        .via(NFT_TOKEN_MINT_TXN),
+                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L).between(TOKEN_TREASURY, OWNER)),
+                // Owner grants approve-for-all to two independent operators.
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, delegatingSpender, true, List.of())
+                        .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, victimSpender, true, List.of())
+                        .signedBy(DEFAULT_PAYER, OWNER),
+                // The residual attack: rather than empty serials (blocked by EMPTY_ALLOWANCES), the delegating
+                // spender includes a real serial to slip past validation, hoping the peer's approve-for-all is
+                // stripped as a side effect. Signed only by the delegating spender - the owner does NOT sign.
+                // The fix leaves the approve-for-all list untouched and only sub-delegates the serial.
+                cryptoApproveAllowance()
+                        .payingWith(DEFAULT_PAYER)
+                        .addDelegatedNftAllowance(
+                                OWNER, NON_FUNGIBLE_TOKEN, victimSpender, delegatingSpender, false, List.of(1L))
+                        .signedBy(DEFAULT_PAYER, delegatingSpender),
+                // Both approve-for-all grants survive, and serial 1 is now sub-delegated to the victim.
+                getAccountDetails(OWNER)
+                        .payingWith(GENESIS)
+                        .has(accountDetailsWith()
+                                .nftApprovedForAllAllowancesCount(2)
+                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, delegatingSpender)
+                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, victimSpender)),
+                getTokenNftInfo(NON_FUNGIBLE_TOKEN, 1L).hasSpenderID(victimSpender),
+                // Proof the victim's approve-for-all survived: it can transfer serial 2, for which it holds NO
+                // per-serial allowance - only the surviving blanket approve-for-all makes this possible.
+                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L).between(OWNER, RECEIVER))
+                        .payingWith(victimSpender)
+                        .signedBy(victimSpender));
+    }
+
+    @HapiTest
     final Stream<DynamicTest> canGrantFungibleAllowancesWithTreasuryOwner() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),


### PR DESCRIPTION
**Description**:

- Refines the handling and validation of delegated NFT allowances (those specifying a delegating spender) in `CryptoApproveAllowance`, and consolidates the shared delegated-allowance check into a single `AllowanceValidator.isDelegatingSpenderPresent(...)` used by both the validator and the handler.
- Adds unit tests and HapiTests.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
