### PR TITLE
fix: Revert "chore: Remove nGen (#26169)"

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
@@ -5,35 +5,37 @@
 module com.hedera.node.app.service.contract.impl {
     exports com.hedera.node.app.service.contract.impl.annotations;
     exports com.hedera.node.app.service.contract.impl.exec.delegation;
-    exports com.hedera.node.app.service.contract.impl.exec.failure to
-            com.hedera.node.app.service.contract.impl.test,
-            com.hedera.node.app.service.contract.impl.test.exec.scope;
-    exports com.hedera.node.app.service.contract.impl.exec.gas to
-            com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.exec.metrics;
-    exports com.hedera.node.app.service.contract.impl.exec.operations to
-            com.hedera.node.app.service.contract.impl.test;
-    exports com.hedera.node.app.service.contract.impl.exec.processors to
-            com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.exec.scope;
     exports com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.associations;
     exports com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.mint;
     exports com.hedera.node.app.service.contract.impl.exec.tracers;
     exports com.hedera.node.app.service.contract.impl.exec.utils;
+    exports com.hedera.node.app.service.contract.impl.exec;
+    exports com.hedera.node.app.service.contract.impl.handlers;
+    exports com.hedera.node.app.service.contract.impl.hevm;
+    exports com.hedera.node.app.service.contract.impl.records;
+    exports com.hedera.node.app.service.contract.impl.utils;
+    exports com.hedera.node.app.service.contract.impl;
+    exports com.hedera.node.app.service.contract.impl.exec.failure to
+            com.hedera.node.app.service.contract.impl.test,
+            com.hedera.node.app.service.contract.impl.test.exec.scope;
+    exports com.hedera.node.app.service.contract.impl.exec.gas to
+            com.hedera.node.app.service.contract.impl.test;
+    exports com.hedera.node.app.service.contract.impl.exec.operations to
+            com.hedera.node.app.service.contract.impl.test;
+    exports com.hedera.node.app.service.contract.impl.exec.processors to
+            com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.exec.v030 to
             com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.exec.v034 to
             com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.exec.v038 to
             com.hedera.node.app.service.contract.impl.test;
-    exports com.hedera.node.app.service.contract.impl.exec;
-    exports com.hedera.node.app.service.contract.impl.handlers;
-    exports com.hedera.node.app.service.contract.impl.hevm;
     exports com.hedera.node.app.service.contract.impl.infra to
             com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.nativelibverification to
             com.hedera.node.app;
-    exports com.hedera.node.app.service.contract.impl.records;
     exports com.hedera.node.app.service.contract.impl.schemas to
             com.hedera.node.app,
             com.hedera.node.app.service.contract.impl.test,
@@ -50,8 +52,15 @@ module com.hedera.node.app.service.contract.impl {
             com.hedera.node.app.service.contract.impl.test,
             com.hedera.node.services.cli,
             com.hedera.node.test.clients;
-    exports com.hedera.node.app.service.contract.impl.utils;
-    exports com.hedera.node.app.service.contract.impl;
+
+    opens com.hedera.node.app.service.contract.impl.exec to
+            com.hedera.node.app.service.contract.impl.test;
+    opens com.hedera.node.app.service.contract.impl.exec.tracers to
+            com.hedera.node.app.service.contract.impl.test;
+    opens com.hedera.node.app.service.contract.impl.exec.utils to
+            com.hedera.node.app.service.contract.impl.test;
+    opens com.hedera.node.app.service.contract.impl.utils to
+            com.hedera.node.app.service.contract.impl.test;
 
     requires transitive com.hedera.node.app.hapi.fees;
     requires transitive com.hedera.node.app.hapi.utils;
@@ -86,13 +95,4 @@ module com.hedera.node.app.service.contract.impl {
     requires org.hyperledger.besu.internal.crypto;
     requires static transitive com.github.spotbugs.annotations;
     requires static java.compiler;
-
-    opens com.hedera.node.app.service.contract.impl.utils to
-            com.hedera.node.app.service.contract.impl.test;
-    opens com.hedera.node.app.service.contract.impl.exec.utils to
-            com.hedera.node.app.service.contract.impl.test;
-    opens com.hedera.node.app.service.contract.impl.exec to
-            com.hedera.node.app.service.contract.impl.test;
-    opens com.hedera.node.app.service.contract.impl.exec.tracers to
-            com.hedera.node.app.service.contract.impl.test;
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
@@ -5,37 +5,35 @@
 module com.hedera.node.app.service.contract.impl {
     exports com.hedera.node.app.service.contract.impl.annotations;
     exports com.hedera.node.app.service.contract.impl.exec.delegation;
-    exports com.hedera.node.app.service.contract.impl.exec.metrics;
-    exports com.hedera.node.app.service.contract.impl.exec.scope;
-    exports com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.associations;
-    exports com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.mint;
-    exports com.hedera.node.app.service.contract.impl.exec.tracers;
-    exports com.hedera.node.app.service.contract.impl.exec.utils;
-    exports com.hedera.node.app.service.contract.impl.exec;
-    exports com.hedera.node.app.service.contract.impl.handlers;
-    exports com.hedera.node.app.service.contract.impl.hevm;
-    exports com.hedera.node.app.service.contract.impl.records;
-    exports com.hedera.node.app.service.contract.impl.utils;
-    exports com.hedera.node.app.service.contract.impl;
     exports com.hedera.node.app.service.contract.impl.exec.failure to
             com.hedera.node.app.service.contract.impl.test,
             com.hedera.node.app.service.contract.impl.test.exec.scope;
     exports com.hedera.node.app.service.contract.impl.exec.gas to
             com.hedera.node.app.service.contract.impl.test;
+    exports com.hedera.node.app.service.contract.impl.exec.metrics;
     exports com.hedera.node.app.service.contract.impl.exec.operations to
             com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.exec.processors to
             com.hedera.node.app.service.contract.impl.test;
+    exports com.hedera.node.app.service.contract.impl.exec.scope;
+    exports com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.associations;
+    exports com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.mint;
+    exports com.hedera.node.app.service.contract.impl.exec.tracers;
+    exports com.hedera.node.app.service.contract.impl.exec.utils;
     exports com.hedera.node.app.service.contract.impl.exec.v030 to
             com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.exec.v034 to
             com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.exec.v038 to
             com.hedera.node.app.service.contract.impl.test;
+    exports com.hedera.node.app.service.contract.impl.exec;
+    exports com.hedera.node.app.service.contract.impl.handlers;
+    exports com.hedera.node.app.service.contract.impl.hevm;
     exports com.hedera.node.app.service.contract.impl.infra to
             com.hedera.node.app.service.contract.impl.test;
     exports com.hedera.node.app.service.contract.impl.nativelibverification to
             com.hedera.node.app;
+    exports com.hedera.node.app.service.contract.impl.records;
     exports com.hedera.node.app.service.contract.impl.schemas to
             com.hedera.node.app,
             com.hedera.node.app.service.contract.impl.test,
@@ -52,15 +50,8 @@ module com.hedera.node.app.service.contract.impl {
             com.hedera.node.app.service.contract.impl.test,
             com.hedera.node.services.cli,
             com.hedera.node.test.clients;
-
-    opens com.hedera.node.app.service.contract.impl.exec to
-            com.hedera.node.app.service.contract.impl.test;
-    opens com.hedera.node.app.service.contract.impl.exec.tracers to
-            com.hedera.node.app.service.contract.impl.test;
-    opens com.hedera.node.app.service.contract.impl.exec.utils to
-            com.hedera.node.app.service.contract.impl.test;
-    opens com.hedera.node.app.service.contract.impl.utils to
-            com.hedera.node.app.service.contract.impl.test;
+    exports com.hedera.node.app.service.contract.impl.utils;
+    exports com.hedera.node.app.service.contract.impl;
 
     requires transitive com.hedera.node.app.hapi.fees;
     requires transitive com.hedera.node.app.hapi.utils;
@@ -95,4 +86,13 @@ module com.hedera.node.app.service.contract.impl {
     requires org.hyperledger.besu.internal.crypto;
     requires static transitive com.github.spotbugs.annotations;
     requires static java.compiler;
+
+    opens com.hedera.node.app.service.contract.impl.utils to
+            com.hedera.node.app.service.contract.impl.test;
+    opens com.hedera.node.app.service.contract.impl.exec.utils to
+            com.hedera.node.app.service.contract.impl.test;
+    opens com.hedera.node.app.service.contract.impl.exec to
+            com.hedera.node.app.service.contract.impl.test;
+    opens com.hedera.node.app.service.contract.impl.exec.tracers to
+            com.hedera.node.app.service.contract.impl.test;
 }

--- a/platform-sdk/consensus-event-creator-impl/src/jmh/java/org/hiero/consensus/event/creator/impl/jmh/EventCreatorNetworkBenchmark.java
+++ b/platform-sdk/consensus-event-creator-impl/src/jmh/java/org/hiero/consensus/event/creator/impl/jmh/EventCreatorNetworkBenchmark.java
@@ -85,7 +85,7 @@ public class EventCreatorNetworkBenchmark {
     /** The number of events after which the event window should be updated */
     private long eventWindowUpdateInterval;
 
-    /** Orphan buffer, required to set the sequence number needed by the event creator */
+    /** Orphan buffer, required to set the nGen value needed by the event creator */
     private OrphanBuffer orphanBuffer;
 
     @Setup(Level.Trial)

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator.impl.tipset;
 
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
-
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -10,6 +8,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.hiero.consensus.model.event.EventConstants;
+import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.roster.RosterUtils;
 
@@ -34,11 +33,11 @@ public class Tipset {
         this.roster = Objects.requireNonNull(roster);
         tips = new long[roster.rosterEntries().size()];
 
-        Arrays.fill(tips, SEQUENCE_NUMBER_UNDEFINED);
+        Arrays.fill(tips, PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER);
     }
 
     /**
-     * Build an empty tipset (i.e. where all sequence numbers are {@link EventConstants#SEQUENCE_NUMBER_UNDEFINED}) using another
+     * Build an empty tipset (i.e. where all generations are {@link EventConstants#GENERATION_UNDEFINED}) using another
      * tipset as a template.
      *
      * @param tipset the tipset to use as a template
@@ -53,7 +52,7 @@ public class Tipset {
      * Merge a list of tipsets together.
      *
      * <p>
-     * The sequence number for each node ID will be equal to the maximum sequence number found for that node ID from all source
+     * The generation for each node ID will be equal to the maximum generation found for that node ID from all source
      * tipsets.
      * In the case of empty list, a new Tipset instance with the current roster will be returned.
      *
@@ -81,8 +80,8 @@ public class Tipset {
     }
 
     /**
-     * Get the tip sequence number for a given node. If the node is not in the roster or no event from that node is known,
-     * return {@link EventConstants#SEQUENCE_NUMBER_UNDEFINED}.
+     * Get the tip generation for a given node. If the node is not in the roster or no event from that node is know,
+     * return {@link EventConstants#GENERATION_UNDEFINED}.
      *
      * @param nodeId the node in question
      * @return the tip generation for the node
@@ -90,7 +89,7 @@ public class Tipset {
     public long getTipSequenceNumberForNode(@NonNull final NodeId nodeId) {
         final int index = RosterUtils.getIndex(roster, nodeId.id());
         if (index == -1) {
-            return SEQUENCE_NUMBER_UNDEFINED;
+            return PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
         }
         return tips[index];
     }

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/ChildlessEventTrackerTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/ChildlessEventTrackerTests.java
@@ -33,28 +33,25 @@ class ChildlessEventTrackerTests {
         // Add some events with no parents
         loadTrackerWithInitialEvents(random, tracker, numNodes);
 
-        // Increase the sequence number. Each creator will create a new event with a higher
-        // sequence number and unknown parents. Only the new events should
-        // be tracked because they have a higher sequence number.
+        // Increase generation. Each creator will create a new event with a higher
+        // non-deterministic generation and unknown parents. Only the new events should
+        // be tracked because they have a higher nGen.
         final List<PlatformEvent> batch2 = new ArrayList<>();
         for (int nodeId = 0; nodeId < numNodes; nodeId++) {
             final NodeId nonExistentParentId1 = NodeId.of(nodeId + 100);
             final PlatformEvent nonExistentParent1 = new TestingEventBuilder(random)
                     .setCreatorId(nonExistentParentId1)
-                    .setEnableSequenceNumberAssignment(true)
                     .build();
 
             final NodeId nonExistentParentId2 = NodeId.of(nodeId + 110);
             final PlatformEvent nonExistentParent2 = new TestingEventBuilder(random)
                     .setCreatorId(nonExistentParentId2)
-                    .setEnableSequenceNumberAssignment(true)
                     .build();
 
             final PlatformEvent event = new TestingEventBuilder(random)
                     .setCreatorId(NodeId.of(nodeId))
                     .setSelfParent(nonExistentParent1)
                     .setOtherParent(nonExistentParent2)
-                    .setEnableSequenceNumberAssignment(true)
                     .build();
 
             tracker.addEvent(event);
@@ -83,22 +80,17 @@ class ChildlessEventTrackerTests {
         // Add some generation 1 events to the tracker
         for (int nodeId = 0; nodeId < numNodes; nodeId++) {
             final NodeId parent1 = NodeId.of(nodeId);
-            final PlatformEvent parentEvent1 = new TestingEventBuilder(random)
-                    .setCreatorId(parent1)
-                    .setEnableSequenceNumberAssignment(true)
-                    .build();
+            final PlatformEvent parentEvent1 =
+                    new TestingEventBuilder(random).setCreatorId(parent1).build();
 
             final NodeId parent2 = NodeId.of(nodeId);
-            final PlatformEvent parentEvent2 = new TestingEventBuilder(random)
-                    .setCreatorId(parent2)
-                    .setEnableSequenceNumberAssignment(true)
-                    .build();
+            final PlatformEvent parentEvent2 =
+                    new TestingEventBuilder(random).setCreatorId(parent2).build();
 
             final PlatformEvent event = new TestingEventBuilder(random)
                     .setCreatorId(NodeId.of(nodeId))
                     .setSelfParent(parentEvent1)
                     .setOtherParent(parentEvent2)
-                    .setEnableSequenceNumberAssignment(true)
                     .build();
             tracker.addEvent(event);
             assertThat(tracker.getChildlessEvents()).contains(event);
@@ -106,21 +98,17 @@ class ChildlessEventTrackerTests {
 
         final Collection<PlatformEvent> childlessEvents = new ArrayList<>(tracker.getChildlessEvents());
 
-        // Create events with a lower sequence number for all nodes. Each creator will create a new event,
-        // with a lower sequence number. None of these events should
-        // be tracked because they have a lower sequence number.
+        // Create events with a lower generation for all nodes. Each creator will create a new event,
+        // with a lower non-deterministic generation. None of these events should
+        // be tracked because they have a lower nGen.
         for (int nodeId = 0; nodeId < numNodes; nodeId++) {
             final NodeId parent1 = NodeId.of(nodeId);
-            final PlatformEvent parentEvent1 = new TestingEventBuilder(random)
-                    .setCreatorId(parent1)
-                    .setEnableSequenceNumberAssignment(true)
-                    .build();
+            final PlatformEvent parentEvent1 =
+                    new TestingEventBuilder(random).setCreatorId(parent1).build();
 
             final NodeId parent2 = NodeId.of(nodeId);
-            final PlatformEvent parentEvent2 = new TestingEventBuilder(random)
-                    .setCreatorId(parent2)
-                    .setEnableSequenceNumberAssignment(true)
-                    .build();
+            final PlatformEvent parentEvent2 =
+                    new TestingEventBuilder(random).setCreatorId(parent2).build();
 
             final PlatformEvent event = new TestingEventBuilder(random)
                     .setCreatorId(NodeId.of(nodeId))
@@ -228,7 +216,6 @@ class ChildlessEventTrackerTests {
                 .setCreatorId(NodeId.of(0))
                 .setSelfParent(initialEvents.get(0))
                 .setOtherParent(initialEvents.get(1))
-                .setEnableSequenceNumberAssignment(true)
                 .build();
         tracker.addEvent(eventWithTwoParents);
 
@@ -247,7 +234,6 @@ class ChildlessEventTrackerTests {
                 .setCreatorId(NodeId.of(2))
                 .setSelfParent(initialEvents.get(2))
                 .setOtherParent(initialEvents.get(2))
-                .setEnableSequenceNumberAssignment(true)
                 .build();
         tracker.addEvent(eventWithSameParents);
 

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/EventCreationTimeTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/EventCreationTimeTests.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator.impl.tipset;
 
-import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.assignSeqNumAndDistributeEvent;
+import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.assignNGenAndDistributeEvent;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.buildEventCreator;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.buildSimulatedNodes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -168,13 +168,13 @@ public class EventCreationTimeTests {
         // Both nodes create their genesis events
         final PlatformEvent genesis0 = nodes.get(nodeA).eventCreator().maybeCreateEvent();
         assertNotNull(genesis0);
-        assignSeqNumAndDistributeEvent(nodes, events, genesis0);
+        assignNGenAndDistributeEvent(nodes, events, genesis0);
 
         time.tick(Duration.ofSeconds(1));
 
         final PlatformEvent genesis1 = nodes.get(nodeB).eventCreator().maybeCreateEvent();
         assertNotNull(genesis1);
-        assignSeqNumAndDistributeEvent(nodes, events, genesis1);
+        assignNGenAndDistributeEvent(nodes, events, genesis1);
 
         // Override the other parent's timeReceived to be far in the future,
         // while its timeCreated remains in the past.

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTestUtils.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTestUtils.java
@@ -137,7 +137,7 @@ public class TipsetEventCreatorTestUtils {
      * <li>if it has a null self-parent, is only during genesis scenario</li>
      * <li>if it has a null other-parent, is only during genesis scenario</li>
      * <li> the event is contained in allEvents</li>
-     * <li> The sequence number should be max of parents plus one</li>
+     * <li> NGen should be max of parents plus one</li>
      * <li> Parent's birthround or generation is never higher than event's.</li>
      * <li> There is a minimum gap of 1-nanosecond between Event's timeCreated and selfparent's ( timeCreated + transactionCount)</li>
      * <li> Except for genesis scenario, new event must have a positive advancement score.</li>
@@ -229,9 +229,9 @@ public class TipsetEventCreatorTestUtils {
     }
 
     /**
-     * Calculate and assign the sequence number to the event and distribute to all nodes in the network.
+     * Calculate and assign the nGen value to the event and distribute to all nodes in the network.
      */
-    public static void assignSeqNumAndDistributeEvent(
+    public static void assignNGenAndDistributeEvent(
             @NonNull final Map<NodeId, SimulatedNode> nodeMap,
             @NonNull final Map<EventDescriptorWrapper, PlatformEvent> events,
             @NonNull final PlatformEvent event) {
@@ -242,7 +242,7 @@ public class TipsetEventCreatorTestUtils {
 
     /**
      * Register the event in the map of all events, and pass the event through the node's orphan buffer to ensure it
-     * gets assigned a sequence number.
+     * gets assigned an nGen value.
      */
     @NonNull
     public static PlatformEvent registerEvent(
@@ -250,9 +250,8 @@ public class TipsetEventCreatorTestUtils {
             @NonNull final Map<EventDescriptorWrapper, PlatformEvent> allEvents,
             @NonNull final PlatformEvent event) {
         node.orphanBuffer().handleEvent(event);
-        assertThat(event.hasSequenceNumber())
-                .withFailMessage(
-                        "Event should have passed through the orphan buffer and been assigned a sequence number")
+        assertThat(event.hasNGen())
+                .withFailMessage("Event should have passed through the orphan buffer and been assigned an nGen value")
                 .isTrue();
         allEvents.put(event.getDescriptor(), event);
         return event;
@@ -302,14 +301,14 @@ public class TipsetEventCreatorTestUtils {
 
     @NonNull
     public static PlatformEvent createTestEventWithParent(
-            @NonNull final Random random, @Nullable final NodeId creator, final long seqNum, final long birthRound) {
+            @NonNull final Random random, @Nullable final NodeId creator, final long nGen, final long birthRound) {
 
         final PlatformEvent selfParent =
                 new TestingEventBuilder(random).setCreatorId(creator).build();
 
         return new TestingEventBuilder(random)
                 .setCreatorId(creator)
-                .setSequenceNumberOverride(seqNum)
+                .setNGen(nGen)
                 .setBirthRound(birthRound)
                 .setSelfParent(selfParent)
                 .build();
@@ -319,7 +318,7 @@ public class TipsetEventCreatorTestUtils {
     public static PlatformEvent createTestEventWithParent(
             @NonNull final Random random,
             @Nullable final NodeId creator,
-            final long seqNum,
+            final long nGen,
             final long birthRound,
             PlatformEvent otherParent) {
 
@@ -328,7 +327,7 @@ public class TipsetEventCreatorTestUtils {
 
         return new TestingEventBuilder(random)
                 .setCreatorId(creator)
-                .setSequenceNumberOverride(seqNum)
+                .setNGen(nGen)
                 .setBirthRound(birthRound)
                 .setSelfParent(selfParent)
                 .setOtherParent(otherParent)

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTests.java
@@ -2,7 +2,7 @@
 package org.hiero.consensus.event.creator.impl.tipset;
 
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
-import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.assignSeqNumAndDistributeEvent;
+import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.assignNGenAndDistributeEvent;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.buildEventCreator;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.buildSimulatedNodes;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.createTestEventWithParent;
@@ -10,7 +10,6 @@ import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTe
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.generateRandomTransactions;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.registerEvent;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.validateNewEventAndMaybeAdvanceCreatorScore;
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
 import static org.hiero.consensus.model.hashgraph.ConsensusConstants.ROUND_FIRST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.hiero.base.utility.test.fixtures.RandomUtils;
 import org.hiero.consensus.event.creator.impl.EventCreator;
 import org.hiero.consensus.model.event.EventDescriptorWrapper;
+import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
@@ -49,8 +49,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @DisplayName("TipsetEventCreatorImpl Tests")
 class TipsetEventCreatorTests {
 
-    private static final long FIRST_SEQUENCE_NUMBER = 1;
-
     /**
      * This test simulates the creation and propagation of events in a small network of simulated nodes (networkSize =
      * 10). It iterates 100 times, and within each iteration, it cycles through all nodes in the roster in order. For
@@ -58,7 +56,7 @@ class TipsetEventCreatorTests {
      * triggers the node to create a new event, distributes this event to other nodes, and then validates the newly
      * created event. The test asserts that every node is always able to create an event and, if the clock is advancing,
      * that the event's creation time matches the simulated current time. The ancientMode parameter is used to assign a
-     * birthround at the time the event is being created.
+     * birthround or a generation at the time the event is being created.
      *
      * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
      */
@@ -104,7 +102,7 @@ class TipsetEventCreatorTests {
                 // In this test, it should be impossible for a node to be unable to create an event.
                 assertNotNull(event);
 
-                assignSeqNumAndDistributeEvent(nodes, events, event);
+                assignNGenAndDistributeEvent(nodes, events, event);
 
                 validateNewEventAndMaybeAdvanceCreatorScore(
                         events, event, transactionSupplier.get(), nodes.get(nodeId), false, false);
@@ -119,7 +117,7 @@ class TipsetEventCreatorTests {
      * triggers the node to create a new event, distributes this event to other nodes, and then validates the newly
      * created event. The test asserts that every node is always able to create an event and, if the clock is advancing,
      * that the event's creation time matches the simulated current time. The ancientMode parameter is used to assign a
-     * birthround at the time the event is being created.
+     * birthround or a generation at the time the event is being created.
      *
      * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
      * @param random         {@link RandomUtils#getRandomPrintSeed()}
@@ -179,7 +177,7 @@ class TipsetEventCreatorTests {
                 }
                 atLeastOneEventCreated = true;
 
-                assignSeqNumAndDistributeEvent(nodes, events, event);
+                assignNGenAndDistributeEvent(nodes, events, event);
 
                 validateNewEventAndMaybeAdvanceCreatorScore(
                         events, event, transactionSupplier.get(), nodes.get(nodeId), false, false);
@@ -190,9 +188,9 @@ class TipsetEventCreatorTests {
     }
 
     /**
-     * This test simulates bug in Orphan Buffer, which resets sequence number to 1 for events in case node has almost fallen behind.
+     * This test simulates bug in Orphan Buffer, which resets NGen to 1 for events in case node has almost fallen behind.
      * This in turn invoked the bug in event creator, which was picking the event due to selfishness reasons, but
-     * was not considering it as advancing weight (due to sequence number being smaller than last used event), leading to
+     * was not considering it as advancing weight (due to NGen being smaller than last used event), leading to
      * not creating the event (and writing scary warnings)
      * In the fixed code, when this situation happens, we fall back to using other eligible events, without focusing
      * on reducing selfishness.
@@ -205,7 +203,7 @@ class TipsetEventCreatorTests {
                 fullyQualifiedClass = "org.hiero.base.utility.test.fixtures.RandomUtils",
                 method = "getRandomPrintSeed")
     })
-    @DisplayName("Tipset failure due to reset sequence number")
+    @DisplayName("Tipset failure due to reset NGEN")
     void tipsetFailureTest(@ParamName("random") final Random random) {
 
         for (int loop = 0; loop < 10; loop++) {
@@ -287,9 +285,9 @@ class TipsetEventCreatorTests {
             eventCreator.registerEvent(eventBToExpire);
             eventCreator.setEventWindow(new EventWindow(106, 107, 90, 60));
 
-            // and here we insert 'broken' event, which comes from bug in Orphan buffer, with reset sequence number
-            final PlatformEvent eventBbrokenSeqNum = createTestEventWithParent(random, nodeB, 1, 107, previousD);
-            eventCreator.registerEvent(eventBbrokenSeqNum);
+            // and here we insert 'broken' event, which comes from bug in Orphan buffer, with reset nGen
+            final PlatformEvent eventBbrokenNGen = createTestEventWithParent(random, nodeB, 1, 107, previousD);
+            eventCreator.registerEvent(eventBbrokenNGen);
 
             // and an useful event, which can be used to advance weight
             final PlatformEvent eventCValid = createTestEventWithParent(random, nodeC, 400, 107, previousD);
@@ -352,7 +350,7 @@ class TipsetEventCreatorTests {
                 if (event == null) {
                     continue;
                 }
-                assignSeqNumAndDistributeEvent(nodes, events, event);
+                assignNGenAndDistributeEvent(nodes, events, event);
                 if (nodeId.equals(reconnectingId)) {
                     latestSelfEvent = event;
                 }
@@ -381,7 +379,7 @@ class TipsetEventCreatorTests {
                 transactionSupplier.set(generateRandomTransactions(random));
                 final PlatformEvent event = nodes.get(nodeId).eventCreator().maybeCreateEvent();
                 if (event != null) {
-                    assignSeqNumAndDistributeEvent(nodes, events, event);
+                    assignNGenAndDistributeEvent(nodes, events, event);
                 }
             }
         }
@@ -453,7 +451,7 @@ class TipsetEventCreatorTests {
                         break;
                     }
 
-                    assignSeqNumAndDistributeEvent(nodes, events, event);
+                    assignNGenAndDistributeEvent(nodes, events, event);
 
                     validateNewEventAndMaybeAdvanceCreatorScore(
                             events, event, transactionSupplier.get(), nodes.get(nodeId), false, false);
@@ -539,7 +537,7 @@ class TipsetEventCreatorTests {
                 }
                 atLeastOneEventCreated = true;
 
-                assignSeqNumAndDistributeEvent(nodes, events, event);
+                assignNGenAndDistributeEvent(nodes, events, event);
 
                 validateNewEventAndMaybeAdvanceCreatorScore(
                         events, event, transactionSupplier.get(), nodes.get(nodeId), false, breakQuiescence);
@@ -634,7 +632,7 @@ class TipsetEventCreatorTests {
                     zeroWeightNodeOtherParentCount++;
                 }
 
-                assignSeqNumAndDistributeEvent(nodes, allEvents, newEvent);
+                assignNGenAndDistributeEvent(nodes, allEvents, newEvent);
 
                 validateNewEventAndMaybeAdvanceCreatorScore(
                         allEvents, newEvent, transactionSupplier.get(), nodes.get(nodeId), false, false);
@@ -746,7 +744,7 @@ class TipsetEventCreatorTests {
                             distributeEvent(nodes, slowEvent);
                         }
                         slowNodeEvents.clear();
-                        assignSeqNumAndDistributeEvent(nodes, allEvents, newEvent);
+                        assignNGenAndDistributeEvent(nodes, allEvents, newEvent);
                     } else {
                         // Most of the time, we don't immediately distribute the slow events.
                         registerEvent(nodes.get(nodeId), allEvents, newEvent);
@@ -758,7 +756,7 @@ class TipsetEventCreatorTests {
                     }
                 } else {
                     // immediately distribute all events not created by the zero stake node
-                    assignSeqNumAndDistributeEvent(nodes, allEvents, newEvent);
+                    assignNGenAndDistributeEvent(nodes, allEvents, newEvent);
                 }
 
                 validateNewEventAndMaybeAdvanceCreatorScore(
@@ -828,7 +826,7 @@ class TipsetEventCreatorTests {
             // In this test, it should be impossible for a node to be unable to create an event.
             assertNotNull(newEvent);
 
-            assignSeqNumAndDistributeEvent(nodes, events, newEvent);
+            assignNGenAndDistributeEvent(nodes, events, newEvent);
         }
     }
 
@@ -872,9 +870,12 @@ class TipsetEventCreatorTests {
         final PlatformEvent eventA1 = eventCreator.maybeCreateEvent();
         assertNotNull(eventA1);
 
-        final PlatformEvent eventB1 = createTestEventWithParent(random, nodeB, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
-        final PlatformEvent eventC1 = createTestEventWithParent(random, nodeC, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
-        final PlatformEvent eventD1 = createTestEventWithParent(random, nodeD, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
+        final PlatformEvent eventB1 =
+                createTestEventWithParent(random, nodeB, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
+        final PlatformEvent eventC1 =
+                createTestEventWithParent(random, nodeC, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
+        final PlatformEvent eventD1 =
+                createTestEventWithParent(random, nodeD, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
 
         eventCreator.registerEvent(eventB1);
         eventCreator.registerEvent(eventC1);
@@ -958,10 +959,14 @@ class TipsetEventCreatorTests {
         final PlatformEvent eventA1 = eventCreator.maybeCreateEvent();
         assertNotNull(eventA1);
 
-        final PlatformEvent eventB1 = createTestEventWithParent(random, nodeB, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
-        final PlatformEvent eventC1 = createTestEventWithParent(random, nodeC, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
-        final PlatformEvent eventD1 = createTestEventWithParent(random, nodeD, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
-        final PlatformEvent eventE1 = createTestEventWithParent(random, nodeE, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
+        final PlatformEvent eventB1 =
+                createTestEventWithParent(random, nodeB, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
+        final PlatformEvent eventC1 =
+                createTestEventWithParent(random, nodeC, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
+        final PlatformEvent eventD1 =
+                createTestEventWithParent(random, nodeD, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
+        final PlatformEvent eventE1 =
+                createTestEventWithParent(random, nodeE, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
 
         eventCreator.registerEvent(eventB1);
         eventCreator.registerEvent(eventC1);
@@ -1089,7 +1094,7 @@ class TipsetEventCreatorTests {
                 // In this test, it should be impossible for a node to be unable to create an event.
                 assertNotNull(event);
 
-                assignSeqNumAndDistributeEvent(nodes, events, event);
+                assignNGenAndDistributeEvent(nodes, events, event);
 
                 if (eventIndex == 0) {
                     final long birthRound = event.getEventCore().birthRound();
@@ -1104,7 +1109,7 @@ class TipsetEventCreatorTests {
 
     /**
      * During PCES replay, the node will learn of self events it created in the past. This test creates a single node
-     * network, sends the event creator self events (with sequence number values assigned), then creates a new event. The new event
+     * network, sends the event creator self events (with nGen values assigned), then creates a new event. The new event
      * should have the proper self parent.
      */
     @TestTemplate
@@ -1115,7 +1120,7 @@ class TipsetEventCreatorTests {
                 fullyQualifiedClass = "org.hiero.base.utility.test.fixtures.RandomUtils",
                 method = "getRandomPrintSeed")
     })
-    @DisplayName("Self event with highest sequence number is used as latest self event on startup")
+    @DisplayName("Self event with highest nGen is used as latest self event on startup")
     void lastSelfEventUpdatedDuringPCESReplay(@ParamName("random") final Random random) {
         final int networkSize = 1;
         final int numEvents = 100;
@@ -1129,12 +1134,11 @@ class TipsetEventCreatorTests {
         eventCreator.setEventWindow(EventWindow.getGenesisEventWindow());
 
         final List<PlatformEvent> pcesEvents = new ArrayList<>();
-        PlatformEvent eventWithHighestSequenceNumber = null;
+        PlatformEvent eventWithHighestNGen = null;
         for (int i = 0; i < numEvents; i++) {
             final PlatformEvent event = createTestEventWithParent(random, selfId, i + 1, ROUND_FIRST);
-            if (eventWithHighestSequenceNumber == null
-                    || event.getSequenceNumber() > eventWithHighestSequenceNumber.getSequenceNumber()) {
-                eventWithHighestSequenceNumber = event;
+            if (eventWithHighestNGen == null || event.getNGen() > eventWithHighestNGen.getNGen()) {
+                eventWithHighestNGen = event;
             }
             pcesEvents.add(event);
         }
@@ -1143,12 +1147,12 @@ class TipsetEventCreatorTests {
         Collections.shuffle(pcesEvents, random);
         pcesEvents.forEach(eventCreator::registerEvent);
 
-        // Verify that the new event created uses a self parent that is the event with the highest sequence number.
-        // This new event should not have an sequence number assigned.
+        // Verify that the new event created uses a self parent that is the event with the highest nGen.
+        // This new event should not have an nGen assigned.
         final PlatformEvent newEvent = eventCreator.maybeCreateEvent();
         assertNotNull(newEvent);
-        assertEquals(eventWithHighestSequenceNumber.getDescriptor(), newEvent.getSelfParent());
-        assertEquals(SEQUENCE_NUMBER_UNDEFINED, newEvent.getSequenceNumber());
+        assertEquals(eventWithHighestNGen.getDescriptor(), newEvent.getSelfParent());
+        assertEquals(NonDeterministicGeneration.GENERATION_UNDEFINED, newEvent.getNGen());
     }
 
     /**
@@ -1180,22 +1184,22 @@ class TipsetEventCreatorTests {
 
         final PlatformEvent newEvent = eventCreator.maybeCreateEvent();
         assertNotNull(newEvent);
-        assertEquals(SEQUENCE_NUMBER_UNDEFINED, newEvent.getSequenceNumber());
+        assertEquals(NonDeterministicGeneration.GENERATION_UNDEFINED, newEvent.getNGen());
 
-        // Create a self event with an sequence number value set and register it with the event creator. This can happen
+        // Create a self event with an nGen value set and register it with the event creator. This can happen
         // if we are forced to reconnect and learn of an event we created a long time ago after we started creating
         // the events. This is a branch, but not necessarily an intentional branch. This old event should be discarded
         // because we want to favor any self event last created by the event creator even though it does not have an
-        // sequence number set.
+        // nGen set.
         final PlatformEvent oldSelfEvent =
-                createTestEventWithParent(random, selfId, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
+                createTestEventWithParent(random, selfId, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
         eventCreator.registerEvent(oldSelfEvent);
 
         // Now create another event and check that the self parent is the expected event.
         final PlatformEvent newEvent2 = eventCreator.maybeCreateEvent();
         assertNotNull(newEvent2);
         assertEquals(newEvent.getDescriptor(), newEvent2.getSelfParent());
-        assertEquals(SEQUENCE_NUMBER_UNDEFINED, newEvent2.getSequenceNumber());
+        assertEquals(NonDeterministicGeneration.GENERATION_UNDEFINED, newEvent2.getNGen());
     }
 
     /**
@@ -1298,7 +1302,8 @@ class TipsetEventCreatorTests {
 
         for (int i = 1; i < networkSize; i++) {
             final NodeId nodeX = NodeId.of(roster.rosterEntries().get(i).nodeId());
-            final PlatformEvent event = createTestEventWithParent(random, nodeX, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
+            final PlatformEvent event =
+                    createTestEventWithParent(random, nodeX, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
             eventCreator.registerEvent(event);
         }
 
@@ -1348,7 +1353,8 @@ class TipsetEventCreatorTests {
 
         for (int i = 1; i < networkSize; i++) {
             final NodeId nodeX = NodeId.of(roster.rosterEntries().get(i).nodeId());
-            final PlatformEvent event = createTestEventWithParent(random, nodeX, FIRST_SEQUENCE_NUMBER, ROUND_FIRST);
+            final PlatformEvent event =
+                    createTestEventWithParent(random, nodeX, NonDeterministicGeneration.FIRST_GENERATION, ROUND_FIRST);
             eventCreator.registerEvent(event);
         }
 

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
@@ -3,7 +3,6 @@ package org.hiero.consensus.event.creator.impl.tipset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -116,8 +115,8 @@ class TipsetTrackerTests {
             assertThat(newTipset.getTipSequenceNumberForNode(selfId))
                     .withFailMessage(String.format(
                             "The sequence number should always be %s for the self node, got %s instead",
-                            SEQUENCE_NUMBER_UNDEFINED, newTipset.getTipSequenceNumberForNode(selfId)))
-                    .isEqualTo(SEQUENCE_NUMBER_UNDEFINED);
+                            PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER, newTipset.getTipSequenceNumberForNode(selfId)))
+                    .isEqualTo(PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER);
             assertSame(newTipset, tracker.getTipset(event.getDescriptor()));
 
             // Now, reconstruct the tipset manually, and make sure it matches what we were expecting.

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
@@ -3,8 +3,7 @@ package org.hiero.consensus.event.creator.impl.tipset;
 
 import static org.hiero.base.utility.Threshold.SUPER_MAJORITY;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetAdvancementWeight.ZERO_ADVANCEMENT_WEIGHT;
-import static org.hiero.consensus.model.event.EventConstants.FIRST_SEQUENCE_NUMBER;
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
+import static org.hiero.consensus.model.event.NonDeterministicGeneration.FIRST_GENERATION;
 import static org.hiero.consensus.model.hashgraph.ConsensusConstants.ROUND_FIRST;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,6 +26,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.hiero.consensus.model.event.EventDescriptorWrapper;
+import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
@@ -52,14 +52,14 @@ class TipsetWeightCalculatorTests {
      *
      * @param random the random instance to use
      * @param creator the creator of the event
-     * @param seqNum the sequence number of the event
+     * @param nGen    the non-deterministic generation of the event
      * @return the event
      */
     private static PlatformEvent newEvent(
-            @NonNull final Random random, @NonNull final NodeId creator, final long seqNum) {
+            @NonNull final Random random, @NonNull final NodeId creator, final long nGen) {
         return new TestingEventBuilder(random)
                 .setCreatorId(creator)
-                .setSequenceNumberOverride(seqNum)
+                .setNGen(nGen)
                 .setBirthRound(ROUND_FIRST)
                 .build();
     }
@@ -70,17 +70,17 @@ class TipsetWeightCalculatorTests {
      * The generation given to the events will be max(selfparent#generation, otherParents#generation) + 1.
      *
      * @param random the random instance to use
-     * @param seqNum the sequence number of the event
+     * @param nGen    the non-deterministic generation of the event
      * @param selfParent the self parent
      * @param otherParents all the other parents for the new event
      * @return the event
      */
     private static PlatformEvent newEvent(
             @NonNull final Random random,
-            final long seqNum,
+            final long nGen,
             @NonNull final PlatformEvent selfParent,
             @NonNull final List<PlatformEvent> otherParents) {
-        return newEvent(random, seqNum, selfParent, otherParents, ROUND_FIRST);
+        return newEvent(random, nGen, selfParent, otherParents, ROUND_FIRST);
     }
 
     /**
@@ -88,7 +88,7 @@ class TipsetWeightCalculatorTests {
      * The generation given to the events will be max(selfparent#generation, otherParents#generation) + 1.
      *
      * @param random the random instance to use
-     * @param seqNum the sequence number of the event
+     * @param nGen    the non-deterministic generation of the event
      * @param selfParent the self-parent
      * @param otherParents all the other parents for the new event
      * @param birthRound the birthRound to assign to the event
@@ -96,13 +96,13 @@ class TipsetWeightCalculatorTests {
      */
     private static PlatformEvent newEvent(
             @NonNull final Random random,
-            final long seqNum,
+            final long nGen,
             @NonNull final PlatformEvent selfParent,
             @NonNull final List<PlatformEvent> otherParents,
             final long birthRound) {
         return new TestingEventBuilder(random)
                 .setCreatorId(selfParent.getCreatorId())
-                .setSequenceNumberOverride(seqNum)
+                .setNGen(nGen)
                 .setSelfParent(selfParent)
                 .setOtherParents(otherParents)
                 .setBirthRound(birthRound)
@@ -156,11 +156,11 @@ class TipsetWeightCalculatorTests {
         for (int eventIndex = 0; eventIndex < 1000; eventIndex++) {
             final NodeId creator = NodeId.of(
                     roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId());
-            final long seqNum;
+            final long nGen;
             if (latestEvents.containsKey(creator)) {
-                seqNum = latestEvents.get(creator).getSequenceNumber() + 1;
+                nGen = latestEvents.get(creator).getNGen() + 1;
             } else {
-                seqNum = FIRST_SEQUENCE_NUMBER;
+                nGen = FIRST_GENERATION;
             }
 
             // Select some nodes we'd like to be our parents.
@@ -190,7 +190,7 @@ class TipsetWeightCalculatorTests {
             }
             final PlatformEvent event = new TestingEventBuilder(random)
                     .setCreatorId(creator)
-                    .setSequenceNumberOverride(seqNum)
+                    .setNGen(nGen)
                     .setSelfParent(selfParent)
                     .setOtherParents(otherParents)
                     .build();
@@ -606,10 +606,10 @@ class TipsetWeightCalculatorTests {
                 new TipsetWeightCalculator(configuration, time, roster, nodeA, tipsetTracker, childlessEventTracker);
 
         // Create generation 0 / birth round 1 events
-        final PlatformEvent a0 = newEvent(random, nodeA, SEQUENCE_NUMBER_UNDEFINED);
-        final PlatformEvent b0 = newEvent(random, nodeB, SEQUENCE_NUMBER_UNDEFINED);
-        final PlatformEvent c0 = newEvent(random, nodeC, SEQUENCE_NUMBER_UNDEFINED);
-        final PlatformEvent d0 = newEvent(random, nodeD, SEQUENCE_NUMBER_UNDEFINED);
+        final PlatformEvent a0 = newEvent(random, nodeA, NonDeterministicGeneration.GENERATION_UNDEFINED);
+        final PlatformEvent b0 = newEvent(random, nodeB, NonDeterministicGeneration.GENERATION_UNDEFINED);
+        final PlatformEvent c0 = newEvent(random, nodeC, NonDeterministicGeneration.GENERATION_UNDEFINED);
+        final PlatformEvent d0 = newEvent(random, nodeD, NonDeterministicGeneration.GENERATION_UNDEFINED);
 
         tipsetTracker.addSelfEvent(a0.getDescriptor(), a0.getAllParents());
         tipsetTracker.addPeerEvent(b0);
@@ -618,9 +618,12 @@ class TipsetWeightCalculatorTests {
 
         final long newEventBirthRound = 2L;
         // Create some events (birth round 2). Node A does not create an event yet.
-        final PlatformEvent b1 = newEvent(random, FIRST_SEQUENCE_NUMBER, b0, List.of(a0, c0, d0), newEventBirthRound);
-        final PlatformEvent c1 = newEvent(random, FIRST_SEQUENCE_NUMBER, c0, List.of(a0, b0, d0), newEventBirthRound);
-        final PlatformEvent d1 = newEvent(random, FIRST_SEQUENCE_NUMBER, d0, List.of(a0, b0, c0), newEventBirthRound);
+        final PlatformEvent b1 = newEvent(
+                random, NonDeterministicGeneration.FIRST_GENERATION, b0, List.of(a0, c0, d0), newEventBirthRound);
+        final PlatformEvent c1 = newEvent(
+                random, NonDeterministicGeneration.FIRST_GENERATION, c0, List.of(a0, b0, d0), newEventBirthRound);
+        final PlatformEvent d1 = newEvent(
+                random, NonDeterministicGeneration.FIRST_GENERATION, d0, List.of(a0, b0, c0), newEventBirthRound);
         tipsetTracker.addPeerEvent(b1);
         tipsetTracker.addPeerEvent(c1);
         tipsetTracker.addPeerEvent(d1);
@@ -641,8 +644,8 @@ class TipsetWeightCalculatorTests {
         // Including generation 0 / birth round 1 events (which are ancient now) as parents shouldn't cause us to throw.
         // (Angry log messages are ok).
         assertDoesNotThrow(() -> {
-            final PlatformEvent a1 =
-                    newEvent(random, FIRST_SEQUENCE_NUMBER, a0, List.of(b0, c0, d0), newEventBirthRound);
+            final PlatformEvent a1 = newEvent(
+                    random, NonDeterministicGeneration.FIRST_GENERATION, a0, List.of(b0, c0, d0), newEventBirthRound);
 
             tipsetWeightCalculator.getTheoreticalAdvancementWeight(a1.getAllParents());
             tipsetTracker.addSelfEvent(a1.getDescriptor(), a1.getAllParents());

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/SyncUtilsSortTest.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/shadowgraph/SyncUtilsSortTest.java
@@ -63,24 +63,17 @@ class SyncUtilsSortTest {
         // Build a small DAG parent-first. TestingEventBuilder assigns an ever-increasing sequence number at build
         // time, mirroring the orphan buffer assigning it at release time, so a parent always has a lower sequence
         // number than its children.
-        final PlatformEvent a = new TestingEventBuilder(random)
-                .setEnableSequenceNumberAssignment(true)
-                .build();
-        final PlatformEvent b = new TestingEventBuilder(random)
-                .setEnableSequenceNumberAssignment(true)
-                .build();
+        final PlatformEvent a = new TestingEventBuilder(random).build();
+        final PlatformEvent b = new TestingEventBuilder(random).build();
         final PlatformEvent c = new TestingEventBuilder(random)
-                .setEnableSequenceNumberAssignment(true)
                 .setSelfParent(a)
                 .setOtherParent(b)
                 .build();
         final PlatformEvent d = new TestingEventBuilder(random)
-                .setEnableSequenceNumberAssignment(true)
                 .setSelfParent(b)
                 .setOtherParent(c)
                 .build();
         final PlatformEvent e = new TestingEventBuilder(random)
-                .setEnableSequenceNumberAssignment(true)
                 .setSelfParent(c)
                 .setOtherParent(d)
                 .build();

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/GuiBranchDetector.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/GuiBranchDetector.java
@@ -48,8 +48,7 @@ public class GuiBranchDetector {
 
         if (!currentEventWindow.isAncient(selfParent)) {
             final int branchIndex = nextBranchIndexPerCreator.merge(creator, 0, (old, v) -> old + 1);
-            branchedEventsMetadata.put(
-                    event.getGossipEvent(), new BranchedEventMetadata(branchIndex, event.getSequenceNumber()));
+            branchedEventsMetadata.put(event.getGossipEvent(), new BranchedEventMetadata(branchIndex, event.getNGen()));
         }
         mostRecentPerCreator.put(creator, event.getDescriptor());
     }

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/GuiEventStorage.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/GuiEventStorage.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.gui.internal;
 
-import static org.hiero.consensus.model.event.EventConstants.FIRST_SEQUENCE_NUMBER;
+import static org.hiero.consensus.model.event.EventConstants.FIRST_GENERATION;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.event.GossipEvent;
@@ -34,7 +34,7 @@ public class GuiEventStorage {
     // A note on concurrency: although all input to this class is sequential and thread safe, access to this class
     // happens asynchronously. This requires all methods to be synchronized.
 
-    private long maxSequenceNumber = FIRST_SEQUENCE_NUMBER;
+    private long maxGeneration = FIRST_GENERATION;
 
     private final Consensus consensus;
     private final ConsensusLinker linker;
@@ -68,10 +68,10 @@ public class GuiEventStorage {
         this.consensus = consensus;
         this.linker = linker;
         this.configuration = configuration;
-        maxSequenceNumber = linker.getNonAncientEvents().stream()
-                .mapToLong(EventImpl::getSequenceNumber)
+        maxGeneration = linker.getNonAncientEvents().stream()
+                .mapToLong(EventImpl::getNGen)
                 .max()
-                .orElse(1);
+                .orElse(FIRST_GENERATION);
     }
 
     /**
@@ -88,7 +88,7 @@ public class GuiEventStorage {
      * @param event the event to handle
      */
     public synchronized void handlePreconsensusEvent(@NonNull final PlatformEvent event) {
-        maxSequenceNumber = Math.max(maxSequenceNumber, event.getSequenceNumber());
+        maxGeneration = Math.max(maxGeneration, event.getNGen());
 
         // Detect branches before linking
         final NodeId creator = event.getCreatorId();
@@ -99,6 +99,7 @@ public class GuiEventStorage {
         if (eventImpl == null) {
             return;
         }
+        eventImpl.getBaseEvent().setNGen(event.getNGen());
         eventImpl.getBaseEvent().setSequenceNumber(event.getSequenceNumber());
 
         final List<ConsensusRound> rounds = consensus.addEvent(eventImpl);
@@ -135,8 +136,8 @@ public class GuiEventStorage {
      *
      * @return the maximum generation of any event in the hashgraph
      */
-    public synchronized long getMaxSequenceNumber() {
-        return maxSequenceNumber;
+    public synchronized long getMaxGeneration() {
+        return maxGeneration;
     }
 
     /**

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/HashgraphGuiConstants.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/HashgraphGuiConstants.java
@@ -9,7 +9,7 @@ import java.util.Locale;
 
 public class HashgraphGuiConstants {
 
-    public static final int DEFAULT_NUM_EVENTS_TO_DISPLAY = 50;
+    public static final int DEFAULT_GENERATIONS_TO_DISPLAY = 25;
     /** outline of labels */
     public static final Color LABEL_OUTLINE = new Color(255, 255, 255);
     /** unknown-fame witness, non-consensus */

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/HashgraphGuiSource.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/HashgraphGuiSource.java
@@ -13,19 +13,19 @@ import org.hiero.consensus.hashgraph.impl.EventImpl;
 public interface HashgraphGuiSource {
 
     /**
-     * @return the maximum sequence number of all events this source has
+     * @return the maximum generation of all events this source has
      */
-    long getMaxSequenceNumber();
+    long getMaxGeneration();
 
     /**
      * Get events to be displayed by the GUI
      *
-     * @param startSequenceNum the start sequence number of events returned
-     * @param numEvents  the number of events to be returned
-     * @return a list of requested events
+     * @param startGeneration the start generation of events returned
+     * @param numGenerations  the number of generations to be returned
+     * @return an list of requested events
      */
     @NonNull
-    List<EventImpl> getEvents(final long startSequenceNum, final int numEvents);
+    List<EventImpl> getEvents(final long startGeneration, final int numGenerations);
 
     @NonNull
     Roster getRoster();

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/HashgraphPictureOptions.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/HashgraphPictureOptions.java
@@ -41,6 +41,11 @@ public interface HashgraphPictureOptions {
     boolean writeConsensusTimeStamp();
 
     /**
+     * @return should the non-deterministic generation be written for every event
+     */
+    boolean writeNGen();
+
+    /**
      * @return should the sequence number be written for every event
      */
     boolean writeSeqNum();
@@ -66,17 +71,17 @@ public interface HashgraphPictureOptions {
     boolean simpleColors();
 
     /**
-     * @return the number of events to display
+     * @return the number of generations to display
      */
-    int getNumEventsDisplay();
+    int getNumGenerationsDisplay();
 
     /**
-     * @return the first sequence number that should be displayed
+     * @return the first generation that should be displayed
      */
-    long getStartSequenceNumber();
+    long getStartGeneration();
 
     /**
-     * @return should the latest events be displayed, ignores {@link #getStartSequenceNumber()}
+     * @return should the latest events be displayed, ignores {@link #getStartGeneration()}
      */
     boolean displayLatestEvents();
 
@@ -84,8 +89,8 @@ public interface HashgraphPictureOptions {
      * When {@link #displayLatestEvents()} is true, this method will be called to notify which is the current starting
      * generation
      *
-     * @param startSequenceNumber
-     * 		the first sequence number being displayed
+     * @param startGeneration
+     * 		the first generation being displayed
      */
-    void setStartSequenceNumber(final long startSequenceNumber);
+    void setStartGeneration(final long startGeneration);
 }

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/CachingGuiSource.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/CachingGuiSource.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.gui.internal.hashgraph.util;
 
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
-
 import com.hedera.hapi.node.state.roster.Roster;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
@@ -20,9 +18,9 @@ public class CachingGuiSource implements HashgraphGuiSource {
     private List<EventImpl> events = null;
     private Roster roster = null;
     private final GuiEventStorage eventStorage;
-    private long maxSequenceNumber = EventConstants.SEQUENCE_NUMBER_UNDEFINED;
-    private long startSequenceNum = 1;
-    private int numEvents = HashgraphGuiConstants.DEFAULT_NUM_EVENTS_TO_DISPLAY;
+    private long maxGeneration = EventConstants.GENERATION_UNDEFINED;
+    private long startGeneration = EventConstants.FIRST_GENERATION;
+    private int numGenerations = HashgraphGuiConstants.DEFAULT_GENERATIONS_TO_DISPLAY;
 
     public CachingGuiSource(final HashgraphGuiSource source) {
         this.source = source;
@@ -30,15 +28,15 @@ public class CachingGuiSource implements HashgraphGuiSource {
     }
 
     @Override
-    public long getMaxSequenceNumber() {
-        return maxSequenceNumber;
+    public long getMaxGeneration() {
+        return maxGeneration;
     }
 
     @Override
     @NonNull
-    public List<EventImpl> getEvents(final long startSequenceNum, final int numEvents) {
-        this.startSequenceNum = startSequenceNum;
-        this.numEvents = numEvents;
+    public List<EventImpl> getEvents(final long startGeneration, final int numGenerations) {
+        this.startGeneration = startGeneration;
+        this.numGenerations = numGenerations;
         return events;
     }
 
@@ -50,7 +48,7 @@ public class CachingGuiSource implements HashgraphGuiSource {
 
     @Override
     public boolean isReady() {
-        return events != null && roster != null && maxSequenceNumber != SEQUENCE_NUMBER_UNDEFINED;
+        return events != null && roster != null && maxGeneration != EventConstants.GENERATION_UNDEFINED;
     }
 
     /**
@@ -66,9 +64,9 @@ public class CachingGuiSource implements HashgraphGuiSource {
      */
     public void refresh() {
         if (source.isReady()) {
-            events = source.getEvents(startSequenceNum, numEvents);
+            events = source.getEvents(startGeneration, numGenerations);
             roster = source.getRoster();
-            maxSequenceNumber = source.getMaxSequenceNumber();
+            maxGeneration = source.getMaxGeneration();
         }
     }
 }

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphGuiControls.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphGuiControls.java
@@ -2,7 +2,7 @@
 package org.hiero.consensus.gui.internal.hashgraph.util;
 
 import static org.hiero.consensus.gui.internal.GuiUtils.wrap;
-import static org.hiero.consensus.gui.internal.hashgraph.HashgraphGuiConstants.DEFAULT_NUM_EVENTS_TO_DISPLAY;
+import static org.hiero.consensus.gui.internal.hashgraph.HashgraphGuiConstants.DEFAULT_GENERATIONS_TO_DISPLAY;
 
 import java.awt.Checkbox;
 import java.awt.Color;
@@ -43,6 +43,8 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
     private final Checkbox labelConsOrderCheckbox;
     /** the consensus time stamp for the event */
     private final Checkbox labelConsTimestampCheckbox;
+    /** the Ngen number for the event */
+    private final Checkbox labelNGenCheckbox;
     /** the Sequence number for the event */
     private final Checkbox labelSeqNumCheckbox;
     /** the birth round number for the event */
@@ -56,9 +58,9 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
 
     private final Component[] comps;
     /** only draw this many generations, at most */
-    private final JSpinner numEvents;
+    private final JSpinner numGenerations;
 
-    private final JSpinner startSequenceNumber;
+    private final JSpinner startGeneration;
 
     public HashgraphGuiControls(final ItemListener freezeListener) {
         freezeCheckbox = new Checkbox("Freeze: don't change this window");
@@ -70,6 +72,7 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
         labelRoundRecCheckbox = new Checkbox("Labels: Round received (consensus)");
         labelConsOrderCheckbox = new Checkbox("Labels: Order (consensus)");
         labelConsTimestampCheckbox = new Checkbox("Labels: Timestamp (consensus)");
+        labelNGenCheckbox = new Checkbox("Labels: NGen (non-deterministic generation)");
         labelSeqNumCheckbox = new Checkbox("Labels: Sequence Number");
         labelBirthroundCheckbox = new Checkbox("Labels: Birth round");
         labelBranchNumberCheckbox = new Checkbox("Labels: Branch number");
@@ -78,27 +81,25 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
         displayLatestEvents.setState(true);
 
         // boxing so that the JSpinner will use an int internally
-        numEvents = new JSpinner(new SpinnerNumberModel(
-                Integer.valueOf(DEFAULT_NUM_EVENTS_TO_DISPLAY),
+        numGenerations = new JSpinner(new SpinnerNumberModel(
+                Integer.valueOf(DEFAULT_GENERATIONS_TO_DISPLAY),
                 Integer.valueOf(5),
                 Integer.valueOf(1000),
                 Integer.valueOf(1)));
-        ((JSpinner.DefaultEditor) numEvents.getEditor()).getTextField().setColumns(10);
+        ((JSpinner.DefaultEditor) numGenerations.getEditor()).getTextField().setColumns(10);
         // boxing so that the JSpinner will use a long internally
-        startSequenceNumber = new JSpinner(new SpinnerNumberModel(
-                Long.valueOf(EventConstants.FIRST_SEQUENCE_NUMBER),
-                Long.valueOf(EventConstants.FIRST_SEQUENCE_NUMBER),
+        startGeneration = new JSpinner(new SpinnerNumberModel(
+                Long.valueOf(EventConstants.FIRST_GENERATION),
+                Long.valueOf(EventConstants.FIRST_GENERATION),
                 Long.valueOf(Long.MAX_VALUE),
                 Long.valueOf(1)));
-        ((JSpinner.DefaultEditor) startSequenceNumber.getEditor())
-                .getTextField()
-                .setColumns(10);
-        startSequenceNumber.setEnabled(false);
+        ((JSpinner.DefaultEditor) startGeneration.getEditor()).getTextField().setColumns(10);
+        startGeneration.setEnabled(false);
 
         displayLatestEvents.addItemListener(e -> {
             switch (e.getStateChange()) {
-                case ItemEvent.SELECTED -> startSequenceNumber.setEnabled(false);
-                case ItemEvent.DESELECTED -> startSequenceNumber.setEnabled(true);
+                case ItemEvent.SELECTED -> startGeneration.setEnabled(false);
+                case ItemEvent.DESELECTED -> startGeneration.setEnabled(true);
             }
         });
 
@@ -111,6 +112,7 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
             labelRoundRecCheckbox,
             labelConsOrderCheckbox,
             labelConsTimestampCheckbox,
+            labelNGenCheckbox,
             labelSeqNumCheckbox,
             labelBirthroundCheckbox,
             labelBranchNumberCheckbox,
@@ -159,10 +161,10 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
         constr.gridwidth = 1; // each component is one cell
         checkboxesPanel.add(new Label("Display "), constr);
         constr.gridx++;
-        checkboxesPanel.add(numEvents, constr);
+        checkboxesPanel.add(numGenerations, constr);
         constr.gridx++;
         constr.gridwidth = GridBagConstraints.RELATIVE;
-        checkboxesPanel.add(new Label(" events"), constr);
+        checkboxesPanel.add(new Label(" generations"), constr);
         constr.gridx++;
         constr.gridwidth = GridBagConstraints.REMAINDER;
         checkboxesPanel.add(new Label(""), constr);
@@ -170,9 +172,9 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
         constr.gridx = 0;
         constr.gridy++;
         constr.gridwidth = 1; // each component is one cell
-        checkboxesPanel.add(new Label("Start sequence number "), constr);
+        checkboxesPanel.add(new Label("Start generation "), constr);
         constr.gridx++;
-        checkboxesPanel.add(startSequenceNumber, constr);
+        checkboxesPanel.add(startGeneration, constr);
         constr.gridx++;
         constr.gridwidth = GridBagConstraints.REMAINDER;
         checkboxesPanel.add(new Label(""), constr);
@@ -234,6 +236,11 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
     }
 
     @Override
+    public boolean writeNGen() {
+        return labelNGenCheckbox.getState();
+    }
+
+    @Override
     public boolean writeSeqNum() {
         return labelSeqNumCheckbox.getState();
     }
@@ -254,19 +261,19 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
     }
 
     @Override
-    public int getNumEventsDisplay() {
-        if (numEvents.getValue() instanceof Integer numEventsInt) {
-            return numEventsInt;
+    public int getNumGenerationsDisplay() {
+        if (numGenerations.getValue() instanceof Integer generations) {
+            return generations;
         }
-        return DEFAULT_NUM_EVENTS_TO_DISPLAY;
+        return DEFAULT_GENERATIONS_TO_DISPLAY;
     }
 
     @Override
-    public long getStartSequenceNumber() {
-        if (startSequenceNumber.getValue() instanceof Long generations) {
+    public long getStartGeneration() {
+        if (startGeneration.getValue() instanceof Long generations) {
             return generations;
         }
-        return EventConstants.SEQUENCE_NUMBER_UNDEFINED;
+        return EventConstants.GENERATION_UNDEFINED;
     }
 
     @Override
@@ -280,7 +287,7 @@ public class HashgraphGuiControls implements HashgraphPictureOptions {
     }
 
     @Override
-    public void setStartSequenceNumber(final long startSequenceNumber) {
-        this.startSequenceNumber.setValue(startSequenceNumber);
+    public void setStartGeneration(final long startGeneration) {
+        this.startGeneration.setValue(startGeneration);
     }
 }

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphPicture.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/HashgraphPicture.java
@@ -93,13 +93,13 @@ public class HashgraphPicture extends JPanel {
 
             List<EventImpl> events;
             if (options.displayLatestEvents()) {
-                final long startSeqNum = Math.max(
-                        hashgraphSource.getMaxSequenceNumber() - options.getNumEventsDisplay() + 1,
-                        EventConstants.FIRST_SEQUENCE_NUMBER);
-                options.setStartSequenceNumber(startSeqNum);
-                events = hashgraphSource.getEvents(startSeqNum, options.getNumEventsDisplay());
+                final long startGen = Math.max(
+                        hashgraphSource.getMaxGeneration() - options.getNumGenerationsDisplay() + 1,
+                        EventConstants.FIRST_GENERATION);
+                options.setStartGeneration(startGen);
+                events = hashgraphSource.getEvents(startGen, options.getNumGenerationsDisplay());
             } else {
-                events = hashgraphSource.getEvents(options.getStartSequenceNumber(), options.getNumEventsDisplay());
+                events = hashgraphSource.getEvents(options.getStartGeneration(), options.getNumGenerationsDisplay());
             }
             // in case the state has events from creators that don't exist, don't show them
             if (events == null) { // in case a screen refresh happens before any events
@@ -207,7 +207,7 @@ public class HashgraphPicture extends JPanel {
                 // treat it as if there is no other parent
                 continue;
             }
-            if (parent.getSequenceNumber() < pictureMetadata.getMinSequenceNumber()) {
+            if (parent.getNGen() < pictureMetadata.getMinGen()) {
                 // parent is out of range, don't draw line to it
                 continue;
             }
@@ -284,6 +284,9 @@ public class HashgraphPicture extends JPanel {
             if (t != null) {
                 s.append(" ").append(HashgraphGuiConstants.FORMATTER.format(t));
             }
+        }
+        if (options.writeNGen()) {
+            s.append(" ").append(event.getNGen());
         }
 
         if (options.writeSeqNum()) {

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/PictureMetadata.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/PictureMetadata.java
@@ -27,7 +27,7 @@ public class PictureMetadata {
     private final int ymin;
     private final int width;
     private final double r;
-    private final long minSequenceNumber;
+    private final long minGen;
     private final long maxGen;
 
     private final HashgraphGuiSource hashgraphSource;
@@ -66,18 +66,18 @@ public class PictureMetadata {
         ymin = (int) Math.round(height1 + 0.025 * height2);
         ymax = (int) Math.round(height1 + 0.975 * height2) - textLineHeight;
 
-        long minSeqNumTmp = Long.MAX_VALUE;
-        long maxSeqNumTmp = Long.MIN_VALUE;
+        long minGenTmp = Long.MAX_VALUE;
+        long maxGenTmp = Long.MIN_VALUE;
         for (final EventImpl event : events) {
-            minSeqNumTmp = Math.min(minSeqNumTmp, event.getSequenceNumber());
-            maxSeqNumTmp = Math.max(maxSeqNumTmp, event.getSequenceNumber());
+            minGenTmp = Math.min(minGenTmp, event.getNGen());
+            maxGenTmp = Math.max(maxGenTmp, event.getNGen());
         }
-        maxSeqNumTmp = Math.max(maxSeqNumTmp, minSeqNumTmp + 2);
-        minSequenceNumber = minSeqNumTmp;
-        maxGen = maxSeqNumTmp;
+        maxGenTmp = Math.max(maxGenTmp, minGenTmp + 2);
+        minGen = minGenTmp;
+        maxGen = maxGenTmp;
 
         final int n = rosterMetadata.getNumMembers() + 1;
-        final double gens = maxGen - minSequenceNumber;
+        final double gens = maxGen - minGen;
         final double dy = (ymax - ymin) * (gens - 1) / gens;
         r = Math.min(width / n / 4, dy / gens / 2);
     }
@@ -123,7 +123,7 @@ public class PictureMetadata {
      * find y position on the screen for an event
      */
     public int ypos(final EventImpl event) {
-        return (event == null) ? -100 : (int) (ymax - r * (1 + 2 * (event.getSequenceNumber() - minSequenceNumber)));
+        return (event == null) ? -100 : (int) (ymax - r * (1 + 2 * (event.getNGen() - minGen)));
     }
 
     /**
@@ -142,10 +142,10 @@ public class PictureMetadata {
     }
 
     /**
-     * @return the minimum sequence number being displayed
+     * @return the minimum generation being displayed
      */
-    public long getMinSequenceNumber() {
-        return minSequenceNumber;
+    public long getMinGen() {
+        return minGen;
     }
 
     /**

--- a/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/StandardGuiSource.java
+++ b/platform-sdk/consensus-gui/src/main/java/org/hiero/consensus/gui/internal/hashgraph/util/StandardGuiSource.java
@@ -32,8 +32,8 @@ public class StandardGuiSource implements HashgraphGuiSource {
      * {@inheritDoc}
      */
     @Override
-    public long getMaxSequenceNumber() {
-        return eventStorage.getMaxSequenceNumber();
+    public long getMaxGeneration() {
+        return eventStorage.getMaxGeneration();
     }
 
     /**
@@ -41,10 +41,9 @@ public class StandardGuiSource implements HashgraphGuiSource {
      */
     @Override
     @NonNull
-    public List<EventImpl> getEvents(final long startSequenceNum, final int numEvents) {
+    public List<EventImpl> getEvents(final long startGeneration, final int numGenerations) {
         return eventStorage.getNonAncientEvents().stream()
-                .filter(e -> e.getSequenceNumber() >= startSequenceNum
-                        && e.getSequenceNumber() < startSequenceNum + numEvents)
+                .filter(e -> e.getNGen() >= startGeneration && e.getNGen() < startGeneration + numGenerations)
                 .toList();
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/jmh/java/org/hiero/consensus/hashgraph/ConsensusImplBenchmark.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/jmh/java/org/hiero/consensus/hashgraph/ConsensusImplBenchmark.java
@@ -55,7 +55,7 @@ public class ConsensusImplBenchmark {
                 .maxOtherParents(numOP)
                 .realSignatures(false)
                 .numNodes(numNodes)
-                .populateSequenceNumber(true)
+                .populateNgen(true)
                 .build();
         final List<PlatformEvent> platformEvents = generator.nextEvents(NUMBER_OF_EVENTS);
 

--- a/platform-sdk/consensus-hashgraph-impl/src/jmh/java/org/hiero/consensus/hashgraph/HashgraphModuleBenchmark.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/jmh/java/org/hiero/consensus/hashgraph/HashgraphModuleBenchmark.java
@@ -82,7 +82,7 @@ public class HashgraphModuleBenchmark {
                 .maxOtherParents(numOP)
                 .realSignatures(false)
                 .numNodes(numNodes)
-                .populateSequenceNumber(true)
+                .populateNgen(true)
                 .configuration(config)
                 .build();
         events = generator.nextEvents(NUMBER_OF_EVENTS);

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/EventImpl.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/EventImpl.java
@@ -458,6 +458,15 @@ public class EventImpl extends LinkedEvent<EventImpl> implements Clearable {
     }
 
     /**
+     * Get the non-deterministic generation of this event
+     *
+     * @return the non-deterministic generation of this event
+     */
+    public long getNGen() {
+        return getPlatformEvent().getNGen();
+    }
+
+    /**
      * The sequence number of this event, order in which it was released from the orphan buffer
      * @return the sequence number of this event.
      */

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java
@@ -8,7 +8,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 import static org.hiero.consensus.model.PbjConverters.fromPbjTimestamp;
 import static org.hiero.consensus.model.PbjConverters.toPbjTimestamp;
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
+import static org.hiero.consensus.model.event.PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
 import static org.hiero.consensus.model.hashgraph.ConsensusConstants.FIRST_CONSENSUS_NUMBER;
 
 import com.hedera.hapi.node.state.roster.Roster;
@@ -474,7 +474,7 @@ public class ConsensusImpl implements Consensus {
         rounds.setConsensusRelevantSeqNum(initJudges.getJudges().stream()
                 .map(EventImpl::getSequenceNumber)
                 .min(Long::compareTo)
-                .orElse(SEQUENCE_NUMBER_UNDEFINED));
+                .orElse(UNASSIGNED_SEQUENCE_NUMBER));
         initJudges = null;
 
         return true;

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusRounds.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusRounds.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
+import static org.hiero.consensus.model.event.PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
@@ -46,7 +46,7 @@ public class ConsensusRounds {
      * Events with a lower sequence number than this (before this event topologically) do not affect any consensus
      * calculations and do not have their metadata recalculated.
      */
-    private long consensusRelevantSeqNum = SEQUENCE_NUMBER_UNDEFINED;
+    private long consensusRelevantSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
 
     /** Constructs an empty object */
     public ConsensusRounds(@NonNull final ConsensusConfig config, @NonNull final Roster roster) {
@@ -63,7 +63,7 @@ public class ConsensusRounds {
         maxRoundCreated = ConsensusConstants.ROUND_UNDEFINED;
         roundElections.reset();
         updateAncientThreshold();
-        consensusRelevantSeqNum = SEQUENCE_NUMBER_UNDEFINED;
+        consensusRelevantSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
     }
 
     /**
@@ -264,7 +264,7 @@ public class ConsensusRounds {
     /**
      * Returns the threshold of all the judges that are not in ancient rounds. This is either a generation value or a
      * birth round value, depending on the ancient mode configured. If no judges are ancient, returns
-     * {@link EventConstants#FIRST_SEQUENCE_NUMBER} or {@link ConsensusConstants#ROUND_FIRST} depending on the ancient mode.
+     * {@link EventConstants#FIRST_GENERATION} or {@link ConsensusConstants#ROUND_FIRST} depending on the ancient mode.
      *
      * @return the threshold
      */

--- a/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/RoundElections.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/RoundElections.java
@@ -2,7 +2,7 @@
 package org.hiero.consensus.hashgraph.impl.consensus;
 
 import static com.swirlds.logging.legacy.LogMarker.CONSENSUS_VOTING;
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
+import static org.hiero.consensus.model.event.PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
 
 import com.hedera.hapi.platform.state.MinimumJudgeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -38,7 +38,7 @@ public class RoundElections {
      */
     private final List<CandidateWitness> elections = new ArrayList<>();
     /** The minimum sequence number of all the judges. Only set once the judges are found. */
-    private long minSeqNum = SEQUENCE_NUMBER_UNDEFINED;
+    private long minSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
     /** the minimum birth round of all the judges, this is only set once the judges are found */
     private long minBirthRound = EventConstants.BIRTH_ROUND_UNDEFINED;
 
@@ -104,7 +104,7 @@ public class RoundElections {
      * @return the minimum sequence number of all the judges(unique famous witnesses) in this round
      */
     public long getMinSeqNum() {
-        if (minSeqNum == SEQUENCE_NUMBER_UNDEFINED) {
+        if (minSeqNum == UNASSIGNED_SEQUENCE_NUMBER) {
             throw new IllegalStateException("Cannot provide the minimum sequence number until all judges are found");
         }
         return minSeqNum;
@@ -190,7 +190,7 @@ public class RoundElections {
         round++;
         numUnknownFame.set(0);
         elections.clear();
-        minSeqNum = SEQUENCE_NUMBER_UNDEFINED;
+        minSeqNum = UNASSIGNED_SEQUENCE_NUMBER;
         minBirthRound = EventConstants.BIRTH_ROUND_UNDEFINED;
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/GeneratorEventGraphSourceTest.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/test/java/org/hiero/consensus/hashgraph/impl/consensus/GeneratorEventGraphSourceTest.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.hashgraph.impl.consensus;
 
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
+import static org.hiero.consensus.model.event.PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -17,6 +17,7 @@ import org.hiero.base.utility.test.fixtures.tags.TestComponentTags;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.GeneratorEventGraphSource;
 import org.hiero.consensus.hashgraph.impl.test.fixtures.event.generator.GeneratorEventGraphSourceBuilder;
 import org.hiero.consensus.model.event.EventDescriptorWrapper;
+import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.roster.RosterUtils;
@@ -340,46 +341,57 @@ class GeneratorEventGraphSourceTest {
 
     @Test
     @Tag(TestComponentTags.PLATFORM)
-    @DisplayName("populateSequenceNumber sets sequence number on generated events")
-    void populateSequenceNumberEnabled() {
+    @DisplayName("populateNgen sets ngen on generated events")
+    void populateNgenEnabled() {
         final GeneratorEventGraphSource generator = GeneratorEventGraphSourceBuilder.builder()
                 .numNodes(4)
                 .seed(0L)
-                .populateSequenceNumber(true)
+                .populateNgen(true)
                 .build();
 
         final List<PlatformEvent> events = generator.nextEvents(200);
 
         for (final PlatformEvent event : events) {
+            assertTrue(event.hasNGen(), "every event should have ngen set when populateNgen is enabled");
+            assertTrue(event.hasSequenceNumber(), "every event should have sequence number assigned");
             assertTrue(
-                    event.hasSequenceNumber(),
-                    "every event should have sequence number set when populateSequence number is enabled");
-            assertTrue(event.getSequenceNumber() >= 1, "sequence number should be at least 1");
+                    event.getNGen() >= NonDeterministicGeneration.FIRST_GENERATION,
+                    "ngen should be at least FIRST_GENERATION");
+            assertTrue(
+                    event.getSequenceNumber() >= UNASSIGNED_SEQUENCE_NUMBER,
+                    "sequence number should be at least UNASSIGNED_SEQUENCE_NUMBER");
         }
 
-        // Verify that sequence number actually advances beyond SEQUENCE_NUMBER_UNDEFINED
+        // Verify that ngen actually advances beyond FIRST_GENERATION
+        final long maxNGen =
+                events.stream().mapToLong(PlatformEvent::getNGen).max().orElse(0);
+        assertTrue(
+                maxNGen > NonDeterministicGeneration.FIRST_GENERATION, "ngen should advance beyond FIRST_GENERATION");
+
+        // Verify that sequence number actually advances beyond UNASSIGNED_SEQUENCE_NUMBER
         final long maxSeqNum = events.stream()
                 .mapToLong(PlatformEvent::getSequenceNumber)
                 .max()
                 .orElse(0);
         assertTrue(
-                maxSeqNum > SEQUENCE_NUMBER_UNDEFINED,
-                "sequence number should advance beyond SEQUENCE_NUMBER_UNDEFINED");
+                maxSeqNum > UNASSIGNED_SEQUENCE_NUMBER,
+                "sequence number should advance beyond UNASSIGNED_SEQUENCE_NUMBER");
     }
 
     @Test
     @Tag(TestComponentTags.PLATFORM)
-    @DisplayName("Events do not have sequence number set when populateSequenceNumber is disabled")
-    void populateSequenceNumberDisabled() {
+    @DisplayName("Events do not have ngen or sequence number set when populateNgen is disabled")
+    void populateNgenDisabled() {
         final GeneratorEventGraphSource generator =
                 GeneratorEventGraphSourceBuilder.builder().numNodes(4).seed(0L).build();
 
         final List<PlatformEvent> events = generator.nextEvents(100);
 
         for (final PlatformEvent event : events) {
+            assertFalse(event.hasNGen(), "events should not have ngen set when populateNgen is disabled");
             assertFalse(
                     event.hasSequenceNumber(),
-                    "events should not have sequence number set when populateSequenceNumber is disabled");
+                    "events should not have sequence number assigned even if populateNgen is disabled");
         }
     }
 

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/GeneratorEventGraphSource.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/GeneratorEventGraphSource.java
@@ -37,7 +37,7 @@ public class GeneratorEventGraphSource implements EventGraphSource {
     private final int maxOtherParents;
     private final Roster roster;
     private final GeneratorEventSigner eventSigner;
-    private final boolean populateSequenceNumber;
+    private final boolean populateNgen;
 
     /** The source of all randomness for this class. */
     private Randotron random;
@@ -63,7 +63,7 @@ public class GeneratorEventGraphSource implements EventGraphSource {
      * @param maxOtherParents the maximum number of other-parents an event can have
      * @param roster          the roster of network nodes
      * @param eventSigner     the signer used to produce event signatures
-     * @param populateSequenceNumber    whether to populate sequence number on generated events
+     * @param populateNgen    whether to populate ngen values on generated events
      */
     GeneratorEventGraphSource(
             @NonNull final Configuration configuration,
@@ -72,7 +72,7 @@ public class GeneratorEventGraphSource implements EventGraphSource {
             final int maxOtherParents,
             @NonNull final Roster roster,
             @NonNull final GeneratorEventSigner eventSigner,
-            final boolean populateSequenceNumber) {
+            final boolean populateNgen) {
         this.configuration = configuration;
         this.time = time;
         this.seed = seed;
@@ -80,7 +80,7 @@ public class GeneratorEventGraphSource implements EventGraphSource {
         this.roster = roster;
         this.hasher = new PbjStreamHasher();
         this.eventSigner = eventSigner;
-        this.populateSequenceNumber = populateSequenceNumber;
+        this.populateNgen = populateNgen;
 
         // These fields get reset in reset()
         this.latestEventPerNode = new EventDescriptor[roster.rosterEntries().size()];
@@ -158,10 +158,10 @@ public class GeneratorEventGraphSource implements EventGraphSource {
         copy.signalPrehandleCompletion();
 
         latestEventPerNode[eventCreator] = copy.getDescriptor().eventDescriptor();
-        if (populateSequenceNumber) {
-            // the event sent to consensus will have its sequence number populated, we should copy this value if the
-            // caller
-            // wants sequence numbers to be populated on the returned events
+        if (populateNgen) {
+            // the event sent to consensus will have its nGen value populated, we should copy this value if the caller
+            // wants ngen values to be populated on the returned events
+            copy.setNGen(platformEvent.getNGen());
             copy.setSequenceNumber(platformEvent.getSequenceNumber());
         }
         return copy;

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/GeneratorEventGraphSourceBuilder.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/GeneratorEventGraphSourceBuilder.java
@@ -27,7 +27,7 @@ public class GeneratorEventGraphSourceBuilder {
     private RosterWithKeys rosterWithKeys;
     private Integer numNodes;
     private boolean realSignatures = false;
-    private boolean populateSequenceNumber = false;
+    private boolean populateNgen = false;
 
     /**
      * Creates a new builder instance.
@@ -137,13 +137,13 @@ public class GeneratorEventGraphSourceBuilder {
     }
 
     /**
-     * Sets whether to populate sequence numbers on generated events.
+     * Sets whether to populate ngen values on generated events.
      *
-     * @param populateSequenceNumber {@code true} to populate sequence numbers, {@code false} otherwise
+     * @param populateNgen {@code true} to populate ngen values, {@code false} otherwise
      * @return this builder
      */
-    public GeneratorEventGraphSourceBuilder populateSequenceNumber(final boolean populateSequenceNumber) {
-        this.populateSequenceNumber = populateSequenceNumber;
+    public GeneratorEventGraphSourceBuilder populateNgen(final boolean populateNgen) {
+        this.populateNgen = populateNgen;
         return this;
     }
 
@@ -192,13 +192,7 @@ public class GeneratorEventGraphSourceBuilder {
         }
 
         return new GeneratorEventGraphSource(
-                getConfiguration(),
-                getTime(),
-                getSeed(),
-                getMaxOtherParents(),
-                actualRoster,
-                signer,
-                populateSequenceNumber);
+                getConfiguration(), getTime(), getSeed(), getMaxOtherParents(), actualRoster, signer, populateNgen);
     }
 
     private Configuration getConfiguration() {

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/StandardGraphGenerator.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/event/generator/StandardGraphGenerator.java
@@ -559,7 +559,7 @@ public class StandardGraphGenerator implements GraphGenerator {
         buildDefaultOtherParentAffinityMatrix();
         // save all non-ancient events
         final List<EventImpl> nonAncientEvents = new ArrayList<>(linker.getNonAncientEvents());
-        nonAncientEvents.sort(Comparator.comparingLong(e -> e.getBaseEvent().getSequenceNumber()));
+        nonAncientEvents.sort(Comparator.comparingLong(e -> e.getBaseEvent().getNGen()));
         // reinitialize the internal consensus with the last snapshot
         initializeInternalConsensus();
         consensus.loadSnapshot(consensusSnapshot);

--- a/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/graph/internal/SimpleEventImplGraph.java
+++ b/platform-sdk/consensus-hashgraph-impl/src/testFixtures/java/org/hiero/consensus/hashgraph/impl/test/fixtures/graph/internal/SimpleEventImplGraph.java
@@ -33,7 +33,7 @@ public class SimpleEventImplGraph implements SimpleGraph<EventImpl> {
      */
     public SimpleEventImplGraph(@NonNull final List<PlatformEvent> events) {
         final List<EventImpl> eventImpls = new ArrayList<>();
-        // we use the orphan buffer to assign sequence numbers to the events
+        // we use the orphan buffer to assign nGen values to the events
         final DefaultOrphanBuffer orphanBuffer =
                 new DefaultOrphanBuffer(new NoOpMetrics(), new NoOpIntakeEventCounter());
         final ConsensusLinker consensusLinker = new ConsensusLinker(NoOpLinkerLogsAndMetrics.getInstance());

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/event/EventConstants.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/event/EventConstants.java
@@ -1,20 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.model.event;
 
+import org.hiero.consensus.model.node.NodeId;
+
 public final class EventConstants {
     /**
      * Private constructor so that this class is never instantiated
      */
     private EventConstants() {}
 
+    /**
+     * the generation number used to represent that the generation is not defined.
+     * an event's computed generation number is always non-negative.
+     * in case it is used as a parent generation, it means there is no parent event
+     */
+    public static final long GENERATION_UNDEFINED = -1;
+    /** the ID number used to represent that the ID is undefined */
+    public static final NodeId CREATOR_ID_UNDEFINED = NodeId.UNDEFINED_NODE_ID;
     /** the smallest round an event can belong to */
     public static final long MINIMUM_ROUND_CREATED = 1;
-    /** represents a birth round number that is undefined */
+    /** the round number to represent that the birth round is undefined */
     public static final long BIRTH_ROUND_UNDEFINED = -1;
-    /** represents an ancient threshold that is undefined */
+    /** represent either a birth round or a generation which is undefined */
     public static final long ANCIENT_THRESHOLD_UNDEFINED = -1;
-    /** the smallest sequence number an event can have */
-    public static final long FIRST_SEQUENCE_NUMBER = 1;
-    /** represents a sequence number that is undefined */
-    public static final long SEQUENCE_NUMBER_UNDEFINED = -1;
+    /** the minimum generation value an event can have. */
+    public static final long FIRST_GENERATION = 0;
 }

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/event/NonDeterministicGeneration.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/event/NonDeterministicGeneration.java
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.model.event;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.hiero.consensus.model.sequence.map.SequenceMap;
+
+/**
+ * The non-deterministic generation calculated locally by each node. NGen is calculated for every event that is not an
+ * orphan. The value can differ between nodes for the same event and must only ever be used for determining one of the
+ * several valid topological orderings, or determining which event is higher in the hashgraph than another (a higher
+ * number indicates the event is higher in the hashgraph). NGen will be {@link #GENERATION_UNDEFINED} until set at the
+ * appropriate point in the pipeline.
+ */
+public class NonDeterministicGeneration {
+
+    /** The generation value that indicates that the event has not been assigned an nGen value. */
+    public static final long GENERATION_UNDEFINED = 0;
+    /** The generation value that indicates that the event is the first generation of events. */
+    public static final long FIRST_GENERATION = 1;
+
+    private NonDeterministicGeneration() {}
+
+    /**
+     * Assigns the non-deterministic generation to an event. The nGen value is relative to the parents of the event if
+     * the parent is in the list.
+     *
+     * @param event             the event to set the nGen of
+     * @param eventsWithParents all non-ancient, non-orphaned events
+     */
+    public static void assignNGen(
+            @NonNull final PlatformEvent event,
+            @NonNull final SequenceMap<EventDescriptorWrapper, PlatformEvent> eventsWithParents) {
+        long maxParentNGen = GENERATION_UNDEFINED;
+        for (final EventDescriptorWrapper parentDesc : event.getAllParents()) {
+            final PlatformEvent parent = eventsWithParents.get(parentDesc);
+            if (parent != null) {
+                maxParentNGen = Math.max(maxParentNGen, parent.getNGen());
+            }
+        }
+        final long nGen = maxParentNGen == GENERATION_UNDEFINED ? FIRST_GENERATION : maxParentNGen + 1;
+        event.setNGen(nGen);
+    }
+}

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/event/PlatformEvent.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/event/PlatformEvent.java
@@ -62,12 +62,26 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
     private final CountDownLatch prehandleCompleted = new CountDownLatch(1);
 
     /**
+     * The non-deterministic generation. For more info, see {@link NonDeterministicGeneration}
+     */
+    private long nGen = NonDeterministicGeneration.GENERATION_UNDEFINED;
+
+    /**
+     * Represents an unassigned sequence number in a {@code PlatformEvent}. This constant is used as a placeholder to
+     * indicate that a specific sequence number has not yet been assigned to an event.
+     * <p>
+     * The value of {@code UNASSIGNED_SEQUENCE_NUMBER} is defined as {@code -1}. This value is chosen because sequence
+     * numbers are non-negative, making {@code -1} a clear and unambiguous indicator of the unassigned state.
+     */
+    public static final long UNASSIGNED_SEQUENCE_NUMBER = -1;
+
+    /**
      * Represents the sequence number assigned to this event. The sequence number is unique and increments with each
      * event released from orphan buffer, providing a way to identify the order of events, which can be used for
      * topological ordering. If the sequence number is not assigned, it will hold the value of
      * {@code UNASSIGNED_SEQUENCE_NUMBER}.
      */
-    private long sequenceNumber = EventConstants.SEQUENCE_NUMBER_UNDEFINED;
+    private long sequenceNumber = UNASSIGNED_SEQUENCE_NUMBER;
 
     /**
      * Construct a new instance from an unsigned event and a signature.
@@ -190,6 +204,34 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
     }
 
     /**
+     * The non-deterministic generation of this event.
+     *
+     * @return the non-deterministic generation of this event. A value of {@link EventConstants#GENERATION_UNDEFINED} if
+     * none has been set yet.
+     */
+    public long getNGen() {
+        return nGen;
+    }
+
+    /**
+     * Checks if the non-deterministic generation for this event has been set.
+     *
+     * @return {@code true} if the nGen has been set, {@code false} otherwise
+     */
+    public boolean hasNGen() {
+        return nGen != NonDeterministicGeneration.GENERATION_UNDEFINED;
+    }
+
+    /**
+     * Sets the non-deterministic generation of this event.
+     *
+     * @param nGen the non-deterministic generation value to set
+     */
+    public void setNGen(final long nGen) {
+        this.nGen = nGen;
+    }
+
+    /**
      * The sequence number of this event.
      *
      * @return the sequence number of this event.
@@ -204,7 +246,7 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
      * @return {@code true} if the sequence number is assigned, {@code false} otherwise.
      */
     public boolean hasSequenceNumber() {
-        return sequenceNumber != EventConstants.SEQUENCE_NUMBER_UNDEFINED;
+        return sequenceNumber != UNASSIGNED_SEQUENCE_NUMBER;
     }
 
     /**

--- a/platform-sdk/consensus-model/src/testFixtures/java/org/hiero/consensus/model/test/fixtures/event/TestingEventBuilder.java
+++ b/platform-sdk/consensus-model/src/testFixtures/java/org/hiero/consensus/model/test/fixtures/event/TestingEventBuilder.java
@@ -2,7 +2,6 @@
 package org.hiero.consensus.model.test.fixtures.event;
 
 import static org.hiero.consensus.model.event.EventConstants.MINIMUM_ROUND_CREATED;
-import static org.hiero.consensus.model.event.EventConstants.SEQUENCE_NUMBER_UNDEFINED;
 
 import com.hedera.hapi.platform.event.EventConsensusData;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
@@ -24,8 +23,10 @@ import org.hiero.base.crypto.Hash;
 import org.hiero.base.crypto.SignatureType;
 import org.hiero.base.crypto.test.fixtures.CryptoRandomUtils;
 import org.hiero.base.utility.test.fixtures.RandomUtils;
+import org.hiero.consensus.model.event.EventConstants;
 import org.hiero.consensus.model.event.EventDescriptorWrapper;
 import org.hiero.consensus.model.event.EventOrigin;
+import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.event.UnsignedEvent;
 import org.hiero.consensus.model.node.NodeId;
@@ -136,17 +137,21 @@ public class TestingEventBuilder {
      */
     private Long consensusOrder;
 
+    /**
+     * The non-deterministic generation of the event. This value is calculated by the orphan buffer in production.
+     * Defaults to {@link EventConstants#GENERATION_UNDEFINED}
+     */
+    private long nGen = NonDeterministicGeneration.GENERATION_UNDEFINED;
+
     /** The hash to use for the event */
     private Hash hash = null;
 
     /** The origin of this events */
     private EventOrigin origin = EventOrigin.GOSSIP;
 
-    private long sequenceNumberOverride = SEQUENCE_NUMBER_UNDEFINED;
+    private long sequenceNumberOverride = PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER;
 
-    private boolean assignSequenceNumber = false;
-
-    private static final AtomicLong sequenceNumber = new AtomicLong(SEQUENCE_NUMBER_UNDEFINED + 1);
+    private static final AtomicLong sequenceNumber = new AtomicLong(PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER + 1);
 
     /**
      * Constructor
@@ -172,28 +177,24 @@ public class TestingEventBuilder {
     }
 
     /**
-     * If set to positive number, override default, automatic, always-increasing event sequence number to one specified.
-     * This value overrides any value set with {@link #setEnableSequenceNumberAssignment(boolean)}
+     * Set the non-deterministic generation to use. If not set, default to {@link EventConstants#GENERATION_UNDEFINED}
+     *
+     * @param nGen the ngen
+     * @return this instance
+     */
+    public @NonNull TestingEventBuilder setNGen(final long nGen) {
+        this.nGen = nGen;
+        return this;
+    }
+
+    /**
+     * If set to positive number, override default, automatic, always-increasing event sequence number to one specified
      *
      * @param sequenceNumberOverride sequence number to use for the next generated event
      * @return this instance
      */
     public @NonNull TestingEventBuilder setSequenceNumberOverride(final long sequenceNumberOverride) {
         this.sequenceNumberOverride = sequenceNumberOverride;
-        this.assignSequenceNumber = true;
-        return this;
-    }
-
-    /**
-     * If set to true, this builder will assign a sequence number to the events it creates. Otherwise, it will not.
-     * Defaults to false.
-     *
-     * @param assignSequenceNumber true if sequence numbers should be assigned, false otherwise
-     * @return this instance
-     */
-    @NonNull
-    public TestingEventBuilder setEnableSequenceNumberAssignment(final boolean assignSequenceNumber) {
-        this.assignSequenceNumber = assignSequenceNumber;
         return this;
     }
 
@@ -410,7 +411,6 @@ public class TestingEventBuilder {
 
     /**
      * Set a custom origin for the event.
-     *
      * @param origin the origin of the event
      * @return this instance
      */
@@ -549,12 +549,11 @@ public class TestingEventBuilder {
 
         platformEvent.setHash(hash != null ? hash : CryptoRandomUtils.randomHash(random));
 
-        if (assignSequenceNumber) {
-            if (sequenceNumberOverride > SEQUENCE_NUMBER_UNDEFINED) {
-                platformEvent.setSequenceNumber(sequenceNumberOverride);
-            } else {
-                platformEvent.setSequenceNumber(sequenceNumber.getAndIncrement());
-            }
+        platformEvent.setNGen(nGen);
+        if (sequenceNumberOverride > PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER) {
+            platformEvent.setSequenceNumber(sequenceNumberOverride);
+        } else {
+            platformEvent.setSequenceNumber(sequenceNumber.getAndIncrement());
         }
 
         if (consensusTimestamp != null || consensusOrder != null) {

--- a/platform-sdk/consensus-network-simulation/src/testFixtures/java/org/hiero/consensus/network/simulation/fixtures/SimulatedBroadcast.java
+++ b/platform-sdk/consensus-network-simulation/src/testFixtures/java/org/hiero/consensus/network/simulation/fixtures/SimulatedBroadcast.java
@@ -87,6 +87,7 @@ public class SimulatedBroadcast {
             final PlatformEvent eventToDeliver = event.copyGossipedData();
             eventToDeliver.setSenderId(sender);
             eventToDeliver.setTimeReceived(deliveryTime);
+            eventToDeliver.setNGen(event.getNGen());
             eventToDeliver.setSequenceNumber(event.getSequenceNumber());
             final EventInTransit eventInTransit = new EventInTransit(eventToDeliver, deliveryTime);
             eventsInTransit.get(receiver).add(eventInTransit);

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultStateSnapshotManager.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultStateSnapshotManager.java
@@ -319,7 +319,7 @@ public class DefaultStateSnapshotManager implements StateSnapshotManager {
         }
 
         if (index < 0) {
-            return EventConstants.BIRTH_ROUND_UNDEFINED;
+            return EventConstants.GENERATION_UNDEFINED;
         }
         final SavedStateMetadata oldestStateMetadata = savedStates.get(index).metadata();
         return oldestStateMetadata.minimumBirthRoundNonAncient();

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/orphan/DefaultOrphanBuffer.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/orphan/DefaultOrphanBuffer.java
@@ -2,6 +2,7 @@
 package org.hiero.consensus.orphan;
 
 import static com.swirlds.metrics.api.Metrics.PLATFORM_CATEGORY;
+import static org.hiero.consensus.model.event.NonDeterministicGeneration.assignNGen;
 
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -14,7 +15,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import org.hiero.consensus.event.IntakeEventCounter;
 import org.hiero.consensus.metrics.FunctionGauge;
-import org.hiero.consensus.model.event.EventConstants;
 import org.hiero.consensus.model.event.EventDescriptorWrapper;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
@@ -65,7 +65,7 @@ public class DefaultOrphanBuffer implements OrphanBuffer {
     private final SequenceMap<EventDescriptorWrapper, List<OrphanedEvent>> missingParentMap;
 
     /**
-     * First sequence number assigned to an event. Has to be greater than {@link EventConstants#SEQUENCE_NUMBER_UNDEFINED}
+     * First sequence number assigned to an event. Has to be greater than {@link PlatformEvent#UNASSIGNED_SEQUENCE_NUMBER}
      */
     private final long FIRST_ASSIGNED_SEQUENCE_NUMBER = 1;
 
@@ -225,6 +225,7 @@ public class DefaultOrphanBuffer implements OrphanBuffer {
 
             unorphanedEvents.add(nonOrphan);
             eventsWithParents.put(nonOrphanDescriptor, nonOrphan);
+            assignNGen(nonOrphan, eventsWithParents);
             nonOrphan.setSequenceNumber(eventSequenceNumber.getAndIncrement());
 
             // since this event is no longer an orphan, we need to recheck all of its children to see if any might

--- a/platform-sdk/consensus-utility/src/test/java/org/hiero/consensus/orphan/OrphanBufferTests.java
+++ b/platform-sdk/consensus-utility/src/test/java/org/hiero/consensus/orphan/OrphanBufferTests.java
@@ -27,8 +27,8 @@ import org.hiero.base.crypto.Hash;
 import org.hiero.base.crypto.Mnemonics;
 import org.hiero.consensus.event.IntakeEventCounter;
 import org.hiero.consensus.metrics.noop.NoOpMetrics;
-import org.hiero.consensus.model.event.EventConstants;
 import org.hiero.consensus.model.event.EventDescriptorWrapper;
+import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
 import org.hiero.consensus.model.hashgraph.EventWindow;
@@ -207,7 +207,7 @@ class OrphanBufferTests {
         for (final PlatformEvent intakeEvent : intakeEvents) {
 
             final List<PlatformEvent> unorphanedEvents = new ArrayList<>(orphanBuffer.handleEvent(intakeEvent));
-            assertValidSequenceNumber(unorphanedEvents);
+            assertValidNgen(unorphanedEvents);
 
             // simulate advancing consensus rounds periodically
             latestConsensusRound += maybeAdvanceRound.apply(random);
@@ -231,14 +231,69 @@ class OrphanBufferTests {
         assertThat(orphanBuffer.getCurrentOrphanCount()).isEqualTo(0);
     }
 
+    private void assertValidNgen(final List<PlatformEvent> unorphanedEvents) {
+        for (final PlatformEvent unorphanedEvent : unorphanedEvents) {
+            assertThat(unorphanedEvent.getNGen())
+                    .withFailMessage(
+                            "Invalid nGen value {} assigned to event {}",
+                            unorphanedEvent.getNGen(),
+                            unorphanedEvent.getHash())
+                    .isGreaterThanOrEqualTo(NonDeterministicGeneration.FIRST_GENERATION);
+        }
+    }
+
     private void assertValidSequenceNumber(final List<PlatformEvent> unorphanedEvents) {
         for (final PlatformEvent unorphanedEvent : unorphanedEvents) {
-            assertThat(unorphanedEvent.getSequenceNumber())
+            assertThat(unorphanedEvent.getNGen())
                     .withFailMessage(
                             "Invalid sequence number value {} assigned to event {}",
-                            unorphanedEvent.getSequenceNumber(),
+                            unorphanedEvent.getNGen(),
                             unorphanedEvent.getHash())
-                    .isGreaterThan(EventConstants.SEQUENCE_NUMBER_UNDEFINED);
+                    .isGreaterThan(PlatformEvent.UNASSIGNED_SEQUENCE_NUMBER);
+        }
+    }
+
+    @Test
+    @DisplayName("Test that events sorted by nGen result in a valid topological ordering")
+    void topologicalOrderByNGen() {
+        final Metrics metrics = new NoOpMetrics();
+        final IntakeEventCounter intakeEventCounter = mock(IntakeEventCounter.class);
+        final DefaultOrphanBuffer orphanBuffer = new DefaultOrphanBuffer(metrics, intakeEventCounter);
+
+        final List<PlatformEvent> emittedEvents = new ArrayList<>();
+        for (final PlatformEvent intakeEvent : intakeEvents) {
+            final List<PlatformEvent> unorphanedEvents = new ArrayList<>(orphanBuffer.handleEvent(intakeEvent));
+            assertValidNgen(unorphanedEvents);
+            emittedEvents.addAll(unorphanedEvents);
+        }
+
+        // The orphan buffer should be empty now, since the event window was never shifted and all events were sent.
+        assertThat(orphanBuffer.getCurrentOrphanCount()).isEqualTo(0);
+        assertThat(emittedEvents.size()).isEqualTo(intakeEvents.size());
+
+        // Verify that when nGen is assigned such that children always have higher values than parents by
+        // shuffling the list, then sorting by ngen and checking that parents are always before children.
+        Collections.shuffle(emittedEvents, random);
+        emittedEvents.sort(Comparator.comparingLong(PlatformEvent::getNGen));
+
+        final Set<Hash> parentHashes = new HashSet<>();
+        for (final PlatformEvent event : emittedEvents) {
+            if (event.getAllParents().isEmpty()) {
+                parentHashes.add(event.getHash());
+            } else {
+                for (final EventDescriptorWrapper parentDescriptor : event.getAllParents()) {
+                    // In this test, the event window is never advanced, so no events are discarded as ancient.
+                    // Every event sent to the orphan buffer should have been returned, therefore an event's parents
+                    // should always be encountered before the child.
+                    assertThat(parentHashes)
+                            .withFailMessage(
+                                    "Parent event {} was not before the child, indicating that child {} does not have a higher nGen value.",
+                                    Mnemonics.generateMnemonic(parentDescriptor.hash()),
+                                    Mnemonics.generateMnemonic(event.getHash()))
+                            .contains(parentDescriptor.hash());
+                }
+                parentHashes.add(event.getHash());
+            }
         }
     }
 
@@ -261,7 +316,7 @@ class OrphanBufferTests {
         assertThat(emittedEvents.size()).isEqualTo(intakeEvents.size());
 
         // Verify that when sequence number is assigned such that children always have higher values than parents by
-        // shuffling the list, then sorting by sequence number and checking that parents are always before children.
+        // shuffling the list, then sorting by ngen and checking that parents are always before children.
         Collections.shuffle(emittedEvents, random);
         emittedEvents.sort(Comparator.comparingLong(PlatformEvent::getSequenceNumber));
 
@@ -323,9 +378,9 @@ class OrphanBufferTests {
         }
     }
 
-    @DisplayName("Verify the assignment of the sequence number for genesis events")
+    @DisplayName("Verify the assignment of nGen for genesis events")
     @Test
-    void testSequenceNumberValueForGenesisEvent() {
+    void testNGenValueForGenesisEvent() {
         final PlatformEvent genesisEvent =
                 new TestingEventBuilder(random).setCreatorId(NodeId.of(0)).build();
 
@@ -336,14 +391,14 @@ class OrphanBufferTests {
         assertThat(unorphanedEvents.size())
                 .withFailMessage("One event was added, and one event should be returned.")
                 .isEqualTo(1);
-        assertThat(unorphanedEvents.getFirst().getSequenceNumber())
-                .withFailMessage("The sequence number for genesis events should be the first sequence number possible.")
-                .isEqualTo(EventConstants.FIRST_SEQUENCE_NUMBER);
+        assertThat(unorphanedEvents.getFirst().getNGen())
+                .withFailMessage("nGen for genesis events should be the first generation possible.")
+                .isEqualTo(NonDeterministicGeneration.FIRST_GENERATION);
     }
 
-    @DisplayName("Verify the assignment of the sequence number for events with ancient parents")
+    @DisplayName("Verify the assignment of nGen for events with ancient parents")
     @Test
-    void testSequenceNumberValueWithAncientParents() {
+    void testNGenValueWithAncientParents() {
         final long latestConsensusRound = 30;
         final long minimumBirthRoundNonAncient = latestConsensusRound - 26 + 1;
         final EventWindow eventWindow = EventWindowBuilder.builder()
@@ -378,15 +433,15 @@ class OrphanBufferTests {
         assertThat(unorphanedEvents.size())
                 .withFailMessage("One event should be returned by the orphan buffer.")
                 .isEqualTo(1);
-        assertThat(unorphanedEvents.getFirst().getSequenceNumber())
+        assertThat(unorphanedEvents.getFirst().getNGen())
                 .withFailMessage(
-                        "The sequence number for events with unknown ancient parents should be the first sequence number possible.")
-                .isEqualTo(EventConstants.FIRST_SEQUENCE_NUMBER);
+                        "nGen for events with unknown ancient parents should be the first generation possible.")
+                .isEqualTo(NonDeterministicGeneration.FIRST_GENERATION);
     }
 
-    @DisplayName("Verify the assignment of the sequence number for events with one ancient and one non-ancient parent")
+    @DisplayName("Verify the assignment of nGen for events one ancient and one non-ancient parent")
     @Test
-    void testSequenceNumberValueWithAncientAndNonAncientParents() {
+    void testNGenValueWithAncientAndNonAncientParents() {
         final long latestConsensusRound = 30;
         final long minimumBirthRoundNonAncient = latestConsensusRound - 26 + 1;
         final EventWindow eventWindow = EventWindowBuilder.builder()
@@ -427,19 +482,25 @@ class OrphanBufferTests {
         assertThat(unorphanedEvents.isEmpty())
                 .withFailMessage("Ancient events should not be returned by the orphan buffer")
                 .isTrue();
+        assertThat(node0AncientEvent.getNGen())
+                .withFailMessage("Ancient events should not be assigned an nGen value")
+                .isEqualTo(NonDeterministicGeneration.GENERATION_UNDEFINED);
 
         unorphanedEvents.addAll(orphanBuffer.handleEvent(node1AncientEvent));
         assertThat(unorphanedEvents.isEmpty())
                 .withFailMessage("Ancient events should not be returned by the orphan buffer")
                 .isTrue();
+        assertThat(node1AncientEvent.getNGen())
+                .withFailMessage("Ancient events should not be assigned an nGen value")
+                .isEqualTo(NonDeterministicGeneration.GENERATION_UNDEFINED);
 
         unorphanedEvents.addAll(orphanBuffer.handleEvent(node1NonAncientEvent));
         assertThat(unorphanedEvents.size())
                 .withFailMessage("Events with only ancient parents should be returned by the orphan buffer")
                 .isEqualTo(1);
-        assertThat(node1NonAncientEvent.getSequenceNumber())
-                .withFailMessage("Events with only ancient parents should have the first possible sequence number")
-                .isEqualTo(EventConstants.FIRST_SEQUENCE_NUMBER);
+        assertThat(node1NonAncientEvent.getNGen())
+                .withFailMessage("Events with only ancient parents should have the first possible nGen value")
+                .isEqualTo(NonDeterministicGeneration.FIRST_GENERATION);
         unorphanedEvents.clear();
 
         unorphanedEvents.addAll(orphanBuffer.handleEvent(node0NonAncientEvent));
@@ -447,15 +508,14 @@ class OrphanBufferTests {
                 .withFailMessage(
                         "Events whose parents are all either ancient or already passed through should be returned by the orphan buffer")
                 .isEqualTo(1);
-        assertThat(node0NonAncientEvent.getSequenceNumber())
-                .withFailMessage("Events should have an sequence number 1 higher than all non ancient parents.")
-                .isEqualTo(EventConstants.FIRST_SEQUENCE_NUMBER + 1);
+        assertThat(node0NonAncientEvent.getNGen())
+                .withFailMessage("Events should have an nGen value 1 higher than all non ancient parents.")
+                .isEqualTo(NonDeterministicGeneration.FIRST_GENERATION + 1);
     }
 
-    @DisplayName(
-            "Verify the assignment of the sequence number for events with non-ancient parents with different sequence numbers")
+    @DisplayName("Verify the assignment of nGen for events non-ancient parents with different nGen values")
     @Test
-    void testSequenceNumberValueWithNonAncientParents() {
+    void testNGenValueWithNonAncientParents() {
         // Pick some values to use. These are arbitrary.
         final long minimumGenerationNonAncient = 100;
         final long latestConsensusRound = 30;
@@ -499,19 +559,25 @@ class OrphanBufferTests {
         assertThat(unorphanedEvents.isEmpty())
                 .withFailMessage("Ancient events should not be returned by the orphan buffer")
                 .isTrue();
+        assertThat(node0AncientEvent.getNGen())
+                .withFailMessage("Ancient events should not be assigned an nGen value")
+                .isEqualTo(NonDeterministicGeneration.GENERATION_UNDEFINED);
 
         unorphanedEvents.addAll(orphanBuffer.handleEvent(node1AncientEvent));
         assertThat(unorphanedEvents.isEmpty())
                 .withFailMessage("Ancient events should not be returned by the orphan buffer")
                 .isTrue();
+        assertThat(node1AncientEvent.getNGen())
+                .withFailMessage("Ancient events should not be assigned an nGen value")
+                .isEqualTo(NonDeterministicGeneration.GENERATION_UNDEFINED);
 
         unorphanedEvents.addAll(orphanBuffer.handleEvent(node1NonAncientEvent));
         assertThat(unorphanedEvents.size())
                 .withFailMessage("Events with only ancient parents should be returned by the orphan buffer")
                 .isEqualTo(1);
-        assertThat(node1NonAncientEvent.getSequenceNumber())
-                .withFailMessage("Events with only ancient parents should have the first possible sequence number")
-                .isEqualTo(EventConstants.FIRST_SEQUENCE_NUMBER);
+        assertThat(node1NonAncientEvent.getNGen())
+                .withFailMessage("Events with only ancient parents should have the first possible nGen value")
+                .isEqualTo(NonDeterministicGeneration.FIRST_GENERATION);
         unorphanedEvents.clear();
 
         unorphanedEvents.addAll(orphanBuffer.handleEvent(node0NonAncientEvent));
@@ -519,9 +585,9 @@ class OrphanBufferTests {
                 .withFailMessage(
                         "Events whose parents are all either ancient or already passed through should be returned by the orphan buffer")
                 .isEqualTo(1);
-        assertThat(node0NonAncientEvent.getSequenceNumber())
-                .withFailMessage("Events should have an sequence number 1 higher than all non ancient parents.")
-                .isEqualTo(EventConstants.FIRST_SEQUENCE_NUMBER + 1);
+        assertThat(node0NonAncientEvent.getNGen())
+                .withFailMessage("Events should have an nGen value 1 higher than all non ancient parents.")
+                .isEqualTo(NonDeterministicGeneration.FIRST_GENERATION + 1);
         unorphanedEvents.clear();
 
         unorphanedEvents.addAll(orphanBuffer.handleEvent(node0NonAncientEvent2));
@@ -529,8 +595,8 @@ class OrphanBufferTests {
                 .withFailMessage(
                         "Events whose parents are all either ancient or already passed through should be returned by the orphan buffer")
                 .isEqualTo(1);
-        assertThat(node0NonAncientEvent2.getSequenceNumber())
-                .withFailMessage("Events should have an sequence number 1 higher than all non ancient parents.")
-                .isEqualTo(EventConstants.FIRST_SEQUENCE_NUMBER + 2);
+        assertThat(node0NonAncientEvent2.getNGen())
+                .withFailMessage("Events should have an nGen value 1 higher than all non ancient parents.")
+                .isEqualTo(NonDeterministicGeneration.FIRST_GENERATION + 2);
     }
 }

--- a/platform-sdk/docs/consensus-layer/architecture/topics/event-intake.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/event-intake.md
@@ -1,7 +1,7 @@
 ---
 type: architecture-topic
 title: Event intake
-last_reviewed: 2026-07-02
+last_reviewed: 2026-05-15
 ---
 
 # Event intake
@@ -309,15 +309,16 @@ The line 220 check is what distinguishes these two cases on release:
 events still non-ancient are emitted, events that have aged out are
 dropped.
 
-**Note on `eventSequenceNumber`:** the monotonic sequence number is
-stamped on each event as it is released
-([line 228](../../../../consensus-utility/src/main/java/org/hiero/consensus/orphan/DefaultOrphanBuffer.java:228)).
-It is the local topological-ordering key that replaced the former
-`nGen` (non-deterministic generation), which had a defect that surfaced
-in an edge case during reconnect: `nGen` reset to 1 when an event's
-parents were already ancient, breaking the per-creator monotonic
-ordering its consumers relied on. Unlike `nGen`, the sequence number
-never resets. `nGen` has since been removed entirely (ADR-008).
+**Note on `eventSequenceNumber` vs. `assignNGen`:** both fire on
+release
+([lines 228-229](../../../../consensus-utility/src/main/java/org/hiero/consensus/orphan/DefaultOrphanBuffer.java:228))
+because the orphan buffer is mid-transition. `nGen` (non-deterministic
+generation) is the legacy identifier; it has a defect that surfaces in
+an edge case during reconnect, which makes it undesirable. The new
+monotonic sequence number is its replacement and eliminates that
+defect. Both are assigned today so consumers can be migrated
+incrementally; once the migration is complete, `assignNGen` will be
+removed.
 
 [TBD: question for engineer —
 [`clear` (line 262)](../../../../consensus-utility/src/main/java/org/hiero/consensus/orphan/DefaultOrphanBuffer.java:262)

--- a/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
+++ b/platform-sdk/docs/consensus-layer/architecture/topics/hashgraph.md
@@ -288,10 +288,10 @@ into the loaded state — is covered in
 > `consensusRelevantSeqNum` / `RoundElections.minSeqNum` and
 > `ConsensusRounds.isOlderThanDecidedRoundSeqNum`) and the `DeGen`/`cGen`
 > family used inside the algorithm. The sequence number replaced `NGen`
-> as the algorithm's ordering key, and `NGen`
-> (`NonDeterministicGeneration`) has since been removed entirely (see
-> [`../../decisions/ADR-008-replace-ngen-with-sequence-number.md`](../../decisions/ADR-008-replace-ngen-with-sequence-number.md)).
-> Conceptual
+> as the algorithm's ordering key (see
+> [`../../decisions/ADR-008-replace-ngen-with-sequence-number.md`](../../decisions/ADR-008-replace-ngen-with-sequence-number.md));
+> `NonDeterministicGeneration` lingers in this module only for the
+> not-yet-migrated `cGen` path. Conceptual
 > background lives in
 > [`../../concepts/rounds-and-witnesses.md`](../../concepts/rounds-and-witnesses.md)
 > and [`../../concepts/birth-round.md`](../../concepts/birth-round.md).

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
@@ -107,11 +107,7 @@ a dependency on it.
   increasing — though not contiguous — numbers even when their parents have gone
   ancient, and every event receives a value distinct from every other. (A
   creator's events stay per-creator-monotonic because a self-parent always
-  leaves the buffer before its child.) One thing for consumers to know: the
-  counter is an in-memory `AtomicLong` that is not persisted, so a process
-  restart constructs a fresh buffer that begins numbering from `1` again and
-  renumbers replayed events. The value is therefore stable only within a single
-  run — never persist it or compare it across restarts.
+  leaves the buffer before its child.)
 - **Disambiguation.** The pre-existing consensus-side `EventImpl.sequence` is
   renamed `consensusSequence` (with `getConsensusSequence` /
   `setConsensusSequence`) so the intake-order sequence number and the
@@ -120,27 +116,26 @@ a dependency on it.
   changes, so the sensitive consumers (consensus, sync) move one at a time with
   their own testing rather than in one large switch:
 
-  |                          Stage                           |                 Scope                  |      Tracking      | State |
-  |----------------------------------------------------------|----------------------------------------|--------------------|-------|
-  | Compute the sequence number in the orphan buffer         | `consensus-utility`, `consensus-model` | #24841 (PR #24937) | done  |
-  | Event creation / tipset                                  | `consensus-event-creator-impl`         | #24991             | done  |
-  | Consensus algorithm                                      | `consensus-hashgraph-impl`             | #24844             | done  |
-  | Sync                                                     | `consensus-gossip-impl`                | #24843             | done  |
-  | `cGen` handling                                          | `consensus-hashgraph-impl`             | #24883             | done  |
-  | Tools (GUI, CLI)                                         | `consensus-gui`, `swirlds-cli`         | #24885             | done  |
-  | Remove `nGen` from the orphan buffer and `PlatformEvent` | `consensus-utility`, `consensus-model` | #24846             | done  |
+  |                          Stage                           |                 Scope                  |      Tracking      |  State  |
+  |----------------------------------------------------------|----------------------------------------|--------------------|---------|
+  | Compute the sequence number in the orphan buffer         | `consensus-utility`, `consensus-model` | #24841 (PR #24937) | done    |
+  | Event creation / tipset                                  | `consensus-event-creator-impl`         | #24991             | done    |
+  | Consensus algorithm                                      | `consensus-hashgraph-impl`             | #24844             | done    |
+  | Sync                                                     | `consensus-gossip-impl`                | #24843             | done    |
+  | `cGen` handling                                          | `consensus-hashgraph-impl`             | #24883             | done    |
+  | Tools (GUI, CLI)                                         | `consensus-gui`, `swirlds-cli`         | #24885             | pending |
+  | Remove `nGen` from the orphan buffer and `PlatformEvent` | `consensus-utility`, `consensus-model` | #24846             | pending |
 
-  The final stage (#24846) deleted `assignNGen`, the `nGen` field, its
-  accessors, and `NonDeterministicGeneration.java`, completing the removal.
+  The final stage (#24846) deletes `assignNGen`, the `nGen` field, and its
+  accessors, completing the removal.
 
 ## Temporary Nature
 
-The retention of `nGen` was always temporary — it was kept only while the staged
-rollout migrated each consumer to the sequence number, during which `nGen` and
-`sequenceNumber` coexisted by design with `nGen` treated as deprecated (read by
-the not-yet-migrated consumers, written by no new ones). That rollout is now
-complete: the closing stage (#24846) removed `nGen` from the orphan buffer and
-`PlatformEvent`, so `sequenceNumber` is the sole local ordering key.
+The retention of `nGen` is temporary. It remains only until every consumer in
+the staged rollout has migrated to the sequence number; the closing stage
+(#24846) removes `nGen` from the orphan buffer and `PlatformEvent`. Until then,
+`nGen` and `sequenceNumber` coexist by design, and `nGen` must be treated as
+deprecated — read by the not-yet-migrated consumers, written by no new ones.
 
 ## Limitations
 
@@ -170,19 +165,19 @@ decisions (event creation, sync ordering) and local bookkeeping.
 ### Negative
 
 - **A large, cross-cutting migration touching the most sensitive code.** The
-  consensus algorithm and the wire-adjacent sync path both depended on `nGen`;
-  moving them carried more risk than the tipset change and had to be staged and
-  tested carefully. The migration was spread across several PRs.
-- **An extended interim where two ordering values coexisted.** Until #24846
-  landed, some consumers read `nGen` and others read `sequenceNumber`; a
-  half-migrated consumer, or one that compared the two, was a live hazard during
-  the rollout.
-- **Some uses of `nGen` were not pure ordering.** The GUI used `nGen` as actual
+  consensus algorithm and the wire-adjacent sync path both depend on `nGen`;
+  moving them carries more risk than the tipset change and must be staged and
+  tested carefully. The migration is spread across several PRs and is not yet
+  complete.
+- **An extended interim where two ordering values coexist.** Until #24846 lands,
+  some consumers read `nGen` and others read `sequenceNumber`; a half-migrated
+  consumer, or one that compares the two, is a live hazard during the rollout.
+- **Some uses of `nGen` are not pure ordering.** The GUI uses `nGen` as actual
   graph **height** to lay out the hashgraph vertically (`PictureMetadata`,
   `HashgraphPicture`), and `cGen` has its own semantics. A sequence number is
   monotonic but is not a height (siblings get different numbers), so those
-  consumers needed their replacement value confirmed case by case rather than a
-  blind substitution — which is why `cGen` (#24883) and tools (#24885) were
+  consumers need their replacement value confirmed case by case rather than a
+  blind substitution — which is why `cGen` (#24883) and tools (#24885) are
   separate stages.
 
 ### Neutral
@@ -225,11 +220,11 @@ See **Decision** above.
   assigns the sequence number at the buffer's exit; `getMissingParents(...)`
   shows that an ancient parent is not "missing", which is why such an event is
   released and its `nGen` resets.
-- `consensus-model/.../NonDeterministicGeneration.java` (deleted) — held
-  `assignNGen`, the `max(parents) + 1` with `FIRST_GENERATION` fallback that
-  produced the reset; removed in the final stage.
+- `consensus-model/.../NonDeterministicGeneration.java` — `assignNGen`, the
+  `max(parents) + 1` with `FIRST_GENERATION` fallback that produces the reset;
+  deleted in the final stage.
 - `consensus-model/.../PlatformEvent.java` — the `sequenceNumber` field,
-  `UNASSIGNED_SEQUENCE_NUMBER`, and accessors (the former `nGen` field has been
+  `UNASSIGNED_SEQUENCE_NUMBER`, and accessors (and the `nGen` field to be
   removed).
 - `consensus-event-creator-impl/.../tipset/TipsetTracker.java`,
   `ChildlessEventTracker.java` — the first consumer migrated (#24991).
@@ -241,8 +236,7 @@ See **Decision** above.
 - `consensus-gossip-impl/.../shadowgraph/SyncUtils.java` — sorts the send list by
   `sequenceNumber` (#24843).
 - `consensus-gui/.../hashgraph/util/PictureMetadata.java`,
-  `HashgraphPicture.java` — used `nGen` as graph height for layout, migrated to
-  the sequence number (`getSequenceNumber()`) in #24885.
+  `HashgraphPicture.java` — use `nGen` as graph height for layout (#24885).
 - `consensus-hashgraph-impl/.../EventImpl.java`, `.../metrics/Sequencer.java` —
   the pre-existing consensus-order `sequence`, renamed `consensusSequence`.
 - `docs/core/tipset-algorithm.md` — the tipset/vector-clock description, updated
@@ -268,11 +262,8 @@ See **Decision** above.
   migrated the tipset. Sync (#24843) migrated the send-list sort to the sequence
   number. Consensus (#24844) migrated the algorithm's ordering key
   (`consensusRelevantSeqNum`, `RoundElections.minSeqNum`,
-  `isOlderThanDecidedRoundSeqNum`), and `cGen` (#24883) migrated
-  `LocalConsensusGeneration.assignCGen`'s initial sort. Tools (#24885) then
-  migrated the GUI and CLI, and the final `nGen` removal (#24846) deleted
-  `assignNGen`, the `nGen` field, and `NonDeterministicGeneration.java`,
-  completing the rollout.
+  `isOlderThanDecidedRoundSeqNum`). `cGen` (#24883), tools (#24885), and the
+  final `nGen` removal (#24846) remain open at the time of writing.
 - This entry fulfills #25482 ("Create ADR for replacing nGen with sequence
   number"). It supersedes an earlier draft scoped to event creation only; the
   scope was broadened to the full `nGen` removal.

--- a/platform-sdk/docs/consensus-layer/glossary.md
+++ b/platform-sdk/docs/consensus-layer/glossary.md
@@ -2,7 +2,7 @@
 type: glossary
 title: Glossary
 description: Canonical one-line definitions for vocabulary used across the consensus-layer KB, with disambiguation for overloaded terms (round, ancient, stale, falling behind).
-last_reviewed: 2026-07-02
+last_reviewed: 2026-06-30
 ---
 
 # Glossary
@@ -70,7 +70,7 @@ See [architecture/topics/gossip.md](architecture/topics/gossip.md).
 *Consensus generation* (`LocalConsensusGeneration`): orders the events that reach consensus
 within a single *Consensus round* (ties broken by event hash). Assigned to those events identically on
 every node, but temporary — cleared once that round is complete. Used only within the
-hashgraph algorithm. Contrast *DeGen*; see *Generation*.
+hashgraph algorithm. Contrast *NGen* and *DeGen*; see *Generation*.
 See [architecture/topics/hashgraph.md](architecture/topics/hashgraph.md).
 
 ### Child
@@ -139,8 +139,8 @@ See [architecture/topics/event-intake.md](architecture/topics/event-intake.md).
 
 *Deterministic generation* (`DeGen`): drives *lastSee* for *Strongly seeing*. Assigned to the
 descendants of the last round's judges, identically on every node, and recomputed whenever
-hashgraph metadata is recalculated. Used only within the hashgraph algorithm. Contrast *CGen*;
-see *Generation*.
+hashgraph metadata is recalculated. Used only within the hashgraph algorithm. Contrast *NGen*
+and *CGen*; see *Generation*.
 See [architecture/topics/hashgraph.md](architecture/topics/hashgraph.md).
 
 ### Descendant
@@ -248,11 +248,12 @@ See [concepts/event-lifecycle.md](concepts/event-lifecycle.md).
 ### Generation
 
 A per-event count: one plus the maximum parent generation. The paper used a single
-*deterministic* generation as the ancient horizon; current code uses *Birth round* for that.
-Local topological ordering is now the event *Sequence number* (which is not a generation;
-it replaced the former *nGen*, ADR-008), leaving two deterministic generation counters, each
-calculated differently and used only within the hashgraph algorithm — *deGen* (for *Strongly
-seeing*) and *cGen* (for consensus ordering within a *Consensus round*).
+*deterministic* generation as the ancient horizon; current code uses *Birth round* for that
+and keeps three separate generation counters instead, each calculated differently and used
+for a different purpose — *nGen* (local; topological ordering, now migrating to the event
+*Sequence number*, ADR-008), *deGen* (deterministic,
+for *Strongly seeing*), and *cGen* (deterministic, for consensus ordering within a
+*Consensus round*).
 See [concepts/birth-round.md](concepts/birth-round.md).
 
 ### Gossip
@@ -316,13 +317,14 @@ See [concepts/event-lifecycle.md](concepts/event-lifecycle.md).
 
 ### NGen
 
-*Non-deterministic generation* (`NonDeterministicGeneration`): the consensus layer's former
-local topological-ordering key, a graph-height number answering "higher in the hashgraph"
-comparisons. Because it reset to 1 when an event's parents were already ancient, breaking the
-per-creator monotonic ordering its consumers relied on, it was replaced by the event *Sequence
-number* and removed entirely (ADR-008). No live code references `nGen`; the term survives only
-in git history and that decision record.
-See [decisions/ADR-008-replace-ngen-with-sequence-number.md](decisions/ADR-008-replace-ngen-with-sequence-number.md).
+*Non-deterministic generation* (`NonDeterministicGeneration`): historically the consensus
+layer's local topological-ordering key, answering "higher in the hashgraph" comparisons.
+Assigned to every non-orphan event, locally by each node, so it may differ between nodes; set
+once at intake and then stable. That ordering role has moved to the event *Sequence number*
+(ADR-008); `nGen` now survives only for the not-yet-migrated `cGen` path, pending removal.
+Contrast the deterministic *DeGen* and *CGen*; see *Generation*.
+See [decisions/ADR-008-replace-ngen-with-sequence-number.md](decisions/ADR-008-replace-ngen-with-sequence-number.md)
+and [architecture/topics/event-intake.md](architecture/topics/event-intake.md).
 
 ### Orphan buffer
 
@@ -476,8 +478,8 @@ A monotonic counter the *Orphan buffer* stamps on each event as it is released
 (`PlatformEvent.sequenceNumber`), assigned locally by each node so it may differ between
 nodes. The canonical local ordering key — used for "higher in the hashgraph" comparisons by
 event creation, *Sync*, and the consensus algorithm (e.g. `consensusRelevantSeqNum`). Unlike
-the former *NGen* it replaced, it never resets, even when an event's parents have gone ancient,
-and it is never used for cross-node agreement.
+*NGen* it never resets, even when an event's parents have gone ancient, and it is never used
+for cross-node agreement.
 See [decisions/ADR-008-replace-ngen-with-sequence-number.md](decisions/ADR-008-replace-ngen-with-sequence-number.md).
 
 ### Shadowgraph

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/PcesSliceCommand.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/PcesSliceCommand.java
@@ -47,14 +47,14 @@ import picocli.CommandLine;
  *
  * <h2>Purpose</h2>
  * <p>When debugging or testing consensus behavior, it's often useful to take a specific section of
- * an existing event graph (e.g., events from a certain birth round or sequence number onwards) and replay it in isolation.
+ * an existing event graph (e.g., events from a certain birth round or ngen onwards) and replay it in isolation.
  * However, events in the middle of a graph have birth rounds and parent references that assume
  * the existence of earlier events. This tool extracts a slice of the graph and transforms it to
  * be self-contained and replayable from genesis.
  *
  * <h2>Transformations Applied</h2>
  * <ul>
- *   <li><b>Filtering:</b> Events are filtered by birth round or sequence number (with the ability to determine individual values per creator) to extract only the portion of the
+ *   <li><b>Filtering:</b> Events are filtered by birth round or ngen (with the ability to determine individual values per creator) to extract only the portion of the
  *       graph that is of interest.</li>
  *   <li><b>Birth round adjustment:</b> Birth rounds are modified (offset to start from 1) so the
  *       sliced graph appears to start from genesis.</li>
@@ -79,7 +79,7 @@ import picocli.CommandLine;
         name = "slice",
         mixinStandardHelpOptions = true,
         description = "Extract a section of an event graph from PCES files and transform it to be "
-                + "replayable from genesis. Events are filtered by birth round or sequence number for each creator, birth rounds are "
+                + "replayable from genesis. Events are filtered by birth round or ngen for each creator, birth rounds are "
                 + "adjusted, and all events are re-hashed and re-signed with newly generated keys.")
 @SubcommandOf(PcesCommand.class)
 public class PcesSliceCommand extends AbstractCommand {
@@ -96,7 +96,7 @@ public class PcesSliceCommand extends AbstractCommand {
 
     // Per-node filter values (populated in call() from the raw lists)
     private final Map<Long, Long> nodeMinBirthRound = new HashMap<>();
-    private final Map<Long, Long> nodeMinSeqNum = new HashMap<>();
+    private final Map<Long, Long> nodeMinNgen = new HashMap<>();
 
     // Raw per-node filter strings from CLI
     @CommandLine.Option(
@@ -107,12 +107,11 @@ public class PcesSliceCommand extends AbstractCommand {
     private List<String> nodeMinBirthRoundRaw = new ArrayList<>();
 
     @CommandLine.Option(
-            names = {"--node-min-seq-num"},
+            names = {"--node-min-ngen"},
             split = ",",
-            description =
-                    "Per-node minimum sequence number filter. Format: nodeId:value,nodeId:value (e.g., 0:150,1:200). "
-                            + "Events from the specified node with lower sequence number are excluded.")
-    private List<String> nodeMinSeqNumRaw = new ArrayList<>();
+            description = "Per-node minimum ngen filter. Format: nodeId:value,nodeId:value (e.g., 0:150,1:200). "
+                    + "Events from the specified node with lower ngen are excluded.")
+    private List<String> nodeMinNgenRaw = new ArrayList<>();
 
     @CommandLine.Parameters(index = "0", description = "The input directory containing PCES files to slice.")
     private void setInputDirectory(final Path inputDirectory) {
@@ -197,9 +196,9 @@ public class PcesSliceCommand extends AbstractCommand {
             final var parsed = parseNodeFilter(filter, "--node-min-birth-round");
             nodeMinBirthRound.put(parsed.nodeId, parsed.value);
         }
-        for (final String filter : nodeMinSeqNumRaw) {
-            final var parsed = parseNodeFilter(filter, "--node-min-seq-num");
-            nodeMinSeqNum.put(parsed.nodeId, parsed.value);
+        for (final String filter : nodeMinNgenRaw) {
+            final var parsed = parseNodeFilter(filter, "--node-min-ngen");
+            nodeMinNgen.put(parsed.nodeId, parsed.value);
         }
 
         // Handle output directory: warn and prompt if it exists and is not empty
@@ -219,9 +218,9 @@ public class PcesSliceCommand extends AbstractCommand {
             System.out.println("Per-node min birth round filters:");
             nodeMinBirthRound.forEach((nodeId, value) -> System.out.println("  Node " + nodeId + ": " + value));
         }
-        if (!nodeMinSeqNum.isEmpty()) {
-            System.out.println("Per-node min sequence number filters:");
-            nodeMinSeqNum.forEach((nodeId, value) -> System.out.println("  Node " + nodeId + ": " + value));
+        if (!nodeMinNgen.isEmpty()) {
+            System.out.println("Per-node min ngen filters:");
+            nodeMinNgen.forEach((nodeId, value) -> System.out.println("  Node " + nodeId + ": " + value));
         }
 
         // Parse consensus snapshot if provided
@@ -272,7 +271,7 @@ public class PcesSliceCommand extends AbstractCommand {
     }
 
     /**
-     * Filters events based on the configured per-node birth round and sequence number criteria.
+     * Filters events based on the configured per-node birth round and ngen criteria.
      * An event must pass both filters (if configured) to be included.
      *
      * @param event the event to filter
@@ -280,7 +279,7 @@ public class PcesSliceCommand extends AbstractCommand {
      */
     private boolean filterEvent(final @NonNull PlatformEvent event) {
         final long birthRound = event.getBirthRound();
-        final long sequenceNumber = event.getSequenceNumber();
+        final long ngen = event.getNGen();
         final long creatorNodeId = event.getCreatorId().id();
 
         // Check per-node birth round filter
@@ -289,9 +288,9 @@ public class PcesSliceCommand extends AbstractCommand {
             return false;
         }
 
-        // Check per-node sequence number filter
-        final Long nodeMinSeqNum = this.nodeMinSeqNum.get(creatorNodeId);
-        return nodeMinSeqNum == null || sequenceNumber >= nodeMinSeqNum;
+        // Check per-node ngen filter
+        final Long nodeMinNG = nodeMinNgen.get(creatorNodeId);
+        return nodeMinNG == null || ngen >= nodeMinNG;
     }
 
     /**

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/graph/OrphanBufferEventGraphSource.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/graph/OrphanBufferEventGraphSource.java
@@ -19,7 +19,7 @@ import org.hiero.consensus.orphan.DefaultOrphanBuffer;
  * <p>This source processes events lazily through:
  * <ol>
  *   <li>Event hasher - computes the hash for each event</li>
- *   <li>Orphan buffer - links parents, assigns the sequence number, filters orphans</li>
+ *   <li>Orphan buffer - links parents, computes ngen, filters orphans</li>
  * </ol>
  *
  * <p>Events that are released from the orphan buffer (i.e., have their parents linked) are returned.
@@ -50,7 +50,7 @@ public class OrphanBufferEventGraphSource implements EventGraphSource {
     }
 
     /**
-     * @return non-ancient, non-orphaned events in topological order, hashed, with the sequence number assigned and parents linked.
+     * @return non-ancient, non-orphaned events in topological order, hashed, with ngen computed and parents linked.
      */
     @Override
     @NonNull

--- a/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/graph/PcesGraphSlicer.java
+++ b/platform-sdk/swirlds-cli/src/main/java/org/hiero/consensus/pcli/graph/PcesGraphSlicer.java
@@ -83,7 +83,7 @@ public class PcesGraphSlicer {
         final PcesEventGraphSource rawSource =
                 new PcesEventGraphSource(builder.existingPcesFilesLocation, this.context);
         // Use OrphanBufferEventGraphSource to process events through hasher and orphan buffer
-        // This assigns the sequence number and links parents without the overhead of running consensus
+        // This computes ngen and links parents without the overhead of running consensus
         final OrphanBufferEventGraphSource orphanBufferSource =
                 new OrphanBufferEventGraphSource(rawSource, this.context);
 

--- a/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/graph/OrphanBufferEventGraphSourceTest.java
+++ b/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/graph/OrphanBufferEventGraphSourceTest.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
-import org.hiero.consensus.model.event.EventConstants;
+import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.roster.test.fixtures.RandomRosterBuilder;
 import org.hiero.consensus.test.fixtures.Randotron;
@@ -79,11 +79,11 @@ class OrphanBufferEventGraphSourceTest {
         orphanBufferSource.forEachRemaining(allEvents::add);
         assertNotNull(allEvents);
 
-        // All orphanBuffer events should have sequence number computed (>= 0)
+        // All orphanBuffer events should have ngen computed (>= 0)
         for (final PlatformEvent event : allEvents) {
             assertTrue(
-                    event.getSequenceNumber() >= EventConstants.FIRST_SEQUENCE_NUMBER,
-                    "orphanBuffer events should have sequence number computed");
+                    event.getNGen() >= NonDeterministicGeneration.FIRST_GENERATION,
+                    "orphanBuffer events should have ngen computed");
         }
     }
 

--- a/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/graph/PcesGraphSlicerTest.java
+++ b/platform-sdk/swirlds-cli/src/test/java/org/hiero/consensus/pcli/graph/PcesGraphSlicerTest.java
@@ -44,7 +44,7 @@ public class PcesGraphSlicerTest {
     private static final List<NodeId> NODE_IDS =
             IntStream.range(START_NODE_ID, END_NODE_ID).mapToObj(NodeId::of).toList();
     private static final Long MINIMUM_BIRTHROUND = 60L;
-    private static final int MIN_SEQUENCE_NUM = 200;
+    private static final int MIN_NGEN = 100;
 
     @TempDir
     private Path baseDir;
@@ -128,9 +128,7 @@ public class PcesGraphSlicerTest {
     }
 
     private static List<EventGraphPipeline.EventFilter> filters() {
-        return List.of(
-                event -> event.getBirthRound() >= MINIMUM_BIRTHROUND,
-                event -> event.getSequenceNumber() >= MIN_SEQUENCE_NUM);
+        return List.of(event -> event.getBirthRound() >= MINIMUM_BIRTHROUND, event -> event.getNGen() >= MIN_NGEN);
     }
 
     private static EventCore overrideBirthround(@NonNull final EventCore event) {


### PR DESCRIPTION
This reverts commit 05847a82c08a7034a0e4358abdd5fef56d7b537f which removed nGen from the consensus layer. We need to restore it in a few places. The restoration of those locations will come in a separate PR.
