### PR TITLE
chore: Remove countOfCryptographicKeys method

### DIFF
--- a/hapi/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
+++ b/hapi/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
@@ -153,22 +153,6 @@ public class HapiUtils {
         return TIMESTAMP_COMPARATOR.compare(t1, t2) < 0;
     }
 
-    /** Given a key, determines the number of cryptographic keys contained within it. */
-    public static int countOfCryptographicKeys(@NonNull final Key key) {
-        return switch (key.key().kind()) {
-            case ECDSA_384, ED25519, RSA_3072, ECDSA_SECP256K1 -> 1;
-            case KEY_LIST ->
-                key.keyListOrThrow().keys().stream()
-                        .mapToInt(HapiUtils::countOfCryptographicKeys)
-                        .sum();
-            case THRESHOLD_KEY ->
-                key.thresholdKeyOrThrow().keysOrElse(KeyList.DEFAULT).keys().stream()
-                        .mapToInt(HapiUtils::countOfCryptographicKeys)
-                        .sum();
-            case CONTRACT_ID, DELEGATABLE_CONTRACT_ID, UNSET -> 0;
-        };
-    }
-
     // Suppressing the warning that this field is not used
     @SuppressWarnings("java:S1068")
     private static final Set<HederaFunctionality> QUERY_FUNCTIONS = EnumSet.of(

--- a/hapi/hapi/src/test/java/com/hedera/hapi/util/HapiUtilsTest.java
+++ b/hapi/hapi/src/test/java/com/hedera/hapi/util/HapiUtilsTest.java
@@ -5,26 +5,18 @@ import static com.hedera.hapi.util.HapiUtils.SEMANTIC_VERSION_COMPARATOR;
 import static com.hedera.hapi.util.HapiUtils.asTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.params.provider.Arguments.of;
 
-import com.hedera.hapi.node.base.ContractID;
-import com.hedera.hapi.node.base.Key;
-import com.hedera.hapi.node.base.KeyList;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.base.ServiceEndpoint;
-import com.hedera.hapi.node.base.ThresholdKey;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
 
 final class HapiUtilsTest {
 
@@ -75,129 +67,6 @@ final class HapiUtilsTest {
         // Then we find the timestamp matches the original instant
         assertThat(timestamp)
                 .isEqualTo(Timestamp.newBuilder().seconds(1000).nanos(123456789).build());
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("cryptoKeys")
-    @DisplayName("Count of primitive cryptographic keys")
-    void countOfPrimitiveCryptoKeys(@NonNull final String name, @NonNull final Key key, final int expectedCount) {
-        // Given a key (which may be a cryptographic key, key list, threshold key, or other)
-        // When we count up the number of primitive keys
-        final var count = HapiUtils.countOfCryptographicKeys(key);
-        // Then we find the answer is expected
-        assertThat(count).isEqualTo(expectedCount);
-    }
-
-    public static Stream<Arguments> cryptoKeys() {
-        // Even though all these bytes are empty, it is OK for the test, since we're not inspecting the keys
-        // for validity, we only need to verify the key exists.
-        final var keyBytes = Bytes.EMPTY;
-        final var contractId = ContractID.DEFAULT;
-        return Stream.of(
-                of("ECDSA_384", Key.newBuilder().ecdsa384(keyBytes).build(), 1),
-                of("ECDSA_SECP256_K1", Key.newBuilder().ecdsaSecp256k1(keyBytes).build(), 1),
-                of("ED25519", Key.newBuilder().ed25519(keyBytes).build(), 1),
-                of("RSA_3072", Key.newBuilder().rsa3072(keyBytes).build(), 1),
-                of("CONTRACT_ID", Key.newBuilder().contractID(contractId).build(), 0),
-                of(
-                        "DELEGATABLE_CONTRACT_ID",
-                        Key.newBuilder().delegatableContractId(contractId).build(),
-                        0),
-                of("UNSET", Key.newBuilder().build(), 0),
-                of(
-                        "KEY_LIST",
-                        Key.newBuilder()
-                                .keyList(KeyList.newBuilder()
-                                        .keys( // Some more-or-less random collection of keys
-                                                Key.newBuilder()
-                                                        .ed25519(keyBytes)
-                                                        .build(),
-                                                Key.newBuilder()
-                                                        .ed25519(keyBytes)
-                                                        .build(),
-                                                Key.newBuilder()
-                                                        .ecdsaSecp256k1(keyBytes)
-                                                        .build(),
-                                                Key.newBuilder()
-                                                        .contractID(contractId)
-                                                        .build(),
-                                                Key.newBuilder()
-                                                        .rsa3072(keyBytes)
-                                                        .build())
-                                        .build())
-                                .build(),
-                        4),
-                of(
-                        "THRESHOLD_KEY",
-                        Key.newBuilder()
-                                .thresholdKey(ThresholdKey.newBuilder()
-                                        .threshold(1)
-                                        .keys(KeyList.newBuilder()
-                                                .keys( // Some more-or-less random collection of keys
-                                                        Key.newBuilder()
-                                                                .ed25519(keyBytes)
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .ed25519(keyBytes)
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .ecdsaSecp256k1(keyBytes)
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .contractID(contractId)
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .rsa3072(keyBytes)
-                                                                .build())
-                                                .build()))
-                                .build(),
-                        4),
-                of(
-                        "COMPLEX_KEY",
-                        Key.newBuilder()
-                                .thresholdKey(ThresholdKey.newBuilder()
-                                        .threshold(1)
-                                        .keys(KeyList.newBuilder()
-                                                .keys( // Some more-or-less random collection of keys
-                                                        Key.newBuilder()
-                                                                .ed25519(keyBytes)
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .ed25519(keyBytes)
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .keyList(KeyList.newBuilder()
-                                                                        .keys( // Some more-or-less random collection of
-                                                                                // keys
-                                                                                Key.newBuilder()
-                                                                                        .ed25519(keyBytes)
-                                                                                        .build(),
-                                                                                Key.newBuilder()
-                                                                                        .ed25519(keyBytes)
-                                                                                        .build(),
-                                                                                Key.newBuilder()
-                                                                                        .ecdsaSecp256k1(keyBytes)
-                                                                                        .build(),
-                                                                                Key.newBuilder()
-                                                                                        .contractID(contractId)
-                                                                                        .build(),
-                                                                                Key.newBuilder()
-                                                                                        .rsa3072(keyBytes)
-                                                                                        .build())
-                                                                        .build())
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .ecdsaSecp256k1(keyBytes)
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .contractID(contractId)
-                                                                .build(),
-                                                        Key.newBuilder()
-                                                                .rsa3072(keyBytes)
-                                                                .build())
-                                                .build()))
-                                .build(),
-                        8));
     }
 
     @Test


### PR DESCRIPTION
**Description**:

`HapiUtils.countOfCryptographicKeys(Key)` is no longer used following the legacy fees cleanup, fee calculation now counts keys via `FeeKeyUtils.countKeys` in the `hapi-fees` module. A repo-wide search confirms the method has no remaining callers (only its own recursion and a single unit test), so it can be safely removed.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
