### PR TITLE
ci(fix): use evn vars instead of direct shell injection for input vars

### DIFF
--- a/.github/workflows/004-user-deploy-preview.yaml
+++ b/.github/workflows/004-user-deploy-preview.yaml
@@ -41,9 +41,11 @@ jobs:
 
       - name: Extract Tag Version
         id: tag
+        env:
+          TAG_TO_DEPLOY: ${{ github.event.inputs.tag-to-deploy }}
         run: |
-          RELEASE_VERSION="$(semver get release "${{ github.event.inputs.tag-to-deploy }}")"
-          PRERELEASE_VERSION="$(semver get prerel "${{ github.event.inputs.tag-to-deploy }}")"
+          RELEASE_VERSION="$(semver get release "${TAG_TO_DEPLOY}")"
+          PRERELEASE_VERSION="$(semver get prerel "${TAG_TO_DEPLOY}")"
 
           FINAL_VERSION="${RELEASE_VERSION}"
           PRERELEASE_FLAG="false"

--- a/.github/workflows/100-user-collect-workflow-logs.yaml
+++ b/.github/workflows/100-user-collect-workflow-logs.yaml
@@ -30,11 +30,12 @@ jobs:
       - name: Get run ID from run number
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          WORKFLOW_ID: ${{ inputs.workflow_id }}
         id: run_id
         run: |
           RUN_ID=$(gh api -H "Accept: application/vnd.github+json" \
             /repos/hiero-ledger/hiero-consensus-node/actions/workflows/900-cron-extended-test-suite.yaml/runs \
-            --jq '.workflow_runs[] | select(.run_number == ${{ inputs.workflow_id }}) | .id')
+            --jq ".workflow_runs[] | select(.run_number == ${WORKFLOW_ID}) | .id")
           echo "::set-output name=value::$RUN_ID"
 
       - name: Get run logs
@@ -49,8 +50,10 @@ jobs:
           path: workflow-run.log
 
       - name: Share log information
+        env:
+          WORKFLOW_ID: ${{ inputs.workflow_id }}
         run: |
           echo "### Logs Collected for Workflow:" >> $GITHUB_STEP_SUMMARY
-          echo "Workflow run ID: ${{ inputs.workflow_id  }}" >> $GITHUB_STEP_SUMMARY
+          echo "Workflow run ID: ${WORKFLOW_ID}" >> $GITHUB_STEP_SUMMARY
           echo "Workflow URL: https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/${{ steps.run_id.outputs.value }}" >> $GITHUB_STEP_SUMMARY
           echo "Log file download URL: ${{ steps.upload-log.outputs.artifact-url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/101-user-trigger-release.yaml
+++ b/.github/workflows/101-user-trigger-release.yaml
@@ -46,24 +46,30 @@ jobs:
           node-version: "20"
 
       - name: Print Input Parameters
+        env:
+          BUILD_NUMBER: ${{ inputs.build_number }}
+          ALPHA_RELEASE: ${{ inputs.alpha-release }}
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           echo "Input Parameters:"
-          echo "  Build Number: ${{ inputs.build_number }}"
-          echo "  Alpha Release: ${{ inputs.alpha-release }}"
-          echo "  Dry Run Enabled: ${{ inputs.dry-run-enabled }}"
+          echo "  Build Number: ${BUILD_NUMBER}"
+          echo "  Alpha Release: ${ALPHA_RELEASE}"
+          echo "  Dry Run Enabled: ${DRY_RUN_ENABLED}"
 
       - name: Build Input Validation
         id: validate
+        env:
+          BUILD_NUMBER: ${{ inputs.build_number }}
         run: |
-          echo "The input is ${{ inputs.build_number }}"
-          if ! [[ "${{ inputs.build_number }}" =~ ^[0-9]+$ ]]; then
+          echo "The input is ${BUILD_NUMBER}"
+          if ! [[ "${BUILD_NUMBER}" =~ ^[0-9]+$ ]]; then
             echo "Input is not a valid integer"
             exit 1
           fi
