### PR TITLE
fix: cherry-pick: Clear jumpstart hash queue

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchema.java
@@ -67,6 +67,7 @@ public class V0750BlockRecordSchema extends Schema<SemanticVersion> {
                         .votingComplete(false)
                         .votingCompletionDeadlineBlockNumber(votingCompletionDeadlineBlockNumber)
                         .migrationRootHashVotes(List.of())
+                        .migrationWrappedHashes(List.of())
                         .build());
                 log.info(
                         "Initialized wrapped record voting singleton with deadline={}",

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0760BlockRecordSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/schemas/V0760BlockRecordSchema.java
@@ -98,6 +98,7 @@ public class V0760BlockRecordSchema extends Schema<SemanticVersion> {
                         .votingComplete(false)
                         .votingCompletionDeadlineBlockNumber(votingCompletionDeadlineBlockNumber)
                         .migrationRootHashVotes(List.of())
+                        .migrationWrappedHashes(List.of())
                         .build());
                 log.info(
                         "Initialized wrapped record voting singleton with deadline={}",

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/schemas/V0750BlockRecordSchemaTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
+import com.hedera.hapi.node.state.blockrecords.MigrationWrappedHashes;
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
@@ -155,6 +156,7 @@ class V0750BlockRecordSchemaTest {
                         .votingComplete(false)
                         .votingCompletionDeadlineBlockNumber(baseBlockInfo().lastBlockNumber() + 10)
                         .migrationRootHashVotes(List.of())
+                        .migrationWrappedHashes(List.of())
                         .build());
     }
 
@@ -176,6 +178,38 @@ class V0750BlockRecordSchemaTest {
                         .votingComplete(false)
                         .votingCompletionDeadlineBlockNumber(baseBlockInfo().lastBlockNumber() + 10)
                         .migrationRootHashVotes(List.of())
+                        .migrationWrappedHashes(List.of())
+                        .build());
+    }
+
+    @Test
+    void restartClearsStaleWrappedHashQueueOnNewJumpstartCycle() {
+        givenRestartPreconditions();
+        givenCutoverDisabled();
+        given(configuration.getConfigData(BlockStreamJumpstartConfig.class)).willReturn(blockStreamJumpstartConfig);
+        given(blockStreamJumpstartConfig.blockNum()).willReturn(1L);
+        given(ctx.newStates()).willReturn(writableStates);
+        given(writableStates.<BlockInfo>getSingleton(BLOCKS_STATE_ID)).willReturn(blockInfoState);
+        final var staleHash = MigrationWrappedHashes.newBuilder()
+                .blockNumber(39952)
+                .consensusTimestampHash(Bytes.fromHex("aa".repeat(48)))
+                .outputItemsTreeRootHash(Bytes.fromHex("bb".repeat(48)))
+                .build();
+        given(blockInfoState.get())
+                .willReturn(baseBlockInfo()
+                        .copyBuilder()
+                        .migrationWrappedHashes(List.of(staleHash))
+                        .build());
+
+        subject.restart(ctx);
+
+        verify(blockInfoState)
+                .put(baseBlockInfo()
+                        .copyBuilder()
+                        .votingComplete(false)
+                        .votingCompletionDeadlineBlockNumber(baseBlockInfo().lastBlockNumber() + 10)
+                        .migrationRootHashVotes(List.of())
+                        .migrationWrappedHashes(List.of())
                         .build());
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/schemas/V0760BlockRecordSchemaTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/schemas/V0760BlockRecordSchemaTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
+import com.hedera.hapi.node.state.blockrecords.MigrationWrappedHashes;
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
@@ -224,6 +225,7 @@ class V0760BlockRecordSchemaTest {
                         .votingComplete(false)
                         .votingCompletionDeadlineBlockNumber(baseBlockInfo().lastBlockNumber() + 10)
                         .migrationRootHashVotes(List.of())
+                        .migrationWrappedHashes(List.of())
                         .build());
     }
 
