### PR TITLE
chore: Cleanup quiescence command

### DIFF
--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/DefaultEventCreatorModule.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/DefaultEventCreatorModule.java
@@ -150,18 +150,26 @@ public class DefaultEventCreatorModule implements EventCreatorModule {
      * {@inheritDoc}
      */
     @Override
-    @NonNull
-    public InputWire<QuiescenceCommand> quiescenceCommandInputWire() {
-        return requireNonNull(eventCreationManagerWiring, "Not initialized")
-                .getInputWire(EventCreationManager::quiescenceCommand);
+    public void destroy() {
+        throw new UnsupportedOperationException("Shutdown mechanism not implemented yet");
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void destroy() {
-        throw new UnsupportedOperationException("Shutdown mechanism not implemented yet");
+    public void submitQuiescenceCommand(@NonNull final QuiescenceCommand quiescenceCommand) {
+        requireNonNull(eventCreationManagerWiring, "Not initialized")
+                .getInputWire(EventCreationManager::quiescenceCommand)
+                .inject(quiescenceCommand);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void flush() {
+        requireNonNull(eventCreationManagerWiring, "Not initialized").flush();
     }
 
     // *****************************************************************
@@ -174,14 +182,6 @@ public class DefaultEventCreatorModule implements EventCreatorModule {
     @Override
     public void startSquelching() {
         requireNonNull(eventCreationManagerWiring, "Not initialized").startSquelching();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void flush() {
-        requireNonNull(eventCreationManagerWiring, "Not initialized").flush();
     }
 
     /**

--- a/platform-sdk/consensus-event-creator/src/main/java/org/hiero/consensus/event/creator/EventCreatorModule.java
+++ b/platform-sdk/consensus-event-creator/src/main/java/org/hiero/consensus/event/creator/EventCreatorModule.java
@@ -112,19 +112,21 @@ public interface EventCreatorModule {
     InputWire<SyncProgress> syncProgressInputWire();
 
     /**
-     * {@link InputWire} for the quiescence command. The event creator will always behave according to the most recent
-     * quiescence command that it has been given.
-     *
-     * @return the {@link InputWire} for the sync round lag
-     */
-    @InputWireLabel("quiescence")
-    @NonNull
-    InputWire<QuiescenceCommand> quiescenceCommandInputWire();
-
-    /**
      * Destroys the module.
      */
     void destroy();
+
+    /**
+     * Submit a quiescence command to the platform monitor.
+     *
+     * @param quiescenceCommand the quiescence command to submit
+     */
+    void submitQuiescenceCommand(@NonNull QuiescenceCommand quiescenceCommand);
+
+    /**
+     * Flushes all events of the internal event creation manager.
+     */
+    void flush();
 
     // **************************************************************
     // Temporary workaround to allow reuse of the EventCreator module
@@ -136,13 +138,6 @@ public interface EventCreatorModule {
      * <p>Please note that this method is a temporary workaround and will be removed in the future.
      */
     void startSquelching();
-
-    /**
-     * Flushes all events of the internal event creation manager.
-     *
-     * <p>Please note that this method is a temporary workaround and will be removed in the future.
-     */
-    void flush();
 
     /**
      * Stops squelching the internal event creation manager.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -12,7 +12,6 @@ import com.swirlds.common.notification.NotificationEngine;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.metrics.RuntimeMetrics;
 import com.swirlds.platform.system.Platform;
-import com.swirlds.platform.wiring.PlatformCoordinator;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,8 +62,6 @@ public class SwirldsPlatform implements Platform {
      */
     private final NotificationEngine notificationEngine;
 
-    private final PlatformCoordinator platformCoordinator;
-
     private final PlatformContext platformContext;
     private final ConsensusLayerInputs inputs;
     private final ConsensusLayerBuildingBlocks buildingBlocks;
@@ -74,7 +71,6 @@ public class SwirldsPlatform implements Platform {
      */
     public SwirldsPlatform(
             @NonNull final ConsensusLayerInputs inputs,
-            @NonNull final PlatformCoordinator platformCoordinator,
             @NonNull final ConsensusLayerBuildingBlocks buildingBlocks,
             final long initialAncientThreshold,
             final long startingRound) {
@@ -86,7 +82,6 @@ public class SwirldsPlatform implements Platform {
                 inputs.metrics(),
                 inputs.fileSystemManager(),
                 inputs.recycleBin());
-        this.platformCoordinator = platformCoordinator;
         this.initialAncientThreshold = initialAncientThreshold;
         this.startingRound = startingRound;
 
@@ -167,7 +162,8 @@ public class SwirldsPlatform implements Platform {
      */
     @Override
     public void quiescenceCommand(@NonNull final QuiescenceCommand quiescenceCommand) {
-        platformCoordinator.quiescenceCommand(quiescenceCommand);
+        buildingBlocks.statusMonitorModule().submitQuiescenceCommand(quiescenceCommand);
+        buildingBlocks.eventCreatorModule().submitQuiescenceCommand(quiescenceCommand);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -202,15 +202,11 @@ public class PlatformBuilder<T extends PlatformBuilder<T>> {
 
         final SwirldsPlatform platform;
         if (startedFromGenesis) {
-            platform = new SwirldsPlatform(inputs, platformCoordinator, buildingBlocks, 0, 0);
+            platform = new SwirldsPlatform(inputs, buildingBlocks, 0, 0);
         } else {
             final long initialAncientThreshold = ancientThresholdOf(initialSignedState.getState());
-            platform = new SwirldsPlatform(
-                    inputs,
-                    platformCoordinator,
-                    buildingBlocks,
-                    initialAncientThreshold,
-                    initialSignedState.getRound());
+            platform =
+                    new SwirldsPlatform(inputs, buildingBlocks, initialAncientThreshold, initialSignedState.getRound());
         }
 
         InitialStateLoader.initializeModulesWithInitialState(platform, inputs, buildingBlocks, platformCoordinator);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -4,9 +4,7 @@ package com.swirlds.platform.wiring;
 import com.swirlds.platform.components.EventWindowManager;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
-import org.hiero.consensus.event.creator.EventCreatorModule;
 import org.hiero.consensus.model.hashgraph.EventWindow;
-import org.hiero.consensus.model.quiescence.QuiescenceCommand;
 
 /**
  * Responsible for coordinating activities through the component's wire for the platform.
@@ -66,13 +64,5 @@ public record PlatformCoordinator(@NonNull PlatformComponents components) {
         // Since there is asynchronous access to the shadowgraph, it's important to ensure that
         // it has fully ingested the new event window before continuing.
         components.gossipModule().flush();
-    }
-
-    /**
-     * @see EventCreatorModule#quiescenceCommandInputWire()
-     */
-    public void quiescenceCommand(@NonNull final QuiescenceCommand quiescenceCommand) {
-        components.statusMonitorModule().submitQuiescenceCommand(quiescenceCommand);
-        components.eventCreatorModule().quiescenceCommandInputWire().inject(quiescenceCommand);
     }
 }


### PR DESCRIPTION
**Description**:

This PR moves the quiescence-calls to the `SwirldsPlatform`. It also replaces the `InputWire` from the `EventCreatorModule` with a direct method.

**Related issue(s)**:

Fixes #26481 