-          echo "Input is a valid integer: $(( ${{ inputs.build_number }} ))"
+          echo "Input is a valid integer: $(( BUILD_NUMBER ))"
 
           # 5-digit padding
-          padded_number="$(printf "%05d" "${{ inputs.build_number }}")"
+          padded_number="$(printf "%05d" "${BUILD_NUMBER}")"
           echo "Padded number is: ${padded_number}"
 
           # Add "build-" prefix to the padded number
@@ -145,6 +151,7 @@ jobs:
       - name: Calculate and Create Release Branch
         env:
           ALPHA_FLAG: ${{ inputs.alpha-release }}
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           # Get current version information
           current_version="$(git-semver latest)"
@@ -184,7 +191,7 @@ jobs:
             echo "Alpha release detected. Skipping release branch creation."
           fi
 
-          if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
+          if [[ "${DRY_RUN_ENABLED}" == "true" ]]; then
             CREATE_RELEASE_BRANCH=false
             echo "Dry run enabled. Skipping release branch creation."
           fi
@@ -203,9 +210,11 @@ jobs:
           fi
 
       - name: Apply Tag with Calculated Next Version
+        env:
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           echo "Applying computed version tag"
-          if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
+          if [[ "${DRY_RUN_ENABLED}" == "true" ]]; then
             echo "Dry run enabled, not applying tag ${{ steps.next-release.outputs.version }}"
           else
             git tag --sign --annotate "${{ steps.next-release.outputs.version }}" --message "${{ steps.next-release.outputs.version }}"
@@ -249,12 +258,14 @@ jobs:
 
       - name: Delete the Temporary Semantic Release Branch
         if: always()
+        env:
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           echo "Deleting the temporary semantic release branch"
           git branch -d "${{ steps.branch.outputs.name }}"
           echo "Deleted Temporary Branch from Local Runner" >> ${GITHUB_STEP_SUMMARY}
 
-          if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
+          if [[ "${DRY_RUN_ENABLED}" == "true" ]]; then
             echo "No remote branches to delete"
           else
             echo "Deleting remote branch now:"
@@ -264,13 +275,15 @@ jobs:
 
       - name: Print Output Parameters for Create Github Release Job
         if: ${{ inputs.alpha-release != true && github.event.repository.private == false }}
+        env:
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           echo "Output Parameters for Create GitHub Release Job:"
           echo "  Ref: ${{ steps.next-release.outputs.version }}"
           echo "  Release Version: ${{ steps.next-release.outputs.version }}"
           echo "  Create Release Notes: true"
           echo "  Create Release: true"
-          echo "  Dry Run: ${{ inputs.dry-run-enabled }}"
+          echo "  Dry Run: ${DRY_RUN_ENABLED}"
 
   create-github-release:
     name: Create GitHub Release

--- a/.github/workflows/102-user-memory-profile-ctrl.yaml
+++ b/.github/workflows/102-user-memory-profile-ctrl.yaml
@@ -120,8 +120,10 @@ jobs:
           node-version: 20.18.0
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version || 'latest' }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
 
           # verify the installation
           solo --version

--- a/.github/workflows/103-user-solo-tests-adhoc.yaml
+++ b/.github/workflows/103-user-solo-tests-adhoc.yaml
@@ -130,8 +130,10 @@ jobs:
           token: ${{ github.token }}
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
       - name: Setup Kind
@@ -318,8 +320,10 @@ jobs:
           token: ${{ github.token }}
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
       - name: Setup Kind
@@ -412,6 +416,7 @@ jobs:
         env:
           CLUSTER_TARGET: ${{ inputs.cluster-target == 'remote-sdlt-n6' && 'remote' || 'kind' }}
           KUBE_CONTEXT: ${{ inputs.cluster-target == 'remote-sdlt-n6' && 'hashgraph.teleport.sh-k8s.pft.chi.lat.ope.eng.hashgraph.io' || '' }}
