### PR TITLE
fix: test-clients.log empty when running HapiBlockNode or GenesisSubProcessTest tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SharedNetworkLauncherSessionListener.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/SharedNetworkLauncherSessionListener.java
@@ -274,7 +274,7 @@ public class SharedNetworkLauncherSessionListener implements LauncherSessionList
             SHARED_NETWORK.get().start();
         }
 
-        private static void reconfigureSharedSubProcessLogging(@NonNull final SubProcessNetwork network) {
+        public static void reconfigureSharedSubProcessLogging(@NonNull final SubProcessNetwork network) {
             final var outputDir = network.nodes()
                     .getFirst()
                     .getExternalPath(ExternalPath.APPLICATION_LOG)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/NetworkTargetingExtension.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/NetworkTargetingExtension.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.junit.extensions;
 
 import static com.hedera.services.bdd.junit.ContextRequirement.FEE_SCHEDULE_OVERRIDES;
 import static com.hedera.services.bdd.junit.ContextRequirement.THROTTLE_OVERRIDES;
+import static com.hedera.services.bdd.junit.SharedNetworkLauncherSessionListener.SharedNetworkExecutionListener.reconfigureSharedSubProcessLogging;
 import static com.hedera.services.bdd.junit.SharedNetworkLauncherSessionListener.SharedNetworkExecutionListener.sharedSubProcessNetwork;
 import static com.hedera.services.bdd.junit.SharedNetworkLauncherSessionListener.buildRsaBootstrapJson;
 import static com.hedera.services.bdd.junit.extensions.ExtensionUtils.hapiTestMethodOf;
@@ -159,6 +160,7 @@ public class NetworkTargetingExtension implements BeforeEachCallback, AfterEachC
                 targetBlockNodeNetwork.start();
                 SHARED_BLOCK_NODE_NETWORK.set(targetBlockNodeNetwork);
                 targetNetwork.start();
+                reconfigureSharedSubProcessLogging(targetNetwork);
                 SHARED_NETWORK.set(targetNetwork);
 
                 // Set both the thread-local and the static shared network reference
@@ -177,6 +179,7 @@ public class NetworkTargetingExtension implements BeforeEachCallback, AfterEachC
                     }
                 }
                 targetNetwork.start();
+                reconfigureSharedSubProcessLogging(targetNetwork);
                 SHARED_NETWORK.set(targetNetwork);
                 HapiSpec.TARGET_NETWORK.set(targetNetwork);
             } else {


### PR DESCRIPTION
**Description**:
This pull request makes improvements to the shared network logging configuration in the test client infrastructure. The main change is to ensure that subprocess logging is reconfigured whenever a new shared network is started, improving test reliability and log management. Additionally, the visibility of the logging reconfiguration method is updated to allow its use from other classes.

The most important changes are:

**Logging configuration improvements:**
* The `reconfigureSharedSubProcessLogging` method is now called immediately after starting a new shared network in the `beforeEach` method of `NetworkTargetingExtension`, ensuring subprocess logging is always correctly set up for the current test network. [[1]](diffhunk://#diff-d6ac5c372f355b7cce26fc15fccdeae7f8af6efbeb8caf69afccf9f7d11522b3R163) [[2]](diffhunk://#diff-d6ac5c372f355b7cce26fc15fccdeae7f8af6efbeb8caf69afccf9f7d11522b3R182)

**Code accessibility:**
* The `reconfigureSharedSubProcessLogging` method in `SharedNetworkLauncherSessionListener` was changed from `private` to `public`, so it can be invoked from other classes such as `NetworkTargetingExtension`.

**Imports update:**
* The static import for `reconfigureSharedSubProcessLogging` was added to `NetworkTargetingExtension` to enable direct usage of the method.

**Related issue(s)**:

Fixes #26583 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
