### PR TITLE
chore: Update wrapsVoteJitterPerRank and pipelineOperationTimeout 

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockNodeConnectionConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockNodeConnectionConfig.java
@@ -58,7 +58,7 @@ public record BlockNodeConnectionConfig(
         @ConfigProperty(defaultValue = "30s") @NodeProperty Duration grpcOverallTimeout,
         @ConfigProperty(defaultValue = "10ms") @NetworkProperty Duration connectionWorkerSleepDuration,
         @ConfigProperty(defaultValue = "100ms") @NetworkProperty Duration maxRequestDelay,
-        @ConfigProperty(defaultValue = "3s") @NodeProperty Duration pipelineOperationTimeout,
+        @ConfigProperty(defaultValue = "20s") @NodeProperty Duration pipelineOperationTimeout,
         @ConfigProperty(defaultValue = "100") @Min(0) @NetworkProperty int streamingRequestPaddingBytes,
         @ConfigProperty(defaultValue = "5") @Min(0) @NetworkProperty int streamingRequestItemPaddingBytes,
         @ConfigProperty(defaultValue = "1s") @NodeProperty Duration blockNodeStatusTimeout,

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TssConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TssConfig.java
@@ -59,7 +59,7 @@ public record TssConfig(
         @ConfigProperty(defaultValue = "10") @Min(0) @NetworkProperty
         int maxWrapsRetries,
 
-        @ConfigProperty(defaultValue = "5s") Duration wrapsVoteJitterPerRank,
+        @ConfigProperty(defaultValue = "2m") Duration wrapsVoteJitterPerRank,
 
         // Whether to double-check aggregate hinTS signature during block signing
         @ConfigProperty(defaultValue = "false") @NetworkProperty


### PR DESCRIPTION
**Description**:
This pull request updates timeout and jitter configuration defaults in the `hedera-config` module to better align with operational requirements. The most important changes are as follows:

**Timeout Configuration Updates**
* Increased the default value of `pipelineOperationTimeout` in `BlockNodeConnectionConfig` from 3 seconds to 20 seconds to allow more time for pipeline operations to complete.

**Jitter Configuration Updates**
* Increased the default value of `wrapsVoteJitterPerRank` in `TssConfig` from 5 seconds to 2 minutes.

**Related issue(s)**:

Fixes #26558 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