+          UPGRADE_075_VERSION: ${{ inputs.cutover-upgrade-075-version || 'v0.75.0-rc.6' }}
         run: |
           set -eo pipefail
           SCRIPT_PATH="hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-e2e-block-stream-cutover.sh"
@@ -419,7 +424,7 @@ jobs:
           timeout --signal=SIGINT --kill-after=5m 150m \
             env \
               BLOCK_NODE_REPO_PATH="${GITHUB_WORKSPACE}/hiero-block-node" \
-              UPGRADE_075_VERSION="${{ inputs.cutover-upgrade-075-version || 'v0.75.0-rc.6' }}" \
+              UPGRADE_075_VERSION="${UPGRADE_075_VERSION}" \
               CLUSTER_TARGET="${CLUSTER_TARGET}" \
               KUBE_CONTEXT="${KUBE_CONTEXT}" \
               SOLO_NAMESPACE="${SOLO_NAMESPACE}" \
@@ -506,8 +511,10 @@ jobs:
           token: ${{ github.token }}
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
       - name: Setup Kind
@@ -551,6 +558,9 @@ jobs:
         run: ${GRADLE_EXEC} assemble
 
       - name: Run 0.75 -> 0.76 TSS Upgrade Scenario
+        env:
+          DEPLOY_RELEASE_TAG: ${{ inputs.tss-starting-tag || 'v0.75.0-rc.6' }}
+          UPGRADE_TAG: ${{ inputs.tss-upgrade-tag }}
         run: |
           set -eo pipefail
           SCRIPT_PATH="hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-075-to-076-tss.sh"
@@ -558,8 +568,8 @@ jobs:
           timeout --signal=SIGINT --kill-after=5m 100m \
             env \
               BLOCK_NODE_REPO_PATH="${GITHUB_WORKSPACE}/hiero-block-node" \
-              DEPLOY_RELEASE_TAG="${{ inputs.tss-starting-tag || 'v0.75.0-rc.6' }}" \
-              UPGRADE_TAG="${{ inputs.tss-upgrade-tag }}" \
+              DEPLOY_RELEASE_TAG="${DEPLOY_RELEASE_TAG}" \
+              UPGRADE_TAG="${UPGRADE_TAG}" \
             "${SCRIPT_PATH}" | tee "${RUNNER_TEMP}/075-to-076-tss-script.log"
 
       - name: Collect Diagnostics On Failure
@@ -634,8 +644,10 @@ jobs:
           node-version: "20.18.0"
 
       - name: Install Solo
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version }}
         run: |
-          npm install -g "@hiero-ledger/solo@${{ inputs.solo-version }}"
+          npm install -g "@hiero-ledger/solo@${SOLO_VERSION}"
           solo --version
 
       - name: Setup Kind

--- a/.github/workflows/817-call-jrs-regression.yaml
+++ b/.github/workflows/817-call-jrs-regression.yaml
@@ -187,15 +187,17 @@ jobs:
         id: jrs-parameters
         env:
           GITHUB_TOKEN: ${{ secrets.access-token }}
+          BRANCH_NAME_INPUT: ${{ inputs.branch-name }}
+          BASE_BRANCH_NAME_INPUT: ${{ inputs.base-branch-name }}
         run: |
-          FEAT_BRANCH_EXISTS="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/hashgraph/jrs-legacy/branches/${{ inputs.branch-name }})"
+          FEAT_BRANCH_EXISTS="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/hashgraph/jrs-legacy/branches/${BRANCH_NAME_INPUT})"
 
           BRANCH_NAME=""
-          [[ "${FEAT_BRANCH_EXISTS}" -eq 200 ]] && BRANCH_NAME="${{ inputs.branch-name }}"
+          [[ "${FEAT_BRANCH_EXISTS}" -eq 200 ]] && BRANCH_NAME="${BRANCH_NAME_INPUT}"
 
           if [[ -z "${BRANCH_NAME}" ]]; then
