### PR TITLE
ci(workflow-fix): fix determinism cache key bug

### DIFF
--- a/.github/workflows/822-call-verify-docker-determinism.yaml
+++ b/.github/workflows/822-call-verify-docker-determinism.yaml
@@ -115,7 +115,7 @@ jobs:
       - name: Baseline Existence Check
         id: baseline
         run: |
-          BASELINE_NAME="${{ steps.commit.outputs.sha }}.tar.gz"
+          BASELINE_NAME="${{ steps.commit-prefix.outputs.prefix }}-${{ steps.commit.outputs.sha }}.tar.gz"
           BASELINE_PATH="gs://hedera-ci-ephemeral-artifacts/${{ github.repository }}/docker/baselines"
           BASELINE_FILE="${BASELINE_PATH}/${BASELINE_NAME}"
           BASELINE_EXISTS="false"

--- a/.github/workflows/823-call-verify-gradle-determinism.yaml
+++ b/.github/workflows/823-call-verify-gradle-determinism.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Baseline Existence Check
         id: baseline
         run: |
-          BASELINE_NAME="${{ steps.commit.outputs.sha }}.tar.gz"
+          BASELINE_NAME="${{ steps.commit-prefix.outputs.prefix }}-${{ steps.commit.outputs.sha }}.tar.gz"
           BASELINE_PATH="gs://hedera-ci-ephemeral-artifacts/${{ github.repository }}/gradle/baselines"
           BASELINE_FILE="${BASELINE_PATH}/${BASELINE_NAME}"
           BASELINE_EXISTS="false"


### PR DESCRIPTION
**Description**:

Update the package name for sha-based determinism checks to ensure cache hit/miss is accurate.

**Related Issue(s)**:

Fixes #26490

**Testing**:

MATS Dry Run for `build-00366` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29936100396) ✅ 
- Previously failed MATS Dry Run for `build-00366` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29923351509)

MATS Dry Run for `release/0.77` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29936270761) 🏃 
- Previously failed MATS Dry Run for `release/0.77` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29919906677)