### PR TITLE
chore: Removed extra right space padding from settingsUsed.txt file

### DIFF
--- a/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/export/ConfigExport.java
+++ b/platform-sdk/swirlds-config-extensions/src/main/java/com/swirlds/config/extensions/export/ConfigExport.java
@@ -56,19 +56,18 @@ public final class ConfigExport {
                 .forEach(name -> nonRecordProperties.put(name, configuration.getValue(name)));
 
         final Set<Object> allConfigValues = combine(recordProperties.values(), nonRecordProperties.values());
-        final int maxValueLength = getMaxPropertyLength(allConfigValues);
 
         // Write all record defined values first, in alphabetical order
         recordProperties.keySet().stream().sorted().forEach(name -> {
             final Object value = recordProperties.get(name);
-            final String line = buildLine(name, value, maxValueLength, "");
+            final String line = buildLine(name, value, "");
             lineConsumer.accept(line);
         });
 
         // Write all values not defined in records next, in alphabetical order
         nonRecordProperties.keySet().stream().sorted().forEach(name -> {
             final Object value = nonRecordProperties.get(name);
-            final String line = buildLine(name, value, maxValueLength, "  [NOT USED IN RECORD]");
+            final String line = buildLine(name, value, "  [NOT USED IN RECORD]");
             lineConsumer.accept(line);
         });
     }
@@ -97,10 +96,9 @@ public final class ConfigExport {
         return Stream.concat(set1.stream(), set2.stream()).collect(Collectors.toSet());
     }
 
-    private static String buildLine(
-            final String name, final Object value, final int maxValueLength, final String suffix) {
+    private static String buildLine(final String name, final Object value, final String suffix) {
         final String valueString = String.valueOf(value);
-        return name + ", " + valueString + createSpaces(valueString, maxValueLength) + suffix;
+        return name + ", " + valueString + suffix;
     }
 
     public static void addConfigContents(

--- a/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/export/ConfigExportTest.java
+++ b/platform-sdk/swirlds-config-extensions/src/test/java/com/swirlds/config/extensions/test/export/ConfigExportTest.java
@@ -46,12 +46,12 @@ class ConfigExportTest {
                 .isNotNull()
                 .isNotEmpty()
                 // Verify properties in file are listed
-                .anySatisfy(value -> assertThat(value).matches("^property, value\\s*$"))
-                .anySatisfy(value -> assertThat(value).matches("^prefix.property, anotherValue\\s*$"))
+                .anySatisfy(value -> assertThat(value).matches("^property, value$"))
+                .anySatisfy(value -> assertThat(value).matches("^prefix.property, anotherValue$"))
                 // Verify properties not in file are listed (spot check only)
+                .anySatisfy(value ->
+                        assertThat(value).matches("^prefix.unmappedProperty, notPresentValue  \\[NOT USED IN RECORD]$"))
                 .anySatisfy(value -> assertThat(value)
-                        .matches("^prefix.unmappedProperty, notPresentValue\\s*\\[NOT USED IN RECORD]$"))
-                .anySatisfy(value -> assertThat(value)
-                        .matches("^unmappedProperty, anotherNotPresentValue\\s*\\[NOT USED IN RECORD]$"));
+                        .matches("^unmappedProperty, anotherNotPresentValue  \\[NOT USED IN RECORD]$"));
     }
 }


### PR DESCRIPTION
**Description**:

In settingsUsed.txt, which is produced on startup, every line is space-padded from the right side to the maximum length of any property in that file. This means that even a simple thing like
`socket.bufferSize, 8192`
ends up being 10000 characters long

**Related issue(s)**:

Fixes #26328 

**Notes for reviewer**:
The change itself is simple; please flag if you know any external tool that can be affected by that change.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