-            BASE_BRANCH_EXISTS="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/hashgraph/jrs-legacy/branches/${{ inputs.base-branch-name }})"
-            [[ "${BASE_BRANCH_EXISTS}" -eq 200 ]] && BRANCH_NAME="${{ inputs.base-branch-name }}"
+            BASE_BRANCH_EXISTS="$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/hashgraph/jrs-legacy/branches/${BASE_BRANCH_NAME_INPUT})"
+            [[ "${BASE_BRANCH_EXISTS}" -eq 200 ]] && BRANCH_NAME="${BASE_BRANCH_NAME_INPUT}"
           fi
 
           echo "branch-name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
@@ -365,8 +367,10 @@ jobs:
 
       - name: Compute Actual Branch Name
         id: branch
+        env:
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
         run: |
-          REF="${{ github.head_ref || github.ref_name }}"
+          REF="${HEAD_REF}"
           REF="${REF##origin/}"
 
           echo "name=${REF}" >> "${GITHUB_OUTPUT}"
@@ -374,9 +378,11 @@ jobs:
       - name: Retrieve Existing JRS Branch History (If Available)
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.name }}
+          SUMMARY_PATH: ${{ inputs.summary-path }}
+          SUMMARY_BUCKET: ${{ inputs.summary-bucket }}
         run: |
-          [[ -d "${{ inputs.summary-path }}" ]] || mkdir -p "${{ inputs.summary-path }}"
-          rclone sync --gcs-bucket-policy-only --checksum --fast-list --stats-one-line -v "gcs:${{ inputs.summary-bucket }}/${BRANCH_NAME}/" "${{ inputs.summary-path }}/"
+          [[ -d "${SUMMARY_PATH}" ]] || mkdir -p "${SUMMARY_PATH}"
+          rclone sync --gcs-bucket-policy-only --checksum --fast-list --stats-one-line -v "gcs:${SUMMARY_BUCKET}/${BRANCH_NAME}/" "${SUMMARY_PATH}/"
 
       - name: Execute JRS Regression (${{ steps.jrs-config.outputs.file }})
         id: run-jrs-regression
@@ -396,19 +402,21 @@ jobs:
           JRS_WEB_PORT: ${{ inputs.jrs-web-port }}
           ACTIONS_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_API_TOKEN: ${{ secrets.slack-api-token }}
+          GH_ACTOR: ${{ github.actor }}
+          GH_JOB: ${{ github.job }}
         working-directory: ${{ github.workspace }}/platform-sdk/${{ inputs.regression-path }}
         run: |
           set -x
 
           readonly BRANCH_VERSION_REGEX="([A-Za-z]+)/?[0-9]+\.([0-9]+)\.?[0-9]*-?[A-Za-z]*\.?[0-9]*"
 
-          if [[ -z "${{ github.actor }}" ]]; then
+          if [[ -z "${GH_ACTOR}" ]]; then
             JRS_USER="swirlds-automation"
           else
-            JRS_USER="${{ github.actor }}"
+            JRS_USER="${GH_ACTOR}"
           fi
 
-          [[ -n "${JRS_BRANCH}" ]] || JRS_BRANCH="${{ github.job }}"
+          [[ -n "${JRS_BRANCH}" ]] || JRS_BRANCH="${GH_JOB}"
 
           JRS_ARGUMENTS="-po"
           JRS_ARGUMENTS="${JRS_ARGUMENTS} -u ${JRS_USER}"
@@ -484,6 +492,10 @@ jobs:
           echo "Test Exit Code: $?"
       - name: Show JRS Folder Structures
         if: ${{ inputs.enable-workflow-debug && always() }}
+        env:
+          SUMMARY_PATH: ${{ inputs.summary-path }}
+          RESULT_PATH: ${{ inputs.result-path }}
+          REGRESSION_PATH_INPUT: ${{ inputs.regression-path }}
         run: |
           if ! command -v tree >/dev/null 2>&1; then
             echo "::group::Install Tree Command"
@@ -493,35 +505,39 @@ jobs:
           fi
 
           echo "::group::Show History Folder Contents"
