### PR TITLE
fix: Treat pure check failures as due diligence failures

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -222,54 +222,41 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
                     configProvider.getConfiguration().getVersion());
         }
 
+        final AccountID payer;
+        final Account payerAccount;
+        // Do node due diligence checks
         try {
-            // But we still re-check for node diligence failures
             transactionChecker.checkParsed(txInfo);
-
-            // Check the transaction size based on enabled features and functionalities
             transactionChecker.checkTransactionSize(txInfo);
-        } catch (PreCheckException e) {
-            return nodeDueDiligenceFailure(
-                    creatorInfo.accountId(),
-                    e.responseCode(),
-                    txInfo,
-                    configProvider.getConfiguration().getVersion());
-        }
 
-        // No reason to do this twice, since every transaction passed to handle is first given to pre-handle
-        if (previousResult == null) {
-            // Also register this txID as having been seen (we don't actually do deduplication in the
-            // pre-handle because deduplication needs to be done deterministically, but we will keep
-            // track of the fact that we have seen this transaction ID, so we can give proper results
-            // in the different receipt queries)
-            deduplicationCache.add(txInfo.transactionID());
-        }
+            // No reason to do this twice, since every transaction passed to handle is first given to pre-handle
+            if (previousResult == null) {
+                // Also register this txID as having been seen (we don't actually do deduplication in the
+                // pre-handle because deduplication needs to be done deterministically, but we will keep
+                // track of the fact that we have seen this transaction ID, so we can give proper results
+                // in the different receipt queries)
+                deduplicationCache.add(txInfo.transactionID());
+            }
 
-        // 2. Get Payer Account---we can never reuse a previous result here, as the payer account could have been
-        // deleted between the last time we looked it up and now
-        final var payer = txInfo.payerID();
-        final var payerAccount = accountStore.getAccountById(payer);
-        if (payerAccount == null) {
-            // If the payer account doesn't exist, then we cannot gather signatures for it, and will need to do
-            // so later during the handle phase. Technically, we could still try to gather and verify the other
-            // signatures, but that might be tricky and complicated with little gain. So just throw.
-            return nodeDueDiligenceFailure(
-                    creatorInfo.accountId(),
-                    PAYER_ACCOUNT_NOT_FOUND,
-                    txInfo,
-                    configProvider.getConfiguration().getVersion());
-        } else if (payerAccount.deleted()) {
-            // this check is not guaranteed, it should be checked again in handle phase. If the payer account is
-            // deleted, we skip the signature verification.
-            return nodeDueDiligenceFailure(
-                    creatorInfo.accountId(),
-                    PAYER_ACCOUNT_DELETED,
-                    txInfo,
-                    configProvider.getConfiguration().getVersion());
-        }
+            // 2. Get Payer Account---we can never reuse a previous result here, as the payer account could have been
+            // deleted between the last time we looked it up and now
+            payer = txInfo.payerID();
+            payerAccount = accountStore.getAccountById(payer);
+            if (payerAccount == null) {
+                // If the payer account doesn't exist, then we cannot gather signatures for it, and will need to do
+                // so later during the handle phase. Technically, we could still try to gather and verify the other
+                // signatures, but that might be tricky and complicated with little gain. So just throw.
+                throw new PreCheckException(PAYER_ACCOUNT_NOT_FOUND);
+            } else if (payerAccount.deleted()) {
+                // this check is not guaranteed, it should be checked again in handle phase. If the payer account is
+                // deleted, we skip the signature verification.
+                throw new PreCheckException(PAYER_ACCOUNT_DELETED);
+            }
 
-        try {
+            // 3. Check size limit based on payer and run pure checks
             transactionChecker.checkTransactionSizeLimitBasedOnPayer(txInfo, payer);
+            final var pureChecksContext = new PureChecksContextImpl(txInfo.txBody(), dispatcher);
+            dispatcher.dispatchPureChecks(pureChecksContext);
         } catch (PreCheckException e) {
             return nodeDueDiligenceFailure(
                     creatorInfo.accountId(),
@@ -278,7 +265,7 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
                     configProvider.getConfiguration().getVersion());
         }
 
