### PR TITLE
fix: Handle close when BlockNodeServiceConnection is interrupted or initialize throws

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -364,9 +364,8 @@ public class BlockNodeConnectionManager {
 
         @Override
         public BlockNodeStatus call() {
-            svcConnection.initialize();
-
             try {
+                svcConnection.initialize();
                 return svcConnection.getBlockNodeStatus();
             } finally {
                 svcConnection.close();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeServiceConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeServiceConnection.java
@@ -196,6 +196,7 @@ public class BlockNodeServiceConnection extends AbstractBlockNodeConnection {
         updateConnectionState(ConnectionState.CLOSING);
 
         Future<?> future = null;
+        boolean wasInterrupted = Thread.interrupted(); // drain pre-existing interrupt flag
 
         try {
             future = blockingIoExecutor.submit(new CloseClientTask(clientHolder));
@@ -205,7 +206,7 @@ public class BlockNodeServiceConnection extends AbstractBlockNodeConnection {
             logger.warn("{} Error occurred while closing connection; it will be suppressed", this, e);
 
             if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
+                wasInterrupted = true;
             }
 
             if (future != null) {
@@ -214,6 +215,9 @@ public class BlockNodeServiceConnection extends AbstractBlockNodeConnection {
         } finally {
             // regardless of outcome, mark this connection as closed
             updateConnectionState(ConnectionState.CLOSED);
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -912,6 +912,22 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
+    void testRetrieveBlockNodeStatusTask_closeCalledWhenInitializeThrows() {
+        final BlockNodeServiceConnection svcConnection = mock(BlockNodeServiceConnection.class);
+        final RuntimeException initError = new RuntimeException("initialization failed");
+        doThrow(initError).when(svcConnection).initialize();
+
+        final RetrieveBlockNodeStatusTask task = new RetrieveBlockNodeStatusTask(svcConnection);
+
+        assertThatThrownBy(task::call).isInstanceOf(RuntimeException.class).hasMessage("initialization failed");
+
+        // close() must be called even when initialize() throws to prevent resource leaks
+        verify(svcConnection).initialize();
+        verify(svcConnection).close();
+        verifyNoMoreInteractions(svcConnection);
+    }
+
+    @Test
     void testGetNextPriorityBlockNode_skipP1GroupBecauseNoCandidates() throws Throwable {
         // Node 1 will have a priority of 1, but it will be unreachable
         final BlockNode node1 = mock(BlockNode.class);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeServiceConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeServiceConnectionTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -443,6 +444,67 @@ class BlockNodeServiceConnectionTest extends BlockNodeCommunicationTestBase {
         verifyNoMoreInteractions(future);
         verifyNoInteractions(client);
         verifyNoInteractions(clientFactory);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testClose_preSetInterruptFlag_closeClientTaskStillRuns() throws Exception {
+        // Use a real single-thread executor, with its thread pre-blocked so that CloseClientTask
+        // is forced into the queue and cannot run until we release it. This makes it deterministic:
+        // with the bug, cancel(true) kills the queued task before it runs; with the fix it runs.
+        final CountDownLatch unblockExecutorLatch = new CountDownLatch(1);
+        final CountDownLatch executorBlockedLatch = new CountDownLatch(1);
+        final java.util.concurrent.ExecutorService realExecutor = Executors.newSingleThreadExecutor();
+        try {
+            realExecutor.execute(() -> {
+                executorBlockedLatch.countDown();
+                try {
+                    unblockExecutorLatch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            assertThat(executorBlockedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+            final BlockNodeServiceConnection conn = new BlockNodeServiceConnection(
+                    createConfigProvider(createDefaultConfigProvider()),
+                    nodeConfiguration,
+                    realExecutor,
+                    clientFactory,
+                    NODE_ID);
+
+            // Force into ACTIVE state with the same shared client mock
+            ((AtomicReference<ServiceClientHolder>) clientRefHandle.get(conn)).set(new ServiceClientHolder(1, client));
+            ((AtomicReference<ConnectionState>) connectionStateHandle.get(conn)).set(ConnectionState.ACTIVE);
+
+            // Call close() from a virtual thread with the interrupt flag already set.
+            // The executor is busy so CloseClientTask goes into the queue.
+            //   Bug:  future.get() throws immediately -> cancel(true) -> task cancelled -> client.close() NOT called
+            //   Fix:  interrupt flag drained -> future.get() blocks  -> task runs     -> client.close() IS called
+            final CountDownLatch closeDone = new CountDownLatch(1);
+            Thread.ofVirtual().start(() -> {
+                Thread.currentThread().interrupt(); // pre-set the interrupt flag
+                conn.close();
+                closeDone.countDown();
+            });
+
+            // Allow close() to begin and reach future.get() (either block or throw immediately),
+            // then release the executor so the queued task can run.
+            Thread.sleep(100);
+            unblockExecutorLatch.countDown();
+
+            assertThat(closeDone.await(5, TimeUnit.SECONDS)).isTrue();
+            realExecutor.shutdown();
+            assertThat(realExecutor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+
+            // Verify the CloseClientTask ran (gRPC channel closed) despite the pre-set interrupt flag
+            verify(client).close();
+            assertThat(((AtomicReference<ConnectionState>) connectionStateHandle.get(conn)))
+                    .hasValue(ConnectionState.CLOSED);
+        } finally {
+            unblockExecutorLatch.countDown();
+            realExecutor.shutdownNow();
+        }
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This pull request improves the robustness and correctness of connection management and resource cleanup in the block node streaming implementation. The main changes address proper handling of thread interruption during connection close operations, ensure resources are always released even if initialization fails, and add comprehensive tests to prevent regressions.

**Connection close robustness:**
- Updated `BlockNodeServiceConnection.close()` to drain any pre-existing thread interrupt flag before submitting the close task, and to restore the flag only after cleanup, ensuring the close operation always runs and resources are released even if the thread was interrupted beforehand. [[1]](diffhunk://#diff-da2f1a0d1f027169cf917bdb3f958a3958845555dfa4338738600ceee6fa02d2R199) [[2]](diffhunk://#diff-da2f1a0d1f027169cf917bdb3f958a3958845555dfa4338738600ceee6fa02d2L208-R209) [[3]](diffhunk://#diff-da2f1a0d1f027169cf917bdb3f958a3958845555dfa4338738600ceee6fa02d2R218-R220)

**Resource cleanup guarantees:**
- Moved the call to `svcConnection.initialize()` inside the try block in `RetrieveBlockNodeStatusTask.call()` so that `close()` is always called, even if initialization throws, preventing resource leaks.

**Testing improvements:**
- Added a unit test to verify that `close()` is called if `initialize()` fails in `RetrieveBlockNodeStatusTask`, ensuring proper cleanup on initialization errors.
- Added a deterministic test to verify that `close()` completes and the client is properly closed even if the thread's interrupt flag is set before calling `close()`, preventing regressions on interrupt handling.
- Added missing import for `Executors` in the test file to support the new test logic.

**Related issue(s)**:

Fixes #26577 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