-          tree -apshug  "${{ inputs.summary-path }}/"
+          tree -apshug  "${SUMMARY_PATH}/"
           echo "::endgroup::"
 
           echo "::group::Show Results Folder Contents"
-          tree -apshug  "${{ inputs.result-path }}/"
+          tree -apshug  "${RESULT_PATH}/"
           echo "::endgroup::"
 
           echo "::group::Show Regression Folder Contents"
-          tree -apshug  "${{ inputs.regression-path }}/"
+          tree -apshug  "${REGRESSION_PATH_INPUT}/"
           echo "::endgroup::"
 
       - name: Store JRS Branch History
         if: ${{ always() }}
         env:
           BRANCH_NAME: ${{ steps.branch.outputs.name }}
+          SUMMARY_PATH: ${{ inputs.summary-path }}
+          SUMMARY_BUCKET: ${{ inputs.summary-bucket }}
         run: |
-          [[ -d "${{ inputs.summary-path }}" ]] || mkdir -p "${{ inputs.summary-path }}"
+          [[ -d "${SUMMARY_PATH}" ]] || mkdir -p "${SUMMARY_PATH}"
           # do not use sync, since another test flow may have uploaded some test results that this test flow did not have
-          rclone copy --gcs-bucket-policy-only --checksum --stats-one-line -v "${{ inputs.summary-path }}/" "gcs:${{ inputs.summary-bucket }}/${BRANCH_NAME}/"
+          rclone copy --gcs-bucket-policy-only --checksum --stats-one-line -v "${SUMMARY_PATH}/" "gcs:${SUMMARY_BUCKET}/${BRANCH_NAME}/"
 
       - name: Upload JRS Results
         env:
           JRS_USER: ${{ github.actor || 'swirlds-automation' }}
           BRANCH_NAME: ${{ steps.branch.outputs.name }}
+          RESULT_PATH: ${{ inputs.result-path }}
+          RESULT_BUCKET: ${{ inputs.result-bucket }}
         if: ${{ !cancelled() && always() }}
         run: |
           set -x
-          [[ ! -d "${{ inputs.result-path }}" ]] && mkdir -p "${{ inputs.result-path }}"
-          rclone copy --gcs-bucket-policy-only --checksum --stats-one-line -v "${{ inputs.result-path }}/" "gcs:${{ inputs.result-bucket }}/${JRS_USER}/${BRANCH_NAME}/"
+          [[ ! -d "${RESULT_PATH}" ]] && mkdir -p "${RESULT_PATH}"
+          rclone copy --gcs-bucket-policy-only --checksum --stats-one-line -v "${RESULT_PATH}/" "gcs:${RESULT_BUCKET}/${JRS_USER}/${BRANCH_NAME}/"
 
       - name: Remove RClone Authentication
         if: ${{ always() }}

--- a/.github/workflows/820-call-mirror-node-regression.yaml
+++ b/.github/workflows/820-call-mirror-node-regression.yaml
@@ -89,7 +89,9 @@ jobs:
         run: ${GRADLE_EXEC} assemble
 
       - name: Install Solo
-        run: npm install -g @hiero-ledger/solo@${{ inputs.solo-version || 'latest' }}
+        env:
+          SOLO_VERSION: ${{ inputs.solo-version || 'latest' }}
+        run: npm install -g @hiero-ledger/solo@${SOLO_VERSION}
 
       - name: Setup Kind
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0

--- a/.github/workflows/850-call-build-release-artifact.yaml
+++ b/.github/workflows/850-call-build-release-artifact.yaml
@@ -141,6 +141,8 @@ jobs:
         env:
           REF_CHECK: ${{ inputs.ref }}
           REPO_URL: "https://github.com/${{ github.repository }}"
+          REF_NAME: ${{ inputs.ref-name }}
+          VERSION_POLICY: ${{ inputs.version-policy }}
         run: |
           REF_INFO=$(git ls-remote "${REPO_URL}" "${REF_CHECK}")
           if [[ -n "${REF_INFO/ /}" ]]; then
