### PR TITLE
chore: [0.75 CP 08/12] cherry-pick (0.75): reduce block buffer size from 150 to 30 blocks

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
@@ -32,10 +32,23 @@ import java.time.Duration;
  */
 @ConfigData("blockStream.buffer")
 public record BlockBufferConfig(
-        @ConfigProperty(defaultValue = "150") @Min(0) @NetworkProperty int maxBlocks,
-        @ConfigProperty(defaultValue = "1s") @Min(1) @NetworkProperty Duration workerInterval,
-        @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty double actionStageThreshold,
-        @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty Duration actionGracePeriod,
-        @ConfigProperty(defaultValue = "85.0") @Min(0) @NetworkProperty double recoveryThreshold,
-        @ConfigProperty(defaultValue = "false") @NodeProperty boolean isBufferPersistenceEnabled,
-        @ConfigProperty(defaultValue = "/opt/hgcapp/blockStreams/buffer") @NodeProperty String bufferDirectory) {}
+        @ConfigProperty(defaultValue = "30") @Min(0) @NetworkProperty
+        int maxBlocks,
+
+        @ConfigProperty(defaultValue = "1s") @Min(1) @NetworkProperty
+        Duration workerInterval,
+
+        @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty
+        double actionStageThreshold,
+
+        @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty
+        Duration actionGracePeriod,
+
+        @ConfigProperty(defaultValue = "85.0") @Min(0) @NetworkProperty
+        double recoveryThreshold,
+
+        @ConfigProperty(defaultValue = "false") @NodeProperty
+        boolean isBufferPersistenceEnabled,
+
+        @ConfigProperty(defaultValue = "/opt/hgcapp/blockStreams/buffer") @NodeProperty
+        String bufferDirectory) {}


### PR DESCRIPTION
Cherry-pick of `reduce block buffer size from 150 to 30 blocks` to `release/0.75`.

Source: `hashgraph/private-hedera-services` PR #448 (commit `452054f534`).

Note: earlier public attempt #26167 was closed unmerged — @timfn-hg please confirm before merge.