### PR TITLE
chore: remove duplicate codeowner team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
 *                                               @hiero-ledger/github-maintainers
-**/*.gradle*                                    @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-foundation-codeowners @hiero-ledger/github-maintainers
+**/*.gradle*                                    @hiero-ledger/hiero-consensus-node-execution-codeowner @hiero-ledger/hiero-consensus-node-foundation-codeowners @hiero-ledger/github-maintainers
 
 #########################
 ##### Example apps ######

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
 *                                               @hiero-ledger/github-maintainers
-**/*.gradle*                                    @hiero-ledger/hiero-consensus-node-execution-codeowner @hiero-ledger/hiero-consensus-node-foundation-codeowners @hiero-ledger/github-maintainers
+**/*.gradle*                                    @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-foundation-codeowners @hiero-ledger/github-maintainers
 
 #########################
 ##### Example apps ######


### PR DESCRIPTION
**Description**:

Remove the dupicate entry for a codeowner team.

**Related Issue(s)**:

Fixes #26330