@@ -150,13 +152,13 @@ jobs:
           fi
 
           echo "COMMIT SHA is: ${COMMIT_SHA}"
-          BRANCH_NAME="${{ inputs.ref-name }}"
+          BRANCH_NAME="${REF_NAME}"
           BRANCH_NAME="${BRANCH_NAME##origin/}"
           BRANCH_NAME_LOWER="$(echo "${BRANCH_NAME}" | tr '[:upper:]' '[:lower:]')"
           BRANCH_NAME_SAFE="$(echo "${BRANCH_NAME_LOWER}" | tr '/' '-' | tr '_' '.')"
 
           COMMIT_PREFIX="adhoc"
-          [[ "${{ inputs.version-policy }}" == "branch-commit" ]] && COMMIT_PREFIX="${BRANCH_NAME_SAFE}"
+          [[ "${VERSION_POLICY}" == "branch-commit" ]] && COMMIT_PREFIX="${BRANCH_NAME_SAFE}"
 
           echo "branch-name=${BRANCH_NAME}" >>"${GITHUB_OUTPUT}"
           echo "branch-name-lower=${BRANCH_NAME_LOWER}" >>"${GITHUB_OUTPUT}"
@@ -175,11 +177,13 @@ jobs:
 
       - name: Verify Version Update (As Specified)
         if: ${{ inputs.version-policy == 'specified' && !cancelled() && !failure() }}
+        env:
+          NEW_VERSION: ${{ inputs.new-version }}
         run: |
-          VALID_VERSION="$(semver validate "${{ inputs.new-version }}")"
+          VALID_VERSION="$(semver validate "${NEW_VERSION}")"
 
           if [[ "${VALID_VERSION}" != "valid" ]]; then
-            echo "::error title=Version Error::The supplied new-version parameter (${{ inputs.new-version }}) is invalid and does not conform to the semantic versioning specifications."
+            echo "::error title=Version Error::The supplied new-version parameter (${NEW_VERSION}) is invalid and does not conform to the semantic versioning specifications."
             exit 2
           fi
 
@@ -202,7 +206,9 @@ jobs:
 
       - name: Gradle Update Version (As Specified)
         if: ${{ inputs.version-policy == 'specified' && !cancelled() && !failure() }}
-        run: ./gradlew versionAsSpecified -PnewVersion=${{ inputs.new-version }}
+        env:
+          NEW_VERSION: ${{ inputs.new-version }}
+        run: ./gradlew versionAsSpecified -PnewVersion="${NEW_VERSION}"
 
       - name: Gradle Update Version (Branch Commit)
         if: ${{ inputs.version-policy != 'specified' && !cancelled() && !failure() }}
@@ -349,8 +355,10 @@ jobs:
       - name: Create Artifact Archive
         id: artifact-release
         working-directory: ${{ steps.artifact-staging.outputs.folder }}
+        env:
+          VERSION_POLICY: ${{ inputs.version-policy }}
         run: |
-          POLICY="${{ inputs.version-policy }}"
+          POLICY="${VERSION_POLICY}"
           ARTIFACT_BASE_DIR="${HOME}/artifact-release"
           mkdir -p "${ARTIFACT_BASE_DIR}"
 
@@ -418,15 +426,18 @@ jobs:
 
       - name: Set Image Registry
         id: set-registry
+        env:
+          VERSION_POLICY: ${{ inputs.version-policy }}
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           DOCKER_REGISTRY="gcr.io"
-          [[ "${{ inputs.version-policy }}" == "branch-commit" ]] && DOCKER_REGISTRY="us-docker.pkg.dev"
+          [[ "${VERSION_POLICY}" == "branch-commit" ]] && DOCKER_REGISTRY="us-docker.pkg.dev"
           echo "docker-registry=${DOCKER_REGISTRY}" >>"${GITHUB_OUTPUT}"
 
           DOCKER_TAG_BASE="gcr.io/hedera-registry"
