### PR TITLE
ci(workflow-fix): add missing packages from cache to direct install

### DIFF
--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -117,6 +117,12 @@ jobs:
       - name: Build hiero-consensus-node
         run: ${GRADLE_EXEC} assemble
 
+      # Install build tools required by redis-memory-server native module compilation
+      - name: Install Build Dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends cmake pkg-config libssl-dev
+
       # Set up the npm dependencies and cache on the json-rpc-relay repository
       - name: Install NodeJS Dependencies (json-rpc-relay)
         run: npm ci


### PR DESCRIPTION
**Description**:

Add missing packages: missing cmake, cargo, pkg-config, libssl-dev

**Related Issue(s)**:

Implements #26605
