### PR TITLE
ci(workflow-fix): fix Slack message failures

### DIFF
--- a/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
@@ -32,6 +32,10 @@
             {
               "type": "mrkdwn",
               "text": {{ printf "*Failing Test(s)*: %s" (getenv "FAILED_TESTS" | required "FAILED_TESTS must be set") | data.ToJSON }}
+            },
+            {
+              "type": "mrkdwn",
+              "text": {{ printf "*Run attempt*: %s" (getenv "RUN_ATTEMPT") | data.ToJSON }}
             }
           ]
         },
@@ -68,10 +72,6 @@
             {
               "type": "mrkdwn",
               "text": {{ getenv "SLACK_USER_ID" | default "N/A" | data.ToJSON }}
-            },
-            {
-              "type": "mrkdwn",
-              "text": {{ printf "*Run attempt*: %s" (getenv "RUN_ATTEMPT") | data.ToJSON }}
             },
             {
               "type": "mrkdwn",

--- a/.github/workflows/templates/slack-xts-test-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-xts-test-failure-detailed.json.tpl
@@ -36,6 +36,10 @@
             {
               "type": "mrkdwn",
               "text": {{ printf "*Failing Test(s)*: %s" (getenv "FAILED_TESTS" | required "FAILED_TESTS must be set") | data.ToJSON }}
+            },
+            {
+              "type": "mrkdwn",
+              "text": {{ printf "*Run attempt*: %s" (getenv "RUN_ATTEMPT") | data.ToJSON }}
             }
           ]
         },
@@ -72,10 +76,6 @@
             {
               "type": "mrkdwn",
               "text": {{ getenv "SLACK_USER_ID" | default "N/A" | data.ToJSON }}
-            },
-            {
-              "type": "mrkdwn",
-              "text": {{ printf "*Run attempt*: %s" (getenv "RUN_ATTEMPT") | data.ToJSON }}
             },
             {
               "type": "mrkdwn",


### PR DESCRIPTION
**Description**:

The number of slack fields is limited at 10. The recent change to add the workflow run number added an 11th field, which broke slack reporting.

**Related Issue(s)**:

Fixes #26300

**Testing**:

Confirmed by locally rendering the gomplate template:
```
  MATS_TESTS_RESULT=failure \
  DEPLOY_CI_TRIGGER_RESULT=skipped \
  FAILED_TESTS="SomeTest#testSomething" \
  RUN_ATTEMPT=2 \
  COMMIT_URL="https://github.com/hiero-ledger/hiero-consensus-node/commit/abc123" \
  COMMIT_AUTHOR="Test User <test@example.com>" \
  SLACK_USER_ID="U12345" \
  WORKFLOW_RUN_ID="99999999" \
  WORKFLOW_RUN_URL="https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/99999999" \
  gomplate -f .github/workflows/templates/slack-mats-test-failure-detailed.json.tpl \
    | jq '.attachments[0].blocks[] | select(.type == "section") | {field_count: (.fields | length)}'
```
Output showing the total field count:
```
{
  "field_count": 4
}
{
  "field_count": 10
}
```