### PR TITLE
ci(fix): install deterministic-zip through checksum-verified action

### DIFF
--- a/.github/workflows/850-call-build-release-artifact.yaml
+++ b/.github/workflows/850-call-build-release-artifact.yaml
@@ -243,7 +243,7 @@ jobs:
       - validate
     steps:
       - name: Prepare Runner
-        uses: pandaswhocode/initialize-github-job@v1.3.0 # TODO: pin to the v1.3.0 release commit SHA once it is cut
+        uses: pandaswhocode/initialize-github-job@c96d9edf7816b4f333b558f2e07fe81ebf1e822d # v1.3.0
         with:
           egress-policy: audit
           setup-deterministic-zip: "true"

--- a/.github/workflows/850-call-build-release-artifact.yaml
+++ b/.github/workflows/850-call-build-release-artifact.yaml
@@ -242,22 +242,11 @@ jobs:
     needs:
       - validate
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@v1.3.0 # TODO: pin to the v1.3.0 release commit SHA once it is cut
         with:
           egress-policy: audit
-
-      - name: Install Deterministic Zip Tooling
-        run: |
-          echo "::group::Download Binary"
-          sudo curl -L -o /usr/local/bin/deterministic-zip https://github.com/timo-reymann/deterministic-zip/releases/download/1.2.0/deterministic-zip_linux-amd64
-          echo "::endgroup::"
-          echo "::group::Change Binary Permissions"
-          sudo chmod -v +x /usr/local/bin/deterministic-zip
-          echo "::endgroup::"
-          echo "::group::Show Binary Version Info"
-          deterministic-zip --version
-          echo "::endgroup::"
+          setup-deterministic-zip: "true"
 
       - name: Install JSON Tools
         run: |

--- a/.github/workflows/850-call-build-release-artifact.yaml
+++ b/.github/workflows/850-call-build-release-artifact.yaml
@@ -126,7 +126,7 @@ jobs:
       prerelease: ${{ steps.effective-version.outputs.prerelease }}
     steps:
       - name: Prepare Runner
-        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        uses: pandaswhocode/initialize-github-job@c96d9edf7816b4f333b558f2e07fe81ebf1e822d # v1.3.0
         with:
           setup-semver: "true"
 
@@ -397,7 +397,7 @@ jobs:
     steps:
       - name: Prepare Runner
         id: prepare-runner
-        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        uses: pandaswhocode/initialize-github-job@c96d9edf7816b4f333b558f2e07fe81ebf1e822d # v1.3.0
         with:
           checkout: "true"
           checkout-ref: "${{ needs.validate.outputs.commit-id }}"
@@ -582,7 +582,7 @@ jobs:
     steps:
       - name: Prepare Runner
         id: prepare-runner
-        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        uses: pandaswhocode/initialize-github-job@c96d9edf7816b4f333b558f2e07fe81ebf1e822d # v1.3.0
         with:
           checkout: "true"
           checkout-ref: "${{ needs.validate.outputs.commit-id }}"
@@ -698,7 +698,7 @@ jobs:
     steps:
       - name: Prepare Runner
         id: prepare-runner
-        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        uses: pandaswhocode/initialize-github-job@c96d9edf7816b4f333b558f2e07fe81ebf1e822d # v1.3.0
         with:
           checkout: "true"
           checkout-ref: "${{ needs.validate.outputs.commit-id }}"


### PR DESCRIPTION
## Description

Harden the release pipeline's `deterministic-zip` install. The `build-artifact` job currently fetches the binary from a mutable release tag with no integrity check:

```yaml
sudo curl -L -o /usr/local/bin/deterministic-zip \
  https://github.com/timo-reymann/deterministic-zip/releases/download/1.2.0/deterministic-zip_linux-amd64
sudo chmod -v +x /usr/local/bin/deterministic-zip
```

This replaces it with the reusable `initialize-github-job` action's `setup-deterministic-zip` input, which pins the release version and verifies a hard-coded per-platform SHA-256 (**fail-closed**) before install — the same hardening already applied to the `semver` install. The standalone `Harden Runner` step is folded into the `Prepare Runner` step (the action runs `step-security/harden-runner` internally with `egress-policy: audit`), matching the `validate` job in this same file.

* Remove inline unpinned/unchecksummed `deterministic-zip` download
* Install it via `initialize-github-job` `setup-deterministic-zip: 'true'`
* Preserve egress hardening (`egress-policy: audit`) through the action

**Related issue(s)**: n/a (CI supply-chain hardening)

**Notes for reviewer**:

The action is pinned to the immutable **v1.3.0** release commit `c96d9edf7816b4f333b558f2e07fe81ebf1e822d` (which adds `setup-deterministic-zip`, from PandasWhoCode/initialize-github-job#92). No longer blocked on a release.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)