### PR TITLE
ci(workflow-fix): fix determinism cache key bug (#26491)

### DIFF
--- a/.github/workflows/822-call-verify-docker-determinism.yaml
+++ b/.github/workflows/822-call-verify-docker-determinism.yaml
@@ -115,7 +115,7 @@ jobs:
       - name: Baseline Existence Check
         id: baseline
         run: |
-          BASELINE_NAME="${{ steps.commit.outputs.sha }}.tar.gz"
+          BASELINE_NAME="${{ steps.commit-prefix.outputs.prefix }}-${{ steps.commit.outputs.sha }}.tar.gz"
           BASELINE_PATH="gs://hedera-ci-ephemeral-artifacts/${{ github.repository }}/docker/baselines"
           BASELINE_FILE="${BASELINE_PATH}/${BASELINE_NAME}"
           BASELINE_EXISTS="false"

--- a/.github/workflows/823-call-verify-gradle-determinism.yaml
+++ b/.github/workflows/823-call-verify-gradle-determinism.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: Baseline Existence Check
         id: baseline
         run: |
-          BASELINE_NAME="${{ steps.commit.outputs.sha }}.tar.gz"
+          BASELINE_NAME="${{ steps.commit-prefix.outputs.prefix }}-${{ steps.commit.outputs.sha }}.tar.gz"
           BASELINE_PATH="gs://hedera-ci-ephemeral-artifacts/${{ github.repository }}/gradle/baselines"
           BASELINE_FILE="${BASELINE_PATH}/${BASELINE_NAME}"
           BASELINE_EXISTS="false"


### PR DESCRIPTION
**Description**:

Cherry-pick for #26490 to the `release/0.77` branch.

**Related issue(s)**:

Fixes #26490 

**Testing**:

Running MATS Dry Run [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29939722309) with private branch workflow and `release/0.77` ref to test. 🏃 
