### PR TITLE
chore: Final cleanup of state module

### DIFF
--- a/platform-sdk/consensus-gossip-impl/src/testFixtures/java/module-info.java
+++ b/platform-sdk/consensus-gossip-impl/src/testFixtures/java/module-info.java
@@ -19,7 +19,7 @@ open module org.hiero.consensus.gossip.impl.test.fixtures {
     requires transitive org.hiero.consensus.model;
     requires com.swirlds.config.extensions.test.fixtures;
     requires org.hiero.consensus.model.test.fixtures;
-    requires com.github.spotbugs.annotations;
     requires java.desktop;
     requires org.junit.jupiter.api;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/consensus-iss-detection/src/main/java/module-info.java
+++ b/platform-sdk/consensus-iss-detection/src/main/java/module-info.java
@@ -3,8 +3,8 @@ import com.swirlds.config.api.ConfigurationExtension;
 import org.hiero.consensus.iss.detection.config.IssDetectionConfigurationExtension;
 
 module org.hiero.consensus.iss.detection {
-    exports org.hiero.consensus.iss.detection;
     exports org.hiero.consensus.iss.detection.config;
+    exports org.hiero.consensus.iss.detection;
     exports org.hiero.consensus.iss.detection.internal to
             org.hiero.otter.fixtures;
 
@@ -25,12 +25,8 @@ module org.hiero.consensus.iss.detection {
     requires org.hiero.consensus.hashgraph;
     requires org.hiero.consensus.pces;
     requires org.hiero.consensus.roster;
-    requires com.github.spotbugs.annotations;
-    requires java.management;
-    requires java.scripting;
-    requires jdk.management;
-    requires jdk.net;
     requires org.apache.logging.log4j;
+    requires static transitive com.github.spotbugs.annotations;
 
     provides ConfigurationExtension with
             IssDetectionConfigurationExtension;

--- a/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/DefaultPcesModule.java
+++ b/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/DefaultPcesModule.java
@@ -75,7 +75,7 @@ public class DefaultPcesModule implements PcesModule {
             @NonNull final FileSystemManager fileSystemManager,
             final long startingRound,
             @NonNull final Runnable flushPrimaryPipeline,
-            @NonNull Supplier<PcesReplayProgress> replayProgressSupplier,
+            @NonNull final Supplier<PcesReplayProgress> replayProgressSupplier,
             @NonNull final Consumer<PlatformStatusAction> statusActionConsumer,
             @NonNull final Runnable platformStatusFlusher,
             @NonNull final Runnable signalEndOfPcesReplay,

--- a/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/replayer/PcesReplayer.java
+++ b/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/replayer/PcesReplayer.java
@@ -111,9 +111,9 @@ public class PcesReplayer {
 
         logger.info(
                 STARTUP.getMarker(),
-                "Replayed {} preconsensus events with max birth roundAfterReplay {}. These events contained {} transactions. "
+                "Replayed {} preconsensus events with max birth round {}. These events contained {} transactions. "
                         + "{} rounds reached consensus spanning {} of consensus time. The latest "
-                        + "roundAfterReplay to reach consensus is roundAfterReplay {}. Replay took {}.",
+                        + "round to reach consensus is round {}. Replay took {}.",
                 commaSeparatedNumber(eventCount),
                 commaSeparatedNumber(maxBirthRound),
                 commaSeparatedNumber(transactionCount),

--- a/platform-sdk/consensus-pces-noop-impl/src/testFixtures/java/org/hiero/consensus/pces/noop/impl/test/fixtures/NoopPcesModule.java
+++ b/platform-sdk/consensus-pces-noop-impl/src/testFixtures/java/org/hiero/consensus/pces/noop/impl/test/fixtures/NoopPcesModule.java
@@ -54,7 +54,7 @@ public class NoopPcesModule implements PcesModule {
             @NonNull final FileSystemManager fileSystemManager,
             final long startingRound,
             @NonNull final Runnable flushPrimaryPipeline,
-            @NonNull Supplier<PcesReplayProgress> replayProgressSupplier,
+            @NonNull final Supplier<PcesReplayProgress> replayProgressSupplier,
             @NonNull final Consumer<PlatformStatusAction> statusActionConsumer,
             @NonNull final Runnable platformStatusFlusher,
             @NonNull final Runnable signalEndOfPcesReplay,

--- a/platform-sdk/consensus-pces/src/main/java/org/hiero/consensus/pces/PcesReplayProgress.java
+++ b/platform-sdk/consensus-pces/src/main/java/org/hiero/consensus/pces/PcesReplayProgress.java
@@ -5,13 +5,22 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 
 /**
- * Represents the progress of a PCES replay.
+ * A snapshot of how far PCES replay has progressed, captured at the moment this record is created.
  *
- * @param round the round that was replayed, {@code 0} if the progress cannot be determined
- * @param consensusTimestamp the consensus timestamp of the round that was replayed, {@code null} if the progress cannot be determined
+ * <p>Replay advances continuously as rounds reach consensus, so these values describe the latest round to reach
+ * consensus <i>at the time the snapshot was taken</i>, not the final outcome of the replay. Comparing two snapshots
+ * (for example one taken before and one after a replay) reveals the progress made in between.
+ *
+ * @param round the number of the latest round to reach consensus at the time this snapshot was taken, or {@code 0} if
+ *     no round had reached consensus yet or the progress could not be determined
+ * @param consensusTimestamp the consensus timestamp of that round, or {@code null} if no round had reached consensus yet
+ *     or the progress could not be determined
  */
 public record PcesReplayProgress(long round, @Nullable Instant consensusTimestamp) {
 
-    /** The replay progress that is empty. This is used to indicate that the progress cannot be determined. */
+    /**
+     * A snapshot indicating that no progress is known: no round has reached consensus, or the progress could not be
+     * determined.
+     */
     public static final PcesReplayProgress EMPTY = new PcesReplayProgress(0L, null);
 }

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/module-info.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module org.hiero.consensus.reconnect.impl {
     requires transitive com.swirlds.state.impl;
     requires transitive com.swirlds.virtualmap;
     requires transitive org.hiero.base.concurrent;
+    requires transitive org.hiero.base.crypto;
     requires transitive org.hiero.consensus.concurrent;
     requires transitive org.hiero.consensus.gossip.impl;
     requires transitive org.hiero.consensus.gossip;
@@ -24,7 +25,6 @@ module org.hiero.consensus.reconnect.impl {
     requires com.hedera.pbj.runtime;
     requires com.swirlds.component.framework;
     requires com.swirlds.logging;
-    requires org.hiero.base.crypto;
     requires org.hiero.consensus.event.creator;
     requires org.hiero.consensus.event.intake;
     requires org.hiero.consensus.hashgraph;
@@ -33,12 +33,8 @@ module org.hiero.consensus.reconnect.impl {
     requires org.hiero.consensus.platformstate;
     requires org.hiero.consensus.roster;
     requires org.hiero.consensus.transaction.handling;
-    requires com.github.spotbugs.annotations;
-    requires java.management;
-    requires java.scripting;
-    requires jdk.management;
-    requires jdk.net;
     requires org.apache.logging.log4j;
+    requires static transitive com.github.spotbugs.annotations;
 
     provides ReconnectModule with
             DefaultReconnectModule;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/DefaultSignedStateValidator.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/DefaultSignedStateValidator.java
@@ -7,8 +7,6 @@ import static org.hiero.consensus.platformstate.PlatformStateUtils.getInfoString
 import static org.hiero.consensus.platformstate.PlatformStateUtils.roundOf;
 
 import com.hedera.hapi.node.state.roster.Roster;
-import com.swirlds.platform.state.signed.SignedStateValidationData;
-import com.swirlds.platform.state.signed.SignedStateValidator;
 import com.swirlds.state.State;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectController.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectController.java
@@ -14,8 +14,6 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.payload.ReconnectFailurePayload;
 import com.swirlds.logging.legacy.payload.ReconnectFailurePayload.CauseOfFailure;
 import com.swirlds.platform.state.ConsensusStateEventHandler;
-import com.swirlds.platform.state.signed.SignedStateValidationData;
-import com.swirlds.platform.state.signed.SignedStateValidator;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.wiring.PlatformCoordinator;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectCoordinator.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectCoordinator.java
@@ -96,7 +96,7 @@ public class ReconnectCoordinator {
         // Data is no longer moving through the system. Clear all the internal data structures in the wiring objects.
         components.eventIntakeModule().clearComponentsInputWire().inject(NoInput.getInstance());
         components.gossipModule().clearInputWire().inject(NoInput.getInstance());
-        components.stateManagementModule().clearInputWire().inject(NoInput.getInstance());
+        components.stateModule().clearInputWire().inject(NoInput.getInstance());
         components.eventCreatorModule().clearCreationMangerInputWire().inject(NoInput.getInstance());
     }
 

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectMetrics.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectMetrics.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.metrics;
+package org.hiero.consensus.reconnect.impl;
 
 import com.swirlds.base.units.TimeUnit;
 import com.swirlds.metrics.api.Counter;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectProtocolFactoryImpl.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectProtocolFactoryImpl.java
@@ -4,7 +4,6 @@ package org.hiero.consensus.reconnect.impl;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.state.StateLifecycleManager;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.virtualmap.VirtualMap;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStateLearner.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStateLearner.java
@@ -12,7 +12,6 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.payload.ReconnectDataUsagePayload;
 import com.swirlds.logging.legacy.payload.SynchronizationCompletePayload;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.state.StateLifecycleManager;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.virtualmap.VirtualMap;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStatePeerProtocol.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStatePeerProtocol.java
@@ -14,7 +14,6 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.payload.ReconnectFinishPayload;
 import com.swirlds.logging.legacy.payload.ReconnectStartPayload;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.state.StateLifecycleManager;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.virtualmap.VirtualMap;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStateSyncProtocol.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStateSyncProtocol.java
@@ -6,7 +6,6 @@ import static java.util.Objects.requireNonNull;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.state.StateLifecycleManager;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStateTeacher.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStateTeacher.java
@@ -11,7 +11,6 @@ import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.payload.ReconnectFinishPayload;
 import com.swirlds.logging.legacy.payload.ReconnectStartPayload;
-import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.virtualmap.sync.TeachingSynchronizer;
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/SignedStateValidationData.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/SignedStateValidationData.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.state.signed;
+package org.hiero.consensus.reconnect.impl;
 
 import static java.util.Objects.requireNonNull;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.consensusTimestampOf;

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/SignedStateValidator.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/SignedStateValidator.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.state.signed;
+package org.hiero.consensus.reconnect.impl;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import org.hiero.consensus.platformstate.ReadablePlatformStateStore;

--- a/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/DefaultSignedStateValidatorTests.java
+++ b/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/DefaultSignedStateValidatorTests.java
@@ -10,7 +10,6 @@ import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
-import com.swirlds.platform.state.signed.SignedStateValidationData;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.state.test.fixtures.merkle.VirtualMapStateTestUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/ReconnectControllerTest.java
+++ b/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/ReconnectControllerTest.java
@@ -26,8 +26,6 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
 import com.swirlds.platform.state.ConsensusStateEventHandler;
-import com.swirlds.platform.state.signed.SignedStateValidationData;
-import com.swirlds.platform.state.signed.SignedStateValidator;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.state.StateLifecycleManager;
 import com.swirlds.state.merkle.VirtualMapState;

--- a/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/ReconnectStatePeerProtocolTests.java
+++ b/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/ReconnectStatePeerProtocolTests.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.state.StateLifecycleManager;
 import com.swirlds.state.merkle.VirtualMapState;
 import java.time.Duration;

--- a/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/ReconnectTest.java
+++ b/platform-sdk/consensus-reconnect-impl/src/test/java/org/hiero/consensus/reconnect/impl/ReconnectTest.java
@@ -10,7 +10,6 @@ import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.test.fixtures.time.FakeTime;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
-import com.swirlds.platform.metrics.ReconnectMetrics;
 import com.swirlds.platform.test.fixtures.state.TestStateUtils;
 import com.swirlds.state.StateLifecycleManager;
 import com.swirlds.state.merkle.VirtualMapState;

--- a/platform-sdk/consensus-roster/src/main/java/module-info.java
+++ b/platform-sdk/consensus-roster/src/main/java/module-info.java
@@ -5,10 +5,12 @@ module org.hiero.consensus.roster {
 
     requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
+    requires transitive com.swirlds.metrics.api;
     requires transitive com.swirlds.state.api;
     requires transitive org.hiero.base.crypto;
     requires transitive org.hiero.consensus.model;
     requires com.swirlds.base;
     requires org.hiero.base.utility;
+    requires org.hiero.consensus.metrics;
     requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/consensus-roster/src/main/java/org/hiero/consensus/roster/RosterMetrics.java
+++ b/platform-sdk/consensus-roster/src/main/java/org/hiero/consensus/roster/RosterMetrics.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.state.address;
+package org.hiero.consensus.roster;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.metrics.api.Metrics;

--- a/platform-sdk/consensus-state/src/main/java/module-info.java
+++ b/platform-sdk/consensus-state/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module org.hiero.consensus.state {
     requires transitive org.hiero.consensus.model;
     requires com.swirlds.logging;
     requires org.hiero.base.concurrent;
+    requires org.hiero.consensus.concurrent;
     requires org.hiero.consensus.pces.impl;
     requires org.hiero.consensus.pces;
     requires org.hiero.consensus.platformstate;

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/StateModule.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/StateModule.java
@@ -2,6 +2,7 @@
 package org.hiero.consensus.state;
 
 import static com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration.DIRECT_THREADSAFE_CONFIGURATION;
+import static com.swirlds.component.framework.wires.SolderType.OFFER;
 
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.swirlds.base.time.Time;
@@ -37,7 +38,11 @@ import org.hiero.consensus.state.hashing.StateHasher;
 import org.hiero.consensus.state.nexus.LatestCompleteStateNexus;
 import org.hiero.consensus.state.persistence.DefaultStateSnapshotManager;
 import org.hiero.consensus.state.persistence.StateSnapshotManager;
+import org.hiero.consensus.state.sentinel.DefaultSignedStateSentinel;
+import org.hiero.consensus.state.sentinel.SignedStateSentinel;
+import org.hiero.consensus.state.signed.DefaultStateGarbageCollector;
 import org.hiero.consensus.state.signed.ReservedSignedState;
+import org.hiero.consensus.state.signed.StateGarbageCollector;
 import org.hiero.consensus.state.signed.StateWithHashComplexity;
 import org.hiero.consensus.state.signing.DefaultStateSignatureCollector;
 import org.hiero.consensus.state.signing.DefaultStateSigner;
@@ -49,7 +54,7 @@ import org.hiero.consensus.state.utils.SignedStateReserver;
 /**
  * Module for signed state management.
  */
-public class StateManagementModule {
+public class StateModule {
 
     private final WireTransformer<ReservedSignedState, ReservedSignedState> stateDispatcher;
 
@@ -62,6 +67,8 @@ public class StateManagementModule {
     private final ComponentWiring<SavedStateController, StateWithHashComplexity> savedStateControllerWiring;
 
     private final ComponentWiring<LatestCompleteStateNexus, Void> latestCompleteStateNexusWiring;
+
+    private final ComponentWiring<StateGarbageCollector, Void> stateGarbageCollectorWiring;
 
     private final OutputWire<ReservedSignedState> hashedStateOutputWire;
 
@@ -79,8 +86,9 @@ public class StateManagementModule {
      * @param swirldName the swirld name
      * @param stateLifecycleManager the state lifecycle manager
      * @param latestCompleteStateNexus the latest complete state nexus
+     * @param savedStateController the saved state controller
      */
-    public StateManagementModule(
+    public StateModule(
             @NonNull final WiringModel model,
             @NonNull final Configuration configuration,
             @NonNull final Metrics metrics,
@@ -115,6 +123,10 @@ public class StateManagementModule {
                 new ComponentWiring<>(model, SavedStateController.class, DIRECT_THREADSAFE_CONFIGURATION);
         this.latestCompleteStateNexusWiring =
                 new ComponentWiring<>(model, LatestCompleteStateNexus.class, DIRECT_THREADSAFE_CONFIGURATION);
+        this.stateGarbageCollectorWiring =
+                new ComponentWiring<>(model, StateGarbageCollector.class, wiringConfig.stateGarbageCollector());
+        final ComponentWiring<SignedStateSentinel, Void> signedStateSentinelWiring =
+                new ComponentWiring<>(model, SignedStateSentinel.class, wiringConfig.signedStateSentinel());
 
         // Eventually mark unhashed state for storage and forward to StateHasher
         savedStateControllerWiring.getOutputWire().solderTo(stateHasherWiring.getInputWire(StateHasher::hashState));
@@ -167,6 +179,12 @@ public class StateManagementModule {
                 })
                 .solderTo(latestCompleteStateNexusWiring.getInputWire(LatestCompleteStateNexus::setStateIfNewer));
 
+        // Setup heartbeat
+        model.buildHeartbeatWire(wiringConfig.stateGarbageCollectorHeartbeatPeriod())
+                .solderTo(stateGarbageCollectorWiring.getInputWire(StateGarbageCollector::heartbeat), OFFER);
+        model.buildHeartbeatWire(wiringConfig.signedStateSentinelHeartbeatPeriod())
+                .solderTo(signedStateSentinelWiring.getInputWire(SignedStateSentinel::checkSignedStates), OFFER);
+
         // Force not soldered wires to be built
         stateSignatureCollectorWiring.getInputWire(StateSignatureCollector::clear);
         stateSnapshotManagerWiring.getInputWire(StateSnapshotManager::dumpStateTask);
@@ -196,6 +214,10 @@ public class StateManagementModule {
         stateSnapshotManagerWiring.bind(stateSnapshotManager);
         savedStateControllerWiring.bind(savedStateController);
         latestCompleteStateNexusWiring.bind(latestCompleteStateNexus);
+        final StateGarbageCollector garbageCollector = new DefaultStateGarbageCollector(metrics);
+        stateGarbageCollectorWiring.bind(garbageCollector);
+        final SignedStateSentinel signedStateSentinel = new DefaultSignedStateSentinel(configuration);
+        signedStateSentinelWiring.bind(signedStateSentinel);
     }
 
     /**
@@ -219,6 +241,17 @@ public class StateManagementModule {
     @NonNull
     public InputWire<ReservedSignedState> hashedStatesInputWire() {
         return stateDispatcher.getInputWire();
+    }
+
+    /**
+     * Get the input wire for registering states in the garbage collector
+     *
+     * @return the input wire for registering states
+     */
+    @InputWireLabel("hashed states")
+    @NonNull
+    public InputWire<ReservedSignedState> garbageCollectorRegistrationInputWire() {
+        return stateGarbageCollectorWiring.getInputWire(StateGarbageCollector::registerState);
     }
 
     /**
@@ -307,7 +340,7 @@ public class StateManagementModule {
     }
 
     /**
-     * Flush the {@code StateManagementModule}.
+     * Flush the {@code StateModule}.
      */
     public void flush() {
         stateHasherWiring.flush();

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/config/StateWiringConfig.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/config/StateWiringConfig.java
@@ -4,6 +4,7 @@ package org.hiero.consensus.state.config;
 import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
+import java.time.Duration;
 
 /**
  * Contains configuration values for the state management wiring.
@@ -13,8 +14,12 @@ import com.swirlds.config.api.ConfigProperty;
  * @param stateSigner configuration for the state signer scheduler
  * @param stateSignatureCollector configuration for the state signature collector scheduler
  * @param stateSnapshotManager configuration for the state snapshot manager scheduler
+ * @param stateGarbageCollector configuration for the state garbage collector scheduler
+ * @param stateGarbageCollectorHeartbeatPeriod the frequency that heartbeats should be sent to the state garbage
+ * @param signedStateSentinel configuration for the signed state sentinel scheduler
+ * @param signedStateSentinelHeartbeatPeriod the frequency of signed state sentinels heartbeats
  */
-@ConfigData("state.management.wiring")
+@ConfigData("state.wiring")
 public record StateWiringConfig(
         @ConfigProperty(
                 defaultValue =
@@ -31,4 +36,14 @@ public record StateWiringConfig(
         TaskSchedulerConfiguration stateSignatureCollector,
 
         @ConfigProperty(defaultValue = "SEQUENTIAL_THREAD CAPACITY(20) UNHANDLED_TASK_METRIC")
-        TaskSchedulerConfiguration stateSnapshotManager) {}
+        TaskSchedulerConfiguration stateSnapshotManager,
+
+        @ConfigProperty(defaultValue = "SEQUENTIAL CAPACITY(60) UNHANDLED_TASK_METRIC")
+        TaskSchedulerConfiguration stateGarbageCollector,
+
+        @ConfigProperty(defaultValue = "200ms") Duration stateGarbageCollectorHeartbeatPeriod,
+
+        @ConfigProperty(defaultValue = "SEQUENTIAL UNHANDLED_TASK_METRIC")
+        TaskSchedulerConfiguration signedStateSentinel,
+
+        @ConfigProperty(defaultValue = "10s") Duration signedStateSentinelHeartbeatPeriod) {}

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/sentinel/DefaultSignedStateSentinel.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/sentinel/DefaultSignedStateSentinel.java
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.state.signed;
+package org.hiero.consensus.state.sentinel;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 
 import com.swirlds.base.time.Time;
-import com.swirlds.common.context.PlatformContext;
+import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.time.Instant;
@@ -33,10 +33,10 @@ public class DefaultSignedStateSentinel implements SignedStateSentinel {
     /**
      * Create an object that monitors signed state lifespans.
      *
-     * @param platformContext the current platform's context
+     * @param configuration the configuration to use
      */
-    public DefaultSignedStateSentinel(@NonNull final PlatformContext platformContext) {
-        final StateConfig stateConfig = platformContext.getConfiguration().getConfigData(StateConfig.class);
+    public DefaultSignedStateSentinel(@NonNull final Configuration configuration) {
+        final StateConfig stateConfig = configuration.getConfigData(StateConfig.class);
         maxSignedStateAge = stateConfig.suspiciousSignedStateAgeGap();
         final Duration rateLimitPeriod = stateConfig.signedStateAgeNotifyRateLimit();
         rateLimiter = new RateLimiter(Time.getCurrent(), rateLimitPeriod);

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/sentinel/SignedStateSentinel.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/sentinel/SignedStateSentinel.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.state.signed;
+package org.hiero.consensus.state.sentinel;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;

--- a/platform-sdk/consensus-state/src/testFixtures/java/module-info.java
+++ b/platform-sdk/consensus-state/src/testFixtures/java/module-info.java
@@ -21,6 +21,6 @@ open module org.hiero.consensus.state.test.fixtures {
     requires org.hiero.consensus.platformstate;
     requires org.hiero.consensus.roster.test.fixtures;
     requires org.hiero.consensus.utility.test.fixtures;
-    requires com.github.spotbugs.annotations;
     requires org.mockito;
+    requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/consensus-transaction-handling/src/main/java/module-info.java
+++ b/platform-sdk/consensus-transaction-handling/src/main/java/module-info.java
@@ -24,12 +24,8 @@ module org.hiero.consensus.transaction.handling {
     requires org.hiero.consensus.hashgraph;
     requires org.hiero.consensus.metrics;
     requires org.hiero.consensus.platformstate;
-    requires com.github.spotbugs.annotations;
-    requires java.management;
-    requires java.scripting;
-    requires jdk.management;
-    requires jdk.net;
     requires org.apache.logging.log4j;
+    requires static transitive com.github.spotbugs.annotations;
 
     provides ConfigurationExtension with
             TransactionHandlingConfigurationExtension;

--- a/platform-sdk/docs/consensus-layer/rules/RUL-002-intake-flush-ordering.md
+++ b/platform-sdk/docs/consensus-layer/rules/RUL-002-intake-flush-ordering.md
@@ -65,7 +65,7 @@ public void flushPrimaryPipeline() {
     components.hashgraphModule().flush();
     components.transactionHandlingModule().flush();
     components.eventCreatorModule().flush();
-    components.stateManagementModule().flush();
+    components.stateModule().flush();
 }
 ```
 

--- a/platform-sdk/docs/proposals/roster-refactor/Rosters.md
+++ b/platform-sdk/docs/proposals/roster-refactor/Rosters.md
@@ -153,7 +153,7 @@ Change all protobuf `Roster` usages to `RosterData`. After this task is complete
   * `com.swirlds.platform.builder.PlatformBuilder`
   * `com.swirlds.platform.system.Platform`
   * `com.swirlds.platform.ReconnectStateLoader`
-  * `com.swirlds.platform.state.address.RosterMetrics`
+  * `org.hiero.consensus.roster.RosterMetrics`
   * `com.swirlds.platform.recovery.internal.EventStreamRoundIterator`
   * `com.swirlds.platform.recovery.internal.StreamedRound`
   * `com.swirlds.platform.uptime.UptimeTracker`
@@ -171,10 +171,10 @@ Change all protobuf `Roster` usages to `RosterData`. After this task is complete
   * `com.swirlds.platform.gossip.DefaultIntakeEventCounter`
 * DefaultSignedStateValidator support code
   * `org.hiero.consensus.reconnect.impl.DefaultSignedStateValidator`
-  * `com.swirlds.platform.state.signed.SignedStateValidator`
+  * `org.hiero.consensus.reconnect.impl.SignedStateValidator`
   * `org.hiero.consensus.state.signed.SignedState`
   * `com.swirlds.platform.state.signed.SignedStateInfo`
-  * `com.swirlds.platform.state.signed.SignedStateValidationData`
+  * `org.hiero.consensus.reconnect.impl.SignedStateValidationData`
   * `org.hiero.consensus.iss.detection.internal.IssMetrics`
 * ReconnectStateLoader support code
   * `com.swirlds.platform.ReconnectStateLoader`

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/DiagramCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/DiagramCommand.java
@@ -37,7 +37,7 @@ import org.hiero.consensus.iss.detection.IssDetectionModule;
 import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.pcli.utility.NoOpExecutionLayer;
 import org.hiero.consensus.pcli.utility.VirtualTerminal;
-import org.hiero.consensus.state.StateManagementModule;
+import org.hiero.consensus.state.StateModule;
 import org.hiero.consensus.transaction.handling.TransactionHandlingModule;
 import picocli.CommandLine;
 
@@ -130,7 +130,7 @@ public final class DiagramCommand extends AbstractCommand {
                 createNoOpIssDetectionModule(model, configuration, fileSystemManager);
         final TransactionHandlingModule transactionHandlingModule =
                 createNoOpTransactionHandlingModule(model, configuration, fileSystemManager);
-        final StateManagementModule statemanagementModule =
+        final StateModule statemanagementModule =
                 createNoOpStateManagementModule(model, configuration, fileSystemManager);
 
         final PlatformComponents platformComponents = PlatformComponents.create(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -3,7 +3,6 @@ package com.swirlds.platform;
 
 import static com.swirlds.logging.legacy.LogMarker.STARTUP;
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getMetricsProvider;
-import static com.swirlds.platform.state.address.RosterMetrics.registerRosterMetrics;
 import static com.swirlds.platform.system.InitTrigger.GENESIS;
 import static com.swirlds.platform.system.InitTrigger.RESTART;
 import static org.hiero.base.concurrent.interrupt.Uninterruptable.abortAndThrowIfInterrupted;
@@ -13,6 +12,7 @@ import static org.hiero.consensus.platformstate.PlatformStateUtils.creationSoftw
 import static org.hiero.consensus.platformstate.PlatformStateUtils.getInfoString;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.legacyRunningEventHashOf;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.setCreationSoftwareVersionTo;
+import static org.hiero.consensus.roster.RosterMetrics.registerRosterMetrics;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.roster.Roster;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/ConsensusNoOpModules.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/ConsensusNoOpModules.java
@@ -51,7 +51,7 @@ import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.pces.PcesReplayProgress;
 import org.hiero.consensus.roster.RosterHistory;
 import org.hiero.consensus.state.SavedStateController;
-import org.hiero.consensus.state.StateManagementModule;
+import org.hiero.consensus.state.StateModule;
 import org.hiero.consensus.state.nexus.DefaultLatestCompleteStateNexus;
 import org.hiero.consensus.state.nexus.LatestCompleteStateNexus;
 import org.hiero.consensus.state.nexus.LockFreeStateNexus;
@@ -318,15 +318,15 @@ public class ConsensusNoOpModules {
     }
 
     /**
-     * Create and initialize a no-op instance of the {@link StateManagementModule}.
+     * Create and initialize a no-op instance of the {@link StateModule}.
      *
      * @param model the wiring model
      * @param configuration the configuration
      * @param fileSystemManager the file system manager
-     * @return an initialized no-op instance of {@code StateManagementModule}
+     * @return an initialized no-op instance of {@code StateModule}
      */
     @NonNull
-    public static StateManagementModule createNoOpStateManagementModule(
+    public static StateModule createNoOpStateManagementModule(
             @NonNull final WiringModel model,
             @NonNull final Configuration configuration,
             @NonNull final FileSystemManager fileSystemManager) {
@@ -347,7 +347,7 @@ public class ConsensusNoOpModules {
                 new DefaultLatestCompleteStateNexus(configuration, metrics);
         final SavedStateController savedStateController = new DefaultSavedStateController(configuration);
 
-        return new StateManagementModule(
+        return new StateModule(
                 model,
                 configuration,
                 metrics,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -68,7 +68,7 @@ import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.pces.PcesReplayProgress;
 import org.hiero.consensus.roster.RosterHistory;
 import org.hiero.consensus.state.SavedStateController;
-import org.hiero.consensus.state.StateManagementModule;
+import org.hiero.consensus.state.StateModule;
 import org.hiero.consensus.state.nexus.DefaultLatestCompleteStateNexus;
 import org.hiero.consensus.state.nexus.LatestCompleteStateNexus;
 import org.hiero.consensus.state.nexus.LockFreeStateNexus;
@@ -518,10 +518,10 @@ public final class PlatformBuilder {
     }
 
     @NonNull
-    private StateManagementModule createStateManagementModule(
+    private StateModule createStateManagementModule(
             @NonNull final LatestCompleteStateNexus latestCompleteStateNexus,
             @NonNull final SavedStateController savedStateController) {
-        return new StateManagementModule(
+        return new StateModule(
                 model,
                 platformContext.getConfiguration(),
                 platformContext.getMetrics(),
@@ -637,8 +637,7 @@ public final class PlatformBuilder {
         final Supplier<ReservedSignedState> latestCompleteStateSupplier =
                 () -> latestCompleteStateNexus.getState("get latest complete state for reconnect");
         final SavedStateController savedStateController = new DefaultSavedStateController(configuration);
-        final StateManagementModule stateManagementModule =
-                createStateManagementModule(latestCompleteStateNexus, savedStateController);
+        final StateModule stateModule = createStateManagementModule(latestCompleteStateNexus, savedStateController);
 
         final PlatformComponents platformComponents = PlatformComponents.create(
                 platformContext,
@@ -650,7 +649,7 @@ public final class PlatformBuilder {
                 gossipModule,
                 issDetectionModule,
                 transactionHandlingModule,
-                stateManagementModule);
+                stateModule);
 
         final PlatformCoordinator platformCoordinator = new PlatformCoordinator(platformComponents);
         statusActionSubmitterReference.set(platformCoordinator);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformComponentBuilder.java
@@ -6,8 +6,6 @@ import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getMet
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.component.framework.component.ComponentWiring;
 import com.swirlds.platform.SwirldsPlatform;
-import com.swirlds.platform.state.signed.DefaultSignedStateSentinel;
-import com.swirlds.platform.state.signed.SignedStateSentinel;
 import com.swirlds.platform.system.DefaultPlatformMonitor;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.PlatformMonitor;
@@ -48,7 +46,6 @@ public class PlatformComponentBuilder {
 
     private StateGarbageCollector stateGarbageCollector;
     private ConsensusEventStream consensusEventStream;
-    private SignedStateSentinel signedStateSentinel;
     private PlatformMonitor platformMonitor;
     private StateSnapshotManager stateSnapshotManager;
 
@@ -211,38 +208,6 @@ public class PlatformComponentBuilder {
             platformMonitor = new DefaultPlatformMonitor(blocks.platformContext(), blocks.selfId());
         }
         return platformMonitor;
-    }
-
-    /**
-     * Provide a signed state sentinel in place of the platform's default signed state sentinel.
-     *
-     * @param signedStateSentinel the signed state sentinel to use
-     * @return this builder
-     */
-    @NonNull
-    public PlatformComponentBuilder withSignedStateSentinel(@NonNull final SignedStateSentinel signedStateSentinel) {
-        throwIfAlreadyUsed();
-        if (this.signedStateSentinel != null) {
-            throw new IllegalStateException("Signed state sentinel has already been set");
-        }
-        this.signedStateSentinel = Objects.requireNonNull(signedStateSentinel);
-        return this;
-    }
-
-    /**
-     * Build the signed state sentinel if it has not yet been built. If one has been provided via
-     * {@link #withSignedStateSentinel(SignedStateSentinel)}, that sentinel will be used. If this method is called more
-     * than once, only the first call will build the signed state sentinel. Otherwise, the default sentinel will be
-     * created and returned.
-     *
-     * @return the signed state sentinel
-     */
-    @NonNull
-    public SignedStateSentinel buildSignedStateSentinel() {
-        if (signedStateSentinel == null) {
-            signedStateSentinel = new DefaultSignedStateSentinel(blocks.platformContext());
-        }
-        return signedStateSentinel;
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformComponents.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformComponents.java
@@ -10,7 +10,6 @@ import com.swirlds.platform.SwirldsPlatform;
 import com.swirlds.platform.builder.PlatformComponentBuilder;
 import com.swirlds.platform.components.AppNotifier;
 import com.swirlds.platform.components.EventWindowManager;
-import com.swirlds.platform.state.signed.SignedStateSentinel;
 import com.swirlds.platform.system.PlatformMonitor;
 import com.swirlds.platform.wiring.components.RunningEventHashOverrideWiring;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -25,8 +24,7 @@ import org.hiero.consensus.iss.detection.IssDetectionModule;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.pces.PcesModule;
-import org.hiero.consensus.state.StateManagementModule;
-import org.hiero.consensus.state.signed.StateGarbageCollector;
+import org.hiero.consensus.state.StateModule;
 import org.hiero.consensus.transaction.handling.TransactionHandlingModule;
 
 /**
@@ -41,13 +39,11 @@ public record PlatformComponents(
         GossipModule gossipModule,
         IssDetectionModule issDetectionModule,
         TransactionHandlingModule transactionHandlingModule,
-        StateManagementModule stateManagementModule,
+        StateModule stateModule,
         ComponentWiring<ConsensusEventStream, Void> consensusEventStreamWiring,
         RunningEventHashOverrideWiring runningEventHashOverrideWiring,
         ComponentWiring<EventWindowManager, EventWindow> eventWindowManagerWiring,
         ComponentWiring<AppNotifier, Void> notifierWiring,
-        ComponentWiring<StateGarbageCollector, Void> stateGarbageCollectorWiring,
-        ComponentWiring<SignedStateSentinel, Void> signedStateSentinelWiring,
         ComponentWiring<PlatformMonitor, PlatformStatus> platformMonitorWiring) {
 
     /**
@@ -65,9 +61,7 @@ public record PlatformComponents(
         eventWindowManagerWiring.bind(eventWindowManager);
         consensusEventStreamWiring.bind(builder::buildConsensusEventStream);
         notifierWiring.bind(notifier);
-        stateGarbageCollectorWiring.bind(builder::buildStateGarbageCollector);
         platformMonitorWiring.bind(builder::buildPlatformMonitor);
-        signedStateSentinelWiring.bind(builder::buildSignedStateSentinel);
     }
 
     /**
@@ -86,7 +80,7 @@ public record PlatformComponents(
             @NonNull final GossipModule gossipModule,
             @NonNull final IssDetectionModule issDetectionModule,
             @NonNull final TransactionHandlingModule transactionHandlingModule,
-            @NonNull final StateManagementModule stateManagementModule) {
+            @NonNull final StateModule stateModule) {
 
         Objects.requireNonNull(platformContext);
         Objects.requireNonNull(model);
@@ -105,13 +99,11 @@ public record PlatformComponents(
                 gossipModule,
                 issDetectionModule,
                 transactionHandlingModule,
-                stateManagementModule,
+                stateModule,
                 new ComponentWiring<>(model, ConsensusEventStream.class, eventStreamConfig.consensusEventStream()),
                 RunningEventHashOverrideWiring.create(model),
                 new ComponentWiring<>(model, EventWindowManager.class, DIRECT_THREADSAFE_CONFIGURATION),
                 new ComponentWiring<>(model, AppNotifier.class, DIRECT_THREADSAFE_CONFIGURATION),
-                new ComponentWiring<>(model, StateGarbageCollector.class, config.stateGarbageCollector()),
-                new ComponentWiring<>(model, SignedStateSentinel.class, config.signedStateSentinel()),
                 new ComponentWiring<>(model, PlatformMonitor.class, config.platformMonitor()));
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -58,7 +58,7 @@ public record PlatformCoordinator(@NonNull PlatformComponents components) implem
         components.hashgraphModule().flush();
         components.transactionHandlingModule().flush();
         components.eventCreatorModule().flush();
-        components.stateManagementModule().flush();
+        components.stateModule().flush();
     }
 
     /**
@@ -77,7 +77,7 @@ public record PlatformCoordinator(@NonNull PlatformComponents components) implem
         final ReservedSignedState stateReservedForHasher = signedState.reserve("logging state hash");
 
         final boolean offerResult =
-                components.stateManagementModule().hashedStatesInputWire().offer(stateReservedForHasher);
+                components.stateModule().hashedStatesInputWire().offer(stateReservedForHasher);
         if (!offerResult) {
             stateReservedForHasher.close();
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformSchedulersConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformSchedulersConfig.java
@@ -4,20 +4,13 @@ package com.swirlds.platform.wiring;
 import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
-import java.time.Duration;
 
 /**
  * Contains configuration values for the platform schedulers.
  *
  * @param consensusEngine                      configuration for the consensus engine scheduler
  * @param pcesSequencer                        configuration for the preconsensus event sequencer scheduler
- * @param stateGarbageCollector                configuration for the state garbage collector scheduler
- * @param stateGarbageCollectorHeartbeatPeriod the frequency that heartbeats should be sent to the state garbage
- *                                             collector
  * @param roundDurabilityBuffer                configuration for the round durability buffer scheduler
- * @param signedStateSentinel                  configuration for the signed state sentinel scheduler
- * @param signedStateSentinelHeartbeatPeriod   the frequency that heartbeats should be sent to the signed state
- *                                             sentinel
  * @param platformMonitor                      configuration for the platform monitor scheduler
  * @param transactionPool                      configuration for the transaction pool scheduler
  */
@@ -32,16 +25,6 @@ public record PlatformSchedulersConfig(
         TaskSchedulerConfiguration futureEventBuffer,
 
         @ConfigProperty(defaultValue = "DIRECT") TaskSchedulerConfiguration pcesSequencer,
-
-        @ConfigProperty(defaultValue = "SEQUENTIAL CAPACITY(60) UNHANDLED_TASK_METRIC")
-        TaskSchedulerConfiguration stateGarbageCollector,
-
-        @ConfigProperty(defaultValue = "200ms") Duration stateGarbageCollectorHeartbeatPeriod,
-
-        @ConfigProperty(defaultValue = "SEQUENTIAL UNHANDLED_TASK_METRIC")
-        TaskSchedulerConfiguration signedStateSentinel,
-
-        @ConfigProperty(defaultValue = "10s") Duration signedStateSentinelHeartbeatPeriod,
 
         @ConfigProperty(defaultValue = "SEQUENTIAL CAPACITY(5) FLUSHABLE UNHANDLED_TASK_METRIC")
         TaskSchedulerConfiguration roundDurabilityBuffer,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -11,7 +11,6 @@ import com.swirlds.platform.builder.ExecutionLayer;
 import com.swirlds.platform.components.AppNotifier;
 import com.swirlds.platform.components.EventWindowManager;
 import com.swirlds.platform.listeners.StateWriteToDiskCompleteNotification;
-import com.swirlds.platform.state.signed.SignedStateSentinel;
 import com.swirlds.platform.system.PlatformMonitor;
 import com.swirlds.platform.system.StaleEventConsumer;
 import com.swirlds.platform.system.state.notifications.StateHashedNotification;
@@ -24,7 +23,6 @@ import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.state.signed.ReservedSignedState;
-import org.hiero.consensus.state.signed.StateGarbageCollector;
 
 /**
  * Encapsulates wiring for {@link com.swirlds.platform.SwirldsPlatform}.
@@ -119,7 +117,7 @@ public class PlatformWiring {
         components
                 .transactionHandlingModule()
                 .preHandleSignaturesOutputWire()
-                .solderTo(components.stateManagementModule().preconsensusSystemTransactionsInputWire());
+                .solderTo(components.stateModule().preconsensusSystemTransactionsInputWire());
 
         solderEventWindow(components);
 
@@ -147,7 +145,7 @@ public class PlatformWiring {
         components
                 .transactionHandlingModule()
                 .handleSignaturesOutputWire()
-                .solderTo(components.stateManagementModule().postconsensusSystemTranscationsInputWire());
+                .solderTo(components.stateModule().postconsensusSystemTranscationsInputWire());
         components
                 .transactionHandlingModule()
                 .handleSignaturesOutputWire()
@@ -156,28 +154,15 @@ public class PlatformWiring {
         components
                 .transactionHandlingModule()
                 .stateWithHashComplexityOutputWire()
-                .solderTo(components.stateManagementModule().unhashedStatesInputWire());
+                .solderTo(components.stateModule().unhashedStatesInputWire());
 
         components
                 .transactionHandlingModule()
                 .stateOutputWire()
-                .solderTo(components.stateGarbageCollectorWiring().getInputWire(StateGarbageCollector::registerState));
-
-        final var config = platformContext.getConfiguration().getConfigData(PlatformSchedulersConfig.class);
-        components
-                .model()
-                .buildHeartbeatWire(config.stateGarbageCollectorHeartbeatPeriod())
-                .solderTo(
-                        components.stateGarbageCollectorWiring().getInputWire(StateGarbageCollector::heartbeat), OFFER);
-        components
-                .model()
-                .buildHeartbeatWire(config.signedStateSentinelHeartbeatPeriod())
-                .solderTo(
-                        components.signedStateSentinelWiring().getInputWire(SignedStateSentinel::checkSignedStates),
-                        OFFER);
+                .solderTo(components.stateModule().garbageCollectorRegistrationInputWire());
 
         final OutputWire<ReservedSignedState> hashedStateOutputWire =
-                components.stateManagementModule().hashedStateOutputWire();
+                components.stateModule().hashedStateOutputWire();
         hashedStateOutputWire.solderTo(components.issDetectionModule().stateInputWire());
         hashedStateOutputWire
                 .buildTransformer("postHasher_notifier", "hashed states", StateHashedNotification::from)
@@ -185,17 +170,17 @@ public class PlatformWiring {
 
         // send state signatures to execution
         components
-                .stateManagementModule()
+                .stateModule()
                 .stateSignaturesOutputWire()
                 .solderTo("ExecutionSignatureSubmission", "state signatures", execution::submitStateSignature);
 
         components
-                .stateManagementModule()
+                .stateModule()
                 .oldestMinimumBirthRoundOnDiskOutputWire()
                 .solderTo(components.pcesModule().minimumBirthRoundInputWire(), INJECT);
 
         components
-                .stateManagementModule()
+                .stateModule()
                 .stateSavingResultOutputWire()
                 .solderTo(components.platformMonitorWiring().getInputWire(PlatformMonitor::stateWrittenToDisk));
 
@@ -233,7 +218,7 @@ public class PlatformWiring {
         components
                 .platformMonitorWiring()
                 .getOutputWire()
-                .solderTo(components.stateManagementModule().platformStatusInputWire(), INJECT);
+                .solderTo(components.stateModule().platformStatusInputWire(), INJECT);
 
         solderNotifier(components);
         buildUnsolderedWires(components);
@@ -250,7 +235,7 @@ public class PlatformWiring {
         eventWindowOutputWire.solderTo(components.gossipModule().eventWindowInputWire(), INJECT);
         eventWindowOutputWire.solderTo(components.pcesModule().eventWindowInputWire(), INJECT);
         eventWindowOutputWire.solderTo(components.eventCreatorModule().eventWindowInputWire(), INJECT);
-        eventWindowOutputWire.solderTo(components.stateManagementModule().eventWindowInputWire());
+        eventWindowOutputWire.solderTo(components.stateModule().eventWindowInputWire());
     }
 
     /**
@@ -258,7 +243,7 @@ public class PlatformWiring {
      */
     private static void solderNotifier(final PlatformComponents components) {
         components
-                .stateManagementModule()
+                .stateModule()
                 .stateSavingResultOutputWire()
                 .buildTransformer(
                         "stateSavedNotifier",

--- a/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/module-info.java
@@ -29,7 +29,6 @@ module com.swirlds.platform.core {
     exports com.swirlds.platform.listeners;
     exports com.swirlds.platform.metrics;
     exports com.swirlds.platform.reconnect;
-    exports com.swirlds.platform.state.address;
     exports com.swirlds.platform.state.signed;
     exports com.swirlds.platform.state;
     exports com.swirlds.platform.system.state.notifications;
@@ -83,14 +82,12 @@ module com.swirlds.platform.core {
     requires org.hiero.consensus.concurrent;
     requires org.hiero.consensus.pces.impl;
     requires org.hiero.consensus.platformstate;
-    requires com.github.spotbugs.annotations;
-    requires java.management;
     requires java.scripting;
     requires jdk.management;
-    requires jdk.net;
     requires org.apache.logging.log4j;
     requires org.bouncycastle.pkix;
     requires org.bouncycastle.provider;
+    requires static transitive com.github.spotbugs.annotations;
 
     uses EventCreatorModule;
     uses EventIntakeModule;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/PlatformWiringTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/PlatformWiringTests.java
@@ -26,7 +26,6 @@ import com.swirlds.platform.builder.PlatformBuildingBlocks;
 import com.swirlds.platform.builder.PlatformComponentBuilder;
 import com.swirlds.platform.components.AppNotifier;
 import com.swirlds.platform.components.EventWindowManager;
-import com.swirlds.platform.state.signed.SignedStateSentinel;
 import com.swirlds.platform.system.PlatformMonitor;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
@@ -48,7 +47,7 @@ import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.roster.RosterHistory;
-import org.hiero.consensus.state.StateManagementModule;
+import org.hiero.consensus.state.StateModule;
 import org.hiero.consensus.state.persistence.StateSnapshotManager;
 import org.hiero.consensus.state.signed.StateGarbageCollector;
 import org.hiero.consensus.transaction.handling.TransactionHandlingModule;
@@ -95,8 +94,7 @@ class PlatformWiringTests {
                 createNoOpIssDetectionModule(model, configuration, fileSystemManager);
         final TransactionHandlingModule transactionHandlingModule =
                 createNoOpTransactionHandlingModule(model, configuration, fileSystemManager);
-        final StateManagementModule stateManagementModule =
-                createNoOpStateManagementModule(model, configuration, fileSystemManager);
+        final StateModule stateModule = createNoOpStateManagementModule(model, configuration, fileSystemManager);
 
         final PlatformComponents platformComponents = PlatformComponents.create(
                 platformContext,
@@ -108,7 +106,7 @@ class PlatformWiringTests {
                 gossipModule,
                 issDetectionModule,
                 transactionHandlingModule,
-                stateManagementModule);
+                stateModule);
         PlatformWiring.wire(platformContext, mock(ExecutionLayer.class), platformComponents, null);
 
         final PlatformComponentBuilder componentBuilder =
@@ -119,7 +117,6 @@ class PlatformWiringTests {
                 .withStateGarbageCollector(mock(StateGarbageCollector.class))
                 .withConsensusEventStream(mock(ConsensusEventStream.class))
                 .withPlatformMonitor(mock(PlatformMonitor.class))
-                .withSignedStateSentinel(mock(SignedStateSentinel.class))
                 .withStateSnapshotManager(mock(StateSnapshotManager.class));
 
         platformComponents.bind(componentBuilder, mock(EventWindowManager.class), mock(AppNotifier.class));


### PR DESCRIPTION
**Description**:

This PR moves the `SignedStateSentinel` functionality into the `consensus-state` module, sets up the wiring, and contains a number of smaller cleanups

**Related issue(s)**:

Fixes #26175 