### PR TITLE
docs: Minor fixes in knowledge base

### DIFF
--- a/platform-sdk/docs/consensus-layer/architecture/topics/event-intake.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/event-intake.md
@@ -34,7 +34,7 @@ the `EventIntakeModule` interface; the wiring is built by
 Intake exposes its inputs and outputs through `EventIntakeModule`
 ([EventIntakeModule.java:24](../../../../consensus-event-intake/src/main/java/org/hiero/consensus/event/intake/EventIntakeModule.java:24)).
 Component soldering happens in
-[`PlatformWiring.wire`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java:56).
+[`PlatformWiring.wire`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java:33).
 
 **Inputs**
 
@@ -86,7 +86,7 @@ Component soldering happens in
 ## Validation pipeline
 
 The pipeline is built in
-[`DefaultEventIntakeModule.initialize`](../../../../consensus-event-intake-impl/src/main/java/org/hiero/consensus/event/intake/impl/DefaultEventIntakeModule.java:72)
+[`DefaultEventIntakeModule.initialize`](../../../../consensus-event-intake-impl/src/main/java/org/hiero/consensus/event/intake/impl/DefaultEventIntakeModule.java:83)
 with five components soldered in series (lines 103-131). Schedulers are configured in
 [`EventIntakeWiringConfig`](../../../../consensus-event-intake/src/main/java/org/hiero/consensus/event/intake/config/EventIntakeWiringConfig.java).
 

--- a/platform-sdk/docs/consensus-layer/architecture/topics/freeze-and-upgrade.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/freeze-and-upgrade.md
@@ -60,7 +60,7 @@ interface; the live binding is built as a lambda in
 that closes over the mutable platform state.
 
 `lastFrozenTime` is written by
-[`DefaultTransactionHandler`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java)`#createSignedState`
+[`DefaultTransactionHandler`](../../../../consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/DefaultTransactionHandler.java)`#createSignedState`
 (via `PlatformStateUtils#updateLastFrozenTime`) before `copyMutableState`
 is called, so the `lastFrozenTime = freezeTime` write is committed to
 disk only as part of the freeze state itself. Execution always writes
@@ -159,12 +159,12 @@ immediately rather than being buffered.
 ### State save
 
 A signed state is marked for disk via
-[`DefaultSavedStateController`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/components/DefaultSavedStateController.java)`#shouldSaveToDisk`.
+[`DefaultSavedStateController`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultSavedStateController.java)`#shouldSaveToDisk`.
 The first branch is `if (signedState.isFreezeState()) return FREEZE_STATE`,
 which short-circuits the periodic-snapshot logic and uses the
 [`StateToDiskReason`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/snapshot/StateToDiskReason.java)`.FREEZE_STATE`
 marker. The actual write happens in
-[`DefaultStateSnapshotManager`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/DefaultStateSnapshotManager.java)`#saveStateTask`,
+[`DefaultStateSnapshotManager`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultStateSnapshotManager.java)`#saveStateTask`,
 which runs downstream of the handle thread (not on it); the resulting
 `StateSavingResult` carries the freeze flag further down the pipeline.
 
@@ -177,7 +177,7 @@ orchestrator class.
    [Trigger](#trigger)).
 2. The first consensus round whose timestamp falls in the freeze
    period is detected in
-   [`DefaultTransactionHandler`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java)`#handleConsensusRound`.
+   [`DefaultTransactionHandler`](../../../../consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/DefaultTransactionHandler.java)`#handleConsensusRound`.
    The handler submits a `FreezePeriodEnteredAction(round)` and sets a
    `freezeRoundReceived` flag; subsequent rounds are then ignored by
    the same handler.
@@ -191,9 +191,9 @@ orchestrator class.
 5. The status state machine transitions `FREEZING` → `FREEZE_COMPLETE`
    when the freeze state has been written. The transition logic lives
    in
-   [`FreezingStatusLogic`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/FreezingStatusLogic.java)
+   [`FreezingStatusLogic`](../../../../consensus-utility/src/main/java/org/hiero/consensus/status/logic/FreezingStatusLogic.java)
    and the terminal status in
-   [`FreezeCompleteStatusLogic`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/FreezeCompleteStatusLogic.java).
+   [`FreezeCompleteStatusLogic`](../../../../consensus-utility/src/main/java/org/hiero/consensus/status/logic/FreezeCompleteStatusLogic.java).
 6. Gossip continues in `FREEZE_COMPLETE` so that signatures on the
    freeze state can be distributed to laggards; event creation does
    not resume because neither `ACTIVE` nor `CHECKING` is reached again

--- a/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Hashgraph
-last_reviewed: 2026-07-02
+last_reviewed: 2026-07-13
 ---
 
 # Hashgraph

--- a/platform-sdk/docs/consensus-layer/architecture/topics/iss-detection.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/iss-detection.md
@@ -41,7 +41,7 @@ Out of scope (covered by sibling topics):
 ### `IssDetector`
 
 Interface at
-[`IssDetector.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssDetector.java).
+[`IssDetector.java`](../../../../consensus-iss-detection/src/main/java/org/hiero/consensus/iss/detection/internal/IssDetector.java).
 Two input methods participate in detection:
 
 - `handleState(ReservedSignedState)` — called once per hashed signed
@@ -66,12 +66,12 @@ Carries a round number and an `IssType` (`SELF_ISS`, `OTHER_ISS`,
 
 Defined in
 [
-`RoundHashValidator.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/RoundHashValidator.java).
+`RoundHashValidator.java`](../../../../consensus-iss-detection/src/main/java/org/hiero/consensus/iss/detection/internal/RoundHashValidator.java).
 Per-round state machine. Buffers asynchronously-arriving evidence (the
 local hash and per-peer reported hashes) until enough data is present
 to decide, then exposes a `HashValidityStatus`
 ([
-`HashValidityStatus.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/HashValidityStatus.java)):
+`HashValidityStatus.java`](../../../../consensus-iss-detection/src/main/java/org/hiero/consensus/iss/detection/internal/HashValidityStatus.java)):
 `UNDECIDED`, `VALID`, `SELF_ISS`, `CATASTROPHIC_ISS`, `LACK_OF_DATA`,
 or `CATASTROPHIC_LACK_OF_DATA`.
 
@@ -79,7 +79,7 @@ or `CATASTROPHIC_LACK_OF_DATA`.
 
 Defined in
 [
-`ConsensusHashFinder.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/ConsensusHashFinder.java).
+`ConsensusHashFinder.java`](../../../../consensus-iss-detection/src/main/java/org/hiero/consensus/iss/detection/internal/ConsensusHashFinder.java).
 Groups peer-reported hashes into weight-summed *partitions* keyed by
 hash value. The consensus hash is the hash of the partition that
 exceeds the `SUPER_MAJORITY` weight threshold; if no partition can
@@ -89,10 +89,10 @@ result is catastrophic.
 ### `IssHandler`
 
 Interface at
-[`IssHandler.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssHandler.java)
+[`IssHandler.java`](../../../../consensus-iss-detection/src/main/java/org/hiero/consensus/iss/detection/internal/IssHandler.java)
 with default implementation at
 [
-`DefaultIssHandler.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/internal/DefaultIssHandler.java).
+`DefaultIssHandler.java`](../../../../consensus-iss-detection/src/main/java/org/hiero/consensus/iss/detection/internal/DefaultIssHandler.java).
 Reads each `IssNotification` and applies the configured response:
 halt, force-restart, or no-op.
 