@@ -245,6 +247,38 @@ class V0760BlockRecordSchemaTest {
                         .votingComplete(false)
                         .votingCompletionDeadlineBlockNumber(baseBlockInfo().lastBlockNumber() + 10)
                         .migrationRootHashVotes(List.of())
+                        .migrationWrappedHashes(List.of())
+                        .build());
+    }
+
+    @Test
+    void restartClearsStaleWrappedHashQueueOnNewJumpstartCycle() {
+        givenRestartPreconditions();
+        givenCutoverDisabled();
+        given(configuration.getConfigData(BlockStreamJumpstartConfig.class)).willReturn(blockStreamJumpstartConfig);
+        given(blockStreamJumpstartConfig.blockNum()).willReturn(1L);
+        given(ctx.newStates()).willReturn(writableStates);
+        given(writableStates.<BlockInfo>getSingleton(BLOCKS_STATE_ID)).willReturn(blockInfoState);
+        final var staleHash = MigrationWrappedHashes.newBuilder()
+                .blockNumber(39952)
+                .consensusTimestampHash(Bytes.fromHex("aa".repeat(48)))
+                .outputItemsTreeRootHash(Bytes.fromHex("bb".repeat(48)))
+                .build();
+        given(blockInfoState.get())
+                .willReturn(baseBlockInfo()
+                        .copyBuilder()
+                        .migrationWrappedHashes(List.of(staleHash))
+                        .build());
+
+        subject.restart(ctx);
+
+        verify(blockInfoState)
+                .put(baseBlockInfo()
+                        .copyBuilder()
+                        .votingComplete(false)
+                        .votingCompletionDeadlineBlockNumber(baseBlockInfo().lastBlockNumber() + 10)
+                        .migrationRootHashVotes(List.of())
+                        .migrationWrappedHashes(List.of())
                         .build());
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/JumpstartFileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/JumpstartFileSuite.java
@@ -44,6 +44,7 @@ import com.hedera.services.bdd.spec.utilops.upgrade.VerifyCutoverBlockStreamOp;
 import com.hedera.services.bdd.suites.regression.system.LifecycleTest;
 import com.hedera.services.bdd.suites.regression.system.MixedOperations;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -52,6 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.DynamicTest;
@@ -188,6 +190,38 @@ class JumpstartFileSuite implements LifecycleTest {
                         wrappedRecordHashes2.get(),
                         nodeComputedHash2.get(),
                         freezeBlockNum2.get())),
+                assertHgcaaLogContainsPattern(
+                        NodeSelector.exceptNodeIds(LATER_NODE_IDS),
+                        "Migration root hash voting finalized after node\\d+ vote, >1/3 threshold reached",
+                        Duration.ofSeconds(30)),
+                // Verify cycle 2's voting handler did not replay stale queued hashes from cycle 1.
+                // All "Applied queued hash for block{N}" entries processed by cycle 2's voting handler
+                // must have block numbers > cycle 2's freeze block (F2). Stale entries from cycle 1's
+                // voting window would have block numbers < F2 and would fail this assertion.
+                sourcing(() -> doingContextual(spec -> {
+                    final var node0 = spec.targetNetworkOrThrow().getRequiredNode(NodeSelector.byNodeId(0));
+                    final String log;
+                    try {
+                        log = Files.readString(node0.getExternalPath(ExternalPath.APPLICATION_LOG));
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    final int initIdx = log.lastIndexOf("Initialized wrapped record voting singleton with deadline=");
+                    assertTrue(initIdx >= 0, "Expected to find cycle 2 voting init in log");
+                    final var logAfterInit = log.substring(initIdx);
+                    final var appliedPattern = Pattern.compile("Applied queued hash for block(\\d+):");
+                    final var matcher = appliedPattern.matcher(logAfterInit);
+                    final long cycle2FreezeBlock = Long.parseLong(freezeBlockNum2.get());
+                    while (matcher.find()) {
+                        final long blockNum = Long.parseLong(matcher.group(1));
+                        assertTrue(
+                                blockNum > cycle2FreezeBlock,
+                                "Stale queued hash from prior jumpstart cycle detected: block "
+                                        + blockNum
+                                        + " <= cycle-2 freeze block "
+                                        + cycle2FreezeBlock);
+                    }
+                })),
                 // Distinct-by-construction: the second cycle used a different jumpstart block than the first.
                 doAdhoc(() -> assertNotEquals(
                         jumpstartConfig.get().blockNum(),


### PR DESCRIPTION
**Description**:
This PR cherry-picks commit c8dc7072c37efcf4ac473de046e34019537f8877 for release/0.76

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
