### PR TITLE
fix: relax reconnect throttle for hapiTestRestart

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -252,7 +252,7 @@ val prCheckPropOverrides =
 val prCheckPlatformOverrides =
     mapOf(
         "hapiTestRestart" to
-            "platformStatus.observingStatusDelay=10s,reconnect.minimumTimeBetweenReconnects=1s"
+            "platformStatus.observingStatusDelay=10s,reconnect.minimumTimeBetweenReconnects=10s"
     )
 val prCheckPrepareUpgradeOffsets = mapOf("hapiTestAdhoc" to "PT300S")
 val prCheckAssertAtLeastOneWraps = setOf("hapiTestWraps", "hapiTestCutover")

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -248,7 +248,14 @@ val prCheckPropOverrides =
             "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestAtomicBatchSerial" to "nodes.nodeRewardsEnabled=false,quiescence.enabled=true",
     )
-val prCheckPlatformOverrides = mapOf("hapiTestRestart" to "platformStatus.observingStatusDelay=10s")
+// hapiTestRestart restarts the same node several times within a few minutes, needing repeated
+// reconnects from the same teacher. In production a teacher helps a given learner only once per
+// minimumTimeBetweenReconnects (10m), which would leave the learner with no willing teacher.
+val prCheckPlatformOverrides =
+    mapOf(
+        "hapiTestRestart" to
+            "platformStatus.observingStatusDelay=10s,reconnect.minimumTimeBetweenReconnects=1s"
+    )
 val prCheckPrepareUpgradeOffsets = mapOf("hapiTestAdhoc" to "PT300S")
 val prCheckAssertAtLeastOneWraps = setOf("hapiTestWraps", "hapiTestCutover")
 // Path to the extracted WRAPS proving-key artifacts (decider_pp.bin, decider_vp.bin,

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -248,9 +248,7 @@ val prCheckPropOverrides =
             "nodes.nodeRewardsEnabled=false,quiescence.enabled=true,hedera.transaction.maximumPermissibleUnhealthySeconds=5",
         "hapiTestAtomicBatchSerial" to "nodes.nodeRewardsEnabled=false,quiescence.enabled=true",
     )
-// hapiTestRestart restarts the same node several times within a few minutes, needing repeated
-// reconnects from the same teacher. In production a teacher helps a given learner only once per
-// minimumTimeBetweenReconnects (10m), which would leave the learner with no willing teacher.
+// hapiTestRestart reconnects the same node repeatedly; the 10m production throttle would starve it.
 val prCheckPlatformOverrides =
     mapOf(
         "hapiTestRestart" to


### PR DESCRIPTION
`DabEnabledUpgradeTest` restarts node8 twice within ~3.5 minutes, so node8 has to reconnect more than once. A teacher only helps the same learner once per 10 minutes (`minimumTimeBetweenReconnects`), and node0 is the only peer node8 asks — a learner asks only peers that reported it behind, and node0's weight alone is enough to trigger that. So the second reconnect is refused, node8 stays BEHIND until the test times out, and `JumpstartFileSuite` and `StreamValidationTest` fail with it on the shared network.

Drop the throttle to 1s, for `hapiTestRestart` only.

Both failed runs show node0 logging `Rejecting reconnect request from node 7 due to a previous reconnect attempt`.

Closes #26516