-        // 3. Expand and verify signatures
+        // 4. Expand and verify signatures
         return expandAndVerifySignatures(
                 txInfo, payer, payerAccount, storeFactory, previousResult, innerTransaction, creatorInfo);
     }
@@ -341,10 +328,7 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
             if (innerTransaction == InnerTransaction.NO && txInfo.txBody().hasBatchKey()) {
                 throw new PreCheckException(BATCH_KEY_SET_ON_NON_INNER_TRANSACTION);
             }
-            // First, perform semantic checks on the transaction
-            final var pureChecksContext = new PureChecksContextImpl(txBody, dispatcher);
-            dispatcher.dispatchPureChecks(pureChecksContext);
-            // Then gather the signatures from the transaction handler
+            // Gather the signatures from the transaction handler
             dispatcher.dispatchPreHandle(context);
         } catch (PreCheckException preCheck) {
             // It is quite possible those semantic checks and other tasks will fail and throw a PreCheckException.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -17,6 +17,7 @@ import static com.hedera.node.app.service.entityid.impl.schemas.V0730EntityIdSch
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.ACCOUNTS_STATE_ID;
 import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.ALIASES_STATE_ID;
 import static com.hedera.node.app.workflows.TransactionScenarioBuilder.scenario;
+import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.NODE_DUE_DILIGENCE_FAILURE;
 import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.SO_FAR_SO_GOOD;
 import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.UNKNOWN_FAILURE;
 import static com.hedera.node.app.workflows.prehandle.PreHandleResult.nodeDueDiligenceFailure;
@@ -26,7 +27,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -485,6 +488,63 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             assertThat(result.payer()).isEqualTo(NODE_1.nodeAccountID());
             // But we do see this transaction registered with the deduplication cache
             verify(deduplicationCache).add(txInfo.txBody().transactionIDOrThrow());
+        }
+
+        @Test
+        @DisplayName("Fail pre-handle due diligence when pure checks fail")
+        void preHandlePureChecksFail() throws PreCheckException {
+            final var txInfo = scenario().withPayer(ALICE.accountID()).txInfo();
+            final Transaction platformTx = createAppPayloadWrapper(asByteArray(txInfo.signedTx()));
+            when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
+                    .thenReturn(txInfo);
+            doThrow(new PreCheckException(INVALID_ACCOUNT_AMOUNTS))
+                    .when(dispatcher)
+                    .dispatchPureChecks(any());
+
+            workflow.preHandle(storeFactory, NODE_1.asInfo(), Stream.of(platformTx), (txns, bytes) -> {});
+
+            final PreHandleResult result = platformTx.getMetadata();
+            assertThat(result.status()).isEqualTo(NODE_DUE_DILIGENCE_FAILURE);
+            assertThat(result.responseCode()).isEqualTo(INVALID_ACCOUNT_AMOUNTS);
+            assertThat(result.payer()).isEqualTo(NODE_1.nodeAccountID());
+            assertThat(result.txInfo()).isSameAs(txInfo);
+            verify(dispatcher, never()).dispatchPreHandle(any());
+            verifyNoInteractions(signatureExpander, signatureVerifier);
+            verify(deduplicationCache).add(txInfo.txBody().transactionIDOrThrow());
+        }
+
+        @Test
+        @DisplayName("Fail inner transaction due diligence when pure checks fail")
+        void preHandleInnerTransactionPureChecksFail() throws PreCheckException {
+            final var innerTxInfo = scenario().withPayer(ALICE.accountID()).txInfo();
+            final var batchTxInfo = scenario().withPayer(ALICE.accountID()).txInfoForBatch(innerTxInfo);
+            final Transaction platformTx = createAppPayloadWrapper(asByteArray(batchTxInfo.signedTx()));
+            when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
+                    .thenReturn(batchTxInfo)
+                    .thenReturn(innerTxInfo);
+            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of());
+            doNothing()
+                    .doThrow(new PreCheckException(INVALID_ACCOUNT_AMOUNTS))
+                    .when(dispatcher)
+                    .dispatchPureChecks(any());
+
+            final var result = workflow.preHandleAllTransactions(
+                    NODE_1.asInfo(),
+                    storeFactory,
+                    storeFactory.readableStore(ReadableAccountStore.class),
+                    platformTx.getApplicationTransaction(),
+                    null,
+                    (txns, bytes) -> {});
+
+            assertThat(result.status()).isEqualTo(SO_FAR_SO_GOOD);
+            assertThat(result.innerResults()).hasSize(1);
+            final var innerResult = result.innerResults().getFirst();
+            assertThat(innerResult.status()).isEqualTo(NODE_DUE_DILIGENCE_FAILURE);
+            assertThat(innerResult.responseCode()).isEqualTo(INVALID_ACCOUNT_AMOUNTS);
+            assertThat(innerResult.payer()).isEqualTo(NODE_1.nodeAccountID());
+            assertThat(innerResult.txInfo()).isSameAs(innerTxInfo);
+            verify(dispatcher, times(2)).dispatchPureChecks(any());
+            verify(dispatcher, times(1)).dispatchPreHandle(any());
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java
@@ -5,6 +5,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.BUSY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.util.HapiUtils.ACCOUNT_ID_COMPARATOR;
 import static com.hedera.services.bdd.junit.EmbeddedReason.MANIPULATES_EVENT_VERSION;
