### PR TITLE
ci(fix): set explicit version number

### DIFF
--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -370,6 +370,7 @@ jobs:
       solo-version: ${{ inputs.solo-version }}
       java-version: "${{ inputs.java-version }}"
       json-rpc-relay-version: "${{ inputs.json-rpc-relay-version }}"
+      mirror-node-version: "${{inputs.mirror-node-version}}"
     secrets:
       access-token: ${{ secrets.regression-access-token }}
       slack-detailed-report-webhook: ${{ secrets.slack-citr-details-token }}

--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -58,6 +58,7 @@ env:
   SOLO_CLUSTER_SETUP_NAMESPACE: "solo-setup"
   GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
   RUN_LOG_NAME: "run.json-rpc-relay-regression.log"
+  MIRROR_NODE_VERSION: "0.158.0"
 
 jobs:
   # Execute JSON-RPC Relay Regression Tests using specified version of hiero-consensus-node
@@ -151,7 +152,7 @@ jobs:
             solo consensus network deploy --deployment "${SOLO_DEPLOYMENT}"
             solo consensus node setup --deployment "${SOLO_DEPLOYMENT}" --local-build-path ./hedera-node/data
             solo consensus node start --deployment "${SOLO_DEPLOYMENT}"
-            solo mirror node add  --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --enable-ingress --pinger
+            solo mirror node add  --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --enable-ingress --pinger --mirror-node-version "${MIRROR_NODE_VERSION}"
           else
             echo "::debug::Solo version ($version) is < 0.44.0"
             solo cluster-ref connect --cluster-ref kind-${SOLO_CLUSTER_NAME} --context kind-${SOLO_CLUSTER_NAME}
@@ -162,7 +163,7 @@ jobs:
             solo network deploy --deployment "${SOLO_DEPLOYMENT}"
             solo node setup --deployment "${SOLO_DEPLOYMENT}" --local-build-path ./hedera-node/data
             solo node start --deployment "${SOLO_DEPLOYMENT}"
-            solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --enable-ingress --pinger
+            solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --enable-ingress --pinger --mirror-node-version "${MIRROR_NODE_VERSION}"
           fi
 
       # Solo tears down its internal port-forward for CN gRPC after setup health checks.

--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -15,6 +15,10 @@ on:
         description: "The version of solo to install (if not specified, latest will be used):"
         required: false
         type: string
+      mirror-node-version:
+        description: "The version of mirror node pass to solo"
+        required: true
+        type: string
       java-distribution:
         description: "Java JDK Distribution:"
         type: string
@@ -58,7 +62,6 @@ env:
   SOLO_CLUSTER_SETUP_NAMESPACE: "solo-setup"
   GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
   RUN_LOG_NAME: "run.json-rpc-relay-regression.log"
-  MIRROR_NODE_VERSION: "0.158.0"
 
 jobs:
   # Execute JSON-RPC Relay Regression Tests using specified version of hiero-consensus-node
@@ -152,7 +155,7 @@ jobs:
             solo consensus network deploy --deployment "${SOLO_DEPLOYMENT}"
             solo consensus node setup --deployment "${SOLO_DEPLOYMENT}" --local-build-path ./hedera-node/data
             solo consensus node start --deployment "${SOLO_DEPLOYMENT}"
-            solo mirror node add  --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --enable-ingress --pinger --mirror-node-version "${MIRROR_NODE_VERSION}"
+            solo mirror node add  --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --enable-ingress --pinger --mirror-node-version "${{inputs.mirror-node-version}}"
           else
             echo "::debug::Solo version ($version) is < 0.44.0"
             solo cluster-ref connect --cluster-ref kind-${SOLO_CLUSTER_NAME} --context kind-${SOLO_CLUSTER_NAME}
@@ -163,7 +166,7 @@ jobs:
             solo network deploy --deployment "${SOLO_DEPLOYMENT}"
             solo node setup --deployment "${SOLO_DEPLOYMENT}" --local-build-path ./hedera-node/data
             solo node start --deployment "${SOLO_DEPLOYMENT}"
-            solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --enable-ingress --pinger --mirror-node-version "${MIRROR_NODE_VERSION}"
+            solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --enable-ingress --pinger --mirror-node-version "${{inputs.mirror-node-version}}"
           fi
 
       # Solo tears down its internal port-forward for CN gRPC after setup health checks.


### PR DESCRIPTION
**Description**:

Set the version of mirror node used for Solo to "0.158.0" until Solo version 0.82 is release, which will internally fix it.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
