### PR TITLE
fix: [0.75 CP 03/12] cherry-pick (0.75): token association refactoring

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-smart-contract-service-impl/build.gradle.kts
@@ -20,4 +20,5 @@ testModuleInfo {
     requires("org.junit.jupiter.params")
     requires("org.mockito")
     requires("org.mockito.junit.jupiter")
+    requires("org.hiero.base.utility")
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/associations/AssociationsDecoder.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/associations/AssociationsDecoder.java
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.associations;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED;
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asTokenIds;
+import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static java.util.Objects.requireNonNull;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.hapi.node.token.TokenAssociateTransactionBody;
 import com.hedera.hapi.node.token.TokenDissociateTransactionBody;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
+import com.hedera.node.config.data.ContractsConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -135,10 +139,25 @@ public class AssociationsDecoder {
         return internalDissociations(attempt, accountAddress, tokenAddresses);
     }
 
+    /**
+     * Validate the max length of token addresses in associate call based on the canonical gas for a single association
+     * @param attempt the HTS call attempt
+     * @param tokenAddresses associate tokens addresses
+     */
+    private void validateTokensMaxLength(
+            @NonNull final HtsCallAttempt attempt, @NonNull final Address... tokenAddresses) {
+        final var canonicalGas = attempt.systemContractGasCalculator().canonicalGasRequirement(DispatchType.ASSOCIATE);
+        final var config = attempt.configuration().getConfigData(ContractsConfig.class);
+        validateTrue(
+                tokenAddresses.length * canonicalGas <= config.maxGasPerTransaction(),
+                TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED);
+    }
+
     private TokenAssociateTransactionBody internalAssociations(
             @NonNull final HtsCallAttempt attempt,
             @NonNull final Address accountAddress,
             @NonNull final Address... tokenAddresses) {
+        validateTokensMaxLength(attempt, tokenAddresses);
         return TokenAssociateTransactionBody.newBuilder()
                 .account(attempt.addressIdConverter().convert(accountAddress))
                 .tokens(asTokenIds(attempt.nativeOperations().entityIdFactory(), tokenAddresses))
@@ -149,6 +168,7 @@ public class AssociationsDecoder {
             @NonNull final HtsCallAttempt attempt,
             @NonNull final Address accountAddress,
             @NonNull final Address... tokenAddresses) {
+        validateTokensMaxLength(attempt, tokenAddresses);
         return TokenDissociateTransactionBody.newBuilder()
                 .account(attempt.addressIdConverter().convert(accountAddress))
                 .tokens(asTokenIds(attempt.nativeOperations().entityIdFactory(), tokenAddresses))

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -12,7 +12,6 @@ import static com.hedera.node.app.service.contract.impl.utils.SynthTxnUtils.hasN
 import static com.hedera.node.app.service.token.AliasUtils.extractEvmAddress;
 import static java.math.BigInteger.ZERO;
 import static java.util.Objects.requireNonNull;
-import static org.hiero.base.utility.CommonUtils.unhex;
 
 import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.block.stream.trace.ContractSlotUsage;
@@ -828,7 +827,11 @@ public class ConversionUtils {
      * @return its explicit 20-byte array
      */
     public static byte[] explicitFromHeadlong(@NonNull final com.esaulpaugh.headlong.abi.Address address) {
-        return unhex(address.toString().substring(2));
+        byte[] raw = address.value().toByteArray(); // normally, 21 byte array
+        byte[] bytes20 = new byte[20];
+        System.arraycopy(
+                raw, Math.max(0, raw.length - 20), bytes20, Math.max(0, 20 - raw.length), Math.min(20, raw.length));
+        return bytes20;
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
@@ -28,7 +28,6 @@ module com.hedera.node.app.service.contract.impl {
     requires transitive tuweni.units;
     requires com.hedera.node.app.service.addressbook;
     requires com.swirlds.base;
-    requires org.hiero.base.utility;
     requires com.github.benmanes.caffeine;
     requires com.google.common;
     requires com.google.protobuf;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/associations/AssociationsDecoderTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/associations/AssociationsDecoderTest.java
@@ -9,18 +9,25 @@ import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_H
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.entityIdFactory;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Address;
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
+import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.AddressIdConverter;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.HtsCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.associations.AssociationsDecoder;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.associations.AssociationsTranslator;
+import com.hedera.node.app.spi.workflows.HandleException;
+import com.hedera.node.config.data.ContractsConfig;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -28,6 +35,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AssociationsDecoderTest {
+
+    private static final long TRANSACTION_MAX_GAS = 15_000_000L;
+    private static final long SINGLE_TOKEN_ASSOCIATION_COST = 705_424L;
+
+    @Mock
+    protected SystemContractGasCalculator gasCalculator;
+
+    @Mock
+    private Configuration configuration;
+
+    private static final ContractsConfig CONFIG_WITH_MAX_GAS = HederaTestConfigBuilder.create()
+            .withValue("contracts.maxGasPerTransaction", TRANSACTION_MAX_GAS)
+            .getOrCreateConfig()
+            .getConfigData(ContractsConfig.class);
+
     @Mock
     private AddressIdConverter addressIdConverter;
 
@@ -44,7 +66,7 @@ class AssociationsDecoderTest {
         given(attempt.senderId()).willReturn(OWNER_ID);
         given(attempt.redirectTokenId()).willReturn(NON_FUNGIBLE_TOKEN_ID);
         final var body = subject.decodeHrcAssociate(attempt);
-        assertAssociationPresent(body, OWNER_ID, NON_FUNGIBLE_TOKEN_ID);
+        assertAssociationPresent(body, NON_FUNGIBLE_TOKEN_ID);
     }
 
     @Test
@@ -52,7 +74,7 @@ class AssociationsDecoderTest {
         given(attempt.senderId()).willReturn(OWNER_ID);
         given(attempt.redirectTokenId()).willReturn(NON_FUNGIBLE_TOKEN_ID);
         final var body = subject.decodeHrcDissociate(attempt);
-        assertDissociationPresent(body, OWNER_ID, NON_FUNGIBLE_TOKEN_ID);
+        assertDissociationPresent(body, NON_FUNGIBLE_TOKEN_ID);
     }
 
     @Test
@@ -60,13 +82,17 @@ class AssociationsDecoderTest {
         final var encoded = AssociationsTranslator.ASSOCIATE_ONE
                 .encodeCallWithArgs(OWNER_HEADLONG_ADDRESS, NON_FUNGIBLE_TOKEN_HEADLONG_ADDRESS)
                 .array();
-        given(attempt.addressIdConverter()).willReturn(addressIdConverter);
+        given(attempt.configuration()).willReturn(configuration);
+        given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
+        given(gasCalculator.canonicalGasRequirement(DispatchType.ASSOCIATE)).willReturn(SINGLE_TOKEN_ASSOCIATION_COST);
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(CONFIG_WITH_MAX_GAS);
         given(attempt.inputBytes()).willReturn(encoded);
+        given(attempt.addressIdConverter()).willReturn(addressIdConverter);
         given(attempt.nativeOperations()).willReturn(hederaNativeOperations);
         given(hederaNativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-        givenConvertible(OWNER_HEADLONG_ADDRESS, OWNER_ID);
+        givenConvertible();
         final var body = subject.decodeAssociateOne(attempt);
-        assertAssociationPresent(body, OWNER_ID, NON_FUNGIBLE_TOKEN_ID);
+        assertAssociationPresent(body, NON_FUNGIBLE_TOKEN_ID);
     }
 
     @Test
@@ -76,14 +102,35 @@ class AssociationsDecoderTest {
                         OWNER_HEADLONG_ADDRESS,
                         new Address[] {NON_FUNGIBLE_TOKEN_HEADLONG_ADDRESS, FUNGIBLE_TOKEN_HEADLONG_ADDRESS})
                 .array();
-        given(attempt.addressIdConverter()).willReturn(addressIdConverter);
+        given(attempt.configuration()).willReturn(configuration);
+        given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
+        given(gasCalculator.canonicalGasRequirement(DispatchType.ASSOCIATE)).willReturn(SINGLE_TOKEN_ASSOCIATION_COST);
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(CONFIG_WITH_MAX_GAS);
         given(attempt.inputBytes()).willReturn(encoded);
+        given(attempt.addressIdConverter()).willReturn(addressIdConverter);
         given(attempt.nativeOperations()).willReturn(hederaNativeOperations);
         given(hederaNativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-        givenConvertible(OWNER_HEADLONG_ADDRESS, OWNER_ID);
+        givenConvertible();
         final var body = subject.decodeAssociateMany(attempt);
-        assertAssociationPresent(body, OWNER_ID, FUNGIBLE_TOKEN_ID);
-        assertAssociationPresent(body, OWNER_ID, NON_FUNGIBLE_TOKEN_ID);
+        assertAssociationPresent(body, FUNGIBLE_TOKEN_ID);
+        assertAssociationPresent(body, NON_FUNGIBLE_TOKEN_ID);
+    }
+
+    @Test
+    void associateManyLimit() {
+        final var encoded = AssociationsTranslator.ASSOCIATE_MANY
+                .encodeCallWithArgs(
+                        OWNER_HEADLONG_ADDRESS,
+                        Stream.generate(() -> FUNGIBLE_TOKEN_HEADLONG_ADDRESS)
+                                .limit(22)
+                                .toArray(Address[]::new))
+                .array();
+        given(attempt.configuration()).willReturn(configuration);
+        given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
+        given(gasCalculator.canonicalGasRequirement(DispatchType.ASSOCIATE)).willReturn(SINGLE_TOKEN_ASSOCIATION_COST);
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(CONFIG_WITH_MAX_GAS);
+        given(attempt.inputBytes()).willReturn(encoded);
+        assertThrows(HandleException.class, () -> subject.decodeAssociateMany(attempt));
     }
 
     @Test
@@ -91,13 +138,17 @@ class AssociationsDecoderTest {
         final var encoded = AssociationsTranslator.DISSOCIATE_ONE
                 .encodeCallWithArgs(OWNER_HEADLONG_ADDRESS, NON_FUNGIBLE_TOKEN_HEADLONG_ADDRESS)
                 .array();
+        given(attempt.configuration()).willReturn(configuration);
+        given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
+        given(gasCalculator.canonicalGasRequirement(DispatchType.ASSOCIATE)).willReturn(SINGLE_TOKEN_ASSOCIATION_COST);
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(CONFIG_WITH_MAX_GAS);
         given(attempt.inputBytes()).willReturn(encoded);
         given(attempt.addressIdConverter()).willReturn(addressIdConverter);
         given(attempt.nativeOperations()).willReturn(hederaNativeOperations);
         given(hederaNativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-        givenConvertible(OWNER_HEADLONG_ADDRESS, OWNER_ID);
+        givenConvertible();
         final var body = subject.decodeDissociateOne(attempt);
-        assertDissociationPresent(body, OWNER_ID, NON_FUNGIBLE_TOKEN_ID);
+        assertDissociationPresent(body, NON_FUNGIBLE_TOKEN_ID);
     }
 
     @Test
@@ -107,31 +158,52 @@ class AssociationsDecoderTest {
                         OWNER_HEADLONG_ADDRESS,
                         new Address[] {NON_FUNGIBLE_TOKEN_HEADLONG_ADDRESS, FUNGIBLE_TOKEN_HEADLONG_ADDRESS})
                 .array();
+        given(attempt.configuration()).willReturn(configuration);
+        given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
+        given(gasCalculator.canonicalGasRequirement(DispatchType.ASSOCIATE)).willReturn(SINGLE_TOKEN_ASSOCIATION_COST);
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(CONFIG_WITH_MAX_GAS);
         given(attempt.inputBytes()).willReturn(encoded);
         given(attempt.addressIdConverter()).willReturn(addressIdConverter);
         given(attempt.nativeOperations()).willReturn(hederaNativeOperations);
         given(hederaNativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-        givenConvertible(OWNER_HEADLONG_ADDRESS, OWNER_ID);
+        givenConvertible();
         final var body = subject.decodeDissociateMany(attempt);
-        assertDissociationPresent(body, OWNER_ID, FUNGIBLE_TOKEN_ID);
-        assertDissociationPresent(body, OWNER_ID, NON_FUNGIBLE_TOKEN_ID);
+        assertDissociationPresent(body, FUNGIBLE_TOKEN_ID);
+        assertDissociationPresent(body, NON_FUNGIBLE_TOKEN_ID);
     }
 
-    private void givenConvertible(@NonNull final Address address, @NonNull final AccountID id) {
-        given(addressIdConverter.convert(address)).willReturn(id);
+    @Test
+    void dissociateManyLimit() {
+        final var encoded = AssociationsTranslator.DISSOCIATE_MANY
+                .encodeCallWithArgs(
+                        OWNER_HEADLONG_ADDRESS,
+                        Stream.generate(() -> FUNGIBLE_TOKEN_HEADLONG_ADDRESS)
+                                .limit(22)
+                                .toArray(Address[]::new))
+                .array();
+        given(attempt.configuration()).willReturn(configuration);
+        given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
+        given(gasCalculator.canonicalGasRequirement(DispatchType.ASSOCIATE)).willReturn(SINGLE_TOKEN_ASSOCIATION_COST);
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(CONFIG_WITH_MAX_GAS);
+        given(attempt.inputBytes()).willReturn(encoded);
+        assertThrows(HandleException.class, () -> subject.decodeDissociateMany(attempt));
     }
 
-    private void assertAssociationPresent(
-            @NonNull final TransactionBody body, @NonNull final AccountID target, @NonNull final TokenID tokenId) {
+    private void givenConvertible() {
+        given(addressIdConverter.convert(
+                        com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_HEADLONG_ADDRESS))
+                .willReturn(com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ID);
+    }
+
+    private void assertAssociationPresent(@NonNull final TransactionBody body, @NonNull final TokenID tokenId) {
         final var associate = body.tokenAssociateOrThrow();
-        assertEquals(target, associate.account());
+        assertEquals(com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ID, associate.account());
         org.assertj.core.api.Assertions.assertThat(associate.tokens()).contains(tokenId);
     }
 
-    private void assertDissociationPresent(
-            @NonNull final TransactionBody body, @NonNull final AccountID target, @NonNull final TokenID tokenId) {
+    private void assertDissociationPresent(@NonNull final TransactionBody body, @NonNull final TokenID tokenId) {
         final var dissociate = body.tokenDissociateOrThrow();
-        assertEquals(target, dissociate.account());
+        assertEquals(com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ID, dissociate.account());
         org.assertj.core.api.Assertions.assertThat(dissociate.tokens()).contains(tokenId);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/fees/FeesAndRatesProvider.java
@@ -51,8 +51,8 @@ public class FeesAndRatesProvider {
 
     private static final int NUM_DOWNLOAD_ATTEMPTS = 10;
 
-    private static final BigDecimal USD_DIVISOR = BigDecimal.valueOf(100L);
-    private static final BigDecimal HBAR_DIVISOR = BigDecimal.valueOf(100_000_000L);
+    public static final BigDecimal USD_DIVISOR = BigDecimal.valueOf(100L);
+    public static final BigDecimal HBAR_DIVISOR = BigDecimal.valueOf(100_000_000L);
 
     private final TxnFactory txns;
     private final KeyFactory keys;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opsduration/OpsDurationThrottleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opsduration/OpsDurationThrottleTest.java
@@ -38,20 +38,20 @@ public class OpsDurationThrottleTest {
     private static final String OPS_DURATION_THROTTLE_UNITS_FREED_PER_SECOND =
             "contracts.opsDurationThrottleUnitsFreedPerSecond";
 
-    private static final long DEFAULT_OPS_DURATION_CAPACITY = 10000000;
+    private static final long DEFAULT_OPS_DURATION_CAPACITY = 10_000_000;
 
-    private SpecOperation enableDefaultOpsDurationThrottleNoRefill() {
+    public static SpecOperation enableDefaultOpsDurationThrottleNoRefill() {
         return overridingAllOf(Map.of(
                 THROTTLE_THROTTLE_BY_OPS_DURATION, Boolean.toString(true),
                 OPS_DURATION_THROTTLE_CAPACITY, Long.toString(DEFAULT_OPS_DURATION_CAPACITY),
                 OPS_DURATION_THROTTLE_UNITS_FREED_PER_SECOND, Long.toString(0)));
     }
 
-    private SpecOperation disableOpsDurationThrottle() {
+    public static SpecOperation disableOpsDurationThrottle() {
         return overriding(THROTTLE_THROTTLE_BY_OPS_DURATION, Boolean.toString(false));
     }
 
-    private void restoreDefaults(HapiSpec spec) {
+    public static void restoreDefaults(HapiSpec spec) {
         allRunFor(
                 spec,
                 restoreDefault(THROTTLE_THROTTLE_BY_OPS_DURATION),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/associate/AssociatePrecompileTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/associate/AssociatePrecompileTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.services.bdd.suites.contract.precompile;
+package com.hedera.services.bdd.suites.contract.precompile.token.associate;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
@@ -20,6 +20,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.emptyChildRecordsCheck;
@@ -43,7 +44,6 @@ import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.keys.KeyShape;
-import com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenType;
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(SMART_CONTRACT)
-public class AssociatePrecompileSuite {
+public class AssociatePrecompileTest {
     private static final long GAS_TO_OFFER = 4_000_000L;
     private static final KeyShape DELEGATE_CONTRACT_KEY_SHAPE = KeyShape.threshOf(1, SIMPLE, DELEGATE_CONTRACT);
     private static final String TOKEN_TREASURY = "treasury";
@@ -83,8 +83,8 @@ public class AssociatePrecompileSuite {
                 contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
                                 "performLessThanFourBytesFunctionCall",
-                                HapiParserUtil.asHeadlongAddress(ACCOUNT_ADDRESS),
-                                HapiParserUtil.asHeadlongAddress(TOKEN_ADDRESS))
+                                asHeadlongAddress(ACCOUNT_ADDRESS),
+                                asHeadlongAddress(TOKEN_ADDRESS))
                         .notTryingAsHexedliteral()
                         .via("Function call with less than 4 bytes txn")
                         .gas(100_000),
@@ -100,11 +100,8 @@ public class AssociatePrecompileSuite {
                 contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
                                 "performInvalidlyFormattedFunctionCall",
-                                HapiParserUtil.asHeadlongAddress(ACCOUNT_ADDRESS),
-                                new Address[] {
-                                    HapiParserUtil.asHeadlongAddress(TOKEN_ADDRESS),
-                                    HapiParserUtil.asHeadlongAddress(TOKEN_ADDRESS)
-                                })
+                                asHeadlongAddress(ACCOUNT_ADDRESS),
+                                new Address[] {asHeadlongAddress(TOKEN_ADDRESS), asHeadlongAddress(TOKEN_ADDRESS)})
                         .notTryingAsHexedliteral()
                         .via("Invalid Abi Function call txn"),
                 childRecordsCheck("Invalid Abi Function call txn", SUCCESS));
@@ -119,8 +116,8 @@ public class AssociatePrecompileSuite {
                 contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
                                 "performNonExistingServiceFunctionCall",
-                                HapiParserUtil.asHeadlongAddress(ACCOUNT_ADDRESS),
-                                HapiParserUtil.asHeadlongAddress(TOKEN_ADDRESS))
+                                asHeadlongAddress(ACCOUNT_ADDRESS),
+                                asHeadlongAddress(TOKEN_ADDRESS))
                         .notTryingAsHexedliteral()
                         .via("nonExistingFunctionCallTxn"),
                 childRecordsCheck("nonExistingFunctionCallTxn", SUCCESS));
@@ -148,16 +145,16 @@ public class AssociatePrecompileSuite {
                         contractCall(
                                         THE_CONTRACT,
                                         "nonSupportedFunction",
-                                        HapiParserUtil.asHeadlongAddress(asAddress(accountID.get())),
-                                        HapiParserUtil.asHeadlongAddress(asAddress(vanillaTokenID.get())))
+                                        asHeadlongAddress(asAddress(accountID.get())),
+                                        asHeadlongAddress(asAddress(vanillaTokenID.get())))
                                 .payingWith(GENESIS)
                                 .via("notSupportedFunctionCallTxn")
                                 .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
                         contractCall(
                                         THE_CONTRACT,
                                         TOKEN_ASSOCIATE_FUNCTION,
-                                        HapiParserUtil.asHeadlongAddress(asAddress(accountID.get())),
-                                        HapiParserUtil.asHeadlongAddress(asAddress(vanillaTokenID.get())))
+                                        asHeadlongAddress(asAddress(accountID.get())),
+                                        asHeadlongAddress(asAddress(vanillaTokenID.get())))
                                 .payingWith(GENESIS)
                                 .via(VANILLA_TOKEN_ASSOCIATE_TXN)
                                 .gas(GAS_TO_OFFER))),
@@ -196,8 +193,8 @@ public class AssociatePrecompileSuite {
                         contractCall(
                                         THE_CONTRACT,
                                         TOKEN_ASSOCIATE_FUNCTION,
-                                        HapiParserUtil.asHeadlongAddress(asAddress(accountID.get())),
-                                        HapiParserUtil.asHeadlongAddress(invalidAbiArgument))
+                                        asHeadlongAddress(asAddress(accountID.get())),
+                                        asHeadlongAddress(invalidAbiArgument))
                                 .payingWith(GENESIS)
                                 .via("functionCallWithInvalidArgumentTxn")
                                 .gas(GAS_TO_OFFER)
@@ -205,8 +202,8 @@ public class AssociatePrecompileSuite {
                         contractCall(
                                         THE_CONTRACT,
                                         TOKEN_ASSOCIATE_FUNCTION,
-                                        HapiParserUtil.asHeadlongAddress(asAddress(accountID.get())),
-                                        HapiParserUtil.asHeadlongAddress(asAddress(vanillaTokenID.get())))
+                                        asHeadlongAddress(asAddress(accountID.get())),
+                                        asHeadlongAddress(asAddress(vanillaTokenID.get())))
                                 .payingWith(GENESIS)
                                 .via(VANILLA_TOKEN_ASSOCIATE_TXN)
                                 .gas(GAS_TO_OFFER))),
@@ -262,7 +259,7 @@ public class AssociatePrecompileSuite {
                 contractCall(
                                 THE_GRACEFULLY_FAILING_CONTRACT,
                                 "performInvalidlyFormattedSingleFunctionCall",
-                                HapiParserUtil.asHeadlongAddress(ACCOUNT_ADDRESS))
+                                asHeadlongAddress(ACCOUNT_ADDRESS))
                         .notTryingAsHexedliteral()
                         .via(INVALID_SINGLE_ABI_CALL_TXN)
                         .hasKnownStatus(CONTRACT_REVERT_EXECUTED),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/associate/AssociatePrecompileV2SecurityModelTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/associate/AssociatePrecompileV2SecurityModelTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.services.bdd.suites.contract.precompile;
+package com.hedera.services.bdd.suites.contract.precompile.token.associate;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(SMART_CONTRACT)
-public class AssociatePrecompileV2SecurityModelSuite {
+public class AssociatePrecompileV2SecurityModelTest {
     private static final long GAS_TO_OFFER = 4_000_000L;
     private static final long TOTAL_SUPPLY = 1_000;
     private static final String SIGNER = "anybody";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/associate/AssociationsLimitsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/associate/AssociationsLimitsTest.java
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.precompile.token.associate;
+
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCallWithFunctionAbi;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.restoreDefault;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
+import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
+import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.esaulpaugh.headlong.abi.Address;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@HapiTestLifecycle
+@Tag(SMART_CONTRACT)
+public class AssociationsLimitsTest {
+
+    private static final int TRANSACTION_MAX_GAS = 15_000_000;
+    private static final int SINGLE_TOKEN_ASSOCIATION_COST = 705_424; // each association = ~705_424 gas
+    // estimating (max amount to tokens) + 1, required for "associateTokens"
+    private static final int TOKENS_TO_CREATE = TRANSACTION_MAX_GAS / SINGLE_TOKEN_ASSOCIATION_COST + 1;
+    private static final String ACCOUNT = "AssociateAccount";
+    private static final String TOKEN_TREASURY = "Treasury";
+    private static final String TOKEN = "Token";
+    private static final String TX_NAME = "associateTokensTx";
+
+    static final AtomicReference<Address> accountAddress = new AtomicReference<>();
+    static final List<Address> tokenAddresses = new ArrayList<>();
+
+    @BeforeAll
+    public static void setup(@NonNull final TestLifecycle lifecycle) {
+        lifecycle.doAdhoc(flattened(
+                // create target account
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(ACCOUNT)
+                        .key(SECP_256K1_SOURCE_KEY)
+                        .balance(ONE_HUNDRED_HBARS)
+                        .exposingEvmAddressTo(accountAddress::set),
+                // create tokens
+                cryptoCreate(TOKEN_TREASURY),
+                IntStream.range(0, TOKENS_TO_CREATE)
+                        .mapToObj(i -> tokenCreate(TOKEN + i)
+                                .tokenType(FUNGIBLE_COMMON)
+                                .initialSupply(1L)
+                                .supplyKey(TOKEN_TREASURY)
+                                .adminKey(TOKEN_TREASURY)
+                                .treasury(TOKEN_TREASURY)
+                                .exposingAddressTo(tokenAddresses::add))
+                        .toList()));
+    }
+
+    private static String messageToHex(String message) {
+        return String.format("0x%040x", new BigInteger(1, message.getBytes()));
+    }
+
+    public Stream<DynamicTest> associateDissociateTokensCall(final String functionName) {
+        final var function = getABIFor(FUNCTION, functionName, "IHederaTokenService");
+        return hapiTest(
+                overriding("contracts.maxGasPerTransaction", String.valueOf(TRANSACTION_MAX_GAS)),
+                // limited by TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED
+                contractCallWithFunctionAbi(
+                                "0x0000000000000000000000000000000000000167",
+                                function,
+                                accountAddress.get(),
+                                tokenAddresses.toArray(Address[]::new))
+                        .gas(TRANSACTION_MAX_GAS)
+                        .payingWith(ACCOUNT)
+                        .via(TX_NAME)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                getTxnRecord(TX_NAME)
+                        .exposingTo(e -> assertEquals(
+                                messageToHex(TOKEN_REFERENCE_LIST_SIZE_LIMIT_EXCEEDED.toString()),
+                                e.getContractCallResult().getErrorMessage())),
+                // increasing 'maxGasPerTransaction' to check if max token associations depends on
+                // 'maxGasPerTransaction'
+                overriding("contracts.maxGasPerTransaction", String.valueOf(TRANSACTION_MAX_GAS * 2)),
+                // should SUCCESS, because we increase 'maxGasPerTransaction'
+                contractCallWithFunctionAbi(
+                                "0x0000000000000000000000000000000000000167",
+                                function,
+                                accountAddress.get(),
+                                tokenAddresses.toArray(Address[]::new))
+                        .gas(TRANSACTION_MAX_GAS * 2)
+                        .payingWith(ACCOUNT)
+                        .via(TX_NAME)
+                        .hasKnownStatus(SUCCESS),
+                restoreDefault("contracts.maxGasPerTransaction"));
+    }
+
+    @LeakyHapiTest(overrides = {"contracts.maxGasPerTransaction"})
+    public Stream<DynamicTest> associateTokensLimitTest() {
+        return associateDissociateTokensCall("associateTokens");
+    }
+
+    @LeakyHapiTest(overrides = {"contracts.maxGasPerTransaction"})
+    public Stream<DynamicTest> dissociateTokensLimitTest() {
+        return associateDissociateTokensCall("dissociateTokens");
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchPrecompileTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchPrecompileTest.java
@@ -457,7 +457,7 @@ class AtomicBatchPrecompileTest {
     }
 
     /**
-     * AssociatePrecompileSuite
+     * AssociatePrecompileTest
      */
     @HapiTest
     final Stream<DynamicTest> atomicFunctionCallWithLessThanFourBytesFailsWithinSingleContractCall() {


### PR DESCRIPTION
Cherry-pick of `token association refactoring` to `release/0.75`.
