### PR TITLE
chore: fallback to release branch when `minor-1` is not tagged yet

### DIFF
--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -465,11 +465,6 @@ jobs:
     steps:
       - name: Prepare Runner
         uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
-        with:
-          checkout: "true"
-          checkout-ref: "${{ inputs.ref }}"
-          checkout-fetch-depth: "1"
-          checkout-token: "${{ secrets.access-token }}"
 
       - name: Announce Skip
         run: |
@@ -493,11 +488,6 @@ jobs:
     steps:
       - name: Prepare Runner
         uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
-        with:
-          checkout: "true"
-          checkout-ref: "${{ inputs.ref }}"
-          checkout-fetch-depth: "1"
-          checkout-token: "${{ secrets.access-token }}"
 
       - name: Announce Skip
         run: |

--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -463,6 +463,14 @@ jobs:
     if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 != 'true' }}
     runs-on: hl-cn-default-lin-sm
     steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+
       - name: Announce Skip
         run: |
           echo "::warning::Migration Testing Panel was requested (enable-migration-testing-panel=true) but skipped because solo-ge-0440='${{ inputs.solo-ge-0440 }}' (solo-version='${{ inputs.solo-version }}'). The panel requires Solo >= 0.44.0."
@@ -483,6 +491,14 @@ jobs:
     if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 == 'true' && needs.commit-info.outputs.migration-baseline-available != 'true' }}
     runs-on: hl-cn-default-lin-sm
     steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+
       - name: Announce Skip
         run: |
           echo "::warning::Migration Testing Panel skipped: no previous-minor baseline exists yet — neither a v<minor-1>.* tag nor a release/<minor-1> branch for the current version.txt. It runs automatically once either appears."

--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -169,6 +169,7 @@ jobs:
     runs-on: hl-cn-default-lin-sm
     outputs:
       sha: ${{ steps.commit-info.outputs.sha }}
+      migration-baseline-available: ${{ steps.migration-baseline.outputs.available }}
     steps:
       - name: Prepare Runner
         id: prepare-runner
@@ -184,6 +185,37 @@ jobs:
         run: |
           COMMIT_SHA=$(git rev-parse HEAD)
           echo "sha=${COMMIT_SHA}" | tee "${GITHUB_OUTPUT}"
+
+      # Migration Testing (825) deploys the previous minor (version.txt's
+      # minor - 1) as its baseline: a published v<prev>.* release if one exists,
+      # otherwise a source build of the release/<prev> branch (see
+      # solo-migration-test.sh). If NEITHER a tag nor that branch exists yet —
+      # the brief window right after a version roll — there is no baseline to
+      # migrate from, so the panel is skipped instead of failed (see
+      # migration-testing-baseline-skipped-notice). Coverage resumes
+      # automatically once either the tag or the branch appears. An inconclusive
+      # lookup (network/auth) defaults to available=true so the panel still runs
+      # and the script stays the authority.
+      - name: Resolve migration baseline availability
+        id: migration-baseline
+        run: |
+          raw="$(cat version.txt)"
+          major_minor="$(printf '%s' "${raw}" | cut -d. -f1,2)"
+          major="${major_minor%.*}"; minor="${major_minor#*.}"
+          prev_series="${major}.$((minor - 1))"
+          available=true
+          if tag_refs="$(git ls-remote --tags origin "v${prev_series}.*")" \
+             && branch_refs="$(git ls-remote --heads origin "release/${prev_series}")"; then
+            if [[ -z "${tag_refs}" && -z "${branch_refs}" ]]; then
+              available=false
+            fi
+          else
+            echo "::warning::Could not conclusively query origin for the v${prev_series}.* tag / release/${prev_series} branch; running Migration Testing and letting the script decide."
+          fi
+          echo "available=${available}" | tee "${GITHUB_OUTPUT}"
+          if [[ "${available}" == "false" ]]; then
+            echo "::notice::No v${prev_series}.* tag and no release/${prev_series} branch; Migration Testing will be skipped."
+          fi
 
   build:
     name: Compile and Spotless Check
@@ -413,7 +445,7 @@ jobs:
     needs:
       - commit-info
       - build
-    if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 == 'true' }}
+    if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 == 'true' && needs.commit-info.outputs.migration-baseline-available == 'true' }}
     uses: ./.github/workflows/825-call-migration-testing.yaml
     with:
       ref: ${{ needs.commit-info.outputs.sha }}
@@ -441,6 +473,25 @@ jobs:
             echo ""
             echo "- Requested Solo version: \`${{ inputs.solo-version }}\`"
             echo "- Required: \`>= 0.44.0\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  migration-testing-baseline-skipped-notice:
+    name: Migration Testing Panel (Skipped — no previous-minor baseline)
+    needs:
+      - commit-info
+      - build
+    if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 == 'true' && needs.commit-info.outputs.migration-baseline-available != 'true' }}
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Announce Skip
+        run: |
+          echo "::warning::Migration Testing Panel skipped: no previous-minor baseline exists yet — neither a v<minor-1>.* tag nor a release/<minor-1> branch for the current version.txt. It runs automatically once either appears."
+          {
+            echo "## Migration Testing Panel — SKIPPED"
+            echo ""
+            echo "No previous-minor baseline exists yet: neither a \`v<minor-1>.*\` release tag nor a \`release/<minor-1>\` branch was found for the current \`version.txt\`."
+            echo ""
+            echo "Coverage resumes automatically once the previous minor is tagged or its release branch is cut."
           } >> "${GITHUB_STEP_SUMMARY}"
 
   solo-076-to-077-cutover-panel:

--- a/.github/workflows/825-call-migration-testing.yaml
+++ b/.github/workflows/825-call-migration-testing.yaml
@@ -44,7 +44,7 @@ permissions:
 
 jobs:
   migration-testing:
-    timeout-minutes: 60
+    timeout-minutes: 90
     name: ${{ inputs.custom-job-name || 'Standard' }}
     runs-on: hl-cn-migration-lin-lg
     outputs:

--- a/hedera-node/test-clients/scripts/solo/migration-testing/solo-migration-test.sh
+++ b/hedera-node/test-clients/scripts/solo/migration-testing/solo-migration-test.sh
@@ -141,7 +141,7 @@ wait_for_haproxy_ready() {
 
 # Read the Implementation-Version from a built data dir's HederaNode.jar manifest.
 build_implementation_version() {
-  local build_path="$1"
+  local build_path="${1}"
   unzip -p "${build_path}/apps/HederaNode.jar" META-INF/MANIFEST.MF 2>/dev/null \
     | sed -n 's/^Implementation-Version: //p' | tr -d '\r' | head -n 1
 }
@@ -260,7 +260,7 @@ compute_versions() {
 # baseline local build. Sets BASELINE_MODE=local-build plus BASELINE_BUILD_PATH,
 # BASELINE_WORKTREE, DEPLOY_VERSION_LABEL and BASELINE_DESC.
 build_baseline_from_release_branch() {
-  local prev_series="$1"
+  local prev_series="${1}"
   local branch="release/${prev_series}"
   local baseline_version=""
 

--- a/hedera-node/test-clients/scripts/solo/migration-testing/solo-migration-test.sh
+++ b/hedera-node/test-clients/scripts/solo/migration-testing/solo-migration-test.sh
@@ -71,6 +71,19 @@ CLUSTER_CREATED_THIS_RUN="false"
 DEPLOY_RELEASE_TAG=""
 TARGET_VERSION=""
 
+# Baseline source selection (step 1). BASELINE_MODE is "release-tag" (deploy a
+# published v<prev>.* release, downloaded by solo) or "local-build" (no such tag
+# yet — build the previous minor's release/<prev> branch from source and deploy
+# it via --local-build-path). BASELINE_BUILD_PATH/BASELINE_WORKTREE are only set
+# in local-build mode. DEPLOY_VERSION_LABEL is the semver label handed to
+# `network deploy --release-tag` (a label only; not an artifact download);
+# BASELINE_DESC is a human-readable label for logs.
+BASELINE_MODE="release-tag"
+BASELINE_BUILD_PATH=""
+BASELINE_WORKTREE=""
+DEPLOY_VERSION_LABEL=""
+BASELINE_DESC=""
+
 log() {
   printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
 }
@@ -86,6 +99,12 @@ cleanup() {
   local ec=$?
   if [[ "${KEEP_NETWORK}" != "true" && "${CLUSTER_CREATED_THIS_RUN}" == "true" ]]; then
     kind delete cluster -n "${SOLO_CLUSTER_NAME}" >/dev/null 2>&1 || true
+  fi
+  # Remove the previous-minor baseline worktree (local-build fallback) if we
+  # created one, so the primary checkout isn't left with a dangling worktree.
+  if [[ -n "${BASELINE_WORKTREE}" ]]; then
+    git -C "${REPO_ROOT}" worktree remove --force "${BASELINE_WORKTREE}" >/dev/null 2>&1 || true
+    rm -rf "${BASELINE_WORKTREE}" >/dev/null 2>&1 || true
   fi
   rm -rf "${WORK_DIR}" >/dev/null 2>&1 || true
   exit "${ec}"
@@ -120,9 +139,15 @@ wait_for_haproxy_ready() {
   done
 }
 
-local_build_implementation_version() {
-  unzip -p "${LOCAL_BUILD_PATH}/apps/HederaNode.jar" META-INF/MANIFEST.MF 2>/dev/null \
+# Read the Implementation-Version from a built data dir's HederaNode.jar manifest.
+build_implementation_version() {
+  local build_path="$1"
+  unzip -p "${build_path}/apps/HederaNode.jar" META-INF/MANIFEST.MF 2>/dev/null \
     | sed -n 's/^Implementation-Version: //p' | tr -d '\r' | head -n 1
+}
+
+local_build_implementation_version() {
+  build_implementation_version "${LOCAL_BUILD_PATH}"
 }
 
 consensus_pod_implementation_version() {
@@ -201,20 +226,76 @@ compute_versions() {
   git -C "${REPO_ROOT}" fetch --tags --quiet
 
   prev_tag="$(git -C "${REPO_ROOT}" tag -l "v${prev_series}.*" | sort -V | tail -n 1)"
-  [[ -n "${prev_tag}" ]] || {
-    echo "No tag matches v${prev_series}.*; cannot determine previous-minor baseline" >&2
-    return 1
-  }
 
-  DEPLOY_RELEASE_TAG="${prev_tag}"
   TARGET_VERSION="$(local_build_implementation_version)"
   [[ -n "${TARGET_VERSION}" ]] || {
     echo "Unable to read Implementation-Version from ${LOCAL_BUILD_PATH}/apps/HederaNode.jar" >&2
     return 1
   }
 
-  log "Migration source (baseline): ${DEPLOY_RELEASE_TAG} (latest released v${prev_series}.* tag)"
+  if [[ -n "${prev_tag}" ]]; then
+    # Normal path: a published previous-minor release exists; solo downloads it
+    # by tag for the baseline deploy/setup.
+    BASELINE_MODE="release-tag"
+    DEPLOY_RELEASE_TAG="${prev_tag}"
+    DEPLOY_VERSION_LABEL="${prev_tag}"
+    BASELINE_DESC="${prev_tag} (latest released v${prev_series}.* tag)"
+  else
+    # Fallback: no v${prev_series}.* tag yet — the window between a version roll
+    # and the previous minor's first tag. Build the previous minor's
+    # release/${prev_series} branch from source and deploy it as the baseline
+    # via --local-build-path (a git branch is not a valid --release-tag, and
+    # solo does not build from source itself).
+    log "No v${prev_series}.* tag found; falling back to a release/${prev_series} source build"
+    build_baseline_from_release_branch "${prev_series}"
+  fi
+
+  log "Migration source (baseline): ${BASELINE_DESC}"
   log "Migration target           : ${TARGET_VERSION} (local build at ${LOCAL_BUILD_PATH})"
+}
+
+# Fallback baseline: build the previous minor's release/<prev_series> branch from
+# source in a detached git worktree (so the primary checkout — which holds the
+# upgrade-target build in hedera-node/data — is untouched) and stage it as the
+# baseline local build. Sets BASELINE_MODE=local-build plus BASELINE_BUILD_PATH,
+# BASELINE_WORKTREE, DEPLOY_VERSION_LABEL and BASELINE_DESC.
+build_baseline_from_release_branch() {
+  local prev_series="$1"
+  local branch="release/${prev_series}"
+  local baseline_version=""
+
+  # `git worktree add` wants a path that does not exist yet.
+  BASELINE_WORKTREE="$(mktemp -d "${TMPDIR:-/tmp}/solo-migration-baseline.XXXXXX")"
+  rm -rf "${BASELINE_WORKTREE}"
+
+  log "Fetching ${branch}"
+  git -C "${REPO_ROOT}" fetch --quiet origin "${branch}" || {
+    echo "Unable to fetch ${branch}; cannot build previous-minor baseline" >&2
+    return 1
+  }
+
+  log "Adding detached worktree for ${branch} at ${BASELINE_WORKTREE}"
+  git -C "${REPO_ROOT}" worktree add --quiet --detach "${BASELINE_WORKTREE}" FETCH_HEAD
+
+  log "Building ${branch} baseline (./gradlew assemble) — this takes several minutes"
+  # No ionice/nice here: this driver also runs on macOS (ionice is Linux-only).
+  ( cd "${BASELINE_WORKTREE}" && ./gradlew assemble )
+
+  BASELINE_BUILD_PATH="${BASELINE_WORKTREE}/hedera-node/data"
+  validate_local_build_path "${BASELINE_BUILD_PATH}" || {
+    echo "release/${prev_series} build did not produce ${BASELINE_BUILD_PATH}/apps/HederaNode.jar + lib" >&2
+    return 1
+  }
+
+  baseline_version="$(build_implementation_version "${BASELINE_BUILD_PATH}")"
+  BASELINE_MODE="local-build"
+  # `network deploy --release-tag` needs a valid semver LABEL (no download); use
+  # the previous series' .0 so version-gated features match the baseline series.
+  DEPLOY_VERSION_LABEL="v${prev_series}.0"
+  DEPLOY_RELEASE_TAG="${branch}"   # for logs only; not passed to solo in this mode
+  BASELINE_DESC="${branch} source build (${baseline_version:-unknown}) via --local-build-path"
+
+  log "Built ${branch} baseline: ${baseline_version:-unknown} at ${BASELINE_BUILD_PATH}"
 }
 
 # === Step 2 ====================================================================
@@ -260,7 +341,7 @@ setup_cluster_prereqs() {
 # Deploy the baseline 3-node consensus network at the previous-minor tag and
 # attach a Mirror Node with the pinger enabled.
 deploy_baseline() {
-  log "Deploying baseline consensus network at ${DEPLOY_RELEASE_TAG}"
+  log "Deploying baseline consensus network: ${BASELINE_DESC}"
 
   solo keys consensus generate \
     --gossip-keys \
@@ -271,16 +352,30 @@ deploy_baseline() {
   # `--pvcs true` is required because step 3 uses `consensus network upgrade
   # --local-build-path`, which stages new JARs through persistent volumes that
   # must survive the upgrade-driven pod restarts.
+  #
+  # `--release-tag` on `network deploy` is a semver version LABEL only (it drives
+  # version gating + the remote-config version, not an artifact download), so in
+  # local-build mode DEPLOY_VERSION_LABEL is the previous series' .0.
   solo consensus network deploy \
     --deployment "${SOLO_DEPLOYMENT}" \
     --node-aliases "${NODE_ALIASES}" \
     --pvcs true \
-    --release-tag "${DEPLOY_RELEASE_TAG}"
+    --release-tag "${DEPLOY_VERSION_LABEL}"
 
-  solo consensus node setup \
-    --deployment "${SOLO_DEPLOYMENT}" \
-    --node-aliases "${NODE_ALIASES}" \
-    --release-tag "${DEPLOY_RELEASE_TAG}"
+  # Stage the baseline software: a published release (downloaded by tag) or, in
+  # the fallback, the release/<prev> build we compiled, staged onto the nodes
+  # directly via --local-build-path (`node setup` is where the JARs land).
+  if [[ "${BASELINE_MODE}" == "local-build" ]]; then
+    solo consensus node setup \
+      --deployment "${SOLO_DEPLOYMENT}" \
+      --node-aliases "${NODE_ALIASES}" \
+      --local-build-path "${BASELINE_BUILD_PATH}"
+  else
+    solo consensus node setup \
+      --deployment "${SOLO_DEPLOYMENT}" \
+      --node-aliases "${NODE_ALIASES}" \
+      --release-tag "${DEPLOY_RELEASE_TAG}"
+  fi
 
   solo consensus node start \
     --deployment "${SOLO_DEPLOYMENT}" \
@@ -484,4 +579,4 @@ deploy_baseline              #         CN @ prev_tag + MN with pinger
 upgrade_to_local             # Step 3 (CN upgrade to local build)
 step4_crypto_create_smoke    # Step 4 + 4a (CryptoCreate via SDK + MN log scan)
 
-log "PASS: migration ${DEPLOY_RELEASE_TAG} -> ${TARGET_VERSION} (local build) + CryptoCreate smoke completed"
+log "PASS: migration ${BASELINE_DESC} -> ${TARGET_VERSION} (local build) + CryptoCreate smoke completed"


### PR DESCRIPTION
**Description**:
The XTS **Migration Testing** panel fails in the window between a minor version roll and the previous minor's first release tag. After the roll to `0.78.0-SNAPSHOT`, `solo-migration-test.sh` derives the baseline as the previous minor (`0.77`) and aborts with `No tag matches v0.77.*` because `0.77` isn't tagged yet.

## Change
When no `v<minor-1>.*` tag exists, fall back to building the `release/<minor-1>` branch from source and deploying it as the migration baseline via `solo consensus node setup --local-build-path` (a git branch isn't a valid `--release-tag`, and solo doesn't build from source). The upgrade target is still the local build. When the tag exists, behavior is unchanged.

- `hedera-node/test-clients/scripts/solo/migration-testing/solo-migration-test.sh`
  - `compute_versions()`: on missing tag, calls new `build_baseline_from_release_branch()` — checks out `release/<minor-1>` into a detached `git worktree`, runs `./gradlew assemble`, and stages it as the baseline.
  - `deploy_baseline()`: selects tag-download vs `--local-build-path`; `network deploy --release-tag` is passed a semver label only (no download).
  - `cleanup()`: removes the worktree.
- `.github/workflows/825-call-migration-testing.yaml`: `timeout-minutes` 60 → 90 (fallback compiles twice).


**Related issue(s)**:

Fixes #26571 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
