### PR TITLE
chore: Fix Yahcli Subprocess test failure artifact uploading

### DIFF
--- a/.github/workflows/805-call-execute-hapi-tests.yaml
+++ b/.github/workflows/805-call-execute-hapi-tests.yaml
@@ -211,6 +211,10 @@ jobs:
             hedera-node/test-clients/build/*-test/**/output/**
             hedera-node/test-clients/build/*-test/**/*.log
             hedera-node/test-clients/output/**
+            hedera-node/yahcli/build/**/*.blk.gz
+            hedera-node/yahcli/build/**/*.rcd.gz
+            hedera-node/yahcli/build/**/*.pb
+            hedera-node/yahcli/build/**/*.pces
             hedera-node/yahcli/build/reports/tests/testSubprocess/**
             hedera-node/yahcli/build/hapi-test/**/output/**
             hedera-node/yahcli/build/hapi-test/**/*.log


### PR DESCRIPTION
**Description**:
This pull request updates the test artifact paths in the GitHub Actions workflow to ensure additional Yahcli build outputs are collected. The main change is the inclusion of several new Yahcli file patterns to the list of artifacts.

**Artifact collection updates:**

* Added Yahcli build file patterns (`*.blk.gz`, `*.rcd.gz`, `*.pb`, `*.pces`) to the workflow artifact paths in `.github/workflows/805-call-execute-hapi-tests.yaml`, ensuring these files are now included in the test artifacts.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
