### PR TITLE
fix: validate full shard.realm.num in Authorizer

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/authorization/AuthorizerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/authorization/AuthorizerImpl.java
@@ -15,6 +15,7 @@ import com.hedera.node.app.spi.authorization.SystemPrivilege;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.ApiPermissionConfig;
+import com.hedera.node.config.data.HederaConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
 import javax.inject.Inject;
@@ -28,13 +29,19 @@ public class AuthorizerImpl implements Authorizer {
 
     private final ConfigProvider configProvider;
     private final AccountsConfig accountsConfig;
+    private final long shard;
+    private final long realm;
     private final PrivilegesVerifier privilegedTransactionChecker;
 
     @Inject
     public AuthorizerImpl(
             @NonNull final ConfigProvider configProvider, @NonNull PrivilegesVerifier privilegedTransactionChecker) {
         this.configProvider = requireNonNull(configProvider);
-        this.accountsConfig = configProvider.getConfiguration().getConfigData(AccountsConfig.class);
+        final var configuration = configProvider.getConfiguration();
+        this.accountsConfig = configuration.getConfigData(AccountsConfig.class);
+        final var hederaConfig = configuration.getConfigData(HederaConfig.class);
+        this.shard = hederaConfig.shard();
+        this.realm = hederaConfig.realm();
         this.privilegedTransactionChecker = requireNonNull(privilegedTransactionChecker);
     }
 
@@ -47,16 +54,27 @@ public class AuthorizerImpl implements Authorizer {
 
     @Override
     public boolean isSuperUser(@NonNull final AccountID accountID) {
-        if (!accountID.hasAccountNum()) return false;
-        long num = accountID.accountNumOrThrow();
+        if (!isOnThisLedger(accountID)) return false;
+        final long num = accountID.accountNumOrThrow();
         return num == accountsConfig.treasury() || num == accountsConfig.systemAdmin();
     }
 
     @Override
     public boolean isTreasury(@NonNull final AccountID accountID) {
-        if (!accountID.hasAccountNum()) return false;
-        long num = accountID.accountNumOrThrow();
-        return num == accountsConfig.treasury();
+        if (!isOnThisLedger(accountID)) return false;
+        return accountID.accountNumOrThrow() == accountsConfig.treasury();
+    }
+
+    /**
+     * Returns whether the given id is a number-based account scoped to this ledger's shard and realm. Privilege
+     * checks must consider the full {@code shard.realm.num} triplet rather than the account number alone, so that a
+     * foreign-shard or foreign-realm id such as {@code 1.0.2} is never treated as the treasury account {@code 0.0.2}.
+     *
+     * @param accountID the account id to check
+     * @return true if the id has an account number in this ledger's shard and realm
+     */
+    private boolean isOnThisLedger(@NonNull final AccountID accountID) {
+        return accountID.hasAccountNum() && accountID.shardNum() == shard && accountID.realmNum() == realm;
     }
 
     @Override

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/authorization/AuthorizerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/authorization/AuthorizerTest.java
@@ -92,4 +92,79 @@ final class AuthorizerTest {
         final var authorized = authorizer.isAuthorized(accountID, hapiFunction);
         assertThat(authorized).isTrue();
     }
+
+    @Test
+    @DisplayName("Super-user status requires the configured shard and realm")
+    void superUserRequiresMatchingShardAndRealm() {
+        // given the default ledger shard/realm of 0.0, with treasury=2 and systemAdmin=50:
+        final var authorizer = new AuthorizerImpl(configProvider, privilegesVerifier);
+
+        // the canonical treasury and system-admin accounts are super-users:
+        assertThat(authorizer.isSuperUser(accountId(0, 0, 2))).isTrue();
+        assertThat(authorizer.isSuperUser(accountId(0, 0, 50))).isTrue();
+
+        // but an id that only matches on the account number is not, regardless of shard or realm:
+        assertThat(authorizer.isSuperUser(accountId(1, 0, 2))).isFalse();
+        assertThat(authorizer.isSuperUser(accountId(0, 1, 2))).isFalse();
+        assertThat(authorizer.isSuperUser(accountId(1, 0, 50))).isFalse();
+        assertThat(authorizer.isSuperUser(accountId(0, 1, 50))).isFalse();
+    }
+
+    @Test
+    @DisplayName("Treasury status requires the configured shard and realm")
+    void treasuryRequiresMatchingShardAndRealm() {
+        // given the default ledger shard/realm of 0.0, with treasury=2:
+        final var authorizer = new AuthorizerImpl(configProvider, privilegesVerifier);
+
+        assertThat(authorizer.isTreasury(accountId(0, 0, 2))).isTrue();
+        assertThat(authorizer.isTreasury(accountId(1, 0, 2))).isFalse();
+        assertThat(authorizer.isTreasury(accountId(0, 1, 2))).isFalse();
+    }
+
+    @Test
+    @DisplayName("Super-user status is scoped to a non-zero configured shard and realm")
+    void superUserScopedToConfiguredNonZeroShardRealm() {
+        // given a ledger configured for shard 1, realm 2:
+        configProvider = () -> new VersionedConfigImpl(
+                HederaTestConfigBuilder.create()
+                        .withValue("hedera.shard", "1")
+                        .withValue("hedera.realm", "2")
+                        .getOrCreateConfig(),
+                1);
+        final var authorizer = new AuthorizerImpl(configProvider, privilegesVerifier);
+
+        // the treasury account lives at 1.2.2 and is a super-user:
+        assertThat(authorizer.isSuperUser(accountId(1, 2, 2))).isTrue();
+        assertThat(authorizer.isTreasury(accountId(1, 2, 2))).isTrue();
+
+        // while the same number in shard/realm 0.0 is not:
+        assertThat(authorizer.isSuperUser(accountId(0, 0, 2))).isFalse();
+        assertThat(authorizer.isTreasury(accountId(0, 0, 2))).isFalse();
+    }
+
+    @Test
+    @DisplayName("A foreign-shard treasury number does not bypass API permissions")
+    void foreignShardTreasuryNumberIsNotAuthorized() {
+        // given a permission list that excludes the treasury and system-admin numbers:
+        configProvider = () -> new VersionedConfigImpl(
+                HederaTestConfigBuilder.create()
+                        .withValue("createTopic", "1000-2000")
+                        .getOrCreateConfig(),
+                1);
+        final var authorizer = new AuthorizerImpl(configProvider, privilegesVerifier);
+
+        // the canonical treasury account still bypasses the permission list as a super-user:
+        assertThat(authorizer.isAuthorized(accountId(0, 0, 2), hapiFunction)).isTrue();
+
+        // but a foreign-shard id with the treasury number is neither a super-user nor permission-listed:
+        assertThat(authorizer.isAuthorized(accountId(1, 0, 2), hapiFunction)).isFalse();
+    }
+
+    private static AccountID accountId(final long shard, final long realm, final long num) {
+        return AccountID.newBuilder()
+                .shardNum(shard)
+                .realmNum(realm)
+                .accountNum(num)
+                .build();
+    }
 }


### PR DESCRIPTION
**Description**:
AuthorizerImpl.isSuperUser/isTreasury compared only the account number, so any id whose num matched treasury (2) or systemAdmin (50) — regardless of shard/realm — was treated as privileged. Added an isOnThisLedger check that requires shardNum/realmNum to match the configured hedera.shard/hedera.realmbefore matching the number (permissibilityOf inherits it via isSuperUser). Defense-in-depth at the privileged/unprivileged trust boundary; no behavior change for valid payers, which are already shard/realm-validated upstream. Added AuthorizerTest cases asserting 1.0.2/0.1.50 aren’t privileged and that recognition tracks a non-zero configured shard/realm.