### PR TITLE
ci(workflow): make mirror node regression mandatory in XTS

### DIFF
--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -343,6 +343,7 @@ jobs:
       solo-version: ${{ needs.parameters.outputs.solo-version }}
       solo-ge-0440: ${{ needs.parameters.outputs.solo-ge-0440 }}
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
+      mirror-node-version: ${{ needs.extract-citr-vars.outputs.citr-mirror-node-version }}
       custom-job-label: "XTS (main):"
       enable-timing-sensitive-test-suite: "true"
       enable-hammer-test-suite: "true"
@@ -351,6 +352,7 @@ jobs:
       enable-hedera-node-jrs-panel: "true"
       enable-sdk-tck-regression-panel: "true"
       enable-block-node-regression-panel: "true"
+      enable-mirror-node-regression-panel: "true"
       java-version: "${{ needs.extract-jdk-version.outputs.jdk-version }}"
       tck-version: "${{ needs.extract-citr-vars.outputs.tck-version }}"
       js-sdk-version: "${{ needs.extract-citr-vars.outputs.js-sdk-version }}"
@@ -389,9 +391,7 @@ jobs:
       solo-version: ${{ needs.parameters.outputs.solo-version }}
       solo-ge-0440: ${{ needs.parameters.outputs.solo-ge-0440 }}
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
-      mirror-node-version: ${{ needs.extract-citr-vars.outputs.citr-mirror-node-version }}
       custom-job-label: "XTS (Optional):"
-      enable-mirror-node-regression-panel: "true"
       enable-rpc-relay-regression-panel: "true"
       enable-migration-testing-panel: "true"
       enable-chaos-otter-test-suite: "true"


### PR DESCRIPTION
**Description**:

Make the mirror node regression test mandatory in XTS runs.

**Related Issue(s)**:

Implements #26240

**Testing**:

Workflow run [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/28873647642) ✅ the MN Reg panel started as expected with no workflow errors. 