+import static com.hedera.services.bdd.junit.EmbeddedReason.MUST_SKIP_INGEST;
 import static com.hedera.services.bdd.junit.EmbeddedReason.NEEDS_STATE_ACCESS;
 import static com.hedera.services.bdd.junit.SharedNetworkLauncherSessionListener.CLASSIC_HAPI_TEST_NETWORK_SIZE;
 import static com.hedera.services.bdd.junit.TestTags.INTEGRATION;
@@ -43,6 +44,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.streamMustIncludePassFrom;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateSpecialFile;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usingEventBirthRound;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedAccount;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilNextBlock;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilStartOfNextStakingPeriod;
 import static com.hedera.services.bdd.spec.utilops.upgrade.BuildUpgradeZipOp.FAKE_UPGRADE_ZIP_LOC;
@@ -51,6 +53,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.contract.Utils.aaWith;
 import static com.hedera.services.bdd.suites.freeze.CommonUpgradeResources.DEFAULT_UPGRADE_FILE_ID;
 import static com.hedera.services.bdd.suites.freeze.CommonUpgradeResources.FAKE_ASSETS_LOC;
 import static com.hedera.services.bdd.suites.freeze.CommonUpgradeResources.upgradeFileAppendsPerBurst;
@@ -58,6 +61,7 @@ import static com.hedera.services.bdd.suites.freeze.CommonUpgradeResources.upgra
 import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.generateX509Certificates;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECORD_NOT_FOUND;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static org.hiero.consensus.roster.RosterStateId.ROSTERS_STATE_ID;
