### PR TITLE
feat: improve BN comms coverage

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
@@ -647,6 +647,79 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         assertThat(blockBufferService.getEarliestAvailableBlockNumber()).isEqualTo(3L);
     }
 
+    @Test
+    void testUnacknowledgedBlocksWalk() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
+                .withValue("blockStream.blockPeriod", Duration.ofSeconds(1))
+                .withValue("blockStream.buffer.maxBlocks", 20)
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+
+        // Step 1: produce (open + close) blocks 1..6 without acking -> 6 outstanding.
+        for (long n = 1; n <= 6; n++) {
+            blockBufferService.openBlock(n);
+            blockBufferService.closeBlock(n);
+        }
+        checkBufferHandle.invoke(blockBufferService);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(6);
+        assertThat(lastPruningResultRef(blockBufferService).get().numBlocksPendingAck)
+                .isEqualTo(6);
+        reset(blockStreamMetrics);
+
+        // Step 2: acknowledge through block 2 (BlockAcknowledgement) -> outstanding drops to 4.
+        blockBufferService.setLatestAcknowledgedBlock(2L);
+        checkBufferHandle.invoke(blockBufferService);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(4);
+        reset(blockStreamMetrics);
+
+        // Step 3: acknowledge through block 4 -> outstanding drops to 2 (blocks 5, 6).
+        blockBufferService.setLatestAcknowledgedBlock(4L);
+        checkBufferHandle.invoke(blockBufferService);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(2);
+        reset(blockStreamMetrics);
+
+        // Step 4: a non-acknowledgement handshake event (SkipBlock/ResendBlock/BehindPublisher) repositions the
+        // stream cursor but does not change the buffer's ack watermark, and an in-progress (opened but not yet
+        // closed) block is excluded from the count. Outstanding must stay at 2.
+        blockBufferService.openBlock(7L); // opened, not closed -> in progress, not pending-ack
+        checkBufferHandle.invoke(blockBufferService);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(2);
+        reset(blockStreamMetrics);
+
+        // Step 5: complete block 7 and add block 8 -> outstanding grows to 4 (blocks 5, 6, 7, 8).
+        blockBufferService.closeBlock(7L);
+        blockBufferService.openBlock(8L);
+        blockBufferService.closeBlock(8L);
+        checkBufferHandle.invoke(blockBufferService);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(4);
+        reset(blockStreamMetrics);
+
+        // Step 6: acknowledge through block 8 (catch-up) -> nothing outstanding.
+        blockBufferService.setLatestAcknowledgedBlock(8L);
+        checkBufferHandle.invoke(blockBufferService);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(0);
+        reset(blockStreamMetrics);
+
+        // Step 7: produce blocks 9, 10 then receive an acknowledgement for a block BEYOND the last produced (this
+        // consensus node was behind its peers, so the block node jumps it ahead) -> still nothing outstanding.
+        blockBufferService.openBlock(9L);
+        blockBufferService.closeBlock(9L);
+        blockBufferService.openBlock(10L);
+        blockBufferService.closeBlock(10L);
+        blockBufferService.setLatestAcknowledgedBlock(15L);
+        checkBufferHandle.invoke(blockBufferService);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(0);
+        assertThat(lastPruningResultRef(blockBufferService).get().numBlocksPendingAck)
+                .isZero();
+    }
+
     private void verifyBlockSizingMetrics() {
         verify(blockStreamMetrics, atLeastOnce()).recordBlockItemsPerBlock(anyInt());
         verify(blockStreamMetrics, atLeastOnce()).recordBlockBytes(anyLong());

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -123,7 +123,7 @@ tasks.test {
 }
 
 val miscTags =
-    "!(INTEGRATION|CRYPTO|TOKEN|RESTART|UPGRADE|SMART_CONTRACT|ND_RECONNECT|LONG_RUNNING|STATE_THROTTLING|ISS|BLOCK_NODE|GENESIS_SUBPROCESS|BLOCK_NODE_SIM|SIMPLE_FEES|ATOMIC_BATCH|WRAPS_DOWNLOAD)"
+    "!(INTEGRATION|CRYPTO|TOKEN|RESTART|UPGRADE|SMART_CONTRACT|ND_RECONNECT|LONG_RUNNING|STATE_THROTTLING|ISS|BLOCK_NODE|GENESIS_SUBPROCESS|SIMPLE_FEES|ATOMIC_BATCH|WRAPS_DOWNLOAD)"
 val miscTagsSerial = "$miscTags&SERIAL"
 
 val prCheckTags =
@@ -144,7 +144,6 @@ val prCheckTags =
         "hapiTestTimeConsumingSerial" to "(LONG_RUNNING&SERIAL)",
         "hapiTestIss" to "ISS",
         "hapiTestBlockNodeCommunication" to "BLOCK_NODE",
-        "hapiTestBlockNodeSimCommunication" to "BLOCK_NODE_SIM",
         "hapiTestMisc" to miscTags,
         "hapiTestMiscSerial" to miscTagsSerial,
         "hapiTestMiscRecords" to miscTags,
@@ -196,7 +195,6 @@ val prCheckStartPorts =
         "hapiTestSimpleFeesSerial" to "29000",
         "hapiTestAtomicBatchSerial" to "29200",
         "hapiTestSmartContractSerial" to "29400",
-        "hapiTestBlockNodeSimCommunication" to "29600",
     )
 val prCheckPropOverrides =
     mapOf(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TestTags.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/TestTags.java
@@ -17,7 +17,6 @@ public class TestTags {
     public static final String UPGRADE = "UPGRADE";
     public static final String ISS = "ISS";
     public static final String BLOCK_NODE = "BLOCK_NODE";
-    public static final String BLOCK_NODE_SIM = "BLOCK_NODE_SIM";
     /**
      * Tags a test that needs a real multi-node subprocess network started at genesis (e.g. to
      * complete a TSS ceremony), but no block nodes. Carried by the {@code @GenesisSubProcessTest}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/BlockNodeOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/BlockNodeOp.java
@@ -7,6 +7,7 @@ import com.hedera.services.bdd.junit.hedera.simulator.BlockNodeController;
 import com.hedera.services.bdd.spec.HapiSpec;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
@@ -33,6 +34,7 @@ public class BlockNodeOp extends UtilOp {
     private final long rangeStart;
     private final long rangeEnd;
     private final Consumer<Map<Long, RecordFileItem>> recordFileItemsConsumer;
+    private final Consumer<Set<Long>> receivedBlockNumbersConsumer;
 
     private BlockNodeOp(
             final long nodeIndex,
@@ -57,6 +59,25 @@ public class BlockNodeOp extends UtilOp {
         this.rangeStart = rangeStart;
         this.rangeEnd = rangeEnd;
         this.recordFileItemsConsumer = recordFileItemsConsumer;
+        this.receivedBlockNumbersConsumer = null;
+    }
+
+    private BlockNodeOp(
+            final long nodeIndex,
+            final BlockNodeAction action,
+            final Consumer<Set<Long>> receivedBlockNumbersConsumer) {
+        this.nodeIndex = nodeIndex;
+        this.action = action;
+        this.responseCode = null;
+        this.blockNumber = 0L;
+        this.lastVerifiedBlockNumber = null;
+        this.lastVerifiedBlockConsumer = null;
+        this.sendBlockAcknowledgementsEnabled = true;
+        this.persistState = true;
+        this.rangeStart = 0L;
+        this.rangeEnd = 0L;
+        this.recordFileItemsConsumer = null;
+        this.receivedBlockNumbersConsumer = receivedBlockNumbersConsumer;
     }
 
     private BlockNodeOp(
@@ -237,6 +258,11 @@ public class BlockNodeOp extends UtilOp {
                     recordFileItemsConsumer.accept(controller.getAllRecordFileItems(nodeIndex));
                 }
                 break;
+            case GET_RECEIVED_BLOCK_NUMBERS:
+                if (receivedBlockNumbersConsumer != null) {
+                    receivedBlockNumbersConsumer.accept(controller.getReceivedBlockNumbers(nodeIndex));
+                }
+                break;
             default:
                 throw new IllegalStateException("Action: " + action + " is not supported for block node simulators");
         }
@@ -318,7 +344,9 @@ public class BlockNodeOp extends UtilOp {
         /** Assert that no {@link RecordFileItem}s have been received for any block in an inclusive range */
         ASSERT_NO_RECORD_FILES_IN_RANGE,
         /** Expose the map of received {@link RecordFileItem}s keyed by block number */
-        EXPOSE_RECORD_FILE_ITEMS
+        EXPOSE_RECORD_FILE_ITEMS,
+        /** Expose the set of block numbers fully received (header + EndOfBlock) by the simulator */
+        GET_RECEIVED_BLOCK_NUMBERS
     }
 
     /**
@@ -955,6 +983,41 @@ public class BlockNodeOp extends UtilOp {
                     0L,
                     0L,
                     consumer);
+        }
+
+        @Override
+        protected boolean submitOp(final HapiSpec spec) throws Throwable {
+            return build().submitOp(spec);
+        }
+    }
+
+    /**
+     * Creates a builder for exposing the set of block numbers fully received by a block node simulator.
+     *
+     * @param nodeIndex the index of the block node simulator (0-based)
+     * @param consumer the consumer to receive the set of received block numbers
+     * @return a builder for the operation
+     */
+    public static GetReceivedBlockNumbersBuilder getReceivedBlockNumbers(
+            final long nodeIndex, final Consumer<Set<Long>> consumer) {
+        return new GetReceivedBlockNumbersBuilder(nodeIndex, consumer);
+    }
+
+    /**
+     * Builder for exposing the set of block numbers fully received by a block node simulator.
+     * This builder also implements UtilOp so it can be used directly in HapiSpec without calling build().
+     */
+    public static class GetReceivedBlockNumbersBuilder extends UtilOp {
+        private final long nodeIndex;
+        private final Consumer<Set<Long>> consumer;
+
+        GetReceivedBlockNumbersBuilder(final long nodeIndex, final Consumer<Set<Long>> consumer) {
+            this.nodeIndex = nodeIndex;
+            this.consumer = consumer;
+        }
+
+        public BlockNodeOp build() {
+            return new BlockNodeOp(nodeIndex, BlockNodeAction.GET_RECEIVED_BLOCK_NUMBERS, consumer);
         }
 
         @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/BlockNodeVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/BlockNodeVerbs.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.spec.utilops;
 
 import com.hedera.hapi.block.stream.RecordFileItem;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream;
@@ -225,6 +226,16 @@ public class BlockNodeVerbs {
          */
         public BlockNodeOp exposingRecordFileItems(Consumer<Map<Long, RecordFileItem>> consumer) {
             return BlockNodeOp.exposingRecordFileItems(nodeIndex, consumer).build();
+        }
+
+        /**
+         * Exposes the set of block numbers fully received (header + EndOfBlock) by the block node simulator.
+         *
+         * @param consumer the consumer to receive the set of received block numbers
+         * @return the operation
+         */
+        public BlockNodeOp getReceivedBlockNumbersExposing(Consumer<Set<Long>> consumer) {
+            return BlockNodeOp.getReceivedBlockNumbers(nodeIndex, consumer).build();
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSimSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSimSuite.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.suites.blocknode;
 
-import static com.hedera.services.bdd.junit.TestTags.BLOCK_NODE_SIM;
+import static com.hedera.services.bdd.junit.TestTags.BLOCK_NODE;
 import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.utilops.BlockNodeVerbs.blockNode;
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
@@ -34,15 +35,14 @@ import org.junit.jupiter.api.Tag;
 
 /**
  * Consensus-node to block-node communication tests that use the in-process block node
- * <b>simulator</b> (no Docker / real block node containers). These are split out from
- * {@link BlockNodeSuite} so they can run as a separate, parallel CI task on a regular runner.
+ * <b>simulator</b> (no Docker / real block node containers).
  * NOTE: com.hedera.node.app.blocks.impl.streaming MUST have DEBUG logging enabled.
  */
-@Tag(BLOCK_NODE_SIM)
+@Tag(BLOCK_NODE)
 @OrderedInIsolation
 public class BlockNodeSimSuite {
     private static final int BLOCK_PERIOD_SECONDS = 2;
-    private static final int STRESS_CYCLES = 12;
+    private static final int STRESS_CYCLES = 50;
 
     @HapiTest
     @HapiBlockNode(
@@ -272,9 +272,10 @@ public class BlockNodeSimSuite {
     }
 
     /**
-     * Exercises the consensus node's handling of the non-error publisher handshake responses
-     * (ResendBlock, BehindPublisher, SkipBlock) and of EndOfStream responses that force a
-     * reconnect.
+     * Exercises the consensus node's handling of the full set of publisher handshake responses: the non-error
+     * responses (ResendBlock, BehindPublisher, SkipBlock) and every EndOfStream code that forces a reconnect
+     * (DUPLICATE_BLOCK, BAD_BLOCK_PROOF, PERSISTENCE_FAILED, TIMEOUT, INVALID_REQUEST, ERROR, SUCCESS). After the
+     * full walk it asserts the block node received a gap-free (contiguous) run of blocks.
      */
     @HapiTest
     @HapiBlockNode(
@@ -290,6 +291,7 @@ public class BlockNodeSimSuite {
                             "blockStream.writerMode", "FILE_AND_GRPC",
                             "blockStream.blockPeriod", BLOCK_PERIOD_SECONDS + "s",
                             "blockStream.streamWrappedRecordBlocks", "false",
+                            "blockNode.maxEndOfStreamsAllowed", "50",
                             "blockNode.globalCoolDownSeconds", "0",
                             "blockNode.basicNodeCoolDownSeconds", "1",
                             "blockNode.extendedNodeCoolDownSeconds", "1"
@@ -298,6 +300,7 @@ public class BlockNodeSimSuite {
     @Order(4)
     final Stream<DynamicTest> publisherHandshakeResponses() {
         final AtomicLong lastVerified = new AtomicLong();
+        final AtomicReference<Set<Long>> received = new AtomicReference<>();
         return hapiTest(
                 // Reach steady-state streaming to the block node.
                 waitUntilNextBlocks(5).withBackgroundTraffic(true),
@@ -350,8 +353,44 @@ public class BlockNodeSimSuite {
                         blockNode(0).sendEndOfStreamWithBlock(EndOfStream.Code.PERSISTENCE_FAILED, lastVerified.get())),
                 awaitBlockNodeCommsLogContainsText(
                         byNodeId(0), "responseCode: PERSISTENCE_FAILED", Duration.ofSeconds(30)),
+                waitUntilNextBlocks(2).withBackgroundTraffic(true),
+
+                // EndOfStream(TIMEOUT) -> transient close + immediate restart at the next block.
+                blockNode(0).getLastVerifiedBlockExposing(lastVerified),
+                sourcingContextual(
+                        spec -> blockNode(0).sendEndOfStreamWithBlock(EndOfStream.Code.TIMEOUT, lastVerified.get())),
+                awaitBlockNodeCommsLogContainsText(byNodeId(0), "responseCode: TIMEOUT", Duration.ofSeconds(30)),
+                waitUntilNextBlocks(2).withBackgroundTraffic(true),
+
+                // EndOfStream(INVALID_REQUEST) -> transient close + immediate restart.
+                blockNode(0).getLastVerifiedBlockExposing(lastVerified),
+                sourcingContextual(spec ->
+                        blockNode(0).sendEndOfStreamWithBlock(EndOfStream.Code.INVALID_REQUEST, lastVerified.get())),
+                awaitBlockNodeCommsLogContainsText(
+                        byNodeId(0), "responseCode: INVALID_REQUEST", Duration.ofSeconds(30)),
+                waitUntilNextBlocks(2).withBackgroundTraffic(true),
+
+                // EndOfStream(ERROR) -> close + reconnect later.
+                blockNode(0).getLastVerifiedBlockExposing(lastVerified),
+                sourcingContextual(
+                        spec -> blockNode(0).sendEndOfStreamWithBlock(EndOfStream.Code.ERROR, lastVerified.get())),
+                awaitBlockNodeCommsLogContainsText(byNodeId(0), "responseCode: ERROR", Duration.ofSeconds(30)),
+                waitUntilNextBlocks(2).withBackgroundTraffic(true),
+
+                // EndOfStream(SUCCESS) -> orderly end + reconnect.
+                blockNode(0).getLastVerifiedBlockExposing(lastVerified),
+                sourcingContextual(
+                        spec -> blockNode(0).sendEndOfStreamWithBlock(EndOfStream.Code.SUCCESS, lastVerified.get())),
+                awaitBlockNodeCommsLogContainsText(byNodeId(0), "responseCode: SUCCESS", Duration.ofSeconds(30)),
+
                 // Final continuity check: block production resumes after the last reconnect.
-                waitUntilNextBlocks(3).withBackgroundTraffic(true));
+                waitUntilNextBlocks(3).withBackgroundTraffic(true),
+
+                // Contiguity / no-data-loss: despite the reconnects triggered above, the block node received a
+                // gap-free run of blocks. The single simulator is never restarted here, so its received-block set
+                // is cumulative across every reconnect.
+                blockNode(0).getReceivedBlockNumbersExposing(received::set),
+                doingContextual(spec -> assertReceivedBlocksContiguous(received.get())));
     }
 
     /**
@@ -469,6 +508,82 @@ public class BlockNodeSimSuite {
         ops.add(doingContextual(_ -> assertThat(blocksAfterChurn.get())
                 .as("block production should advance across the reconnect churn")
                 .isGreaterThan(blocksBeforeChurn.get())));
+        // Contiguity: node 0 is recreated on each restart (its received-block set is wiped), so after the final
+        // restart and settle window it holds the run of blocks streamed to it since coming back up. That run must
+        // be gap-free, proving the consensus node resumed a contiguous stream after all the churn.
+        final AtomicReference<Set<Long>> receivedAfterChurn = new AtomicReference<>();
+        ops.add(blockNode(0).getReceivedBlockNumbersExposing(receivedAfterChurn::set));
+        ops.add(doingContextual(_ -> assertReceivedBlocksContiguous(receivedAfterChurn.get())));
         return hapiTest(ops.toArray(new SpecOperation[0]));
+    }
+
+    /**
+     * Exercises the high-latency QoS path: a slow (high-latency) block node whose acknowledgements lag beyond the
+     * configured threshold is abandoned after enough consecutive high-latency events, and the consensus node fails
+     * over to a healthy node. The high-latency threshold is lowered below the simulator's fixed 1500ms ack delay
+     * so the switch fires deterministically.
+     */
+    @HapiTest
+    @HapiBlockNode(
+            networkSize = 1,
+            blockNodeConfigs = {
+                @BlockNodeConfig(nodeId = 0, mode = BlockNodeMode.SIMULATOR, highLatency = true),
+                @BlockNodeConfig(nodeId = 1, mode = BlockNodeMode.SIMULATOR)
+            },
+            subProcessNodeConfigs = {
+                @SubProcessNodeConfig(
+                        nodeId = 0,
+                        blockNodeIds = {0, 1},
+                        blockNodePriorities = {0, 1},
+                        applicationPropertiesOverrides = {
+                            "blockStream.streamMode", "BLOCKS",
+                            "blockStream.writerMode", "FILE_AND_GRPC",
+                            "blockStream.blockPeriod", BLOCK_PERIOD_SECONDS + "s",
+                            "blockStream.streamWrappedRecordBlocks", "false",
+                            "blockNode.highLatencyThreshold", "1s",
+                            "blockNode.highLatencyEventsBeforeSwitching", "3",
+                            "blockNode.globalCoolDownSeconds", "0",
+                            "blockNode.basicNodeCoolDownSeconds", "1",
+                            "blockNode.extendedNodeCoolDownSeconds", "1"
+                        })
+            })
+    @Order(7)
+    final Stream<DynamicTest> publisherHandshakeHighLatencySwitch() {
+        final List<Integer> portNumbers = new ArrayList<>();
+        return hapiTest(
+                doingContextual(spec -> {
+                    portNumbers.add(spec.getBlockNodePortById(0));
+                    portNumbers.add(spec.getBlockNodePortById(1));
+                }),
+                // Node 0 (high latency) delays acknowledgements past the lowered threshold; after enough
+                // consecutive high-latency events the consensus node closes the connection and fails over to node 1.
+                waitUntilNextBlocks(5).withBackgroundTraffic(true),
+                awaitBlockNodeCommsLogContainsText(
+                        byNodeId(0), "Block node has exceeded high latency threshold", Duration.ofSeconds(90)),
+                sourcingContextual(spec -> awaitBlockNodeCommsLogContainsText(
+                        byNodeId(0),
+                        String.format("Selected new block node for streaming: localhost:%s", portNumbers.get(1)),
+                        Duration.ofSeconds(90))),
+                waitUntilNextBlocks(3).withBackgroundTraffic(true));
+    }
+
+    /**
+     * Asserts that the given set of received block numbers is non-empty and gap-free (contiguous) from its minimum
+     * to its maximum, i.e. no block in the streamed range was lost.
+     */
+    private static void assertReceivedBlocksContiguous(final Set<Long> received) {
+        assertThat(received)
+                .as("block node should have received at least one block")
+                .isNotEmpty();
+        final long min = received.stream().mapToLong(Long::longValue).min().orElseThrow();
+        final long max = received.stream().mapToLong(Long::longValue).max().orElseThrow();
+        for (long b = min; b <= max; b++) {
+            final long block = b;
+            assertThat(received)
+                    .as(
+                            "Block sequence is not contiguous: block %d missing from received range [%d, %d]",
+                            block, min, max)
+                    .contains(block);
+        }
     }
 }


### PR DESCRIPTION
## Improve block-node communication test coverage

Expands CN → BN publisher-handshake test coverage and wires the
in-process block node **simulator** suite into CI in XTS.

### HAPI simulator suite (`BlockNodeSimSuite`)
- `publisherHandshakeResponses` now covers **every** `EndOfStream` code that forces a
  reconnect — adds `TIMEOUT`, `INVALID_REQUEST`, `ERROR`, `SUCCESS` to the existing
  `DUPLICATE_BLOCK` / `BAD_BLOCK_PROOF` / `PERSISTENCE_FAILED`.
- Add a gap-free block-sequence (no-data-loss) assertion to `publisherHandshakeResponses`
  and the reconnect-stress test.
- New `publisherHandshakeHighLatencySwitch` — verifies failover away from a high-latency
  block node.
- Raise reconnect-stress cycles 12 → 50.

### Unit (`BlockBufferServiceTest`)
- New `testUnacknowledgedBlocksWalk` — asserts the `numBlocksPendingAck` metric tracks the
  outstanding-ack count across produce / ack / in-flight / catch-up / jump-ahead steps.

### Test infrastructure
- New `blockNode(i).getReceivedBlockNumbersExposing(...)` verb exposing the simulator's
  received-block set (backs the contiguity assertions).
- Remove the now-unused `BLOCK_NODE_SIM` tag and the `hapiTestBlockNodeSimCommunication`
  Gradle task/port.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
