### PR TITLE
build(deps): bump bouncycastle from 1.83 to 1.84

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
 }
 
 val besu = "25.2.2"
-val bouncycastle = "1.83"
+val bouncycastle = "1.84"
 val dagger = "2.59.2"
 val eclipseCollections = "13.0.0"
 val grpc = "1.81.0"


### PR DESCRIPTION
build(deps): bump bouncycastle from 1.83 to 1.84 in /hiero-dependency-versions (#25836)