### PR TITLE
fix: make copyLib/copyApp outputs world-readable for Solo local-build deploys

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -113,6 +113,13 @@ val copyLib =
     tasks.register<Sync>("copyLib") {
         from(project.configurations.getByName("runtimeClasspath"))
         into(layout.projectDirectory.dir("../data/lib"))
+        // Gradle 9.6+ stores downloaded artifacts with owner-only (0600) permissions, and Sync
+        // preserves the source mode. Jars deployed to a consensus node via Solo's
+        // --local-build-path keep that mode and owner uid in the container, where the node JVM
+        // runs as a different user and silently skips any classpath jar it cannot read
+        // (NoClassDefFoundError at startup). Normalize to world-readable.
+        filePermissions { unix("0644") }
+        dirPermissions { unix("0755") }
     }
 
 // Copy built jar into `data/apps` and rename HederaNode.jar
@@ -122,6 +129,8 @@ val copyApp =
         into(layout.projectDirectory.dir("../data/apps"))
         rename { "HederaNode.jar" }
         shouldRunAfter(tasks.named("copyLib"))
+        filePermissions { unix("0644") }
+        dirPermissions { unix("0755") }
     }
 
 // Working directory for 'run' tasks


### PR DESCRIPTION
## Problem

The solo-based XTS jobs (`Solo 0.76 -> 0.77 Cutover`, `Migration Testing`) fail 100% since 2026-07-13: after the local-build upgrade, every consensus node crash-loops with `NoClassDefFoundError: org/apache/logging/log4j/LogManager` and never leaves `STARTING` (SOLO-5068). Example: run [29251591341](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29251591341), nightly XTS [29305021214](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29305021214).

## Root cause

The gradle-wrapper 9.5.1 → 9.6.0 bump (#26000, merged Jul 11). Gradle 9.6 stores downloaded dependency-cache artifacts with owner-only (`0600`) permissions. `copyLib` (a `Sync` task) copies already-modular jars (log4j, libsodium, hedera-cryptography-*) verbatim from the cache into `hedera-node/data/lib`, preserving that mode. Solo's `--local-build-path` upgrade then tars them into the node containers with mode and owner uid intact — where the node JVM runs as the `hedera` user and silently skips every classpath jar it cannot read. The first class resolved from an unreadable jar surfaces as `NoClassDefFoundError`. Solo's pre-start gate only counts jars (`ls … | wc -l > 0`), which passes because directory listing does not require read permission on the files.

Timeline fits exactly: last green XTS cutover Jul 9 (gradle 9.5.1); red from the first runs on cold 9.6 dependency caches (Jul 13). Confirmed live by `chmod a+r` on the jars inside a crash-looping node container — all 4 nodes then reached ACTIVE on the same build.

## Fix

Explicit `0644`/`0755` file/dir permissions on the `copyLib` and `copyApp` sync tasks so the deployable build output is world-readable regardless of Gradle's cache file modes.

## Validation

- `./gradlew :app:copyLib :app:copyApp`: all 211 jars in `data/lib` now `rw-r--r--` (previously 4 jars `rw-------`)
- Full 0.76→0.77 cutover scenario green on the previously-failing runner pool with this fix: run [29336346582](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29336346582)
- Full cutover script (TSS/WRAPS, mirror, block node, real-TSS post-cutover verification) green locally against latest main