### PR TITLE
fix: pass the configured mirror-node version to solo in the XTS mirror-node regression panel

### DIFF
--- a/.github/workflows/820-call-mirror-node-regression.yaml
+++ b/.github/workflows/820-call-mirror-node-regression.yaml
@@ -136,7 +136,7 @@ jobs:
             solo consensus network deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
             solo consensus node setup -i node1 --deployment "${SOLO_DEPLOYMENT}" --local-build-path ./hedera-node/data
             solo consensus node start -i node1 --deployment "${SOLO_DEPLOYMENT}"
-            solo mirror node add --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${SOLO_CLUSTER_NAME}" --pinger --values-file mirror.yml
+            solo mirror node add --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${SOLO_CLUSTER_NAME}" --pinger --mirror-node-version "${MIRROR_NODE_VERSION}" --values-file mirror.yml
           else
             echo "::debug::Solo version ($version) is < 0.44.0"
             solo cluster-ref connect --cluster-ref "kind-${SOLO_CLUSTER_NAME}" --context "kind-${SOLO_CLUSTER_NAME}"
@@ -147,7 +147,7 @@ jobs:
             solo network deploy -i node1 --deployment "${SOLO_DEPLOYMENT}"
             solo node setup -i node1 --deployment "${SOLO_DEPLOYMENT}" --local-build-path ./hedera-node/data
             solo node start -i node1 --deployment "${SOLO_DEPLOYMENT}"
-            solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${SOLO_CLUSTER_NAME}" --pinger --values-file mirror.yml
+            solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref "kind-${SOLO_CLUSTER_NAME}" --pinger --mirror-node-version "${MIRROR_NODE_VERSION}" --values-file mirror.yml
           fi
 
           echo "solo-ge-0440=${solo_ge_0440}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Problem

The XTS Mirror Node Regression panel (`820-call-mirror-node-regression.yaml`) sets `MIRROR_NODE_VERSION` from the value plumbed out of `.citr-env` (`citr-mirror-node-version` → `855` → `001`/`900` → `815` → `820`), but that env var is only emitted as a `::debug::` line — it is **never passed to solo**. Both `solo mirror node add` and `solo mirror-node deploy` run without `--mirror-node-version`, so the panel always deploys solo's built-in default regardless of the configured version.

Net effect: the configured mirror-node version for this suite is a no-op; it cannot be pinned or bumped.

## Fix

Pass `--mirror-node-version "${MIRROR_NODE_VERSION}"` to both solo invocations, matching how `821-call-block-node-regression.yaml` already does it.

## Verification

On an XTS dry-run with the flag wired in, the panel deployed the configured version (confirmed in the job log: `solo mirror node add ... --mirror-node-version <configured> ...`) instead of solo's default, see: [https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/28783261584/job/85344999227](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/28783261584/job/85344999227)

## Note

This change only wires the configured version through to solo; the panel will now deploy whatever `.citr-env` points to (`citr-mirror-node-version`), so ensuring that value references a mirror-node release appropriate for the suite is a separate concern from this fix.

Relatedly, the panel's `Validate Ethereum Contract create and call` scenario currently fails at the hollow-account-creation step with `INVALID_SIGNATURE`, caused by a mirror-node acceptance-test client bug that signed EIP-1559 transactions without the chain ID. That fix first shipped in mirror-node `v0.158.0-rc1`, so the configured version must be at or above that release for the scenario to pass.