@@ -119,6 +123,29 @@ public class ConcurrentIntegrationTests {
     @BeforeAll
     static void setupAll() {
         gossipCertificates = generateX509Certificates(2);
+    }
+
+    @EmbeddedHapiTest(MUST_SKIP_INGEST)
+    final Stream<DynamicTest> pureCheckFailureIsChargedToSubmittingNode() {
+        final var dueDiligenceTxn = "pureCheckDueDiligenceTxn";
+        final var party = "party";
+        final var counterparty = "counterparty";
+        final var otherAccount = "otherAccount";
+
+        return hapiTest(
+                cryptoCreate(party).balance(0L),
+                cryptoCreate(counterparty).balance(0L),
+                cryptoCreate(otherAccount).balance(0L),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, "4", ONE_HBAR)),
+                cryptoTransfer((spec, b) -> b.setTransfers(TransferList.newBuilder()
+                                .addAccountAmounts(aaWith(spec.registry().getAccountID(party), +Long.MAX_VALUE))
+                                .addAccountAmounts(aaWith(spec.registry().getAccountID(otherAccount), +Long.MAX_VALUE))
+                                .addAccountAmounts(aaWith(spec.registry().getAccountID(counterparty), +2))))
+                        .signedBy(DEFAULT_PAYER)
+                        .via(dueDiligenceTxn)
+                        .setNode("4")
+                        .hasKnownStatus(INVALID_ACCOUNT_AMOUNTS),
+                validateChargedAccount(dueDiligenceTxn, "4"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/DuplicateManagementTest.java
@@ -27,14 +27,18 @@ import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.generateX509Certificates;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_GOSSIP_CA_CERTIFICATE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PAYER_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateEncodingException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -115,9 +119,11 @@ public class DuplicateManagementTest {
 
     @LeakyEmbeddedHapiTest(reason = MUST_SKIP_INGEST, requirement = SYSTEM_ACCOUNT_BALANCES)
     @DisplayName("if a node submits an authorized transaction without payer signature, it is charged the network fee")
-    final Stream<DynamicTest> chargesNetworkFeeToNodeThatSubmitsAuthorizedTransactionWithoutPayerSignature() {
+    final Stream<DynamicTest> chargesNetworkFeeToNodeThatSubmitsAuthorizedTransactionWithoutPayerSignature()
+            throws CertificateEncodingException {
         final var submittingNodeAccountId = "4";
         final var nodeAccount = "nodeAccount";
+        final var gossipCertificate = generateX509Certificates(1).getFirst().getEncoded();
         return hapiTest(
                 newKeyNamed("notTreasuryKey"),
                 cryptoCreate(nodeAccount),
@@ -127,10 +133,27 @@ public class DuplicateManagementTest {
                 // Bypass ingest using a non-default node to submit a privileged transaction that claims
                 // 0.0.2 as the payer, but signs with the wrong key
                 nodeCreate("newNode", nodeAccount)
+                        .gossipCaCertificate(gossipCertificate)
                         .signedBy("notTreasuryKey")
                         .setNode(submittingNodeAccountId)
                         .hasKnownStatus(INVALID_PAYER_SIGNATURE),
                 // And verify that the node is charged the network fee for submitting this transaction
+                getAccountBalance(submittingNodeAccountId).hasTinyBars(reducedFromSnapshot("preConsensus")));
+    }
+
+    @LeakyEmbeddedHapiTest(reason = MUST_SKIP_INGEST, requirement = SYSTEM_ACCOUNT_BALANCES)
+    @DisplayName("if a node submits a transaction with an invalid gossip certificate, it is charged the network fee")
+    final Stream<DynamicTest> chargesNetworkFeeToNodeThatSubmitsInvalidGossipCertificate() {
+        final var submittingNodeAccountId = "4";
+        final var nodeAccount = "nodeAccount";
+        return hapiTest(
+                cryptoCreate(nodeAccount),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, submittingNodeAccountId, ONE_HBAR)),
+                balanceSnapshot("preConsensus", submittingNodeAccountId),
+                nodeCreate("newNode", nodeAccount)
+                        .gossipCaCertificate("invalidCert".getBytes(StandardCharsets.UTF_8))
+                        .setNode(submittingNodeAccountId)
+                        .hasKnownStatus(INVALID_GOSSIP_CA_CERTIFICATE),
                 getAccountBalance(submittingNodeAccountId).hasTinyBars(reducedFromSnapshot("preConsensus")));
     }
 


### PR DESCRIPTION
## Summary

- classify service pure-check failures during pre-handle as due diligence failures
- group pre-handle validation failures once transaction information is available
- cover top-level and atomic-batch pure-check failures with unit tests
- verify through an embedded concurrent integration test that the submitting node is charged

## Testing

- `./gradlew :app:test --tests com.hedera.node.app.workflows.prehandle.PreHandleWorkflowImplTest`
- `./gradlew :test-clients:test --tests com.hedera.services.bdd.suites.integration.ConcurrentIntegrationTests.pureCheckFailureIsChargedToSubmittingNode`
- [XTS dry run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/30449154112) — passed