### PR TITLE
fix(contract): fail cleanly on insufficient transfer value

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/CustomExceptionalHaltReason.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/failure/CustomExceptionalHaltReason.java
@@ -29,6 +29,7 @@ public enum CustomExceptionalHaltReason implements ExceptionalHaltReason {
     NOT_SUPPORTED("Not supported."),
     CONTRACT_ENTITY_LIMIT_REACHED("Contract entity limit reached."),
     INVALID_FEE_SUBMITTED("Invalid fee submitted for an EVM call."),
+    INSUFFICIENT_BALANCE("Insufficient balance for value transfer"),
     INSUFFICIENT_CHILD_RECORDS("Result cannot be externalized due to insufficient child records");
 
     private final String description;
@@ -55,6 +56,7 @@ public enum CustomExceptionalHaltReason implements ExceptionalHaltReason {
         map.put(INVALID_CONTRACT_ID, ResponseCodeEnum.INVALID_CONTRACT_ID);
         map.put(INVALID_FEE_SUBMITTED, ResponseCodeEnum.INVALID_FEE_SUBMITTED);
         map.put(INSUFFICIENT_GAS, ResponseCodeEnum.INSUFFICIENT_GAS);
+        map.put(INSUFFICIENT_BALANCE, ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE);
         map.put(ILLEGAL_STATE_CHANGE, ResponseCodeEnum.LOCAL_CALL_MODIFICATION_EXCEPTION);
         HALT_REASON_TO_STATUS = Collections.unmodifiableMap(map);
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/DispatchingEvmFrameState.java
@@ -9,6 +9,7 @@ import static com.hedera.hapi.util.HapiUtils.CONTRACT_ID_COMPARATOR;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.CONTRACT_IS_TREASURY;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.FAILURE_DURING_LAZY_ACCOUNT_CREATION;
+import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INSUFFICIENT_BALANCE;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INSUFFICIENT_CHILD_RECORDS;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_ALIAS_KEY;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
@@ -401,6 +402,12 @@ public class DispatchingEvmFrameState implements EvmFrameState {
             return Optional.of(INVALID_SOLIDITY_ADDRESS);
         } else if (to instanceof TokenEvmAccount || to instanceof ScheduleEvmAccount) {
             return Optional.of(ILLEGAL_STATE_CHANGE);
+        }
+        // In-EVM CALL/CREATE opcodes already guard value against the sender balance (Besu pushes 0 on a
+        // failed transfer), so this only fires for a top-level create/call whose value exceeds the sender
+        // balance; halt cleanly instead of letting transferFromTo throw (see #26402).
+        if (from.toNativeAccount().tinybarBalance() < amount) {
+            return Optional.of(INSUFFICIENT_BALANCE);
         }
         // Note we can still use top-level signatures to meet receiver signature requirements
         final var status = nativeOperations.transferWithReceiverSigCheck(

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
@@ -7,6 +7,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.CONTRACT_IS_TREASURY;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.CONTRACT_STILL_OWNS_NFTS;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.FAILURE_DURING_LAZY_ACCOUNT_CREATION;
+import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INSUFFICIENT_BALANCE;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_ALIAS_KEY;
 import static com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason.INVALID_SOLIDITY_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations.MISSING_ENTITY_NUMBER;
@@ -555,7 +556,7 @@ class DispatchingEvmFrameStateTest {
     @Test
     void transferDelegationUsesExpectedVerifierForNonDelegate() {
         final var captor = ArgumentCaptor.forClass(VerificationStrategy.class);
-        givenWellKnownAccount(contractWith(A_ACCOUNT_ID).smartContract(true));
+        givenWellKnownAccount(contractWith(A_ACCOUNT_ID).smartContract(true).tinybarBalance(1234));
         givenWellKnownAccount(B_ACCOUNT_ID, contractWith(B_ACCOUNT_ID));
         given(nativeOperations.transferWithReceiverSigCheck(
                         eq(123L), eq(A_ACCOUNT_ID), eq(B_ACCOUNT_ID), captor.capture()))
@@ -571,7 +572,7 @@ class DispatchingEvmFrameStateTest {
 
     @Test
     void transferDelegationReportsInvalidSignature() {
-        givenWellKnownAccount(contractWith(A_ACCOUNT_ID).smartContract(true));
+        givenWellKnownAccount(contractWith(A_ACCOUNT_ID).smartContract(true).tinybarBalance(1234));
         givenWellKnownAccount(B_ACCOUNT_ID, contractWith(B_ACCOUNT_ID));
         given(nativeOperations.transferWithReceiverSigCheck(eq(123L), eq(A_ACCOUNT_ID), eq(B_ACCOUNT_ID), any()))
                 .willReturn(INVALID_SIGNATURE);
@@ -583,7 +584,7 @@ class DispatchingEvmFrameStateTest {
 
     @Test
     void transferDelegationThrowsOnApparentlyImpossibleFailureMode() {
-        givenWellKnownAccount(contractWith(A_ACCOUNT_ID).smartContract(true));
+        givenWellKnownAccount(contractWith(A_ACCOUNT_ID).smartContract(true).tinybarBalance(1234));
         givenWellKnownAccount(B_ACCOUNT_ID, contractWith(B_ACCOUNT_ID));
         given(nativeOperations.transferWithReceiverSigCheck(eq(123L), eq(A_ACCOUNT_ID), eq(B_ACCOUNT_ID), any()))
                 .willReturn(INSUFFICIENT_ACCOUNT_BALANCE);
@@ -591,6 +592,16 @@ class DispatchingEvmFrameStateTest {
         assertThrows(
                 IllegalStateException.class,
                 () -> subject.tryTransfer(LONG_ZERO_ADDRESS, BENEFICIARY_ADDRESS, 123L, false));
+    }
+
+    @Test
+    void transferHaltsWhenSenderBalanceBelowAmount() {
+        givenWellKnownAccount(contractWith(A_ACCOUNT_ID).smartContract(true).tinybarBalance(122L));
+        givenWellKnownAccount(B_ACCOUNT_ID, contractWith(B_ACCOUNT_ID));
+        given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        final var reasonToHalt = subject.tryTransfer(LONG_ZERO_ADDRESS, BENEFICIARY_ADDRESS, 123L, false);
+        assertTrue(reasonToHalt.isPresent());
+        assertEquals(INSUFFICIENT_BALANCE, reasonToHalt.get());
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -253,9 +253,7 @@ public class ContractCreateSuite {
                 contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
                         .balance(Long.MAX_VALUE)
                         .refusingEthConversion()
-                        .via("overBalanceCreate")
-                        .hasKnownStatus(INSUFFICIENT_PAYER_BALANCE),
-                getTxnRecord("overBalanceCreate").logged());
+                        .hasKnownStatus(INSUFFICIENT_PAYER_BALANCE));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -243,6 +243,21 @@ public class ContractCreateSuite {
                         .hasPrecheck(INSUFFICIENT_PAYER_BALANCE));
     }
 
+    // Regression for #26402: an initial balance exceeding the payer's balance used to reach the EVM
+    // value-transfer invariant and throw IllegalArgumentException, which was caught as FAIL_INVALID and
+    // logged as a "Possibly CATASTROPHIC failure". It now fails cleanly with INSUFFICIENT_PAYER_BALANCE.
+    @HapiTest
+    final Stream<DynamicTest> contractCreateWithInitialBalanceOverPayerBalanceFailsCleanly() {
+        return hapiTest(
+                uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
+                contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
+                        .balance(Long.MAX_VALUE)
+                        .refusingEthConversion()
+                        .via("overBalanceCreate")
+                        .hasKnownStatus(INSUFFICIENT_PAYER_BALANCE),
+                getTxnRecord("overBalanceCreate").logged());
+    }
+
     @HapiTest
     final Stream<DynamicTest> disallowCreationsOfEmptyInitCode() {
         final var contract = "EmptyContract";


### PR DESCRIPTION
A top-level ContractCreate whose value exceeds the sender balance used to throw `IllegalArgumentException` deep in the EVM (`transferFromTo`), which was caught as `FAIL_INVALID` and logged as a "Possibly CATASTROPHIC failure". Now the value-transfer gate pre-checks the sender balance and halts with `INSUFFICIENT_PAYER_BALANCE`.

This status matches the eth/relayer path, which already rejects `balance < gasCost + value` with `INSUFFICIENT_PAYER_BALANCE` in `CustomGasCharging`. The HAPI path only checked gas, so the value shortfall surfaced as an unchecked throw instead.

In-EVM CALL/CREATE opcodes already guard value against balance (Besu pushes 0 on a failed transfer), so only the top-level path reaches this gate, with no EVM-equivalence impact. The check sits at the shared `tryTransfer` gate, which also serves top-level contract calls carrying value. Regression test added in `ContractCreateSuite`.

Closes #26402
