### PR TITLE
ci(workflow-fix): pin redis version

### DIFF
--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -119,6 +119,13 @@ jobs:
 
       # Set up the npm dependencies and cache on the json-rpc-relay repository
       - name: Install NodeJS Dependencies (json-rpc-relay)
+        env:
+          # Pin the Redis binary that redis-memory-server compiles in its postinstall. It otherwise
+          # tracks the rolling "stable" tarball (download.redis.io/redis-stable.tar.gz), which moved to
+          # Redis 8.10.0 on 2026-07-29 and now builds bundled modules needing a toolchain
+          # (pkg-config/libssl-dev/cmake/rust) absent on this runner. 7.4.x is module-free and compiles
+          # with the runner's existing toolchain (the last pre-8 line that worked here).
+          REDISMS_VERSION: "7.4.10"
         run: npm ci
         working-directory: regression-tests/json-rpc-relay
 


### PR DESCRIPTION
**Description**:

Pin the redis version to 7.4.10

**Related Issue(s)**:

Fixes #26605 

**Testing**:

✅ XTS Dry Run passes [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/30568975712/job/90961897632) showing completed JSON RPC Relay Regression run.