-          if [[ "${{ inputs.version-policy }}" == "branch-commit" && "${{ inputs.dry-run-enabled }}" != true ]]; then
+          if [[ "${VERSION_POLICY}" == "branch-commit" && "${DRY_RUN_ENABLED}" != true ]]; then
              DOCKER_TAG_BASE="us-docker.pkg.dev/swirlds-registry/local-node"
-          elif [[ "${{ inputs.dry-run-enabled }}" == true ]]; then
+          elif [[ "${DRY_RUN_ENABLED}" == true ]]; then
              DOCKER_TAG_BASE="localhost:5000"
           fi
 
@@ -495,12 +506,14 @@ jobs:
           tags: ${{ steps.set-registry.outputs.docker-tag-base }}/main-network-node:${{ needs.validate.outputs.version }}
 
       - name: Render Job Summary
+        env:
+          DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled }}
         run: |
           NETWORK_NODE_BASE_LINK="Not Applicable"
           NETWORK_NODE_HAVEGED_LINK="Not Applicable"
           NETWORK_NODE_MAIN_LINK="Not Applicable"
 
-          if [[ "${{ inputs.dry-run-enabled }}" != true ]]; then
+          if [[ "${DRY_RUN_ENABLED}" != true ]]; then
             NETWORK_NODE_BASE_LINK="[GCP Console](https://${{ steps.set-registry.outputs.docker-tag-base }}/network-node-base:${{ needs.validate.outputs.version }})"
             NETWORK_NODE_HAVEGED_LINK="[GCP Console](https://${{ steps.set-registry.outputs.docker-tag-base }}/network-node-haveged:${{ needs.validate.outputs.version }})"
             NETWORK_NODE_MAIN_LINK="[GCP Console](https://${{ steps.set-registry.outputs.docker-tag-base }}/main-network-node:${{ needs.validate.outputs.version }})"
@@ -856,7 +869,9 @@ jobs:
 
       - name: Gradle Publish to Google Artifact Registry (${{ inputs.release-profile }})
         if: ${{ inputs.version-policy != 'specified' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
-        run: ./gradlew release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false
+        env:
+          RELEASE_PROFILE: ${{ inputs.release-profile }}
+        run: ./gradlew "release${RELEASE_PROFILE}" -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false
 
       - name: Gradle Publish to Maven Central
         if: ${{ inputs.version-policy == 'specified' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
@@ -882,9 +897,11 @@ jobs:
       - name: Set GH Create Release Flag
         id: set-gh-release-flag
         if: ${{ inputs.version-policy == 'specified' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
+        env:
+          REF_NAME: ${{ inputs.ref-name }}
         run: |
           CREATE_RELEASE="false"
-          if [[ "${{ inputs.ref-name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Tag ${GITHUB_REF#refs/tags/} matches release tag pattern"
             CREATE_RELEASE="true"
           fi
@@ -923,12 +940,14 @@ jobs:
 
       - name: Determine Notification Parameters
         id: parameters
+        env:
+          RELEASE_PROFILE: ${{ inputs.release-profile }}
         run: |
           ARTIFACT_URL="https://repo1.maven.org/maven2/com/swirlds/swirlds-platform-core/${{ needs.validate.outputs.version }}/"
           ARTIFACT_LINK_NAME="MC Availability Check"
           ARTIFACT_REGISTRY="Maven Central"
 
-          if [[ "${{ inputs.release-profile }}" == "PrereleaseChannel" ]]; then
+          if [[ "${RELEASE_PROFILE}" == "PrereleaseChannel" ]]; then
             ARTIFACT_URL="https://console.cloud.google.com/artifacts/maven/swirlds-registry/us/maven-prerelease-channel/com.swirlds:swirlds-platform-core/${{ needs.validate.outputs.version }}?project=swirlds-registry"
             ARTIFACT_LINK_NAME="GCP Registry"
             ARTIFACT_REGISTRY="GCP Artifact Registry"


### PR DESCRIPTION
**Description**:

Replace direct use of some github and input vars in run scripts with ENV. This ensures the vars are passed a strings.



**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