@@ -203,7 +203,7 @@ halt-bit to flip outside `haltOnAnyIss`.
 
 For `SELF_ISS` and `CATASTROPHIC_ISS`, the round number is written to a
 persistent `IssScratchpad` ([
-`IssScratchpad.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/iss/IssScratchpad.java))
+`IssScratchpad.java`](../../../../consensus-iss-detection/src/main/java/org/hiero/consensus/iss/detection/internal/IssScratchpad.java))
 under key `LAST_ISS_ROUND`, monotonically increasing only. The
 scratchpad survives restarts so an operator can observe the latest ISS
 round even after an automated recovery.

--- a/platform-sdk/docs/consensus-layer/architecture/topics/quiescence.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/quiescence.md
@@ -155,10 +155,10 @@ A quiescing node holds platform status `ACTIVE`; no dedicated quiescence
 status exists. The mechanism:
 [`DefaultPlatformMonitor`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/system/DefaultPlatformMonitor.java)`#heartbeat`
 stamps each `TimeElapsedAction` with a
-[`TimeElapsedAction.QuiescingStatus`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/actions/TimeElapsedAction.java)
+[`TimeElapsedAction.QuiescingStatus`](../../../../consensus-utility/src/main/java/org/hiero/consensus/status/actions/TimeElapsedAction.java)
 record (`isQuiescing = lastQuiescenceCommand == QUIESCE`, plus the instant
 the command last changed). In
-[`ActiveStatusLogic`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ActiveStatusLogic.java)`#processTimeElapsedAction`,
+[`ActiveStatusLogic`](../../../../consensus-utility/src/main/java/org/hiero/consensus/status/logic/ActiveStatusLogic.java)`#processTimeElapsedAction`,
 while `isQuiescing` is true the node stays `ACTIVE` regardless of how long
 it has been since one of its own events reached consensus — which would
 otherwise drop it to `CHECKING`.
@@ -185,7 +185,7 @@ The QB is built on a **single self-parent only**, with no other-parent —
 the simplest event that still propagates the waiting transactions.
 
 On exit, platform status returns to normal via the grace period in
-[`ActiveStatusLogic`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ActiveStatusLogic.java)`#processTimeElapsedAction`:
+[`ActiveStatusLogic`](../../../../consensus-utility/src/main/java/org/hiero/consensus/status/logic/ActiveStatusLogic.java)`#processTimeElapsedAction`:
 once `isQuiescing` is false, the node still stays `ACTIVE` until
 `activeStatusDelay` (TUN-020) has elapsed since the stop command — giving a
 freshly created post-quiescence event time to reach consensus — after which

--- a/platform-sdk/docs/consensus-layer/architecture/topics/quiescence.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/quiescence.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Quiescence
-last_reviewed: 2026-06-08
+last_reviewed: 2026-07-13
 ---
 
 # Quiescence

--- a/platform-sdk/docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/reasons-not-to-gossip.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Reasons not to gossip
-last_reviewed: 2026-06-12
+last_reviewed: 2026-07-13
 ---
 
 # Reasons not to gossip

--- a/platform-sdk/docs/consensus-layer/architecture/topics/restart-and-pces.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/restart-and-pces.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Restart and PCES
-last_reviewed: 2026-06-26
+last_reviewed: 2026-07-13
 ---
 
 # Restart and PCES

--- a/platform-sdk/docs/consensus-layer/architecture/topics/signed-state-management.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/signed-state-management.md
@@ -269,8 +269,8 @@ the component framework it also crosses scheduler queues, and every
 fan-out from one wire to multiple listeners must mint one reservation
 per listener so that the fastest consumer cannot release the last
 reservation while a slower consumer is still waiting in queue. Three
-`AdvancedTransformation` implementations in
-`com.swirlds.platform.wiring` enforce this:
+`AdvancedTransformation` implementations (in `consensus-state` and
+`consensus-transaction-handling`) enforce this:
 
 - [`SignedStateReserver`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/utils/SignedStateReserver.java)
   — fans out a `ReservedSignedState`.
@@ -358,13 +358,6 @@ behavior are covered in [iss-detection.md](iss-detection.md).
 The proposal at
 [`Consensus-Layer.md`](../../../proposals/consensus-layer/Consensus-Layer.md)
 places signed-state lifecycle entirely under Execution. Current code
-reflects a partial move: the runtime types (`SignedState`,
-`ReservedSignedState`, `SignedStateReference`, `StateToDiskReason`,
-`DefaultStateGarbageCollector`, `StateConfig`) live in the
-`consensus-state` module under the `org.hiero.consensus.state` package.
-File I/O and snapshot orchestration (`SignedStateFileWriter` /
-`SignedStateFileReader`, `SignedStateFilePath`, `SavedStateMetadata`,
-`StateDumpRequest`, `DefaultStateSignatureCollector`,
-`DefaultSavedStateController`) remain in `swirlds-platform-core` under
-`com.swirlds.platform.state.snapshot` and
-`com.swirlds.platform.components`.
+reflects a partial move: the signed-state types and machinery described
+above now live in the `consensus-state` module, but have not yet moved
+to Execution.

--- a/platform-sdk/docs/consensus-layer/architecture/topics/signed-state-management.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/signed-state-management.md
@@ -68,7 +68,7 @@ under [Latest-state exposure](#latest-state-exposure) instead.
 ### `StateWithHashComplexity`
 
 Defined in
-[`StateWithHashComplexity.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/StateWithHashComplexity.java).
+[`StateWithHashComplexity.java`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/signed/StateWithHashComplexity.java).
 Record that pairs a `ReservedSignedState` with an estimate of how
 expensive hashing the state will be (measured in applied transactions,
 minimum 1). The wiring graph carries this record from the
@@ -82,7 +82,7 @@ A signed state passes through six phases.
 1. **Create.** Only consensus rounds that close a block, plus the
    freeze round, produce a `SignedState`.
    `DefaultTransactionHandler#handleConsensusRound`
-   ([`DefaultTransactionHandler.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java))
+   ([`DefaultTransactionHandler.java`](../../../../consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/DefaultTransactionHandler.java))
    applies each round's transactions to the mutable state and then
    calls `ConsensusStateEventHandler#onSealConsensusRound`, which
    returns whether the round aligns with the end of a block. If it
@@ -97,10 +97,10 @@ A signed state passes through six phases.
    genesis state — follows this same lifecycle but is marked with
    `FIRST_ROUND_AFTER_GENESIS` so that it is always written to disk.
 2. **Hash and locally sign.** `DefaultStateHasher#hashState`
-   ([`DefaultStateHasher.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/hasher/DefaultStateHasher.java))
+   ([`DefaultStateHasher.java`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/hashing/DefaultStateHasher.java))
    forces computation of the merkle root, and
    `DefaultStateSigner#signState`
-   ([`DefaultStateSigner.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/signer/DefaultStateSigner.java))
+   ([`DefaultStateSigner.java`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/signing/DefaultStateSigner.java))
    produces a `StateSignatureTransaction` containing this node's
    signature over the hash. The transaction is submitted to Execution
    for inclusion in the gossiped event stream. (PCES-replay rounds are
@@ -109,7 +109,7 @@ A signed state passes through six phases.
    re-signing would only duplicate what replay is about to surface.)
 3. **Collect peer signatures.**
    `DefaultStateSignatureCollector#addSignature`
-   ([`DefaultStateSignatureCollector.java`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/DefaultStateSignatureCollector.java))
+   ([`DefaultStateSignatureCollector.java`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/signing/DefaultStateSignatureCollector.java))
    accumulates signatures from `StateSignatureTransaction` payloads sent
    by peers, adding them to the state's `SigSet` until the
    signing-weight threshold is reached. Collection is best-effort, not
@@ -125,7 +125,7 @@ A signed state passes through six phases.
    they are expected to lack quorum and are emitted immediately on
    arrival at the collector.
 4. **Decide to save.** `DefaultSavedStateController#shouldSaveToDisk`
-   ([`DefaultSavedStateController.java:111`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/components/DefaultSavedStateController.java))
+   ([`DefaultSavedStateController.java:111`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultSavedStateController.java))
    marks freeze states for saving unconditionally; for non-freeze rounds
    it tests whether the round's consensus timestamp crosses a
    `stateConfig.saveStatePeriod` boundary (read at line 116; the period
@@ -142,7 +142,7 @@ A signed state passes through six phases.
    `executeAndRename`. After the state files are written, it copies PCES
    files into the round directory by calling
    `pcesModule.copyPcesFilesRetryOnFailure`
-   ([`SignedStateFileWriter.java:303`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java)).
+   ([`SignedStateFileWriter.java:303`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java)).
 6. **Reclaim.** `DefaultStateGarbageCollector#heartbeat`
    ([`DefaultStateGarbageCollector.java`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/signed/DefaultStateGarbageCollector.java))
    destroys states whose reservation count has reached zero, off the hot
@@ -157,11 +157,11 @@ reproduced here.
 ## On-disk layout
 
 `SignedStateFileWriter.writeSignedStateToDisk`
-([`SignedStateFileWriter.java:362`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java))
+([`SignedStateFileWriter.java:362`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java))
 is the entry point used whenever a signed state is persisted — periodic
 snapshot, freeze state, or state dump. The writer computes the round
 directory via
-[`SignedStateFilePath`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFilePath.java):
+[`SignedStateFilePath`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/persistence/SignedStateFilePath.java):
 
 ```
 <savedStateDirectory>/<mainClassName>/<selfId>/<swirldName>/<round>/
@@ -169,7 +169,7 @@ directory via
 
 The whole round directory is built under a temporary path and moved into
 place via `executeAndRename`
-([`SignedStateFileWriter.java:386`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java)),
+([`SignedStateFileWriter.java:386`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java)),
 so readers never observe a half-built directory; on a mid-write crash the
 temporary tree is orphaned without affecting the live `saved/…/<round>/`
 hierarchy.
@@ -177,7 +177,7 @@ hierarchy.
 A complete round directory contains:
 
 - `stateMetadata.txt` — human-readable key/value file written by
-  [`SavedStateMetadata`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SavedStateMetadata.java).
+  [`SavedStateMetadata`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/saved/SavedStateMetadata.java).
 - `hashInfo.txt` — mnemonic of the state hash, diagnostic only.
 - `currentRoster.json` — the active `Roster` as PBJ JSON.
 - `consensusSnapshot.json` — the round's `ConsensusSnapshot` as PBJ JSON.
@@ -196,7 +196,7 @@ For the full schema, file-by-file format, and field-by-field detail, see
 
 ### Reading
 
-[`SignedStateFileReader.readState`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java)
+[`SignedStateFileReader.readState`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileReader.java)
 is the canonical reader for the on-disk format. In production it is
 reached through
 [`StartupStateUtils.loadStateFile`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java),
@@ -216,16 +216,16 @@ and expose an in-memory `SignedState` to consumers outside it. Each holds
 the most recent state matching a different criterion:
 
 - **`LatestImmutableStateNexus`**
-  ([interface](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/SignedStateNexus.java),
+  ([interface](../../../../consensus-state/src/main/java/org/hiero/consensus/state/nexus/SignedStateNexus.java),
   implemented by
-  [`LockFreeStateNexus`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/LockFreeStateNexus.java))
+  [`LockFreeStateNexus`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/nexus/LockFreeStateNexus.java))
   holds the latest immutable state produced by the transaction handler.
   Execution reads from it to prehandle incoming transactions against an
   up-to-date state without blocking the handle thread.
 - **`LatestCompleteStateNexus`**
-  ([interface](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/LatestCompleteStateNexus.java),
+  ([interface](../../../../consensus-state/src/main/java/org/hiero/consensus/state/nexus/LatestCompleteStateNexus.java),
   implemented by
-  [`DefaultLatestCompleteStateNexus`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/DefaultLatestCompleteStateNexus.java))
+  [`DefaultLatestCompleteStateNexus`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/nexus/DefaultLatestCompleteStateNexus.java))
   holds the latest signed state that has collected at least the
   signing-weight threshold of signatures. Reconnect teachers serve this
   state to learners. The holder is cleared in two cases:
@@ -272,12 +272,12 @@ reservation while a slower consumer is still waiting in queue. Three
 `AdvancedTransformation` implementations in
 `com.swirlds.platform.wiring` enforce this:
 
-- [`SignedStateReserver`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/SignedStateReserver.java)
+- [`SignedStateReserver`](../../../../consensus-state/src/main/java/org/hiero/consensus/state/utils/SignedStateReserver.java)
   — fans out a `ReservedSignedState`.
-- [`StateWithHashComplexityReserver`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/StateWithHashComplexityReserver.java)
+- [`StateWithHashComplexityReserver`](../../../../consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/StateWithHashComplexityReserver.java)
   — fans out a `StateWithHashComplexity` (used between
   `TransactionHandler` and `SavedStateController`).
-- [`StateWithHashComplexityToStateReserver`](../../../../swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/StateWithHashComplexityToStateReserver.java)
+- [`StateWithHashComplexityToStateReserver`](../../../../consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/StateWithHashComplexityToStateReserver.java)
   — unwraps a `StateWithHashComplexity` to a `ReservedSignedState`
   while fanning out (feeds `SignedStateNexus` and
   `StateGarbageCollector`).

--- a/platform-sdk/docs/consensus-layer/concepts/stale-events.md
+++ b/platform-sdk/docs/consensus-layer/concepts/stale-events.md
@@ -72,7 +72,7 @@ create their own events (see
 [`../architecture/topics/event-creator.md`](../architecture/topics/event-creator.md));
 peers fail to do that for `s` either because they never received it
 (gossip never delivered it — partition is one cause, and
-[`reasons-not-to-gossip.md`](reasons-not-to-gossip.md) covers the
+[`reasons-not-to-gossip.md`](../architecture/topics/reasons-not-to-gossip.md) covers the
 others) or because they had `s` but chose different other-parents.
 Eventually the ancient threshold advances past 50; the linker
 unlinks `s` as ancient, and because `s` never reached consensus the

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-001-pces-state-snapshot-coordination.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-001-pces-state-snapshot-coordination.md
@@ -2,7 +2,7 @@
 type: decision
 id: ADR-001
 title: No Coordination Between PCES Writer and Signed State Writer for Snapshot PCES Copy
-topics: [signed-state, pces]
+topics: [signed-state-management, restart-and-pces]
 related:
   invariants: []
   decisions: []

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-002-execution-freeze-signature-handoff.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-002-execution-freeze-signature-handoff.md
@@ -2,7 +2,7 @@
 type: decision
 id: ADR-002
 title: Block `onSealConsensusRound` to Hand Off Freeze Block Signatures from Execution to Consensus
-topics: [freeze-and-upgrade, execution-layer-interface]
+topics: [freeze-and-upgrade, consensus-execution-boundary]
 related:
   invariants: []
   decisions: []

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
@@ -75,14 +75,14 @@ easiest path — using artifacts from one node sidesteps any cross-node-consiste
    and transactions handle as during normal startup.
 3. **Capture the resulting state.** Acquire the latest immutable state via the `latestImmutableStateNexus`
    (`SwirldsPlatform.java:114`; interface `SignedStateNexus.getState(reason)` at
-   `platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/SignedStateNexus.java:24`). The
+   `platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/nexus/SignedStateNexus.java:24`). The
    result is a `ReservedSignedState`
    (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/signed/ReservedSignedState.java:23`) that
    must be closed when done.
 4. **Mark and dump.** On the underlying `SignedState`, call `markAsStateToSave(StateToDiskReason.PCES_RECOVERY_COMPLETE)`
    (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/snapshot/StateToDiskReason.java:38`);
    construct a `StateDumpRequest` via `StateDumpRequest.create(...)`
-   (`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/StateDumpRequest.java:28`);
+   (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/saved/StateDumpRequest.java:28`);
    hand it to `PlatformCoordinator.dumpStateToDisk(request)`
    (`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java:199`); block
    on `request.waitForFinished()` so the process does not exit before the on-disk write completes.

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
@@ -2,7 +2,7 @@
 type: decision
 id: ADR-003
 title: Remove `SwirldsPlatform.performPcesRecovery()` and Drive ISS Recovery On the Spot
-topics: [pces]
+topics: [restart-and-pces]
 related:
   invariants: []
   decisions: []

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-004-retain-observing-status-for-self-event-recovery.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-004-retain-observing-status-for-self-event-recovery.md
@@ -28,9 +28,9 @@ after replaying events, the platform transitions into `OBSERVING`
 permits creation only in `ACTIVE` or `CHECKING`
 (`platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/PlatformStatusRule.java:37-45`).
 The node remains in `OBSERVING` for a configured span of wall-clock time — `platformStatus.observingStatusDelay`,
-default `10s` (`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusConfig.java:23`) —
+default `10s` (`platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/config/PlatformStatusConfig.java:23`) —
 then transitions to `CHECKING` (or `FREEZING` if a freeze boundary was crossed while observing)
-(`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ObservingStatusLogic.java:176-187`).
+(`platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/status/logic/ObservingStatusLogic.java:176-187`).
 
 The purpose of this pause is to give the node a high chance of **learning its latest self event before it starts
 creating new ones**, so it does not create a new event off an old self-parent. A node that creates two events sharing
@@ -152,9 +152,9 @@ See **Decision** above.
   for the ordinary-crash case.
 - `platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/status/PlatformStatus.java:38-41` — the
   `OBSERVING` status definition.
-- `platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ObservingStatusLogic.java:176-187`
+- `platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/status/logic/ObservingStatusLogic.java:176-187`
   — the exit transition driven by `observingStatusDelay`.
-- `platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusConfig.java:23` —
+- `platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/config/PlatformStatusConfig.java:23` —
   the `observingStatusDelay` config field (default `10s`).
 - `platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/PlatformStatusRule.java:37-45`
   — the event-creation gate that withholds creation while in `OBSERVING`.

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-004-retain-observing-status-for-self-event-recovery.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-004-retain-observing-status-for-self-event-recovery.md
@@ -2,7 +2,7 @@
 type: decision
 id: ADR-004
 title: Retain the OBSERVING Platform Status for Self-Event Recovery After Disk Loss
-topics: [event-creation, pces, platform-status]
+topics: [event-creator, restart-and-pces, platform-status]
 related:
   invariants: []
   decisions: []

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-007-save-reconnect-state-before-resuming-event-creation.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-007-save-reconnect-state-before-resuming-event-creation.md
@@ -89,7 +89,7 @@ path is described in [`../architecture/topics/reconnect.md`](../architecture/top
   `RECONNECT_COMPLETE` by the time the save runs
   (`platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectController.java:247-250`).
   The same path immediately marks the learned state to be saved to disk with reason `RECONNECT`
-  (`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/DefaultSavedStateController.java:62-67`).
+  (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultSavedStateController.java:62-67`).
 - In `RECONNECT_COMPLETE` the platform **gossips but does not create events**. The event-creation gate permits creation
   only in `ACTIVE`, `CHECKING`, or `FREEZING` (the last only to emit the freeze-state signature)
   (`platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/PlatformStatusRule.java:37-45`).
@@ -97,7 +97,7 @@ path is described in [`../architecture/topics/reconnect.md`](../architecture/top
   later state) has been written to disk**. A disk write for a round *prior* to the reconnect state is treated as stale
   and the node keeps waiting. Once the reconnect state is persisted, the node transitions to `CHECKING` — or to
   `FREEZING` if a freeze boundary was crossed — and event creation resumes
-  (`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ReconnectCompleteStatusLogic.java:156-187`).
+  (`platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/status/logic/ReconnectCompleteStatusLogic.java:156-187`).
 
 Writing the learned state to disk closes the PCES gap as a recovery concern: the node now has a startable on-disk point
 covering the post-reconnect consensus position. Only then is it allowed to rejoin event creation and again contribute to
@@ -184,10 +184,10 @@ See **Decision** above.
   and `RECONNECT_COMPLETE` status definitions and their javadoc.
 - `platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectController.java:247-250`
   — the reconnect path transitions to `RECONNECT_COMPLETE` and then marks the learned state for disk save.
-- `platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/components/DefaultSavedStateController.java:62-67`
+- `platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultSavedStateController.java:62-67`
   — `reconnectStateReceived(...)` marks the learned state to be written to disk with reason `RECONNECT`.
 - `platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/PlatformStatusRule.java:37-45`
   — the event-creation gate; creation is withheld in `RECONNECT_COMPLETE`.
-- `platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ReconnectCompleteStatusLogic.java:156-187`
+- `platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/status/logic/ReconnectCompleteStatusLogic.java:156-187`
   — exit from `RECONNECT_COMPLETE` on `StateWrittenToDiskAction`: wait while the persisted round is below the reconnect
   round, then transition to `CHECKING` (or `FREEZING`).

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-007-save-reconnect-state-before-resuming-event-creation.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-007-save-reconnect-state-before-resuming-event-creation.md
@@ -2,7 +2,7 @@
 type: decision
 id: ADR-007
 title: Save the Reconnect State to Disk Before Resuming Event Creation
-topics: [reconnect, platform-status, event-creation, pces, signed-state]
+topics: [reconnect, platform-status, event-creator, restart-and-pces, signed-state-management]
 related:
   invariants: []
   decisions: []

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
@@ -2,7 +2,9 @@
 type: decision
 id: ADR-008
 title: Replace nGen with a monotonic event sequence number and remove nGen
-topics: [event-intake, event-creation, hashgraph, gossip]
+topics: [event-intake, event-creator, hashgraph, gossip]
+historical:
+  - consensus-model/src/main/java/org/hiero/consensus/model/event/NonDeterministicGeneration.java
 related:
   invariants: []
   decisions: []

--- a/platform-sdk/docs/consensus-layer/rules/RUL-001-signed-state-reservations.md
+++ b/platform-sdk/docs/consensus-layer/rules/RUL-001-signed-state-reservations.md
@@ -9,12 +9,12 @@ components:
   - consensus-state/src/main/java/org/hiero/consensus/state/signed/ReservedSignedState.java
   - consensus-state/src/main/java/org/hiero/consensus/state/signed/SignedStateReference.java
   - consensus-state/src/main/java/org/hiero/consensus/state/signed/DefaultStateGarbageCollector.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/SignedStateReserver.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/StateWithHashComplexityReserver.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/StateWithHashComplexityToStateReserver.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/LockFreeStateNexus.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/state/nexus/DefaultLatestCompleteStateNexus.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/DefaultStateSignatureCollector.java
+  - consensus-state/src/main/java/org/hiero/consensus/state/utils/SignedStateReserver.java
+  - consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/StateWithHashComplexityReserver.java
+  - consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/StateWithHashComplexityToStateReserver.java
+  - consensus-state/src/main/java/org/hiero/consensus/state/nexus/LockFreeStateNexus.java
+  - consensus-state/src/main/java/org/hiero/consensus/state/nexus/DefaultLatestCompleteStateNexus.java
+  - consensus-state/src/main/java/org/hiero/consensus/state/signing/DefaultStateSignatureCollector.java
 related:
   invariants: []
   decisions: []

--- a/platform-sdk/docs/consensus-layer/rules/RUL-003-consensus-contributors-independently-restartable.md
+++ b/platform-sdk/docs/consensus-layer/rules/RUL-003-consensus-contributors-independently-restartable.md
@@ -8,10 +8,10 @@ components:
   - swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
   - consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/writer/DefaultInlinePcesWriter.java
   - consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/common/CommonPcesWriter.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/components/DefaultSavedStateController.java
+  - consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java
+  - consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultSavedStateController.java
   - consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/PlatformStatusRule.java
-  - swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/logic/ReconnectCompleteStatusLogic.java
+  - consensus-utility/src/main/java/org/hiero/consensus/status/logic/ReconnectCompleteStatusLogic.java
   - consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectController.java
 related:
   invariants: []

--- a/platform-sdk/docs/consensus-layer/tunables.md
+++ b/platform-sdk/docs/consensus-layer/tunables.md
@@ -103,14 +103,14 @@ Module: `swirlds-platform-core`. Source: [PlatformSchedulersConfig.java](../../s
 
 Per-component `TaskSchedulerConfiguration` values that shape the platform wiring (scheduler type, queue capacity, flushable / squelchable flags, metric publication).
 
-| ID | Key | Type | Default | Effect | Range | Fragility |
-|---|---|---|---|---|---|---|
-| TUN-023 | `platformSchedulers.consensusEngine` | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(500) FLUSHABLE SQUELCHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the consensus engine. |  | — |
-| TUN-026 | `platformSchedulers.futureEventBuffer` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the future-event buffer. |  | — |
-| TUN-027 | `platformSchedulers.pcesSequencer` | TaskSchedulerConfiguration | `DIRECT` | Scheduler configuration for the preconsensus event sequencer. |  | — |
-| TUN-040 | `platformSchedulers.roundDurabilityBuffer` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(5) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the round durability buffer. |  | — |
-| TUN-041 | `platformSchedulers.platformMonitor` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the platform monitor. |  | — |
-| TUN-042 | `platformSchedulers.transactionPool` | TaskSchedulerConfiguration | `DIRECT_THREADSAFE` | Scheduler configuration for the transaction pool. |  | — |
+|   ID    |                    Key                     |            Type            |                                              Default                                               |                            Effect                             | Range | Fragility |
+|---------|--------------------------------------------|----------------------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------|-------|-----------|
+| TUN-023 | `platformSchedulers.consensusEngine`       | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(500) FLUSHABLE SQUELCHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the consensus engine.             |       | —         |
+| TUN-026 | `platformSchedulers.futureEventBuffer`     | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC`                    | Scheduler configuration for the future-event buffer.          |       | —         |
+| TUN-027 | `platformSchedulers.pcesSequencer`         | TaskSchedulerConfiguration | `DIRECT`                                                                                           | Scheduler configuration for the preconsensus event sequencer. |       | —         |
+| TUN-040 | `platformSchedulers.roundDurabilityBuffer` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(5) FLUSHABLE UNHANDLED_TASK_METRIC`                                           | Scheduler configuration for the round durability buffer.      |       | —         |
+| TUN-041 | `platformSchedulers.platformMonitor`       | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                                         | Scheduler configuration for the platform monitor.             |       | —         |
+| TUN-042 | `platformSchedulers.transactionPool`       | TaskSchedulerConfiguration | `DIRECT_THREADSAFE`                                                                                | Scheduler configuration for the transaction pool.             |       | —         |
 
 **Retired.** Keys extracted from this record as the platform wiring was modularised; IDs retired, not reused:
 
@@ -254,17 +254,17 @@ Module: `consensus-state`. Source: [StateWiringConfig.java](../../consensus-stat
 
 Per-component `TaskSchedulerConfiguration` values for the state-management pipeline. Consolidated here from the retired `PlatformSchedulersConfig` keys (state garbage collector and signed-state sentinel, each with a heartbeat period) and the former `StateManagementWiringConfig` (state hasher, hash logger, state signer, state signature collector, state snapshot manager) when `consensus-state-management` was merged into `consensus-state`; defaults are unchanged.
 
-| ID | Key | Type | Default | Effect | Range | Fragility |
-|---|---|---|---|---|---|---|
-| TUN-197 | `state.wiring.stateHasher` | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(100000) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the state hasher. |  | — |
-| TUN-198 | `state.wiring.hashLogger` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(100) UNHANDLED_TASK_METRIC` | Scheduler configuration for the hash logger. |  | — |
-| TUN-199 | `state.wiring.stateSigner` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(10) UNHANDLED_TASK_METRIC` | Scheduler configuration for the state signer. |  | — |
-| TUN-200 | `state.wiring.stateSignatureCollector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the state signature collector. |  | — |
-| TUN-201 | `state.wiring.stateSnapshotManager` | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(20) UNHANDLED_TASK_METRIC` | Scheduler configuration for the state snapshot manager. |  | — |
-| TUN-202 | `state.wiring.stateGarbageCollector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(60) UNHANDLED_TASK_METRIC` | Scheduler configuration for the state garbage collector. |  | — |
-| TUN-203 | `state.wiring.stateGarbageCollectorHeartbeatPeriod` | Duration | `200ms` | Heartbeat frequency sent to the state garbage collector. |  | — |
-| TUN-204 | `state.wiring.signedStateSentinel` | TaskSchedulerConfiguration | `SEQUENTIAL UNHANDLED_TASK_METRIC` | Scheduler configuration for the signed-state sentinel. |  | — |
-| TUN-205 | `state.wiring.signedStateSentinelHeartbeatPeriod` | Duration | `10s` | Heartbeat frequency sent to the signed-state sentinel. |  | — |
+|   ID    |                         Key                         |            Type            |                                          Default                                          |                           Effect                           | Range | Fragility |
+|---------|-----------------------------------------------------|----------------------------|-------------------------------------------------------------------------------------------|------------------------------------------------------------|-------|-----------|
+| TUN-197 | `state.wiring.stateHasher`                          | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(100000) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the state hasher.              |       | —         |
+| TUN-198 | `state.wiring.hashLogger`                           | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(100) UNHANDLED_TASK_METRIC`                                          | Scheduler configuration for the hash logger.               |       | —         |
+| TUN-199 | `state.wiring.stateSigner`                          | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(10) UNHANDLED_TASK_METRIC`                                           | Scheduler configuration for the state signer.              |       | —         |
+| TUN-200 | `state.wiring.stateSignatureCollector`              | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                                | Scheduler configuration for the state signature collector. |       | —         |
+| TUN-201 | `state.wiring.stateSnapshotManager`                 | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(20) UNHANDLED_TASK_METRIC`                                    | Scheduler configuration for the state snapshot manager.    |       | —         |
+| TUN-202 | `state.wiring.stateGarbageCollector`                | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(60) UNHANDLED_TASK_METRIC`                                           | Scheduler configuration for the state garbage collector.   |       | —         |
+| TUN-203 | `state.wiring.stateGarbageCollectorHeartbeatPeriod` | Duration                   | `200ms`                                                                                   | Heartbeat frequency sent to the state garbage collector.   |       | —         |
+| TUN-204 | `state.wiring.signedStateSentinel`                  | TaskSchedulerConfiguration | `SEQUENTIAL UNHANDLED_TASK_METRIC`                                                        | Scheduler configuration for the signed-state sentinel.     |       | —         |
+| TUN-205 | `state.wiring.signedStateSentinelHeartbeatPeriod`   | Duration                   | `10s`                                                                                     | Heartbeat frequency sent to the signed-state sentinel.     |       | —         |
 
 ## `iss.detection.wiring.*` — IssDetectionWiringConfig
 
@@ -272,10 +272,10 @@ Module: `consensus-iss-detection`. Source: [IssDetectionWiringConfig.java](../..
 
 Per-component `TaskSchedulerConfiguration` values for the ISS-detection wiring, extracted from the retired `PlatformSchedulersConfig` keys; defaults are unchanged.
 
-| ID | Key | Type | Default | Effect | Range | Fragility |
-|---|---|---|---|---|---|---|
-| TUN-206 | `iss.detection.wiring.issDetector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) UNHANDLED_TASK_METRIC` | Scheduler configuration for the ISS detector. |  | — |
-| TUN-207 | `iss.detection.wiring.issHandler` | TaskSchedulerConfiguration | `DIRECT` | Scheduler configuration for the ISS handler. |  | — |
+|   ID    |                Key                 |            Type            |                     Default                      |                    Effect                     | Range | Fragility |
+|---------|------------------------------------|----------------------------|--------------------------------------------------|-----------------------------------------------|-------|-----------|
+| TUN-206 | `iss.detection.wiring.issDetector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) UNHANDLED_TASK_METRIC` | Scheduler configuration for the ISS detector. |       | —         |
+| TUN-207 | `iss.detection.wiring.issHandler`  | TaskSchedulerConfiguration | `DIRECT`                                         | Scheduler configuration for the ISS handler.  |       | —         |
 
 ## `event.stream.wiring.*` — EventStreamWiringConfig
 
@@ -283,9 +283,9 @@ Module: `consensus-event-stream`. Source: [EventStreamWiringConfig.java](../../c
 
 Extracted from the retired `PlatformSchedulersConfig` `consensusEventStream` key; default unchanged.
 
-| ID | Key | Type | Default | Effect | Range | Fragility |
-|---|---|---|---|---|---|---|
-| TUN-208 | `event.stream.wiring.consensusEventStream` | TaskSchedulerConfiguration | `DIRECT_THREADSAFE` | Scheduler configuration for the consensus event stream. |  | — |
+|   ID    |                    Key                     |            Type            |       Default       |                         Effect                          | Range | Fragility |
+|---------|--------------------------------------------|----------------------------|---------------------|---------------------------------------------------------|-------|-----------|
+| TUN-208 | `event.stream.wiring.consensusEventStream` | TaskSchedulerConfiguration | `DIRECT_THREADSAFE` | Scheduler configuration for the consensus event stream. |       | —         |
 
 ## `transaction.handling.wiring.*` — TransactionHandlingWiringConfig
 
@@ -293,10 +293,10 @@ Module: `consensus-transaction-handling`. Source: [TransactionHandlingWiringConf
 
 Per-component `TaskSchedulerConfiguration` values for the transaction-handling wiring, extracted from the retired `PlatformSchedulersConfig` keys (`applicationTransactionPrehandler` → `prehandler`, `transactionHandler` → `handler`); defaults are unchanged.
 
-| ID | Key | Type | Default | Effect | Range | Fragility |
-|---|---|---|---|---|---|---|
-| TUN-209 | `transaction.handling.wiring.prehandler` | TaskSchedulerConfiguration | `CONCURRENT CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the application transaction prehandler. |  | — |
-| TUN-210 | `transaction.handling.wiring.handler` | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(100000) FLUSHABLE SQUELCHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the transaction handler. |  | — |
+|   ID    |                   Key                    |            Type            |                                                Default                                                |                               Effect                                | Range | Fragility |
+|---------|------------------------------------------|----------------------------|-------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|-------|-----------|
+| TUN-209 | `transaction.handling.wiring.prehandler` | TaskSchedulerConfiguration | `CONCURRENT CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                                            | Scheduler configuration for the application transaction prehandler. |       | —         |
+| TUN-210 | `transaction.handling.wiring.handler`    | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(100000) FLUSHABLE SQUELCHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the transaction handler.                |       | —         |
 
 ## `consensus.*` — ConsensusConfig
 
@@ -358,7 +358,7 @@ Preconsensus event storage (PCES).
 | TUN-119 | `event.preconsensus.spanOverlapFactor`                   | double             | `1.2`                 | Multiplier on the previous-file-span running average during steady state.                                     | ≥1    | —         |
 | TUN-120 | `event.preconsensus.minimumSpan`                         | int                | `5`                   | Floor on the available span when creating a new file (sanity floor on the heuristic).                         |       | —         |
 | TUN-121 | `event.preconsensus.permitGaps`                          | boolean            | `false`               | If false, throw on detected gaps in the PCES file sequence (only relevant if files were deleted out of band). |       | —         |
-| TUN-122 | `event.preconsensus.databaseDirectory`                   | Path               | `preconsensus-events` | Directory where PCES events are stored, relative to `paths.savedStateDir`.                  |       | —         |
+| TUN-122 | `event.preconsensus.databaseDirectory`                   | Path               | `preconsensus-events` | Directory where PCES events are stored, relative to `paths.savedStateDir`.                                    |       | —         |
 | TUN-123 | `event.preconsensus.copyRecentStreamToStateSnapshots`    | boolean            | `true`                | If true, copy recent PCES files into the saved-state snapshot directory whenever a snapshot is taken.         |       | —         |
 | TUN-124 | `event.preconsensus.compactLastFileOnStartup`            | boolean            | `true`                | If true, compact the last file's span at startup.                                                             |       | —         |
 | TUN-125 | `event.preconsensus.forceIgnorePcesSignatures`           | boolean            | `false`               | If true, ignore PCES event signatures. **TEST ONLY** — must never be enabled in production.                   |       | —         |
@@ -417,8 +417,8 @@ Shares the `event.intake.wiring.*` prefix with [PcesWiringConfig](#eventintakewi
 | TUN-144 | `event.intake.wiring.eventDeduplicator`       | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(5000) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the event deduplicator.        |       | —         |
 | TUN-145 | `event.intake.wiring.eventSignatureValidator` | TaskSchedulerConfiguration | `CONCURRENT CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                       | Scheduler configuration for the event signature validator. |       | —         |
 | TUN-146 | `event.intake.wiring.orphanBuffer`            | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC`  | Scheduler configuration for the orphan buffer.             |       | —         |
-| TUN-211 | `event.intake.wiring.branchDetector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the branch detector. |  | — |
-| TUN-212 | `event.intake.wiring.branchReporter` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the branch reporter. |  | — |
+| TUN-211 | `event.intake.wiring.branchDetector`          | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                       | Scheduler configuration for the branch detector.           |       | —         |
+| TUN-212 | `event.intake.wiring.branchReporter`          | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                       | Scheduler configuration for the branch reporter.           |       | —         |
 
 ## `gossip.*` — GossipConfig
 

--- a/platform-sdk/docs/consensus-layer/tunables.md
+++ b/platform-sdk/docs/consensus-layer/tunables.md
@@ -32,21 +32,13 @@ Column conventions:
   otherwise blank. Blank means "not constrained beyond the type."
 - **Fragility** — reserved for SME curation; `—` until filled in.
 
-## `state.*` — StateCommonConfig
+## StateCommonConfig — removed
 
-Module: `swirlds-common`. Source: [StateCommonConfig.java](../../swirlds-common/src/main/java/com/swirlds/common/config/StateCommonConfig.java).
+`StateCommonConfig` (`swirlds-common`) was removed. Its sole key `state.savedStateDirectory` (TUN-001, retired) is superseded by [`paths.savedStateDir`](#paths---pathsconfig) (TUN-062). ID retired, not reused.
 
-|   ID    |             Key             | Type |   Default    |                                       Effect                                       | Range | Fragility |
-|---------|-----------------------------|------|--------------|------------------------------------------------------------------------------------|-------|-----------|
-| TUN-001 | `state.savedStateDirectory` | Path | `data/saved` | Directory where states are saved; relative to CWD unless the path begins with `/`. |       | —         |
+## TemporaryFileConfig — removed
 
-## `temporaryFiles.*` — TemporaryFileConfig
-
-Module: `swirlds-common`. Source: [TemporaryFileConfig.java](../../swirlds-common/src/main/java/com/swirlds/common/io/config/TemporaryFileConfig.java).
-
-|   ID    |                Key                 | Type |    Default    |                                   Effect                                   | Range | Fragility |
-|---------|------------------------------------|------|---------------|----------------------------------------------------------------------------|-------|-----------|
-| TUN-002 | `temporaryFiles.temporaryFilePath` | Path | `swirlds-tmp` | Directory where temporary files are created (relative to saved-state dir). |       | —         |
+`TemporaryFileConfig` (`swirlds-common`) was removed as obsolete. Its key `temporaryFiles.temporaryFilePath` (TUN-002, retired) has no replacement; the temporary-files directory is configured via [`paths.tmpDir`](#paths---pathsconfig) (TUN-063). ID retired, not reused.
 
 ## `platform.wiring.*` — WiringConfig
 
@@ -111,29 +103,23 @@ Module: `swirlds-platform-core`. Source: [PlatformSchedulersConfig.java](../../s
 
 Per-component `TaskSchedulerConfiguration` values that shape the platform wiring (scheduler type, queue capacity, flushable / squelchable flags, metric publication).
 
-|   ID    |                            Key                            |            Type            |                                                Default                                                |                               Effect                                | Range | Fragility |
-|---------|-----------------------------------------------------------|----------------------------|-------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|-------|-----------|
-| TUN-023 | `platformSchedulers.consensusEngine`                      | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(500) FLUSHABLE SQUELCHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC`    | Scheduler configuration for the consensus engine.                   |       | —         |
-| TUN-026 | `platformSchedulers.futureEventBuffer`                    | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC`                       | Scheduler configuration for the future-event buffer.                |       | —         |
-| TUN-027 | `platformSchedulers.pcesSequencer`                        | TaskSchedulerConfiguration | `DIRECT`                                                                                              | Scheduler configuration for the preconsensus event sequencer.       |       | —         |
-| TUN-028 | `platformSchedulers.applicationTransactionPrehandler`     | TaskSchedulerConfiguration | `CONCURRENT CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                                            | Scheduler configuration for the application transaction prehandler. |       | —         |
-| TUN-030 | `platformSchedulers.transactionHandler`                   | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(100000) FLUSHABLE SQUELCHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the transaction handler.                |       | —         |
-| TUN-031 | `platformSchedulers.issDetector`                          | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) UNHANDLED_TASK_METRIC`                                                      | Scheduler configuration for the ISS detector.                       |       | —         |
-| TUN-032 | `platformSchedulers.issHandler`                           | TaskSchedulerConfiguration | `DIRECT`                                                                                              | Scheduler configuration for the ISS handler.                        |       | —         |
-| TUN-035 | `platformSchedulers.stateGarbageCollector`                | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(60) UNHANDLED_TASK_METRIC`                                                       | Scheduler configuration for the state garbage collector.            |       | —         |
-| TUN-036 | `platformSchedulers.stateGarbageCollectorHeartbeatPeriod` | Duration                   | `200ms`                                                                                               | Heartbeat frequency sent to the state garbage collector.            |       | —         |
-| TUN-037 | `platformSchedulers.signedStateSentinel`                  | TaskSchedulerConfiguration | `SEQUENTIAL UNHANDLED_TASK_METRIC`                                                                    | Scheduler configuration for the signed-state sentinel.              |       | —         |
-| TUN-038 | `platformSchedulers.signedStateSentinelHeartbeatPeriod`   | Duration                   | `10s`                                                                                                 | Heartbeat frequency sent to the signed-state sentinel.              |       | —         |
-| TUN-039 | `platformSchedulers.consensusEventStream`                 | TaskSchedulerConfiguration | `DIRECT_THREADSAFE`                                                                                   | Scheduler configuration for the consensus event stream.             |       | —         |
-| TUN-040 | `platformSchedulers.roundDurabilityBuffer`                | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(5) FLUSHABLE UNHANDLED_TASK_METRIC`                                              | Scheduler configuration for the round durability buffer.            |       | —         |
-| TUN-041 | `platformSchedulers.platformMonitor`                      | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                                            | Scheduler configuration for the platform monitor.                   |       | —         |
-| TUN-042 | `platformSchedulers.transactionPool`                      | TaskSchedulerConfiguration | `DIRECT_THREADSAFE`                                                                                   | Scheduler configuration for the transaction pool.                   |       | —         |
-| TUN-043 | `platformSchedulers.branchDetector`                       | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                                            | Scheduler configuration for the branch detector.                    |       | —         |
-| TUN-044 | `platformSchedulers.branchReporter`                       | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                                            | Scheduler configuration for the branch reporter.                    |       | —         |
+| ID | Key | Type | Default | Effect | Range | Fragility |
+|---|---|---|---|---|---|---|
+| TUN-023 | `platformSchedulers.consensusEngine` | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(500) FLUSHABLE SQUELCHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the consensus engine. |  | — |
+| TUN-026 | `platformSchedulers.futureEventBuffer` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the future-event buffer. |  | — |
+| TUN-027 | `platformSchedulers.pcesSequencer` | TaskSchedulerConfiguration | `DIRECT` | Scheduler configuration for the preconsensus event sequencer. |  | — |
+| TUN-040 | `platformSchedulers.roundDurabilityBuffer` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(5) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the round durability buffer. |  | — |
+| TUN-041 | `platformSchedulers.platformMonitor` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the platform monitor. |  | — |
+| TUN-042 | `platformSchedulers.transactionPool` | TaskSchedulerConfiguration | `DIRECT_THREADSAFE` | Scheduler configuration for the transaction pool. |  | — |
 
-**Retired.** TUN-024, TUN-025, TUN-029, TUN-033, TUN-034 moved out of this record to
-[`state.management.wiring.*` — StateManagementWiringConfig](#statemanagementwiring---statemanagementwiringconfig)
-(now TUN-192…TUN-196) when the state-management schedulers were extracted into `consensus-state-management`. IDs retired, not reused.
+**Retired.** Keys extracted from this record as the platform wiring was modularised; IDs retired, not reused:
+
+- TUN-024, TUN-025, TUN-029, TUN-033, TUN-034 — state hasher / hash logger / state signer / state signature collector / state snapshot manager, now [`state.wiring.*` — StateWiringConfig](#statewiring---statewiringconfig) (TUN-197…TUN-201).
+- TUN-035, TUN-036, TUN-037, TUN-038 — state garbage collector and signed-state sentinel (each with heartbeat period), now [`state.wiring.*` — StateWiringConfig](#statewiring---statewiringconfig) (TUN-202…TUN-205).
+- TUN-031, TUN-032 — ISS detector / handler, now [`iss.detection.wiring.*` — IssDetectionWiringConfig](#issdetectionwiring---issdetectionwiringconfig) (TUN-206, TUN-207).
+- TUN-039 — consensus event stream, now [`event.stream.wiring.*` — EventStreamWiringConfig](#eventstreamwiring---eventstreamwiringconfig) (TUN-208).
+- TUN-028, TUN-030 — application transaction prehandler / transaction handler, now [`transaction.handling.wiring.*` — TransactionHandlingWiringConfig](#transactionhandlingwiring---transactionhandlingwiringconfig) (TUN-209, TUN-210).
+- TUN-043, TUN-044 — branch detector / reporter, now [`event.intake.wiring.*` — EventIntakeWiringConfig](#eventintakewiring---eventintakewiringconfig) (TUN-211, TUN-212).
 
 ## `os.health.*` — OSHealthCheckConfig
 
@@ -236,7 +222,7 @@ Module: `consensus-reconnect`. Source: [ReconnectConfig.java](../../consensus-re
 
 Module: `consensus-state`. Source: [StateConfig.java](../../consensus-state/src/main/java/org/hiero/consensus/state/config/StateConfig.java).
 
-Shares the `state.*` prefix with [StateCommonConfig](#state---statecommonconfig); the keys below come from `StateConfig` (SignedStateManager / SignedStateFileManager behavior).
+The keys below come from `StateConfig` (SignedStateManager / SignedStateFileManager behavior).
 
 |   ID    |                  Key                  |   Type   | Default |                                                                    Effect                                                                     | Range | Fragility |
 |---------|---------------------------------------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------|-----------|
@@ -262,19 +248,55 @@ Shares the `state.*` prefix with [StateCommonConfig](#state---statecommonconfig)
 | TUN-098 | `state.validateInitialState`          | boolean  | `true`  | If false, skip ISS validation on the state loaded from disk at startup (test-only).                                                           |       | —         |
 | TUN-099 | `state.periodicSnapshotsEnabled`      | boolean  | `true`  | Create periodic snapshots of the signed state.                                                                                                |       | —         |
 
-## `state.management.wiring.*` — StateManagementWiringConfig
+## `state.wiring.*` — StateWiringConfig
 
-Module: `consensus-state-management`. Source: [StateManagementWiringConfig.java](../../consensus-state-management/src/main/java/org/hiero/consensus/state/management/config/StateManagementWiringConfig.java).
+Module: `consensus-state`. Source: [StateWiringConfig.java](../../consensus-state/src/main/java/org/hiero/consensus/state/config/StateWiringConfig.java).
 
-Per-component `TaskSchedulerConfiguration` values for the state-management pipeline. These schedulers were extracted from [PlatformSchedulersConfig](#platformschedulers---platformschedulersconfig) (retired TUN-024, TUN-025, TUN-029, TUN-033, TUN-034); defaults are unchanged.
+Per-component `TaskSchedulerConfiguration` values for the state-management pipeline. Consolidated here from the retired `PlatformSchedulersConfig` keys (state garbage collector and signed-state sentinel, each with a heartbeat period) and the former `StateManagementWiringConfig` (state hasher, hash logger, state signer, state signature collector, state snapshot manager) when `consensus-state-management` was merged into `consensus-state`; defaults are unchanged.
 
-|   ID    |                        Key                        |            Type            |                                          Default                                          |                           Effect                           | Range | Fragility |
-|---------|---------------------------------------------------|----------------------------|-------------------------------------------------------------------------------------------|------------------------------------------------------------|-------|-----------|
-| TUN-192 | `state.management.wiring.stateHasher`             | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(100000) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the state hasher.              |       | —         |
-| TUN-193 | `state.management.wiring.hashLogger`              | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(100) UNHANDLED_TASK_METRIC`                                          | Scheduler configuration for the hash logger.               |       | —         |
-| TUN-194 | `state.management.wiring.stateSigner`             | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(10) UNHANDLED_TASK_METRIC`                                           | Scheduler configuration for the state signer.              |       | —         |
-| TUN-195 | `state.management.wiring.stateSignatureCollector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                                | Scheduler configuration for the state signature collector. |       | —         |
-| TUN-196 | `state.management.wiring.stateSnapshotManager`    | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(20) UNHANDLED_TASK_METRIC`                                    | Scheduler configuration for the state snapshot manager.    |       | —         |
+| ID | Key | Type | Default | Effect | Range | Fragility |
+|---|---|---|---|---|---|---|
+| TUN-197 | `state.wiring.stateHasher` | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(100000) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the state hasher. |  | — |
+| TUN-198 | `state.wiring.hashLogger` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(100) UNHANDLED_TASK_METRIC` | Scheduler configuration for the hash logger. |  | — |
+| TUN-199 | `state.wiring.stateSigner` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(10) UNHANDLED_TASK_METRIC` | Scheduler configuration for the state signer. |  | — |
+| TUN-200 | `state.wiring.stateSignatureCollector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the state signature collector. |  | — |
+| TUN-201 | `state.wiring.stateSnapshotManager` | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(20) UNHANDLED_TASK_METRIC` | Scheduler configuration for the state snapshot manager. |  | — |
+| TUN-202 | `state.wiring.stateGarbageCollector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(60) UNHANDLED_TASK_METRIC` | Scheduler configuration for the state garbage collector. |  | — |
+| TUN-203 | `state.wiring.stateGarbageCollectorHeartbeatPeriod` | Duration | `200ms` | Heartbeat frequency sent to the state garbage collector. |  | — |
+| TUN-204 | `state.wiring.signedStateSentinel` | TaskSchedulerConfiguration | `SEQUENTIAL UNHANDLED_TASK_METRIC` | Scheduler configuration for the signed-state sentinel. |  | — |
+| TUN-205 | `state.wiring.signedStateSentinelHeartbeatPeriod` | Duration | `10s` | Heartbeat frequency sent to the signed-state sentinel. |  | — |
+
+## `iss.detection.wiring.*` — IssDetectionWiringConfig
+
+Module: `consensus-iss-detection`. Source: [IssDetectionWiringConfig.java](../../consensus-iss-detection/src/main/java/org/hiero/consensus/iss/detection/config/IssDetectionWiringConfig.java).
+
+Per-component `TaskSchedulerConfiguration` values for the ISS-detection wiring, extracted from the retired `PlatformSchedulersConfig` keys; defaults are unchanged.
+
+| ID | Key | Type | Default | Effect | Range | Fragility |
+|---|---|---|---|---|---|---|
+| TUN-206 | `iss.detection.wiring.issDetector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) UNHANDLED_TASK_METRIC` | Scheduler configuration for the ISS detector. |  | — |
+| TUN-207 | `iss.detection.wiring.issHandler` | TaskSchedulerConfiguration | `DIRECT` | Scheduler configuration for the ISS handler. |  | — |
+
+## `event.stream.wiring.*` — EventStreamWiringConfig
+
+Module: `consensus-event-stream`. Source: [EventStreamWiringConfig.java](../../consensus-event-stream/src/main/java/org/hiero/consensus/event/stream/config/EventStreamWiringConfig.java).
+
+Extracted from the retired `PlatformSchedulersConfig` `consensusEventStream` key; default unchanged.
+
+| ID | Key | Type | Default | Effect | Range | Fragility |
+|---|---|---|---|---|---|---|
+| TUN-208 | `event.stream.wiring.consensusEventStream` | TaskSchedulerConfiguration | `DIRECT_THREADSAFE` | Scheduler configuration for the consensus event stream. |  | — |
+
+## `transaction.handling.wiring.*` — TransactionHandlingWiringConfig
+
+Module: `consensus-transaction-handling`. Source: [TransactionHandlingWiringConfig.java](../../consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/config/TransactionHandlingWiringConfig.java).
+
+Per-component `TaskSchedulerConfiguration` values for the transaction-handling wiring, extracted from the retired `PlatformSchedulersConfig` keys (`applicationTransactionPrehandler` → `prehandler`, `transactionHandler` → `handler`); defaults are unchanged.
+
+| ID | Key | Type | Default | Effect | Range | Fragility |
+|---|---|---|---|---|---|---|
+| TUN-209 | `transaction.handling.wiring.prehandler` | TaskSchedulerConfiguration | `CONCURRENT CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the application transaction prehandler. |  | — |
+| TUN-210 | `transaction.handling.wiring.handler` | TaskSchedulerConfiguration | `SEQUENTIAL_THREAD CAPACITY(100000) FLUSHABLE SQUELCHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the transaction handler. |  | — |
 
 ## `consensus.*` — ConsensusConfig
 
@@ -336,7 +358,7 @@ Preconsensus event storage (PCES).
 | TUN-119 | `event.preconsensus.spanOverlapFactor`                   | double             | `1.2`                 | Multiplier on the previous-file-span running average during steady state.                                     | ≥1    | —         |
 | TUN-120 | `event.preconsensus.minimumSpan`                         | int                | `5`                   | Floor on the available span when creating a new file (sanity floor on the heuristic).                         |       | —         |
 | TUN-121 | `event.preconsensus.permitGaps`                          | boolean            | `false`               | If false, throw on detected gaps in the PCES file sequence (only relevant if files were deleted out of band). |       | —         |
-| TUN-122 | `event.preconsensus.databaseDirectory`                   | Path               | `preconsensus-events` | Directory where PCES events are stored, relative to `StateCommonConfig.savedStateDirectory`.                  |       | —         |
+| TUN-122 | `event.preconsensus.databaseDirectory`                   | Path               | `preconsensus-events` | Directory where PCES events are stored, relative to `paths.savedStateDir`.                  |       | —         |
 | TUN-123 | `event.preconsensus.copyRecentStreamToStateSnapshots`    | boolean            | `true`                | If true, copy recent PCES files into the saved-state snapshot directory whenever a snapshot is taken.         |       | —         |
 | TUN-124 | `event.preconsensus.compactLastFileOnStartup`            | boolean            | `true`                | If true, compact the last file's span at startup.                                                             |       | —         |
 | TUN-125 | `event.preconsensus.forceIgnorePcesSignatures`           | boolean            | `false`               | If true, ignore PCES event signatures. **TEST ONLY** — must never be enabled in production.                   |       | —         |
@@ -395,6 +417,8 @@ Shares the `event.intake.wiring.*` prefix with [PcesWiringConfig](#eventintakewi
 | TUN-144 | `event.intake.wiring.eventDeduplicator`       | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(5000) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC` | Scheduler configuration for the event deduplicator.        |       | —         |
 | TUN-145 | `event.intake.wiring.eventSignatureValidator` | TaskSchedulerConfiguration | `CONCURRENT CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC`                       | Scheduler configuration for the event signature validator. |       | —         |
 | TUN-146 | `event.intake.wiring.orphanBuffer`            | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC BUSY_FRACTION_METRIC`  | Scheduler configuration for the orphan buffer.             |       | —         |
+| TUN-211 | `event.intake.wiring.branchDetector` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the branch detector. |  | — |
+| TUN-212 | `event.intake.wiring.branchReporter` | TaskSchedulerConfiguration | `SEQUENTIAL CAPACITY(500) FLUSHABLE UNHANDLED_TASK_METRIC` | Scheduler configuration for the branch reporter. |  | — |
 
 ## `gossip.*` — GossipConfig
 

--- a/platform-sdk/docs/consensus-layer/tunables.md
+++ b/platform-sdk/docs/consensus-layer/tunables.md
@@ -89,7 +89,7 @@ Selects consensus module implementations via ServiceLoader. Each value is a JPMS
 
 ## `platformStatus.*` — PlatformStatusConfig
 
-Module: `swirlds-platform-core`. Source: [PlatformStatusConfig.java](../../swirlds-platform-core/src/main/java/com/swirlds/platform/system/status/PlatformStatusConfig.java).
+Module: `consensus-utility`. Source: [PlatformStatusConfig.java](../../consensus-utility/src/main/java/org/hiero/consensus/config/PlatformStatusConfig.java).
 
 |   ID    |                        Key                         |   Type   | Default |                                                Effect                                                 | Range | Fragility |
 |---------|----------------------------------------------------|----------|---------|-------------------------------------------------------------------------------------------------------|-------|-----------|


### PR DESCRIPTION
**Description**:

This PR makes a number of minor corrections to the knowledge base. All were discovered by the KB freshness checker:
- Multiple links have become outdated when code was moved into the new modules
- Some configuration changes, most related to the new modules, were not updated in `tunables.md`
- Some older documents contained references to documents that never existed.

**Related issue(s)**:

Fixes #26301 