### PR TITLE
chore: [0.76 CP 08/12] cherry-pick (0.76): reduce block buffer size from 150 to 30 blocks

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
@@ -39,7 +39,7 @@ import java.time.Duration;
 // spotless:off
 @ConfigData("blockStream.buffer")
 public record BlockBufferConfig(
-        @ConfigProperty(defaultValue = "150") @Min(0) @NetworkProperty int maxBlocks,
+        @ConfigProperty(defaultValue = "30") @Min(0) @NetworkProperty int maxBlocks,
         @ConfigProperty(defaultValue = "1s") @Min(1) @NetworkProperty Duration workerInterval,
         @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty double actionStageThreshold,
         @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty Duration actionGracePeriod,


### PR DESCRIPTION
Cherry-pick of #26388 (`[0.75 CP 08/12]`) onto `release/0.76`.

Reduces the block buffer `maxBlocks` default from 150 to 30 blocks (`blockStream.buffer.maxBlocks`).

**Conflict resolution:** `BlockBufferConfig.java` conflicted because 0.76 added a `minAckedBlocksToBuffer` config property (absent in the 0.75 base) and uses single-line formatting, while CP 08's diff reformats the record and predates that field. Resolved by keeping 0.76's record verbatim — including `minAckedBlocksToBuffer` — and applying only the functional change (`maxBlocks` default 150 → 30). Net diff to this file is a single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
