### PR TITLE
fix: (0.76) Refresh stale TSS controllers after reconnect (#26625)

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -814,6 +814,12 @@ public final class Hedera
         this.platform = requireNonNull(platform);
         //  Reconnect states are constructed from raw VirtualMap and need schema metadata initialization.
         if (trigger == InitTrigger.RECONNECT) {
+            // The TSS services outlive the Dagger application graph rebuilt below, so their process-local
+            // controllers may still reflect the pre-reconnect state. Construction IDs alone cannot detect
+            // a learned state that has advanced the same construction; discard the cached controllers so
+            // the first post-reconnect reconciliation rebuilds them from the learned state.
+            hintsService.stop();
+            historyService.stop();
             initializeStatesApi(state, trigger, platform.getContext().getConfiguration());
         }
         // With the States API grounded in the working state, we can create the object graph from it

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/HistoryService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/HistoryService.java
@@ -105,6 +105,11 @@ public interface HistoryService extends Service, OnProofFinished {
             @Nullable HintsConstruction activeConstruction);
 
     /**
+     * Stops the history service, causing it to abandon any in-progress work.
+     */
+    void stop();
+
+    /**
      * Returns a proof of inclusion of the given metadata for the current roster.
      *
      * @param metadata the metadata that must be included in the proof

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/HistoryServiceImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/HistoryServiceImpl.java
@@ -158,6 +158,11 @@ public class HistoryServiceImpl implements HistoryService {
     }
 
     @Override
+    public void stop() {
+        component.controllers().stop();
+    }
+
+    @Override
     public boolean isReady() {
         // Not ready until there is a chain-of-trust proof for the genesis hinTS verification key
         return historyProof != null && historyProof.hasChainOfTrustProof();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/ProofControllers.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/ProofControllers.java
@@ -123,6 +123,16 @@ public class ProofControllers {
     }
 
     /**
+     * Stops the current controller, if it exists.
+     */
+    public void stop() {
+        if (controller != null) {
+            controller.cancelPendingWork();
+            controller = null;
+        }
+    }
+
+    /**
      * Returns a new controller for the given active rosters and history proof construction.
      *
      * @param activeRosters the active rosters

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/HederaReconnectTssControllerResetTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/HederaReconnectTssControllerResetTest.java
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app;
+
+import static com.swirlds.platform.system.InitTrigger.RECONNECT;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import com.hedera.node.app.hints.HintsService;
+import com.hedera.node.app.history.HistoryService;
+import com.swirlds.platform.system.Platform;
+import com.swirlds.state.State;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Pins the reconnect lifecycle boundary that clears process-local TSS controllers before a learned state is
+ * initialized. The deliberate exception from {@link Platform#getContext()} stops the partial {@link Hedera} mock at
+ * the first operation after both controllers must have been reset.
+ */
+@ExtendWith(MockitoExtension.class)
+class HederaReconnectTssControllerResetTest {
+    @Mock
+    private State state;
+
+    @Mock
+    private Platform platform;
+
+    @Mock
+    private HintsService hintsService;
+
+    @Mock
+    private HistoryService historyService;
+
+    @Test
+    void stopsTssControllersBeforeInitializingReconnectState() throws Exception {
+        final var hedera = mock(Hedera.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+        final var initializationBoundary = new IllegalStateException("Stop after verifying TSS reset order");
+        given(platform.getContext()).willThrow(initializationBoundary);
+        setField(hedera, "hintsService", hintsService);
+        setField(hedera, "historyService", historyService);
+
+        final var thrown = assertThrows(
+                IllegalStateException.class, () -> hedera.onStateInitialized(state, platform, RECONNECT, null));
+
+        assertSame(initializationBoundary, thrown);
+        final InOrder inOrder = inOrder(hintsService, historyService, platform);
+        inOrder.verify(hintsService).stop();
+        inOrder.verify(historyService).stop();
+        inOrder.verify(platform).getContext();
+    }
+
+    private static void setField(final Object target, final String name, final Object value) throws Exception {
+        final Field field = Hedera.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsControllersTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsControllersTest.java
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.hints.impl;
 
+import static com.hedera.hapi.util.HapiUtils.asTimestamp;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.state.hints.CRSState;
 import com.hedera.hapi.node.state.hints.HintsConstruction;
@@ -13,6 +15,7 @@ import com.hedera.node.app.service.roster.impl.RosterTransitionWeights;
 import com.hedera.node.app.spi.info.NodeInfo;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.time.Instant;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +61,9 @@ class HintsControllersTest {
 
     @Mock
     private OnHintsFinished onHintsFinished;
+
+    @Mock
+    private HintsController controller;
 
     private HintsControllers subject;
 
@@ -105,8 +111,34 @@ class HintsControllersTest {
                 subject.getOrCreateFor(activeRosters, ONE_CONSTRUCTION, hintsStore, HintsConstruction.DEFAULT);
 
         assertInstanceOf(HintsControllerImpl.class, controller);
+    }
 
-        assertDoesNotThrow(() -> subject.stop());
-        assertDoesNotThrow(() -> subject.stop());
+    @Test
+    void stopCancelsAndRefreshesControllerForSameConstructionId() throws Exception {
+        final var learnedConstruction = HintsConstruction.newBuilder()
+                .constructionId(1L)
+                .preprocessingStartTime(asTimestamp(Instant.EPOCH))
+                .build();
+        given(controller.constructionId()).willReturn(1L);
+        setController(controller);
+
+        final var staleController =
+                subject.getOrCreateFor(activeRosters, learnedConstruction, hintsStore, HintsConstruction.DEFAULT);
+        assertSame(controller, staleController);
+
+        subject.stop();
+        subject.stop();
+
+        verify(controller).cancelPendingWork();
+        given(activeRosters.transitionWeights(null)).willReturn(weights);
+        final var refreshedController =
+                subject.getOrCreateFor(activeRosters, learnedConstruction, hintsStore, HintsConstruction.DEFAULT);
+        assertNotSame(staleController, refreshedController);
+    }
+
+    private void setController(final HintsController controller) throws Exception {
+        final var field = HintsControllers.class.getDeclaredField("controller");
+        field.setAccessible(true);
+        field.set(subject, controller);
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/HistoryServiceImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/HistoryServiceImplTest.java
@@ -147,6 +147,16 @@ class HistoryServiceImplTest {
     }
 
     @Test
+    void stopsControllersWorkWhenAsked() {
+        withMockSubject();
+        given(component.controllers()).willReturn(controllers);
+
+        subject.stop();
+
+        verify(controllers).stop();
+    }
+
+    @Test
     void handoffIsNoop() {
         withMockSubject();
         given(activeRosters.phase()).willReturn(HANDOFF);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/ProofControllersTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/ProofControllersTest.java
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.history.impl;
 
+import static com.hedera.hapi.util.HapiUtils.asTimestamp;
 import static com.hedera.node.app.fixtures.AppTestBase.DEFAULT_CONFIG;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.state.hints.HintsConstruction;
 import com.hedera.hapi.node.state.history.HistoryProofConstruction;
@@ -15,6 +17,7 @@ import com.hedera.node.app.service.roster.impl.RosterTransitionWeights;
 import com.hedera.node.app.spi.info.NodeInfo;
 import com.hedera.node.config.data.TssConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.time.Instant;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,6 +71,9 @@ class ProofControllersTest {
 
     @Mock
     private ReadableHistoryStore historyStore;
+
+    @Mock
+    private ProofController controller;
 
     private ProofControllers subject;
 
@@ -130,5 +136,44 @@ class ProofControllersTest {
                 DEFAULT_CONFIG.getConfigData(TssConfig.class));
 
         assertInstanceOf(ProofControllerImpl.class, controller);
+    }
+
+    @Test
+    void stopCancelsAndRefreshesControllerForSameConstructionId() throws Exception {
+        final var learnedConstruction = HistoryProofConstruction.newBuilder()
+                .constructionId(1L)
+                .assemblyStartTime(asTimestamp(Instant.EPOCH))
+                .build();
+        given(controller.constructionId()).willReturn(1L);
+        setController(controller);
+
+        final var staleController = subject.getOrCreateFor(
+                activeRosters,
+                learnedConstruction,
+                historyStore,
+                HintsConstruction.DEFAULT,
+                HistoryProofConstruction.DEFAULT,
+                DEFAULT_CONFIG.getConfigData(TssConfig.class));
+        assertSame(controller, staleController);
+
+        subject.stop();
+        subject.stop();
+
+        verify(controller).cancelPendingWork();
+        given(activeRosters.transitionWeights(null)).willReturn(weights);
+        final var refreshedController = subject.getOrCreateFor(
+                activeRosters,
+                learnedConstruction,
+                historyStore,
+                HintsConstruction.DEFAULT,
+                HistoryProofConstruction.DEFAULT,
+                DEFAULT_CONFIG.getConfigData(TssConfig.class));
+        assertNotSame(staleController, refreshedController);
+    }
+
+    private void setController(final ProofController controller) throws Exception {
+        final var field = ProofControllers.class.getDeclaredField("controller");
+        field.setAccessible(true);
+        field.set(subject, controller);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeHistoryService.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/fakes/FakeHistoryService.java
@@ -92,6 +92,11 @@ public class FakeHistoryService implements HistoryService {
     }
 
     @Override
+    public void stop() {
+        delegate.stop();
+    }
+
+    @Override
     public void onFinished(
             @NonNull final WritableHistoryStore historyStore,
             @NonNull final HistoryProofConstruction construction,


### PR DESCRIPTION
## Summary
- Backports #26625 to `release/0.76`.
- Clears cached history and hinTS controllers before reconnect installs a learned state.
- Prevents same-ID process-local controllers from overwriting more advanced learned TSS state.

## Validation
- `./gradlew :app:spotlessCheck :test-clients:spotlessCheck`
- 42 focused app tests covering reconnect reset behavior, hinTS controllers, and history proof controllers
- `./gradlew :test-clients:compileJava`