### PR TITLE
fix: [0.75 CP 12/12] cherry-pick (0.75): Fix jumpstart migration PBJ parsing

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigration.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigration.java
@@ -11,6 +11,7 @@ import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.node.config.data.BlockStreamJumpstartConfig;
 import com.hedera.node.config.types.StreamMode;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -194,8 +195,12 @@ public class WrappedRecordBlockHashMigration {
 
     private WrappedRecordFileBlockHashesLog loadRecentHashes(@NonNull final Path recentHashesPath) throws Exception {
         final var loadedBytes = Files.readAllBytes(recentHashesPath);
-        final var allRecentWrappedRecordHashes =
-                WrappedRecordFileBlockHashesLog.PROTOBUF.parseStrict(Bytes.wrap(loadedBytes));
+        final var allRecentWrappedRecordHashes = WrappedRecordFileBlockHashesLog.PROTOBUF.parse(
+                com.hedera.pbj.runtime.io.buffer.Bytes.wrap(loadedBytes).toReadableSequentialData(),
+                true,
+                false,
+                Codec.DEFAULT_MAX_DEPTH,
+                loadedBytes.length + loadedBytes.length / 10);
         if (allRecentWrappedRecordHashes.entries().isEmpty()) {
             log.error("Recent wrapped record hashes file contains no entries. {}", RESUME_MESSAGE);
             return null;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesDiskWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesDiskWriter.java
@@ -10,6 +10,7 @@ import com.hedera.hapi.block.internal.WrappedRecordFileBlockHashesLog;
 import com.hedera.node.app.metrics.BlockStreamMetrics;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
+import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedOutputStream;
@@ -185,8 +186,8 @@ public class WrappedRecordFileBlockHashesDiskWriter implements AutoCloseable {
                     com.hedera.pbj.runtime.io.buffer.Bytes.wrap(allBytes).toReadableSequentialData(),
                     true,
                     false,
-                    512,
-                    allBytes.length);
+                    Codec.DEFAULT_MAX_DEPTH,
+                    allBytes.length + allBytes.length / 10);
             for (final var entry : log.entries()) {
                 index.add(entry.blockNumber());
             }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigrationTest.java
@@ -3,6 +3,7 @@ package com.hedera.node.app.records.impl;
 
 import static com.hedera.node.app.records.impl.BlockRecordInfoUtils.HASH_SIZE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -15,6 +16,7 @@ import com.hedera.node.config.types.StreamMode;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.state.State;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -419,6 +421,38 @@ class WrappedRecordBlockHashMigrationTest {
                 Bytes.wrap(new byte[HASH_SIZE]));
         subject.execute(StreamMode.RECORDS, config, badConfig, false);
         assertNull(subject.result());
+    }
+
+    @Test
+    void loadRecentHashesParsesLargeFileWithoutException() throws Exception {
+        final int entryCount = 4_000_000;
+        final var entries = new ArrayList<WrappedRecordFileBlockHashes>(entryCount);
+        final byte[] fakeHash = new byte[HASH_SIZE];
+        final var hashBytes = Bytes.wrap(fakeHash);
+        for (int i = 0; i < entryCount; i++) {
+            entries.add(WrappedRecordFileBlockHashes.newBuilder()
+                    .blockNumber(i + 1L)
+                    .consensusTimestampHash(hashBytes)
+                    .outputItemsTreeRootHash(hashBytes)
+                    .build());
+        }
+
+        final var log =
+                WrappedRecordFileBlockHashesLog.newBuilder().entries(entries).build();
+        final byte[] serialized =
+                WrappedRecordFileBlockHashesLog.PROTOBUF.toBytes(log).toByteArray();
+
+        final var file = tempDir.resolve(WrappedRecordFileBlockHashesDiskWriter.DEFAULT_FILE_NAME);
+        Files.write(file, serialized);
+
+        final Method loadRecentHashes =
+                WrappedRecordBlockHashMigration.class.getDeclaredMethod("loadRecentHashes", Path.class);
+        loadRecentHashes.setAccessible(true);
+
+        final var result =
+                assertDoesNotThrow(() -> (WrappedRecordFileBlockHashesLog) loadRecentHashes.invoke(subject, file));
+        assertThat(result).isNotNull();
+        assertThat(result.entries().size()).isEqualTo(entryCount);
     }
 
     private Path createRecentHashesDir(List<WrappedRecordFileBlockHashes> entries) throws Exception {


### PR DESCRIPTION
Cherry-pick of `Fix jumpstart migration PBJ parsing` to `release/0.75`.
