### PR TITLE
build: remove accidentally added flaky test configuration

### DIFF
--- a/gradle/besu-native-patch/build.gradle.kts
+++ b/gradle/besu-native-patch/build.gradle.kts
@@ -4,7 +4,6 @@ plugins { `java-gradle-plugin` }
 repositories { gradlePluginPortal() }
 
 dependencies {
-    compileOnly("org.gradlex:extra-java-module-info:1.13.1")
     compileOnly("net.java.dev.jna:jna:5.18.1")
 }
 

--- a/gradle/besu-native-patch/src/main/java/org/hiero/gradle/feature/BesuNativePatchPlugin.java
+++ b/gradle/besu-native-patch/src/main/java/org/hiero/gradle/feature/BesuNativePatchPlugin.java
@@ -7,7 +7,6 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradlex.javamodule.moduleinfo.ExtraJavaModuleInfoPluginExtension;
 import org.hiero.gradle.transforms.BesuNativePatchTransform;
 
 @SuppressWarnings("UnstableApiUsage")
@@ -19,18 +18,7 @@ public abstract class BesuNativePatchPlugin implements Plugin<Settings> {
     }
 
     private static void configureProject(Project project) {
-        project.getPlugins().withId("org.hiero.gradle.base.jpms-modules", plugin -> {
-            configureExtraModuleInfo(project);
-            configureTransform(project);
-        });
-    }
-
-    private static void configureExtraModuleInfo(Project project) {
-        project.getExtensions().configure(ExtraJavaModuleInfoPluginExtension.class, ext -> {
-            ext.module("io.consensys.tuweni:tuweni-bytes", "tuweni.bytes");
-            ext.module("io.consensys.tuweni:tuweni-units", "tuweni.units");
-            ext.module("io.vertx:vertx-core", "io.vertx.core");
-        });
+        project.getPlugins().withId("org.hiero.gradle.base.jpms-modules", _ -> configureTransform(project));
     }
 
     private static void configureTransform(Project project) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,37 +54,9 @@ javaModules {
     module("hedera-state-validator") { group = "com.hedera.hashgraph" }
 }
 
-// Configure test retry for CI flaky test handling using the retry plugin bundled with Develocity.
-// Retries only in CI (when the CI env var is set).
-// Flaky tests (passed after retry) do not fail the build.
-gradle.lifecycle.beforeProject {
-    configurations.all {
-        resolutionStrategy.dependencySubstitution {
-            substitute(module("io.tmio:tuweni-bytes"))
-                .using(module("io.consensys.tuweni:tuweni-bytes:2.7.2"))
-            substitute(module("io.tmio:tuweni-units"))
-                .using(module("io.consensys.tuweni:tuweni-units:2.7.2"))
-        }
-    }
-    pluginManager.withPlugin("java") {
-        tasks.withType(Test::class.java).configureEach {
-            develocity.testRetry {
-                maxRetries.set(providers.environmentVariable("CI").map { 2 }.orElse(0))
-                maxFailures.set(10)
-                failOnPassedAfterRetry.set(false)
-            }
-            reports.junitXml.mergeReruns.set(true)
-
-            // Write a marker when tests actually execute (not on cache restore).
-            // Resolve eagerly to avoid capturing Project in the doLast closure (configuration
-            // cache).
-            val markerFile = layout.buildDirectory.file("test-executed/${name}.marker").get().asFile
-            doLast {
-                markerFile.parentFile.mkdirs()
-                markerFile.writeText(java.time.Instant.now().toString())
-            }
-        }
-    }
+@Suppress("UnstableApiUsage")
+gradle.lifecycle.afterProject {
+    // remove below once https://github.com/hiero-ledger/hiero-gradle-conventions/issues/536 is done
     plugins.withId("org.hiero.gradle.base.jpms-modules") {
         configure<org.gradlex.javamodule.moduleinfo.ExtraJavaModuleInfoPluginExtension> {
             module("org.hyperledger.besu:besu-evm", "org.hyperledger.besu.evm") {
@@ -110,11 +82,8 @@ gradle.lifecycle.beforeProject {
             module("io.vertx:vertx-core", "io.vertx.core")
         }
     }
-}
 
-// Flaky test handling
-@Suppress("UnstableApiUsage")
-gradle.lifecycle.afterProject {
+    // Flaky test handling
     tasks.withType<Test>().configureEach {
         // Local build: add '-PrunUntilFailure=<maxRetries>' option to check that a test is (likely)
         // not flaky

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -80,6 +80,8 @@ gradle.lifecycle.afterProject {
             module("org.hyperledger.besu.internal:besu-util", "org.hyperledger.besu.internal.util")
             module("org.hyperledger.besu:boringssl", "org.hyperledger.besu.nativelib.boringssl")
             module("io.vertx:vertx-core", "io.vertx.core")
+            module("io.consensys.tuweni:tuweni-bytes", "tuweni.bytes")
+            module("io.consensys.tuweni:tuweni-units", "tuweni.units")
         }
     }
 


### PR DESCRIPTION
**Description**:

- Removes config code in `settings.gradle.kts` that was accidentally added back in #25309 through a merge conflict
- Clarifies what should be moved to Gradle plugins eventually: https://github.com/hiero-ledger/hiero-gradle-conventions/issues/536

**Related issue(s)**:

Follow up to  #25309
