### PR TITLE
chore: Pin container versions

### DIFF
--- a/platform-sdk/consensus-otter-docker-app/src/testFixtures/docker/Dockerfile
+++ b/platform-sdk/consensus-otter-docker-app/src/testFixtures/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25
+FROM eclipse-temurin:25.0.2_10-jdk
 
 # Create non-root user and group
 RUN groupadd -r appuser && useradd -r -g appuser appuser

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/chaosbot/NetworkPartitionExperiment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/chaosbot/NetworkPartitionExperiment.java
@@ -120,8 +120,7 @@ public record NetworkPartitionExperiment(
         }
         final double partitionFraction =
                 minPartitionFraction + (randotron.nextDouble() * (maxPartitionFraction - minPartitionFraction));
-        final int partitionSize =
-                Math.clamp((int) Math.round((nodes.size() - 1) * partitionFraction), 1, nodes.size() - 1);
+        final int partitionSize = Math.clamp(Math.round((nodes.size() - 1) * partitionFraction), 1, nodes.size() - 1);
         final List<Node> shuffledNodes = new ArrayList<>(nodes);
         Collections.shuffle(shuffledNodes, randotron);
         final List<Node> partitionNodes = shuffledNodes.subList(0, partitionSize);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNetwork.java
@@ -118,7 +118,7 @@ public class ContainerNetwork extends AbstractNetwork {
      */
     @Override
     protected void recreateConnections(@NonNull final Map<ConnectionKey, ConnectionState> connections) {
-        if (networkBehavior != null) {
+        if (networkBehavior != null && toxiproxyContainer != null) {
             toxiproxyContainer.restart();
             networkBehavior.reconnect(toxiproxyContainer.getHost(), toxiproxyContainer.getControlPort(), connections);
         }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ToxiproxyContainer.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ToxiproxyContainer.java
@@ -33,7 +33,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
     /** The control port on which the Toxiproxy server is running. */
     public static final int CONTROL_PORT = 8474;
 
-    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy");
+    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.12.0");
 
     /** How long to wait for the control API to serve again after a restart. */
     private static final Duration RESTART_READINESS_TIMEOUT = Duration.ofSeconds(60L);


### PR DESCRIPTION
**Description**:

This PR pins the container versions used in Otter tests. It also contains some unrelated small fixes.

**Related issue(s)**:

Fixes #26408 