### PR TITLE
chore: bump mirror-node version to 0.158.0 for the XTS Mirror Node Regression panel

### DIFF
--- a/.github/workflows/support/citr/.citr-env
+++ b/.github/workflows/support/citr/.citr-env
@@ -1,7 +1,7 @@
 citr-solo-version=0.79.0
 adhoc-solo-version=0.79.0
 adhoc-xts-solo-version=0.79.0
-citr-mirror-node-version=0.157.0
+citr-mirror-node-version=0.158.0
 mqpt-cluster=Dallas_n10
 tck-version=v0.11.0
 js-sdk-version=v2.85.0


### PR DESCRIPTION
## Summary

Bumps `citr-mirror-node-version` from `0.157.0` to `0.158.0` in `.citr-env`.

## Why

`0.158.0` is now released and includes the mirror-node acceptance-test client fix that signs EIP-1559 transactions with the chain ID (first shipped in `v0.158.0-rc1`). Before that fix, the XTS Mirror Node Regression panel's `Validate Ethereum Contract create and call` scenario failed at the hollow-account-creation step with `INVALID_SIGNATURE`.

Following #26219 — which wired `--mirror-node-version` through to solo — this value is now actually applied when the panel deploys the mirror node. Bumping it to `0.158.0` makes the panel deploy a build containing the signing fix, resolving the failing Ethereum scenario.