### PR TITLE
ci(workflow-fix): prevent SIGPIPE from crashing XTS candidate tag lookup

### DIFF
--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -158,11 +158,13 @@ jobs:
           RC_TAG: ${{ inputs.rc-tag || '' }}
           DEFAULT_BRANCH_NAME: "main"
         run: |
+          set +o pipefail
           # Check if the tag exists and if so grab its commit id
           echo "::group::Check for XTS Candidate Tag"
           if [[ -n "${RC_TAG}" ]]; then
             echo "::group::Use RC Tag"
             echo "Using RC Tag: ${RC_TAG}"
+            set +e
             XTS_COMMIT=$(git rev-list -n 1 "${RC_TAG}") >/dev/null 2>&1
             XTS_COMMIT_FOUND="${?}"
             set -e

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -158,7 +158,6 @@ jobs:
           RC_TAG: ${{ inputs.rc-tag || '' }}
           DEFAULT_BRANCH_NAME: "main"
         run: |
-          set +o pipefail
           # Check if the tag exists and if so grab its commit id
           echo "::group::Check for XTS Candidate Tag"
           if [[ -n "${RC_TAG}" ]]; then
@@ -211,8 +210,10 @@ jobs:
 
             # Get the list of commits between the previous XTS Pass and the current commit
             COMMIT_LIST=""
+            set +e
             LATEST_XTS_PASS_TAG="$(git tag --list --sort=-version:refname "${XTS_PASS_PATTERN}" | head --lines 1)"
             LATEST_PROMOTED_BUILD_TAG="$(git tag --list --sort=-version:refname "${BUILD_PATTERN}" | head --lines 1)"
+            set -e
             if [[ -n "${LATEST_XTS_PASS_TAG}" ]]; then
               echo "::debug::Using latest xts-pass tag"
               echo "Latest XTS Pass Tag: ${LATEST_XTS_PASS_TAG}"
@@ -230,13 +231,16 @@ jobs:
 
           echo "::group::Check if XTS COMMIT is on default branch"
           # Determine which branch the commit belongs to
+          set +e
           XTS_COMMIT_BRANCHES="$(git branch -r --contains "${XTS_COMMIT}" | sed 's/^[ *]*//')"
+          set -e
           echo "::debug::XTS_COMMIT_BRANCHES=${XTS_COMMIT_BRANCHES}"
 
           XTS_COMMIT_BRANCH="${DEFAULT_BRANCH_NAME}"
           COMMIT_ON_DEFAULT_BRANCH=0
 
           # Check if the commit on the default branch
+          set +e
           if echo "${XTS_COMMIT_BRANCHES}" | grep -qE "(^|/)${DEFAULT_BRANCH_NAME}$"; then
             echo "::debug::Commit ${XTS_COMMIT} found on main branch."
           else
@@ -248,6 +252,7 @@ jobs:
               | sed 's/~.*//'
             )"
           fi
+          set -e
 
           # Print branch debug info
           echo "::debug::XTS_COMMIT_BRANCH=${XTS_COMMIT_BRANCH}"


### PR DESCRIPTION
**Description**:

SIGPIPE will no longer crash the XTS candidate tag lookup.

**Related Issue(s)**:

Fixes #26223 

**Testing**:

Successful test [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/28799099313) proving existing functionality works.
