### PR TITLE
fix: require an empty incoming treasury for every NFT treasury change

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -175,17 +175,23 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
         // Validate both accounts are not frozen and have the right keys
         final var oldTreasuryRel = getIfUsable(oldTreasury, tokenId, tokenRelStore);
         final var newTreasuryRel = getIfUsable(newTreasury, tokenId, tokenRelStore);
-        if (oldTreasuryRel.balance() > 0) {
+        final var hasBalanceToTransfer = oldTreasuryRel.balance() > 0;
+        if (hasBalanceToTransfer) {
             validateFrozenAndKey(oldTreasuryRel);
             validateFrozenAndKey(newTreasuryRel);
-
-            if (token.tokenType().equals(FUNGIBLE_COMMON)) {
+        }
+        if (token.tokenType().equals(FUNGIBLE_COMMON)) {
+            if (hasBalanceToTransfer) {
                 // Transfers fungible balances and updates account's numOfPositiveBalances
                 // and puts to modifications on state.
                 transferFungibleTokensToTreasury(oldTreasuryRel, newTreasuryRel, tokenRelStore, accountStore);
-            } else {
-                // Check whether new treasury has balance, if it does throw TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES
-                validateTrue(newTreasuryRel.balance() == 0, TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
+            }
+        } else {
+            // The incoming treasury must own no serials itself, whether the outgoing one has any
+            // left: changeOwnerToNewTreasury() hands NFTs over by relation balance alone, so serials the
+            // incoming treasury already owns would be orphaned by this or a later handoff
+            validateTrue(newTreasuryRel.balance() == 0, TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
+            if (hasBalanceToTransfer) {
                 // Transfers NFT ownerships and updates account's numOwnedNfts and
                 // tokenRelation's balance and puts to modifications on state.
                 changeOwnerToNewTreasury(oldTreasuryRel, newTreasuryRel, tokenRelStore, accountStore);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -187,9 +187,9 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
                 transferFungibleTokensToTreasury(oldTreasuryRel, newTreasuryRel, tokenRelStore, accountStore);
             }
         } else {
-            // The incoming treasury must own no serials itself, whether the outgoing one has any
-            // left: changeOwnerToNewTreasury() hands NFTs over by relation balance alone, so serials the
-            // incoming treasury already owns would be orphaned by this or a later handoff
+            // The incoming treasury must own no serials of its own, even when the outgoing one is empty:
+            // changeOwnerToNewTreasury() moves NFTs by relation balance alone, so a later handoff away
+            // from this account would zero counters covering serials it owns explicitly, orphaning them
             validateTrue(newTreasuryRel.balance() == 0, TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES);
             if (hasBalanceToTransfer) {
                 // Transfers NFT ownerships and updates account's numOwnedNfts and

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
@@ -521,6 +521,33 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     }
 
     @Test
+    void reportsMissingKycBeforeNonZeroBalanceWhenBothTreasuriesHoldNfts() {
+        // Dropping the kycKey stops updateTreasuryTitles() from resetting kycGranted on the incoming
+        // relation, leaving validateFrozenAndKey() something to reject. It must be reported ahead of
+        // the zero-balance check; hoisting that check above it would silently change this status.
+        writableTokenStore.put(writableTokenStore
+                .get(nonFungibleTokenId)
+                .copyBuilder()
+                .kycKey((Key) null)
+                .build());
+        given(storeFactory.readableStore(ReadableTokenStore.class)).willReturn(writableTokenStore);
+        givenTreasuryBalances(1, 1);
+        writableTokenRelStore.put(writableTokenRelStore
+                .get(payerId, nonFungibleTokenId)
+                .copyBuilder()
+                .kycGranted(false)
+                .build());
+        txn = new TokenUpdateBuilder()
+                .withTreasury(payerId)
+                .withToken(nonFungibleTokenId)
+                .build();
+        given(handleContext.body()).willReturn(txn);
+        assertThatThrownBy(() -> subject.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(TOKEN_HAS_NO_KYC_KEY));
+    }
+
+    @Test
     void worksWhenBothTreasuriesAreEmptyForNFT() {
         givenTreasuryBalances(0, 0);
         txn = new TokenUpdateBuilder()
@@ -560,23 +587,6 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         assertThat(writableTokenStore.get(fungibleTokenId).treasuryAccountId()).isEqualTo(ownerId);
         assertThat(writableTokenRelStore.get(treasuryId, fungibleTokenId).balance())
                 .isZero();
-    }
-
-    private void givenTreasuryBalances(final long oldTreasuryBalance, final long newTreasuryBalance) {
-        writableTokenRelStore.put(writableTokenRelStore
-                .get(treasuryId, nonFungibleTokenId)
-                .copyBuilder()
-                .balance(oldTreasuryBalance)
-                .build());
-        writableTokenRelStore.put(writableTokenRelStore
-                .get(payerId, nonFungibleTokenId)
-                .copyBuilder()
-                .balance(newTreasuryBalance)
-                .build());
-        given(expiryValidator.resolveUpdateAttempt(any(), any()))
-                .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
-        given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
-        given(storeFactory.readableStore(ReadableTokenRelationStore.class)).willReturn(writableTokenRelStore);
     }
 
     @Test
@@ -1322,6 +1332,27 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     }
 
     /* --------------------------------- Helpers --------------------------------- */
+    /**
+     * Sets the NFT relation balances of the outgoing ({@code treasuryId}) and incoming
+     * ({@code payerId}) treasuries, and stubs the expiry validation the handler needs.
+     */
+    private void givenTreasuryBalances(final long oldTreasuryBalance, final long newTreasuryBalance) {
+        writableTokenRelStore.put(writableTokenRelStore
+                .get(treasuryId, nonFungibleTokenId)
+                .copyBuilder()
+                .balance(oldTreasuryBalance)
+                .build());
+        writableTokenRelStore.put(writableTokenRelStore
+                .get(payerId, nonFungibleTokenId)
+                .copyBuilder()
+                .balance(newTreasuryBalance)
+                .build());
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
+                .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
+        given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
+        given(storeFactory.readableStore(ReadableTokenRelationStore.class)).willReturn(writableTokenRelStore);
+    }
+
     /**
      * A builder for {@link com.hedera.hapi.node.transaction.TransactionBody} instances.
      */

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
@@ -27,6 +27,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_IS_PAUSED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_NAME_TOO_LONG;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_SYMBOL_TOO_LONG;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_WAS_DELETED;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES;
 import static com.hedera.hapi.node.base.TokenType.FUNGIBLE_COMMON;
 import static com.hedera.hapi.node.base.TokenType.NON_FUNGIBLE_UNIQUE;
 import static com.hedera.node.app.service.token.impl.handlers.BaseCryptoHandler.asAccount;
@@ -504,6 +505,78 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(ACCOUNT_FROZEN_FOR_TOKEN));
+    }
+
+    @Test
+    void failsIfNewTreasuryOwnsNftsWhenOldTreasuryIsEmpty() {
+        givenTreasuryBalances(0, 1);
+        txn = new TokenUpdateBuilder()
+                .withTreasury(payerId)
+                .withToken(nonFungibleTokenId)
+                .build();
+        given(handleContext.body()).willReturn(txn);
+        assertThatThrownBy(() -> subject.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES));
+    }
+
+    @Test
+    void worksWhenBothTreasuriesAreEmptyForNFT() {
+        givenTreasuryBalances(0, 0);
+        txn = new TokenUpdateBuilder()
+                .withTreasury(payerId)
+                .withToken(nonFungibleTokenId)
+                .build();
+        given(handleContext.body()).willReturn(txn);
+
+        assertThatNoException().isThrownBy(() -> subject.handle(handleContext));
+
+        assertThat(writableTokenStore.get(nonFungibleTokenId).treasuryAccountId())
+                .isEqualTo(payerId);
+        // Nothing was moved, so neither relation's balance changed
+        assertThat(writableTokenRelStore.get(treasuryId, nonFungibleTokenId).balance())
+                .isZero();
+        assertThat(writableTokenRelStore.get(payerId, nonFungibleTokenId).balance())
+                .isZero();
+    }
+
+    @Test
+    void worksWhenOldTreasuryIsEmptyForFungibleToken() {
+        final var emptyOldRel = writableTokenRelStore
+                .get(treasuryId, fungibleTokenId)
+                .copyBuilder()
+                .balance(0)
+                .build();
+        writableTokenRelStore.put(emptyOldRel);
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
+                .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
+        given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
+        given(storeFactory.readableStore(ReadableTokenRelationStore.class)).willReturn(writableTokenRelStore);
+        txn = new TokenUpdateBuilder().build();
+        given(handleContext.body()).willReturn(txn);
+
+        assertThatNoException().isThrownBy(() -> subject.handle(handleContext));
+
+        assertThat(writableTokenStore.get(fungibleTokenId).treasuryAccountId()).isEqualTo(ownerId);
+        assertThat(writableTokenRelStore.get(treasuryId, fungibleTokenId).balance())
+                .isZero();
+    }
+
+    private void givenTreasuryBalances(final long oldTreasuryBalance, final long newTreasuryBalance) {
+        writableTokenRelStore.put(writableTokenRelStore
+                .get(treasuryId, nonFungibleTokenId)
+                .copyBuilder()
+                .balance(oldTreasuryBalance)
+                .build());
+        writableTokenRelStore.put(writableTokenRelStore
+                .get(payerId, nonFungibleTokenId)
+                .copyBuilder()
+                .balance(newTreasuryBalance)
+                .build());
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
+                .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
+        given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
+        given(storeFactory.readableStore(ReadableTokenRelationStore.class)).willReturn(writableTokenRelStore);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -736,6 +736,82 @@ public class TokenUpdateSpecs {
                         cryptoDelete(previousTreasury).transfer(beneficiary));
     }
 
+    /**
+     * An account that already owns serials of a token cannot become that token's treasury, even
+     * when the outgoing treasury is empty.
+     *
+     * <p>{@code changeOwnerToNewTreasury()} hands NFTs over by rewriting relation balances alone;
+     * it never touches an {@code Nft} record, which is correct only because treasury-held serials
+     * carry a null {@code ownerId} sentinel and so follow the treasury automatically. A serial
+     * acquired by transfer carries an <i>explicit</i> {@code ownerId} instead, and would be
+     * silently orphaned by the next handoff - left owned by an account whose relation balance,
+     * {@code numberPositiveBalances} and {@code numberOwnedNfts} have all been zeroed, and which
+     * can then pass the {@code CryptoDelete} gate in {@code TokenServiceApiImpl}.
+     *
+     * <p>Compare {@link #updateTokenTreasuryRequiresZeroTokenBalance()}, which covers the same
+     * rejection when the outgoing treasury is non-empty, and
+     * {@link #canDeletePreviousNftTreasuryAfterSuccessiveTreasuryUpdates()}, the sentinel-owned
+     * case that must keep working.
+     */
+    @HapiTest
+    final Stream<DynamicTest> nftTreasuryHandoffRejectsIncomingTreasuryHoldingSerials() {
+        final var token = "handoffNft";
+        final var originalTreasury = "handoffOriginalTreasury";
+        final var candidateTreasury = "handoffCandidateTreasury";
+        final var holder = "handoffHolder";
+        final var beneficiary = "handoffBeneficiary";
+        final var adminKey = "handoffAdminKey";
+        final var supplyKey = "handoffSupplyKey";
+
+        return hapiTest(
+                newKeyNamed(adminKey),
+                newKeyNamed(supplyKey),
+                cryptoCreate(originalTreasury),
+                cryptoCreate(candidateTreasury),
+                cryptoCreate(holder),
+                cryptoCreate(beneficiary),
+                tokenCreate(token)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .adminKey(adminKey)
+                        .supplyKey(supplyKey)
+                        .treasury(originalTreasury),
+
+                // Mint one serial, then transfer it away. The transfer writes an explicit ownerId
+                // and drains the original treasury's relation to zero.
+                mintToken(token, List.of(ByteString.copyFromUtf8("memo"))),
+                tokenAssociate(candidateTreasury, token),
+                cryptoTransfer(movingUnique(token, 1).between(originalTreasury, candidateTreasury)),
+                getAccountInfo(originalTreasury)
+                        .hasOwnedNfts(0)
+                        .hasToken(ExpectedTokenRel.relationshipWith(token).balance(0)),
+
+                // The candidate now owns serial 1 outright, so it cannot take the treasury title -
+                // an empty outgoing treasury must not skip this check.
+                tokenUpdate(token)
+                        .treasury(candidateTreasury)
+                        .signedByPayerAnd(adminKey, candidateTreasury)
+                        .hasKnownStatus(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES),
+
+                // Nothing moved, and the candidate is still correctly accounted for as the owner.
+                getTokenInfo(token).hasTreasury(originalTreasury),
+                getTokenNftInfo(token, 1).hasAccountID(candidateTreasury),
+                getAccountInfo(candidateTreasury)
+                        .hasOwnedNfts(1)
+                        .hasToken(ExpectedTokenRel.relationshipWith(token).balance(1)),
+                cryptoDelete(candidateTreasury)
+                        .transfer(beneficiary)
+                        .hasKnownStatus(TRANSACTION_REQUIRES_ZERO_TOKEN_BALANCES),
+
+                // Once the candidate holds nothing the handoff is allowed again, with both the
+                // outgoing and incoming relations empty - the case the guard newly evaluates.
+                tokenAssociate(holder, token),
+                cryptoTransfer(movingUnique(token, 1).between(candidateTreasury, holder)),
+                tokenUpdate(token).treasury(candidateTreasury).signedByPayerAnd(adminKey, candidateTreasury),
+                getTokenInfo(token).hasTreasury(candidateTreasury),
+                getTokenNftInfo(token, 1).hasAccountID(holder));
+    }
+
     @HapiTest
     final Stream<DynamicTest> tokenUpdateCanClearMemo() {
         final var token = "token";


### PR DESCRIPTION
`TokenUpdateHandler` only enforced the zero-balance check on the incoming NFT treasury when the outgoing treasury still held a balance, so an account that already owned serials of the token could become its treasury and have those serials orphaned by the next handoff. Adds a spec covering the rejection and confirming the handoff still succeeds once both relations are empty.
