### PR TITLE
fix: improve how the connection worker loop handles pending requests

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnection.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringJoiner;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow;
@@ -1214,48 +1215,79 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
                 final int itemSize = item.size() + requestItemPaddingBytes;
                 final long newRequestBytes = pendingRequestBytes + itemSize;
 
-                if (itemSize > hardLimitBytes) {
-                    // the item exceeds the absolute max request size (even without accounting for request overhead)
-                    // if there are any pending items, attempt to send them but regardless of the outcome we want to
-                    // close the connection
-                    try {
-                        trySendPendingRequest();
-                    } catch (final Exception _) {
-                        // ignore exception... we are about to close the connection
-                    }
-                    blockStreamMetrics.recordRequestExceedsHardLimit();
-                    logger.error(
-                            "{} !!! FATAL: Block item exceeds max message size hard limit; closing connection (block: {}, itemIndex: {}, itemSize: {} bytes, sizeHardLimit: {} bytes)",
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                            "{} Trying to add item to pending request (block: {}, itemIndex: {}, itemBytes: {}, itemType: {}, pendingItems: {}->{}, estimatedPendingBytes: {}->{})",
                             BlockNodeStreamingConnection.this,
                             block.blockNumber(),
                             itemIndex,
                             itemSize,
+                            item.itemType(),
+                            pendingRequestItems.size(),
+                            pendingRequestItems.size() + 1,
+                            pendingRequestBytes,
+                            newRequestBytes);
+                }
+
+                if (itemSize > hardLimitBytes) {
+                    // the item exceeds the absolute max request size (even without accounting for request overhead)
+                    // if there are any pending items, attempt to send them but regardless of the outcome we want to
+                    // ultimately close the connection
+                    if (!pendingRequestItems.isEmpty()) {
+                        logger.trace(
+                                "{} Block item exceeds the max message size hard limit; attempting to send any preceding items (largeItemIndex: {})",
+                                BlockNodeStreamingConnection.this,
+                                item.index());
+                        if (trySendPendingRequest() && itemIndex != item.index()) {
+                            // we've successfully sent some pending items, but there are still more to send so try again
+                            // before closing the connection
+                            continue;
+                        }
+                    }
+                    blockStreamMetrics.recordRequestExceedsHardLimit();
+                    logger.error(
+                            "{} !!! FATAL: Block item exceeds max message size hard limit; closing connection (block: {}, itemIndex: {}, itemSize: {} bytes, itemType: {}, sizeHardLimit: {} bytes)",
+                            BlockNodeStreamingConnection.this,
+                            block.blockNumber(),
+                            itemIndex,
+                            itemSize,
+                            item.itemType(),
                             hardLimitBytes);
                     sendEndStream(ERROR);
                     close(CloseReason.INTERNAL_ERROR, true);
                     return true;
-                } else if (itemSize >= softLimitBytes) {
+                } else if (newRequestBytes >= softLimitBytes) {
+                    if (logger.isTraceEnabled()) {
+                        logger.trace(
+                                "{} Item (block: {}, index: {}, type: {}, bytes: {}) will cause current pending request to exceed soft limit; it will be sent in another request (expectedBytes: {}, softLimitBytes: {})",
+                                BlockNodeStreamingConnection.this,
+                                block.blockNumber(),
+                                itemIndex,
+                                item.itemType(),
+                                itemSize,
+                                newRequestBytes,
+                                softLimitBytes);
+                    }
                     // the item is too large to fit into a normal request, so make it a part of its own request
                     // we want to send any previous pending items first though
                     if (!pendingRequestItems.isEmpty() && !trySendPendingRequest()) {
                         return true; // failed to send the request for some reason; exit early
                     }
 
-                    // add the new large item to its own request and try to send it
-                    pendingRequestItems.add(item);
-                    pendingRequestBytes += itemSize;
-                    pendingRequestHasBlockProof |= item.isProof();
-                    pendingRequestHasBlockHeader |= item.isHeader();
-                    ++itemIndex;
-
-                    if (!trySendPendingRequest()) {
-                        return true; // failed to send the request for some reason; exit early
-                    }
-                } else if (newRequestBytes > softLimitBytes) {
-                    // if we add the item to the current request, the request would exceed the soft limit so send
-                    // the pending request and start a new request with the item
-                    if (!trySendPendingRequest()) {
-                        return true; // failed to send the request for some reason; exit early
+                    if (itemIndex == item.index()) {
+                        /*
+                        trySendPendingRequest() may rollback the items added to the pending request if the actual
+                        request exceeds our limits. When this happens, the current item index is decremented one or more
+                        times. Thus, we should only add the current item to the next pending request if, and only if,
+                        the current item index is the same as the item we originally tried to add. If they don't match,
+                        we don't want to add the item and instead reenter the main loop and let it add the correct
+                        item(s) to maintain proper order.
+                         */
+                        pendingRequestItems.add(item);
+                        pendingRequestBytes += itemSize;
+                        pendingRequestHasBlockProof |= item.isProof();
+                        pendingRequestHasBlockHeader |= item.isHeader();
+                        ++itemIndex;
                     }
                 } else {
                     // adding the item to the current pending item wouldn't exceed the soft limit so add it
@@ -1418,15 +1450,28 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
             // now that we are able to build the real request we can finally determine the true size of the request
             // instead of just doing a best-guess estimate that we've been doing up until this point
 
+            if (logger.isTraceEnabled()) {
+                final StringJoiner joiner = new StringJoiner(",");
+                pendingRequestItems.forEach(item -> joiner.add(Integer.toString(item.index())));
+                logger.trace(
+                        "{} Wanting to send pending items (block: {}, items: {}=[{}], reqBytes: {})",
+                        BlockNodeStreamingConnection.this,
+                        block.blockNumber(),
+                        pendingRequestItems.size(),
+                        joiner,
+                        reqBytes);
+            }
+
             if (reqBytes > softLimitBytes && pendingRequestItems.size() > 1) {
                 // the multi-item request exceeds the soft limit
                 // try to remove the last item from the request and try sending again
                 blockStreamMetrics.recordMultiItemRequestExceedsSoftLimit();
                 logger.trace(
-                        "{} Multi-item request exceeds soft limit; will attempt to remove last item and send again (requestSize: {}, items: {})",
+                        "{} Multi-item request exceeds soft limit; will attempt to remove last item and send again (items: {}, requestSize: {}, softLimitBytes: {})",
                         BlockNodeStreamingConnection.this,
+                        pendingRequestItems.size(),
                         reqBytes,
-                        pendingRequestItems.size());
+                        softLimitBytes);
                 // remove the last item from the pending item set and update state to reflect the removal of the item
                 final BufferedItem item = pendingRequestItems.removeLast();
                 --itemIndex;
@@ -1453,13 +1498,18 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
                 return false;
             }
 
-            logger.trace(
-                    "{} Attempting to send request (block: {}, request: {}, itemCount: {}, bytes: {})",
-                    BlockNodeStreamingConnection.this,
-                    block.blockNumber(),
-                    requestCtr.get(),
-                    pendingRequestItems.size(),
-                    reqBytes);
+            if (logger.isTraceEnabled()) {
+                final StringJoiner joiner = new StringJoiner(",");
+                pendingRequestItems.forEach(item -> joiner.add(Integer.toString(item.index())));
+                logger.trace(
+                        "{} Attempting to send request (block: {}, request: {}, items: {}=[{}], bytes: {})",
+                        BlockNodeStreamingConnection.this,
+                        block.blockNumber(),
+                        requestCtr.get(),
+                        pendingRequestItems.size(),
+                        joiner,
+                        reqBytes);
+            }
 
             try {
                 final SendRequestResult result = sendRequest(new BlockItemsStreamRequest(

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
@@ -96,7 +96,7 @@ public class BlockState {
         }
 
         final int index = itemIndex.incrementAndGet();
-        bufferedItems.put(index, new BufferedItem(serializedItem, itemType));
+        bufferedItems.put(index, new BufferedItem(serializedItem, itemType, index));
         if (itemType == BlockItem.ItemOneOfType.BLOCK_HEADER) {
             openedNanos = System.nanoTime();
             openedTimestamp = Instant.now();
@@ -336,9 +336,10 @@ public class BlockState {
      *
      * @param serializedItem the full serialized bytes of a single {@link BlockItem}
      * @param itemType the type of the item
+     * @param index the position of the item within the block (0-based)
      */
     public record BufferedItem(
-            @NonNull Bytes serializedItem, @NonNull BlockItem.ItemOneOfType itemType) {
+            @NonNull Bytes serializedItem, @NonNull BlockItem.ItemOneOfType itemType, int index) {
         public BufferedItem {
             requireNonNull(serializedItem, "serializedItem must not be null");
             requireNonNull(itemType, "itemType must not be null");

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
@@ -44,8 +44,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -60,6 +62,7 @@ import org.hiero.block.api.PublishStreamRequest.EndStream;
 import org.hiero.block.api.PublishStreamResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -338,7 +341,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
          */
         final BlockItem item1 = newBlockTxItem(2_095_148);
         final BlockItem item2 = newBlockTxItem(997);
-        final BlockItem item3 = newBlockTxItem(997);
+        final BlockItem item3 = newBlockTxItem(996);
         final BlockItem item4 = newBlockTxItem(1_500);
 
         block.addItem(item1);
@@ -505,6 +508,8 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
      * - Few items (1-2) that test minimal block case
      */
     @Test
+    @Disabled(
+            "This test creates a lot of data that isn't being cleaned up for some reason and causes memory exhaustion")
     void testConnectionWorker_sendMultipleBlocks() throws InterruptedException {
         // Fixed seed for reproducibility - if this test fails, the seed ensures the exact same
         // sequence of values will be generated, making the failure reproducible.
@@ -651,6 +656,282 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         // The worker checks if the connection has fallen too far behind.
         verify(bufferService, atLeastOnce()).getEarliestAvailableBlockNumber();
         verifyNoMoreInteractions(bufferService);
+    }
+
+    @Test
+    void testConnectionWorker_sendPendingRequest_multiItemRequestExceedsSoftLimit_lotsOfSmallItems() throws Exception {
+        /*
+        This test generates a lot of small items. The initial fast calculation to add items to the pending request will
+        cause too many items to be added. When an attempt is made to send the pending request, we will detect that the
+        actual size of the request is too large. When this happens, multiple items will be removed from the pending
+        request to try to reach the size requirement. This test ensures that the requests contain the proper items in
+        the proper order when we "unroll" a pending request multiple times.
+         */
+        final TestConfigBuilder cfgBuilder = createDefaultConfigProvider()
+                .withValue("blockNode.streamingRequestPaddingBytes", "0")
+                .withValue("blockNode.streamingRequestItemPaddingBytes", "0");
+        configProvider = createConfigProvider(cfgBuilder);
+        connection = new BlockNodeStreamingConnection(
+                configProvider,
+                new BlockNode(configProvider, nodeConfig, globalActiveStreamingConnectionCount, new BlockNodeStats()),
+                connectionManager,
+                bufferService,
+                metrics,
+                pipelineExecutor,
+                null,
+                clientFactory,
+                NODE_ID,
+                streamingObs);
+
+        lenient().doReturn(requestCall).when(grpcServiceClient).publishBlockStream(connection);
+        openConnectionAndResetMocks();
+        final AtomicReference<Thread> workerThreadRef = workerThreadRef();
+        workerThreadRef.set(null); // clear the fake worker thread
+        final AtomicLong streamingBlockNumber = streamingBlockNumber();
+
+        streamingBlockNumber.set(10);
+
+        final BlockNodeConfiguration config = connection.configuration();
+        // sanity check to make sure the sizes we are about to use are within the scope of the soft and hard limits
+        assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
+        assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
+
+        final BlockState block = new BlockState(10);
+        doReturn(block).when(bufferService).getBlockState(10);
+
+        final Map<Integer, BlockItem> items = new TreeMap<>();
+        items.put(0, newBlockTxItem(2_095_148));
+        items.put(1, newBlockTxItem(997));
+        items.put(2, newBlockTxItem(950));
+
+        for (int i = 3; i < 30; ++i) {
+            items.put(i, newBlockTxItem(2));
+        }
+
+        items.forEach((_, item) -> block.addItem(item));
+        block.closeBlock();
+
+        final CountDownLatch latestBlockEndSentLatch = new CountDownLatch(1);
+        doAnswer(_ -> {
+                    latestBlockEndSentLatch.countDown();
+                    return null;
+                })
+                .when(metrics)
+                .recordLatestBlockEndOfBlockSent(anyLong());
+
+        connection.updateConnectionState(ConnectionState.ACTIVE);
+
+        assertThat(latestBlockEndSentLatch.await(2, TimeUnit.SECONDS))
+                .as("Worker thread should record latest block end-of-block sent")
+                .isTrue();
+
+        final ArgumentCaptor<PublishStreamRequestBytes> requestCaptor =
+                ArgumentCaptor.forClass(PublishStreamRequestBytes.class);
+        verify(requestCall, times(3)).sendRequest(requestCaptor.capture(), anyBoolean());
+        assertThat(requestCaptor.getAllValues()).hasSize(3);
+        final List<PublishStreamRequestBytes> requests = requestCaptor.getAllValues();
+
+        final Bytes[] expectedReq1Items = new Bytes[] {
+            toBytes(items.get(0)),
+            toBytes(items.get(1)),
+            toBytes(items.get(2)),
+            toBytes(items.get(3)),
+            toBytes(items.get(4)),
+            toBytes(items.get(5)),
+            toBytes(items.get(6)),
+            toBytes(items.get(7))
+        };
+        final PublishStreamRequestBytes req1 = requests.get(0);
+        final List<Bytes> actualReq1Items =
+                req1.blockItemsOrElse(BlockItemSetBytes.DEFAULT).blockItems();
+        assertThat(actualReq1Items).hasSize(expectedReq1Items.length);
+        for (int i = 0; i < expectedReq1Items.length; ++i) {
+            final Bytes expected = expectedReq1Items[i];
+            final Bytes actual = actualReq1Items.get(i);
+            assertThat(actual)
+                    .withFailMessage(
+                            "Req 1 item at index %s does not match expected (expected: %s, actual: %s)",
+                            i, expected, actual)
+                    .isEqualTo(expected);
+        }
+
+        final Bytes[] expectedReq2Items = new Bytes[22];
+        for (int i = 8; i < 30; ++i) {
+            expectedReq2Items[i - 8] = toBytes(items.get(i));
+        }
+        final PublishStreamRequestBytes req2 = requests.get(1);
+        final List<Bytes> actualReq2Items =
+                req2.blockItemsOrElse(BlockItemSetBytes.DEFAULT).blockItems();
+        assertThat(actualReq2Items).hasSize(expectedReq2Items.length);
+        for (int i = 0; i < expectedReq2Items.length; ++i) {
+            final Bytes expected = expectedReq2Items[i];
+            final Bytes actual = actualReq2Items.get(i);
+            assertThat(actual)
+                    .withFailMessage(
+                            "Req 2 item at index %s does not match expected (expected: %s, actual: %s)",
+                            i, expected, actual)
+                    .isEqualTo(expected);
+        }
+
+        final PublishStreamRequestBytes req3 = requests.get(2);
+        assertThat(req3.endOfBlockOrElse(BlockEnd.DEFAULT).blockNumber()).isEqualTo(block.blockNumber());
+
+        verify(metrics, times(6)).recordMultiItemRequestExceedsSoftLimit();
+        verify(metrics, times(3)).recordRequestLatency(anyLong());
+        verify(metrics, times(2)).recordBlockItemsSent(anyInt());
+        verify(metrics, times(2)).recordRequestSent(RequestOneOfType.BLOCK_ITEMS);
+        verify(metrics).recordRequestSent(RequestOneOfType.END_OF_BLOCK);
+        verify(metrics, atLeastOnce()).recordRequestBlockItemCount(anyInt());
+        verify(metrics, atLeastOnce()).recordRequestBytes(anyLong());
+        verify(metrics, atLeastOnce()).recordStreamingBlockNumber(anyLong());
+        verify(metrics, atLeastOnce()).recordLatestBlockEndOfBlockSent(anyLong());
+        verify(connectionManager).notifyConnectionActive(connection);
+        verifyNoMoreInteractions(metrics);
+        verifyNoMoreInteractions(requestCall);
+        verifyNoMoreInteractions(connectionManager);
+    }
+
+    @Test
+    void testConnectionWorker_sendPendingRequest_lotsOfSmallItemsWithOneTooBig() throws Exception {
+        /*
+        This test generates a lot of small items. The initial fast calculation to add items to the pending request will
+        cause too many items to be added. When an attempt is made to send the pending request, we will detect that the
+        actual size of the request is too large. When this happens, multiple items will be removed from the pending
+        request to try to reach the size requirement. This test ensures that the requests contain the proper items in
+        the proper order when we "unroll" a pending request multiple times.
+         */
+        final TestConfigBuilder cfgBuilder = createDefaultConfigProvider()
+                .withValue("blockNode.streamingRequestPaddingBytes", "0")
+                .withValue("blockNode.streamingRequestItemPaddingBytes", "0");
+        configProvider = createConfigProvider(cfgBuilder);
+        connection = new BlockNodeStreamingConnection(
+                configProvider,
+                new BlockNode(configProvider, nodeConfig, globalActiveStreamingConnectionCount, new BlockNodeStats()),
+                connectionManager,
+                bufferService,
+                metrics,
+                pipelineExecutor,
+                null,
+                clientFactory,
+                NODE_ID,
+                streamingObs);
+
+        lenient().doReturn(requestCall).when(grpcServiceClient).publishBlockStream(connection);
+        openConnectionAndResetMocks();
+        final AtomicReference<Thread> workerThreadRef = workerThreadRef();
+        workerThreadRef.set(null); // clear the fake worker thread
+        final AtomicLong streamingBlockNumber = streamingBlockNumber();
+
+        streamingBlockNumber.set(10);
+
+        final BlockNodeConfiguration config = connection.configuration();
+        // sanity check to make sure the sizes we are about to use are within the scope of the soft and hard limits
+        assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
+        assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
+
+        final BlockState block = new BlockState(10);
+        doReturn(block).when(bufferService).getBlockState(10);
+
+        final Map<Integer, BlockItem> items = new TreeMap<>();
+        items.put(0, newBlockTxItem(2_095_148));
+        items.put(1, newBlockTxItem(997));
+        items.put(2, newBlockTxItem(950));
+
+        for (int i = 3; i < 14; ++i) {
+            items.put(i, newBlockTxItem(2));
+        }
+
+        items.put(14, newBlockTxItem(40_000_000));
+
+        items.forEach((_, item) -> block.addItem(item));
+
+        block.closeBlock();
+
+        final CountDownLatch connectionClosedLatch = new CountDownLatch(1);
+        doAnswer(_ -> {
+                    connectionClosedLatch.countDown();
+                    return null;
+                })
+                .when(metrics)
+                .recordConnectionClosed(any(CloseReason.class));
+
+        connection.updateConnectionState(ConnectionState.ACTIVE);
+
+        assertThat(connectionClosedLatch.await(2, TimeUnit.SECONDS))
+                .as("Worker thread should record latest block end-of-block sent")
+                .isTrue();
+
+        final ArgumentCaptor<PublishStreamRequestBytes> requestCaptor =
+                ArgumentCaptor.forClass(PublishStreamRequestBytes.class);
+        verify(requestCall, times(3)).sendRequest(requestCaptor.capture(), anyBoolean());
+        assertThat(requestCaptor.getAllValues()).hasSize(3);
+        final List<PublishStreamRequestBytes> requests = requestCaptor.getAllValues();
+
+        final Bytes[] expectedReq1Items = new Bytes[] {
+            toBytes(items.get(0)),
+            toBytes(items.get(1)),
+            toBytes(items.get(2)),
+            toBytes(items.get(3)),
+            toBytes(items.get(4)),
+            toBytes(items.get(5)),
+            toBytes(items.get(6)),
+            toBytes(items.get(7))
+        };
+        final PublishStreamRequestBytes req1 = requests.get(0);
+        final List<Bytes> actualReq1Items =
+                req1.blockItemsOrElse(BlockItemSetBytes.DEFAULT).blockItems();
+        assertThat(actualReq1Items).hasSize(expectedReq1Items.length);
+        for (int i = 0; i < expectedReq1Items.length; ++i) {
+            final Bytes expected = expectedReq1Items[i];
+            final Bytes actual = actualReq1Items.get(i);
+            assertThat(actual)
+                    .withFailMessage(
+                            "Req 1 item at index %s does not match expected (expected: %s, actual: %s)",
+                            i, expected, actual)
+                    .isEqualTo(expected);
+        }
+
+        final Bytes[] expectedReq2Items = new Bytes[] {
+            toBytes(items.get(8)),
+            toBytes(items.get(9)),
+            toBytes(items.get(10)),
+            toBytes(items.get(11)),
+            toBytes(items.get(12)),
+            toBytes(items.get(13)),
+        };
+        final PublishStreamRequestBytes req2 = requests.get(1);
+        final List<Bytes> actualReq2Items =
+                req2.blockItemsOrElse(BlockItemSetBytes.DEFAULT).blockItems();
+        assertThat(actualReq2Items).hasSize(expectedReq2Items.length);
+        for (int i = 0; i < expectedReq2Items.length; ++i) {
+            final Bytes expected = expectedReq2Items[i];
+            final Bytes actual = actualReq2Items.get(i);
+            assertThat(actual)
+                    .withFailMessage(
+                            "Req 2 item at index %s does not match expected (expected: %s, actual: %s)",
+                            i, expected, actual)
+                    .isEqualTo(expected);
+        }
+
+        final PublishStreamRequestBytes req3 = requests.get(2);
+        assertThat(req3.endStreamOrElse(EndStreamBytes.DEFAULT).endCode()).isEqualTo(EndStream.Code.ERROR);
+
+        verify(metrics, times(6)).recordMultiItemRequestExceedsSoftLimit();
+        verify(metrics, times(3)).recordRequestLatency(anyLong());
+        verify(metrics, times(2)).recordBlockItemsSent(anyInt());
+        verify(metrics, times(2)).recordRequestSent(RequestOneOfType.BLOCK_ITEMS);
+        verify(metrics).recordRequestEndStreamSent(EndStream.Code.ERROR);
+        verify(metrics, atLeastOnce()).recordRequestBlockItemCount(anyInt());
+        verify(metrics, atLeastOnce()).recordRequestBytes(anyLong());
+        verify(metrics, atLeastOnce()).recordStreamingBlockNumber(anyLong());
+        verify(connectionManager).notifyConnectionActive(connection);
+        verify(connectionManager).notifyConnectionClosed(connection);
+        verify(metrics).recordRequestExceedsHardLimit();
+        verify(metrics).recordConnectionClosed(CloseReason.INTERNAL_ERROR);
+        verify(requestCall).completeRequests();
+        verifyNoMoreInteractions(metrics);
+        verifyNoMoreInteractions(requestCall);
+        verifyNoMoreInteractions(connectionManager);
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
@@ -60,12 +60,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.hiero.block.api.BlockEnd;
 import org.hiero.block.api.PublishStreamRequest.EndStream;
 import org.hiero.block.api.PublishStreamResponse;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -191,6 +192,15 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         if (workerThread != null) {
             assertThat(workerThread.join(Duration.ofSeconds(2))).isTrue();
         }
+    }
+
+    @AfterAll
+    static void afterAll() {
+        // This test generates a lot of data that gets used in mocks. Mockito seems to hold on to this data even after
+        // these tests have fully completed. Because of this, there is elevated memory utilization after this test class
+        // is completed that can cause heap exhaustion. Thus, we force Mockito to clear out its data after all the
+        // tests have finished.
+        Mockito.framework().clearInlineMocks();
     }
 
     @Test
@@ -508,8 +518,6 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
      * - Few items (1-2) that test minimal block case
      */
     @Test
-    @Disabled(
-            "This test creates a lot of data that isn't being cleaned up for some reason and causes memory exhaustion")
     void testConnectionWorker_sendMultipleBlocks() throws InterruptedException {
         // Fixed seed for reproducibility - if this test fails, the seed ensures the exact same
         // sequence of values will be generated, making the failure reproducible.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionTest.java
@@ -62,6 +62,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.block.api.BlockEnd;
 import org.hiero.block.api.PublishStreamRequest.EndStream;
 import org.hiero.block.api.PublishStreamResponse;
 import org.hiero.block.api.PublishStreamResponse.EndOfStream;
@@ -1417,6 +1418,111 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         verifyNoMoreInteractions(connectionManager);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestCall);
+    }
+
+    @Test
+    void testConnectionWorker_nearSoftLimitSize() throws Exception {
+        activateConnection();
+        final AtomicLong streamingBlockNumber = streamingBlockNumber();
+
+        streamingBlockNumber.set(10);
+
+        final BlockNodeConfiguration config = connection.configuration();
+        // sanity check to make sure the sizes we are about to use are within the scope of the soft and hard limits
+        assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
+        assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
+
+        final BlockState block = new BlockState(10);
+        final BlockItem header = newBlockHeaderItem(10);
+        final BlockItem item = newBlockTxItem(2097120);
+        final BlockItem proof = newBlockProofItem(10, 2_000);
+
+        doReturn(block).when(bufferService).getBlockState(10);
+        lenient().when(bufferService.getEarliestAvailableBlockNumber()).thenReturn(10L);
+        lenient().when(bufferService.getHighestAckedBlockNumber()).thenReturn(-1L);
+
+        final ArgumentCaptor<PublishStreamRequestBytes> requestCaptor =
+                ArgumentCaptor.forClass(PublishStreamRequestBytes.class);
+        final Object worker = createWorker();
+
+        block.addItem(header);
+        invokeDoWork(worker); // header should get sent
+
+        Thread.sleep(200);
+        block.addItem(item);
+        invokeDoWork(worker); // the block item should get sent
+
+        Thread.sleep(200);
+        block.addItem(proof);
+        block.closeBlock();
+        invokeDoWork(worker); // the proof should be sent
+
+        verify(requestCall, times(4)).sendRequest(requestCaptor.capture(), anyBoolean());
+
+        final List<PublishStreamRequestBytes> requests = requestCaptor.getAllValues();
+        assertThat(requests).hasSize(4);
+
+        final PublishStreamRequestBytes req1 = requests.get(0);
+        assertThat(req1.blockItemsOrElse(BlockItemSetBytes.DEFAULT).blockItems())
+                .hasSize(1)
+                .containsExactly(toBytes(header));
+        final PublishStreamRequestBytes req2 = requests.get(1);
+        assertThat(req2.blockItemsOrElse(BlockItemSetBytes.DEFAULT).blockItems())
+                .hasSize(1)
+                .containsExactly(toBytes(item));
+        final PublishStreamRequestBytes req3 = requests.get(2);
+        assertThat(req3.blockItemsOrElse(BlockItemSetBytes.DEFAULT).blockItems())
+                .hasSize(1)
+                .containsExactly(toBytes(proof));
+        final PublishStreamRequestBytes req4 = requests.get(3);
+        assertThat(req4.endOfBlockOrElse(BlockEnd.DEFAULT).blockNumber()).isEqualTo(10);
+    }
+
+    @Test
+    void testConnectionWorker_twoConsecutiveItemsBetweenSoftAndHardLimit_mustNotFatallyClose() throws Exception {
+        activateConnection();
+        final AtomicLong streamingBlockNumber = streamingBlockNumber();
+
+        streamingBlockNumber.set(10);
+
+        final BlockNodeConfiguration config = connection.configuration();
+        // sanity check to make sure the sizes we are about to use are within the scope of the soft and hard limits
+        assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
+        assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
+
+        final BlockState block = new BlockState(10);
+        // Each item is 20 MB: above the 2 MB soft limit but well below the 36 MB hard limit.
+        // Individually valid, but 20 MB + 20 MB = 40 MB exceeds the hard limit.
+        final BlockItem item1 = newBlockTxItem(20_000_000);
+        final BlockItem item2 = newBlockTxItem(20_000_000);
+
+        block.addItem(item1);
+        block.addItem(item2);
+        block.closeBlock();
+
+        doReturn(block).when(bufferService).getBlockState(10);
+        lenient().when(bufferService.getEarliestAvailableBlockNumber()).thenReturn(10L);
+        lenient().when(bufferService.getHighestAckedBlockNumber()).thenReturn(-1L);
+
+        final ArgumentCaptor<PublishStreamRequestBytes> requestCaptor =
+                ArgumentCaptor.forClass(PublishStreamRequestBytes.class);
+        final Object worker = createWorker();
+
+        invokeDoWork(worker);
+
+        // The connection must NOT have been fatally closed: both items are valid and can each be sent in their own
+        // request. This is the primary signal of the bug.
+        verify(metrics, never()).recordRequestExceedsHardLimit();
+        verify(metrics, never()).recordRequestEndStreamSent(EndStream.Code.ERROR);
+        assertThat(connection.currentState()).isNotEqualTo(ConnectionState.CLOSED);
+        assertThat(connection.closeReason()).isNotEqualTo(CloseReason.INTERNAL_ERROR);
+
+        // Both items must actually have been sent, each in its own request.
+        verify(requestCall, atLeast(2)).sendRequest(requestCaptor.capture(), anyBoolean());
+        final List<Bytes> allSentItems = requestCaptor.getAllValues().stream()
+                .flatMap(req -> req.blockItemsOrElse(BlockItemSetBytes.DEFAULT).blockItems().stream())
+                .toList();
+        assertThat(allSentItems).contains(toBytes(item1), toBytes(item2));
     }
 
     @Test


### PR DESCRIPTION
**Description**:
Improve how the connection worker loop handles pending requests that are within the padding size of the soft/hard message size limits.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
