### PR TITLE
chore: Update BlockRecordStreamConfig for WRB hash writing to disk

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockRecordStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockRecordStreamConfig.java
@@ -54,7 +54,7 @@ public record BlockRecordStreamConfig(
         @ConfigProperty(defaultValue = "concurrent") @NetworkProperty
         String streamFileProducer,
 
-        @ConfigProperty(defaultValue = "false") @NetworkProperty
+        @ConfigProperty(defaultValue = "true") @NetworkProperty
         boolean writeWrappedRecordFileBlockHashesToDisk,
 
         @ConfigProperty(defaultValue = "/opt/hgcapp/wrappedRecordHashes") @NodeProperty


### PR DESCRIPTION
**Description**:
This pull request makes a minor configuration change to the `BlockRecordStreamConfig` class. The default value for the `writeWrappedRecordFileBlockHashesToDisk` property is changed from `false` to `true`, enabling this feature by default.

- Configuration change:
  * The `writeWrappedRecordFileBlockHashesToDisk` property in `BlockRecordStreamConfig` now defaults to `true` instead of `false`, so wrapped record file block hashes will be written to disk by default.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
