### PR TITLE
fix: [0.75 CP 02/12] cherry-pick (0.75): Refactor access list encoding

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -602,10 +602,18 @@ public record EthTxData(
         throw new OutOfRangeException();
     }
 
-    private static Object[] encodeRlpList(final RLPList rlpList) {
+    private static final int MAX_ACCESS_LIST_DEPTH = 2;
 
+    private static Object[] encodeRlpList(final RLPList rlpList) {
+        return encodeRlpList(rlpList, 0);
+    }
+
+    private static Object[] encodeRlpList(final RLPList rlpList, final int depth) {
+        if (depth > MAX_ACCESS_LIST_DEPTH) {
+            throw new IllegalArgumentException("RLP access list nested too deeply");
+        }
         return rlpList.elements().stream()
-                .map(rlpItem -> rlpItem.isList() ? encodeRlpList(rlpItem.asRLPList()) : rlpItem.data())
+                .map(rlpItem -> rlpItem.isList() ? encodeRlpList(rlpItem.asRLPList(), depth + 1) : rlpItem.data())
                 .toArray();
     }
 }

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -668,6 +668,33 @@ class EthTxDataTest {
     }
 
     @Test
+    void encodeRlpListEncodesAccessListItemWithThreeEmptyNestedLists() {
+        final Object[] encodedAccessList = new Object[] {
+            new Object[] {
+                new Object[] {new Object[] {RLPEncoder.list("invalid_key".getBytes(), "invalid_value".getBytes())}}
+            }
+        };
+        final var oneByte = new byte[] {1};
+        final byte[] raw = RLPEncoder.sequence(
+                Integers.toBytes(0x02),
+                List.of(
+                        oneByte,
+                        oneByte,
+                        oneByte,
+                        oneByte,
+                        Integers.toBytes(100),
+                        oneByte,
+                        Integers.toBytesUnsigned(BigInteger.ZERO),
+                        new byte[] {},
+                        encodedAccessList,
+                        Integers.toBytes(27),
+                        oneByte,
+                        oneByte));
+
+        assertNull(EthTxData.populateEthTxData(raw));
+    }
+
+    @Test
     void maxGasIsPositive() {
         final var oneByte = new byte[] {1};
         // high bit of most significant byte is zero

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumSuite.java
@@ -125,6 +125,7 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TransferList;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -136,6 +137,7 @@ import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
 import org.hiero.base.utility.CommonUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
@@ -1309,6 +1311,71 @@ public class EthereumSuite {
                         .gasLimit(2_000_000L * -1)
                         .via(PAY_TXN)
                         .hasPrecheck(INVALID_ETHEREUM_TRANSACTION));
+    }
+
+    @HapiTest
+    @DisplayName("Should fail if access list is deeper than needed")
+    public Stream<DynamicTest> deeplyNestedAccessListIsRejectedCleanly() {
+        final var accessListDepth = 35_000;
+        // Prepare EIP-1559 transaction with deeper access list
+        final byte[] rawBytes = rawEIP1559BytesWithDeepAccessList(accessListDepth);
+
+        return hapiTest(
+                cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS),
+                explicitEthereumTransaction(
+                                "rawEthTransaction", (spec, b) -> b.setEthereumData(ByteString.copyFrom(rawBytes))
+                                        .setMaxGasAllowance(ONE_HUNDRED_HBARS))
+                        .payingWith(RELAYER)
+                        .markAsJumboTxn()
+                        .logged()
+                        .hasPrecheck(INVALID_ETHEREUM_TRANSACTION),
+                cryptoCreate("test").hasKnownStatus(SUCCESS));
+    }
+
+    // RLP-encode a list from its already-encoded payload
+    static byte[] rlpList(byte[] p) {
+        if (p.length <= 55) {
+            byte[] o = new byte[p.length + 1];
+            o[0] = (byte) (0xc0 + p.length);
+            System.arraycopy(p, 0, o, 1, p.length);
+            return o;
+        }
+        byte[] l = minimalBE(p.length);
+        byte[] o = new byte[1 + l.length + p.length];
+        o[0] = (byte) (0xf7 + l.length);
+        System.arraycopy(l, 0, o, 1, l.length);
+        System.arraycopy(p, 0, o, 1 + l.length, p.length);
+        return o;
+    }
+
+    static byte[] minimalBE(int v) {
+        if (v == 0) return new byte[] {0};
+        int n = (32 - Integer.numberOfLeadingZeros(v) + 7) / 8;
+        byte[] b = new byte[n];
+        for (int i = n - 1; i >= 0; i--) {
+            b[i] = (byte) (v & 0xff);
+            v >>>= 8;
+        }
+        return b;
+    }
+
+    static final byte[] EMPTY = {(byte) 0x80};
+
+    // EIP-1559 typed transaction with element 8 (access list) nested `depth`
+    static byte[] rawEIP1559BytesWithDeepAccessList(int depth) {
+        byte[] cur = {(byte) 0xc0}; // empty RLP list
+        for (int i = 0; i < depth; i++) cur = rlpList(cur); // nest depth times
+        ByteArrayOutputStream p = new ByteArrayOutputStream();
+        for (int i = 0; i < 8; i++) p.writeBytes(EMPTY); // chainId..callData
+        p.writeBytes(cur); // accessList (element 8)
+        p.writeBytes(EMPTY); // recId
+        p.writeBytes(EMPTY);
+        p.writeBytes(EMPTY); // r, s
+        byte[] list = rlpList(p.toByteArray());
+        byte[] tx = new byte[1 + list.length];
+        tx[0] = 0x02; // EIP-1559 type byte
+        System.arraycopy(list, 0, tx, 1, list.length);
+        return tx;
     }
 
     // Ensuring that the BLS12 precompile is not working before the Pectra support


### PR DESCRIPTION
Cherry-pick of `Refactor access list encoding` to `release/0.75`.
