### PR TITLE
ci(workflow): remove xts cancelled messages from operations channel

### DIFF
--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -701,7 +701,7 @@ jobs:
       # Notification routing:
       #   test failures       -> citr-operations (detailed)
       #   environment         -> citr-operations (summary) + citr-failures (detailed)
-      #   canceled            -> citr-operations (summary) + citr-failures (summary)
+      #   canceled            -> citr-operations (summary)
       - name: Notify test failure detailed (citr-operations)
         if: ${{ steps.report-category.outputs.category == 'test' }}
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
@@ -734,15 +734,6 @@ jobs:
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
           webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload_summary.json
-
-      - name: Notify cancelled summary (citr-failures)
-        if: ${{ steps.report-category.outputs.category == 'cancelled' }}
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_CITR_FAILURES_WEBHOOK }}
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload_summary.json


### PR DESCRIPTION
**Description**:

Remove the XTS Cancelled message from the CITR Operations Slack channel.

**Related Issue(s)**:

Implements #26305
