### PR TITLE
chore: [main CP 08/12] cherry-pick to main: reduce block buffer size from 150 to 30 blocks

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
@@ -39,7 +39,7 @@ import java.time.Duration;
 // spotless:off
 @ConfigData("blockStream.buffer")
 public record BlockBufferConfig(
-        @ConfigProperty(defaultValue = "150") @Min(0) @NetworkProperty int maxBlocks,
+        @ConfigProperty(defaultValue = "30") @Min(0) @NetworkProperty int maxBlocks,
         @ConfigProperty(defaultValue = "1s") @Min(1) @NetworkProperty Duration workerInterval,
         @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty double actionStageThreshold,
         @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty Duration actionGracePeriod,


### PR DESCRIPTION
Forward-port of the 0.75 CP #26388 (also on release/0.76 as #26417) onto `main`.

Reduces the block buffer `maxBlocks` default from 150 to 30 (`blockStream.buffer.maxBlocks`).

**Conflict resolution:** kept main's `BlockBufferConfig` record verbatim (including `minAckedBlocksToBuffer`, absent from the 0.75 base) and applied only the functional change 150 → 30. Net diff is a single line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
