### PR TITLE
build(deps): bump io.netty:netty-bom from 4.2.13.Final to 4.2.15.Final

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 dependencies {
-    api(platform("io.netty:netty-bom:4.2.13.Final"))
+    api(platform("io.netty:netty-bom:4.2.15.Final"))
 
     // forward logging from modules using SLF4J (e.g. 'org.hyperledger.besu.evm') to Log4J
     runtime("org.apache.logging.log4j:log4j-slf4j2-impl") {


### PR DESCRIPTION
build(deps): bump io.netty:netty-bom from 4.2.13.Final to 4.2.15.Final in /hiero-dependency-versions (#25839)