### PR TITLE
test: Fix flaky ReconnetTest

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/ReconnectTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/ReconnectTest.java
@@ -331,18 +331,6 @@ public class ReconnectTest {
 
         final Node nodeToReconnect = network.nodes().getLast();
 
-        network.newReconnectResults().subscribe(notification -> {
-            if (notification.payload().getClass().equals(ReconnectStartPayload.class)) {
-                final ReconnectStartPayload payload = (ReconnectStartPayload) notification.payload();
-                final Node node = network.nodes().stream()
-                        .filter(n -> n.selfId().id() == payload.getOtherNodeId())
-                        .findFirst()
-                        .orElse(nodeToReconnect);
-                network.isolate(node);
-            }
-            return SubscriberAction.CONTINUE;
-        });
-
         enableSyntheticBottleneck(Duration.ofMinutes(10), nodeToReconnect);
         timeManager.waitForCondition(
                 nodeToReconnect::isBehind,


### PR DESCRIPTION
**Description**:

This PR fixes the flake `ReconnectTest.testNodeShutsDownAfterMaxFailedReconnects()`

**Related issue(s)**:

Fixes #26312 