### PR TITLE
ci(workflow-fix): pass the BN version in XTS correctly

### DIFF
--- a/.github/workflows/821-call-block-node-regression.yaml
+++ b/.github/workflows/821-call-block-node-regression.yaml
@@ -116,7 +116,7 @@ jobs:
       - name: Retrieve BN Release Tag
         run: |
           bn_url="https://api.github.com/repos/hiero-ledger/hiero-block-node/releases/latest"
-          if [[ "${{ inputs.bn-release-version }}" != "latest" ]]; then
+          if [[ -n "${{ inputs.bn-release-version }}" && "${{ inputs.bn-release-version }}" != "latest" ]]; then
             bn_url="https://api.github.com/repos/hiero-ledger/hiero-block-node/releases/tags/${{ inputs.bn-release-version }}"
           fi
           curl_response=$(curl -s -H "Accept: application/vnd.github+json" "${bn_url}") || exit 1

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -347,6 +347,8 @@ jobs:
       java-version: "${{ needs.extract-jdk-version.outputs.jdk-version }}"
       tck-version: "${{ needs.extract-citr-vars.outputs.tck-version }}"
       js-sdk-version: "${{ needs.extract-citr-vars.outputs.js-sdk-version }}"
+      bn-release-version: "${{ needs.extract-citr-vars.outputs.bn-release-version }}"
+      bn-mirror-node-version: "${{ needs.extract-citr-vars.outputs.bn-mirror-node-version }}"
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
       platform-access-token: ${{ secrets.JRS_GH_ACCESS_TOKEN }}


### PR DESCRIPTION
**Description**:

Update how the BN version is handled in the XTS workflow so it passes correctly.

**Related Issue(s)**:

Implements #26228

**Testing**:

Test run [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/28801236390) showing successful BN version identification. 🏃 
